### PR TITLE
SATS: Clean up wallet balance display: remove redundant labels, relocate controls

### DIFF
--- a/src/components/WalletBalance.svelte
+++ b/src/components/WalletBalance.svelte
@@ -143,7 +143,7 @@
       {:else}
         <span class="min-w-[3.5rem] text-right">***</span>
       {/if}
-      <span class="text-caption text-xs">sats</span>
+
       <CaretDownIcon size={12} class="text-caption ml-0.5" />
     </button>
 
@@ -256,7 +256,7 @@
       {:else}
         <span class="min-w-[3.5rem] text-right">***</span>
       {/if}
-      <span class="text-caption text-xs">sats</span>
+
       <CaretDownIcon size={12} class="text-caption ml-0.5" />
     </button>
 
@@ -361,7 +361,7 @@
       {:else}
         <span class="min-w-[3.5rem] text-right">***</span>
       {/if}
-      <span class="text-caption text-xs">sats</span>
+
       <CaretDownIcon size={12} class="text-caption ml-0.5" />
     </button>
 

--- a/src/routes/settings/wallet/+page.svelte
+++ b/src/routes/settings/wallet/+page.svelte
@@ -1,75 +1,76 @@
 <script lang="ts">
-	import { onMount } from 'svelte'
-	import { goto } from '$app/navigation'
-	import { browser } from '$app/environment'
-	import {
-		walletBalance,
-		walletConnected,
-		activeWallet,
-		getWalletKindName
-	} from '$lib/wallet'
-	import {
-		lightningAddress,
-		walletInitialized
-	} from '$lib/spark'
-	import { userPublickey } from '$lib/nostr'
-	import Button from '../../../components/Button.svelte'
-	import LightningIcon from 'phosphor-svelte/lib/Lightning'
-	import WalletIcon from 'phosphor-svelte/lib/Wallet'
-	import ArrowRightIcon from 'phosphor-svelte/lib/ArrowRight'
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { browser } from '$app/environment';
+  import { walletBalance, walletConnected, activeWallet, getWalletKindName } from '$lib/wallet';
+  import { lightningAddress, walletInitialized } from '$lib/spark';
+  import { userPublickey } from '$lib/nostr';
+  import Button from '../../../components/Button.svelte';
+  import LightningIcon from 'phosphor-svelte/lib/Lightning';
+  import WalletIcon from 'phosphor-svelte/lib/Wallet';
+  import ArrowRightIcon from 'phosphor-svelte/lib/ArrowRight';
 
-	// Redirect to new wallet page on mount
-	onMount(() => {
-		if (browser) {
-			goto('/wallet')
-		}
-	})
+  // Redirect to new wallet page on mount
+  onMount(() => {
+    if (browser) {
+      goto('/wallet');
+    }
+  });
 
-	function formatBalance(balance: number | null): string {
-		if (balance === null) return '---'
-		return balance.toLocaleString()
-	}
+  function formatBalance(balance: number | null): string {
+    if (balance === null) return '---';
+    return balance.toLocaleString();
+  }
 </script>
 
 <div class="space-y-6 p-4">
-	<h1 class="text-2xl font-bold" style="color: var(--color-text-primary)">Wallet Settings</h1>
+  <h1 class="text-2xl font-bold" style="color: var(--color-text-primary)">Wallet Settings</h1>
 
-	<p class="text-caption">
-		Wallet management has moved to a dedicated page with more features.
-	</p>
+  <p class="text-caption">Wallet management has moved to a dedicated page with more features.</p>
 
-	<!-- Quick status if wallet connected -->
-	{#if $walletConnected && $activeWallet}
-		<div class="rounded-xl p-4" style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);">
-			<div class="flex items-center gap-3 mb-2">
-				<LightningIcon size={24} weight="fill" class="text-amber-500" />
-				<span class="font-medium" style="color: var(--color-text-primary)">Connected Wallet</span>
-			</div>
-			<div class="ml-9 space-y-1">
-				<p style="color: var(--color-text-primary)">{$activeWallet.name} ({getWalletKindName($activeWallet.kind)})</p>
-				<p class="text-2xl font-bold" style="color: var(--color-text-primary)">{formatBalance($walletBalance)} <span class="text-sm font-normal text-caption">sats</span></p>
-				{#if $lightningAddress}
-					<p class="text-sm text-caption">Lightning: {$lightningAddress}</p>
-				{/if}
-			</div>
-		</div>
-	{:else}
-		<div class="rounded-xl p-4" style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);">
-			<div class="flex items-center gap-3">
-				<WalletIcon size={24} class="text-caption" />
-				<span style="color: var(--color-text-primary)">No wallet connected</span>
-			</div>
-		</div>
-	{/if}
+  <!-- Quick status if wallet connected -->
+  {#if $walletConnected && $activeWallet}
+    <div
+      class="rounded-xl p-4"
+      style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+    >
+      <div class="flex items-center gap-3 mb-2">
+        <LightningIcon size={24} weight="fill" class="text-amber-500" />
+        <span class="font-medium" style="color: var(--color-text-primary)">Connected Wallet</span>
+      </div>
+      <div class="ml-9 space-y-1">
+        <p style="color: var(--color-text-primary)">
+          {$activeWallet.name} ({getWalletKindName($activeWallet.kind)})
+        </p>
+        <p class="text-2xl font-bold" style="color: var(--color-text-primary)">
+          {formatBalance($walletBalance)}
+        </p>
+        {#if $lightningAddress}
+          <p class="text-sm text-caption">Lightning: {$lightningAddress}</p>
+        {/if}
+      </div>
+    </div>
+  {:else}
+    <div
+      class="rounded-xl p-4"
+      style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+    >
+      <div class="flex items-center gap-3">
+        <WalletIcon size={24} class="text-caption" />
+        <span style="color: var(--color-text-primary)">No wallet connected</span>
+      </div>
+    </div>
+  {/if}
 
-	<Button on:click={() => goto('/wallet')}>
-		<span class="flex items-center gap-2">
-			Go to Wallet Page
-			<ArrowRightIcon size={16} />
-		</span>
-	</Button>
+  <Button on:click={() => goto('/wallet')}>
+    <span class="flex items-center gap-2">
+      Go to Wallet Page
+      <ArrowRightIcon size={16} />
+    </span>
+  </Button>
 
-	<p class="text-sm text-caption">
-		The wallet page lets you connect WebLN, NWC, or Spark wallets, view your balance, and manage multiple wallets.
-	</p>
+  <p class="text-sm text-caption">
+    The wallet page lets you connect WebLN, NWC, or Spark wallets, view your balance, and manage
+    multiple wallets.
+  </p>
 </div>

--- a/src/routes/wallet/+page.svelte
+++ b/src/routes/wallet/+page.svelte
@@ -2265,61 +2265,56 @@
     <!-- WebLN Balance Overview -->
     {#if $weblnConnected}
       <div class="mb-8 p-6 rounded-2xl bg-input border border-input">
-        <div class="flex items-center justify-between mb-4">
-          <div class="flex items-center gap-2">
-            <div
-              class="w-6 h-6 rounded-full bg-gradient-to-br from-orange-500 to-amber-500 flex items-center justify-center"
-            >
-              <WeblnLogo size={14} className="text-white" />
-            </div>
-            <span class="font-medium text-primary-color">Balance</span>
-          </div>
-          <div class="flex items-center gap-3">
-            <button
-              class="flex items-center gap-1 text-sm text-caption hover:text-primary transition-colors cursor-pointer"
-              on:click={toggleBalanceVisibility}
-              title={$balanceVisible ? 'Hide balance' : 'Show balance'}
-            >
-              {#if $balanceVisible}
-                <EyeSlashIcon size={16} />
-              {:else}
-                <EyeIcon size={16} />
-              {/if}
-            </button>
-            <button
-              class="text-caption hover:text-primary transition-colors cursor-pointer disabled:opacity-50"
-              on:click={refreshWeblnBalance}
-              disabled={weblnBalanceLoading}
-              title="Refresh balance"
-            >
-              <span class:animate-spin={weblnBalanceLoading}>
-                <ArrowsClockwiseIcon size={16} />
-              </span>
-            </button>
-          </div>
-        </div>
         <div class="flex items-start justify-between mb-2">
           <div>
             <div class="text-4xl font-bold text-primary-color flex items-center gap-3">
+              <div
+                class="w-8 h-8 rounded-full bg-gradient-to-br from-orange-500 to-amber-500 flex items-center justify-center flex-shrink-0"
+              >
+                <WeblnLogo size={18} className="text-white" />
+              </div>
               {#if weblnBalanceLoading}
                 <span class="animate-pulse">...</span>
               {:else if weblnBalance === null}
                 <span class="text-2xl text-caption">Balance not available</span>
               {:else if $balanceVisible}
                 {formatBalance(weblnBalance)}
-                <span class="text-lg font-normal text-caption">sats</span>
               {:else}
-                *** <span class="text-lg font-normal text-caption">sats</span>
+                ***
               {/if}
             </div>
             {#if weblnBalance !== null}
-              <FiatBalance satoshis={weblnBalance} visible={$balanceVisible} />
+              <div class="ml-11">
+                <FiatBalance satoshis={weblnBalance} visible={$balanceVisible} />
+              </div>
             {/if}
           </div>
-          <CurrencySelector compact />
-        </div>
-        <div class="text-sm text-caption">
-          Active: {$weblnWalletName || 'Browser Wallet'} (WebLN)
+          <div class="flex flex-col items-end gap-2">
+            <CurrencySelector compact />
+            <div class="flex items-center gap-3">
+              <button
+                class="flex items-center gap-1 text-sm text-caption hover:text-primary transition-colors cursor-pointer"
+                on:click={toggleBalanceVisibility}
+                title={$balanceVisible ? 'Hide balance' : 'Show balance'}
+              >
+                {#if $balanceVisible}
+                  <EyeSlashIcon size={16} />
+                {:else}
+                  <EyeIcon size={16} />
+                {/if}
+              </button>
+              <button
+                class="text-caption hover:text-primary transition-colors cursor-pointer disabled:opacity-50"
+                on:click={refreshWeblnBalance}
+                disabled={weblnBalanceLoading}
+                title="Refresh balance"
+              >
+                <span class:animate-spin={weblnBalanceLoading}>
+                  <ArrowsClockwiseIcon size={16} />
+                </span>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     {/if}
@@ -2327,65 +2322,60 @@
     <!-- Balance Overview -->
     {#if $walletConnected && $activeWallet && !$weblnConnected}
       <div class="mb-8 p-6 rounded-2xl bg-input border border-input">
-        <div class="flex items-center justify-between mb-4">
-          <div class="flex items-center gap-2">
-            <LightningIcon size={24} weight="fill" class="text-amber-500" />
-            <span class="font-medium text-primary-color">Balance</span>
-          </div>
-          <div class="flex items-center gap-3">
-            <button
-              class="flex items-center gap-1 text-sm text-caption hover:text-primary transition-colors cursor-pointer"
-              on:click={toggleBalanceVisibility}
-              title={$balanceVisible ? 'Hide balance' : 'Show balance'}
-            >
-              {#if $balanceVisible}
-                <EyeSlashIcon size={16} />
-              {:else}
-                <EyeIcon size={16} />
-              {/if}
-            </button>
-            <button
-              class="text-caption hover:text-primary transition-colors cursor-pointer disabled:opacity-50"
-              on:click={() => refreshBalance()}
-              disabled={$walletLoading}
-              title="Refresh balance"
-            >
-              <span class:animate-spin={$walletLoading}>
-                <ArrowsClockwiseIcon size={16} />
-              </span>
-            </button>
-          </div>
-        </div>
         <div class="flex items-start justify-between mb-2">
           <div>
             <div class="text-4xl font-bold text-primary-color flex items-center gap-3">
+              <LightningIcon size={32} weight="fill" class="text-amber-500 flex-shrink-0" />
               {#if $walletLoading || $walletBalance === null}
                 <span class="animate-pulse">...</span>
               {:else if $balanceVisible}
                 {formatBalance($walletBalance)}
-                <span class="text-lg font-normal text-caption">sats</span>
               {:else}
-                *** <span class="text-lg font-normal text-caption">sats</span>
+                ***
               {/if}
             </div>
-            <FiatBalance satoshis={$walletBalance} visible={$balanceVisible} />
+            <div class="ml-11">
+              <FiatBalance satoshis={$walletBalance} visible={$balanceVisible} />
+            </div>
             <!-- Syncing indicator when Spark wallet balance is zero -->
             {#if $activeWallet?.kind === 4 && $walletBalance === 0n && $sparkSyncing}
-              <div class="text-xs text-caption flex items-center gap-1 mt-1">
+              <div class="text-xs text-caption flex items-center gap-1 mt-1 ml-11">
                 <ArrowsClockwiseIcon size={12} class="animate-spin" />
                 Syncing wallet...
               </div>
             {/if}
           </div>
-          <CurrencySelector compact />
-        </div>
-        <div class="text-sm text-caption mb-4">
-          Active: {$activeWallet.name} ({getWalletKindName($activeWallet.kind)})
+          <div class="flex flex-col items-end gap-2">
+            <CurrencySelector compact />
+            <div class="flex items-center gap-3">
+              <button
+                class="flex items-center gap-1 text-sm text-caption hover:text-primary transition-colors cursor-pointer"
+                on:click={toggleBalanceVisibility}
+                title={$balanceVisible ? 'Hide balance' : 'Show balance'}
+              >
+                {#if $balanceVisible}
+                  <EyeSlashIcon size={16} />
+                {:else}
+                  <EyeIcon size={16} />
+                {/if}
+              </button>
+              <button
+                class="text-caption hover:text-primary transition-colors cursor-pointer disabled:opacity-50"
+                on:click={() => refreshBalance()}
+                disabled={$walletLoading}
+                title="Refresh balance"
+              >
+                <span class:animate-spin={$walletLoading}>
+                  <ArrowsClockwiseIcon size={16} />
+                </span>
+              </button>
+            </div>
+          </div>
         </div>
 
         <!-- Send/Receive buttons - only for NWC and Spark wallets -->
         {#if $activeWallet.kind !== 1}
-          <div class="flex gap-3">
+          <div class="flex gap-3 mt-4">
             <button
               class="flex-1 flex items-center justify-center gap-2 py-3 px-4 rounded-xl bg-amber-500 hover:bg-amber-600 text-white font-medium transition-colors"
               on:click={() => {

--- a/src/routes/wallet/+page.svelte
+++ b/src/routes/wallet/+page.svelte
@@ -2560,9 +2560,8 @@
               <p class="text-2xl font-bold mb-1" style="color: var(--color-text-primary)">
                 {#if $balanceVisible}
                   {$bitcoinConnectBalance.toLocaleString()}
-                  <span class="text-sm font-normal text-caption">sats</span>
                 {:else}
-                  *** <span class="text-sm font-normal text-caption">sats</span>
+                  ***
                 {/if}
               </p>
             {:else}


### PR DESCRIPTION
## Changes
- Removed "Balance" text, lightning bolt icon now inline with amount
- Removed "sats" label because sats are the standard (SATS)
- Fiat amount left-justified under balance number
- Eye/refresh icons moved below currency selector
- Removed active wallet indicator (already shown in connected wallets)
- Added spacing between balance and action buttons