### PR TITLE
ui: Add wallet widget toggle and confirmations

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -13,6 +13,9 @@
   import WalletBalance from './WalletBalance.svelte';
   import UserSidePanel from './UserSidePanel.svelte';
   import { timerStore } from '$lib/timerStore';
+  import { navBalanceVisible, walletConnected } from '$lib/wallet';
+  import { weblnConnected } from '$lib/wallet/webln';
+  import { bitcoinConnectEnabled, bitcoinConnectWalletInfo } from '$lib/wallet/bitcoinConnect';
   import { timerWidgetOpen } from '$lib/stores/timerWidget';
   import TimerWidget from './TimerWidget.svelte';
   import CreateMenuButton from './CreateMenuButton.svelte';
@@ -51,6 +54,10 @@
   // Reactive resolved theme for logo switching
   $: resolvedTheme = $theme === 'system' ? theme.getResolvedTheme() : $theme;
   $: isDarkMode = resolvedTheme === 'dark';
+  $: hasNavWallet =
+    $walletConnected ||
+    $weblnConnected ||
+    ($bitcoinConnectEnabled && $bitcoinConnectWalletInfo.connected);
 
   function toggleTimerWidget() {
     timerWidgetOpen.update((open) => !open);
@@ -141,7 +148,7 @@
     <CreateMenuButton variant="header" />
 
     <!-- Wallet Balance - only show when logged in and wallet connected -->
-    {#if $userPublickey}
+    {#if $userPublickey && $navBalanceVisible && hasNavWallet}
       <div class="hidden sm:block">
         <WalletBalance />
       </div>

--- a/src/components/WalletBalance.svelte
+++ b/src/components/WalletBalance.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
+  import { browser } from '$app/environment';
   import { clickOutside } from '$lib/clickOutside';
   import { fade } from 'svelte/transition';
+  import { portal } from './Modal.svelte';
+  import Button from './Button.svelte';
   import {
     wallets,
     activeWallet,
@@ -44,6 +47,10 @@
   import BitcoinConnectLogo from './icons/BitcoinConnectLogo.svelte';
 
   let dropdownActive = false;
+  let showRemoveBitcoinConnectModal = false;
+  let portalTarget: HTMLElement | null = null;
+
+  $: portalTarget = browser ? document.body : null;
 
   // WebLN balance state
   let weblnBalance: number | null = null;
@@ -105,6 +112,11 @@
   function handleDisconnectBitcoinConnect() {
     disableBitcoinConnect();
     dropdownActive = false;
+  }
+
+  function confirmRemoveBitcoinConnect() {
+    dropdownActive = false;
+    showRemoveBitcoinConnectModal = true;
   }
 </script>
 
@@ -323,7 +335,7 @@
 
           <button
             class="flex items-center gap-2 text-sm text-red-500 hover:text-red-600 transition-colors cursor-pointer"
-            on:click={handleDisconnectBitcoinConnect}
+            on:click={confirmRemoveBitcoinConnect}
           >
             <SignOutIcon size={16} />
             Disconnect
@@ -445,5 +457,41 @@
         </div>
       </div>
     {/if}
+  </div>
+{/if}
+
+{#if showRemoveBitcoinConnectModal && portalTarget}
+  <div use:portal={portalTarget}>
+    <div
+      class="fixed inset-0 bg-black/50 flex z-50 p-4"
+      style="display: flex; align-items: center; justify-content: center;"
+    >
+      <div
+        class="rounded-2xl p-6 max-w-sm w-full max-h-[90vh] overflow-y-auto"
+        style="background-color: var(--color-bg-primary);"
+      >
+        <h2 class="text-xl font-bold mb-2" style="color: var(--color-text-primary)">
+          Remove External Wallet
+        </h2>
+        <p class="text-caption mb-6">
+          Are you sure you want to disconnect your external wallet? You can reconnect it at any time
+          from the wallet settings.
+        </p>
+        <div class="flex gap-3">
+          <Button on:click={() => (showRemoveBitcoinConnectModal = false)} class="flex-1">
+            Cancel
+          </Button>
+          <button
+            class="flex-1 px-4 py-2 rounded-full bg-red-500 hover:bg-red-600 text-white font-medium transition-colors cursor-pointer"
+            on:click={() => {
+              handleDisconnectBitcoinConnect();
+              showRemoveBitcoinConnectModal = false;
+            }}
+          >
+            Remove
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 {/if}

--- a/src/lib/wallet/index.ts
+++ b/src/lib/wallet/index.ts
@@ -9,56 +9,58 @@
 
 // Export stores
 export {
-	type Wallet,
-	type WalletKind,
-	wallets,
-	activeWallet,
-	walletBalance,
-	walletConnected,
-	walletLoading,
-	walletLastSync,
-	balanceVisible,
-	getWalletKindName,
-	setActiveWallet,
-	addWallet,
-	removeWallet,
-	clearAllWallets,
-	getActiveWallet,
-	hasWalletKind,
-	toggleBalanceVisibility
-} from './walletStore'
+  type Wallet,
+  type WalletKind,
+  wallets,
+  activeWallet,
+  walletBalance,
+  walletConnected,
+  walletLoading,
+  walletLastSync,
+  balanceVisible,
+  navBalanceVisible,
+  getWalletKindName,
+  setActiveWallet,
+  addWallet,
+  removeWallet,
+  clearAllWallets,
+  getActiveWallet,
+  hasWalletKind,
+  toggleBalanceVisibility,
+  setNavBalanceVisible
+} from './walletStore';
 
 // Export manager functions
 export {
-	connectWallet,
-	disconnectWallet,
-	refreshBalance,
-	sendPayment,
-	createInvoice,
-	isWalletReady,
-	getLightningAddress,
-	getPaymentHistory,
-	initializeWalletManager,
-	isWeblnAvailable,
-	isValidNwcUrl,
-	pendingTransactions,
-	addPendingTransaction,
-	removePendingTransaction,
-	updatePendingTransactionStatus,
-	clearPendingTransactions,
-	ensurePendingTransactionsLoaded,
-	transactionsNeedRefresh,
-	signalTransactionsRefresh,
-	type Transaction
-} from './walletManager'
+  connectWallet,
+  disconnectWallet,
+  refreshBalance,
+  sendPayment,
+  createInvoice,
+  isWalletReady,
+  getLightningAddress,
+  getPaymentHistory,
+  initializeWalletManager,
+  isWeblnAvailable,
+  isValidNwcUrl,
+  pendingTransactions,
+  addPendingTransaction,
+  removePendingTransaction,
+  updatePendingTransactionStatus,
+  clearPendingTransactions,
+  ensurePendingTransactionsLoaded,
+  transactionsNeedRefresh,
+  signalTransactionsRefresh,
+  type Transaction
+} from './walletManager';
 
 // Export NWC functions that may be needed directly
-export { getNwcInfo } from './nwc'
+export { getNwcInfo } from './nwc';
 
 // Export Bitcoin Connect external wallet state
 export {
-	bitcoinConnectEnabled,
-	enableBitcoinConnect,
-	disableBitcoinConnect,
-	isBitcoinConnectEnabled
-} from './bitcoinConnect'
+  bitcoinConnectEnabled,
+  enableBitcoinConnect,
+  disableBitcoinConnect,
+  isBitcoinConnectEnabled
+} from './bitcoinConnect';

--- a/src/lib/wallet/walletStore.ts
+++ b/src/lib/wallet/walletStore.ts
@@ -1,173 +1,200 @@
-import { writable, derived, get } from 'svelte/store'
-import { browser } from '$app/environment'
+import { writable, derived, get } from 'svelte/store';
+import { browser } from '$app/environment';
 
 // Wallet types using kind system (matching sparkihonne)
-export type WalletKind = 1 | 3 | 4 // 1=WebLN, 3=NWC, 4=Spark
+export type WalletKind = 1 | 3 | 4; // 1=WebLN, 3=NWC, 4=Spark
 
 export interface Wallet {
-	id: number
-	kind: WalletKind
-	name: string
-	active: boolean
-	data: string // NWC connection string, 'webln', or 'spark'
+  id: number;
+  kind: WalletKind;
+  name: string;
+  active: boolean;
+  data: string; // NWC connection string, 'webln', or 'spark'
 }
 
-const STORAGE_KEY = 'zapcooking_wallets'
+const STORAGE_KEY = 'zapcooking_wallets';
 
 // Load wallets from localStorage
 function loadWallets(): Wallet[] {
-	if (!browser) return []
-	try {
-		const stored = localStorage.getItem(STORAGE_KEY)
-		if (stored) {
-			return JSON.parse(stored)
-		}
-	} catch (e) {
-		console.error('[WalletStore] Failed to load wallets:', e)
-	}
-	return []
+  if (!browser) return [];
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      return JSON.parse(stored);
+    }
+  } catch (e) {
+    console.error('[WalletStore] Failed to load wallets:', e);
+  }
+  return [];
 }
 
 // Save wallets to localStorage
 function saveWallets(wallets: Wallet[]): void {
-	if (!browser) return
-	try {
-		localStorage.setItem(STORAGE_KEY, JSON.stringify(wallets))
-	} catch (e) {
-		console.error('[WalletStore] Failed to save wallets:', e)
-	}
+  if (!browser) return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(wallets));
+  } catch (e) {
+    console.error('[WalletStore] Failed to save wallets:', e);
+  }
 }
 
 // --- Stores ---
 
 // All connected wallets - initialize empty to match SSR, load on client
-export const wallets = writable<Wallet[]>([])
+export const wallets = writable<Wallet[]>([]);
 
 // Track if we've loaded from storage (to avoid clearing on initial SSR)
-let hasLoadedFromStorage = false
+let hasLoadedFromStorage = false;
 
 // Load wallets from localStorage on client (after hydration)
 if (browser) {
-	// Use setTimeout to defer loading until after hydration
-	setTimeout(() => {
-		const saved = loadWallets()
-		hasLoadedFromStorage = true
-		if (saved.length > 0) {
-			wallets.set(saved)
-		}
-	}, 0)
+  // Use setTimeout to defer loading until after hydration
+  setTimeout(() => {
+    const saved = loadWallets();
+    hasLoadedFromStorage = true;
+    if (saved.length > 0) {
+      wallets.set(saved);
+    }
+  }, 0);
 }
 
 // Subscribe to persist changes
 wallets.subscribe((value) => {
-	if (browser && hasLoadedFromStorage) {
-		saveWallets(value)
-	}
-})
+  if (browser && hasLoadedFromStorage) {
+    saveWallets(value);
+  }
+});
 
 // Currently active wallet
-export const activeWallet = derived(wallets, ($wallets) => $wallets.find((w) => w.active) || null)
+export const activeWallet = derived(wallets, ($wallets) => $wallets.find((w) => w.active) || null);
 
 // Cached balance storage key
-const CACHED_BALANCE_KEY = 'zapcooking_cached_balance'
+const CACHED_BALANCE_KEY = 'zapcooking_cached_balance';
 
 function getCachedBalance(walletId: number): number | null {
-	if (!browser) return null
-	try {
-		const stored = localStorage.getItem(`${CACHED_BALANCE_KEY}_${walletId}`)
-		if (stored) {
-			return parseInt(stored, 10)
-		}
-	} catch {
-		// Ignore storage errors
-	}
-	return null
+  if (!browser) return null;
+  try {
+    const stored = localStorage.getItem(`${CACHED_BALANCE_KEY}_${walletId}`);
+    if (stored) {
+      return parseInt(stored, 10);
+    }
+  } catch {
+    // Ignore storage errors
+  }
+  return null;
 }
 
 function setCachedBalance(walletId: number, balance: number): void {
-	if (!browser) return
-	try {
-		localStorage.setItem(`${CACHED_BALANCE_KEY}_${walletId}`, String(balance))
-	} catch {
-		// Ignore storage errors
-	}
+  if (!browser) return;
+  try {
+    localStorage.setItem(`${CACHED_BALANCE_KEY}_${walletId}`, String(balance));
+  } catch {
+    // Ignore storage errors
+  }
 }
 
 // Wallet balance in sats (updated by wallet manager)
-export const walletBalance = writable<number | null>(null)
+export const walletBalance = writable<number | null>(null);
 
 // Load cached balance for active wallet on startup
 if (browser) {
-	setTimeout(() => {
-		const saved = loadWallets()
-		const active = saved.find((w) => w.active)
-		if (active) {
-			const cached = getCachedBalance(active.id)
-			if (cached !== null) {
-				walletBalance.set(cached)
-			}
-		}
-	}, 0)
+  setTimeout(() => {
+    const saved = loadWallets();
+    const active = saved.find((w) => w.active);
+    if (active) {
+      const cached = getCachedBalance(active.id);
+      if (cached !== null) {
+        walletBalance.set(cached);
+      }
+    }
+  }, 0);
 }
 
 // Cache balance when it changes
 walletBalance.subscribe((balance) => {
-	if (browser && balance !== null) {
-		const saved = loadWallets()
-		const active = saved.find((w) => w.active)
-		if (active) {
-			setCachedBalance(active.id, balance)
-		}
-	}
-})
+  if (browser && balance !== null) {
+    const saved = loadWallets();
+    const active = saved.find((w) => w.active);
+    if (active) {
+      setCachedBalance(active.id, balance);
+    }
+  }
+});
 
 // Whether any wallet is connected and ready
-export const walletConnected = derived(activeWallet, ($active) => $active !== null)
+export const walletConnected = derived(activeWallet, ($active) => $active !== null);
 
 // Loading state for balance fetching
-export const walletLoading = writable<boolean>(false)
+export const walletLoading = writable<boolean>(false);
 
 // Last sync timestamp
-export const walletLastSync = writable<number | null>(null)
+export const walletLastSync = writable<number | null>(null);
 
 // Balance visibility (privacy feature)
-const BALANCE_VISIBLE_KEY = 'zapcooking_balance_visible'
+const BALANCE_VISIBLE_KEY = 'zapcooking_balance_visible';
+const NAV_BALANCE_VISIBLE_KEY = 'zapcooking_nav_balance_visible';
 
 function loadBalanceVisibility(): boolean {
-	if (!browser) return true
-	try {
-		const stored = localStorage.getItem(BALANCE_VISIBLE_KEY)
-		return stored !== 'false' // Default to visible
-	} catch {
-		return true
-	}
+  if (!browser) return true;
+  try {
+    const stored = localStorage.getItem(BALANCE_VISIBLE_KEY);
+    return stored !== 'false'; // Default to visible
+  } catch {
+    return true;
+  }
 }
 
-export const balanceVisible = writable<boolean>(true)
+function loadNavBalanceVisibility(): boolean {
+  if (!browser) return true;
+  try {
+    const stored = localStorage.getItem(NAV_BALANCE_VISIBLE_KEY);
+    return stored !== 'false'; // Default to visible
+  } catch {
+    return true;
+  }
+}
+
+export const balanceVisible = writable<boolean>(true);
+export const navBalanceVisible = writable<boolean>(true);
 
 // Initialize on client
 if (browser) {
-	setTimeout(() => {
-		balanceVisible.set(loadBalanceVisibility())
-	}, 0)
+  setTimeout(() => {
+    balanceVisible.set(loadBalanceVisibility());
+    navBalanceVisible.set(loadNavBalanceVisibility());
+  }, 0);
 }
 
 // Persist changes
 balanceVisible.subscribe((visible) => {
-	if (browser) {
-		try {
-			localStorage.setItem(BALANCE_VISIBLE_KEY, String(visible))
-		} catch {
-			// Ignore storage errors
-		}
-	}
-})
+  if (browser) {
+    try {
+      localStorage.setItem(BALANCE_VISIBLE_KEY, String(visible));
+    } catch {
+      // Ignore storage errors
+    }
+  }
+});
+
+navBalanceVisible.subscribe((visible) => {
+  if (browser) {
+    try {
+      localStorage.setItem(NAV_BALANCE_VISIBLE_KEY, String(visible));
+    } catch {
+      // Ignore storage errors
+    }
+  }
+});
 
 /**
  * Toggle balance visibility
  */
 export function toggleBalanceVisibility(): void {
-	balanceVisible.update((v) => !v)
+  balanceVisible.update((v) => !v);
+}
+
+export function setNavBalanceVisible(visible: boolean): void {
+  navBalanceVisible.set(visible);
 }
 
 // --- Wallet Operations ---
@@ -176,94 +203,94 @@ export function toggleBalanceVisibility(): void {
  * Add a new wallet
  */
 export function addWallet(kind: WalletKind, name: string, data: string): Wallet {
-	const newWallet: Wallet = {
-		id: Date.now(),
-		kind,
-		name,
-		active: false,
-		data
-	}
+  const newWallet: Wallet = {
+    id: Date.now(),
+    kind,
+    name,
+    active: false,
+    data
+  };
 
-	wallets.update((current) => {
-		if (current.length === 0) newWallet.active = true
-		return [...current, newWallet]
-	})
-	return newWallet
+  wallets.update((current) => {
+    if (current.length === 0) newWallet.active = true;
+    return [...current, newWallet];
+  });
+  return newWallet;
 }
 
 /**
  * Remove a wallet by ID
  */
 export function removeWallet(id: number): void {
-	wallets.update((current) => {
-		const filtered = current.filter((w) => w.id !== id)
-		if (!filtered.some((w) => w.active) && filtered.length > 0) {
-			filtered[0].active = true
-		}
-		return filtered
-	})
-	walletBalance.set(null)
-	walletLastSync.set(null)
+  wallets.update((current) => {
+    const filtered = current.filter((w) => w.id !== id);
+    if (!filtered.some((w) => w.active) && filtered.length > 0) {
+      filtered[0].active = true;
+    }
+    return filtered;
+  });
+  walletBalance.set(null);
+  walletLastSync.set(null);
 }
 
 /**
  * Set the active wallet
  */
 export function setActiveWallet(id: number): void {
-	wallets.update((current) => current.map((w) => ({ ...w, active: w.id === id })))
-	walletBalance.set(null)
-	walletLastSync.set(null)
+  wallets.update((current) => current.map((w) => ({ ...w, active: w.id === id })));
+  walletBalance.set(null);
+  walletLastSync.set(null);
 }
 
 /**
  * Update wallet name
  */
 export function updateWalletName(id: number, name: string): void {
-	wallets.update((current) => current.map((w) => (w.id === id ? { ...w, name } : w)))
+  wallets.update((current) => current.map((w) => (w.id === id ? { ...w, name } : w)));
 }
 
 /**
  * Get wallet by kind (useful for checking if a wallet type is already connected)
  */
 export function getWalletByKind(kind: WalletKind): Wallet | undefined {
-	return get(wallets).find((w) => w.kind === kind)
+  return get(wallets).find((w) => w.kind === kind);
 }
 
 /**
  * Check if a specific wallet type is connected
  */
 export function hasWalletKind(kind: WalletKind): boolean {
-	return get(wallets).some((w) => w.kind === kind)
+  return get(wallets).some((w) => w.kind === kind);
 }
 
 /**
  * Get the currently active wallet
  */
 export function getActiveWallet(): Wallet | null {
-	return get(activeWallet)
+  return get(activeWallet);
 }
 
 /**
  * Clear all wallets
  */
 export function clearAllWallets(): void {
-	wallets.set([])
-	walletBalance.set(null)
-	walletLastSync.set(null)
+  wallets.set([]);
+  walletBalance.set(null);
+  walletLastSync.set(null);
 }
 
 /**
  * Get wallet kind display name
  */
 export function getWalletKindName(kind: WalletKind): string {
-	switch (kind) {
-		case 1:
-			return 'WebLN'
-		case 3:
-			return 'NWC'
-		case 4:
-			return 'Self-custodial'
-		default:
-			return 'Unknown'
-	}
+  switch (kind) {
+    case 1:
+      return 'WebLN';
+    case 3:
+      return 'NWC';
+    case 4:
+      return 'Self-custodial';
+    default:
+      return 'Unknown';
+  }
 }

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -24,8 +24,8 @@
     getCurrentRelays,
     type RelayMode
   } from '$lib/nostr';
-  import { wallets } from '$lib/wallet/walletStore';
-  import { bitcoinConnectEnabled } from '$lib/wallet/bitcoinConnect';
+  import { wallets, navBalanceVisible, setNavBalanceVisible } from '$lib/wallet/walletStore';
+  import { bitcoinConnectEnabled, bitcoinConnectWalletInfo } from '$lib/wallet/bitcoinConnect';
   import { weblnConnected, weblnWalletName } from '$lib/wallet/webln';
   import {
     oneTapZapEnabled,
@@ -274,6 +274,10 @@
   $: activeWallet = connectedWallets.find((w) => w.active);
   // Check if user has an in-app wallet (Spark kind=4 or NWC kind=3) for auto-zap
   $: hasInAppWallet = $wallets.some((w) => w.kind === 3 || w.kind === 4);
+  $: hasNavWallet =
+    connectedWallets.length > 0 ||
+    $weblnConnected ||
+    ($bitcoinConnectEnabled && $bitcoinConnectWalletInfo.connected);
 
   function getWalletTypeName(kind: number): string {
     switch (kind) {
@@ -624,6 +628,38 @@
           </div>
         {/if}
 
+        <div
+          class="p-4 rounded-xl {!hasNavWallet ? 'opacity-50' : ''}"
+          style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+        >
+          <div class="flex items-center justify-between">
+            <div class="flex-1">
+              <div class="font-medium" style="color: var(--color-text-primary)">Wallet Widget</div>
+              <p class="text-sm text-caption mt-1">Show the wallet widget in the top navigation.</p>
+            </div>
+            <button
+              role="switch"
+              aria-checked={$navBalanceVisible}
+              disabled={!hasNavWallet}
+              class="relative w-12 h-7 rounded-full transition-colors {hasNavWallet
+                ? 'cursor-pointer'
+                : 'cursor-not-allowed'} {$navBalanceVisible
+                ? 'bg-amber-500'
+                : 'bg-gray-300 dark:bg-gray-600'}"
+              on:click={() => hasNavWallet && setNavBalanceVisible(!$navBalanceVisible)}
+            >
+              <span
+                class="absolute top-1 left-1 w-5 h-5 bg-white rounded-full shadow transition-transform {$navBalanceVisible
+                  ? 'translate-x-5'
+                  : ''}"
+              ></span>
+            </button>
+          </div>
+          {#if !hasNavWallet}
+            <p class="text-xs text-amber-500 mt-3">Connect a wallet to enable this setting.</p>
+          {/if}
+        </div>
+
         <Button on:click={() => goto('/wallet')}>Manage Wallets</Button>
       </div>
     </Accordion>
@@ -646,7 +682,7 @@
                   >One-Tap Zaps</span
                 >
               </div>
-              <p class="text-sm text-caption mt-1">Tap a preset to zap instantly</p>
+              <p class="text-sm text-caption mt-1">Zap a preset amount instantly.</p>
             </div>
             <button
               role="switch"

--- a/src/routes/wallet/+page.svelte
+++ b/src/routes/wallet/+page.svelte
@@ -2903,8 +2903,10 @@
               <!-- Wallet type selection -->
               <div class="space-y-3">
                 <!-- Embedded wallet options - disabled when external wallet (WebLN) is connected -->
-                <div class="mb-2">
-                  <span class="text-xs text-caption uppercase tracking-wide">Embedded Wallets</span>
+                <div class="mb-2 text-center">
+                  <span class="text-xs text-caption uppercase tracking-wide block">
+                    Embedded Wallets
+                  </span>
                 </div>
 
                 {#if $weblnConnected}
@@ -3002,6 +3004,37 @@
                     </p>
                   </div>
                 {:else}
+                  <!-- Bitcoin Connect option -->
+                  <button
+                    class="w-full p-4 rounded-xl text-left flex items-center gap-4 transition-colors"
+                    class:cursor-pointer={!$bitcoinConnectEnabled && !$weblnConnected}
+                    class:cursor-not-allowed={$bitcoinConnectEnabled || $weblnConnected}
+                    class:opacity-50={$bitcoinConnectEnabled || $weblnConnected}
+                    style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+                    on:click={handleConnectBitcoinConnect}
+                    disabled={$bitcoinConnectEnabled || $weblnConnected}
+                  >
+                    <div
+                      class="w-10 h-10 rounded-full bg-orange-500 flex items-center justify-center"
+                    >
+                      <BitcoinConnectLogo size={20} className="text-white" />
+                    </div>
+                    <div>
+                      <div class="font-medium" style="color: var(--color-text-primary)">
+                        Bitcoin Connect
+                      </div>
+                      {#if $bitcoinConnectEnabled}
+                        <div class="text-sm text-amber-500">External wallet connected</div>
+                      {:else if $weblnConnected}
+                        <div class="text-sm text-caption">
+                          Disconnect WebLN to use Bitcoin Connect
+                        </div>
+                      {:else}
+                        <div class="text-sm text-caption">Connect any Bitcoin Connect wallet</div>
+                      {/if}
+                    </div>
+                  </button>
+
                   <!-- WebLN option - only show if browser has WebLN provider -->
                   {#if isWeblnAvailable()}
                     <button
@@ -3034,37 +3067,6 @@
                       </div>
                     </button>
                   {/if}
-
-                  <!-- Bitcoin Connect option -->
-                  <button
-                    class="w-full p-4 rounded-xl text-left flex items-center gap-4 transition-colors"
-                    class:cursor-pointer={!$bitcoinConnectEnabled && !$weblnConnected}
-                    class:cursor-not-allowed={$bitcoinConnectEnabled || $weblnConnected}
-                    class:opacity-50={$bitcoinConnectEnabled || $weblnConnected}
-                    style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
-                    on:click={handleConnectBitcoinConnect}
-                    disabled={$bitcoinConnectEnabled || $weblnConnected}
-                  >
-                    <div
-                      class="w-10 h-10 rounded-full bg-orange-500 flex items-center justify-center"
-                    >
-                      <BitcoinConnectLogo size={20} className="text-white" />
-                    </div>
-                    <div>
-                      <div class="font-medium" style="color: var(--color-text-primary)">
-                        Bitcoin Connect
-                      </div>
-                      {#if $bitcoinConnectEnabled}
-                        <div class="text-sm text-amber-500">External wallet connected</div>
-                      {:else if $weblnConnected}
-                        <div class="text-sm text-caption">
-                          Disconnect WebLN to use Bitcoin Connect
-                        </div>
-                      {:else}
-                        <div class="text-sm text-caption">Connect any Bitcoin Connect wallet</div>
-                      {/if}
-                    </div>
-                  </button>
                 {/if}
               </div>
             {:else if selectedWalletType === 3}


### PR DESCRIPTION
- Add a confirmation modal before disconnecting an external wallet from the navigation mini‑wallet.
- Add a persisted “Wallet Widget” setting that controls header mini‑wallet visibility and disables when no wallet is connected.
- Tidy wallet UI copy/layout (Zap Settings text, centered “Embedded Wallets” label, and external wallet order).