### PR TITLE
Fix zap modal rendering on community feed posts

### DIFF
--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -1748,7 +1748,10 @@ import ClientAttribution from './ClientAttribution.svelte';
   // Zap modal
   function openZapModal(event: NDKEvent) {
     selectedEvent = event;
-    zapModal = true;
+    // Use setTimeout to allow component to mount before opening
+    setTimeout(() => {
+      zapModal = true;
+    }, 0);
   }
 
   // Image modal
@@ -2111,7 +2114,7 @@ import ClientAttribution from './ClientAttribution.svelte';
 
                     <button
                       class="flex items-center hover:bg-amber-50 rounded-full p-1.5 transition-colors cursor-pointer"
-                      on:click={() => openZapModal(event)}
+                      on:click|stopPropagation={() => openZapModal(event)}
                     >
                       <NoteTotalZaps {event} />
                     </button>
@@ -2173,7 +2176,7 @@ import ClientAttribution from './ClientAttribution.svelte';
   </div>
 </FeedErrorBoundary>
 
-{#if zapModal && selectedEvent}
+{#if selectedEvent}
   <ZapModal
     bind:open={zapModal}
     event={selectedEvent}

--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -2,9 +2,18 @@
   import { blur, scale } from 'svelte/transition';
   import CloseIcon from 'phosphor-svelte/lib/XCircle';
     import { has } from 'markdown-it/lib/common/utils';
+  import { onMount, onDestroy } from 'svelte';
+
   export let open = false;
   export let cleanup: (() => void) | null = null;
   export let noHeader = false;
+
+  // Portal target - render at document body level
+  let portalTarget: HTMLElement;
+
+  onMount(() => {
+    portalTarget = document.body;
+  });
 
   // if some variables need to be erased when it's closed, we can do that here.
   function close() {
@@ -14,21 +23,23 @@
   }
 </script>
 
-{#if open}
-  <div
-    on:click|self={close}
-    role="presentation"
-    transition:blur={{ duration: 250 }}
-    class="fixed top-0 left-0 z-30 w-full h-full backdrop-brightness-50 backdrop-blur"
-  >
-    <dialog
-      transition:scale={{ duration: 250 }}
-      aria-labelledby="title"
-      aria-modal="true"
-      class="absolute m-0 top-1/2 left-1/2 px-2 md:px-8 pt-6 pb-8 rounded-3xl w-[calc(100%-1rem)] md:w-[calc(100vw-4em)] max-w-xl max-h-[90vh] overflow-y-auto -translate-x-1/2 -translate-y-1/2"
-      style="background-color: var(--color-bg-secondary);"
-      open
+{#if open && portalTarget}
+  <!-- Portal to body - render modal at document level -->
+  <div use:portal={portalTarget}>
+    <div
+      on:click|self={close}
+      role="presentation"
+      transition:blur={{ duration: 250 }}
+      class="fixed top-0 left-0 z-50 w-full h-full backdrop-brightness-50 backdrop-blur"
     >
+      <dialog
+        transition:scale={{ duration: 250 }}
+        aria-labelledby="title"
+        aria-modal="true"
+        class="absolute m-0 top-1/2 left-1/2 px-2 md:px-8 pt-6 pb-8 rounded-3xl w-[calc(100%-1rem)] md:w-[calc(100vw-4em)] max-w-xl max-h-[90vh] overflow-y-auto -translate-x-1/2 -translate-y-1/2"
+        style="background-color: var(--color-bg-secondary);"
+        open
+      >
       <div class="flex flex-col gap-6">
         {#if !noHeader}
           <div class="flex justify-between">
@@ -43,6 +54,7 @@
         <slot />
       </div>
     </dialog>
+    </div>
   </div>
   <style>
     html {
@@ -51,3 +63,18 @@
     }
   </style>
 {/if}
+
+<script context="module" lang="ts">
+  // Portal action to move element to target
+  export function portal(node: HTMLElement, target: HTMLElement) {
+    target.appendChild(node);
+
+    return {
+      destroy() {
+        if (node.parentNode === target) {
+          target.removeChild(node);
+        }
+      }
+    };
+  }
+</script>

--- a/src/components/ZapModal.svelte
+++ b/src/components/ZapModal.svelte
@@ -33,6 +33,7 @@
 
   export let open = false;
   export let event: NDKEvent | NDKUser;
+
   let amount: number = 21;
   let message: string = '';
 


### PR DESCRIPTION
The zap modal was not appearing when clicking zap buttons on community feed posts due to a CSS positioning context issue. Parent containers with transform/filter properties were creating a new containing block, causing position:fixed elements to render incorrectly.

Changes:
- Add portal system to Modal.svelte to render modals at document.body level
- Add stopPropagation to zap button click handler to prevent event bubbling
- Add setTimeout delay in openZapModal to ensure component mounts before opening
- Fix conditional rendering logic for ZapModal component

This fix applies to all modals in the application, ensuring they always render correctly regardless of parent container CSS.

Tested on both desktop and mobile browsers.