### PR TITLE
feat: Atomic mentions

### DIFF
--- a/src/components/CommentReplies.svelte
+++ b/src/components/CommentReplies.svelte
@@ -11,9 +11,10 @@
   import { buildNip22CommentTags } from '$lib/tagUtils';
   import CommentLikes from './CommentLikes.svelte';
   import { get } from 'svelte/store';
+  import { searchProfiles } from '$lib/profileSearchService';
 
   export let parentComment: NDKEvent;
-  
+
   let showReplies = false;
   let replies: NDKEvent[] = [];
   let loading = false;
@@ -22,42 +23,49 @@
   let replyCount = 0;
   let errorMessage = '';
   let successMessage = '';
-  let replyTextareaEl: HTMLTextAreaElement;
+  let replyComposerEl: HTMLDivElement;
+  let lastRenderedReply = '';
   let replySubscription: any = null;
 
   // @ mention autocomplete state
   let mentionQuery = '';
   let showMentionSuggestions = false;
-  let mentionStartPos = 0;
-  let mentionSuggestions: { name: string; npub: string; picture?: string; pubkey: string }[] = [];
+  let mentionSuggestions: {
+    name: string;
+    npub: string;
+    picture?: string;
+    pubkey: string;
+    nip05?: string;
+  }[] = [];
   let selectedMentionIndex = 0;
-  let mentionProfileCache: Map<string, { name: string; npub: string; picture?: string; pubkey: string }> = new Map();
+  let mentionProfileCache: Map<
+    string,
+    { name: string; npub: string; picture?: string; pubkey: string; nip05?: string }
+  > = new Map();
   let mentionFollowListLoaded = false;
   let mentionSearchTimeout: ReturnType<typeof setTimeout>;
+  let mentionSearching = false;
 
   // Load follow list profiles for mention autocomplete
   async function loadMentionFollowList() {
     if (mentionFollowListLoaded) return;
-    
+
     const pubkey = get(userPublickey);
     if (!pubkey || !$ndk) return;
-    
+
     try {
       const contactEvent = await $ndk.fetchEvent({
         kinds: [3],
         authors: [pubkey],
         limit: 1
       });
-      
+
       if (!contactEvent) return;
-      
-      const followPubkeys = contactEvent.tags
-        .filter(t => t[0] === 'p' && t[1])
-        .map(t => t[1])
-        .slice(0, 500);
-      
+
+      const followPubkeys = contactEvent.tags.filter((t) => t[0] === 'p' && t[1]).map((t) => t[1]);
+
       if (followPubkeys.length === 0) return;
-      
+
       const batchSize = 100;
       for (let i = 0; i < followPubkeys.length; i += batchSize) {
         const batch = followPubkeys.slice(i, i + batchSize);
@@ -66,17 +74,18 @@
             kinds: [0],
             authors: batch
           });
-          
+
           for (const event of events) {
             try {
               const profile = JSON.parse(event.content);
               const name = profile.display_name || profile.name || '';
-              if (name) {
+              if (name || profile.nip05) {
                 mentionProfileCache.set(event.pubkey, {
-                  name,
+                  name: name || profile.nip05?.split('@')[0] || 'Unknown',
                   npub: nip19.npubEncode(event.pubkey),
                   picture: profile.picture,
-                  pubkey: event.pubkey
+                  pubkey: event.pubkey,
+                  nip05: profile.nip05
                 });
               }
             } catch {}
@@ -85,7 +94,7 @@
           console.debug('Failed to fetch mention profile batch:', e);
         }
       }
-      
+
       mentionFollowListLoaded = true;
     } catch (e) {
       console.debug('Failed to load mention follow list:', e);
@@ -94,38 +103,323 @@
 
   // Search users for mention autocomplete
   async function searchMentionUsers(query: string) {
-    if (!mentionFollowListLoaded) {
-      await loadMentionFollowList();
-    }
-    
+    loadMentionFollowList();
+
     const queryLower = query.toLowerCase();
-    const matches: { name: string; npub: string; picture?: string; pubkey: string }[] = [];
-    
+    const matches: {
+      name: string;
+      npub: string;
+      picture?: string;
+      pubkey: string;
+      nip05?: string;
+    }[] = [];
+    const seenPubkeys = new Set<string>();
+
     for (const profile of mentionProfileCache.values()) {
-      if (profile.name.toLowerCase().includes(queryLower)) {
+      const nameMatch = profile.name.toLowerCase().includes(queryLower);
+      const nip05Match = profile.nip05?.toLowerCase().includes(queryLower);
+
+      if (nameMatch || nip05Match) {
         matches.push(profile);
-        if (matches.length >= 8) break;
+        seenPubkeys.add(profile.pubkey);
       }
     }
-    
-    mentionSuggestions = matches;
+
+    if (matches.length > 0) {
+      mentionSuggestions = matches.slice(0, 10);
+      selectedMentionIndex = 0;
+    }
+
+    const shouldSearchPrimal = query.length >= 2;
+    const shouldSearchNdk = query.length >= 1 && $ndk;
+
+    if (shouldSearchPrimal || shouldSearchNdk) {
+      mentionSearching = true;
+      try {
+        if (shouldSearchPrimal) {
+          const primalResults = await searchProfiles(query, 25);
+          for (const profile of primalResults) {
+            if (seenPubkeys.has(profile.pubkey)) continue;
+
+            const name =
+              profile.displayName || profile.name || profile.nip05?.split('@')[0] || 'Unknown';
+            const profileData = {
+              name,
+              npub: profile.npub || nip19.npubEncode(profile.pubkey),
+              picture: profile.picture,
+              pubkey: profile.pubkey,
+              nip05: profile.nip05
+            };
+
+            matches.push(profileData);
+            seenPubkeys.add(profile.pubkey);
+            mentionProfileCache.set(profile.pubkey, profileData);
+          }
+        }
+
+        if (shouldSearchNdk && $ndk) {
+          const searchResults = await $ndk.fetchEvents({
+            kinds: [0],
+            search: query,
+            limit: 50
+          });
+
+          for (const event of searchResults) {
+            if (seenPubkeys.has(event.pubkey)) continue;
+
+            try {
+              const profile = JSON.parse(event.content);
+              const name = profile.display_name || profile.name || '';
+              const nip05 = profile.nip05;
+
+              const profileData = {
+                name: name || nip05?.split('@')[0] || profile.name || 'Unknown',
+                npub: nip19.npubEncode(event.pubkey),
+                picture: profile.picture,
+                pubkey: event.pubkey,
+                nip05
+              };
+
+              matches.push(profileData);
+              seenPubkeys.add(event.pubkey);
+              mentionProfileCache.set(event.pubkey, profileData);
+            } catch {}
+          }
+        }
+      } catch (e) {
+        console.debug('Network search failed:', e);
+      } finally {
+        mentionSearching = false;
+      }
+    }
+
+    matches.sort((a, b) => {
+      const aExact =
+        a.name.toLowerCase().startsWith(queryLower) ||
+        a.nip05?.toLowerCase().startsWith(queryLower);
+      const bExact =
+        b.name.toLowerCase().startsWith(queryLower) ||
+        b.nip05?.toLowerCase().startsWith(queryLower);
+      if (aExact && !bExact) return -1;
+      if (!aExact && bExact) return 1;
+      return a.name.localeCompare(b.name);
+    });
+
+    mentionSuggestions = matches.slice(0, 10);
     selectedMentionIndex = 0;
   }
 
-  // Handle textarea input for @ mentions
-  function handleReplyInput(event: Event) {
-    const textarea = event.target as HTMLTextAreaElement;
-    const cursorPos = textarea.selectionStart;
-    const text = replyText;
-    
-    const textBeforeCursor = text.substring(0, cursorPos);
-    const mentionMatch = textBeforeCursor.match(/@(\w*)$/);
-    
+  function syncComposerContent(value: string) {
+    if (!replyComposerEl) return;
+    const html = renderTextWithMentions(value);
+    if (replyComposerEl.innerHTML !== html) {
+      replyComposerEl.innerHTML = html;
+    }
+    lastRenderedReply = value;
+  }
+
+  function escapeHtml(value: string): string {
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function escapeRegex(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  function formatNpubShort(npub: string): string {
+    if (npub.length <= 16) return npub;
+    return `${npub.slice(0, 10)}...${npub.slice(-6)}`;
+  }
+
+  function getDisplayNameForMention(mention: string): string {
+    const identifier = mention.replace('nostr:', '');
+    try {
+      const decoded = nip19.decode(identifier);
+      if (decoded.type === 'npub') {
+        const profile = mentionProfileCache.get(decoded.data);
+        if (profile?.name) return profile.name;
+        return formatNpubShort(identifier);
+      }
+      if (decoded.type === 'nprofile') {
+        const profile = mentionProfileCache.get(decoded.data.pubkey);
+        if (profile?.name) return profile.name;
+        return formatNpubShort(nip19.npubEncode(decoded.data.pubkey));
+      }
+    } catch {}
+    return formatNpubShort(identifier);
+  }
+
+  function renderTextWithMentions(text: string): string {
+    if (!text) return '';
+    const mentionRegex =
+      /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)|@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g;
+    let html = '';
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = mentionRegex.exec(text)) !== null) {
+      const beforeText = text.substring(lastIndex, match.index);
+      if (beforeText) {
+        html += escapeHtml(beforeText).replace(/\n/g, '<br>');
+      }
+
+      const rawMention = match[0];
+      const mention = rawMention.startsWith('@') ? `nostr:${rawMention.slice(1)}` : rawMention;
+      const displayName = getDisplayNameForMention(mention);
+      html += `<span class="mention-pill" contenteditable="false" data-mention="${mention}">@${escapeHtml(displayName)}</span>`;
+
+      lastIndex = match.index + rawMention.length;
+    }
+
+    if (lastIndex < text.length) {
+      html += escapeHtml(text.substring(lastIndex)).replace(/\n/g, '<br>');
+    }
+
+    return html;
+  }
+
+  function htmlToPlainText(element: Node): string {
+    let text = '';
+    let isFirstChild = true;
+
+    element.childNodes.forEach((node) => {
+      if (node.nodeType === Node.TEXT_NODE) {
+        const content = (node.textContent || '').replace(/\u200B/g, '');
+        text += content;
+        if (content) {
+          isFirstChild = false;
+        }
+      } else if (node.nodeType === Node.ELEMENT_NODE) {
+        const el = node as HTMLElement;
+
+        if (el.dataset.mention) {
+          text += el.dataset.mention;
+          isFirstChild = false;
+        } else if (el.tagName === 'BR') {
+          text += '\n';
+        } else if (el.tagName === 'DIV') {
+          if (!isFirstChild) {
+            text += '\n';
+          }
+
+          const hasOnlyBr = el.childNodes.length === 1 && el.firstChild?.nodeName === 'BR';
+          if (!hasOnlyBr) {
+            text += htmlToPlainText(node);
+          }
+          isFirstChild = false;
+        } else if (el.tagName === 'SPAN') {
+          const spanContent = htmlToPlainText(node);
+          text += spanContent;
+          if (spanContent) {
+            isFirstChild = false;
+          }
+        } else {
+          const childContent = htmlToPlainText(node);
+          text += childContent;
+          if (childContent) {
+            isFirstChild = false;
+          }
+        }
+      }
+    });
+
+    return text;
+  }
+
+  function getTextBeforeCursor(element: HTMLDivElement): string {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return '';
+
+    const range = selection.getRangeAt(0);
+    const preCaretRange = range.cloneRange();
+    preCaretRange.selectNodeContents(element);
+    preCaretRange.setEnd(range.startContainer, range.startOffset);
+
+    const tempDiv = document.createElement('div');
+    tempDiv.appendChild(preCaretRange.cloneContents());
+
+    return htmlToPlainText(tempDiv);
+  }
+
+  function updateContentFromComposer() {
+    if (!replyComposerEl) return;
+    const newText = htmlToPlainText(replyComposerEl);
+    lastRenderedReply = newText;
+    replyText = newText;
+  }
+
+  function handleBeforeInput(event: InputEvent) {
+    if (
+      event.isComposing ||
+      event.inputType === 'historyUndo' ||
+      event.inputType === 'historyRedo'
+    ) {
+      return;
+    }
+
+    const selection = window.getSelection();
+    if (!selection || !replyComposerEl) return;
+    const range = selection.getRangeAt(0);
+    let node: Node | null = range.startContainer;
+
+    while (node && node !== replyComposerEl) {
+      if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).dataset.mention) {
+        event.preventDefault();
+
+        if (event.inputType === 'insertText' || event.inputType === 'insertCompositionText') {
+          const newRange = document.createRange();
+          newRange.setStartAfter(node);
+          newRange.collapse(true);
+          selection.removeAllRanges();
+          selection.addRange(newRange);
+        }
+        return;
+      }
+      node = node.parentNode;
+    }
+  }
+
+  function handlePaste(event: ClipboardEvent) {
+    event.preventDefault();
+    const plainText = event.clipboardData?.getData('text/plain');
+    if (!plainText) return;
+
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return;
+    const range = selection.getRangeAt(0);
+
+    range.deleteContents();
+    const textNode = document.createTextNode(plainText);
+    range.insertNode(textNode);
+    range.setStartAfter(textNode);
+    range.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    handleReplyInput();
+  }
+
+  function handleReplyInput() {
+    updateContentFromComposer();
+    if (!replyComposerEl) return;
+
+    const converted = convertRawMentionsToPills();
+    if (converted) {
+      updateContentFromComposer();
+    }
+
+    const textBeforeCursor = getTextBeforeCursor(replyComposerEl);
+    const mentionMatch = textBeforeCursor.match(/@([^\s@]*)$/);
+
     if (mentionMatch) {
-      mentionStartPos = cursorPos - mentionMatch[0].length;
-      mentionQuery = mentionMatch[1];
+      mentionQuery = mentionMatch[1] || '';
       showMentionSuggestions = true;
-      
+
       if (mentionSearchTimeout) clearTimeout(mentionSearchTimeout);
       mentionSearchTimeout = setTimeout(() => {
         if (mentionQuery.length > 0) {
@@ -141,53 +435,302 @@
     }
   }
 
-  // Insert mention into textarea
-  function insertMention(user: { name: string; npub: string }) {
-    if (!replyTextareaEl) return;
-    
-    const beforeMention = replyText.substring(0, mentionStartPos);
-    const afterMention = replyText.substring(replyTextareaEl.selectionStart);
-    const mentionText = `@${user.name} `;
-    
-    replyText = beforeMention + mentionText + afterMention;
-    showMentionSuggestions = false;
-    mentionSuggestions = [];
-    
-    setTimeout(() => {
-      const newPos = beforeMention.length + mentionText.length;
-      replyTextareaEl.setSelectionRange(newPos, newPos);
-      replyTextareaEl.focus();
-    }, 0);
-  }
+  function deleteCharsBeforeCursor(count: number) {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return;
 
-  // Parse @ mentions from content and return pubkeys
-  function parseMentions(text: string): Map<string, string> {
-    const mentions = new Map<string, string>();
-    const mentionRegex = /@(\w+)\s/g;
-    let match;
-    
-    while ((match = mentionRegex.exec(text)) !== null) {
-      const username = match[1];
-      for (const [pubkey, profile] of mentionProfileCache.entries()) {
-        if (profile.name.toLowerCase() === username.toLowerCase()) {
-          mentions.set(`@${username}`, pubkey);
-          break;
-        }
+    const range = selection.getRangeAt(0);
+    let remaining = count;
+    let currentNode: Node | null = range.startContainer;
+    let currentOffset = range.startOffset;
+
+    if (currentNode.nodeType === Node.ELEMENT_NODE) {
+      const walker = document.createTreeWalker(currentNode, NodeFilter.SHOW_TEXT, null);
+      let lastText: Text | null = null;
+      while (walker.nextNode()) {
+        lastText = walker.currentNode as Text;
+      }
+      if (lastText) {
+        currentNode = lastText;
+        currentOffset = lastText.length;
       }
     }
-    
+
+    while (remaining > 0 && currentNode) {
+      if (currentNode.nodeType === Node.TEXT_NODE) {
+        const textNode = currentNode as Text;
+        const deleteCount = Math.min(remaining, currentOffset);
+        if (deleteCount > 0) {
+          textNode.deleteData(currentOffset - deleteCount, deleteCount);
+          remaining -= deleteCount;
+          currentOffset -= deleteCount;
+        }
+
+        if (remaining > 0) {
+          let prev: Node | null = textNode.previousSibling;
+          while (prev && prev.nodeType !== Node.TEXT_NODE) {
+            prev = prev.previousSibling;
+          }
+          if (prev) {
+            currentNode = prev;
+            currentOffset = (prev as Text).length;
+          } else {
+            break;
+          }
+        }
+      } else {
+        break;
+      }
+    }
+  }
+
+  function createMentionPill(mention: string, displayName: string): HTMLSpanElement {
+    const pill = document.createElement('span');
+    pill.contentEditable = 'false';
+    pill.dataset.mention = mention;
+    pill.className = 'mention-pill';
+    pill.textContent = `@${displayName}`;
+    return pill;
+  }
+
+  function insertMentionNode(mention: string, displayName: string, addTrailingSpace = false) {
+    if (!replyComposerEl) return;
+
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return;
+    const range = selection.getRangeAt(0);
+
+    const pill = createMentionPill(mention, displayName);
+    const newRange = document.createRange();
+    newRange.setStart(range.startContainer, range.startOffset);
+    newRange.collapse(true);
+    newRange.insertNode(pill);
+
+    if (addTrailingSpace) {
+      const spacer = document.createTextNode(' ');
+      pill.after(spacer);
+      newRange.setStartAfter(spacer);
+    } else {
+      newRange.setStartAfter(pill);
+    }
+
+    newRange.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(newRange);
+  }
+
+  function convertRawMentionsToPills(): boolean {
+    if (!replyComposerEl) return false;
+
+    const rawText = replyComposerEl.textContent || '';
+    if (!rawText.includes('npub1')) return false;
+
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0 || !selection.isCollapsed) return false;
+
+    const range = selection.getRangeAt(0);
+    const marker = document.createElement('span');
+    marker.dataset.mentionCaret = 'true';
+    marker.textContent = '\u200B';
+    range.insertNode(marker);
+
+    const textNodes: Text[] = [];
+    const walker = document.createTreeWalker(replyComposerEl, NodeFilter.SHOW_TEXT, {
+      acceptNode(node) {
+        const parent = node.parentElement;
+        if (!parent) return NodeFilter.FILTER_REJECT;
+        if (parent.dataset.mention || parent.dataset.mentionCaret) return NodeFilter.FILTER_REJECT;
+        return NodeFilter.FILTER_ACCEPT;
+      }
+    });
+
+    while (walker.nextNode()) {
+      textNodes.push(walker.currentNode as Text);
+    }
+
+    let converted = false;
+    for (const textNode of textNodes) {
+      const text = textNode.nodeValue;
+      if (!text || !text.includes('npub1')) continue;
+
+      const mentionRegex =
+        /@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)/g;
+      let lastIndex = 0;
+      let match: RegExpExecArray | null;
+      let hasMatch = false;
+      const fragment = document.createDocumentFragment();
+
+      while ((match = mentionRegex.exec(text)) !== null) {
+        hasMatch = true;
+        const before = text.slice(lastIndex, match.index);
+        if (before) {
+          fragment.appendChild(document.createTextNode(before));
+        }
+
+        const rawMention = match[0];
+        const mention = rawMention.startsWith('@') ? `nostr:${rawMention.slice(1)}` : rawMention;
+        const displayName = getDisplayNameForMention(mention);
+        fragment.appendChild(createMentionPill(mention, displayName));
+
+        lastIndex = match.index + rawMention.length;
+      }
+
+      if (!hasMatch) continue;
+      converted = true;
+
+      if (lastIndex < text.length) {
+        fragment.appendChild(document.createTextNode(text.slice(lastIndex)));
+      }
+
+      textNode.parentNode?.replaceChild(fragment, textNode);
+    }
+
+    const caretMarker = replyComposerEl.querySelector('[data-mention-caret]');
+    if (caretMarker) {
+      const newRange = document.createRange();
+      newRange.setStartAfter(caretMarker);
+      newRange.collapse(true);
+      selection.removeAllRanges();
+      selection.addRange(newRange);
+      caretMarker.remove();
+    }
+
+    return converted;
+  }
+
+  function insertMention(user: { name: string; npub: string; pubkey: string }) {
+    if (!replyComposerEl) return;
+
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return;
+    const textBeforeCursor = getTextBeforeCursor(replyComposerEl);
+    const mentionMatch = textBeforeCursor.match(/@([^\s@]*)$/);
+
+    if (mentionMatch?.[0]) {
+      deleteCharsBeforeCursor(mentionMatch[0].length);
+    }
+
+    const mention = `nostr:${user.npub}`;
+    insertMentionNode(mention, user.name, true);
+
+    mentionProfileCache.set(user.pubkey, user);
+    updateContentFromComposer();
+    showMentionSuggestions = false;
+    mentionSuggestions = [];
+  }
+
+  function replacePlainMentions(text: string): string {
+    let output = text;
+    output = output.replace(
+      /@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g,
+      (match) => `nostr:${match.slice(1)}`
+    );
+    for (const profile of mentionProfileCache.values()) {
+      if (!profile.name) continue;
+      const mentionText = `@${profile.name}`;
+      const mentionRegex = new RegExp(`${escapeRegex(mentionText)}(?=\\s|$|[.,!?;:])`, 'gi');
+      if (mentionRegex.test(output)) {
+        output = output.replace(mentionRegex, `nostr:${profile.npub}`);
+      }
+    }
+    return output;
+  }
+
+  function parseMentions(text: string): Map<string, string> {
+    const mentions = new Map<string, string>();
+    const mentionRegex =
+      /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)|@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g;
+    let match;
+
+    while ((match = mentionRegex.exec(text)) !== null) {
+      const mention = match[1] || match[0].slice(1);
+      try {
+        const decoded = nip19.decode(mention);
+        if (decoded.type === 'npub') {
+          mentions.set(mention, decoded.data);
+        } else if (decoded.type === 'nprofile') {
+          mentions.set(mention, decoded.data.pubkey);
+        }
+      } catch {}
+    }
+
     return mentions;
   }
 
-  // Handle keyboard navigation in mention suggestions
   function handleReplyKeydown(event: KeyboardEvent) {
+    const selection = window.getSelection();
+    if (selection && selection.rangeCount) {
+      const range = selection.getRangeAt(0);
+
+      if (event.key === 'Delete' && range.collapsed) {
+        const { startContainer, startOffset } = range;
+        if (startContainer.nodeType === Node.TEXT_NODE) {
+          const textNode = startContainer as Text;
+          if (startOffset === textNode.length) {
+            const nextSibling = startContainer.nextSibling;
+            if (
+              nextSibling &&
+              nextSibling.nodeType === Node.ELEMENT_NODE &&
+              (nextSibling as HTMLElement).dataset.mention
+            ) {
+              event.preventDefault();
+              nextSibling.remove();
+              updateContentFromComposer();
+              return;
+            }
+          }
+        }
+      }
+
+      if (event.key === 'Backspace') {
+        if (!range.collapsed) {
+          const container = range.commonAncestorContainer;
+          let mentionElement: HTMLElement | null = null;
+
+          if (container.nodeType === Node.ELEMENT_NODE) {
+            const el = container as HTMLElement;
+            if (el.dataset.mention) {
+              mentionElement = el;
+            }
+          } else if (container.parentElement?.dataset.mention) {
+            mentionElement = container.parentElement;
+          }
+
+          if (mentionElement) {
+            event.preventDefault();
+            mentionElement.remove();
+            updateContentFromComposer();
+            return;
+          }
+        }
+
+        if (range.collapsed) {
+          const { startContainer, startOffset } = range;
+          if (startContainer.nodeType === Node.TEXT_NODE && startOffset === 0) {
+            const prevSibling = startContainer.previousSibling;
+            if (
+              prevSibling &&
+              prevSibling.nodeType === Node.ELEMENT_NODE &&
+              (prevSibling as HTMLElement).dataset.mention
+            ) {
+              event.preventDefault();
+              prevSibling.remove();
+              updateContentFromComposer();
+              return;
+            }
+          }
+        }
+      }
+    }
+
     if (showMentionSuggestions && mentionSuggestions.length > 0) {
       if (event.key === 'ArrowDown') {
         event.preventDefault();
         selectedMentionIndex = (selectedMentionIndex + 1) % mentionSuggestions.length;
       } else if (event.key === 'ArrowUp') {
         event.preventDefault();
-        selectedMentionIndex = selectedMentionIndex === 0 ? mentionSuggestions.length - 1 : selectedMentionIndex - 1;
+        selectedMentionIndex =
+          selectedMentionIndex === 0 ? mentionSuggestions.length - 1 : selectedMentionIndex - 1;
       } else if (event.key === 'Enter' || event.key === 'Tab') {
         event.preventDefault();
         insertMention(mentionSuggestions[selectedMentionIndex]);
@@ -202,30 +745,33 @@
   // Load replies for this comment
   async function loadReplies() {
     if (loading) return;
-    
+
     loading = true;
     replies = [];
     replyCount = 0;
-    
+
     // Close previous subscription if exists
     if (replySubscription) {
       replySubscription.stop();
     }
-    
+
     try {
       // Use subscribe collection for more reliable reply loading
-      replySubscription = $ndk.subscribe({
-        kinds: [1, 1111],
-        '#e': [parentComment.id] // Replies that reference this comment
-      }, { closeOnEose: true });
-      
-      replySubscription.on("event", (ev) => {
+      replySubscription = $ndk.subscribe(
+        {
+          kinds: [1, 1111],
+          '#e': [parentComment.id] // Replies that reference this comment
+        },
+        { closeOnEose: true }
+      );
+
+      replySubscription.on('event', (ev) => {
         loading = false;
         replies.push(ev);
         replies = replies;
       });
-      
-      replySubscription.on("eose", () => {
+
+      replySubscription.on('eose', () => {
         loading = false;
       });
     } catch (error) {
@@ -237,23 +783,32 @@
   // Post a new reply
   async function postReply() {
     if (!replyText.trim() || postingReply || !$ndk.signer) return;
-    
+
     postingReply = true;
     errorMessage = '';
     successMessage = '';
-    
+
     try {
+      if (replyComposerEl) {
+        replyText = htmlToPlainText(replyComposerEl);
+        lastRenderedReply = replyText;
+      }
+
       const replyEvent = new NDKEvent($ndk);
-      
+
       // Check if this is a reply to a recipe comment
       // If the parent comment is kind 1111 or has an 'a' tag referencing kind 30023, use kind 1111
       const aTag = parentComment.getMatchingTags('a')[0];
       const ATag = parentComment.getMatchingTags('A')[0];
-      const isRecipeReply = parentComment.kind === 1111 || (aTag && aTag[1]?.startsWith('30023:')) || (ATag && ATag[1]?.startsWith('30023:'));
+      const isRecipeReply =
+        parentComment.kind === 1111 ||
+        (aTag && aTag[1]?.startsWith('30023:')) ||
+        (ATag && ATag[1]?.startsWith('30023:'));
       replyEvent.kind = isRecipeReply ? 1111 : 1;
-      
-      replyEvent.content = replyText.trim();
-      
+
+      const replyContent = replacePlainMentions(replyText.trim());
+      replyEvent.content = replyContent;
+
       // Reconstruct a minimal event object for the parent comment
       const parentEventObj = {
         id: parentComment.id,
@@ -261,12 +816,13 @@
         kind: parentComment.kind,
         tags: parentComment.tags
       };
-      
+
       // For recipe replies, we need to get the root event info from the parent's tags
       if (isRecipeReply) {
         // Get root event info from parent comment's tags
-        const rootATag = parentComment.getMatchingTags('A')[0] || parentComment.getMatchingTags('a')[0];
-        
+        const rootATag =
+          parentComment.getMatchingTags('A')[0] || parentComment.getMatchingTags('a')[0];
+
         if (rootATag) {
           // Parse the address tag to extract root event info.
           // Format is kind:pubkey:d, where d may itself contain colons.
@@ -278,9 +834,12 @@
             kind: parseInt(kind),
             pubkey: pubkey,
             id: '', // We don't need the actual event ID for tag generation
-            tags: [['d', dTag], ['relay', rootATag[2] || '']]
+            tags: [
+              ['d', dTag],
+              ['relay', rootATag[2] || '']
+            ]
           };
-          
+
           // Use the utility with both root and parent event
           replyEvent.tags = buildNip22CommentTags(rootEventObj, parentEventObj);
         } else {
@@ -294,34 +853,39 @@
           ['p', parentComment.pubkey]
         ];
       }
-      
+
       // Parse and add @ mention tags (p tags)
-      const mentions = parseMentions(replyText.trim());
+      const mentions = parseMentions(replyContent);
       for (const pubkey of mentions.values()) {
         // Avoid duplicate p tags
-        if (!replyEvent.tags.some(t => t[0] === 'p' && t[1] === pubkey)) {
+        if (!replyEvent.tags.some((t) => t[0] === 'p' && t[1] === pubkey)) {
           replyEvent.tags.push(['p', pubkey]);
         }
       }
-      
+
       // Add NIP-89 client tag
       addClientTagToEvent(replyEvent);
-      
+
       await replyEvent.publish();
-      
+
       // Clear the form and show success
       replyText = '';
+      lastRenderedReply = '';
+      if (replyComposerEl) {
+        replyComposerEl.innerHTML = '';
+      }
       showMentionSuggestions = false;
+      mentionSuggestions = [];
+      mentionQuery = '';
       successMessage = 'Reply posted successfully!';
-      
+
       // Reload replies to show the new one
       await loadReplies();
-      
+
       // Clear success message after a delay
       setTimeout(() => {
         successMessage = '';
       }, 3000);
-      
     } catch (error) {
       console.error('Error posting reply:', error);
       errorMessage = 'Failed to post reply. Please try again.';
@@ -350,6 +914,10 @@
       replySubscription.stop();
     }
   });
+
+  $: if (replyComposerEl && replyText !== lastRenderedReply) {
+    syncComposerContent(replyText);
+  }
 </script>
 
 <div class="comment-replies" data-comment-id={parentComment.id}>
@@ -358,7 +926,8 @@
     on:click={toggleReplies}
     class="text-sm text-caption hover:text-primary font-medium cursor-pointer transition duration-300 print:hidden"
   >
-    {showReplies ? 'Hide replies' : 'Reply'} {replyCount > 0 ? `(${replyCount})` : ''}
+    {showReplies ? 'Hide replies' : 'Reply'}
+    {replyCount > 0 ? `(${replyCount})` : ''}
   </button>
 
   <!-- Replies Section -->
@@ -370,37 +939,42 @@
           <strong>Please log in</strong> to reply to comments.
         </div>
       {/if}
-      
+
       <!-- Error/Success Messages -->
       {#if errorMessage}
         <div class="text-xs text-red-600 bg-red-50 p-2 rounded print:hidden">
           {errorMessage}
         </div>
       {/if}
-      
+
       {#if successMessage}
         <div class="text-xs text-green-600 bg-green-50 p-2 rounded print:hidden">
           {successMessage}
         </div>
       {/if}
-      
+
       <!-- Reply Form -->
       <div class="space-y-1 print:hidden">
         <div class="relative">
-          <textarea
-            bind:this={replyTextareaEl}
-            bind:value={replyText}
-            placeholder={$ndk.signer ? "Add a reply..." : "Log in to reply..."}
-            disabled={!$ndk.signer}
-            class="w-full px-4 py-3 text-sm input rounded-xl resize-none focus:ring-2 focus:ring-primary focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed transition duration-200"
-            rows="3"
+          <div
+            bind:this={replyComposerEl}
+            class="reply-input w-full px-4 py-3 text-sm input rounded-xl transition duration-200"
+            class:opacity-50={!$ndk.signer || postingReply}
+            class:cursor-not-allowed={!$ndk.signer || postingReply}
+            contenteditable={$ndk.signer && !postingReply}
+            role="textbox"
+            aria-multiline="true"
+            aria-disabled={!$ndk.signer || postingReply}
+            data-placeholder={$ndk.signer ? 'Add a reply...' : 'Log in to reply...'}
             on:input={handleReplyInput}
             on:keydown={handleReplyKeydown}
-          />
-          
+            on:beforeinput={handleBeforeInput}
+            on:paste={handlePaste}
+          ></div>
+
           <!-- Mention suggestions dropdown -->
           {#if showMentionSuggestions && mentionSuggestions.length > 0}
-            <div 
+            <div
               class="absolute z-50 mt-1 w-full max-w-md bg-input rounded-lg shadow-lg border overflow-hidden"
               style="border-color: var(--color-input-border); max-height: 200px; overflow-y: auto;"
             >
@@ -413,7 +987,9 @@
                   class:bg-accent-gray={index === selectedMentionIndex}
                 >
                   <CustomAvatar pubkey={suggestion.pubkey} size={24} />
-                  <span class="text-sm" style="color: var(--color-text-primary)">{suggestion.name}</span>
+                  <span class="text-sm" style="color: var(--color-text-primary)"
+                    >{suggestion.name}</span
+                  >
                 </button>
               {/each}
             </div>
@@ -425,7 +1001,7 @@
             disabled={!replyText.trim() || postingReply || !$ndk.signer}
             class="px-4 py-2 text-sm"
           >
-            {postingReply ? 'Posting...' : ($ndk.signer ? 'Post Reply' : 'Log in to reply')}
+            {postingReply ? 'Posting...' : $ndk.signer ? 'Post Reply' : 'Log in to reply'}
           </Button>
         </div>
       </div>
@@ -440,11 +1016,7 @@
           {#each replies as reply}
             <div class="reply-row">
               <div class="reply-avatar">
-                <CustomAvatar
-                  className="flex-shrink-0"
-                  pubkey={reply.pubkey}
-                  size={24}
-                />
+                <CustomAvatar className="flex-shrink-0" pubkey={reply.pubkey} size={24} />
               </div>
               <div class="reply-content">
                 <div class="reply-header">
@@ -478,19 +1050,19 @@
     flex-direction: column;
     gap: 0.5rem;
   }
-  
+
   /* Reply row - 2 column flex layout */
   .reply-row {
     display: flex;
     gap: 0.5rem;
   }
-  
+
   /* Avatar gutter - fixed width, never shrinks */
   .reply-avatar {
     flex: 0 0 auto;
     width: 24px;
   }
-  
+
   /* Content column - takes remaining width, CAN shrink */
   .reply-content {
     flex: 1 1 0%;
@@ -498,7 +1070,7 @@
     overflow-wrap: anywhere;
     word-break: break-word;
   }
-  
+
   /* Name + Time header - wraps naturally on mobile */
   .reply-header {
     display: flex;
@@ -507,7 +1079,7 @@
     gap: 0.125rem 0.5rem;
     margin-bottom: 0.25rem;
   }
-  
+
   .reply-author {
     font-weight: 600;
     font-size: 0.875rem;
@@ -515,13 +1087,13 @@
     overflow-wrap: anywhere;
     word-break: break-word;
   }
-  
+
   .reply-time {
     font-size: 0.75rem;
     color: var(--color-text-secondary);
     white-space: nowrap;
   }
-  
+
   /* Reply body text */
   .reply-body {
     font-size: 0.875rem;
@@ -531,5 +1103,28 @@
     overflow-wrap: anywhere;
     word-break: break-word;
   }
-</style>
 
+  .reply-input {
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  .reply-input:empty:before {
+    content: attr(data-placeholder);
+    color: var(--color-caption);
+    pointer-events: none;
+  }
+
+  .mention-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.1rem 0.45rem;
+    border-radius: 0.5rem;
+    background: rgba(236, 71, 0, 0.15);
+    color: var(--color-primary);
+    font-weight: 600;
+    user-select: all;
+    margin: 0 0.1rem;
+  }
+</style>

--- a/src/components/Comments.svelte
+++ b/src/components/Comments.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ndk } from '$lib/nostr';
+  import { ndk, userPublickey } from '$lib/nostr';
   import { NDKEvent } from '@nostr-dev-kit/ndk';
   import Button from './Button.svelte';
   import { addClientTagToEvent } from '$lib/nip89';
@@ -7,18 +7,43 @@
   import Comment from './Comment.svelte';
   import { onDestroy } from 'svelte';
   import { createCommentFilter } from '$lib/commentFilters';
+  import { nip19 } from 'nostr-tools';
+  import { get } from 'svelte/store';
+  import CustomAvatar from './CustomAvatar.svelte';
+  import { searchProfiles } from '$lib/profileSearchService';
 
   export let event: NDKEvent;
   let events = [];
   let commentText = '';
+  let commentComposerEl: HTMLDivElement;
+  let lastRenderedComment = '';
   let processedEvents = new Set();
   let subscribed = false;
   let commentSubscription: any = null;
 
+  // @ mention autocomplete state
+  let mentionQuery = '';
+  let showMentionSuggestions = false;
+  let mentionSuggestions: {
+    name: string;
+    npub: string;
+    picture?: string;
+    pubkey: string;
+    nip05?: string;
+  }[] = [];
+  let selectedMentionIndex = 0;
+  let mentionProfileCache: Map<
+    string,
+    { name: string; npub: string; picture?: string; pubkey: string; nip05?: string }
+  > = new Map();
+  let mentionFollowListLoaded = false;
+  let mentionSearchTimeout: ReturnType<typeof setTimeout>;
+  let mentionSearching = false;
+
   // Create subscription once when ndk is ready
   $: if ($ndk && !subscribed) {
     subscribed = true;
-    
+
     const filter = createCommentFilter(event);
     commentSubscription = $ndk.subscribe(filter, { closeOnEose: false });
 
@@ -37,6 +62,9 @@
   }
 
   onDestroy(() => {
+    if (mentionSearchTimeout) {
+      clearTimeout(mentionSearchTimeout);
+    }
     if (commentSubscription) {
       commentSubscription.stop();
     }
@@ -47,23 +75,725 @@
     // No-op: the subscription will automatically receive new events
   }
 
+  // Load follow list profiles for mention autocomplete
+  async function loadMentionFollowList() {
+    if (mentionFollowListLoaded) return;
+
+    const pubkey = get(userPublickey);
+    if (!pubkey || !$ndk) return;
+
+    try {
+      const contactEvent = await $ndk.fetchEvent({
+        kinds: [3],
+        authors: [pubkey],
+        limit: 1
+      });
+
+      if (!contactEvent) return;
+
+      const followPubkeys = contactEvent.tags.filter((t) => t[0] === 'p' && t[1]).map((t) => t[1]);
+
+      if (followPubkeys.length === 0) return;
+
+      const batchSize = 100;
+      for (let i = 0; i < followPubkeys.length; i += batchSize) {
+        const batch = followPubkeys.slice(i, i + batchSize);
+        try {
+          const events = await $ndk.fetchEvents({
+            kinds: [0],
+            authors: batch
+          });
+
+          for (const event of events) {
+            try {
+              const profile = JSON.parse(event.content);
+              const name = profile.display_name || profile.name || '';
+              if (name || profile.nip05) {
+                mentionProfileCache.set(event.pubkey, {
+                  name: name || profile.nip05?.split('@')[0] || 'Unknown',
+                  npub: nip19.npubEncode(event.pubkey),
+                  picture: profile.picture,
+                  pubkey: event.pubkey,
+                  nip05: profile.nip05
+                });
+              }
+            } catch {}
+          }
+        } catch (e) {
+          console.debug('Failed to fetch mention profile batch:', e);
+        }
+      }
+
+      mentionFollowListLoaded = true;
+    } catch (e) {
+      console.debug('Failed to load mention follow list:', e);
+    }
+  }
+
+  // Search users for mention autocomplete
+  async function searchMentionUsers(query: string) {
+    loadMentionFollowList();
+
+    const queryLower = query.toLowerCase();
+    const matches: {
+      name: string;
+      npub: string;
+      picture?: string;
+      pubkey: string;
+      nip05?: string;
+    }[] = [];
+    const seenPubkeys = new Set<string>();
+
+    for (const profile of mentionProfileCache.values()) {
+      const nameMatch = profile.name.toLowerCase().includes(queryLower);
+      const nip05Match = profile.nip05?.toLowerCase().includes(queryLower);
+
+      if (nameMatch || nip05Match) {
+        matches.push(profile);
+        seenPubkeys.add(profile.pubkey);
+      }
+    }
+
+    if (matches.length > 0) {
+      mentionSuggestions = matches.slice(0, 10);
+      selectedMentionIndex = 0;
+    }
+
+    const shouldSearchPrimal = query.length >= 2;
+    const shouldSearchNdk = query.length >= 1 && $ndk;
+
+    if (shouldSearchPrimal || shouldSearchNdk) {
+      mentionSearching = true;
+      try {
+        if (shouldSearchPrimal) {
+          const primalResults = await searchProfiles(query, 25);
+          for (const profile of primalResults) {
+            if (seenPubkeys.has(profile.pubkey)) continue;
+
+            const name =
+              profile.displayName || profile.name || profile.nip05?.split('@')[0] || 'Unknown';
+            const profileData = {
+              name,
+              npub: profile.npub || nip19.npubEncode(profile.pubkey),
+              picture: profile.picture,
+              pubkey: profile.pubkey,
+              nip05: profile.nip05
+            };
+
+            matches.push(profileData);
+            seenPubkeys.add(profile.pubkey);
+            mentionProfileCache.set(profile.pubkey, profileData);
+          }
+        }
+
+        if (shouldSearchNdk && $ndk) {
+          const searchResults = await $ndk.fetchEvents({
+            kinds: [0],
+            search: query,
+            limit: 50
+          });
+
+          for (const event of searchResults) {
+            if (seenPubkeys.has(event.pubkey)) continue;
+
+            try {
+              const profile = JSON.parse(event.content);
+              const name = profile.display_name || profile.name || '';
+              const nip05 = profile.nip05;
+
+              const profileData = {
+                name: name || nip05?.split('@')[0] || profile.name || 'Unknown',
+                npub: nip19.npubEncode(event.pubkey),
+                picture: profile.picture,
+                pubkey: event.pubkey,
+                nip05
+              };
+
+              matches.push(profileData);
+              seenPubkeys.add(event.pubkey);
+              mentionProfileCache.set(event.pubkey, profileData);
+            } catch {}
+          }
+        }
+      } catch (e) {
+        console.debug('Network search failed:', e);
+      } finally {
+        mentionSearching = false;
+      }
+    }
+
+    matches.sort((a, b) => {
+      const aExact =
+        a.name.toLowerCase().startsWith(queryLower) ||
+        a.nip05?.toLowerCase().startsWith(queryLower);
+      const bExact =
+        b.name.toLowerCase().startsWith(queryLower) ||
+        b.nip05?.toLowerCase().startsWith(queryLower);
+      if (aExact && !bExact) return -1;
+      if (!aExact && bExact) return 1;
+      return a.name.localeCompare(b.name);
+    });
+
+    mentionSuggestions = matches.slice(0, 10);
+    selectedMentionIndex = 0;
+  }
+
+  function syncComposerContent(value: string) {
+    if (!commentComposerEl) return;
+    const html = renderTextWithMentions(value);
+    if (commentComposerEl.innerHTML !== html) {
+      commentComposerEl.innerHTML = html;
+    }
+    lastRenderedComment = value;
+  }
+
+  function escapeHtml(value: string): string {
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function escapeRegex(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  function formatNpubShort(npub: string): string {
+    if (npub.length <= 16) return npub;
+    return `${npub.slice(0, 10)}...${npub.slice(-6)}`;
+  }
+
+  function getDisplayNameForMention(mention: string): string {
+    const identifier = mention.replace('nostr:', '');
+    try {
+      const decoded = nip19.decode(identifier);
+      if (decoded.type === 'npub') {
+        const profile = mentionProfileCache.get(decoded.data);
+        if (profile?.name) return profile.name;
+        return formatNpubShort(identifier);
+      }
+      if (decoded.type === 'nprofile') {
+        const profile = mentionProfileCache.get(decoded.data.pubkey);
+        if (profile?.name) return profile.name;
+        return formatNpubShort(nip19.npubEncode(decoded.data.pubkey));
+      }
+    } catch {}
+    return formatNpubShort(identifier);
+  }
+
+  function renderTextWithMentions(text: string): string {
+    if (!text) return '';
+    const mentionRegex =
+      /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)|@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g;
+    let html = '';
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = mentionRegex.exec(text)) !== null) {
+      const beforeText = text.substring(lastIndex, match.index);
+      if (beforeText) {
+        html += escapeHtml(beforeText).replace(/\n/g, '<br>');
+      }
+
+      const rawMention = match[0];
+      const mention = rawMention.startsWith('@') ? `nostr:${rawMention.slice(1)}` : rawMention;
+      const displayName = getDisplayNameForMention(mention);
+      html += `<span class="mention-pill" contenteditable="false" data-mention="${mention}">@${escapeHtml(displayName)}</span>`;
+
+      lastIndex = match.index + rawMention.length;
+    }
+
+    if (lastIndex < text.length) {
+      html += escapeHtml(text.substring(lastIndex)).replace(/\n/g, '<br>');
+    }
+
+    return html;
+  }
+
+  function htmlToPlainText(element: Node): string {
+    let text = '';
+    let isFirstChild = true;
+
+    element.childNodes.forEach((node) => {
+      if (node.nodeType === Node.TEXT_NODE) {
+        const content = (node.textContent || '').replace(/\u200B/g, '');
+        text += content;
+        if (content) {
+          isFirstChild = false;
+        }
+      } else if (node.nodeType === Node.ELEMENT_NODE) {
+        const el = node as HTMLElement;
+
+        if (el.dataset.mention) {
+          text += el.dataset.mention;
+          isFirstChild = false;
+        } else if (el.tagName === 'BR') {
+          text += '\n';
+        } else if (el.tagName === 'DIV') {
+          if (!isFirstChild) {
+            text += '\n';
+          }
+
+          const hasOnlyBr = el.childNodes.length === 1 && el.firstChild?.nodeName === 'BR';
+          if (!hasOnlyBr) {
+            text += htmlToPlainText(node);
+          }
+          isFirstChild = false;
+        } else if (el.tagName === 'SPAN') {
+          const spanContent = htmlToPlainText(node);
+          text += spanContent;
+          if (spanContent) {
+            isFirstChild = false;
+          }
+        } else {
+          const childContent = htmlToPlainText(node);
+          text += childContent;
+          if (childContent) {
+            isFirstChild = false;
+          }
+        }
+      }
+    });
+
+    return text;
+  }
+
+  function getTextBeforeCursor(element: HTMLDivElement): string {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return '';
+
+    const range = selection.getRangeAt(0);
+    const preCaretRange = range.cloneRange();
+    preCaretRange.selectNodeContents(element);
+    preCaretRange.setEnd(range.startContainer, range.startOffset);
+
+    const tempDiv = document.createElement('div');
+    tempDiv.appendChild(preCaretRange.cloneContents());
+
+    return htmlToPlainText(tempDiv);
+  }
+
+  function updateContentFromComposer() {
+    if (!commentComposerEl) return;
+    const newText = htmlToPlainText(commentComposerEl);
+    lastRenderedComment = newText;
+    commentText = newText;
+  }
+
+  function handleBeforeInput(event: InputEvent) {
+    if (
+      event.isComposing ||
+      event.inputType === 'historyUndo' ||
+      event.inputType === 'historyRedo'
+    ) {
+      return;
+    }
+
+    const selection = window.getSelection();
+    if (!selection || !commentComposerEl) return;
+    const range = selection.getRangeAt(0);
+    let node: Node | null = range.startContainer;
+
+    while (node && node !== commentComposerEl) {
+      if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).dataset.mention) {
+        event.preventDefault();
+
+        if (event.inputType === 'insertText' || event.inputType === 'insertCompositionText') {
+          const newRange = document.createRange();
+          newRange.setStartAfter(node);
+          newRange.collapse(true);
+          selection.removeAllRanges();
+          selection.addRange(newRange);
+        }
+        return;
+      }
+      node = node.parentNode;
+    }
+  }
+
+  function handlePaste(event: ClipboardEvent) {
+    event.preventDefault();
+    const plainText = event.clipboardData?.getData('text/plain');
+    if (!plainText) return;
+
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return;
+    const range = selection.getRangeAt(0);
+
+    range.deleteContents();
+    const textNode = document.createTextNode(plainText);
+    range.insertNode(textNode);
+    range.setStartAfter(textNode);
+    range.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    handleCommentInput();
+  }
+
+  function handleCommentInput() {
+    updateContentFromComposer();
+    if (!commentComposerEl) return;
+
+    const converted = convertRawMentionsToPills();
+    if (converted) {
+      updateContentFromComposer();
+    }
+
+    const textBeforeCursor = getTextBeforeCursor(commentComposerEl);
+    const mentionMatch = textBeforeCursor.match(/@([^\s@]*)$/);
+
+    if (mentionMatch) {
+      mentionQuery = mentionMatch[1] || '';
+      showMentionSuggestions = true;
+
+      if (mentionSearchTimeout) clearTimeout(mentionSearchTimeout);
+      mentionSearchTimeout = setTimeout(() => {
+        if (mentionQuery.length > 0) {
+          searchMentionUsers(mentionQuery);
+        } else {
+          mentionSuggestions = Array.from(mentionProfileCache.values()).slice(0, 8);
+          selectedMentionIndex = 0;
+        }
+      }, 150);
+    } else {
+      showMentionSuggestions = false;
+      mentionSuggestions = [];
+    }
+  }
+
+  function deleteCharsBeforeCursor(count: number) {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return;
+
+    const range = selection.getRangeAt(0);
+    let remaining = count;
+    let currentNode: Node | null = range.startContainer;
+    let currentOffset = range.startOffset;
+
+    if (currentNode.nodeType === Node.ELEMENT_NODE) {
+      const walker = document.createTreeWalker(currentNode, NodeFilter.SHOW_TEXT, null);
+      let lastText: Text | null = null;
+      while (walker.nextNode()) {
+        lastText = walker.currentNode as Text;
+      }
+      if (lastText) {
+        currentNode = lastText;
+        currentOffset = lastText.length;
+      }
+    }
+
+    while (remaining > 0 && currentNode) {
+      if (currentNode.nodeType === Node.TEXT_NODE) {
+        const textNode = currentNode as Text;
+        const deleteCount = Math.min(remaining, currentOffset);
+        if (deleteCount > 0) {
+          textNode.deleteData(currentOffset - deleteCount, deleteCount);
+          remaining -= deleteCount;
+          currentOffset -= deleteCount;
+        }
+
+        if (remaining > 0) {
+          let prev: Node | null = textNode.previousSibling;
+          while (prev && prev.nodeType !== Node.TEXT_NODE) {
+            prev = prev.previousSibling;
+          }
+          if (prev) {
+            currentNode = prev;
+            currentOffset = (prev as Text).length;
+          } else {
+            break;
+          }
+        }
+      } else {
+        break;
+      }
+    }
+  }
+
+  function createMentionPill(mention: string, displayName: string): HTMLSpanElement {
+    const pill = document.createElement('span');
+    pill.contentEditable = 'false';
+    pill.dataset.mention = mention;
+    pill.className = 'mention-pill';
+    pill.textContent = `@${displayName}`;
+    return pill;
+  }
+
+  function insertMentionNode(mention: string, displayName: string, addTrailingSpace = false) {
+    if (!commentComposerEl) return;
+
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return;
+    const range = selection.getRangeAt(0);
+
+    const pill = createMentionPill(mention, displayName);
+    const newRange = document.createRange();
+    newRange.setStart(range.startContainer, range.startOffset);
+    newRange.collapse(true);
+    newRange.insertNode(pill);
+
+    if (addTrailingSpace) {
+      const spacer = document.createTextNode(' ');
+      pill.after(spacer);
+      newRange.setStartAfter(spacer);
+    } else {
+      newRange.setStartAfter(pill);
+    }
+
+    newRange.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(newRange);
+  }
+
+  function convertRawMentionsToPills(): boolean {
+    if (!commentComposerEl) return false;
+
+    const rawText = commentComposerEl.textContent || '';
+    if (!rawText.includes('npub1')) return false;
+
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0 || !selection.isCollapsed) return false;
+
+    const range = selection.getRangeAt(0);
+    const marker = document.createElement('span');
+    marker.dataset.mentionCaret = 'true';
+    marker.textContent = '\u200B';
+    range.insertNode(marker);
+
+    const textNodes: Text[] = [];
+    const walker = document.createTreeWalker(commentComposerEl, NodeFilter.SHOW_TEXT, {
+      acceptNode(node) {
+        const parent = node.parentElement;
+        if (!parent) return NodeFilter.FILTER_REJECT;
+        if (parent.dataset.mention || parent.dataset.mentionCaret) return NodeFilter.FILTER_REJECT;
+        return NodeFilter.FILTER_ACCEPT;
+      }
+    });
+
+    while (walker.nextNode()) {
+      textNodes.push(walker.currentNode as Text);
+    }
+
+    let converted = false;
+    for (const textNode of textNodes) {
+      const text = textNode.nodeValue;
+      if (!text || !text.includes('npub1')) continue;
+
+      const mentionRegex =
+        /@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)/g;
+      let lastIndex = 0;
+      let match: RegExpExecArray | null;
+      let hasMatch = false;
+      const fragment = document.createDocumentFragment();
+
+      while ((match = mentionRegex.exec(text)) !== null) {
+        hasMatch = true;
+        const before = text.slice(lastIndex, match.index);
+        if (before) {
+          fragment.appendChild(document.createTextNode(before));
+        }
+
+        const rawMention = match[0];
+        const mention = rawMention.startsWith('@') ? `nostr:${rawMention.slice(1)}` : rawMention;
+        const displayName = getDisplayNameForMention(mention);
+        fragment.appendChild(createMentionPill(mention, displayName));
+
+        lastIndex = match.index + rawMention.length;
+      }
+
+      if (!hasMatch) continue;
+      converted = true;
+
+      if (lastIndex < text.length) {
+        fragment.appendChild(document.createTextNode(text.slice(lastIndex)));
+      }
+
+      textNode.parentNode?.replaceChild(fragment, textNode);
+    }
+
+    const caretMarker = commentComposerEl.querySelector('[data-mention-caret]');
+    if (caretMarker) {
+      const newRange = document.createRange();
+      newRange.setStartAfter(caretMarker);
+      newRange.collapse(true);
+      selection.removeAllRanges();
+      selection.addRange(newRange);
+      caretMarker.remove();
+    }
+
+    return converted;
+  }
+
+  function insertMention(user: { name: string; npub: string; pubkey: string }) {
+    if (!commentComposerEl) return;
+
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return;
+    const textBeforeCursor = getTextBeforeCursor(commentComposerEl);
+    const mentionMatch = textBeforeCursor.match(/@([^\s@]*)$/);
+
+    if (mentionMatch?.[0]) {
+      deleteCharsBeforeCursor(mentionMatch[0].length);
+    }
+
+    const mention = `nostr:${user.npub}`;
+    insertMentionNode(mention, user.name, true);
+
+    mentionProfileCache.set(user.pubkey, user);
+    updateContentFromComposer();
+    showMentionSuggestions = false;
+    mentionSuggestions = [];
+  }
+
+  function replacePlainMentions(text: string): string {
+    let output = text;
+    output = output.replace(
+      /@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g,
+      (match) => `nostr:${match.slice(1)}`
+    );
+    for (const profile of mentionProfileCache.values()) {
+      if (!profile.name) continue;
+      const mentionText = `@${profile.name}`;
+      const mentionRegex = new RegExp(`${escapeRegex(mentionText)}(?=\\s|$|[.,!?;:])`, 'gi');
+      if (mentionRegex.test(output)) {
+        output = output.replace(mentionRegex, `nostr:${profile.npub}`);
+      }
+    }
+    return output;
+  }
+
+  function parseMentions(text: string): Map<string, string> {
+    const mentions = new Map<string, string>();
+    const mentionRegex =
+      /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)|@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g;
+    let match: RegExpExecArray | null;
+
+    while ((match = mentionRegex.exec(text)) !== null) {
+      const mention = match[1] || match[0].slice(1);
+      try {
+        const decoded = nip19.decode(mention);
+        if (decoded.type === 'npub') {
+          mentions.set(mention, decoded.data);
+        } else if (decoded.type === 'nprofile') {
+          mentions.set(mention, decoded.data.pubkey);
+        }
+      } catch {}
+    }
+
+    return mentions;
+  }
+
+  function handleCommentKeydown(event: KeyboardEvent) {
+    const selection = window.getSelection();
+    if (selection && selection.rangeCount) {
+      const range = selection.getRangeAt(0);
+
+      if (event.key === 'Delete' && range.collapsed) {
+        const { startContainer, startOffset } = range;
+        if (startContainer.nodeType === Node.TEXT_NODE) {
+          const textNode = startContainer as Text;
+          if (startOffset === textNode.length) {
+            const nextSibling = startContainer.nextSibling;
+            if (
+              nextSibling &&
+              nextSibling.nodeType === Node.ELEMENT_NODE &&
+              (nextSibling as HTMLElement).dataset.mention
+            ) {
+              event.preventDefault();
+              nextSibling.remove();
+              updateContentFromComposer();
+              return;
+            }
+          }
+        }
+      }
+
+      if (event.key === 'Backspace') {
+        if (!range.collapsed) {
+          const container = range.commonAncestorContainer;
+          let mentionElement: HTMLElement | null = null;
+
+          if (container.nodeType === Node.ELEMENT_NODE) {
+            const el = container as HTMLElement;
+            if (el.dataset.mention) {
+              mentionElement = el;
+            }
+          } else if (container.parentElement?.dataset.mention) {
+            mentionElement = container.parentElement;
+          }
+
+          if (mentionElement) {
+            event.preventDefault();
+            mentionElement.remove();
+            updateContentFromComposer();
+            return;
+          }
+        }
+
+        if (range.collapsed) {
+          const { startContainer, startOffset } = range;
+          if (startContainer.nodeType === Node.TEXT_NODE && startOffset === 0) {
+            const prevSibling = startContainer.previousSibling;
+            if (
+              prevSibling &&
+              prevSibling.nodeType === Node.ELEMENT_NODE &&
+              (prevSibling as HTMLElement).dataset.mention
+            ) {
+              event.preventDefault();
+              prevSibling.remove();
+              updateContentFromComposer();
+              return;
+            }
+          }
+        }
+      }
+    }
+
+    if (showMentionSuggestions && mentionSuggestions.length > 0) {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        selectedMentionIndex = (selectedMentionIndex + 1) % mentionSuggestions.length;
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        selectedMentionIndex =
+          selectedMentionIndex === 0 ? mentionSuggestions.length - 1 : selectedMentionIndex - 1;
+      } else if (event.key === 'Enter' || event.key === 'Tab') {
+        event.preventDefault();
+        insertMention(mentionSuggestions[selectedMentionIndex]);
+      } else if (event.key === 'Escape') {
+        showMentionSuggestions = false;
+        mentionSuggestions = [];
+      }
+      return;
+    }
+  }
+
   async function postComment() {
     if (!commentText.trim()) {
       return;
     }
-    
+
+    if (commentComposerEl) {
+      commentText = htmlToPlainText(commentComposerEl);
+      lastRenderedComment = commentText;
+    }
+
     if (!$ndk?.signer) {
       console.error('No signer available - user must be logged in');
       alert('Please log in to post comments');
       return;
     }
-    
+
     const ev = new NDKEvent($ndk);
     // Recipe replies should be kind 1111, not kind 1
     const isRecipe = event.kind === 30023;
     ev.kind = isRecipe ? 1111 : 1;
-    ev.content = commentText.trim();
-    
+    const commentContent = replacePlainMentions(commentText.trim());
+    ev.content = commentContent;
+
     // Use shared utility to build NIP-22 or NIP-10 tags
     ev.tags = buildNip22CommentTags({
       kind: event.kind,
@@ -71,7 +801,15 @@
       id: event.id,
       tags: event.tags
     });
-    
+
+    // Parse and add @ mention tags (p tags)
+    const mentions = parseMentions(commentContent);
+    for (const pubkey of mentions.values()) {
+      if (!ev.tags.some((t) => t[0] === 'p' && t[1] === pubkey)) {
+        ev.tags.push(['p', pubkey]);
+      }
+    }
+
     // Add NIP-89 client tag
     addClientTagToEvent(ev);
 
@@ -80,33 +818,40 @@
       if (!ev.created_at) {
         ev.created_at = Math.floor(Date.now() / 1000);
       }
-      
+
       // Sign the event - NIP-07 extension should prompt user
       // Don't timeout signing - let the extension handle it naturally
       // Users may need time to approve in their extension
       await ev.sign();
-      
+
       if (!ev.id) {
         throw new Error('Event was not signed - no ID generated');
       }
-      
+
       // Publish the event with a reasonable timeout
       await Promise.race([
         ev.publish(),
-        new Promise((_, reject) => 
+        new Promise((_, reject) =>
           setTimeout(() => reject(new Error('Publishing timeout after 30 seconds')), 30000)
         )
       ]);
-      
+
       // Immediately add to local events array so it appears right away
       if (!processedEvents.has(ev.id)) {
         processedEvents.add(ev.id);
         events.push(ev);
         events = events; // Trigger reactivity
       }
-      
+
       // Clear the comment text
       commentText = '';
+      lastRenderedComment = '';
+      if (commentComposerEl) {
+        commentComposerEl.innerHTML = '';
+      }
+      showMentionSuggestions = false;
+      mentionSuggestions = [];
+      mentionQuery = '';
     } catch (error) {
       console.error('Error posting comment:', error);
       console.error('Error stack:', error instanceof Error ? error.stack : 'No stack trace');
@@ -116,9 +861,11 @@
   }
 
   // Sort all comments chronologically (oldest first)
-  $: sortedComments = [...events].sort((a, b) => 
-    (a.created_at || 0) - (b.created_at || 0)
-  );
+  $: sortedComments = [...events].sort((a, b) => (a.created_at || 0) - (b.created_at || 0));
+
+  $: if (commentComposerEl && commentText !== lastRenderedComment) {
+    syncComposerContent(commentText);
+  }
 </script>
 
 <div id="comments-section" class="space-y-6">
@@ -130,7 +877,7 @@
       <p class="text-caption">No comments yet. Be the first to comment!</p>
     {:else}
       {#each sortedComments as comment (comment.id)}
-        <Comment event={comment} allReplies={events} refresh={refresh} />
+        <Comment event={comment} allReplies={events} {refresh} />
       {/each}
     {/if}
   </div>
@@ -138,18 +885,56 @@
   <!-- Add Comment Form -->
   <div class="space-y-3 pt-4 border-t">
     <h3 class="text-lg font-semibold">Add a comment</h3>
-    <textarea
-      id="comment-input"
-      bind:value={commentText}
-      placeholder="Share your thoughts..."
-      class="w-full px-4 py-3 text-base input rounded-lg resize-none focus:ring-2 focus:ring-primary focus:border-transparent"
-      rows="4"
-    />
-    <Button 
+    <div class="relative">
+      <div
+        id="comment-input"
+        bind:this={commentComposerEl}
+        class="comment-composer-input w-full px-4 py-3 text-base input rounded-lg"
+        contenteditable="true"
+        role="textbox"
+        aria-multiline="true"
+        data-placeholder="Share your thoughts..."
+        on:input={handleCommentInput}
+        on:keydown={handleCommentKeydown}
+        on:beforeinput={handleBeforeInput}
+        on:paste={handlePaste}
+      ></div>
+
+      {#if showMentionSuggestions}
+        <div class="mention-dropdown" style="border-color: var(--color-input-border);">
+          {#if mentionSuggestions.length > 0}
+            <div class="mention-dropdown-content">
+              {#each mentionSuggestions as suggestion, index}
+                <button
+                  type="button"
+                  on:click={() => insertMention(suggestion)}
+                  on:mousedown|preventDefault={() => insertMention(suggestion)}
+                  class="mention-option"
+                  class:mention-selected={index === selectedMentionIndex}
+                >
+                  <CustomAvatar pubkey={suggestion.pubkey} size={24} />
+                  <div class="mention-info">
+                    <span class="mention-name">{suggestion.name}</span>
+                    {#if suggestion.nip05}
+                      <span class="mention-nip05">{suggestion.nip05}</span>
+                    {/if}
+                  </div>
+                </button>
+              {/each}
+            </div>
+          {:else if mentionSearching}
+            <div class="mention-empty">Searching...</div>
+          {:else if mentionQuery.length > 0}
+            <div class="mention-empty">No users found</div>
+          {/if}
+        </div>
+      {/if}
+    </div>
+    <Button
       on:click={(e) => {
         e.preventDefault?.();
         postComment();
-      }} 
+      }}
       disabled={!commentText.trim()}
     >
       Post Comment
@@ -162,5 +947,117 @@
     display: flex;
     flex-direction: column;
     gap: 1rem;
+  }
+
+  .comment-composer-input {
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  .comment-composer-input:empty:before {
+    content: attr(data-placeholder);
+    color: var(--color-caption);
+    pointer-events: none;
+  }
+
+  .mention-dropdown {
+    position: absolute;
+    z-index: 50;
+    top: 100%;
+    left: 0;
+    margin-top: 0.25rem;
+    width: 280px;
+    max-width: calc(100vw - 2rem);
+    background: var(--color-input-bg);
+    border: 1px solid var(--color-input-border);
+    border-radius: 0.5rem;
+    box-shadow:
+      0 4px 6px -1px rgb(0 0 0 / 0.1),
+      0 2px 4px -1px rgb(0 0 0 / 0.06);
+    overflow: hidden;
+  }
+
+  .mention-dropdown-content {
+    max-height: 200px;
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+
+  .mention-dropdown-content::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  .mention-dropdown-content::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .mention-dropdown-content::-webkit-scrollbar-thumb {
+    background: var(--color-input-border);
+    border-radius: 3px;
+  }
+
+  .mention-dropdown-content::-webkit-scrollbar-thumb:hover {
+    background: var(--color-caption);
+  }
+
+  .mention-option {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+    transition: background-color 0.15s;
+    border: none;
+    background: transparent;
+  }
+
+  .mention-option:hover,
+  .mention-selected {
+    background: var(--color-accent-gray);
+  }
+
+  .mention-info {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    flex: 1;
+  }
+
+  .mention-name {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mention-nip05 {
+    font-size: 0.75rem;
+    color: var(--color-caption);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mention-empty {
+    padding: 0.75rem;
+    text-align: center;
+    font-size: 0.875rem;
+    color: var(--color-caption);
+  }
+
+  .mention-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.1rem 0.45rem;
+    border-radius: 0.5rem;
+    background: rgba(236, 71, 0, 0.15);
+    color: var(--color-primary);
+    font-weight: 600;
+    user-select: all;
+    margin: 0 0.1rem;
   }
 </style>

--- a/src/components/FeedComment.svelte
+++ b/src/components/FeedComment.svelte
@@ -13,7 +13,9 @@
   import { addClientTagToEvent } from '$lib/nip89';
   import { buildNip22CommentTags } from '$lib/tagUtils';
   import { onMount, onDestroy } from 'svelte';
+  import { get } from 'svelte/store';
   import { decode } from '@gandlaf21/bolt11-decode';
+  import { searchProfiles } from '$lib/profileSearchService';
 
   export let event: NDKEvent;
   export let allComments: NDKEvent[] = []; // All comments for finding parent
@@ -33,6 +35,27 @@
   let showReplyBox = false;
   let replyText = '';
   let postingReply = false;
+  let replyComposerEl: HTMLDivElement;
+  let lastRenderedReply = '';
+
+  // @ mention autocomplete state
+  let mentionQuery = '';
+  let showMentionSuggestions = false;
+  let mentionSuggestions: {
+    name: string;
+    npub: string;
+    picture?: string;
+    pubkey: string;
+    nip05?: string;
+  }[] = [];
+  let selectedMentionIndex = 0;
+  let mentionProfileCache: Map<
+    string,
+    { name: string; npub: string; picture?: string; pubkey: string; nip05?: string }
+  > = new Map();
+  let mentionFollowListLoaded = false;
+  let mentionSearchTimeout: ReturnType<typeof setTimeout>;
+  let mentionSearching = false;
 
   // Like state
   let liked = false;
@@ -52,23 +75,718 @@
   function getParentCommentId(): string | null {
     const eTags = event.getMatchingTags('e');
     // Look for a 'reply' tag that points to something other than mainEventId
-    const replyTag = eTags.find(tag => tag[3] === 'reply' && tag[1] !== mainEventId);
+    const replyTag = eTags.find((tag) => tag[3] === 'reply' && tag[1] !== mainEventId);
     if (replyTag) return replyTag[1];
-    
+
     // If no explicit reply tag, check if there are multiple e tags
     // The last one (before root) might be the parent comment
-    const nonRootTags = eTags.filter(tag => tag[3] !== 'root' && tag[1] !== mainEventId);
+    const nonRootTags = eTags.filter((tag) => tag[3] !== 'root' && tag[1] !== mainEventId);
     if (nonRootTags.length > 0) {
       return nonRootTags[nonRootTags.length - 1][1];
     }
-    
+
     return null;
+  }
+
+  // Load follow list profiles for mention autocomplete
+  async function loadMentionFollowList() {
+    if (mentionFollowListLoaded) return;
+
+    const pubkey = get(userPublickey);
+    if (!pubkey || !$ndk) return;
+
+    try {
+      const contactEvent = await $ndk.fetchEvent({
+        kinds: [3],
+        authors: [pubkey],
+        limit: 1
+      });
+
+      if (!contactEvent) return;
+
+      const followPubkeys = contactEvent.tags.filter((t) => t[0] === 'p' && t[1]).map((t) => t[1]);
+
+      if (followPubkeys.length === 0) return;
+
+      const batchSize = 100;
+      for (let i = 0; i < followPubkeys.length; i += batchSize) {
+        const batch = followPubkeys.slice(i, i + batchSize);
+        try {
+          const events = await $ndk.fetchEvents({
+            kinds: [0],
+            authors: batch
+          });
+
+          for (const event of events) {
+            try {
+              const profile = JSON.parse(event.content);
+              const name = profile.display_name || profile.name || '';
+              if (name || profile.nip05) {
+                mentionProfileCache.set(event.pubkey, {
+                  name: name || profile.nip05?.split('@')[0] || 'Unknown',
+                  npub: nip19.npubEncode(event.pubkey),
+                  picture: profile.picture,
+                  pubkey: event.pubkey,
+                  nip05: profile.nip05
+                });
+              }
+            } catch {}
+          }
+        } catch (e) {
+          console.debug('Failed to fetch mention profile batch:', e);
+        }
+      }
+
+      mentionFollowListLoaded = true;
+    } catch (e) {
+      console.debug('Failed to load mention follow list:', e);
+    }
+  }
+
+  // Search users for mention autocomplete
+  async function searchMentionUsers(query: string) {
+    loadMentionFollowList();
+
+    const queryLower = query.toLowerCase();
+    const matches: {
+      name: string;
+      npub: string;
+      picture?: string;
+      pubkey: string;
+      nip05?: string;
+    }[] = [];
+    const seenPubkeys = new Set<string>();
+
+    for (const profile of mentionProfileCache.values()) {
+      const nameMatch = profile.name.toLowerCase().includes(queryLower);
+      const nip05Match = profile.nip05?.toLowerCase().includes(queryLower);
+
+      if (nameMatch || nip05Match) {
+        matches.push(profile);
+        seenPubkeys.add(profile.pubkey);
+      }
+    }
+
+    if (matches.length > 0) {
+      mentionSuggestions = matches.slice(0, 10);
+      selectedMentionIndex = 0;
+    }
+
+    const shouldSearchPrimal = query.length >= 2;
+    const shouldSearchNdk = query.length >= 1 && $ndk;
+
+    if (shouldSearchPrimal || shouldSearchNdk) {
+      mentionSearching = true;
+      try {
+        if (shouldSearchPrimal) {
+          const primalResults = await searchProfiles(query, 25);
+          for (const profile of primalResults) {
+            if (seenPubkeys.has(profile.pubkey)) continue;
+
+            const name =
+              profile.displayName || profile.name || profile.nip05?.split('@')[0] || 'Unknown';
+            const profileData = {
+              name,
+              npub: profile.npub || nip19.npubEncode(profile.pubkey),
+              picture: profile.picture,
+              pubkey: profile.pubkey,
+              nip05: profile.nip05
+            };
+
+            matches.push(profileData);
+            seenPubkeys.add(profile.pubkey);
+            mentionProfileCache.set(profile.pubkey, profileData);
+          }
+        }
+
+        if (shouldSearchNdk && $ndk) {
+          const searchResults = await $ndk.fetchEvents({
+            kinds: [0],
+            search: query,
+            limit: 50
+          });
+
+          for (const event of searchResults) {
+            if (seenPubkeys.has(event.pubkey)) continue;
+
+            try {
+              const profile = JSON.parse(event.content);
+              const name = profile.display_name || profile.name || '';
+              const nip05 = profile.nip05;
+
+              const profileData = {
+                name: name || nip05?.split('@')[0] || profile.name || 'Unknown',
+                npub: nip19.npubEncode(event.pubkey),
+                picture: profile.picture,
+                pubkey: event.pubkey,
+                nip05
+              };
+
+              matches.push(profileData);
+              seenPubkeys.add(event.pubkey);
+              mentionProfileCache.set(event.pubkey, profileData);
+            } catch {}
+          }
+        }
+      } catch (e) {
+        console.debug('Network search failed:', e);
+      } finally {
+        mentionSearching = false;
+      }
+    }
+
+    matches.sort((a, b) => {
+      const aExact =
+        a.name.toLowerCase().startsWith(queryLower) ||
+        a.nip05?.toLowerCase().startsWith(queryLower);
+      const bExact =
+        b.name.toLowerCase().startsWith(queryLower) ||
+        b.nip05?.toLowerCase().startsWith(queryLower);
+      if (aExact && !bExact) return -1;
+      if (!aExact && bExact) return 1;
+      return a.name.localeCompare(b.name);
+    });
+
+    mentionSuggestions = matches.slice(0, 10);
+    selectedMentionIndex = 0;
+  }
+
+  function syncComposerContent(value: string) {
+    if (!replyComposerEl) return;
+    const html = renderTextWithMentions(value);
+    if (replyComposerEl.innerHTML !== html) {
+      replyComposerEl.innerHTML = html;
+    }
+    lastRenderedReply = value;
+  }
+
+  function escapeHtml(value: string): string {
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function escapeRegex(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  function formatNpubShort(npub: string): string {
+    if (npub.length <= 16) return npub;
+    return `${npub.slice(0, 10)}...${npub.slice(-6)}`;
+  }
+
+  function getDisplayNameForMention(mention: string): string {
+    const identifier = mention.replace('nostr:', '');
+    try {
+      const decoded = nip19.decode(identifier);
+      if (decoded.type === 'npub') {
+        const profile = mentionProfileCache.get(decoded.data);
+        if (profile?.name) return profile.name;
+        return formatNpubShort(identifier);
+      }
+      if (decoded.type === 'nprofile') {
+        const profile = mentionProfileCache.get(decoded.data.pubkey);
+        if (profile?.name) return profile.name;
+        return formatNpubShort(nip19.npubEncode(decoded.data.pubkey));
+      }
+    } catch {}
+    return formatNpubShort(identifier);
+  }
+
+  function renderTextWithMentions(text: string): string {
+    if (!text) return '';
+    const mentionRegex =
+      /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)|@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g;
+    let html = '';
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = mentionRegex.exec(text)) !== null) {
+      const beforeText = text.substring(lastIndex, match.index);
+      if (beforeText) {
+        html += escapeHtml(beforeText).replace(/\n/g, '<br>');
+      }
+
+      const rawMention = match[0];
+      const mention = rawMention.startsWith('@') ? `nostr:${rawMention.slice(1)}` : rawMention;
+      const displayName = getDisplayNameForMention(mention);
+      html += `<span class="mention-pill" contenteditable="false" data-mention="${mention}">@${escapeHtml(displayName)}</span>`;
+
+      lastIndex = match.index + rawMention.length;
+    }
+
+    if (lastIndex < text.length) {
+      html += escapeHtml(text.substring(lastIndex)).replace(/\n/g, '<br>');
+    }
+
+    return html;
+  }
+
+  function htmlToPlainText(element: Node): string {
+    let text = '';
+    let isFirstChild = true;
+
+    element.childNodes.forEach((node) => {
+      if (node.nodeType === Node.TEXT_NODE) {
+        const content = (node.textContent || '').replace(/\u200B/g, '');
+        text += content;
+        if (content) {
+          isFirstChild = false;
+        }
+      } else if (node.nodeType === Node.ELEMENT_NODE) {
+        const el = node as HTMLElement;
+
+        if (el.dataset.mention) {
+          text += el.dataset.mention;
+          isFirstChild = false;
+        } else if (el.tagName === 'BR') {
+          text += '\n';
+        } else if (el.tagName === 'DIV') {
+          if (!isFirstChild) {
+            text += '\n';
+          }
+
+          const hasOnlyBr = el.childNodes.length === 1 && el.firstChild?.nodeName === 'BR';
+          if (!hasOnlyBr) {
+            text += htmlToPlainText(node);
+          }
+          isFirstChild = false;
+        } else if (el.tagName === 'SPAN') {
+          const spanContent = htmlToPlainText(node);
+          text += spanContent;
+          if (spanContent) {
+            isFirstChild = false;
+          }
+        } else {
+          const childContent = htmlToPlainText(node);
+          text += childContent;
+          if (childContent) {
+            isFirstChild = false;
+          }
+        }
+      }
+    });
+
+    return text;
+  }
+
+  function getTextBeforeCursor(element: HTMLDivElement): string {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return '';
+
+    const range = selection.getRangeAt(0);
+    const preCaretRange = range.cloneRange();
+    preCaretRange.selectNodeContents(element);
+    preCaretRange.setEnd(range.startContainer, range.startOffset);
+
+    const tempDiv = document.createElement('div');
+    tempDiv.appendChild(preCaretRange.cloneContents());
+
+    return htmlToPlainText(tempDiv);
+  }
+
+  function updateContentFromComposer() {
+    if (!replyComposerEl) return;
+    const newText = htmlToPlainText(replyComposerEl);
+    lastRenderedReply = newText;
+    replyText = newText;
+  }
+
+  function handleBeforeInput(event: InputEvent) {
+    if (
+      event.isComposing ||
+      event.inputType === 'historyUndo' ||
+      event.inputType === 'historyRedo'
+    ) {
+      return;
+    }
+
+    const selection = window.getSelection();
+    if (!selection || !replyComposerEl) return;
+    const range = selection.getRangeAt(0);
+    let node: Node | null = range.startContainer;
+
+    while (node && node !== replyComposerEl) {
+      if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).dataset.mention) {
+        event.preventDefault();
+
+        if (event.inputType === 'insertText' || event.inputType === 'insertCompositionText') {
+          const newRange = document.createRange();
+          newRange.setStartAfter(node);
+          newRange.collapse(true);
+          selection.removeAllRanges();
+          selection.addRange(newRange);
+        }
+        return;
+      }
+      node = node.parentNode;
+    }
+  }
+
+  function handlePaste(event: ClipboardEvent) {
+    event.preventDefault();
+    const plainText = event.clipboardData?.getData('text/plain');
+    if (!plainText) return;
+
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return;
+    const range = selection.getRangeAt(0);
+
+    range.deleteContents();
+    const textNode = document.createTextNode(plainText);
+    range.insertNode(textNode);
+    range.setStartAfter(textNode);
+    range.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    handleReplyInput();
+  }
+
+  function handleReplyInput() {
+    updateContentFromComposer();
+    if (!replyComposerEl) return;
+
+    const converted = convertRawMentionsToPills();
+    if (converted) {
+      updateContentFromComposer();
+    }
+
+    const textBeforeCursor = getTextBeforeCursor(replyComposerEl);
+    const mentionMatch = textBeforeCursor.match(/@([^\s@]*)$/);
+
+    if (mentionMatch) {
+      mentionQuery = mentionMatch[1] || '';
+      showMentionSuggestions = true;
+
+      if (mentionSearchTimeout) clearTimeout(mentionSearchTimeout);
+      mentionSearchTimeout = setTimeout(() => {
+        if (mentionQuery.length > 0) {
+          searchMentionUsers(mentionQuery);
+        } else {
+          mentionSuggestions = Array.from(mentionProfileCache.values()).slice(0, 8);
+          selectedMentionIndex = 0;
+        }
+      }, 150);
+    } else {
+      showMentionSuggestions = false;
+      mentionSuggestions = [];
+    }
+  }
+
+  function deleteCharsBeforeCursor(count: number) {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return;
+
+    const range = selection.getRangeAt(0);
+    let remaining = count;
+    let currentNode: Node | null = range.startContainer;
+    let currentOffset = range.startOffset;
+
+    if (currentNode.nodeType === Node.ELEMENT_NODE) {
+      const walker = document.createTreeWalker(currentNode, NodeFilter.SHOW_TEXT, null);
+      let lastText: Text | null = null;
+      while (walker.nextNode()) {
+        lastText = walker.currentNode as Text;
+      }
+      if (lastText) {
+        currentNode = lastText;
+        currentOffset = lastText.length;
+      }
+    }
+
+    while (remaining > 0 && currentNode) {
+      if (currentNode.nodeType === Node.TEXT_NODE) {
+        const textNode = currentNode as Text;
+        const deleteCount = Math.min(remaining, currentOffset);
+        if (deleteCount > 0) {
+          textNode.deleteData(currentOffset - deleteCount, deleteCount);
+          remaining -= deleteCount;
+          currentOffset -= deleteCount;
+        }
+
+        if (remaining > 0) {
+          let prev: Node | null = textNode.previousSibling;
+          while (prev && prev.nodeType !== Node.TEXT_NODE) {
+            prev = prev.previousSibling;
+          }
+          if (prev) {
+            currentNode = prev;
+            currentOffset = (prev as Text).length;
+          } else {
+            break;
+          }
+        }
+      } else {
+        break;
+      }
+    }
+  }
+
+  function createMentionPill(mention: string, displayName: string): HTMLSpanElement {
+    const pill = document.createElement('span');
+    pill.contentEditable = 'false';
+    pill.dataset.mention = mention;
+    pill.className = 'mention-pill';
+    pill.textContent = `@${displayName}`;
+    return pill;
+  }
+
+  function insertMentionNode(mention: string, displayName: string, addTrailingSpace = false) {
+    if (!replyComposerEl) return;
+
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return;
+    const range = selection.getRangeAt(0);
+
+    const pill = createMentionPill(mention, displayName);
+    const newRange = document.createRange();
+    newRange.setStart(range.startContainer, range.startOffset);
+    newRange.collapse(true);
+    newRange.insertNode(pill);
+
+    if (addTrailingSpace) {
+      const spacer = document.createTextNode(' ');
+      pill.after(spacer);
+      newRange.setStartAfter(spacer);
+    } else {
+      newRange.setStartAfter(pill);
+    }
+
+    newRange.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(newRange);
+  }
+
+  function convertRawMentionsToPills(): boolean {
+    if (!replyComposerEl) return false;
+
+    const rawText = replyComposerEl.textContent || '';
+    if (!rawText.includes('npub1')) return false;
+
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0 || !selection.isCollapsed) return false;
+
+    const range = selection.getRangeAt(0);
+    const marker = document.createElement('span');
+    marker.dataset.mentionCaret = 'true';
+    marker.textContent = '\u200B';
+    range.insertNode(marker);
+
+    const textNodes: Text[] = [];
+    const walker = document.createTreeWalker(replyComposerEl, NodeFilter.SHOW_TEXT, {
+      acceptNode(node) {
+        const parent = node.parentElement;
+        if (!parent) return NodeFilter.FILTER_REJECT;
+        if (parent.dataset.mention || parent.dataset.mentionCaret) return NodeFilter.FILTER_REJECT;
+        return NodeFilter.FILTER_ACCEPT;
+      }
+    });
+
+    while (walker.nextNode()) {
+      textNodes.push(walker.currentNode as Text);
+    }
+
+    let converted = false;
+    for (const textNode of textNodes) {
+      const text = textNode.nodeValue;
+      if (!text || !text.includes('npub1')) continue;
+
+      const mentionRegex =
+        /@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)/g;
+      let lastIndex = 0;
+      let match: RegExpExecArray | null;
+      let hasMatch = false;
+      const fragment = document.createDocumentFragment();
+
+      while ((match = mentionRegex.exec(text)) !== null) {
+        hasMatch = true;
+        const before = text.slice(lastIndex, match.index);
+        if (before) {
+          fragment.appendChild(document.createTextNode(before));
+        }
+
+        const rawMention = match[0];
+        const mention = rawMention.startsWith('@') ? `nostr:${rawMention.slice(1)}` : rawMention;
+        const displayName = getDisplayNameForMention(mention);
+        fragment.appendChild(createMentionPill(mention, displayName));
+
+        lastIndex = match.index + rawMention.length;
+      }
+
+      if (!hasMatch) continue;
+      converted = true;
+
+      if (lastIndex < text.length) {
+        fragment.appendChild(document.createTextNode(text.slice(lastIndex)));
+      }
+
+      textNode.parentNode?.replaceChild(fragment, textNode);
+    }
+
+    const caretMarker = replyComposerEl.querySelector('[data-mention-caret]');
+    if (caretMarker) {
+      const newRange = document.createRange();
+      newRange.setStartAfter(caretMarker);
+      newRange.collapse(true);
+      selection.removeAllRanges();
+      selection.addRange(newRange);
+      caretMarker.remove();
+    }
+
+    return converted;
+  }
+
+  function insertMention(user: { name: string; npub: string; pubkey: string }) {
+    if (!replyComposerEl) return;
+
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return;
+    const textBeforeCursor = getTextBeforeCursor(replyComposerEl);
+    const mentionMatch = textBeforeCursor.match(/@([^\s@]*)$/);
+
+    if (mentionMatch?.[0]) {
+      deleteCharsBeforeCursor(mentionMatch[0].length);
+    }
+
+    const mention = `nostr:${user.npub}`;
+    insertMentionNode(mention, user.name, true);
+
+    mentionProfileCache.set(user.pubkey, user);
+    updateContentFromComposer();
+    showMentionSuggestions = false;
+    mentionSuggestions = [];
+  }
+
+  function replacePlainMentions(text: string): string {
+    let output = text;
+    output = output.replace(
+      /@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g,
+      (match) => `nostr:${match.slice(1)}`
+    );
+    for (const profile of mentionProfileCache.values()) {
+      if (!profile.name) continue;
+      const mentionText = `@${profile.name}`;
+      const mentionRegex = new RegExp(`${escapeRegex(mentionText)}(?=\\s|$|[.,!?;:])`, 'gi');
+      if (mentionRegex.test(output)) {
+        output = output.replace(mentionRegex, `nostr:${profile.npub}`);
+      }
+    }
+    return output;
+  }
+
+  function parseMentions(text: string): Map<string, string> {
+    const mentions = new Map<string, string>();
+    const mentionRegex =
+      /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)|@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g;
+    let match: RegExpExecArray | null;
+
+    while ((match = mentionRegex.exec(text)) !== null) {
+      const mention = match[1] || match[0].slice(1);
+      try {
+        const decoded = nip19.decode(mention);
+        if (decoded.type === 'npub') {
+          mentions.set(mention, decoded.data);
+        } else if (decoded.type === 'nprofile') {
+          mentions.set(mention, decoded.data.pubkey);
+        }
+      } catch {}
+    }
+
+    return mentions;
+  }
+
+  function handleReplyKeydown(event: KeyboardEvent) {
+    const selection = window.getSelection();
+    if (selection && selection.rangeCount) {
+      const range = selection.getRangeAt(0);
+
+      if (event.key === 'Delete' && range.collapsed) {
+        const { startContainer, startOffset } = range;
+        if (startContainer.nodeType === Node.TEXT_NODE) {
+          const textNode = startContainer as Text;
+          if (startOffset === textNode.length) {
+            const nextSibling = startContainer.nextSibling;
+            if (
+              nextSibling &&
+              nextSibling.nodeType === Node.ELEMENT_NODE &&
+              (nextSibling as HTMLElement).dataset.mention
+            ) {
+              event.preventDefault();
+              nextSibling.remove();
+              updateContentFromComposer();
+              return;
+            }
+          }
+        }
+      }
+
+      if (event.key === 'Backspace') {
+        if (!range.collapsed) {
+          const container = range.commonAncestorContainer;
+          let mentionElement: HTMLElement | null = null;
+
+          if (container.nodeType === Node.ELEMENT_NODE) {
+            const el = container as HTMLElement;
+            if (el.dataset.mention) {
+              mentionElement = el;
+            }
+          } else if (container.parentElement?.dataset.mention) {
+            mentionElement = container.parentElement;
+          }
+
+          if (mentionElement) {
+            event.preventDefault();
+            mentionElement.remove();
+            updateContentFromComposer();
+            return;
+          }
+        }
+
+        if (range.collapsed) {
+          const { startContainer, startOffset } = range;
+          if (startContainer.nodeType === Node.TEXT_NODE && startOffset === 0) {
+            const prevSibling = startContainer.previousSibling;
+            if (
+              prevSibling &&
+              prevSibling.nodeType === Node.ELEMENT_NODE &&
+              (prevSibling as HTMLElement).dataset.mention
+            ) {
+              event.preventDefault();
+              prevSibling.remove();
+              updateContentFromComposer();
+              return;
+            }
+          }
+        }
+      }
+    }
+
+    if (showMentionSuggestions && mentionSuggestions.length > 0) {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        selectedMentionIndex = (selectedMentionIndex + 1) % mentionSuggestions.length;
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        selectedMentionIndex =
+          selectedMentionIndex === 0 ? mentionSuggestions.length - 1 : selectedMentionIndex - 1;
+      } else if (event.key === 'Enter' || event.key === 'Tab') {
+        event.preventDefault();
+        insertMention(mentionSuggestions[selectedMentionIndex]);
+      } else if (event.key === 'Escape') {
+        showMentionSuggestions = false;
+        mentionSuggestions = [];
+      }
+    }
   }
 
   // Load zaps for this comment
   function loadZaps() {
     if (!event?.id || !$ndk) return;
-    
+
     totalZapAmount = 0;
     processedZaps.clear();
     hasUserZapped = false;
@@ -123,8 +841,8 @@
     const parentId = getParentCommentId();
     if (parentId) {
       // First check in allComments
-      parentComment = allComments.find(c => c.id === parentId) || null;
-      
+      parentComment = allComments.find((c) => c.id === parentId) || null;
+
       // If not found locally, fetch it with timeout
       if (!parentComment && $ndk) {
         try {
@@ -132,7 +850,7 @@
             kinds: [1, 1111],
             ids: [parentId]
           });
-          const timeoutPromise = new Promise<null>((resolve) => 
+          const timeoutPromise = new Promise<null>((resolve) =>
             setTimeout(() => resolve(null), 5000)
           );
           parentComment = await Promise.race([fetchPromise, timeoutPromise]);
@@ -140,7 +858,7 @@
           console.debug('Failed to fetch parent comment:', e);
         }
       }
-      
+
       // Load parent author name (resolveProfileByPubkey already has timeout)
       if (parentComment?.pubkey) {
         try {
@@ -178,6 +896,9 @@
   });
 
   onDestroy(() => {
+    if (mentionSearchTimeout) {
+      clearTimeout(mentionSearchTimeout);
+    }
     if (likeSubscription) {
       likeSubscription.stop();
     }
@@ -213,14 +934,20 @@
 
     postingReply = true;
     try {
+      if (replyComposerEl) {
+        replyText = htmlToPlainText(replyComposerEl);
+        lastRenderedReply = replyText;
+      }
+
       const ev = new NDKEvent($ndk);
-      
+
       // Check if this is a reply to a recipe comment (kind 1111)
       // If the parent comment is kind 1111, use kind 1111 for nested reply
       const isRecipeReply = event.kind === 1111;
       ev.kind = isRecipeReply ? 1111 : 1;
-      ev.content = replyText.trim();
-      
+      const replyContent = replacePlainMentions(replyText.trim());
+      ev.content = replyContent;
+
       // Reconstruct a minimal event object for the parent comment
       const parentEventObj = {
         id: event.id,
@@ -228,12 +955,12 @@
         kind: event.kind,
         tags: event.tags
       };
-      
+
       // For recipe replies, we need to get the root event info from the parent's tags
       if (isRecipeReply) {
         // Get root event info from parent comment's tags
         const rootATag = event.getMatchingTags('A')[0] || event.getMatchingTags('a')[0];
-        
+
         if (rootATag) {
           // Parse the address tag to extract root event info
           const [kind, pubkey, ...dTagParts] = rootATag[1].split(':');
@@ -242,9 +969,12 @@
             kind: parseInt(kind),
             pubkey: pubkey,
             id: '', // We don't need the actual event ID for tag generation
-            tags: [['d', dTag], ['relay', rootATag[2] || '']]
+            tags: [
+              ['d', dTag],
+              ['relay', rootATag[2] || '']
+            ]
           };
-          
+
           // Use the utility with both root and parent event
           ev.tags = buildNip22CommentTags(rootEventObj, parentEventObj);
         } else {
@@ -255,8 +985,9 @@
         // For non-recipe replies, construct tags for standard note replies
         // Try to derive the root event's pubkey from the parent event's tags.
         // Prefer any 'p'/'P' tag, which typically references the root author.
-        const rootPubkeyFromTags =
-          event.tags.find((t) => (t[0] === 'p' || t[0] === 'P') && t[1])?.[1];
+        const rootPubkeyFromTags = event.tags.find(
+          (t) => (t[0] === 'p' || t[0] === 'P') && t[1]
+        )?.[1];
 
         const rootEventObj = {
           kind: 1,
@@ -266,10 +997,24 @@
         };
         ev.tags = buildNip22CommentTags(rootEventObj, parentEventObj);
       }
-      
+
+      const mentions = parseMentions(replyContent);
+      for (const pubkey of mentions.values()) {
+        if (!ev.tags.some((t) => t[0] === 'p' && t[1] === pubkey)) {
+          ev.tags.push(['p', pubkey]);
+        }
+      }
+
       addClientTagToEvent(ev);
       await ev.publish();
       replyText = '';
+      lastRenderedReply = '';
+      if (replyComposerEl) {
+        replyComposerEl.innerHTML = '';
+      }
+      showMentionSuggestions = false;
+      mentionSuggestions = [];
+      mentionQuery = '';
       showReplyBox = false;
       refresh();
     } catch {
@@ -293,6 +1038,10 @@
       .trim();
     if (cleaned.length <= maxLength) return cleaned;
     return cleaned.slice(0, maxLength).trim() + '...';
+  }
+
+  $: if (replyComposerEl && replyText !== lastRenderedReply) {
+    syncComposerContent(replyText);
   }
 </script>
 
@@ -375,7 +1124,12 @@
         <!-- Reply Button -->
         {#if $userPublickey}
           <button
-            on:click={() => (showReplyBox = !showReplyBox)}
+            on:click={() => {
+              showReplyBox = !showReplyBox;
+              if (showReplyBox && $userPublickey) {
+                loadMentionFollowList();
+              }
+            }}
             class="action-btn action-btn-text"
           >
             {showReplyBox ? 'Cancel' : 'Reply'}
@@ -386,12 +1140,50 @@
       <!-- Inline Reply Box -->
       {#if showReplyBox}
         <div class="reply-form">
-          <textarea
-            bind:value={replyText}
-            placeholder="Add a reply..."
-            class="reply-textarea"
-            rows="2"
-          />
+          <div class="relative">
+            <div
+              bind:this={replyComposerEl}
+              class="reply-input"
+              contenteditable={!postingReply}
+              role="textbox"
+              aria-multiline="true"
+              data-placeholder="Add a reply..."
+              on:input={handleReplyInput}
+              on:keydown={handleReplyKeydown}
+              on:beforeinput={handleBeforeInput}
+              on:paste={handlePaste}
+            ></div>
+
+            {#if showMentionSuggestions}
+              <div class="mention-dropdown" style="border-color: var(--color-input-border);">
+                {#if mentionSuggestions.length > 0}
+                  <div class="mention-dropdown-content">
+                    {#each mentionSuggestions as suggestion, index}
+                      <button
+                        type="button"
+                        on:click={() => insertMention(suggestion)}
+                        on:mousedown|preventDefault={() => insertMention(suggestion)}
+                        class="mention-option"
+                        class:mention-selected={index === selectedMentionIndex}
+                      >
+                        <CustomAvatar pubkey={suggestion.pubkey} size={24} />
+                        <div class="mention-info">
+                          <span class="mention-name">{suggestion.name}</span>
+                          {#if suggestion.nip05}
+                            <span class="mention-nip05">{suggestion.nip05}</span>
+                          {/if}
+                        </div>
+                      </button>
+                    {/each}
+                  </div>
+                {:else if mentionSearching}
+                  <div class="mention-empty">Searching...</div>
+                {:else if mentionQuery.length > 0}
+                  <div class="mention-empty">No users found</div>
+                {/if}
+              </div>
+            {/if}
+          </div>
           <div class="reply-buttons">
             <button
               on:click={postReply}
@@ -404,6 +1196,13 @@
               on:click={() => {
                 showReplyBox = false;
                 replyText = '';
+                lastRenderedReply = '';
+                if (replyComposerEl) {
+                  replyComposerEl.innerHTML = '';
+                }
+                showMentionSuggestions = false;
+                mentionSuggestions = [];
+                mentionQuery = '';
               }}
               class="btn-cancel"
             >
@@ -563,21 +1362,28 @@
     gap: 0.5rem;
   }
 
-  .reply-textarea {
+  .reply-input {
     width: 100%;
     padding: 0.375rem 0.5rem;
     font-size: 0.875rem;
     border-radius: 0.5rem;
-    resize: none;
-    background: var(--color-input);
+    background: var(--color-input-bg);
     border: 1px solid var(--color-input-border);
     color: var(--color-text-primary);
+    white-space: pre-wrap;
+    word-break: break-word;
   }
 
-  .reply-textarea:focus {
+  .reply-input:focus {
     outline: none;
     ring: 2px;
     ring-color: var(--color-primary);
+  }
+
+  .reply-input:empty:before {
+    content: attr(data-placeholder);
+    color: var(--color-caption);
+    pointer-events: none;
   }
 
   .reply-buttons {
@@ -610,5 +1416,106 @@
 
   .btn-cancel:hover {
     opacity: 0.8;
+  }
+
+  .mention-dropdown {
+    position: absolute;
+    z-index: 50;
+    top: 100%;
+    left: 0;
+    margin-top: 0.25rem;
+    width: 280px;
+    max-width: calc(100vw - 2rem);
+    background: var(--color-input-bg);
+    border: 1px solid var(--color-input-border);
+    border-radius: 0.5rem;
+    box-shadow:
+      0 4px 6px -1px rgb(0 0 0 / 0.1),
+      0 2px 4px -1px rgb(0 0 0 / 0.06);
+    overflow: hidden;
+  }
+
+  .mention-dropdown-content {
+    max-height: 200px;
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+
+  .mention-dropdown-content::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  .mention-dropdown-content::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .mention-dropdown-content::-webkit-scrollbar-thumb {
+    background: var(--color-input-border);
+    border-radius: 3px;
+  }
+
+  .mention-dropdown-content::-webkit-scrollbar-thumb:hover {
+    background: var(--color-caption);
+  }
+
+  .mention-option {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+    transition: background-color 0.15s;
+    border: none;
+    background: transparent;
+  }
+
+  .mention-option:hover,
+  .mention-selected {
+    background: var(--color-accent-gray);
+  }
+
+  .mention-info {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    flex: 1;
+  }
+
+  .mention-name {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mention-nip05 {
+    font-size: 0.75rem;
+    color: var(--color-caption);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mention-empty {
+    padding: 0.75rem;
+    text-align: center;
+    font-size: 0.875rem;
+    color: var(--color-caption);
+  }
+
+  .mention-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.1rem 0.45rem;
+    border-radius: 0.5rem;
+    background: rgba(236, 71, 0, 0.15);
+    color: var(--color-primary);
+    font-weight: 600;
+    user-select: all;
+    margin: 0 0.1rem;
   }
 </style>

--- a/src/lib/primalCache.ts
+++ b/src/lib/primalCache.ts
@@ -1,0 +1,258 @@
+import { browser } from '$app/environment';
+
+export interface PrimalProfile {
+  pubkey: string;
+  name?: string;
+  display_name?: string;
+  picture?: string;
+  nip05?: string;
+  about?: string;
+}
+
+interface PrimalSearchResult {
+  profiles: PrimalProfile[];
+}
+
+interface PendingRequest {
+  resolve: (value: PrimalSearchResult) => void;
+  reject: (error: Error) => void;
+  timeout: ReturnType<typeof setTimeout>;
+  profiles: PrimalProfile[];
+}
+
+export class PrimalCacheService {
+  private ws: WebSocket | null = null;
+  private pendingRequests: Map<string, PendingRequest> = new Map();
+  private reconnectAttempts = 0;
+  private maxReconnectAttempts = 3;
+  private currentEndpoint = 0;
+  private endpoints = ['wss://cache2.primal.net/v1', 'wss://cache1.primal.net/v1'];
+  private connectionPromise: Promise<void> | null = null;
+
+  constructor() {
+    if (browser) {
+      this.connect();
+    }
+  }
+
+  private connect(): Promise<void> {
+    if (!browser || typeof WebSocket === 'undefined') {
+      return Promise.reject(new Error('WebSocket unavailable'));
+    }
+
+    if (this.connectionPromise) {
+      return this.connectionPromise;
+    }
+
+    this.connectionPromise = new Promise((resolve, reject) => {
+      const endpoint = this.endpoints[this.currentEndpoint];
+      if (!endpoint) {
+        reject(new Error('No endpoint available'));
+        return;
+      }
+
+      try {
+        this.ws = new WebSocket(endpoint);
+
+        this.ws.onopen = () => {
+          this.reconnectAttempts = 0;
+          this.connectionPromise = null;
+          resolve();
+        };
+
+        this.ws.onmessage = (event) => {
+          try {
+            const data = JSON.parse(event.data);
+            this.handleMessage(data);
+          } catch (error) {
+            console.error('[PrimalCache] Error parsing message:', error);
+          }
+        };
+
+        this.ws.onerror = (error) => {
+          console.error('[PrimalCache] WebSocket error:', error);
+        };
+
+        this.ws.onclose = () => {
+          this.connectionPromise = null;
+          this.handleDisconnect();
+        };
+
+        setTimeout(() => {
+          if (this.ws?.readyState !== WebSocket.OPEN) {
+            this.ws?.close();
+            reject(new Error('Connection timeout'));
+          }
+        }, 5000);
+      } catch (error) {
+        this.connectionPromise = null;
+        reject(error);
+      }
+    });
+
+    return this.connectionPromise;
+  }
+
+  private handleDisconnect() {
+    this.pendingRequests.forEach(({ reject, timeout }) => {
+      clearTimeout(timeout);
+      reject(new Error('WebSocket disconnected'));
+    });
+    this.pendingRequests.clear();
+
+    if (this.reconnectAttempts < this.maxReconnectAttempts) {
+      this.reconnectAttempts += 1;
+      this.currentEndpoint = (this.currentEndpoint + 1) % this.endpoints.length;
+      setTimeout(() => this.connect(), 1000 * this.reconnectAttempts);
+    } else {
+      console.error('[PrimalCache] Max reconnect attempts reached');
+    }
+  }
+
+  private handleMessage(data: unknown) {
+    if (!Array.isArray(data) || data.length < 2) return;
+
+    const [messageType, requestId, ...rest] = data;
+
+    if (messageType === 'EVENT' && requestId && rest.length > 0) {
+      const event = rest[0] as { kind: number; pubkey: string; content: string };
+      const pending = this.pendingRequests.get(requestId as string);
+
+      if (pending && event.kind === 0) {
+        try {
+          const metadata = JSON.parse(event.content);
+          pending.profiles.push({
+            pubkey: event.pubkey,
+            name: metadata.name,
+            display_name: metadata.display_name,
+            picture: metadata.picture,
+            nip05: metadata.nip05,
+            about: metadata.about
+          });
+        } catch (error) {
+          console.error('[PrimalCache] Error parsing profile metadata:', error);
+        }
+      }
+    } else if (messageType === 'EOSE' && requestId) {
+      const pending = this.pendingRequests.get(requestId as string);
+      if (pending) {
+        clearTimeout(pending.timeout);
+        pending.resolve({ profiles: pending.profiles });
+        this.pendingRequests.delete(requestId as string);
+      }
+    } else if (messageType === 'NOTICE') {
+      console.warn('[PrimalCache] Notice:', rest);
+    }
+  }
+
+  private generateRequestId(): string {
+    return `search_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+  }
+
+  public async searchProfiles(query: string, limit: number = 10, timeoutMs: number = 5000): Promise<PrimalProfile[]> {
+    if (!query || query.length < 2) {
+      return [];
+    }
+
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      await this.connect();
+    }
+
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error('WebSocket not connected');
+    }
+
+    const requestId = this.generateRequestId();
+    const request = [
+      'REQ',
+      requestId,
+      {
+        cache: ['user_search', { query, limit }]
+      }
+    ];
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pendingRequests.delete(requestId);
+        reject(new Error('Search request timed out'));
+      }, timeoutMs);
+
+      this.pendingRequests.set(requestId, {
+        resolve: (result) => resolve(result.profiles),
+        reject,
+        timeout,
+        profiles: []
+      });
+
+      try {
+        this.ws!.send(JSON.stringify(request));
+      } catch (error) {
+        clearTimeout(timeout);
+        this.pendingRequests.delete(requestId);
+        reject(error as Error);
+      }
+    });
+  }
+
+  public async fetchProfile(pubkey: string, timeoutMs: number = 5000): Promise<PrimalProfile | null> {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      await this.connect();
+    }
+
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error('WebSocket not connected');
+    }
+
+    const requestId = this.generateRequestId();
+    const request = [
+      'REQ',
+      requestId,
+      {
+        cache: ['user_infos', { pubkeys: [pubkey] }]
+      }
+    ];
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pendingRequests.delete(requestId);
+        reject(new Error('Profile fetch timed out'));
+      }, timeoutMs);
+
+      this.pendingRequests.set(requestId, {
+        resolve: (result) => resolve(result.profiles[0] || null),
+        reject,
+        timeout,
+        profiles: []
+      });
+
+      try {
+        this.ws!.send(JSON.stringify(request));
+      } catch (error) {
+        clearTimeout(timeout);
+        this.pendingRequests.delete(requestId);
+        reject(error as Error);
+      }
+    });
+  }
+
+  public isConnected(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  public disconnect() {
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+  }
+}
+
+let primalCache: PrimalCacheService | null = null;
+
+export const getPrimalCache = (): PrimalCacheService | null => {
+  if (!browser) return null;
+  if (!primalCache) {
+    primalCache = new PrimalCacheService();
+  }
+  return primalCache;
+};

--- a/src/lib/profileSearchService.ts
+++ b/src/lib/profileSearchService.ts
@@ -1,0 +1,184 @@
+import { nip19 } from 'nostr-tools';
+import { browser } from '$app/environment';
+import { getPrimalCache, type PrimalProfile } from '$lib/primalCache';
+
+export interface SearchProfile {
+  pubkey: string;
+  npub: string;
+  name?: string;
+  displayName?: string;
+  picture?: string;
+  nip05?: string;
+  about?: string;
+}
+
+class ProfileCache {
+  private cache = new Map<string, SearchProfile>();
+  private maxSize: number;
+
+  constructor(maxSize: number = 100) {
+    this.maxSize = maxSize;
+  }
+
+  get(pubkey: string): SearchProfile | undefined {
+    const profile = this.cache.get(pubkey);
+    if (profile) {
+      this.cache.delete(pubkey);
+      this.cache.set(pubkey, profile);
+    }
+    return profile;
+  }
+
+  set(pubkey: string, profile: SearchProfile): void {
+    if (this.cache.has(pubkey)) {
+      this.cache.delete(pubkey);
+    }
+    if (this.cache.size >= this.maxSize) {
+      const oldest = this.cache.keys().next().value;
+      if (oldest) this.cache.delete(oldest);
+    }
+    this.cache.set(pubkey, profile);
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+}
+
+const profileCache = new ProfileCache(100);
+
+function toSearchProfile(profile: PrimalProfile): SearchProfile {
+  return {
+    pubkey: profile.pubkey,
+    npub: nip19.npubEncode(profile.pubkey),
+    name: profile.name,
+    displayName: profile.display_name,
+    picture: profile.picture,
+    nip05: profile.nip05,
+    about: profile.about
+  };
+}
+
+export function parseIdentifier(input: string): { pubkey: string; relays?: string[] } | null {
+  const trimmed = input.trim().replace(/^@/, '').replace(/^nostr:/, '');
+
+  if (/^[0-9a-fA-F]{64}$/.test(trimmed)) {
+    return { pubkey: trimmed.toLowerCase() };
+  }
+
+  try {
+    const decoded = nip19.decode(trimmed);
+    if (decoded.type === 'npub') {
+      return { pubkey: decoded.data };
+    }
+    if (decoded.type === 'nprofile') {
+      return { pubkey: decoded.data.pubkey, relays: decoded.data.relays };
+    }
+  } catch {}
+
+  return null;
+}
+
+export function formatNpub(pubkey: string): string {
+  try {
+    const npub = nip19.npubEncode(pubkey);
+    return `${npub.slice(0, 12)}...${npub.slice(-8)}`;
+  } catch {
+    return `${pubkey.slice(0, 8)}...${pubkey.slice(-8)}`;
+  }
+}
+
+export function getDisplayName(profile: SearchProfile): string {
+  return profile.displayName || profile.name || formatNpub(profile.pubkey);
+}
+
+export async function searchProfiles(query: string, limit: number = 10): Promise<SearchProfile[]> {
+  if (!browser || !query) {
+    return [];
+  }
+
+  const parsed = parseIdentifier(query);
+  if (parsed) {
+    const cached = profileCache.get(parsed.pubkey);
+    if (cached) {
+      return [cached];
+    }
+
+    const primal = getPrimalCache();
+    if (primal) {
+      try {
+        const profile = await primal.fetchProfile(parsed.pubkey);
+        if (profile) {
+          const searchProfile = toSearchProfile(profile);
+          profileCache.set(parsed.pubkey, searchProfile);
+          return [searchProfile];
+        }
+      } catch (error) {
+        console.error('[ProfileSearch] Error fetching profile:', error);
+      }
+    }
+
+    return [
+      {
+        pubkey: parsed.pubkey,
+        npub: nip19.npubEncode(parsed.pubkey)
+      }
+    ];
+  }
+
+  if (query.length < 2) {
+    return [];
+  }
+
+  const primal = getPrimalCache();
+  if (!primal) {
+    return [];
+  }
+
+  try {
+    const results = await primal.searchProfiles(query, limit);
+
+    const filtered = results.filter((profile) => !profile.nip05?.endsWith('@mostr.pub'));
+
+    const searchResults = filtered.map(toSearchProfile);
+    searchResults.forEach((profile) => profileCache.set(profile.pubkey, profile));
+
+    return searchResults;
+  } catch (error) {
+    console.error('[ProfileSearch] Search error:', error);
+    return [];
+  }
+}
+
+export async function fetchProfile(pubkey: string): Promise<SearchProfile | null> {
+  const cached = profileCache.get(pubkey);
+  if (cached) {
+    return cached;
+  }
+
+  const primal = getPrimalCache();
+  if (!primal) {
+    return null;
+  }
+
+  try {
+    const profile = await primal.fetchProfile(pubkey);
+    if (profile) {
+      const searchProfile = toSearchProfile(profile);
+      profileCache.set(pubkey, searchProfile);
+      return searchProfile;
+    }
+  } catch (error) {
+    console.error('[ProfileSearch] Error fetching profile:', error);
+  }
+
+  return null;
+}
+
+export function getCachedProfile(pubkey: string): SearchProfile | undefined {
+  return profileCache.get(pubkey);
+}
+
+export function clearProfileCache(): void {
+  profileCache.clear();
+}

--- a/src/routes/community/+page.svelte
+++ b/src/routes/community/+page.svelte
@@ -18,6 +18,7 @@
   import type { PageData } from './$types';
   import type { NDKEvent as NDKEventType } from '@nostr-dev-kit/ndk';
   import { get } from 'svelte/store';
+  import { searchProfiles } from '$lib/profileSearchService';
 
   // Pull-to-refresh refs
   let pullToRefreshEl: PullToRefresh;
@@ -38,25 +39,25 @@
 
   // Tab state - use local state for immediate reactivity
   type FilterMode = 'global' | 'following' | 'replies' | 'members' | 'garden';
-  
+
   // Local state for immediate UI updates
   let activeTab: FilterMode = 'following';
-  
+
   // Check if user has active membership (for Members tab)
   let hasActiveMembership = false;
   let checkingMembership = false;
-  
+
   // Tab initialization is now in the onMount with quote listener
-  
+
   // Key to force component recreation
   let feedKey = 0;
-  
+
   async function setTab(tab: FilterMode) {
     if (tab === activeTab) return;
-    
+
     activeTab = tab;
     feedKey++; // This forces component recreation with new filterMode
-    
+
     // Update URL for bookmarking/sharing
     const url = new URL($page.url);
     url.searchParams.set('tab', tab);
@@ -68,7 +69,8 @@
   let posting = false;
   let success = false;
   let error = '';
-  let textareaEl: HTMLTextAreaElement;
+  let composerEl: HTMLDivElement;
+  let lastRenderedContent = '';
   let uploadedImages: string[] = [];
   let uploadedVideos: string[] = [];
   let uploadingImage = false;
@@ -80,10 +82,18 @@
   // @ mention autocomplete state
   let mentionQuery = '';
   let showMentionSuggestions = false;
-  let mentionStartPos = 0;
-  let mentionSuggestions: { name: string; npub: string; picture?: string; pubkey: string; nip05?: string }[] = [];
+  let mentionSuggestions: {
+    name: string;
+    npub: string;
+    picture?: string;
+    pubkey: string;
+    nip05?: string;
+  }[] = [];
   let selectedMentionIndex = 0;
-  let mentionProfileCache: Map<string, { name: string; npub: string; picture?: string; pubkey: string; nip05?: string }> = new Map();
+  let mentionProfileCache: Map<
+    string,
+    { name: string; npub: string; picture?: string; pubkey: string; nip05?: string }
+  > = new Map();
   let mentionFollowListLoaded = false;
   let mentionSearchTimeout: ReturnType<typeof setTimeout>;
   let mentionSearching = false;
@@ -97,7 +107,7 @@
   // Check membership status
   async function checkMembership() {
     if (!$userPublickey || checkingMembership) return;
-    
+
     checkingMembership = true;
     try {
       const res = await fetch('/api/membership/check-status', {
@@ -105,7 +115,7 @@
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ pubkey: $userPublickey })
       });
-      
+
       if (res.ok) {
         const data = await res.json();
         hasActiveMembership = data.isActive === true;
@@ -119,17 +129,23 @@
 
   onMount(() => {
     const tab = $page.url.searchParams.get('tab');
-    if (tab === 'following' || tab === 'replies' || tab === 'global' || tab === 'members' || tab === 'garden') {
+    if (
+      tab === 'following' ||
+      tab === 'replies' ||
+      tab === 'global' ||
+      tab === 'members' ||
+      tab === 'garden'
+    ) {
       activeTab = tab;
     }
-    
+
     // Check membership status if user is logged in
     if ($userPublickey) {
       checkMembership();
     }
-    
+
     window.addEventListener('quote-note', handleQuoteNote as EventListener);
-    
+
     // Preload mention profiles in background
     if ($userPublickey) {
       loadMentionFollowList();
@@ -148,7 +164,10 @@
   function openComposer() {
     isComposerOpen = true;
     setTimeout(() => {
-      textareaEl?.focus();
+      if (composerEl) {
+        syncComposerContent(content);
+        composerEl.focus();
+      }
     }, 50);
   }
 
@@ -156,10 +175,17 @@
     if (!posting) {
       isComposerOpen = false;
       content = '';
+      lastRenderedContent = '';
       error = '';
+      showMentionSuggestions = false;
+      mentionSuggestions = [];
+      mentionQuery = '';
       uploadedImages = [];
       uploadedVideos = [];
       quotedNote = null;
+      if (composerEl) {
+        composerEl.innerHTML = '';
+      }
     }
   }
 
@@ -175,7 +201,7 @@
     ];
 
     await template.sign();
-    
+
     const authEvent = {
       id: template.id,
       pubkey: template.pubkey,
@@ -204,7 +230,9 @@
         } catch {
           errorData = { message: errorText || `HTTP ${response.status}: ${response.statusText}` };
         }
-        throw new Error(errorData.message || errorData.error || `Upload failed with status ${response.status}`);
+        throw new Error(
+          errorData.message || errorData.error || `Upload failed with status ${response.status}`
+        );
       }
 
       const result = await response.json();
@@ -222,32 +250,32 @@
   async function handleImageUpload(event: Event) {
     const target = event.target as HTMLInputElement;
     if (!target.files || target.files.length === 0) return;
-    
+
     uploadingImage = true;
     error = '';
-    
+
     try {
       const file = target.files[0];
-      
+
       // Validate file type
       if (!file.type.startsWith('image/')) {
         error = 'Please upload an image file';
         uploadingImage = false;
         return;
       }
-      
+
       // Validate file size (max 10MB)
       if (file.size > 10 * 1024 * 1024) {
         error = 'Image must be less than 10MB';
         uploadingImage = false;
         return;
       }
-      
+
       const body = new FormData();
       body.append('file[]', file);
-      
+
       const result = await uploadToNostrBuild(body);
-      
+
       if (result && result.data && result.data[0]?.url) {
         uploadedImages = [...uploadedImages, result.data[0].url];
       } else {
@@ -268,20 +296,20 @@
   async function handleVideoUpload(event: Event) {
     const target = event.target as HTMLInputElement;
     if (!target.files || target.files.length === 0) return;
-    
+
     uploadingVideo = true;
     error = '';
-    
+
     try {
       const file = target.files[0];
-      
+
       // Validate file type
       if (!file.type.startsWith('video/')) {
         error = 'Please upload a video file';
         uploadingVideo = false;
         return;
       }
-      
+
       // Validate file size - minimum 1KB (very small files are likely invalid)
       const minSize = 1024; // 1KB
       if (file.size < minSize) {
@@ -289,7 +317,7 @@
         uploadingVideo = false;
         return;
       }
-      
+
       // Validate file size (max 20MB for videos - nostr.build API limit)
       const maxSize = 20 * 1024 * 1024; // 20MB
       if (file.size > maxSize) {
@@ -297,7 +325,7 @@
         uploadingVideo = false;
         return;
       }
-      
+
       // Get video metadata to check duration and bitrate
       let videoDuration = 0;
       try {
@@ -316,29 +344,35 @@
           };
           video.src = videoUrl;
         });
-        
+
         // Calculate approximate bitrate (bits per second)
         if (videoDuration > 0) {
           const bitrate = (file.size * 8) / videoDuration; // bits per second
           const bitrateMbps = bitrate / (1024 * 1024);
-          console.log(`Video metadata - duration: ${videoDuration.toFixed(1)}s, bitrate: ${bitrateMbps.toFixed(2)} Mbps, size: ${(file.size / 1024 / 1024).toFixed(2)}MB`);
-          
+          console.log(
+            `Video metadata - duration: ${videoDuration.toFixed(1)}s, bitrate: ${bitrateMbps.toFixed(2)} Mbps, size: ${(file.size / 1024 / 1024).toFixed(2)}MB`
+          );
+
           // Warn if bitrate is suspiciously low (< 0.1 Mbps) - might indicate compression issues
           if (bitrateMbps < 0.1 && videoDuration > 5) {
-            console.warn(`Video has very low bitrate (${bitrateMbps.toFixed(3)} Mbps), might cause upload issues`);
+            console.warn(
+              `Video has very low bitrate (${bitrateMbps.toFixed(3)} Mbps), might cause upload issues`
+            );
           }
         }
       } catch (metaError) {
         console.warn('Could not read video metadata:', metaError);
       }
-      
-      console.log(`Uploading video: ${file.name}, size: ${(file.size / 1024 / 1024).toFixed(2)}MB, type: ${file.type}, duration: ${videoDuration > 0 ? videoDuration.toFixed(1) + 's' : 'unknown'}`);
-      
+
+      console.log(
+        `Uploading video: ${file.name}, size: ${(file.size / 1024 / 1024).toFixed(2)}MB, type: ${file.type}, duration: ${videoDuration > 0 ? videoDuration.toFixed(1) + 's' : 'unknown'}`
+      );
+
       const body = new FormData();
       body.append('file[]', file);
-      
+
       const result = await uploadToNostrBuild(body);
-      
+
       if (result && result.data && result.data[0]?.url) {
         uploadedVideos = [...uploadedVideos, result.data[0].url];
       } else {
@@ -350,7 +384,8 @@
     } catch (err: any) {
       console.error('Error uploading video:', err);
       // Extract error message from the error object
-      const errorMsg = err?.message || err?.response?.message || err?.response?.error || 'Unknown error';
+      const errorMsg =
+        err?.message || err?.response?.message || err?.response?.error || 'Unknown error';
       error = `Failed to upload video${errorMsg !== 'Unknown error' ? `: ${errorMsg}` : '. Please try again.'}`;
     } finally {
       uploadingVideo = false;
@@ -370,7 +405,12 @@
   }
 
   async function postToFeed() {
-    if (!content.trim() && !quotedNote && uploadedImages.length === 0 && uploadedVideos.length === 0) {
+    if (
+      !content.trim() &&
+      !quotedNote &&
+      uploadedImages.length === 0 &&
+      uploadedVideos.length === 0
+    ) {
       error = 'Please enter some content';
       return;
     }
@@ -384,6 +424,11 @@
     error = '';
 
     try {
+      if (composerEl) {
+        content = htmlToPlainText(composerEl);
+        lastRenderedContent = content;
+      }
+
       // Ensure NIP-46 signer is ready if using remote signer
       const { getAuthManager } = await import('$lib/authManager');
       const authManager = getAuthManager();
@@ -393,52 +438,56 @@
 
       const event = new NDKEvent($ndk);
       event.kind = 1;
-      
+
       // Build content with text, image URLs, and video URLs
       let postContent = content.trim();
       const mediaUrls: string[] = [];
-      
+
       if (uploadedImages.length > 0) {
         mediaUrls.push(...uploadedImages);
       }
-      
+
       if (uploadedVideos.length > 0) {
         mediaUrls.push(...uploadedVideos);
       }
-      
+
       if (mediaUrls.length > 0) {
         // Add media URLs to content (one per line for better display)
         const mediaUrlsText = mediaUrls.join('\n');
         postContent = postContent ? `${postContent}\n\n${mediaUrlsText}` : mediaUrlsText;
       }
-      
+
       // Add quoted note reference if quoting
       if (quotedNote) {
-        postContent = postContent ? `${postContent}\n\nnostr:${quotedNote.nevent}` : `nostr:${quotedNote.nevent}`;
+        postContent = postContent
+          ? `${postContent}\n\nnostr:${quotedNote.nevent}`
+          : `nostr:${quotedNote.nevent}`;
       }
-      
+
+      postContent = replacePlainMentions(postContent);
+      const mentions = parseMentions(postContent);
+
       event.content = postContent;
       event.tags = [['t', 'zapcooking']];
-      
+
       // Parse and add @ mention tags (p tags)
-      const mentions = parseMentions(postContent);
       for (const pubkey of mentions.values()) {
         // Avoid duplicate p tags
-        if (!event.tags.some(t => t[0] === 'p' && t[1] === pubkey)) {
+        if (!event.tags.some((t) => t[0] === 'p' && t[1] === pubkey)) {
           event.tags.push(['p', pubkey]);
         }
       }
-      
+
       // Add quote tags if quoting
       if (quotedNote) {
         const quotedPubkey = quotedNote.event.pubkey;
         event.tags.push(['q', quotedNote.event.id]);
         // Only add p tag if not already mentioned
-        if (!event.tags.some(t => t[0] === 'p' && t[1] === quotedPubkey)) {
+        if (!event.tags.some((t) => t[0] === 'p' && t[1] === quotedPubkey)) {
           event.tags.push(['p', quotedPubkey]);
         }
       }
-      
+
       // Add NIP-89 client tag
       addClientTagToEvent(event);
 
@@ -451,19 +500,19 @@
         // This ensures the post only goes to garden.zap.cooking
         const { NDKRelaySet } = await import('@nostr-dev-kit/ndk');
         const gardenRelayUrl = 'wss://garden.zap.cooking';
-        
+
         console.log('[Garden] Publishing to garden relay only:', gardenRelayUrl);
-        
+
         // Create a relay set with ONLY the garden relay
         // Use true for third param to allow temporary connection if not in pool
         const gardenRelaySet = NDKRelaySet.fromRelayUrls([gardenRelayUrl], $ndk, true);
-        
+
         // Publish to the relay set - this ensures ONLY garden relay receives the event
         publishPromise = event.publish(gardenRelaySet).then((publishedRelays) => {
           console.log('[Garden] Publish result:', publishedRelays.size, 'relays confirmed');
           // Verify garden relay received the event
           const gardenRelayPublished = Array.from(publishedRelays).some(
-            relay => normalizeRelayUrl(relay.url) === normalizeRelayUrl(gardenRelayUrl)
+            (relay) => normalizeRelayUrl(relay.url) === normalizeRelayUrl(gardenRelayUrl)
           );
           if (!gardenRelayPublished) {
             throw new Error('Failed to publish to garden relay. Please try again.');
@@ -474,15 +523,15 @@
         // For members mode, publish ONLY to the members relay using NDKRelaySet
         const { NDKRelaySet } = await import('@nostr-dev-kit/ndk');
         const membersRelayUrl = 'wss://members.zap.cooking';
-        
+
         // Create a relay set with ONLY the members relay
         const membersRelaySet = NDKRelaySet.fromRelayUrls([membersRelayUrl], $ndk, true);
-        
+
         // Publish to the relay set - this ensures ONLY members relay receives the event
         publishPromise = event.publish(membersRelaySet).then((publishedRelays) => {
           // Verify members relay received the event
           const membersRelayPublished = Array.from(publishedRelays).some(
-            relay => relay.url === membersRelayUrl || relay.url === membersRelayUrl + '/'
+            (relay) => relay.url === membersRelayUrl || relay.url === membersRelayUrl + '/'
           );
           if (!membersRelayPublished) {
             throw new Error('Failed to publish to members relay');
@@ -492,20 +541,30 @@
       } else {
         publishPromise = event.publish().then(() => true);
       }
-      
+
       const timeoutPromise = new Promise<never>((_, reject) => {
-        setTimeout(() => reject(new Error('Publishing timeout - signer may not be responding')), 30000);
+        setTimeout(
+          () => reject(new Error('Publishing timeout - signer may not be responding')),
+          30000
+        );
       });
-      
+
       const publishedEvent = await Promise.race([publishPromise, timeoutPromise]);
-      
+
       if (publishedEvent) {
         success = true;
         content = '';
+        lastRenderedContent = '';
+        if (composerEl) {
+          composerEl.innerHTML = '';
+        }
+        showMentionSuggestions = false;
+        mentionSuggestions = [];
+        mentionQuery = '';
         uploadedImages = [];
         uploadedVideos = [];
         quotedNote = null;
-        
+
         setTimeout(() => {
           isComposerOpen = false;
           success = false;
@@ -524,26 +583,24 @@
   // Load follow list profiles for mention autocomplete
   async function loadMentionFollowList() {
     if (mentionFollowListLoaded) return;
-    
+
     const pubkey = get(userPublickey);
     if (!pubkey || !$ndk) return;
-    
+
     try {
       const contactEvent = await $ndk.fetchEvent({
         kinds: [3],
         authors: [pubkey],
         limit: 1
       });
-      
+
       if (!contactEvent) return;
-      
+
       // Load ALL follows, not just 500
-      const followPubkeys = contactEvent.tags
-        .filter(t => t[0] === 'p' && t[1])
-        .map(t => t[1]);
-      
+      const followPubkeys = contactEvent.tags.filter((t) => t[0] === 'p' && t[1]).map((t) => t[1]);
+
       if (followPubkeys.length === 0) return;
-      
+
       const batchSize = 100;
       for (let i = 0; i < followPubkeys.length; i += batchSize) {
         const batch = followPubkeys.slice(i, i + batchSize);
@@ -552,7 +609,7 @@
             kinds: [0],
             authors: batch
           });
-          
+
           for (const event of events) {
             try {
               const profile = JSON.parse(event.content);
@@ -572,7 +629,7 @@
           console.debug('Failed to fetch mention profile batch:', e);
         }
       }
-      
+
       mentionFollowListLoaded = true;
     } catch (e) {
       console.debug('Failed to load mention follow list:', e);
@@ -583,55 +640,77 @@
   async function searchMentionUsers(query: string) {
     // Don't wait for follow list - search in parallel
     loadMentionFollowList();
-    
+
     const queryLower = query.toLowerCase();
-    const matches: { name: string; npub: string; picture?: string; pubkey: string; nip05?: string }[] = [];
+    const matches: {
+      name: string;
+      npub: string;
+      picture?: string;
+      pubkey: string;
+      nip05?: string;
+    }[] = [];
     const seenPubkeys = new Set<string>();
-    
+
     // Search local cache first (follows) - search by name AND NIP-05
     for (const profile of mentionProfileCache.values()) {
       const nameMatch = profile.name.toLowerCase().includes(queryLower);
       const nip05Match = profile.nip05?.toLowerCase().includes(queryLower);
-      
+
       if (nameMatch || nip05Match) {
         matches.push(profile);
         seenPubkeys.add(profile.pubkey);
       }
     }
-    
+
     // Show local matches immediately
     if (matches.length > 0) {
       mentionSuggestions = matches.slice(0, 10);
       selectedMentionIndex = 0;
     }
-    
-    // Always search the network for more results (even if we have local matches)
-    if (query.length >= 1 && $ndk) {
+
+    const shouldSearchPrimal = query.length >= 2;
+    const shouldSearchNdk = query.length >= 1 && $ndk;
+
+    if (shouldSearchPrimal || shouldSearchNdk) {
       mentionSearching = true;
-      
+
       try {
-        // Search for profiles by name using NIP-50 search
-        const searchResults = await $ndk.fetchEvents({
-          kinds: [0],
-          search: query,
-          limit: 50
-        });
-        
-        for (const event of searchResults) {
-          // Skip if already in matches
-          if (seenPubkeys.has(event.pubkey)) continue;
-          
-          try {
-            const profile = JSON.parse(event.content);
-            const name = profile.display_name || profile.name || '';
-            const nip05 = profile.nip05;
-            
-            // Check if matches query (be more lenient - include all search results)
-            const nameMatch = name.toLowerCase().includes(queryLower);
-            const nip05Match = nip05?.toLowerCase().includes(queryLower);
-            const usernameMatch = (profile.name || '').toLowerCase().includes(queryLower);
-            
-            if (nameMatch || nip05Match || usernameMatch || true) { // Include all NIP-50 results
+        if (shouldSearchPrimal) {
+          const primalResults = await searchProfiles(query, 25);
+          for (const profile of primalResults) {
+            if (seenPubkeys.has(profile.pubkey)) continue;
+
+            const name =
+              profile.displayName || profile.name || profile.nip05?.split('@')[0] || 'Unknown';
+            const profileData = {
+              name,
+              npub: profile.npub || nip19.npubEncode(profile.pubkey),
+              picture: profile.picture,
+              pubkey: profile.pubkey,
+              nip05: profile.nip05
+            };
+
+            matches.push(profileData);
+            seenPubkeys.add(profile.pubkey);
+            mentionProfileCache.set(profile.pubkey, profileData);
+          }
+        }
+
+        if (shouldSearchNdk && $ndk) {
+          const searchResults = await $ndk.fetchEvents({
+            kinds: [0],
+            search: query,
+            limit: 50
+          });
+
+          for (const event of searchResults) {
+            if (seenPubkeys.has(event.pubkey)) continue;
+
+            try {
+              const profile = JSON.parse(event.content);
+              const name = profile.display_name || profile.name || '';
+              const nip05 = profile.nip05;
+
               const profileData = {
                 name: name || nip05?.split('@')[0] || profile.name || 'Unknown',
                 npub: nip19.npubEncode(event.pubkey),
@@ -639,13 +718,12 @@
                 pubkey: event.pubkey,
                 nip05
               };
-              
+
               matches.push(profileData);
               seenPubkeys.add(event.pubkey);
-              // Cache for future lookups
               mentionProfileCache.set(event.pubkey, profileData);
-            }
-          } catch {}
+            } catch {}
+          }
         }
       } catch (e) {
         console.debug('Network search failed:', e);
@@ -653,41 +731,258 @@
         mentionSearching = false;
       }
     }
-    
+
     // Sort: prioritize exact matches, then by name
     matches.sort((a, b) => {
-      const aExact = a.name.toLowerCase().startsWith(queryLower) || a.nip05?.toLowerCase().startsWith(queryLower);
-      const bExact = b.name.toLowerCase().startsWith(queryLower) || b.nip05?.toLowerCase().startsWith(queryLower);
+      const aExact =
+        a.name.toLowerCase().startsWith(queryLower) ||
+        a.nip05?.toLowerCase().startsWith(queryLower);
+      const bExact =
+        b.name.toLowerCase().startsWith(queryLower) ||
+        b.nip05?.toLowerCase().startsWith(queryLower);
       if (aExact && !bExact) return -1;
       if (!aExact && bExact) return 1;
       return a.name.localeCompare(b.name);
     });
-    
+
     mentionSuggestions = matches.slice(0, 10);
     selectedMentionIndex = 0;
   }
 
-  // Handle textarea input for @ mentions
-  function handleContentInput(event: Event) {
-    const textarea = event.target as HTMLTextAreaElement;
-    const cursorPos = textarea.selectionStart;
-    const text = content;
-    
-    // Find @ mention before cursor
-    const textBeforeCursor = text.substring(0, cursorPos);
-    const mentionMatch = textBeforeCursor.match(/@(\w*)$/);
-    
+  function syncComposerContent(value: string) {
+    if (!composerEl) return;
+    const html = renderTextWithMentions(value);
+    if (composerEl.innerHTML !== html) {
+      composerEl.innerHTML = html;
+    }
+    lastRenderedContent = value;
+  }
+
+  function escapeHtml(value: string): string {
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function escapeRegex(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  function formatNpubShort(npub: string): string {
+    if (npub.length <= 16) return npub;
+    return `${npub.slice(0, 10)}...${npub.slice(-6)}`;
+  }
+
+  function getDisplayNameForMention(mention: string): string {
+    const identifier = mention.replace('nostr:', '');
+    try {
+      const decoded = nip19.decode(identifier);
+      if (decoded.type === 'npub') {
+        const profile = mentionProfileCache.get(decoded.data);
+        if (profile?.name) return profile.name;
+        return formatNpubShort(identifier);
+      }
+      if (decoded.type === 'nprofile') {
+        const profile = mentionProfileCache.get(decoded.data.pubkey);
+        if (profile?.name) return profile.name;
+        return formatNpubShort(nip19.npubEncode(decoded.data.pubkey));
+      }
+    } catch {}
+    return formatNpubShort(identifier);
+  }
+
+  function renderTextWithMentions(text: string): string {
+    if (!text) return '';
+    const mentionRegex =
+      /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)|@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g;
+    let html = '';
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = mentionRegex.exec(text)) !== null) {
+      const beforeText = text.substring(lastIndex, match.index);
+      if (beforeText) {
+        html += escapeHtml(beforeText).replace(/\n/g, '<br>');
+      }
+
+      const rawMention = match[0];
+      const mention = rawMention.startsWith('@') ? `nostr:${rawMention.slice(1)}` : rawMention;
+      const displayName = getDisplayNameForMention(mention);
+      html += `<span class="mention-pill" contenteditable="false" data-mention="${mention}">@${escapeHtml(displayName)}</span>`;
+
+      lastIndex = match.index + rawMention.length;
+    }
+
+    if (lastIndex < text.length) {
+      html += escapeHtml(text.substring(lastIndex)).replace(/\n/g, '<br>');
+    }
+
+    return html;
+  }
+
+  function replacePlainMentions(text: string): string {
+    let output = text;
+    output = output.replace(
+      /@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g,
+      (match) => `nostr:${match.slice(1)}`
+    );
+    for (const profile of mentionProfileCache.values()) {
+      if (!profile.name) continue;
+      const mentionText = `@${profile.name}`;
+      const mentionRegex = new RegExp(`${escapeRegex(mentionText)}(?=\\s|$|[.,!?;:])`, 'gi');
+      if (mentionRegex.test(output)) {
+        output = output.replace(mentionRegex, `nostr:${profile.npub}`);
+      }
+    }
+    return output;
+  }
+
+  function htmlToPlainText(element: Node): string {
+    let text = '';
+    let isFirstChild = true;
+
+    element.childNodes.forEach((node) => {
+      if (node.nodeType === Node.TEXT_NODE) {
+        const content = (node.textContent || '').replace(/\u200B/g, '');
+        text += content;
+        if (content) {
+          isFirstChild = false;
+        }
+      } else if (node.nodeType === Node.ELEMENT_NODE) {
+        const el = node as HTMLElement;
+
+        if (el.dataset.mention) {
+          text += el.dataset.mention;
+          isFirstChild = false;
+        } else if (el.tagName === 'BR') {
+          text += '\n';
+        } else if (el.tagName === 'DIV') {
+          if (!isFirstChild) {
+            text += '\n';
+          }
+
+          const hasOnlyBr = el.childNodes.length === 1 && el.firstChild?.nodeName === 'BR';
+          if (!hasOnlyBr) {
+            text += htmlToPlainText(node);
+          }
+          isFirstChild = false;
+        } else if (el.tagName === 'SPAN') {
+          const spanContent = htmlToPlainText(node);
+          text += spanContent;
+          if (spanContent) {
+            isFirstChild = false;
+          }
+        } else {
+          const childContent = htmlToPlainText(node);
+          text += childContent;
+          if (childContent) {
+            isFirstChild = false;
+          }
+        }
+      }
+    });
+
+    return text;
+  }
+
+  function getTextBeforeCursor(element: HTMLDivElement): string {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return '';
+
+    const range = selection.getRangeAt(0);
+    const preCaretRange = range.cloneRange();
+    preCaretRange.selectNodeContents(element);
+    preCaretRange.setEnd(range.startContainer, range.startOffset);
+
+    const tempDiv = document.createElement('div');
+    tempDiv.appendChild(preCaretRange.cloneContents());
+
+    return htmlToPlainText(tempDiv);
+  }
+
+  function updateContentFromComposer() {
+    if (!composerEl) return;
+    const newText = htmlToPlainText(composerEl);
+    lastRenderedContent = newText;
+    content = newText;
+  }
+
+  function handleBeforeInput(event: InputEvent) {
+    if (
+      event.isComposing ||
+      event.inputType === 'historyUndo' ||
+      event.inputType === 'historyRedo'
+    ) {
+      return;
+    }
+
+    const selection = window.getSelection();
+    if (!selection || !composerEl) return;
+    const range = selection.getRangeAt(0);
+    let node: Node | null = range.startContainer;
+
+    while (node && node !== composerEl) {
+      if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).dataset.mention) {
+        event.preventDefault();
+
+        if (event.inputType === 'insertText' || event.inputType === 'insertCompositionText') {
+          const newRange = document.createRange();
+          newRange.setStartAfter(node);
+          newRange.collapse(true);
+          selection.removeAllRanges();
+          selection.addRange(newRange);
+        }
+        return;
+      }
+      node = node.parentNode;
+    }
+  }
+
+  function handlePaste(event: ClipboardEvent) {
+    event.preventDefault();
+    const plainText = event.clipboardData?.getData('text/plain');
+    if (!plainText) return;
+
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return;
+    const range = selection.getRangeAt(0);
+
+    range.deleteContents();
+    const textNode = document.createTextNode(plainText);
+    range.insertNode(textNode);
+    range.setStartAfter(textNode);
+    range.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    handleContentInput();
+  }
+
+  // Handle composer input for @ mentions
+  function handleContentInput() {
+    updateContentFromComposer();
+    if (!composerEl) return;
+
+    const converted = convertRawMentionsToPills();
+    if (converted) {
+      updateContentFromComposer();
+    }
+
+    const textBeforeCursor = getTextBeforeCursor(composerEl);
+    const mentionMatch = textBeforeCursor.match(/@([^\s@]*)$/);
+
     if (mentionMatch) {
-      mentionStartPos = cursorPos - mentionMatch[0].length;
-      mentionQuery = mentionMatch[1];
+      mentionQuery = mentionMatch[1] || '';
       showMentionSuggestions = true;
-      
+
       if (mentionSearchTimeout) clearTimeout(mentionSearchTimeout);
       mentionSearchTimeout = setTimeout(() => {
         if (mentionQuery.length > 0) {
           searchMentionUsers(mentionQuery);
         } else {
-          // Show all cached users if query is empty
           mentionSuggestions = Array.from(mentionProfileCache.values()).slice(0, 8);
           selectedMentionIndex = 0;
         }
@@ -698,35 +993,266 @@
     }
   }
 
-  // Insert mention into textarea
-  function insertMention(user: { name: string; npub: string }) {
-    if (!textareaEl) return;
-    
-    const beforeMention = content.substring(0, mentionStartPos);
-    const afterMention = content.substring(textareaEl.selectionStart);
-    const mentionText = `@${user.name} `;
-    
-    content = beforeMention + mentionText + afterMention;
-    showMentionSuggestions = false;
-    mentionSuggestions = [];
-    
-    // Set cursor position after mention
-    setTimeout(() => {
-      const newPos = beforeMention.length + mentionText.length;
-      textareaEl.setSelectionRange(newPos, newPos);
-      textareaEl.focus();
-    }, 0);
+  function deleteCharsBeforeCursor(count: number) {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return;
+
+    const range = selection.getRangeAt(0);
+    let remaining = count;
+    let currentNode: Node | null = range.startContainer;
+    let currentOffset = range.startOffset;
+
+    if (currentNode.nodeType === Node.ELEMENT_NODE) {
+      const walker = document.createTreeWalker(currentNode, NodeFilter.SHOW_TEXT, null);
+      let lastText: Text | null = null;
+      while (walker.nextNode()) {
+        lastText = walker.currentNode as Text;
+      }
+      if (lastText) {
+        currentNode = lastText;
+        currentOffset = lastText.length;
+      }
+    }
+
+    while (remaining > 0 && currentNode) {
+      if (currentNode.nodeType === Node.TEXT_NODE) {
+        const textNode = currentNode as Text;
+        const deleteCount = Math.min(remaining, currentOffset);
+        if (deleteCount > 0) {
+          textNode.deleteData(currentOffset - deleteCount, deleteCount);
+          remaining -= deleteCount;
+          currentOffset -= deleteCount;
+        }
+
+        if (remaining > 0) {
+          let prev: Node | null = textNode.previousSibling;
+          while (prev && prev.nodeType !== Node.TEXT_NODE) {
+            prev = prev.previousSibling;
+          }
+          if (prev) {
+            currentNode = prev;
+            currentOffset = (prev as Text).length;
+          } else {
+            break;
+          }
+        }
+      } else {
+        break;
+      }
+    }
   }
 
-  // Handle keyboard navigation in mention suggestions
+  function createMentionPill(mention: string, displayName: string): HTMLSpanElement {
+    const pill = document.createElement('span');
+    pill.contentEditable = 'false';
+    pill.dataset.mention = mention;
+    pill.className = 'mention-pill';
+    pill.textContent = `@${displayName}`;
+    return pill;
+  }
+
+  function insertMentionNode(mention: string, displayName: string, addTrailingSpace = false) {
+    if (!composerEl) return;
+
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return;
+    const range = selection.getRangeAt(0);
+
+    const pill = createMentionPill(mention, displayName);
+    const newRange = document.createRange();
+    newRange.setStart(range.startContainer, range.startOffset);
+    newRange.collapse(true);
+    newRange.insertNode(pill);
+
+    if (addTrailingSpace) {
+      const spacer = document.createTextNode(' ');
+      pill.after(spacer);
+      newRange.setStartAfter(spacer);
+    } else {
+      newRange.setStartAfter(pill);
+    }
+
+    newRange.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(newRange);
+  }
+
+  function convertRawMentionsToPills(): boolean {
+    if (!composerEl) return false;
+
+    const rawText = composerEl.textContent || '';
+    if (!rawText.includes('npub1')) return false;
+
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0 || !selection.isCollapsed) return false;
+
+    const range = selection.getRangeAt(0);
+    const marker = document.createElement('span');
+    marker.dataset.mentionCaret = 'true';
+    marker.textContent = '\u200B';
+    range.insertNode(marker);
+
+    const textNodes: Text[] = [];
+    const walker = document.createTreeWalker(composerEl, NodeFilter.SHOW_TEXT, {
+      acceptNode(node) {
+        const parent = node.parentElement;
+        if (!parent) return NodeFilter.FILTER_REJECT;
+        if (parent.dataset.mention || parent.dataset.mentionCaret) return NodeFilter.FILTER_REJECT;
+        return NodeFilter.FILTER_ACCEPT;
+      }
+    });
+
+    while (walker.nextNode()) {
+      textNodes.push(walker.currentNode as Text);
+    }
+
+    let converted = false;
+    for (const textNode of textNodes) {
+      const text = textNode.nodeValue;
+      if (!text || !text.includes('npub1')) continue;
+
+      const mentionRegex =
+        /@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)/g;
+      let lastIndex = 0;
+      let match: RegExpExecArray | null;
+      let hasMatch = false;
+      const fragment = document.createDocumentFragment();
+
+      while ((match = mentionRegex.exec(text)) !== null) {
+        hasMatch = true;
+        const before = text.slice(lastIndex, match.index);
+        if (before) {
+          fragment.appendChild(document.createTextNode(before));
+        }
+
+        const rawMention = match[0];
+        const mention = rawMention.startsWith('@') ? `nostr:${rawMention.slice(1)}` : rawMention;
+        const displayName = getDisplayNameForMention(mention);
+        fragment.appendChild(createMentionPill(mention, displayName));
+
+        lastIndex = match.index + rawMention.length;
+      }
+
+      if (!hasMatch) continue;
+      converted = true;
+
+      if (lastIndex < text.length) {
+        fragment.appendChild(document.createTextNode(text.slice(lastIndex)));
+      }
+
+      textNode.parentNode?.replaceChild(fragment, textNode);
+    }
+
+    const caretMarker = composerEl.querySelector('[data-mention-caret]');
+    if (caretMarker) {
+      const newRange = document.createRange();
+      newRange.setStartAfter(caretMarker);
+      newRange.collapse(true);
+      selection.removeAllRanges();
+      selection.addRange(newRange);
+      caretMarker.remove();
+    }
+
+    return converted;
+  }
+
+  // Insert mention pill into composer
+  function insertMention(user: { name: string; npub: string; pubkey: string }) {
+    if (!composerEl) return;
+
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return;
+    const textBeforeCursor = getTextBeforeCursor(composerEl);
+    const mentionMatch = textBeforeCursor.match(/@([^\s@]*)$/);
+
+    if (mentionMatch?.[0]) {
+      deleteCharsBeforeCursor(mentionMatch[0].length);
+    }
+
+    const mention = `nostr:${user.npub}`;
+    insertMentionNode(mention, user.name, true);
+
+    mentionProfileCache.set(user.pubkey, user);
+    updateContentFromComposer();
+    showMentionSuggestions = false;
+    mentionSuggestions = [];
+  }
+
+  // Handle keyboard navigation in mention suggestions and pill deletion
   function handleKeydown(event: KeyboardEvent) {
+    const selection = window.getSelection();
+    if (selection && selection.rangeCount) {
+      const range = selection.getRangeAt(0);
+
+      if (event.key === 'Delete' && range.collapsed) {
+        const { startContainer, startOffset } = range;
+        if (startContainer.nodeType === Node.TEXT_NODE) {
+          const textNode = startContainer as Text;
+          if (startOffset === textNode.length) {
+            const nextSibling = startContainer.nextSibling;
+            if (
+              nextSibling &&
+              nextSibling.nodeType === Node.ELEMENT_NODE &&
+              (nextSibling as HTMLElement).dataset.mention
+            ) {
+              event.preventDefault();
+              nextSibling.remove();
+              updateContentFromComposer();
+              return;
+            }
+          }
+        }
+      }
+
+      if (event.key === 'Backspace') {
+        if (!range.collapsed) {
+          const container = range.commonAncestorContainer;
+          let mentionElement: HTMLElement | null = null;
+
+          if (container.nodeType === Node.ELEMENT_NODE) {
+            const el = container as HTMLElement;
+            if (el.dataset.mention) {
+              mentionElement = el;
+            }
+          } else if (container.parentElement?.dataset.mention) {
+            mentionElement = container.parentElement;
+          }
+
+          if (mentionElement) {
+            event.preventDefault();
+            mentionElement.remove();
+            updateContentFromComposer();
+            return;
+          }
+        }
+
+        if (range.collapsed) {
+          const { startContainer, startOffset } = range;
+          if (startContainer.nodeType === Node.TEXT_NODE && startOffset === 0) {
+            const prevSibling = startContainer.previousSibling;
+            if (
+              prevSibling &&
+              prevSibling.nodeType === Node.ELEMENT_NODE &&
+              (prevSibling as HTMLElement).dataset.mention
+            ) {
+              event.preventDefault();
+              prevSibling.remove();
+              updateContentFromComposer();
+              return;
+            }
+          }
+        }
+      }
+    }
+
     if (showMentionSuggestions && mentionSuggestions.length > 0) {
       if (event.key === 'ArrowDown') {
         event.preventDefault();
         selectedMentionIndex = (selectedMentionIndex + 1) % mentionSuggestions.length;
       } else if (event.key === 'ArrowUp') {
         event.preventDefault();
-        selectedMentionIndex = selectedMentionIndex === 0 ? mentionSuggestions.length - 1 : selectedMentionIndex - 1;
+        selectedMentionIndex =
+          selectedMentionIndex === 0 ? mentionSuggestions.length - 1 : selectedMentionIndex - 1;
       } else if (event.key === 'Enter' || event.key === 'Tab') {
         event.preventDefault();
         insertMention(mentionSuggestions[selectedMentionIndex]);
@@ -736,7 +1262,7 @@
       }
       return;
     }
-    
+
     if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
       event.preventDefault();
       postToFeed();
@@ -746,342 +1272,416 @@
     }
   }
 
-  // Parse @ mentions from content and return pubkeys
+  // Parse nostr: mentions from content and return pubkeys
   function parseMentions(text: string): Map<string, string> {
-    // Map of @username to pubkey
     const mentions = new Map<string, string>();
-    const mentionRegex = /@(\w+)\s/g;
-    let match;
-    
+    const mentionRegex =
+      /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)|@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g;
+    let match: RegExpExecArray | null;
+
     while ((match = mentionRegex.exec(text)) !== null) {
-      const username = match[1];
-      // Find user in cache by name (case-insensitive)
-      for (const [pubkey, profile] of mentionProfileCache.entries()) {
-        if (profile.name.toLowerCase() === username.toLowerCase()) {
-          mentions.set(`@${username}`, pubkey);
-          break;
+      const mention = match[1] || match[0].slice(1);
+      try {
+        const decoded = nip19.decode(mention);
+        if (decoded.type === 'npub') {
+          mentions.set(mention, decoded.data);
+        } else if (decoded.type === 'nprofile') {
+          mentions.set(mention, decoded.data.pubkey);
         }
-      }
+      } catch {}
     }
-    
+
     return mentions;
   }
 
+  $: if (composerEl && content !== lastRenderedContent) {
+    syncComposerContent(content);
+  }
 </script>
 
 <svelte:head>
   <title>Community - zap.cooking</title>
-  <meta name="description" content="Community - Share and discover delicious food content from the Nostr network" />
+  <meta
+    name="description"
+    content="Community - Share and discover delicious food content from the Nostr network"
+  />
 </svelte:head>
 
 <PullToRefresh bind:this={pullToRefreshEl} on:refresh={handleRefresh}>
-<div class="container mx-auto px-4 max-w-2xl community-page">
-  <!-- Orientation text for signed-out users -->
-  {#if $userPublickey === ''}
-    <div class="mb-4 pt-1">
-      <p class="text-sm text-caption">Food. Friends. Freedom.</p>
-      <p class="text-xs text-caption mt-0.5">People share meals, recipes, and food ideas here. <a href="/login" class="text-caption hover:opacity-80 underline">Sign in</a> to share your own and follow cooks you like.</p>
-    </div>
-  {/if}
+  <div class="container mx-auto px-4 max-w-2xl community-page">
+    <!-- Orientation text for signed-out users -->
+    {#if $userPublickey === ''}
+      <div class="mb-4 pt-1">
+        <p class="text-sm text-caption">Food. Friends. Freedom.</p>
+        <p class="text-xs text-caption mt-0.5">
+          People share meals, recipes, and food ideas here. <a
+            href="/login"
+            class="text-caption hover:opacity-80 underline">Sign in</a
+          > to share your own and follow cooks you like.
+        </p>
+      </div>
+    {/if}
 
-  <!-- Inline Post Composer for logged-in users -->
-  {#if $userPublickey !== ''}
-    <div class="mb-4 bg-input rounded-xl overflow-hidden transition-all" style="border: 1px solid var(--color-input-border)">
-      {#if !isComposerOpen}
-        <!-- Collapsed state -->
-        <button
-          class="w-full p-3 hover:bg-accent-gray transition-colors cursor-pointer text-left"
-          on:click={openComposer}
-        >
-          <div class="flex items-center gap-3">
-            <div class="w-9 h-9 bg-accent-gray rounded-full flex items-center justify-center">
-              <PencilSimpleIcon size={18} class="text-caption" />
-            </div>
-            <span class="text-caption text-sm">Share what you're eating, cooking, or loving</span>
-          </div>
-        </button>
-      {:else}
-        <!-- Expanded composer -->
-        <div class="p-3">
-          <div class="flex gap-3">
-            <CustomAvatar pubkey={$userPublickey} size={36} />
-            <div class="flex-1">
-              <div class="relative">
-              <textarea
-                bind:this={textareaEl}
-                bind:value={content}
-                placeholder="What are you eating, cooking, or loving?"
-                class="w-full min-h-[80px] p-2 border-0 focus:outline-none focus:ring-0 resize-none bg-transparent"
-                style="color: var(--color-text-primary); font-size: 16px;"
-                disabled={posting}
-                on:keydown={handleKeydown}
-                  on:input={handleContentInput}
-              ></textarea>
-                
-                <!-- Mention suggestions dropdown -->
-                {#if showMentionSuggestions}
-                  <div 
-                    class="mention-dropdown"
-                    style="border-color: var(--color-input-border);"
-                  >
-                    {#if mentionSuggestions.length > 0}
-                      <div class="mention-dropdown-content">
-                        {#each mentionSuggestions as suggestion, index}
-                          <button
-                            type="button"
-                            on:click={() => insertMention(suggestion)}
-                            on:mousedown|preventDefault={() => insertMention(suggestion)}
-                            class="mention-option"
-                            class:mention-selected={index === selectedMentionIndex}
-                          >
-                            <CustomAvatar pubkey={suggestion.pubkey} size={24} />
-                            <div class="mention-info">
-                              <span class="mention-name">{suggestion.name}</span>
-                              {#if suggestion.nip05}
-                                <span class="mention-nip05">{suggestion.nip05}</span>
-                              {/if}
-                            </div>
-                          </button>
-                        {/each}
-                      </div>
-                    {:else if mentionSearching}
-                      <div class="mention-empty">
-                        Searching...
-                      </div>
-                    {:else if mentionQuery.length > 0}
-                      <div class="mention-empty">
-                        No users found
-                      </div>
-                    {/if}
-                  </div>
-                {/if}
+    <!-- Inline Post Composer for logged-in users -->
+    {#if $userPublickey !== ''}
+      <div
+        class="mb-4 bg-input rounded-xl transition-all"
+        class:overflow-hidden={!isComposerOpen}
+        class:overflow-visible={isComposerOpen}
+        style="border: 1px solid var(--color-input-border)"
+      >
+        {#if !isComposerOpen}
+          <!-- Collapsed state -->
+          <button
+            class="w-full p-3 hover:bg-accent-gray transition-colors cursor-pointer text-left"
+            on:click={openComposer}
+          >
+            <div class="flex items-center gap-3">
+              <div class="w-9 h-9 bg-accent-gray rounded-full flex items-center justify-center">
+                <PencilSimpleIcon size={18} class="text-caption" />
               </div>
-              
-              {#if error}
-                <p class="text-red-500 text-xs mb-2">{error}</p>
-              {/if}
-              
-              {#if success}
-                <p class="text-green-600 text-xs mb-2">Posted!</p>
-              {/if}
-              
-              <!-- Quoted note preview -->
-              {#if quotedNote}
-                <div class="mb-3 rounded-xl overflow-hidden bg-input" style="border: 1px solid var(--color-input-border)">
-                  <!-- Header with remove button -->
-                  <div class="flex items-center justify-between px-3 py-2 bg-accent-gray" style="border-bottom: 1px solid var(--color-input-border)">
-                    <span class="text-xs font-medium text-caption">Quoting post</span>
-                    <button
-                      type="button"
-                      on:click={() => quotedNote = null}
-                      class="text-caption hover:opacity-80 p-1 hover:bg-input rounded transition-colors"
-                      aria-label="Remove quote"
-                    >
-                      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                      </svg>
-                    </button>
-                  </div>
-                  
-                  <!-- Quoted note content -->
-                  <div class="p-3">
-                    <!-- Author info -->
-                    <div class="flex items-center gap-2 mb-2">
-                      <CustomAvatar pubkey={quotedNote.event.pubkey} size={24} />
-                      <ProfileLink nostrString={'nostr:' + nip19.npubEncode(quotedNote.event.pubkey)} />
+              <span class="text-caption text-sm">Share what you're eating, cooking, or loving</span>
+            </div>
+          </button>
+        {:else}
+          <!-- Expanded composer -->
+          <div class="p-3">
+            <div class="flex gap-3">
+              <CustomAvatar pubkey={$userPublickey} size={36} />
+              <div class="flex-1">
+                <div class="relative">
+                  <div
+                    bind:this={composerEl}
+                    class="composer-input w-full min-h-[80px] p-2 border-0 focus:outline-none focus:ring-0 bg-transparent"
+                    style="color: var(--color-text-primary); font-size: 16px;"
+                    contenteditable={!posting}
+                    role="textbox"
+                    aria-multiline="true"
+                    data-placeholder="What are you eating, cooking, or loving?"
+                    on:keydown={handleKeydown}
+                    on:input={handleContentInput}
+                    on:beforeinput={handleBeforeInput}
+                    on:paste={handlePaste}
+                  ></div>
+
+                  <!-- Mention suggestions dropdown -->
+                  {#if showMentionSuggestions}
+                    <div class="mention-dropdown" style="border-color: var(--color-input-border);">
+                      {#if mentionSuggestions.length > 0}
+                        <div class="mention-dropdown-content">
+                          {#each mentionSuggestions as suggestion, index}
+                            <button
+                              type="button"
+                              on:click={() => insertMention(suggestion)}
+                              on:mousedown|preventDefault={() => insertMention(suggestion)}
+                              class="mention-option"
+                              class:mention-selected={index === selectedMentionIndex}
+                            >
+                              <CustomAvatar pubkey={suggestion.pubkey} size={24} />
+                              <div class="mention-info">
+                                <span class="mention-name">{suggestion.name}</span>
+                                {#if suggestion.nip05}
+                                  <span class="mention-nip05">{suggestion.nip05}</span>
+                                {/if}
+                              </div>
+                            </button>
+                          {/each}
+                        </div>
+                      {:else if mentionSearching}
+                        <div class="mention-empty">Searching...</div>
+                      {:else if mentionQuery.length > 0}
+                        <div class="mention-empty">No users found</div>
+                      {/if}
                     </div>
-                    
-                    <!-- Note content with proper rendering -->
-                    <div class="text-sm max-h-32 overflow-hidden" style="color: var(--color-text-primary)">
-                      <NoteContent content={quotedNote.event.content || ''} />
-                    </div>
-                  </div>
-                </div>
-              {/if}
-              
-              <!-- Image previews -->
-              {#if uploadedImages.length > 0}
-                <div class="mb-2 flex flex-wrap gap-2">
-                  {#each uploadedImages as imageUrl, index}
-                    <div class="relative group">
-                      <img
-                        src={imageUrl}
-                        alt="Upload preview"
-                        class="w-20 h-20 object-cover rounded-lg"
-                        style="border: 1px solid var(--color-input-border)"
-                      />
-                      <button
-                        type="button"
-                        on:click={() => removeImage(index)}
-                        class="absolute -top-2 -right-2 bg-red-500 hover:bg-red-600 text-white rounded-full p-1 shadow-lg transition-all opacity-90 hover:opacity-100"
-                        disabled={posting}
-                        aria-label="Remove image"
-                      >
-                        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                        </svg>
-                      </button>
-                    </div>
-                  {/each}
-                </div>
-              {/if}
-              
-              <!-- Video previews -->
-              {#if uploadedVideos.length > 0}
-                <div class="mb-2 flex flex-wrap gap-2">
-                  {#each uploadedVideos as videoUrl, index}
-                    <div class="relative group">
-                      <video
-                        src={videoUrl}
-                        class="w-32 h-20 object-cover rounded-lg"
-                        style="border: 1px solid var(--color-input-border)"
-                        preload="metadata"
-                        muted
-                      />
-                      <button
-                        type="button"
-                        on:click={() => removeVideo(index)}
-                        class="absolute -top-2 -right-2 bg-red-500 hover:bg-red-600 text-white rounded-full p-1 shadow-lg transition-all opacity-90 hover:opacity-100"
-                        disabled={posting}
-                        aria-label="Remove video"
-                      >
-                        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                        </svg>
-                      </button>
-                    </div>
-                  {/each}
-                </div>
-              {/if}
-              
-              <!-- Relay indicator for members/garden tabs -->
-              {#if activeTab === 'members'}
-                <div class="mb-2 px-3 py-1.5 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800">
-                  <p class="text-xs font-medium text-blue-700 dark:text-blue-300">
-                    📡 Posting to: <span class="font-semibold">members.zap.cooking</span>
-                  </p>
-                </div>
-              {:else if activeTab === 'garden'}
-                <div class="mb-2 px-3 py-1.5 rounded-lg bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800">
-                  <p class="text-xs font-medium text-green-700 dark:text-green-300">
-                    🌱 Posting to: <span class="font-semibold">garden.zap.cooking</span>
-                  </p>
-                </div>
-              {/if}
-              
-              <div class="flex items-center justify-between pt-2 border-t" style="border-color: var(--color-input-border)">
-                <div class="flex items-center gap-3">
-                  <!-- Image upload button -->
-                  <label
-                    class="cursor-pointer p-1.5 rounded-full hover:bg-accent-gray transition-colors"
-                    class:opacity-50={posting || uploadingImage || uploadingVideo}
-                    class:cursor-not-allowed={posting || uploadingImage || uploadingVideo}
-                    aria-disabled={posting || uploadingImage}
-                    title="Upload image"
-                  >
-                    <ImageIcon size={18} class="text-caption" />
-                    <input
-                      bind:this={imageInputEl}
-                      type="file"
-                      accept="image/*"
-                      class="sr-only"
-                      on:change={handleImageUpload}
-                      disabled={posting || uploadingImage}
-                    />
-                  </label>
-                  
-                  <!-- Video upload button -->
-                  <label
-                    class="cursor-pointer p-1.5 rounded-full hover:bg-accent-gray transition-colors"
-                    class:opacity-50={posting || uploadingVideo}
-                    class:cursor-not-allowed={posting || uploadingVideo}
-                    aria-disabled={posting || uploadingVideo}
-                    title="Upload video"
-                  >
-                    <VideoIcon size={18} class="text-caption" />
-                    <input
-                      bind:this={videoInputEl}
-                      type="file"
-                      accept="video/*"
-                      class="sr-only"
-                      on:change={handleVideoUpload}
-                      disabled={posting || uploadingVideo}
-                    />
-                  </label>
-                  
-                  {#if uploadingImage}
-                    <span class="text-xs text-caption">Uploading image...</span>
-                  {:else if uploadingVideo}
-                    <span class="text-xs text-caption">Uploading video...</span>
                   {/if}
                 </div>
 
-                <div class="flex items-center gap-2">
-                  <button
-                    on:click={closeComposer}
-                    class="px-3 py-1.5 text-xs text-caption hover:opacity-80 transition-colors"
-                    disabled={posting}
+                {#if error}
+                  <p class="text-red-500 text-xs mb-2">{error}</p>
+                {/if}
+
+                {#if success}
+                  <p class="text-green-600 text-xs mb-2">Posted!</p>
+                {/if}
+
+                <!-- Quoted note preview -->
+                {#if quotedNote}
+                  <div
+                    class="mb-3 rounded-xl overflow-hidden bg-input"
+                    style="border: 1px solid var(--color-input-border)"
                   >
-                    Cancel
-                  </button>
-                  <button
-                    on:click={postToFeed}
-                    disabled={posting || uploadingImage || uploadingVideo || (!content.trim() && uploadedImages.length === 0 && uploadedVideos.length === 0 && !quotedNote)}
-                    class="px-4 py-1.5 text-xs font-medium text-white bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 rounded-full disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+                    <!-- Header with remove button -->
+                    <div
+                      class="flex items-center justify-between px-3 py-2 bg-accent-gray"
+                      style="border-bottom: 1px solid var(--color-input-border)"
+                    >
+                      <span class="text-xs font-medium text-caption">Quoting post</span>
+                      <button
+                        type="button"
+                        on:click={() => (quotedNote = null)}
+                        class="text-caption hover:opacity-80 p-1 hover:bg-input rounded transition-colors"
+                        aria-label="Remove quote"
+                      >
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            d="M6 18L18 6M6 6l12 12"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+
+                    <!-- Quoted note content -->
+                    <div class="p-3">
+                      <!-- Author info -->
+                      <div class="flex items-center gap-2 mb-2">
+                        <CustomAvatar pubkey={quotedNote.event.pubkey} size={24} />
+                        <ProfileLink
+                          nostrString={'nostr:' + nip19.npubEncode(quotedNote.event.pubkey)}
+                        />
+                      </div>
+
+                      <!-- Note content with proper rendering -->
+                      <div
+                        class="text-sm max-h-32 overflow-hidden"
+                        style="color: var(--color-text-primary)"
+                      >
+                        <NoteContent content={quotedNote.event.content || ''} />
+                      </div>
+                    </div>
+                  </div>
+                {/if}
+
+                <!-- Image previews -->
+                {#if uploadedImages.length > 0}
+                  <div class="mb-2 flex flex-wrap gap-2">
+                    {#each uploadedImages as imageUrl, index}
+                      <div class="relative group">
+                        <img
+                          src={imageUrl}
+                          alt="Upload preview"
+                          class="w-20 h-20 object-cover rounded-lg"
+                          style="border: 1px solid var(--color-input-border)"
+                        />
+                        <button
+                          type="button"
+                          on:click={() => removeImage(index)}
+                          class="absolute -top-2 -right-2 bg-red-500 hover:bg-red-600 text-white rounded-full p-1 shadow-lg transition-all opacity-90 hover:opacity-100"
+                          disabled={posting}
+                          aria-label="Remove image"
+                        >
+                          <svg
+                            class="w-3 h-3"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              d="M6 18L18 6M6 6l12 12"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    {/each}
+                  </div>
+                {/if}
+
+                <!-- Video previews -->
+                {#if uploadedVideos.length > 0}
+                  <div class="mb-2 flex flex-wrap gap-2">
+                    {#each uploadedVideos as videoUrl, index}
+                      <div class="relative group">
+                        <video
+                          src={videoUrl}
+                          class="w-32 h-20 object-cover rounded-lg"
+                          style="border: 1px solid var(--color-input-border)"
+                          preload="metadata"
+                          muted
+                        />
+                        <button
+                          type="button"
+                          on:click={() => removeVideo(index)}
+                          class="absolute -top-2 -right-2 bg-red-500 hover:bg-red-600 text-white rounded-full p-1 shadow-lg transition-all opacity-90 hover:opacity-100"
+                          disabled={posting}
+                          aria-label="Remove video"
+                        >
+                          <svg
+                            class="w-3 h-3"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              d="M6 18L18 6M6 6l12 12"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    {/each}
+                  </div>
+                {/if}
+
+                <!-- Relay indicator for members/garden tabs -->
+                {#if activeTab === 'members'}
+                  <div
+                    class="mb-2 px-3 py-1.5 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800"
                   >
-                    {posting ? 'Posting...' : 'Post'}
-                  </button>
+                    <p class="text-xs font-medium text-blue-700 dark:text-blue-300">
+                      📡 Posting to: <span class="font-semibold">members.zap.cooking</span>
+                    </p>
+                  </div>
+                {:else if activeTab === 'garden'}
+                  <div
+                    class="mb-2 px-3 py-1.5 rounded-lg bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800"
+                  >
+                    <p class="text-xs font-medium text-green-700 dark:text-green-300">
+                      🌱 Posting to: <span class="font-semibold">garden.zap.cooking</span>
+                    </p>
+                  </div>
+                {/if}
+
+                <div
+                  class="flex items-center justify-between pt-2 border-t"
+                  style="border-color: var(--color-input-border)"
+                >
+                  <div class="flex items-center gap-3">
+                    <!-- Image upload button -->
+                    <label
+                      class="cursor-pointer p-1.5 rounded-full hover:bg-accent-gray transition-colors"
+                      class:opacity-50={posting || uploadingImage || uploadingVideo}
+                      class:cursor-not-allowed={posting || uploadingImage || uploadingVideo}
+                      aria-disabled={posting || uploadingImage}
+                      title="Upload image"
+                    >
+                      <ImageIcon size={18} class="text-caption" />
+                      <input
+                        bind:this={imageInputEl}
+                        type="file"
+                        accept="image/*"
+                        class="sr-only"
+                        on:change={handleImageUpload}
+                        disabled={posting || uploadingImage}
+                      />
+                    </label>
+
+                    <!-- Video upload button -->
+                    <label
+                      class="cursor-pointer p-1.5 rounded-full hover:bg-accent-gray transition-colors"
+                      class:opacity-50={posting || uploadingVideo}
+                      class:cursor-not-allowed={posting || uploadingVideo}
+                      aria-disabled={posting || uploadingVideo}
+                      title="Upload video"
+                    >
+                      <VideoIcon size={18} class="text-caption" />
+                      <input
+                        bind:this={videoInputEl}
+                        type="file"
+                        accept="video/*"
+                        class="sr-only"
+                        on:change={handleVideoUpload}
+                        disabled={posting || uploadingVideo}
+                      />
+                    </label>
+
+                    {#if uploadingImage}
+                      <span class="text-xs text-caption">Uploading image...</span>
+                    {:else if uploadingVideo}
+                      <span class="text-xs text-caption">Uploading video...</span>
+                    {/if}
+                  </div>
+
+                  <div class="flex items-center gap-2">
+                    <button
+                      on:click={closeComposer}
+                      class="px-3 py-1.5 text-xs text-caption hover:opacity-80 transition-colors"
+                      disabled={posting}
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      on:click={postToFeed}
+                      disabled={posting ||
+                        uploadingImage ||
+                        uploadingVideo ||
+                        (!content.trim() &&
+                          uploadedImages.length === 0 &&
+                          uploadedVideos.length === 0 &&
+                          !quotedNote)}
+                      class="px-4 py-1.5 text-xs font-medium text-white bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 rounded-full disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+                    >
+                      {posting ? 'Posting...' : 'Post'}
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-      {/if}
-    </div>
-  {/if}
-
-  <!-- Filter Tabs -->
-  <div class="mb-4 border-b" style="border-color: var(--color-input-border)">
-    <div class="flex gap-1">
-      <button
-        on:click={() => setTab('global')}
-        class="px-4 py-2 text-sm font-medium transition-colors relative"
-        style="color: {activeTab === 'global' ? 'var(--color-text-primary)' : 'var(--color-text-secondary)'}"
-      >
-        Global Food
-        {#if activeTab === 'global'}
-          <span class="absolute bottom-0 left-0 right-0 h-0.5 bg-gradient-to-r from-orange-500 to-amber-500"></span>
         {/if}
-      </button>
+      </div>
+    {/if}
 
-      <button
-        on:click={() => setTab('following')}
-        class="px-4 py-2 text-sm font-medium transition-colors relative"
-        style="color: {activeTab === 'following' ? 'var(--color-text-primary)' : 'var(--color-text-secondary)'}"
-        disabled={!$userPublickey}
-        class:opacity-50={!$userPublickey}
-        class:cursor-not-allowed={!$userPublickey}
-        class:cursor-pointer={$userPublickey}
-      >
-        Following
-        {#if activeTab === 'following'}
-          <span class="absolute bottom-0 left-0 right-0 h-0.5 bg-gradient-to-r from-orange-500 to-amber-500"></span>
-        {/if}
-      </button>
+    <!-- Filter Tabs -->
+    <div class="mb-4 border-b" style="border-color: var(--color-input-border)">
+      <div class="flex gap-1">
+        <button
+          on:click={() => setTab('global')}
+          class="px-4 py-2 text-sm font-medium transition-colors relative"
+          style="color: {activeTab === 'global'
+            ? 'var(--color-text-primary)'
+            : 'var(--color-text-secondary)'}"
+        >
+          Global Food
+          {#if activeTab === 'global'}
+            <span
+              class="absolute bottom-0 left-0 right-0 h-0.5 bg-gradient-to-r from-orange-500 to-amber-500"
+            ></span>
+          {/if}
+        </button>
 
-      <button
-        on:click={() => setTab('replies')}
-        class="px-4 py-2 text-sm font-medium transition-colors relative"
-        style="color: {activeTab === 'replies' ? 'var(--color-text-primary)' : 'var(--color-text-secondary)'}"
-      >
-        Notes & Replies
-        {#if activeTab === 'replies'}
-          <span class="absolute bottom-0 left-0 right-0 h-0.5 bg-gradient-to-r from-orange-500 to-amber-500"></span>
-        {/if}
-      </button>
+        <button
+          on:click={() => setTab('following')}
+          class="px-4 py-2 text-sm font-medium transition-colors relative"
+          style="color: {activeTab === 'following'
+            ? 'var(--color-text-primary)'
+            : 'var(--color-text-secondary)'}"
+          disabled={!$userPublickey}
+          class:opacity-50={!$userPublickey}
+          class:cursor-not-allowed={!$userPublickey}
+          class:cursor-pointer={$userPublickey}
+        >
+          Following
+          {#if activeTab === 'following'}
+            <span
+              class="absolute bottom-0 left-0 right-0 h-0.5 bg-gradient-to-r from-orange-500 to-amber-500"
+            ></span>
+          {/if}
+        </button>
 
-      <!-- Members tab hidden for now - keeping functionality intact -->
-      <!-- {#if hasActiveMembership}
+        <button
+          on:click={() => setTab('replies')}
+          class="px-4 py-2 text-sm font-medium transition-colors relative"
+          style="color: {activeTab === 'replies'
+            ? 'var(--color-text-primary)'
+            : 'var(--color-text-secondary)'}"
+        >
+          Notes & Replies
+          {#if activeTab === 'replies'}
+            <span
+              class="absolute bottom-0 left-0 right-0 h-0.5 bg-gradient-to-r from-orange-500 to-amber-500"
+            ></span>
+          {/if}
+        </button>
+
+        <!-- Members tab hidden for now - keeping functionality intact -->
+        <!-- {#if hasActiveMembership}
         <button
           on:click={() => setTab('members')}
           class="px-4 py-2 text-sm font-medium transition-colors relative"
@@ -1094,42 +1694,52 @@
         </button>
       {/if} -->
 
-      <button
-        on:click={() => setTab('garden')}
-        class="px-4 py-2 text-sm font-medium transition-colors relative"
-        style="color: {activeTab === 'garden' ? 'var(--color-text-primary)' : 'var(--color-text-secondary)'}"
-      >
-        The Garden
-        {#if activeTab === 'garden'}
-          <span class="absolute bottom-0 left-0 right-0 h-0.5 bg-gradient-to-r from-orange-500 to-amber-500"></span>
-        {/if}
-      </button>
+        <button
+          on:click={() => setTab('garden')}
+          class="px-4 py-2 text-sm font-medium transition-colors relative"
+          style="color: {activeTab === 'garden'
+            ? 'var(--color-text-primary)'
+            : 'var(--color-text-secondary)'}"
+        >
+          The Garden
+          {#if activeTab === 'garden'}
+            <span
+              class="absolute bottom-0 left-0 right-0 h-0.5 bg-gradient-to-r from-orange-500 to-amber-500"
+            ></span>
+          {/if}
+        </button>
+      </div>
     </div>
-  </div>
 
-  <!-- Show login prompt for Following/Replies tabs if not logged in -->
-  {#if (activeTab === 'following' || activeTab === 'replies') && !$userPublickey}
-    <div class="mb-4 p-4 bg-accent-gray rounded-lg" style="border: 1px solid var(--color-input-border)">
-      <p class="text-sm" style="color: var(--color-text-primary)">
-        <a href="/login" class="font-medium underline hover:opacity-80">Log in</a> to see {activeTab === 'following' ? 'posts from people you follow' : 'replies from people you follow'}.
-      </p>
-    </div>
-  {/if}
-  
-  <!-- Members tab and membership prompt hidden for now -->
-  <!-- Show membership prompt for Members tab if not a member -->
-  <!-- {#if activeTab === 'members' && $userPublickey && !hasActiveMembership && !checkingMembership}
+    <!-- Show login prompt for Following/Replies tabs if not logged in -->
+    {#if (activeTab === 'following' || activeTab === 'replies') && !$userPublickey}
+      <div
+        class="mb-4 p-4 bg-accent-gray rounded-lg"
+        style="border: 1px solid var(--color-input-border)"
+      >
+        <p class="text-sm" style="color: var(--color-text-primary)">
+          <a href="/login" class="font-medium underline hover:opacity-80">Log in</a> to see {activeTab ===
+          'following'
+            ? 'posts from people you follow'
+            : 'replies from people you follow'}.
+        </p>
+      </div>
+    {/if}
+
+    <!-- Members tab and membership prompt hidden for now -->
+    <!-- Show membership prompt for Members tab if not a member -->
+    <!-- {#if activeTab === 'members' && $userPublickey && !hasActiveMembership && !checkingMembership}
     <div class="mb-4 p-4 bg-accent-gray rounded-lg" style="border: 1px solid var(--color-input-border)">
       <p class="text-sm" style="color: var(--color-text-primary)">
         <a href="/membership" class="font-medium underline hover:opacity-80">Become a member</a> to access exclusive content from the private member community.
       </p>
     </div>
   {/if} -->
-  
-  {#key feedKey}
-    <FoodstrFeedOptimized bind:this={feedComponent} filterMode={activeTab} />
-  {/key}
-</div>
+
+    {#key feedKey}
+      <FoodstrFeedOptimized bind:this={feedComponent} filterMode={activeTab} />
+    {/key}
+  </div>
 </PullToRefresh>
 
 <style>
@@ -1137,7 +1747,7 @@
   .community-page {
     padding-bottom: calc(80px + env(safe-area-inset-bottom, 0px));
   }
-  
+
   /* Desktop doesn't need bottom nav spacing */
   @media (min-width: 768px) {
     .community-page {
@@ -1154,10 +1764,12 @@
     margin-top: 0.25rem;
     width: 280px;
     max-width: calc(100vw - 2rem);
-    background: var(--color-input);
+    background: var(--color-input-bg);
     border: 1px solid var(--color-input-border);
     border-radius: 0.5rem;
-    box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -1px rgb(0 0 0 / 0.06);
+    box-shadow:
+      0 4px 6px -1px rgb(0 0 0 / 0.1),
+      0 2px 4px -1px rgb(0 0 0 / 0.06);
     overflow: hidden;
   }
 
@@ -1202,6 +1814,30 @@
     background: var(--color-accent-gray);
   }
 
+  .composer-input {
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  .composer-input[contenteditable='true']:empty:before {
+    content: attr(data-placeholder);
+    color: var(--color-caption);
+    pointer-events: none;
+  }
+
+  .mention-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.1rem 0.45rem;
+    border-radius: 0.5rem;
+    background: rgba(236, 71, 0, 0.15);
+    color: var(--color-primary);
+    font-weight: 600;
+    user-select: all;
+    margin: 0 0.1rem;
+  }
+
   .mention-info {
     display: flex;
     flex-direction: column;
@@ -1232,5 +1868,4 @@
     font-size: 0.875rem;
     color: var(--color-caption);
   }
-
 </style>


### PR DESCRIPTION
- Adds atomic mention pills across community posts, comments, and replies with safe deletion behavior.
- Auto-convert raw `@npub…` / `nostr:npub…` into mention pills and normalize to `nostr:` links on publish.
- Improved mention autocomplete by merging follow list, Primal cache search, and NDK fallback.
- Preserved whitespace around inline profile links so tags don’t stick to adjacent text.