### PR TITLE
Display recipe summary on recipe page

### DIFF
--- a/src/components/Recipe/Recipe.svelte
+++ b/src/components/Recipe/Recipe.svelte
@@ -422,6 +422,12 @@ async function getLists(): Promise<NDKEvent[]> {
         {/if}
         </div>
       </div>
+      <!-- Recipe Summary -->
+      {#if event.tags.find((e) => e[0] === 'summary')?.[1]}
+        <p class="text-lg text-caption leading-relaxed">
+          {event.tags.find((e) => e[0] === 'summary')?.[1]}
+        </p>
+      {/if}
       <div class="prose">
         {#if $translateOption.lang}
           {#await translate($translateOption, parseMarkdown(event.content))}


### PR DESCRIPTION
Displays the recipe summary tag on the recipe page, below the photo and reactions. The summary was previously not visible on zap.cooking but is shown on other Nostr clients like habla.news.