### PR TITLE
fix: improve OG tags and optimize membership lookups

### DIFF
--- a/src/routes/r/[naddr]/+page.server.ts
+++ b/src/routes/r/[naddr]/+page.server.ts
@@ -160,17 +160,15 @@ async function fetchFromRelay(relayUrl: string, identifier: string, pubkey: stri
 							.replace(/\n+/g, ' ') // Replace newlines with spaces
 							.trim();
 						
-						// Get first 200 characters, but try to end at a sentence
-						if (text.length > 200) {
-							const truncated = text.slice(0, 200);
-							const lastPeriod = truncated.lastIndexOf('.');
-							const lastExclamation = truncated.lastIndexOf('!');
-							const lastQuestion = truncated.lastIndexOf('?');
-							const lastSentence = Math.max(lastPeriod, lastExclamation, lastQuestion);
-							if (lastSentence > 100) {
+						// Get first 155 characters, but try to end at a natural boundary
+						if (text.length > 155) {
+							const truncated = text.slice(0, 155);
+							const lastSpace = truncated.lastIndexOf(' ');
+							const lastSentence = Math.max(truncated.lastIndexOf('.'), truncated.lastIndexOf('!'), truncated.lastIndexOf('?'));
+							if (lastSentence > 80) {
 								description = text.slice(0, lastSentence + 1);
 							} else {
-								description = truncated + '...';
+								description = (lastSpace > 80 ? truncated.slice(0, lastSpace) : truncated) + '...';
 							}
 						} else {
 							description = text;

--- a/src/routes/r/[naddr]/+page.svelte
+++ b/src/routes/r/[naddr]/+page.svelte
@@ -153,10 +153,12 @@
             .replace(/\n+/g, ' ')
             .trim();
 
-          if (text.length > 200) {
-            const truncated = text.slice(0, 200);
+          if (text.length > 155) {
+            const truncated = text.slice(0, 155);
+            const lastSpace = truncated.lastIndexOf(' ');
             const lastSentence = Math.max(truncated.lastIndexOf('.'), truncated.lastIndexOf('!'), truncated.lastIndexOf('?'));
-            return lastSentence > 100 ? text.slice(0, lastSentence + 1) : truncated + '...';
+            if (lastSentence > 80) return text.slice(0, lastSentence + 1);
+            return (lastSpace > 80 ? truncated.slice(0, lastSpace) : truncated) + '...';
           }
           return text || 'A delicious recipe shared on zap.cooking';
         }
@@ -168,6 +170,17 @@
     ? (event.tags?.find((tag) => tag[0] === 'image')?.[1] || 'https://zap.cooking/social-share.png')
     : (data?.ogMeta?.image || 'https://zap.cooking/social-share.png');
 
+  // Cap description at ~155 chars for Facebook/social preview
+  $: og_desc = (() => {
+    const d = og_description;
+    if (!d || d.length <= 155) return d;
+    const t = d.slice(0, 155);
+    const ls = Math.max(t.lastIndexOf('.'), t.lastIndexOf('!'), t.lastIndexOf('?'));
+    if (ls > 80) return d.slice(0, ls + 1);
+    const sp = t.lastIndexOf(' ');
+    return (sp > 80 ? t.slice(0, sp) : t) + '...';
+  })();
+
   // Check if this is a longform article (not a recipe) to show "Back to Reads" link
   $: isLongformArticle = event && event.kind === 30023 && !event.tags.some(
     (tag) => tag[0] === 't' && RECIPE_TAGS.includes(tag[1]?.toLowerCase() || '')
@@ -176,18 +189,15 @@
 
 <svelte:head>
   <title>{fullPageTitle || 'Recipe - zap.cooking'}</title>
-  <meta name="description" content={og_description} />
-  
+  <meta name="description" content={og_desc} />
+
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="article" />
   <meta property="og:url" content={`https://zap.cooking/r/${$page.params.naddr}`} />
   <meta property="og:title" content={og_title} />
-  <meta property="og:description" content={og_description} />
+  <meta property="og:description" content={og_desc} />
   <meta property="og:image" content={og_image} />
   <meta property="og:image:secure_url" content={og_image} />
-  <meta property="og:image:type" content="image/jpeg" />
-  <meta property="og:image:width" content="1200" />
-  <meta property="og:image:height" content="630" />
   <meta property="og:site_name" content="zap.cooking" />
   {#if event?.created_at || data?.ogMeta?.created_at}
     <meta property="article:published_time" content={new Date((event?.created_at || data?.ogMeta?.created_at) * 1000).toISOString()} />
@@ -200,7 +210,7 @@
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:url" content={`https://zap.cooking/r/${$page.params.naddr}`} />
   <meta name="twitter:title" content={og_title} />
-  <meta name="twitter:description" content={og_description} />
+  <meta name="twitter:description" content={og_desc} />
   <meta name="twitter:image" content={og_image} />
 </svelte:head>
 

--- a/src/routes/reads/[naddr]/+page.server.ts
+++ b/src/routes/reads/[naddr]/+page.server.ts
@@ -118,17 +118,15 @@ async function fetchFromRelay(relayUrl: string, identifier: string, pubkey: stri
 							.replace(/\n+/g, ' ') // Replace newlines with spaces
 							.trim();
 						
-						// Get first 200 characters, but try to end at a sentence
-						if (text.length > 200) {
-							const truncated = text.slice(0, 200);
-							const lastPeriod = truncated.lastIndexOf('.');
-							const lastExclamation = truncated.lastIndexOf('!');
-							const lastQuestion = truncated.lastIndexOf('?');
-							const lastSentence = Math.max(lastPeriod, lastExclamation, lastQuestion);
-							if (lastSentence > 100) {
+						// Get first 155 characters, but try to end at a natural boundary
+						if (text.length > 155) {
+							const truncated = text.slice(0, 155);
+							const lastSpace = truncated.lastIndexOf(' ');
+							const lastSentence = Math.max(truncated.lastIndexOf('.'), truncated.lastIndexOf('!'), truncated.lastIndexOf('?'));
+							if (lastSentence > 80) {
 								description = text.slice(0, lastSentence + 1);
 							} else {
-								description = truncated + '...';
+								description = (lastSpace > 80 ? truncated.slice(0, lastSpace) : truncated) + '...';
 							}
 						} else {
 							description = text;

--- a/src/routes/reads/[naddr]/+page.svelte
+++ b/src/routes/reads/[naddr]/+page.svelte
@@ -115,17 +115,12 @@
             .replace(/\n+/g, ' ') // Replace newlines with spaces
             .trim();
           
-          if (text.length > 200) {
-            const truncated = text.slice(0, 200);
-            const lastPeriod = truncated.lastIndexOf('.');
-            const lastExclamation = truncated.lastIndexOf('!');
-            const lastQuestion = truncated.lastIndexOf('?');
-            const lastSentence = Math.max(lastPeriod, lastExclamation, lastQuestion);
-            if (lastSentence > 100) {
-              return text.slice(0, lastSentence + 1);
-            } else {
-              return truncated + '...';
-            }
+          if (text.length > 155) {
+            const truncated = text.slice(0, 155);
+            const lastSpace = truncated.lastIndexOf(' ');
+            const lastSentence = Math.max(truncated.lastIndexOf('.'), truncated.lastIndexOf('!'), truncated.lastIndexOf('?'));
+            if (lastSentence > 80) return text.slice(0, lastSentence + 1);
+            return (lastSpace > 80 ? truncated.slice(0, lastSpace) : truncated) + '...';
           }
           return text || 'An article shared on zap.cooking';
         }
@@ -136,27 +131,37 @@
   $: og_image = event
     ? (event.tags?.find((tag) => tag[0] === 'image')?.[1] || 'https://zap.cooking/social-share.png')
     : (data?.ogMeta?.image || 'https://zap.cooking/social-share.png');
+
+  // Cap description at ~155 chars for Facebook/social preview
+  $: og_desc = (() => {
+    const d = og_description;
+    if (!d || d.length <= 155) return d;
+    const t = d.slice(0, 155);
+    const ls = Math.max(t.lastIndexOf('.'), t.lastIndexOf('!'), t.lastIndexOf('?'));
+    if (ls > 80) return d.slice(0, ls + 1);
+    const sp = t.lastIndexOf(' ');
+    return (sp > 80 ? t.slice(0, sp) : t) + '...';
+  })();
 </script>
 
 <svelte:head>
   <title>{fullPageTitle || 'Article - zap.cooking'}</title>
-  <meta name="description" content={og_description} />
-  
+  <meta name="description" content={og_desc} />
+
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="article" />
   <meta property="og:url" content={`https://zap.cooking/reads/${$page.params.naddr}`} />
   <meta property="og:title" content={og_title} />
-  <meta property="og:description" content={og_description} />
+  <meta property="og:description" content={og_desc} />
   <meta property="og:image" content={og_image} />
   <meta property="og:image:secure_url" content={og_image} />
-  <meta property="og:image:type" content="image/jpeg" />
-  <meta property="og:site_name" content="Zap Cooking" />
+  <meta property="og:site_name" content="zap.cooking" />
   
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:url" content={`https://zap.cooking/reads/${$page.params.naddr}`} />
   <meta name="twitter:title" content={og_title} />
-  <meta name="twitter:description" content={og_description} />
+  <meta name="twitter:description" content={og_desc} />
   <meta name="twitter:image" content={og_image} />
 </svelte:head>
 

--- a/src/routes/recipe/[slug]/+page.server.ts
+++ b/src/routes/recipe/[slug]/+page.server.ts
@@ -169,17 +169,15 @@ async function fetchFromRelay(relayUrl: string, identifier: string, pubkey: stri
 							.replace(/\n+/g, ' ') // Replace newlines with spaces
 							.trim();
 						
-						// Get first 200 characters, but try to end at a sentence
-						if (text.length > 200) {
-							const truncated = text.slice(0, 200);
-							const lastPeriod = truncated.lastIndexOf('.');
-							const lastExclamation = truncated.lastIndexOf('!');
-							const lastQuestion = truncated.lastIndexOf('?');
-							const lastSentence = Math.max(lastPeriod, lastExclamation, lastQuestion);
-							if (lastSentence > 100) {
+						// Get first 155 characters, but try to end at a natural boundary
+						if (text.length > 155) {
+							const truncated = text.slice(0, 155);
+							const lastSpace = truncated.lastIndexOf(' ');
+							const lastSentence = Math.max(truncated.lastIndexOf('.'), truncated.lastIndexOf('!'), truncated.lastIndexOf('?'));
+							if (lastSentence > 80) {
 								description = text.slice(0, lastSentence + 1);
 							} else {
-								description = truncated + '...';
+								description = (lastSpace > 80 ? truncated.slice(0, lastSpace) : truncated) + '...';
 							}
 						} else {
 							description = text;


### PR DESCRIPTION
## Summary
- **Fix Facebook large card preview**: Removed hardcoded `og:image:width/height/type` tags that falsely claimed 1200x630 for arbitrary user-uploaded images. Facebook detected the mismatch and downgraded to small cards. Now lets Facebook auto-detect real image dimensions.
- **Optimize membership API**: Replaced O(n) full member list fetches with O(1) direct single-member lookups via `pantry.zap.cooking/api/members/{pubkey}`, extracted into a shared `membershipApi.server.ts` utility.
- **Improve OG meta tags**: Added structured recipe descriptions (servings, cook time, ingredients preview), proper `og:site_name` ("zap.cooking" everywhere), and capped `og:description` at ~155 chars with natural word-boundary truncation.

## Test plan
- [ ] Share a recipe link on Facebook and verify the **large card** format (full-width image on top) appears
- [ ] Use [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) — scrape a recipe URL twice, confirm no image size warnings and `og:site_name` shows "zap.cooking"
- [ ] Verify `og:description` is ≤155 chars and doesn't cut off mid-word
- [ ] Test membership check endpoints (`/api/membership/check-status`, `/api/extract-recipe`, `/api/zappy`) still work correctly
- [ ] Verify recipe pages render correctly on `/recipe/[slug]`, `/r/[naddr]`, and `/reads/[naddr]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)