### PR TITLE
Release v4.2.0: Restore production pricing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.0.0",
+  "version": "4.2.0",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/stripeService.server.ts
+++ b/src/lib/stripeService.server.ts
@@ -59,15 +59,14 @@ export async function createCheckoutSession(params: {
   const stripe = await getStripeInstance();
   
   // Pricing configuration (in cents for Stripe)
-  // TODO: Restore production prices before launch (cook annual: 4900, pro annual: 8900)
   const pricing = {
     cook: {
-      annual: 100, // TEMP $1 for testing — production: $49.00 (4900)
-      '2year': 100, // TEMP $1 for testing — production: $83.30 (8330)
+      annual: 4900, // $49.00
+      '2year': 8330, // $83.30
     },
     pro: {
-      annual: 100, // TEMP $1 for testing — production: $89.00 (8900)
-      '2year': 100, // TEMP $1 for testing — production: $152.40 (15240)
+      annual: 8900, // $89.00
+      '2year': 15240, // $152.40
     },
   };
   

--- a/src/routes/api/genesis/create-lightning-invoice/+server.ts
+++ b/src/routes/api/genesis/create-lightning-invoice/+server.ts
@@ -31,8 +31,7 @@ import { createInvoice as createStrikeInvoice } from '$lib/strikeService.server'
 import { storeInvoiceMetadata } from '$lib/invoiceMetadataStore.server';
 
 // Founders Club pricing in USD (lifetime membership)
-// TODO: Restore production price before launch ($210)
-const FOUNDERS_CLUB_PRICE_USD = 1; // TEMP $1 for testing — production: $210
+const FOUNDERS_CLUB_PRICE_USD = 210; // $210
 
 // Discount percentage for Bitcoin payments
 const BITCOIN_DISCOUNT_PERCENT = 5;

--- a/src/routes/api/membership/create-lightning-invoice/+server.ts
+++ b/src/routes/api/membership/create-lightning-invoice/+server.ts
@@ -32,15 +32,14 @@ import { createInvoice as createStrikeInvoice } from '$lib/strikeService.server'
 import { storeInvoiceMetadata } from '$lib/invoiceMetadataStore.server';
 
 // Pricing in USD
-// TODO: Restore production prices before launch (cook: 49/83.30, pro: 89/152.40)
 const PRICING_USD = {
   cook: {
-    annual: 1, // TEMP $1 for testing — production: $49/year
-    '2year': 1, // TEMP $1 for testing — production: $83.30/2years
+    annual: 49, // $49/year
+    '2year': 83.30, // $83.30/2years
   },
   pro: {
-    annual: 1, // TEMP $1 for testing — production: $89/year
-    '2year': 1, // TEMP $1 for testing — production: $152.40/2years
+    annual: 89, // $89/year
+    '2year': 152.40, // $152.40/2years
   },
 };
 


### PR DESCRIPTION
## Summary
- Restore original production pricing across all payment backends (was set to $1 for testing)
- **Stripe (card):** Cook+ $49/$83.30, Pro Kitchen $89/$152.40
- **Strike (Lightning):** Cook+ $49/$83.30, Pro Kitchen $89/$152.40, Founders Club $210
- Bump version to 4.2.0

## Test plan
- [ ] Verify Stripe checkout sessions are created with correct USD amounts for each tier/period
- [ ] Verify Lightning invoices are generated with correct sat amounts (based on discounted USD) for each tier
- [ ] Verify Founders Club Lightning invoice uses $210 base price
- [ ] Confirm front-end display prices match backend pricing

🤖 Generated with [Claude Code](https://claude.com/claude-code)