### PR TITLE
fix: UI improvements for feed, modals, and quoted notes

### DIFF
--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -4930,11 +4930,8 @@
               {#if getImageUrls(event).length > 0}
                 {@const mediaUrls = getImageUrls(event)}
 
-                <div class="mb-3 -mx-2 sm:mx-0">
-                  <div
-                    class="relative rounded-none sm:rounded-lg border-0 sm:border bg-input"
-                    style="border-color: var(--color-input-border)"
-                  >
+                <div class="mb-3">
+                  <div class="relative rounded-lg overflow-hidden">
                     <!-- Swipeable carousel container -->
                     <div
                       class="carousel-container flex overflow-x-auto snap-x snap-mandatory"
@@ -5077,10 +5074,10 @@
                       />
                     </div>
                   {:else}
-                    <span class="text-caption p-1.5">♡ –</span>
-                    <span class="text-caption p-1.5">💬 –</span>
-                    <span class="text-caption p-1.5">🔁 –</span>
-                    <span class="text-caption p-1.5">⚡ –</span>
+                    <span class="text-caption p-1.5 opacity-40">♡</span>
+                    <span class="text-caption p-1.5 opacity-40">💬</span>
+                    <span class="text-caption p-1.5 opacity-40">🔁</span>
+                    <span class="text-caption p-1.5 opacity-40">⚡</span>
                   {/if}
                 </div>
               </div>

--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -52,13 +52,13 @@
         transition:scale={{ duration: 250 }}
         aria-labelledby="title"
         aria-modal="true"
-        class="absolute m-0 top-1/2 left-1/2 px-4 md:px-8 pt-6 pb-8 rounded-3xl w-[calc(100%-3rem)] md:w-[calc(100vw-4em)] max-w-xl max-h-[90vh] -translate-x-1/2 -translate-y-1/2"
+        class="absolute m-0 top-1/2 left-1/2 px-4 md:px-8 pt-6 pb-8 rounded-3xl w-[calc(100%-2rem)] md:w-[calc(100vw-4em)] max-w-xl min-h-[50vh] md:min-h-0 max-h-[85vh] md:max-h-[90vh] -translate-x-1/2 -translate-y-1/2 flex flex-col"
         class:overflow-y-auto={!allowOverflow}
         class:overflow-visible={allowOverflow}
         style="background-color: var(--color-bg-secondary);"
         open
       >
-        <div class="flex flex-col gap-6">
+        <div class="flex flex-col gap-6 flex-1">
           {#if !noHeader}
             <div class="flex justify-between">
               <h2

--- a/src/components/NoteRepost.svelte
+++ b/src/components/NoteRepost.svelte
@@ -11,7 +11,7 @@
   import { openComposerWithQuote } from '$lib/postComposerStore';
 
   export let event: NDKEvent;
-  
+
   const store = getEngagementStore(event.id);
   let showMenu = false;
 
@@ -23,7 +23,7 @@
 
   async function repost() {
     showMenu = false;
-    
+
     if ($store.reposts.userReposted) {
       console.log('Already reposted');
       return;
@@ -40,7 +40,7 @@
       console.log('Creating repost for:', event.id);
 
       // Optimistic update
-      store.update(s => ({
+      store.update((s) => ({
         ...s,
         reposts: { count: s.reposts.count + 1, userReposted: true }
       }));
@@ -62,11 +62,10 @@
 
       await repostEvent.publish();
       console.log('Successfully reposted');
-
     } catch (error) {
       console.error('Error reposting:', error);
       // Revert optimistic update
-      store.update(s => ({
+      store.update((s) => ({
         ...s,
         reposts: { count: s.reposts.count - 1, userReposted: false }
       }));
@@ -75,7 +74,7 @@
 
   function quote() {
     showMenu = false;
-    
+
     if (!$userPublickey) {
       window.location.href = '/login';
       return;
@@ -86,23 +85,29 @@
       id: event.id,
       author: event.pubkey
     });
-    
+
     // Open the post composer modal with the quoted note
     openComposerWithQuote(nevent, event);
-    
+
     // Also dispatch event for inline composer compatibility
-    window.dispatchEvent(new CustomEvent('quote-note', { 
-      detail: { nevent, event } 
-    }));
+    window.dispatchEvent(
+      new CustomEvent('quote-note', {
+        detail: { nevent, event }
+      })
+    );
   }
 </script>
 
 <div class="relative">
   <button
-    on:click={() => showMenu = !showMenu}
+    on:click={() => (showMenu = !showMenu)}
     class="flex items-center gap-1.5 hover:bg-input rounded px-0.5 transition duration-300 cursor-pointer"
     class:opacity-50={!$userPublickey}
-    title={!$userPublickey ? 'Login to repost' : $store.reposts.userReposted ? 'You reposted this' : 'Repost'}
+    title={!$userPublickey
+      ? 'Login to repost'
+      : $store.reposts.userReposted
+        ? 'You reposted this'
+        : 'Repost'}
   >
     <ArrowsClockwise
       size={24}
@@ -110,7 +115,7 @@
       class={$store.reposts.userReposted ? 'text-green-500' : 'text-caption'}
     />
     <span class="text-caption">
-      {#if $store.loading}–{:else}{$store.reposts.count}{/if}
+      {#if $store.loading}<span class="opacity-0">0</span>{:else}{$store.reposts.count}{/if}
     </span>
   </button>
 
@@ -119,7 +124,7 @@
       class="absolute bottom-full left-0 mb-2 bg-input rounded-lg shadow-lg py-1 z-50 min-w-[120px]"
       style="border: 1px solid var(--color-input-border); color: var(--color-text-primary);"
       use:clickOutside
-      on:click_outside={() => showMenu = false}
+      on:click_outside={() => (showMenu = false)}
     >
       <button
         on:click={repost}

--- a/src/components/NoteTotalComments.svelte
+++ b/src/components/NoteTotalComments.svelte
@@ -7,7 +7,7 @@
   import { getEngagementStore, fetchEngagement } from '$lib/engagementCache';
 
   export let event: NDKEvent;
-  
+
   const store = getEngagementStore(event.id);
 
   onMount(() => {
@@ -22,7 +22,9 @@
   style="color: var(--color-text-primary)"
   on:click={() => {
     // Find the InlineComments component for this event and trigger toggleComments
-    const inlineCommentsComponent = document.querySelector(`[data-event-id="${event.id}"]`)?.closest('.inline-comments');
+    const inlineCommentsComponent = document
+      .querySelector(`[data-event-id="${event.id}"]`)
+      ?.closest('.inline-comments');
     if (inlineCommentsComponent) {
       // Dispatch a custom event to trigger the toggleComments function
       inlineCommentsComponent.dispatchEvent(new CustomEvent('toggleComments'));
@@ -32,6 +34,6 @@
 >
   <CommentIcon size={24} class="text-caption" />
   <span class="text-caption">
-    {#if $store.loading}–{:else}{$store.comments.count}{/if}
+    {#if $store.loading}<span class="opacity-0">0</span>{:else}{$store.comments.count}{/if}
   </span>
 </button>

--- a/src/components/NoteTotalZaps.svelte
+++ b/src/components/NoteTotalZaps.svelte
@@ -56,7 +56,7 @@
     e.stopPropagation();
     isLongPress = false;
     pressStartTime = Date.now();
-    
+
     // Track touch position for mobile
     if (isTouchEvent(e) && e.touches.length > 0) {
       touchStartPos = {
@@ -83,12 +83,12 @@
   function handlePressEnd(e: MouseEvent | TouchEvent) {
     const wasLongPress = isLongPress;
     const hadTimer = longPressTimer !== null;
-    
+
     if (longPressTimer) {
       clearTimeout(longPressTimer);
       longPressTimer = null;
     }
-    
+
     // For touch events on Safari, we need to trigger the zap action here
     // because the click event may not fire after preventDefault on touchstart
     if (isTouchEvent(e) && !wasLongPress && touchStartPos !== null) {
@@ -98,20 +98,20 @@
       handleZapIconClick(e);
       return;
     }
-    
+
     touchStartPos = null;
   }
 
   // Handle touch move - cancel long press if user is scrolling
   function handleTouchMove(e: TouchEvent) {
     if (!touchStartPos || !longPressTimer) return;
-    
+
     if (e.touches.length > 0) {
       const currentX = e.touches[0].clientX;
       const currentY = e.touches[0].clientY;
       const deltaX = Math.abs(currentX - touchStartPos.x);
       const deltaY = Math.abs(currentY - touchStartPos.y);
-      
+
       // If touch moved significantly, cancel long press (user is scrolling)
       if (deltaX > TOUCH_MOVE_THRESHOLD || deltaY > TOUCH_MOVE_THRESHOLD) {
         if (longPressTimer) {
@@ -151,19 +151,19 @@
     // If one-tap zap is available, send immediately
     if (canOneTapZap()) {
       console.log('[NoteTotalZaps] One-tap zap starting...');
-      
+
       // Haptic feedback on tap - immediate confirmation that tap was registered
       if ('vibrate' in navigator) {
         navigator.vibrate(30); // Short vibration on tap
       }
-      
+
       // Set loading state immediately for visual feedback
       isZapping = true;
-      
+
       // Optimistic update happens inside sendOneTapZap
       // The store should update reactively and show the new amount
       const result = await sendOneTapZap(event);
-      
+
       console.log('[NoteTotalZaps] One-tap zap result:', result);
       isZapping = false;
 
@@ -184,7 +184,7 @@
         // If zap failed, we need to revert the optimistic update
         // Refresh to get accurate counts (this will revert the optimistic update)
         fetchEngagement($ndk, event.id, $userPublickey);
-        
+
         if (onZapClick) {
           // Fall back to modal if one-tap fails
           onZapClick();
@@ -219,8 +219,8 @@
     class="flex items-center gap-1.5 rounded px-0.5 transition duration-300"
     style="color: var(--color-text-primary)"
   >
-    <button 
-      class="hover:bg-input rounded p-1 select-none touch-none" 
+    <button
+      class="hover:bg-input rounded p-1 select-none touch-none"
       style="touch-action: manipulation; -webkit-tap-highlight-color: transparent;"
       on:mousedown={handlePressStart}
       on:mouseup={handlePressEnd}
@@ -230,20 +230,29 @@
       on:touchend|preventDefault={handlePressEnd}
       on:touchcancel={handleTouchCancel}
       on:click|preventDefault={handleZapIconClick}
-      on:contextmenu|preventDefault={() => { if (onZapClick) onZapClick(); }}
-      title={canOneTapZap() ? `Zap ${getOneTapAmount()} sats (hold for custom amount)` : 'Send a zap'}
+      on:contextmenu|preventDefault={() => {
+        if (onZapClick) onZapClick();
+      }}
+      title={canOneTapZap()
+        ? `Zap ${getOneTapAmount()} sats (hold for custom amount)`
+        : 'Send a zap'}
     >
       <LightningIcon size={24} class="text-caption" weight="regular" />
     </button>
-    <span class="text-caption">–</span>
+    <span class="text-caption opacity-0">0</span>
   </div>
 {:else if onlyPills && showPills && $store.zaps.topZappers.length > 0}
   <!-- Pills-only row (one row only; +X at end shows remaining); contain horizontal scroll for Safari -->
-  <div class="zap-pills-row flex flex-nowrap items-center gap-1.5 w-full min-w-0 overflow-x-auto overflow-y-hidden">
+  <div
+    class="zap-pills-row flex flex-nowrap items-center gap-1.5 w-full min-w-0 overflow-x-auto overflow-y-hidden"
+  >
     {#each visibleZappers as zapper (zapper.pubkey)}
       <button
         on:click|stopPropagation={handleCountClick}
-        class="zap-pill flex items-center gap-1 h-6 pl-1 pr-2 rounded-full bg-accent-gray hover:bg-yellow-500/20 transition-colors cursor-pointer flex-shrink-0 {zapper.pubkey === $userPublickey ? 'ring-1 ring-yellow-500' : ''}"
+        class="zap-pill flex items-center gap-1 h-6 pl-1 pr-2 rounded-full bg-accent-gray hover:bg-yellow-500/20 transition-colors cursor-pointer flex-shrink-0 {zapper.pubkey ===
+        $userPublickey
+          ? 'ring-1 ring-yellow-500'
+          : ''}"
         title="{zapper.amount} sats"
       >
         <CustomAvatar pubkey={zapper.pubkey} size={18} className="rounded-full flex-shrink-0" />
@@ -264,7 +273,9 @@
   </div>
 {:else if showPills && $store.zaps.topZappers.length > 0}
   <!-- Pill format: Lightning icon + pfp pills with amounts (inline, one row; +X at end); contain horizontal scroll for Safari -->
-  <div class="zap-pills-row flex flex-nowrap items-center gap-1.5 overflow-x-auto overflow-y-hidden">
+  <div
+    class="zap-pills-row flex flex-nowrap items-center gap-1.5 overflow-x-auto overflow-y-hidden"
+  >
     <!-- Zap Button -->
     <button
       class="hover:bg-input rounded p-1 transition-colors select-none touch-none flex-shrink-0"
@@ -279,13 +290,19 @@
       on:touchend|preventDefault={handlePressEnd}
       on:touchcancel={handleTouchCancel}
       on:click|preventDefault={handleZapIconClick}
-      on:contextmenu|preventDefault={() => { if (onZapClick) onZapClick(); }}
+      on:contextmenu|preventDefault={() => {
+        if (onZapClick) onZapClick();
+      }}
       disabled={isZapping}
-      title={canOneTapZap() ? `Zap ${getOneTapAmount()} sats (hold for custom amount)` : 'Send a zap'}
+      title={canOneTapZap()
+        ? `Zap ${getOneTapAmount()} sats (hold for custom amount)`
+        : 'Send a zap'}
     >
       <LightningIcon
         size={18}
-        class="{totalSats > 0 ? 'text-yellow-500' : 'text-caption'} {isZapping ? 'animate-pulse' : ''}"
+        class="{totalSats > 0 ? 'text-yellow-500' : 'text-caption'} {isZapping
+          ? 'animate-pulse'
+          : ''}"
         weight={$store.zaps.userZapped ? 'fill' : 'regular'}
       />
     </button>
@@ -294,7 +311,10 @@
     {#each visibleZappers as zapper (zapper.pubkey)}
       <button
         on:click|stopPropagation={handleCountClick}
-        class="zap-pill flex items-center gap-1 h-6 pl-1 pr-2 rounded-full bg-accent-gray hover:bg-yellow-500/20 transition-colors cursor-pointer flex-shrink-0 {zapper.pubkey === $userPublickey ? 'ring-1 ring-yellow-500' : ''}"
+        class="zap-pill flex items-center gap-1 h-6 pl-1 pr-2 rounded-full bg-accent-gray hover:bg-yellow-500/20 transition-colors cursor-pointer flex-shrink-0 {zapper.pubkey ===
+        $userPublickey
+          ? 'ring-1 ring-yellow-500'
+          : ''}"
         title="{zapper.amount} sats"
       >
         <CustomAvatar pubkey={zapper.pubkey} size={18} className="rounded-full flex-shrink-0" />
@@ -335,9 +355,13 @@
       on:touchend|preventDefault={handlePressEnd}
       on:touchcancel={handleTouchCancel}
       on:click|preventDefault={handleZapIconClick}
-      on:contextmenu|preventDefault={() => { if (onZapClick) onZapClick(); }}
+      on:contextmenu|preventDefault={() => {
+        if (onZapClick) onZapClick();
+      }}
       disabled={isZapping}
-      title={canOneTapZap() ? `Zap ${getOneTapAmount()} sats (hold for custom amount)` : 'Send a zap'}
+      title={canOneTapZap()
+        ? `Zap ${getOneTapAmount()} sats (hold for custom amount)`
+        : 'Send a zap'}
     >
       <LightningIcon
         size={24}

--- a/src/components/PostComposer.svelte
+++ b/src/components/PostComposer.svelte
@@ -1187,7 +1187,7 @@
 
 {#if $userPublickey !== '' || variant === 'modal'}
   <div
-    class={`bg-input rounded-xl transition-all ${variant === 'inline' ? 'mb-4' : ''}`}
+    class={`bg-input rounded-xl transition-all ${variant === 'inline' ? 'mb-4' : 'flex-1 flex flex-col'}`}
     class:overflow-hidden={!isComposerOpen}
     class:overflow-visible={isComposerOpen}
     style="border: 1px solid var(--color-input-border)"
@@ -1210,14 +1210,14 @@
         <a href="/login" class="text-sm underline hover:opacity-80">Sign in</a>
       </div>
     {:else}
-      <div class="p-3">
-        <div class="flex gap-3">
+      <div class={`p-3 ${variant === 'modal' ? 'flex-1 flex flex-col' : ''}`}>
+        <div class={`flex gap-3 ${variant === 'modal' ? 'flex-1' : ''}`}>
           <CustomAvatar pubkey={$userPublickey} size={36} />
-          <div class="flex-1">
-            <div class="relative">
+          <div class={`flex-1 ${variant === 'modal' ? 'flex flex-col' : ''}`}>
+            <div class={`relative ${variant === 'modal' ? 'flex-1' : ''}`}>
               <div
                 bind:this={composerEl}
-                class="composer-input w-full min-h-[80px] max-h-[300px] overflow-y-auto p-2 border-0 focus:outline-none focus:ring-0 bg-transparent"
+                class={`composer-input w-full min-h-[120px] sm:min-h-[100px] overflow-y-auto p-2 border-0 focus:outline-none focus:ring-0 bg-transparent ${variant === 'modal' ? 'flex-1' : 'max-h-[50vh]'}`}
                 style="color: var(--color-text-primary); font-size: 16px;"
                 contenteditable={!posting}
                 role="textbox"
@@ -1645,9 +1645,11 @@
   /* Quoted note embed - orange bracket style matching feed */
   .quoted-note-embed {
     padding: 0.5rem 0.75rem;
-    background: var(--color-input);
+    background: var(--color-bg-secondary);
     border-left: 3px solid var(--color-primary, #f97316);
     border-radius: 0.375rem;
+    overflow: hidden;
+    max-width: 100%;
   }
 
   .quoted-note-header {
@@ -1679,11 +1681,11 @@
     overflow-wrap: anywhere;
     word-break: break-word;
     display: -webkit-box;
-    -webkit-line-clamp: 3;
-    line-clamp: 3;
+    -webkit-line-clamp: 5;
+    line-clamp: 5;
     -webkit-box-orient: vertical;
     overflow: hidden;
-    max-height: 4.2em;
+    max-height: 7em;
   }
 
   .quoted-note-content :global(p) {
@@ -1692,5 +1694,20 @@
 
   .quoted-note-content :global(a) {
     color: var(--color-primary, #f97316);
+  }
+
+  /* Hide images and videos in quoted note preview - they cause overflow */
+  .quoted-note-content :global(img),
+  .quoted-note-content :global(video),
+  .quoted-note-content :global(.video-preview),
+  .quoted-note-content :global(.my-1.relative),
+  .quoted-note-content :global(div[style*='aspect-ratio']) {
+    display: none !important;
+  }
+
+  /* Ensure all text breaks properly */
+  .quoted-note-content :global(*) {
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 </style>

--- a/src/components/PostModal.svelte
+++ b/src/components/PostModal.svelte
@@ -16,7 +16,7 @@
 </script>
 
 <Modal bind:open allowOverflow={true} noHeader={true}>
-  <div class="flex flex-col gap-4">
+  <div class="flex flex-col gap-4 flex-1">
     <!-- Header: relay selector on left, X on right -->
     <div class="flex items-center justify-between">
       <div class="flex items-center gap-2">
@@ -48,11 +48,11 @@
       </button>
     </div>
 
-    <PostComposer 
-      variant="modal" 
-      {selectedRelay} 
+    <PostComposer
+      variant="modal"
+      {selectedRelay}
       initialQuotedNote={$quotedNoteStore}
-      on:close={handleClose} 
+      on:close={handleClose}
     />
   </div>
 </Modal>

--- a/src/components/Reactions/ReactionTrigger.svelte
+++ b/src/components/Reactions/ReactionTrigger.svelte
@@ -53,20 +53,23 @@
 
     if (!wasReacted) {
       // Optimistic update
-      store.update(s => {
+      store.update((s) => {
         const updated = { ...s };
         updated.reactions.userReactions.add(emoji);
         updated.reactions.count++;
         updated.reactions.userReacted = true;
-        
-        const existingGroup = updated.reactions.groups.find(g => g.emoji === emoji);
+
+        const existingGroup = updated.reactions.groups.find((g) => g.emoji === emoji);
         if (existingGroup) {
           existingGroup.count++;
           existingGroup.userReacted = true;
         } else {
-          updated.reactions.groups = [{ emoji, count: 1, userReacted: true }, ...updated.reactions.groups];
+          updated.reactions.groups = [
+            { emoji, count: 1, userReacted: true },
+            ...updated.reactions.groups
+          ];
         }
-        
+
         return updated;
       });
 
@@ -79,20 +82,20 @@
 
       if (!result?.id) {
         // Revert on failure
-        store.update(s => {
+        store.update((s) => {
           const updated = { ...s };
           updated.reactions.userReactions.delete(emoji);
           updated.reactions.count--;
-          
-          const group = updated.reactions.groups.find(g => g.emoji === emoji);
+
+          const group = updated.reactions.groups.find((g) => g.emoji === emoji);
           if (group) {
             group.count--;
             group.userReacted = false;
             if (group.count === 0) {
-              updated.reactions.groups = updated.reactions.groups.filter(g => g.emoji !== emoji);
+              updated.reactions.groups = updated.reactions.groups.filter((g) => g.emoji !== emoji);
             }
           }
-          
+
           updated.reactions.userReacted = updated.reactions.userReactions.size > 0;
           return updated;
         });
@@ -112,14 +115,10 @@
   {#if hasUserReacted && userEmoji}
     <span class={compact ? 'text-lg' : 'text-xl'}>{userEmoji}</span>
   {:else}
-    <HeartIcon
-      size={compact ? 20 : 24}
-      weight="regular"
-      class="text-caption"
-    />
+    <HeartIcon size={compact ? 20 : 24} weight="regular" class="text-caption" />
   {/if}
   <span class="text-caption {compact ? 'text-sm' : ''}">
-    {#if $store.loading}–{:else}{$store.reactions.count}{/if}
+    {#if $store.loading}<span class="opacity-0">0</span>{:else}{$store.reactions.count}{/if}
   </span>
 </button>
 
@@ -133,7 +132,7 @@
       showPicker = false;
       showFullPicker = true;
     }}
-    on:close={() => showPicker = false}
+    on:close={() => (showPicker = false)}
   />
 {/if}
 
@@ -142,5 +141,5 @@
   open={showFullPicker}
   anchorEl={buttonEl}
   on:select={(e) => handleReaction(e.detail.emoji)}
-  on:close={() => showFullPicker = false}
+  on:close={() => (showFullPicker = false)}
 />

--- a/src/routes/[nip19]/+page.svelte
+++ b/src/routes/[nip19]/+page.svelte
@@ -3,7 +3,7 @@
   import { goto } from '$app/navigation';
   import { nip19 } from 'nostr-tools';
   import { ndk, userPublickey } from '$lib/nostr';
-  import { mutedPubkeys } from '$lib/muteListStore';
+  import { mutedPubkeys, muteListStore } from '$lib/muteListStore';
   import { onMount, onDestroy } from 'svelte';
   import { get } from 'svelte/store';
   import CustomAvatar from '../../components/CustomAvatar.svelte';
@@ -941,6 +941,13 @@
     }
   }
 
+  // Load mute list when user is logged in
+  onMount(() => {
+    if ($userPublickey) {
+      muteListStore.load();
+    }
+  });
+
   onDestroy(() => {
     if (mentionSearchTimeout) {
       clearTimeout(mentionSearchTimeout);
@@ -1145,6 +1152,42 @@
           <p class="text-lg font-medium">Note not found</p>
           <p class="text-sm">The referenced note could not be loaded.</p>
         </div>
+      </div>
+    </div>
+  {:else if event && $mutedPubkeys.has(event.author?.hexpubkey || event.pubkey)}
+    <!-- Muted user content -->
+    <div class="py-12 text-center">
+      <div class="max-w-sm mx-auto space-y-6">
+        <div style="color: var(--color-caption)">
+          <svg
+            class="h-12 w-12 mx-auto mb-4 opacity-50"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z"
+            />
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M17 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2"
+            />
+          </svg>
+          <p class="text-lg font-medium">Content from muted user</p>
+          <p class="text-sm">You have muted this user. Their content is hidden.</p>
+        </div>
+        <button
+          on:click={() => goto('/community')}
+          class="px-4 py-2 bg-input rounded-lg hover:bg-accent-gray transition-colors"
+          style="color: var(--color-text-primary)"
+        >
+          Back to Community
+        </button>
       </div>
     </div>
   {:else if event}


### PR DESCRIPTION
## Summary

This PR addresses several UI/UX issues across the feed, note detail pages, and post composer.

## Changes

### Image Modal in Feed Notes
- Images in feed notes can now be clicked to enlarge in a modal
- Keyboard navigation support (Escape to close, Arrow keys to navigate between images)

### Muted User Handling
- Notes from muted users are now properly hidden on the note detail page
- Shows "This note is from a muted user" message with option to go back

### Loading State Improvements
- Replaced dash (`–`) placeholders with invisible placeholder elements for cleaner loading states
- Affects reaction counts, comments, reposts, and zaps across all feeds

### Feed Image Styling
- Removed 1px border from images in content feeds
- Added rounded corners to image containers

### Post Composer Fixes
- Fixed quoted note content overflowing on mobile (especially when quoting notes with videos)
- Videos and images are now hidden in quoted note previews to prevent overflow
- Quoted note embed now has higher contrast background for better visibility

### Mobile Post Modal
- Post/quote modal is now taller on mobile devices
- Inner content expands to fill available modal space

Closes #131