### PR TITLE
feat: Bitcoin Connect Balance & One-Tap Zaps

### DIFF
--- a/src/components/NoteTotalZaps.svelte
+++ b/src/components/NoteTotalZaps.svelte
@@ -6,12 +6,14 @@
   import LightningIcon from 'phosphor-svelte/lib/Lightning';
   import { getEngagementStore, fetchEngagement } from '$lib/engagementCache';
   import ZappersListModal from './ZappersListModal.svelte';
+  import { canOneTapZap, sendOneTapZap, getOneTapAmount } from '$lib/oneTapZap';
 
   export let event: NDKEvent;
-  export let onZapClick: (() => void) | undefined = undefined; // Callback for zap button click
-  
+  export let onZapClick: (() => void) | undefined = undefined; // Callback for zap button click (fallback when one-tap not available)
+
   const store = getEngagementStore(event.id);
   let showZappersModal = false;
+  let isZapping = false;
 
   onMount(() => {
     fetchEngagement($ndk, event.id, $userPublickey);
@@ -25,53 +27,79 @@
     }
   }
 
-  function handleZapIconClick(e: MouseEvent) {
+  async function handleZapIconClick(e: MouseEvent) {
     e.stopPropagation(); // Prevent parent click handlers
-    if (onZapClick) {
+
+    // If one-tap zap is available, send immediately
+    if (canOneTapZap()) {
+      isZapping = true;
+      const result = await sendOneTapZap(event);
+      isZapping = false;
+
+      if (result.success) {
+        // Refresh engagement data after successful zap
+        fetchEngagement($ndk, event.id, $userPublickey);
+      } else if (onZapClick) {
+        // Fall back to modal if one-tap fails
+        onZapClick();
+      }
+    } else if (onZapClick) {
+      // No one-tap available, use the callback to open modal
       onZapClick();
     }
   }
 </script>
 
 {#if $store.loading}
-  <div class="flex items-center gap-1.5 rounded px-0.5 transition duration-300" style="color: var(--color-text-primary)">
-    <button
-      class="hover:bg-input rounded p-1"
-      on:click={handleZapIconClick}
-      title="Send a zap"
-    >
+  <div
+    class="flex items-center gap-1.5 rounded px-0.5 transition duration-300"
+    style="color: var(--color-text-primary)"
+  >
+    <button class="hover:bg-input rounded p-1" on:click={handleZapIconClick} title="Send a zap">
       <LightningIcon size={24} class="text-caption" weight="regular" />
     </button>
     <span class="text-caption">–</span>
   </div>
 {:else}
-  <div class="flex items-center gap-1.5 rounded px-0.5 transition duration-300" style="color: var(--color-text-primary)">
-    <!-- Zap Icon Button - Opens ZapModal -->
+  <div
+    class="flex items-center gap-1.5 rounded px-0.5 transition duration-300"
+    style="color: var(--color-text-primary)"
+  >
+    <!-- Zap Icon Button -->
     <button
       class="hover:bg-input rounded p-1 transition-colors"
+      class:opacity-50={isZapping}
+      class:cursor-wait={isZapping}
       on:click={handleZapIconClick}
-      title="Send a zap"
+      disabled={isZapping}
+      title={canOneTapZap() ? `Zap ${getOneTapAmount()} sats` : 'Send a zap'}
     >
-      <LightningIcon 
-        size={24} 
-        class={$store.zaps.totalAmount > 0 ? 'text-yellow-500' : 'text-caption'} 
-        weight={$store.zaps.userZapped ? "fill" : "regular"} 
+      <LightningIcon
+        size={24}
+        class="{$store.zaps.totalAmount > 0 ? 'text-yellow-500' : 'text-caption'} {isZapping
+          ? 'animate-pulse'
+          : ''}"
+        weight={$store.zaps.userZapped ? 'fill' : 'regular'}
       />
     </button>
 
     <!-- Count Button - Opens ZappersListModal -->
     <button
-      class="hover:bg-input rounded px-1 transition-colors text-caption {$store.zaps.count > 0 ? 'cursor-pointer' : ''}"
+      class="hover:bg-input rounded px-1 transition-colors text-caption {$store.zaps.count > 0
+        ? 'cursor-pointer'
+        : ''}"
       on:click={handleCountClick}
       disabled={$store.zaps.count === 0}
-      title={$store.zaps.count > 0 ? `View ${$store.zaps.count} ${$store.zaps.count === 1 ? 'zap' : 'zaps'}` : 'No zaps yet'}
+      title={$store.zaps.count > 0
+        ? `View ${$store.zaps.count} ${$store.zaps.count === 1 ? 'zap' : 'zaps'}`
+        : 'No zaps yet'}
     >
       {formatAmount($store.zaps.totalAmount / 1000)}
     </button>
   </div>
 {/if}
 
-<ZappersListModal 
+<ZappersListModal
   bind:open={showZappersModal}
   zappers={$store.zaps.topZappers}
   totalAmount={$store.zaps.totalAmount}

--- a/src/components/Recipe/TopZappers.svelte
+++ b/src/components/Recipe/TopZappers.svelte
@@ -7,6 +7,7 @@
   import LightningIcon from 'phosphor-svelte/lib/Lightning';
 
   export let event: NDKEvent;
+  export let refreshKey: number = 0;
 
   type ZapperInfo = {
     pubkey: string;
@@ -61,7 +62,11 @@
           }, 6000);
 
           ws.onopen = () => {
-            const req = JSON.stringify(['REQ', 'zaps', { kinds: [9735], '#e': [eventId], limit: 500 }]);
+            const req = JSON.stringify([
+              'REQ',
+              'zaps',
+              { kinds: [9735], '#e': [eventId], limit: 500 }
+            ]);
             ws.send(req);
           };
 
@@ -86,7 +91,7 @@
           };
 
           ws.onclose = () => {
-            activeWebSockets = activeWebSockets.filter(w => w !== ws);
+            activeWebSockets = activeWebSockets.filter((w) => w !== ws);
           };
         } catch (e) {
           resolve();
@@ -150,9 +155,18 @@
     loadTopZappers();
   });
 
+  // Reload when refreshKey changes
+  $: if (refreshKey > 0) {
+    loadTopZappers();
+  }
+
   onDestroy(() => {
-    activeWebSockets.forEach(ws => {
-      try { ws.close(); } catch (e) { /* ignore */ }
+    activeWebSockets.forEach((ws) => {
+      try {
+        ws.close();
+      } catch (e) {
+        /* ignore */
+      }
     });
     activeWebSockets = [];
   });
@@ -168,7 +182,10 @@
     {#each visibleZappers as zapper}
       <a
         href="/user/{zapper.pubkey}"
-        class="flex items-center gap-1 h-6 px-1 pr-2 rounded-full bg-accent-gray hover:bg-yellow-500/20 transition-colors {zapper.pubkey === $userPublickey ? 'ring-1 ring-yellow-500' : ''}"
+        class="flex items-center gap-1 h-6 px-1 pr-2 rounded-full bg-accent-gray hover:bg-yellow-500/20 transition-colors {zapper.pubkey ===
+        $userPublickey
+          ? 'ring-1 ring-yellow-500'
+          : ''}"
         title="{zapper.totalSats} sats"
       >
         <CustomAvatar pubkey={zapper.pubkey} size={18} className="rounded-full" />

--- a/src/components/WalletBalance.svelte
+++ b/src/components/WalletBalance.svelte
@@ -21,6 +21,14 @@
     disableWebln,
     getWeblnBalance
   } from '$lib/wallet/webln';
+  import {
+    bitcoinConnectEnabled,
+    bitcoinConnectWalletInfo,
+    bitcoinConnectBalance,
+    bitcoinConnectBalanceLoading,
+    refreshBitcoinConnectBalance,
+    disableBitcoinConnect
+  } from '$lib/wallet/bitcoinConnect';
   import LightningIcon from 'phosphor-svelte/lib/Lightning';
   import WalletIcon from 'phosphor-svelte/lib/Wallet';
   import ArrowsClockwiseIcon from 'phosphor-svelte/lib/ArrowsClockwise';
@@ -33,6 +41,7 @@
   import SparkLogo from './icons/SparkLogo.svelte';
   import NwcLogo from './icons/NwcLogo.svelte';
   import WeblnLogo from './icons/WeblnLogo.svelte';
+  import BitcoinConnectLogo from './icons/BitcoinConnectLogo.svelte';
 
   let dropdownActive = false;
 
@@ -87,6 +96,15 @@
   function goToWallet() {
     dropdownActive = false;
     goto('/wallet');
+  }
+
+  async function handleRefreshBitcoinConnect() {
+    await refreshBitcoinConnectBalance();
+  }
+
+  function handleDisconnectBitcoinConnect() {
+    disableBitcoinConnect();
+    dropdownActive = false;
   }
 </script>
 
@@ -195,6 +213,117 @@
               weblnBalance = null;
               dropdownActive = false;
             }}
+          >
+            <SignOutIcon size={16} />
+            Disconnect
+          </button>
+        </div>
+      </div>
+    {/if}
+  </div>
+{:else if $bitcoinConnectEnabled && $bitcoinConnectWalletInfo.connected}
+  <!-- Bitcoin Connect Wallet Widget -->
+  <div class="relative" use:clickOutside on:click_outside={() => (dropdownActive = false)}>
+    <!-- Balance button -->
+    <button
+      class="flex items-center gap-1.5 px-3 py-1.5 rounded-full transition-colors cursor-pointer text-sm font-medium"
+      style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+      on:click={() => (dropdownActive = !dropdownActive)}
+    >
+      <div
+        class="w-4 h-4 rounded-full bg-gradient-to-br from-yellow-500 to-orange-500 flex items-center justify-center flex-shrink-0"
+      >
+        <BitcoinConnectLogo size={10} className="text-white" />
+      </div>
+      {#if $bitcoinConnectBalanceLoading}
+        <span class="animate-pulse min-w-[3.5rem] text-right">...</span>
+      {:else if $bitcoinConnectBalance === null}
+        <span class="min-w-[3.5rem] text-right">---</span>
+      {:else if $balanceVisible}
+        <span class="min-w-[3.5rem] text-right">{formatBalance($bitcoinConnectBalance)}</span>
+      {:else}
+        <span class="min-w-[3.5rem] text-right">***</span>
+      {/if}
+      <span class="text-caption text-xs">sats</span>
+      <CaretDownIcon size={12} class="text-caption ml-0.5" />
+    </button>
+
+    <!-- Dropdown menu -->
+    {#if dropdownActive}
+      <div
+        class="absolute right-0 top-full mt-2 z-20"
+        transition:fade={{ delay: 0, duration: 150 }}
+      >
+        <div
+          role="menu"
+          tabindex="-1"
+          on:keydown={(e) => e.key === 'Escape' && (dropdownActive = false)}
+          class="flex flex-col gap-3 bg-input rounded-2xl drop-shadow px-4 py-4 min-w-[220px] max-w-[280px]"
+          style="color: var(--color-text-primary)"
+        >
+          <!-- Current wallet info -->
+          <button
+            class="flex items-center gap-2 pb-2 border-b w-full text-left hover:opacity-80 transition-opacity cursor-pointer"
+            style="border-color: var(--color-input-border);"
+            on:click={() => {
+              dropdownActive = false;
+              goto('/wallet');
+            }}
+          >
+            <div
+              class="w-5 h-5 rounded-full bg-gradient-to-br from-yellow-500 to-orange-500 flex items-center justify-center flex-shrink-0"
+            >
+              <BitcoinConnectLogo size={12} className="text-white" />
+            </div>
+            <div class="flex-1 min-w-0">
+              <div class="font-medium text-sm truncate">
+                {$bitcoinConnectWalletInfo.alias || 'Bitcoin Connect'}
+              </div>
+              <div class="text-xs text-caption">External Wallet</div>
+            </div>
+          </button>
+
+          <!-- Actions -->
+          <button
+            class="flex items-center gap-2 text-sm hover:text-primary transition-colors cursor-pointer"
+            on:click={toggleBalanceVisibility}
+          >
+            {#if $balanceVisible}
+              <EyeSlashIcon size={16} />
+              Hide Balance
+            {:else}
+              <EyeIcon size={16} />
+              Show Balance
+            {/if}
+          </button>
+
+          <button
+            class="flex items-center gap-2 text-sm hover:text-primary transition-colors cursor-pointer"
+            on:click={handleRefreshBitcoinConnect}
+            disabled={$bitcoinConnectBalanceLoading}
+          >
+            <span class:animate-spin={$bitcoinConnectBalanceLoading}>
+              <ArrowsClockwiseIcon size={16} />
+            </span>
+            Refresh Balance
+          </button>
+
+          <button
+            class="flex items-center gap-2 text-sm hover:text-primary transition-colors cursor-pointer"
+            on:click={() => {
+              dropdownActive = false;
+              goto('/wallet');
+            }}
+          >
+            <GearIcon size={16} />
+            Wallet Settings
+          </button>
+
+          <div class="border-t" style="border-color: var(--color-input-border);"></div>
+
+          <button
+            class="flex items-center gap-2 text-sm text-red-500 hover:text-red-600 transition-colors cursor-pointer"
+            on:click={handleDisconnectBitcoinConnect}
           >
             <SignOutIcon size={16} />
             Disconnect

--- a/src/components/ZapModal.svelte
+++ b/src/components/ZapModal.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-  import { NDKEvent, NDKUser } from "@nostr-dev-kit/ndk";
-  import { ndk } from "$lib/nostr";
+  import { NDKEvent, NDKUser } from '@nostr-dev-kit/ndk';
+  import { ndk } from '$lib/nostr';
   import Modal from './Modal.svelte';
   import PanLoader from './PanLoader.svelte';
   import Button from './Button.svelte';
-  import Checkmark from "phosphor-svelte/lib/CheckFat"
-  import XIcon from "phosphor-svelte/lib/X"
+  import Checkmark from 'phosphor-svelte/lib/CheckFat';
+  import XIcon from 'phosphor-svelte/lib/X';
+
   import CustomAvatar from './CustomAvatar.svelte';
   import CustomName from './CustomName.svelte';
   import { browser } from '$app/environment';
@@ -28,7 +29,7 @@
     { amount: 1000, emoji: '🍕', label: '1K' },
     { amount: 2100, emoji: '🍔', label: '2.1K' },
     { amount: 10000, emoji: '🍣', label: '10K' },
-    { amount: 21000, emoji: '👨‍🍳', label: '21K' },
+    { amount: 21000, emoji: '👨‍🍳', label: '21K' }
   ];
 
   export let open = false;
@@ -37,7 +38,7 @@
   let amount: number = 21;
   let message: string = '';
 
-  let state: "pre" | "pending" | "success" | "error" = "pre";
+  let state: 'pre' | 'pending' | 'success' | 'error' = 'pre';
   let error: Error | null = null;
 
   let zapManager: ZapManager;
@@ -65,9 +66,11 @@
   function startPendingTimeout() {
     clearPendingTimeout();
     pendingTimeout = setTimeout(() => {
-      if (state === "pending") {
-        error = new Error('Zap request timed out. The payment service may be unavailable. Please try again.');
-        state = "error";
+      if (state === 'pending') {
+        error = new Error(
+          'Zap request timed out. The payment service may be unavailable. Please try again.'
+        );
+        state = 'error';
       }
     }, PENDING_TIMEOUT_MS);
   }
@@ -95,7 +98,7 @@
   }
 
   async function submitWithInAppWallet() {
-    state = "pending";
+    state = 'pending';
     error = null;
     startPendingTimeout();
 
@@ -124,7 +127,12 @@
       recipientPubkeyForDisplay = recipientPubkey;
 
       // Get the invoice from zapManager
-      const zapResult = await zapManager.createZap(recipientPubkey, amount * 1000, message, eventId);
+      const zapResult = await zapManager.createZap(
+        recipientPubkey,
+        amount * 1000,
+        message,
+        eventId
+      );
 
       // Use the unified wallet manager to send payment (handles both Spark and NWC)
       // Pass metadata so a pending transaction appears immediately
@@ -139,11 +147,11 @@
       }
 
       clearPendingTimeout();
-      state = "success";
-      
+      state = 'success';
+
       // Notify parent that zap completed so it can refresh zap totals
       dispatch('zap-complete', { amount });
-      
+
       // Auto-close modal after 1 second to show lightning animation on note
       successTimeout = setTimeout(() => {
         open = false;
@@ -152,7 +160,7 @@
       clearPendingTimeout();
       console.error('In-app wallet payment failed:', e);
       error = e as Error;
-      state = "error";
+      state = 'error';
     }
   }
 
@@ -187,7 +195,12 @@
       recipientPubkeyForDisplay = recipientPubkey;
 
       // Get the invoice from zapManager
-      const zapResult = await zapManager.createZap(recipientPubkey, amount * 1000, message, eventId);
+      const zapResult = await zapManager.createZap(
+        recipientPubkey,
+        amount * 1000,
+        message,
+        eventId
+      );
 
       isCreatingInvoice = false;
 
@@ -207,13 +220,17 @@
           open = true;
         }
       });
-
     } catch (e) {
       isCreatingInvoice = false;
       console.error('External wallet payment failed:', e);
       error = e as Error;
-      state = "error";
+      state = 'error';
     }
+  }
+
+  // Handle preset amount selection
+  function handlePresetClick(presetAmount: number) {
+    amount = presetAmount;
   }
 
   // Clean up when modal closes
@@ -222,8 +239,8 @@
     clearSuccessTimeout();
     // Reset state when modal closes (with small delay to allow animation to trigger)
     setTimeout(() => {
-      if (!open && state !== "pre") {
-        state = "pre";
+      if (!open && state !== 'pre') {
+        state = 'pre';
         error = null;
       }
     }, 100);
@@ -233,23 +250,23 @@
 <Modal bind:open>
   <h1 slot="title">Zap</h1>
   <div class="flex flex-col gap-3">
-  {#if state == "pending"}
-    <!-- Only shows for in-app wallet payments -->
-    <div class="flex flex-col text-2xl items-center">
-      <PanLoader size="md" />
-      <span class="self-center" style="color: var(--color-text-primary)">Sending Payment...</span>
-    </div>
-  {:else if state == "pre"}
+    {#if state == 'pending'}
+      <!-- Only shows for in-app wallet payments -->
+      <div class="flex flex-col text-2xl items-center">
+        <PanLoader size="md" />
+        <span class="self-center mt-4" style="color: var(--color-text-primary)">Sending Zap!</span>
+      </div>
+    {:else if state == 'pre'}
       <div class="flex flex-col gap-3">
         <div class="grid grid-cols-4 gap-2">
           {#each defaultZapSatsAmounts as zapOption}
             <button
-              on:click={() => (amount = zapOption.amount)}
+              on:click={() => handlePresetClick(zapOption.amount)}
               class="flex flex-col items-center justify-center py-3 px-2 rounded-xl transition-all duration-200 cursor-pointer
                 {amount === zapOption.amount
-                  ? 'bg-gradient-to-r from-orange-500 to-amber-500 text-white shadow-md scale-105'
-                  : 'bg-input hover:bg-accent-gray'}"
-              style="{amount !== zapOption.amount ? 'color: var(--color-text-primary)' : ''}"
+                ? 'bg-gradient-to-r from-orange-500 to-amber-500 text-white shadow-md scale-105'
+                : 'bg-input hover:bg-accent-gray'}"
+              style={amount !== zapOption.amount ? 'color: var(--color-text-primary)' : ''}
             >
               <span class="text-xl">{zapOption.emoji}</span>
               <span class="text-sm font-semibold">{zapOption.label}</span>
@@ -265,7 +282,9 @@
           <div class="p-3 bg-input rounded-xl">
             <div class="flex items-center gap-2">
               <span class="text-sm text-caption">Paying with:</span>
-              <span class="font-semibold" style="color: var(--color-text-primary)">{$activeWallet.name}</span>
+              <span class="font-semibold" style="color: var(--color-text-primary)"
+                >{$activeWallet.name}</span
+              >
               <span class="text-xs text-caption">({getWalletKindName($activeWallet.kind)})</span>
             </div>
           </div>
@@ -274,7 +293,9 @@
           <div class="p-3 bg-input rounded-xl">
             <div class="flex items-center gap-2">
               <span class="text-sm text-caption">Payment:</span>
-              <span class="font-semibold" style="color: var(--color-text-primary)">External Wallet</span>
+              <span class="font-semibold" style="color: var(--color-text-primary)"
+                >External Wallet</span
+              >
             </div>
             <p class="text-xs text-caption mt-1">Scan QR code or connect wallet</p>
           </div>
@@ -282,9 +303,25 @@
         <Button class="w-full py-3 text-lg" on:click={submitZap} disabled={isCreatingInvoice}>
           {#if isCreatingInvoice}
             <span class="flex items-center justify-center gap-2">
-              <svg class="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+              <svg
+                class="animate-spin h-5 w-5"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  class="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  stroke-width="4"
+                ></circle>
+                <path
+                  class="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                ></path>
               </svg>
               Creating Invoice...
             </span>
@@ -293,43 +330,49 @@
           {/if}
         </Button>
       </div>
-  {:else if state == "error"}
-    <div class="flex flex-col items-center justify-center">
-      <XIcon color="red" weight="bold" class="w-36 h-36" />
-      <span class="text-2xl ml-4 text-center" style="color: var(--color-text-primary)">An Error Occurred.</span>
-      <span class="text-base text-caption text-center mt-2">{error && error.toString()}</span>
-      <div class="flex gap-2 mt-4">
-        <Button on:click={() => open = false}>Close</Button>
-        <Button on:click={() => {
-          state = "pre";
-          error = null;
-        }}>Try Again</Button>
-      </div>
-    </div>
-  {:else if state == "success"}
-    <!-- Payment Success -->
-    <div class="flex flex-col items-center justify-center">
-      {#if recipientPubkeyForDisplay}
-        <div class="flex gap-3 items-center mb-4">
-          <CustomAvatar className="flex-shrink-0" pubkey={recipientPubkeyForDisplay} size={56} />
-          <div class="flex flex-col gap-1">
-            <span class="font-semibold" style="color: var(--color-text-primary)">
-              <CustomName pubkey={recipientPubkeyForDisplay} />
-            </span>
-          </div>
+    {:else if state == 'error'}
+      <div class="flex flex-col items-center justify-center">
+        <XIcon color="red" weight="bold" class="w-36 h-36" />
+        <span class="text-2xl ml-4 text-center" style="color: var(--color-text-primary)"
+          >An Error Occurred.</span
+        >
+        <span class="text-base text-caption text-center mt-2">{error && error.toString()}</span>
+        <div class="flex gap-2 mt-4">
+          <Button on:click={() => (open = false)}>Close</Button>
+          <Button
+            on:click={() => {
+              state = 'pre';
+              error = null;
+            }}>Try Again</Button
+          >
         </div>
-      {/if}
-      <Checkmark color="#90EE90" weight="fill" class="w-36 h-36" />
-      <span class="text-2xl ml-4 text-center" style="color: var(--color-text-primary)">Payment Sent!</span>
-      <span class="text-lg text-caption text-center mt-2">
-        Your zap of {amount} sats has been sent.
-      </span>
-      <div class="flex gap-2 mt-4">
-        <Button on:click={() => open = false}>Close</Button>
       </div>
-    </div>
-  {/if}
-    </div>
+    {:else if state == 'success'}
+      <!-- Payment Success -->
+      <div class="flex flex-col items-center justify-center">
+        {#if recipientPubkeyForDisplay}
+          <div class="flex gap-3 items-center mb-4">
+            <CustomAvatar className="flex-shrink-0" pubkey={recipientPubkeyForDisplay} size={56} />
+            <div class="flex flex-col gap-1">
+              <span class="font-semibold" style="color: var(--color-text-primary)">
+                <CustomName pubkey={recipientPubkeyForDisplay} />
+              </span>
+            </div>
+          </div>
+        {/if}
+        <Checkmark color="#90EE90" weight="fill" class="w-36 h-36" />
+        <span class="text-2xl ml-4 text-center" style="color: var(--color-text-primary)"
+          >Payment Sent!</span
+        >
+        <span class="text-lg text-caption text-center mt-2">
+          Your zap of {amount} sats has been sent.
+        </span>
+        <div class="flex gap-2 mt-4">
+          <Button on:click={() => (open = false)}>Close</Button>
+        </div>
+      </div>
+    {/if}
+  </div>
 </Modal>
 
 <style>

--- a/src/lib/autoZapSettings.ts
+++ b/src/lib/autoZapSettings.ts
@@ -1,0 +1,175 @@
+/**
+ * One-Tap Zap Settings
+ *
+ * Allows users to send zaps with a single tap on preset amounts,
+ * skipping the zap modal entirely. Only applies to in-app wallets (Spark/NWC).
+ *
+ * The threshold is the user's preferred default zap amount - tapping a preset
+ * at or below this amount sends immediately without showing the modal.
+ *
+ * Bitcoin Connect has its own confirmation modal, so one-tap zaps don't apply.
+ */
+
+import { writable, get } from 'svelte/store';
+import { browser } from '$app/environment';
+
+// Storage keys
+const ONE_TAP_ZAP_ENABLED_KEY = 'zapcooking_one_tap_zap_enabled';
+const ONE_TAP_ZAP_AMOUNT_KEY = 'zapcooking_one_tap_zap_amount';
+
+// Default amount in sats (user's preferred zap amount)
+const DEFAULT_AMOUNT = 21;
+
+// Maximum allowed amount (safety limit)
+export const MAX_ONE_TAP_ZAP_AMOUNT = 10000;
+
+/**
+ * Load one-tap zap enabled state from localStorage
+ */
+function loadEnabled(): boolean {
+  if (!browser) return false;
+  try {
+    // Check new key first, then fall back to old key for migration
+    const stored =
+      localStorage.getItem(ONE_TAP_ZAP_ENABLED_KEY) ??
+      localStorage.getItem('zapcooking_auto_zap_enabled');
+    return stored === 'true';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Load one-tap zap amount from localStorage
+ */
+function loadAmount(): number {
+  if (!browser) return DEFAULT_AMOUNT;
+  try {
+    // Check new key first, then fall back to old key for migration
+    const stored =
+      localStorage.getItem(ONE_TAP_ZAP_AMOUNT_KEY) ??
+      localStorage.getItem('zapcooking_auto_zap_threshold');
+    if (stored) {
+      const parsed = parseInt(stored, 10);
+      if (!isNaN(parsed) && parsed > 0 && parsed <= MAX_ONE_TAP_ZAP_AMOUNT) {
+        return parsed;
+      }
+    }
+    return DEFAULT_AMOUNT;
+  } catch {
+    return DEFAULT_AMOUNT;
+  }
+}
+
+/**
+ * Save one-tap zap enabled state to localStorage
+ */
+function saveEnabled(enabled: boolean): void {
+  if (!browser) return;
+  try {
+    localStorage.setItem(ONE_TAP_ZAP_ENABLED_KEY, String(enabled));
+    // Clean up old key if it exists
+    localStorage.removeItem('zapcooking_auto_zap_enabled');
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+/**
+ * Save one-tap zap amount to localStorage
+ */
+function saveAmount(amount: number): void {
+  if (!browser) return;
+  try {
+    localStorage.setItem(ONE_TAP_ZAP_AMOUNT_KEY, String(amount));
+    // Clean up old key if it exists
+    localStorage.removeItem('zapcooking_auto_zap_threshold');
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+// --- Stores ---
+
+/** Whether one-tap zap is enabled */
+export const oneTapZapEnabled = writable<boolean>(false);
+
+/** One-tap zap amount in sats - user's preferred default zap amount */
+export const oneTapZapAmount = writable<number>(DEFAULT_AMOUNT);
+
+// Legacy exports for compatibility during transition
+export const autoZapEnabled = oneTapZapEnabled;
+export const autoZapThreshold = oneTapZapAmount;
+export const MAX_AUTO_ZAP_THRESHOLD = MAX_ONE_TAP_ZAP_AMOUNT;
+
+// Track if we've loaded from storage
+let hasLoaded = false;
+
+// Load from localStorage on client
+if (browser) {
+  setTimeout(() => {
+    hasLoaded = true;
+    oneTapZapEnabled.set(loadEnabled());
+    oneTapZapAmount.set(loadAmount());
+  }, 0);
+}
+
+// Persist changes
+oneTapZapEnabled.subscribe((enabled) => {
+  if (browser && hasLoaded) {
+    saveEnabled(enabled);
+  }
+});
+
+oneTapZapAmount.subscribe((amount) => {
+  if (browser && hasLoaded) {
+    saveAmount(amount);
+  }
+});
+
+// --- Functions ---
+
+/**
+ * Set one-tap zap enabled state
+ */
+export function setOneTapZapEnabled(enabled: boolean): void {
+  oneTapZapEnabled.set(enabled);
+}
+
+/**
+ * Set one-tap zap amount (capped at MAX_ONE_TAP_ZAP_AMOUNT)
+ */
+export function setOneTapZapAmount(sats: number): void {
+  const capped = Math.min(Math.max(1, sats), MAX_ONE_TAP_ZAP_AMOUNT);
+  oneTapZapAmount.set(capped);
+}
+
+/**
+ * Check if a given amount qualifies for one-tap zap
+ * @param amount Amount in sats
+ * @returns true if one-tap zap is enabled and amount is within the user's preferred amount
+ */
+export function isOneTapZapAmount(amount: number): boolean {
+  return get(oneTapZapEnabled) && amount <= get(oneTapZapAmount);
+}
+
+/**
+ * Get current one-tap zap enabled state
+ */
+export function getOneTapZapEnabled(): boolean {
+  return get(oneTapZapEnabled);
+}
+
+/**
+ * Get current one-tap zap amount
+ */
+export function getOneTapZapAmount(): number {
+  return get(oneTapZapAmount);
+}
+
+// Legacy function exports for compatibility
+export const setAutoZapEnabled = setOneTapZapEnabled;
+export const setAutoZapThreshold = setOneTapZapAmount;
+export const isAutoZapAmount = isOneTapZapAmount;
+export const getAutoZapEnabled = getOneTapZapEnabled;
+export const getAutoZapThreshold = getOneTapZapAmount;

--- a/src/lib/oneTapZap.ts
+++ b/src/lib/oneTapZap.ts
@@ -1,0 +1,126 @@
+/**
+ * One-Tap Zap Service
+ *
+ * Provides functionality to send zaps instantly without opening the ZapModal.
+ * Used when one-tap zaps are enabled and user has an in-app wallet.
+ */
+
+import { get } from 'svelte/store';
+import { browser } from '$app/environment';
+import { NDKEvent, NDKUser } from '@nostr-dev-kit/ndk';
+import { ndk } from '$lib/nostr';
+import { ZapManager } from '$lib/zapManager';
+import { activeWallet } from '$lib/wallet';
+import { sendPayment } from '$lib/wallet/walletManager';
+import { oneTapZapEnabled, oneTapZapAmount } from '$lib/autoZapSettings';
+
+/**
+ * Check if one-tap zap is available (enabled + has in-app wallet)
+ */
+export function canOneTapZap(): boolean {
+  if (!browser) return false;
+
+  const wallet = get(activeWallet);
+  const enabled = get(oneTapZapEnabled);
+
+  // Must have one-tap enabled and an in-app wallet (Spark kind=4 or NWC kind=3)
+  return enabled && wallet !== null && (wallet.kind === 3 || wallet.kind === 4);
+}
+
+/**
+ * Get the one-tap zap amount
+ */
+export function getOneTapAmount(): number {
+  return get(oneTapZapAmount);
+}
+
+export interface OneTapZapResult {
+  success: boolean;
+  amount?: number;
+  error?: string;
+}
+
+/**
+ * Send a one-tap zap to an event or user
+ *
+ * @param target - NDKEvent or NDKUser to zap
+ * @returns Result with success status and amount or error
+ */
+export async function sendOneTapZap(target: NDKEvent | NDKUser): Promise<OneTapZapResult> {
+  console.log('[OneTapZap] sendOneTapZap called with target:', target);
+
+  if (!browser) {
+    console.log('[OneTapZap] Not in browser');
+    return { success: false, error: 'Not in browser' };
+  }
+
+  if (!canOneTapZap()) {
+    console.log('[OneTapZap] canOneTapZap returned false');
+    return { success: false, error: 'One-tap zap not available' };
+  }
+
+  const ndkInstance = get(ndk);
+  if (!ndkInstance) {
+    console.log('[OneTapZap] NDK not initialized');
+    return { success: false, error: 'NDK not initialized' };
+  }
+
+  const wallet = get(activeWallet);
+  if (!wallet) {
+    console.log('[OneTapZap] No wallet connected');
+    return { success: false, error: 'No wallet connected' };
+  }
+
+  const amount = get(oneTapZapAmount);
+  console.log('[OneTapZap] Amount:', amount, 'sats, Wallet kind:', wallet.kind);
+
+  try {
+    const zapManager = new ZapManager(ndkInstance);
+
+    // Determine recipient pubkey and event ID
+    let recipientPubkey: string;
+    let eventId: string | undefined;
+
+    if (target instanceof NDKUser) {
+      recipientPubkey = target.pubkey;
+      eventId = undefined;
+      console.log('[OneTapZap] Target is NDKUser, pubkey:', recipientPubkey);
+    } else if (target && target.author) {
+      recipientPubkey = target.author?.hexpubkey || target.pubkey;
+      eventId = target.id;
+      console.log('[OneTapZap] Target is NDKEvent, pubkey:', recipientPubkey, 'eventId:', eventId);
+    } else {
+      console.log('[OneTapZap] Invalid target');
+      return { success: false, error: 'Invalid target for zap' };
+    }
+
+    // Create the zap invoice
+    console.log('[OneTapZap] Creating zap invoice...');
+    const zapResult = await zapManager.createZap(
+      recipientPubkey,
+      amount * 1000, // Convert to millisats
+      '', // No message for one-tap zaps
+      eventId
+    );
+    console.log('[OneTapZap] Zap invoice created:', zapResult.invoice?.substring(0, 50) + '...');
+
+    // Send the payment
+    console.log('[OneTapZap] Sending payment...');
+    const paymentResult = await sendPayment(zapResult.invoice, {
+      amount,
+      description: `Zap to ${recipientPubkey.substring(0, 8)}...`,
+      pubkey: recipientPubkey
+    });
+    console.log('[OneTapZap] Payment result:', paymentResult);
+
+    if (!paymentResult.success) {
+      return { success: false, error: paymentResult.error || 'Payment failed' };
+    }
+
+    return { success: true, amount };
+  } catch (e) {
+    const errorMessage = e instanceof Error ? e.message : 'Unknown error';
+    console.error('[OneTapZap] Failed:', errorMessage, e);
+    return { success: false, error: errorMessage };
+  }
+}

--- a/src/lib/wallet/bitcoinConnect.ts
+++ b/src/lib/wallet/bitcoinConnect.ts
@@ -1,94 +1,230 @@
 /**
  * Bitcoin Connect External Wallet State
  *
- * Simple enabled/disabled state for external wallet connections.
+ * Manages Bitcoin Connect wallet connections including:
+ * - Enabled/disabled state
+ * - Connected wallet info (alias, pubkey)
+ * - Balance fetching (when supported by wallet)
+ *
  * When enabled and no embedded wallet is active, payments use Bitcoin Connect modal.
  * The actual connection happens via lightningService.ts when paying.
  */
 
-import { writable, get } from 'svelte/store'
-import { browser } from '$app/environment'
+import { writable, get } from 'svelte/store';
+import { browser } from '$app/environment';
 
-const STORAGE_KEY = 'zapcooking_bitcoin_connect_enabled'
+const STORAGE_KEY = 'zapcooking_bitcoin_connect_enabled';
+
+// WebLN provider types
+interface WebLNProvider {
+  enable(): Promise<void>;
+  getInfo?(): Promise<{ node?: { alias?: string; pubkey?: string } }>;
+  getBalance?(): Promise<{ balance: number; currency?: string }>;
+  sendPayment(paymentRequest: string): Promise<{ preimage: string }>;
+}
+
+// Wallet info type
+export interface BitcoinConnectWalletInfo {
+  alias?: string;
+  pubkey?: string;
+  connected: boolean;
+}
 
 /**
  * Load enabled state from localStorage
  */
 function loadEnabled(): boolean {
-	if (!browser) return false
-	try {
-		const stored = localStorage.getItem(STORAGE_KEY)
-		return stored === 'true'
-	} catch {
-		return false
-	}
+  if (!browser) return false;
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored === 'true';
+  } catch {
+    return false;
+  }
 }
 
 /**
  * Save enabled state to localStorage
  */
 function saveEnabled(enabled: boolean): void {
-	if (!browser) return
-	try {
-		localStorage.setItem(STORAGE_KEY, String(enabled))
-	} catch {
-		// Ignore storage errors
-	}
+  if (!browser) return;
+  try {
+    localStorage.setItem(STORAGE_KEY, String(enabled));
+  } catch {
+    // Ignore storage errors
+  }
 }
 
-// --- Store ---
+// --- Stores ---
 
-export const bitcoinConnectEnabled = writable<boolean>(false)
+/** Whether Bitcoin Connect is enabled as the external wallet option */
+export const bitcoinConnectEnabled = writable<boolean>(false);
+
+/** Info about the connected Bitcoin Connect wallet */
+export const bitcoinConnectWalletInfo = writable<BitcoinConnectWalletInfo>({
+  connected: false
+});
+
+/** Balance from Bitcoin Connect wallet (null if unavailable or not connected) */
+export const bitcoinConnectBalance = writable<number | null>(null);
+
+/** Whether balance is currently being fetched */
+export const bitcoinConnectBalanceLoading = writable<boolean>(false);
 
 // Track if we've loaded from storage
-let hasLoaded = false
+let hasLoaded = false;
+
+// Reference to the WebLN provider when connected
+let bcProvider: WebLNProvider | null = null;
 
 // Load from localStorage on client
 if (browser) {
-	setTimeout(() => {
-		hasLoaded = true
-		bitcoinConnectEnabled.set(loadEnabled())
-	}, 0)
+  setTimeout(() => {
+    hasLoaded = true;
+    bitcoinConnectEnabled.set(loadEnabled());
+  }, 0);
 }
 
 // Persist changes
 bitcoinConnectEnabled.subscribe((enabled) => {
-	if (browser && hasLoaded) {
-		saveEnabled(enabled)
-	}
-})
+  if (browser && hasLoaded) {
+    saveEnabled(enabled);
+  }
+});
 
 // --- Functions ---
+
+/**
+ * Set the WebLN provider reference (called from lightningService when connected)
+ */
+export function setBitcoinConnectProvider(provider: WebLNProvider | null): void {
+  bcProvider = provider;
+  if (provider) {
+    bitcoinConnectWalletInfo.update((info) => ({ ...info, connected: true }));
+    // Fetch info and balance when provider is set
+    fetchBitcoinConnectInfo();
+    fetchBitcoinConnectBalance();
+  } else {
+    bitcoinConnectWalletInfo.set({ connected: false });
+    bitcoinConnectBalance.set(null);
+  }
+}
+
+/**
+ * Get the current WebLN provider
+ */
+export function getBitcoinConnectProvider(): WebLNProvider | null {
+  return bcProvider;
+}
+
+/**
+ * Fetch wallet info from the connected Bitcoin Connect wallet
+ */
+export async function fetchBitcoinConnectInfo(): Promise<void> {
+  if (!bcProvider) return;
+
+  try {
+    if (typeof bcProvider.getInfo === 'function') {
+      const info = await bcProvider.getInfo();
+      bitcoinConnectWalletInfo.set({
+        alias: info.node?.alias,
+        pubkey: info.node?.pubkey,
+        connected: true
+      });
+    }
+  } catch (e) {
+    console.warn('[BitcoinConnect] Failed to fetch wallet info:', e);
+    // Keep connected state, just don't update info
+  }
+}
+
+/**
+ * Fetch balance from the connected Bitcoin Connect wallet
+ * Returns null if wallet doesn't support getBalance or if fetch fails
+ */
+export async function fetchBitcoinConnectBalance(): Promise<number | null> {
+  if (!bcProvider) {
+    bitcoinConnectBalance.set(null);
+    return null;
+  }
+
+  bitcoinConnectBalanceLoading.set(true);
+
+  try {
+    if (typeof bcProvider.getBalance === 'function') {
+      const response = await bcProvider.getBalance();
+      const balance = response.balance;
+      bitcoinConnectBalance.set(balance);
+      return balance;
+    }
+    // Wallet doesn't support getBalance
+    bitcoinConnectBalance.set(null);
+    return null;
+  } catch (e) {
+    console.warn('[BitcoinConnect] Failed to fetch balance:', e);
+    bitcoinConnectBalance.set(null);
+    return null;
+  } finally {
+    bitcoinConnectBalanceLoading.set(false);
+  }
+}
+
+/**
+ * Refresh Bitcoin Connect balance
+ */
+export async function refreshBitcoinConnectBalance(): Promise<void> {
+  await fetchBitcoinConnectBalance();
+}
 
 /**
  * Enable Bitcoin Connect as external wallet
  */
 export function enableBitcoinConnect(): void {
-	bitcoinConnectEnabled.set(true)
+  bitcoinConnectEnabled.set(true);
 }
 
 /**
- * Disable Bitcoin Connect
+ * Disable Bitcoin Connect and clear all state
  */
 export function disableBitcoinConnect(): void {
-	bitcoinConnectEnabled.set(false)
-	// Also disconnect any active BC session
-	if (browser) {
-		import('@getalby/bitcoin-connect').then(({ disconnect }) => {
-			try {
-				disconnect()
-			} catch {
-				// Ignore disconnect errors
-			}
-		}).catch(() => {
-			// Ignore import errors
-		})
-	}
+  bitcoinConnectEnabled.set(false);
+  bcProvider = null;
+  bitcoinConnectWalletInfo.set({ connected: false });
+  bitcoinConnectBalance.set(null);
+
+  // Also disconnect any active BC session
+  if (browser) {
+    import('@getalby/bitcoin-connect')
+      .then(({ disconnect }) => {
+        try {
+          disconnect();
+        } catch {
+          // Ignore disconnect errors
+        }
+      })
+      .catch(() => {
+        // Ignore import errors
+      });
+  }
 }
 
 /**
  * Check if Bitcoin Connect is enabled
  */
 export function isBitcoinConnectEnabled(): boolean {
-	return get(bitcoinConnectEnabled)
+  return get(bitcoinConnectEnabled);
+}
+
+/**
+ * Check if Bitcoin Connect wallet is currently connected
+ */
+export function isBitcoinConnectConnected(): boolean {
+  return get(bitcoinConnectWalletInfo).connected;
+}
+
+/**
+ * Get current Bitcoin Connect balance
+ */
+export function getBitcoinConnectBalance(): number | null {
+  return get(bitcoinConnectBalance);
 }

--- a/src/routes/wallet/+page.svelte
+++ b/src/routes/wallet/+page.svelte
@@ -113,9 +113,14 @@
   import CheckRelayBackupsModal from '../../components/CheckRelayBackupsModal.svelte';
   import {
     bitcoinConnectEnabled,
+    bitcoinConnectWalletInfo,
+    bitcoinConnectBalance,
+    bitcoinConnectBalanceLoading,
     enableBitcoinConnect,
-    disableBitcoinConnect
+    disableBitcoinConnect,
+    refreshBitcoinConnectBalance
   } from '$lib/wallet/bitcoinConnect';
+
   import {
     weblnConnected,
     weblnWalletName,
@@ -1913,16 +1918,62 @@
               <BitcoinConnectLogo size={32} className="text-white" />
             </div>
             <p class="font-medium mb-1" style="color: var(--color-text-primary)">
-              External wallet connected
+              {$bitcoinConnectWalletInfo.alias || 'External wallet connected'}
             </p>
+
+            <!-- Balance display -->
+            {#if $bitcoinConnectBalanceLoading}
+              <p
+                class="text-2xl font-bold mb-1 animate-pulse"
+                style="color: var(--color-text-primary)"
+              >
+                ...
+              </p>
+            {:else if $bitcoinConnectBalance !== null}
+              <p class="text-2xl font-bold mb-1" style="color: var(--color-text-primary)">
+                {#if $balanceVisible}
+                  {$bitcoinConnectBalance.toLocaleString()}
+                  <span class="text-sm font-normal text-caption">sats</span>
+                {:else}
+                  *** <span class="text-sm font-normal text-caption">sats</span>
+                {/if}
+              </p>
+            {:else}
+              <p class="text-sm text-caption mb-1">Balance unavailable</p>
+            {/if}
+
             <p class="text-sm text-caption mb-4">Payments will use Bitcoin Connect</p>
-            <button
-              class="px-5 py-2.5 rounded-full font-semibold text-sm text-caption hover:text-red-500 transition-colors cursor-pointer"
-              style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
-              on:click={() => (showRemoveBitcoinConnectModal = true)}
-            >
-              Remove External Wallet
-            </button>
+
+            <!-- Wallet info -->
+            {#if $bitcoinConnectWalletInfo.pubkey}
+              <p class="text-xs text-caption mb-3 font-mono">
+                {$bitcoinConnectWalletInfo.pubkey.slice(
+                  0,
+                  8
+                )}...{$bitcoinConnectWalletInfo.pubkey.slice(-8)}
+              </p>
+            {/if}
+
+            <div class="flex gap-2">
+              <button
+                class="px-4 py-2 rounded-full font-semibold text-sm transition-colors cursor-pointer"
+                style="background-color: var(--color-bg-primary); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+                on:click={refreshBitcoinConnectBalance}
+                disabled={$bitcoinConnectBalanceLoading}
+              >
+                <span class:animate-spin={$bitcoinConnectBalanceLoading}>
+                  <ArrowsClockwiseIcon size={16} class="inline" />
+                </span>
+                Refresh
+              </button>
+              <button
+                class="px-4 py-2 rounded-full font-semibold text-sm text-caption hover:text-red-500 transition-colors cursor-pointer"
+                style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+                on:click={() => (showRemoveBitcoinConnectModal = true)}
+              >
+                Disconnect
+              </button>
+            </div>
           {:else}
             <WalletIcon size={48} class="mb-4 text-caption" />
             <p class="text-caption mb-4">No wallets connected yet</p>


### PR DESCRIPTION
### Features

**Bitcoin Connect Balance Display**
- Shows wallet balance in header mini-wallet when using Bitcoin Connect
- Displays wallet alias, balance, and node pubkey on wallet page
- Graceful fallback when wallet doesn't support `getBalance()` or `getInfo()`

**One-Tap Zaps**
- New feature for in-app wallets (Spark/NWC) to zap instantly without opening the modal
- Configurable in Settings > Zap Settings
- Default amount: 21 sats (max 10,000 sats)
- Setting is disabled/greyed out when no in-app wallet connected
- Works on recipes, community feed, and user profiles

**UX Improvements**
- Orange spinning lightning bolt while zap is processing
- "+X sats" success animation after zap completes
- TopZappers list auto-refreshes after zapping
- Wait cursor during zap instead of not-allowed cursor

**Other Changes**
- Premium recipe price now shows sats instead of mSats
- Premium recipe unlock temporarily disabled (backend issue - see TODO in code)

### Files Changed
- `src/lib/autoZapSettings.ts` - New: one-tap zap settings store
- `src/lib/oneTapZap.ts` - New: one-tap zap service
- `src/lib/wallet/bitcoinConnect.ts` - Balance/info stores and fetch functions
- `src/lib/lightningService.ts` - Enable showBalance, capture WebLN provider
- `src/components/WalletBalance.svelte` - BC balance display
- `src/components/ZapButton.svelte` - One-tap zap support
- `src/components/ZapModal.svelte` - UI tweaks
- `src/components/NoteTotalZaps.svelte` - One-tap zap support
- `src/components/Recipe/Recipe.svelte` - One-tap zap with loading/success states
- `src/components/Recipe/TopZappers.svelte` - Refresh support
- `src/components/GatedRecipePayment.svelte` - Sats display, coming soon message
- `src/routes/settings/+page.svelte` - Zap Settings section
- `src/routes/wallet/+page.svelte` - BC wallet info display
- `src/routes/user/[slug]/+page.svelte` - One-tap zap support