### PR TITLE
Fix NWC connection error when creating/looking up invoices

### DIFF
--- a/src/lib/wallet/walletManager.ts
+++ b/src/lib/wallet/walletManager.ts
@@ -446,6 +446,12 @@ export async function createInvoice(
   try {
     walletLoading.set(true);
 
+    // Ensure the wallet is connected before trying to create invoice
+    const connected = await ensureWalletConnected(wallet);
+    if (!connected) {
+      throw new Error('Wallet not connected. Please try again.');
+    }
+
     switch (wallet.kind) {
       case 3: // NWC
         const nwcResult = await createNwcInvoice(amountSats, description);
@@ -499,6 +505,12 @@ export async function lookupInvoice(
   }
 
   try {
+    // Ensure the wallet is connected before trying to lookup
+    const connected = await ensureWalletConnected(wallet);
+    if (!connected) {
+      return { paid: false };
+    }
+
     switch (wallet.kind) {
       case 3: // NWC
         return await lookupNwcInvoice(paymentHash);


### PR DESCRIPTION
## Problem
NWC wallet operations (`createInvoice` and `lookupInvoice`) would fail with "NWC not connected" error if the relay connection had dropped due to network issues or timeouts.

## Solution
Add `ensureWalletConnected()` call before NWC operations in both functions, matching the existing behavior in `refreshBalance` and `sendPayment`.

## Changes
- `src/lib/wallet/walletManager.ts`: Add wallet reconnection logic to `createInvoice` and `lookupInvoice` functions

## Testing
- Connect NWC wallet
- Wait for relay connection to drop (or manually disconnect)
- Attempt to create an invoice - should now auto-reconnect instead of failing
