### PR TITLE
Add Reads tab to profiles, fix line breaks, theme improvements

### DIFF
--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -679,29 +679,18 @@
   }
 
   function deduplicateText(text: string): string {
-    if (!text || text.length < 20) return text;
+    if (!text || text.length < 40) return text;
 
-    const segments = text.split(/(?<=[.!?\n])(?:\s+|$)/);
-    if (segments.length < 2) return text;
-
-    const deduplicated: string[] = [];
-    for (const segment of segments) {
-      const current = segment.trim();
-      const prev = deduplicated[deduplicated.length - 1]?.trim();
-      if (current && current !== prev) {
-        deduplicated.push(segment);
-      }
-    }
-
-    const result = deduplicated.join(' ').trim();
-    const halfLen = Math.floor(result.length / 2);
+    // Check if the entire text is duplicated (first half equals second half)
+    const trimmed = text.trim();
+    const halfLen = Math.floor(trimmed.length / 2);
     if (halfLen > 20) {
-      const firstHalf = result.substring(0, halfLen).trim();
-      const secondHalf = result.substring(halfLen).trim();
+      const firstHalf = trimmed.substring(0, halfLen).trim();
+      const secondHalf = trimmed.substring(halfLen).trim();
       if (firstHalf === secondHalf) return firstHalf;
     }
 
-    return result;
+    return text;
   }
 
   function getContentWithoutMedia(content: string): string {
@@ -709,7 +698,6 @@
       .replace(URL_REGEX, (url) => {
         return isImageUrl(url) || isVideoUrl(url) ? '' : url;
       })
-      .replace(/\s+/g, ' ')
       .trim();
 
     return deduplicateText(cleaned);
@@ -5392,7 +5380,7 @@
     }
   }
 
-  /* Tiered zap glow effects - visible amber glow */
+  /* Tiered zap glow effects - amber/gold glow for dark mode */
   /* Tier 1: Soft glow (>500 sats) - Gentle amber hint */
   .zap-glow-soft {
     border-radius: 12px;
@@ -5466,6 +5454,55 @@
         0 0 85px rgba(251, 191, 36, 0.15),
         0 0 110px rgba(251, 191, 36, 0.08),
         inset 0 0 50px rgba(251, 191, 36, 0.07);
+    }
+  }
+
+  /* Light mode: More visible orange glow (when .dark is NOT present) */
+  :global(html:not(.dark)) .zap-glow-soft {
+    background: linear-gradient(135deg, rgba(249, 115, 22, 0.08) 0%, transparent 100%);
+    box-shadow:
+      0 0 15px rgba(249, 115, 22, 0.4),
+      0 0 30px rgba(249, 115, 22, 0.2),
+      inset 0 0 20px rgba(249, 115, 22, 0.05);
+  }
+
+  :global(html:not(.dark)) .zap-glow-medium {
+    background: linear-gradient(135deg, rgba(249, 115, 22, 0.1) 0%, transparent 100%);
+    box-shadow:
+      0 0 20px rgba(249, 115, 22, 0.5),
+      0 0 40px rgba(249, 115, 22, 0.28),
+      0 0 60px rgba(249, 115, 22, 0.15),
+      inset 0 0 30px rgba(249, 115, 22, 0.06);
+  }
+
+  :global(html:not(.dark)) .zap-glow-bright {
+    background: linear-gradient(135deg, rgba(249, 115, 22, 0.12) 0%, rgba(234, 88, 12, 0.06) 100%);
+    box-shadow:
+      0 0 25px rgba(249, 115, 22, 0.6),
+      0 0 50px rgba(249, 115, 22, 0.35),
+      0 0 75px rgba(249, 115, 22, 0.18),
+      0 0 100px rgba(249, 115, 22, 0.1),
+      inset 0 0 40px rgba(249, 115, 22, 0.07);
+    animation: subtle-glow-pulse-light 4s ease-in-out infinite;
+  }
+
+  @keyframes subtle-glow-pulse-light {
+    0%,
+    100% {
+      box-shadow:
+        0 0 25px rgba(249, 115, 22, 0.6),
+        0 0 50px rgba(249, 115, 22, 0.35),
+        0 0 75px rgba(249, 115, 22, 0.18),
+        0 0 100px rgba(249, 115, 22, 0.1),
+        inset 0 0 40px rgba(249, 115, 22, 0.07);
+    }
+    50% {
+      box-shadow:
+        0 0 35px rgba(249, 115, 22, 0.7),
+        0 0 60px rgba(249, 115, 22, 0.4),
+        0 0 85px rgba(249, 115, 22, 0.22),
+        0 0 110px rgba(249, 115, 22, 0.12),
+        inset 0 0 50px rgba(249, 115, 22, 0.09);
     }
   }
 

--- a/src/components/NoteContent.svelte
+++ b/src/components/NoteContent.svelte
@@ -220,27 +220,15 @@
   }
 </script>
 
-<div class="whitespace-pre-wrap break-words note-content {className} w-full">
+<div
+  class="whitespace-pre-wrap break-words note-content {className} w-full"
+  style="white-space: pre-wrap;"
+>
   {#each finalParsedContent as part, i}
-    {#if part.type === 'text'}
-      {@const prevPart = finalParsedContent[i - 1]}
-      {@const nextPart = finalParsedContent[i + 1]}
-      {@const prevIsBlock = isBlockPart(prevPart)}
-      {@const nextIsBlock = isBlockPart(nextPart)}
-      {@const isBetweenBlocks = prevIsBlock && nextIsBlock}
-      {@const isOnlyWhitespace = /^\s*$/.test(part.content)}
-      {#if isBetweenBlocks && isOnlyWhitespace}
-        <!-- Skip whitespace between block elements -->
-      {:else if prevIsBlock && nextIsBlock}
-        {part.content.replace(/\n{2,}/g, '\n').trim()}
-      {:else if prevIsBlock}
-        {part.content.replace(/^\n+/, '').replace(/\n{2,}/g, '\n')}
-      {:else if nextIsBlock}
-        {part.content.replace(/\n+$/, '').replace(/\n{2,}/g, '\n')}
-      {:else}{part.content}{/if}
+    {#if part.type === 'text'}<span>{part.content}</span>
     {:else if part.type === 'hashtag'}
       <button
-        class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-orange-50 text-orange-600 hover:bg-orange-500 hover:text-white transition-colors cursor-pointer"
+        class="hashtag-pill inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium transition-colors cursor-pointer"
         on:click={() => handleHashtagClick(part.content)}
       >
         {part.content}
@@ -323,5 +311,25 @@
   .note-content :global(> a + div),
   .note-content :global(> div + a) {
     margin-top: 0.125rem;
+  }
+
+  /* Hashtag pill - light mode (default) */
+  .hashtag-pill {
+    background-color: rgb(255 247 237); /* bg-orange-50 */
+    color: rgb(234 88 12); /* text-orange-600 */
+  }
+  .hashtag-pill:hover {
+    background-color: rgb(249 115 22); /* bg-orange-500 */
+    color: white;
+  }
+
+  /* Hashtag pill - dark mode */
+  :global(html.dark) .hashtag-pill {
+    background-color: rgb(55 48 45); /* dark brownish-gray */
+    color: rgb(251 146 60); /* text-orange-400 */
+  }
+  :global(html.dark) .hashtag-pill:hover {
+    background-color: rgb(234 88 12); /* bg-orange-600 */
+    color: white;
   }
 </style>

--- a/src/routes/founders/+page.svelte
+++ b/src/routes/founders/+page.svelte
@@ -1,17 +1,26 @@
 <script lang="ts">
+  import { nip19 } from 'nostr-tools';
   import CustomAvatar from '../../components/CustomAvatar.svelte';
   import CustomName from '../../components/CustomName.svelte';
   import type { PageData } from './$types';
-  
+
   export let data: PageData;
-  
+
+  function getNpub(pubkey: string): string {
+    try {
+      return nip19.npubEncode(pubkey);
+    } catch {
+      return pubkey;
+    }
+  }
+
   interface Founder {
     number: number;
     pubkey: string;
     tier: string;
     joined: string | null;
   }
-  
+
   // CustomAvatar and CustomName handle their own profile loading
   let founders: Founder[] = (data.founders || []).map((f: any) => ({
     number: f.number,
@@ -33,7 +42,7 @@
   <section class="genesis-founders">
     <h2>🔥 Genesis Founders</h2>
     <p class="subtitle">The first believers who made this possible</p>
-  
+
     {#if founders.length === 0}
       <div class="empty-state">
         <p>No founders found.</p>
@@ -43,20 +52,18 @@
         {#each founders as founder}
           <div class="founder-card">
             <div class="founder-number">#{founder.number}</div>
-            
-            <div class="founder-avatar-wrapper">
+
+            <a href="/user/{getNpub(founder.pubkey)}" class="founder-avatar-wrapper">
               <CustomAvatar pubkey={founder.pubkey} size={80} className="founder-avatar-img" />
-            </div>
+            </a>
 
             <div class="founder-info">
-              <div class="founder-name">
+              <a href="/user/{getNpub(founder.pubkey)}" class="founder-name">
                 <CustomName pubkey={founder.pubkey} className="founder-name-text" />
-              </div>
+              </a>
             </div>
 
-            <div class="founder-badge">
-              Genesis Founder
-            </div>
+            <div class="founder-badge">Genesis Founder</div>
           </div>
         {/each}
       </div>
@@ -113,7 +120,9 @@
     text-align: center;
     position: relative;
     color: var(--color-text-primary);
-    transition: transform 0.2s, box-shadow 0.2s;
+    transition:
+      transform 0.2s,
+      box-shadow 0.2s;
   }
 
   .founder-card:hover {
@@ -137,6 +146,11 @@
   .founder-avatar-wrapper {
     margin: 1rem auto;
     position: relative;
+    width: 80px;
+    height: 80px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   .founder-avatar-img {
@@ -153,10 +167,17 @@
   .founder-name {
     font-weight: 600;
     font-size: 1rem;
+    text-decoration: none;
+    color: var(--color-text-primary);
+    transition: color 0.2s;
+  }
+
+  .founder-name:hover {
+    color: var(--color-primary);
   }
 
   .founder-name-text {
-    color: var(--color-text-primary);
+    color: inherit;
   }
 
   .founder-badge {


### PR DESCRIPTION
### Changes

**User Profile Reads Feed**
- Added new "Reads" tab to user profile pages showing longform articles (kind:30023)
- Displays article image, title, summary, and estimated read time
- Excludes recipes to keep content separate from existing Recipes tab

**Note Content Line Breaks**
- Fixed missing line breaks in note content rendering
- Removed aggressive whitespace collapsing in `getContentWithoutMedia()` 
- Simplified `deduplicateText()` to only handle full-text duplication without destroying formatting

**Glow Effects Theme Support**
- Light mode: Orange glow (`rgba(249, 115, 22)`) for better visibility on light backgrounds
- Dark mode: Amber/gold glow (`rgba(251, 191, 36)`) unchanged
- Fixed theme detection using `html:not(.dark)` selector

**Hashtag Pills Dark Mode**
- Hashtag pills now use dark background (`rgb(55, 48, 45)`) in dark mode
- Light mode retains light orange background (`bg-orange-50`)

**Profile Page Glow Fix**
- Fixed glow effect being cropped on profile feed by removing `overflow-x-hidden` from containers

### Files Changed
- `src/routes/user/[slug]/+page.svelte` - Reads tab, overflow fix
- `src/components/FoodstrFeedOptimized.svelte` - Line breaks fix, glow colors
- `src/components/NoteContent.svelte` - Line breaks, hashtag pill styling