### PR TITLE
Add video upload support for kind 1 notes on community feed

### DIFF
--- a/src/routes/community/+page.svelte
+++ b/src/routes/community/+page.svelte
@@ -787,8 +787,8 @@
                   <!-- Image upload button -->
                   <label
                     class="cursor-pointer p-1.5 rounded-full hover:bg-accent-gray transition-colors"
-                    class:opacity-50={posting || uploadingImage}
-                    class:cursor-not-allowed={posting || uploadingImage}
+                    class:opacity-50={posting || uploadingImage || uploadingVideo}
+                    class:cursor-not-allowed={posting || uploadingImage || uploadingVideo}
                     aria-disabled={posting || uploadingImage}
                     title="Upload image"
                   >


### PR DESCRIPTION
- Add video upload button with VideoIcon next to image upload
- Implement handleVideoUpload function with 200MB file size limit
- Add video preview thumbnails in composer
- Include video URLs in post content
- Videos automatically render in feed via existing NoteContent component
- Support for common video formats (mp4, webm, mov, avi, mkv)