### PR TITLE
Messaging improvements / Mention system refactor

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -107,8 +107,11 @@ html {
 }
 
 .input:focus {
-  --tw-ring-color: #ec4700;
+  --tw-ring-shadow: 0 0 0 0 transparent;
+  --tw-ring-offset-shadow: 0 0 0 0 transparent;
   border-color: #ec4700;
+  box-shadow: inset 0 0 0 1px #ec4700 !important;
+  outline: none;
 }
 
 /* Typography */

--- a/src/components/Comment.svelte
+++ b/src/components/Comment.svelte
@@ -15,7 +15,8 @@
   import { onMount, onDestroy } from 'svelte';
   import { get } from 'svelte/store';
   import { decode } from '@gandlaf21/bolt11-decode';
-  import { searchProfiles } from '$lib/profileSearchService';
+  import MentionDropdown from './MentionDropdown.svelte';
+  import { MentionComposerController, type MentionState } from '$lib/mentionComposer';
 
   export let event: NDKEvent;
   export let allReplies: NDKEvent[] = []; // All replies for finding parent
@@ -37,24 +38,31 @@
   let replyComposerEl: HTMLDivElement;
   let lastRenderedReply = '';
 
-  // @ mention autocomplete state
-  let mentionQuery = '';
-  let showMentionSuggestions = false;
-  let mentionSuggestions: {
-    name: string;
-    npub: string;
-    picture?: string;
-    pubkey: string;
-    nip05?: string;
-  }[] = [];
-  let selectedMentionIndex = 0;
-  let mentionProfileCache: Map<
-    string,
-    { name: string; npub: string; picture?: string; pubkey: string; nip05?: string }
-  > = new Map();
-  let mentionFollowListLoaded = false;
-  let mentionSearchTimeout: ReturnType<typeof setTimeout>;
-  let mentionSearching = false;
+  // Mention autocomplete
+  let mentionState: MentionState = {
+    mentionQuery: '',
+    showMentionSuggestions: false,
+    mentionSuggestions: [],
+    selectedMentionIndex: 0,
+    mentionSearching: false
+  };
+
+  const mentionCtrl = new MentionComposerController(
+    (state) => {
+      mentionState = state;
+    },
+    (text) => {
+      replyText = text;
+      lastRenderedReply = text;
+    }
+  );
+
+  $: mentionCtrl.setComposerEl(replyComposerEl);
+
+  $: if (replyComposerEl && replyText !== lastRenderedReply) {
+    mentionCtrl.syncContent(replyText);
+    lastRenderedReply = replyText;
+  }
 
   // Like state
   let liked = false;
@@ -90,723 +98,11 @@
     return null;
   }
 
-  // Load follow list profiles for mention autocomplete
-  async function loadMentionFollowList() {
-    if (mentionFollowListLoaded) return;
-
-    const pubkey = get(userPublickey);
-    if (!pubkey || !$ndk) return;
-
-    try {
-      const contactEvent = await $ndk.fetchEvent({
-        kinds: [3],
-        authors: [pubkey],
-        limit: 1
-      });
-
-      if (!contactEvent) return;
-
-      // Load ALL follows
-      const followPubkeys = contactEvent.tags.filter((t) => t[0] === 'p' && t[1]).map((t) => t[1]);
-
-      if (followPubkeys.length === 0) return;
-
-      const batchSize = 100;
-      for (let i = 0; i < followPubkeys.length; i += batchSize) {
-        const batch = followPubkeys.slice(i, i + batchSize);
-        try {
-          const events = await $ndk.fetchEvents({
-            kinds: [0],
-            authors: batch
-          });
-
-          for (const event of events) {
-            try {
-              const profile = JSON.parse(event.content);
-              const name = profile.display_name || profile.name || '';
-              if (name || profile.nip05) {
-                mentionProfileCache.set(event.pubkey, {
-                  name: name || profile.nip05?.split('@')[0] || 'Unknown',
-                  npub: nip19.npubEncode(event.pubkey),
-                  picture: profile.picture,
-                  pubkey: event.pubkey,
-                  nip05: profile.nip05
-                });
-              }
-            } catch {}
-          }
-        } catch (e) {
-          console.debug('Failed to fetch mention profile batch:', e);
-        }
-      }
-
-      mentionFollowListLoaded = true;
-    } catch (e) {
-      console.debug('Failed to load mention follow list:', e);
-    }
-  }
-
-  // Search users for mention autocomplete
-  async function searchMentionUsers(query: string) {
-    // Don't wait for follow list - search in parallel
-    loadMentionFollowList();
-
-    const queryLower = query.toLowerCase();
-    const matches: {
-      name: string;
-      npub: string;
-      picture?: string;
-      pubkey: string;
-      nip05?: string;
-    }[] = [];
-    const seenPubkeys = new Set<string>();
-
-    // Search local cache - by name AND NIP-05
-    for (const profile of mentionProfileCache.values()) {
-      const nameMatch = profile.name.toLowerCase().includes(queryLower);
-      const nip05Match = profile.nip05?.toLowerCase().includes(queryLower);
-
-      if (nameMatch || nip05Match) {
-        matches.push(profile);
-        seenPubkeys.add(profile.pubkey);
-      }
-    }
-
-    // Show local matches immediately
-    if (matches.length > 0) {
-      mentionSuggestions = matches.slice(0, 10);
-      selectedMentionIndex = 0;
-    }
-
-    const shouldSearchPrimal = query.length >= 2;
-    const shouldSearchNdk = query.length >= 1 && $ndk;
-
-    if (shouldSearchPrimal || shouldSearchNdk) {
-      mentionSearching = true;
-      try {
-        if (shouldSearchPrimal) {
-          const primalResults = await searchProfiles(query, 25);
-          for (const profile of primalResults) {
-            if (seenPubkeys.has(profile.pubkey)) continue;
-
-            const name =
-              profile.displayName || profile.name || profile.nip05?.split('@')[0] || 'Unknown';
-            const profileData = {
-              name,
-              npub: profile.npub || nip19.npubEncode(profile.pubkey),
-              picture: profile.picture,
-              pubkey: profile.pubkey,
-              nip05: profile.nip05
-            };
-            matches.push(profileData);
-            seenPubkeys.add(profile.pubkey);
-            mentionProfileCache.set(profile.pubkey, profileData);
-          }
-        }
-
-        if (shouldSearchNdk && $ndk) {
-          const searchResults = await $ndk.fetchEvents({
-            kinds: [0],
-            search: query,
-            limit: 50
-          });
-
-          for (const event of searchResults) {
-            if (seenPubkeys.has(event.pubkey)) continue;
-
-            try {
-              const profile = JSON.parse(event.content);
-              const name = profile.display_name || profile.name || '';
-              const nip05 = profile.nip05;
-
-              const profileData = {
-                name: name || nip05?.split('@')[0] || profile.name || 'Unknown',
-                npub: nip19.npubEncode(event.pubkey),
-                picture: profile.picture,
-                pubkey: event.pubkey,
-                nip05
-              };
-              matches.push(profileData);
-              seenPubkeys.add(event.pubkey);
-              mentionProfileCache.set(event.pubkey, profileData);
-            } catch {}
-          }
-        }
-      } catch (e) {
-        console.debug('Network search failed:', e);
-      } finally {
-        mentionSearching = false;
-      }
-    }
-
-    // Sort: prioritize exact matches
-    matches.sort((a, b) => {
-      const aExact =
-        a.name.toLowerCase().startsWith(queryLower) ||
-        a.nip05?.toLowerCase().startsWith(queryLower);
-      const bExact =
-        b.name.toLowerCase().startsWith(queryLower) ||
-        b.nip05?.toLowerCase().startsWith(queryLower);
-      if (aExact && !bExact) return -1;
-      if (!aExact && bExact) return 1;
-      return a.name.localeCompare(b.name);
-    });
-
-    mentionSuggestions = matches.slice(0, 10);
-    selectedMentionIndex = 0;
-  }
-
-  function syncComposerContent(value: string) {
-    if (!replyComposerEl) return;
-    const html = renderTextWithMentions(value);
-    if (replyComposerEl.innerHTML !== html) {
-      replyComposerEl.innerHTML = html;
-    }
-    lastRenderedReply = value;
-  }
-
-  function escapeHtml(value: string): string {
-    return value
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#39;');
-  }
-
-  function escapeRegex(value: string): string {
-    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  }
-
-  function formatNpubShort(npub: string): string {
-    if (npub.length <= 16) return npub;
-    return `${npub.slice(0, 10)}...${npub.slice(-6)}`;
-  }
-
-  function getDisplayNameForMention(mention: string): string {
-    const identifier = mention.replace('nostr:', '');
-    try {
-      const decoded = nip19.decode(identifier);
-      if (decoded.type === 'npub') {
-        const profile = mentionProfileCache.get(decoded.data);
-        if (profile?.name) return profile.name;
-        return formatNpubShort(identifier);
-      }
-      if (decoded.type === 'nprofile') {
-        const profile = mentionProfileCache.get(decoded.data.pubkey);
-        if (profile?.name) return profile.name;
-        return formatNpubShort(nip19.npubEncode(decoded.data.pubkey));
-      }
-    } catch {}
-    return formatNpubShort(identifier);
-  }
-
-  function renderTextWithMentions(text: string): string {
-    if (!text) return '';
-    const mentionRegex =
-      /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)|@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g;
-    let html = '';
-    let lastIndex = 0;
-    let match: RegExpExecArray | null;
-
-    while ((match = mentionRegex.exec(text)) !== null) {
-      const beforeText = text.substring(lastIndex, match.index);
-      if (beforeText) {
-        html += escapeHtml(beforeText).replace(/\n/g, '<br>');
-      }
-
-      const rawMention = match[0];
-      const mention = rawMention.startsWith('@') ? `nostr:${rawMention.slice(1)}` : rawMention;
-      const displayName = getDisplayNameForMention(mention);
-      html += `<span class="mention-pill" contenteditable="false" data-mention="${mention}">@${escapeHtml(displayName)}</span>`;
-
-      lastIndex = match.index + rawMention.length;
-    }
-
-    if (lastIndex < text.length) {
-      html += escapeHtml(text.substring(lastIndex)).replace(/\n/g, '<br>');
-    }
-
-    return html;
-  }
-
-  function htmlToPlainText(element: Node): string {
-    let text = '';
-    let isFirstChild = true;
-
-    element.childNodes.forEach((node) => {
-      if (node.nodeType === Node.TEXT_NODE) {
-        const content = (node.textContent || '').replace(/\u200B/g, '');
-        text += content;
-        if (content) {
-          isFirstChild = false;
-        }
-      } else if (node.nodeType === Node.ELEMENT_NODE) {
-        const el = node as HTMLElement;
-
-        if (el.dataset.mention) {
-          text += el.dataset.mention;
-          isFirstChild = false;
-        } else if (el.tagName === 'BR') {
-          text += '\n';
-        } else if (el.tagName === 'DIV') {
-          if (!isFirstChild) {
-            text += '\n';
-          }
-
-          const hasOnlyBr = el.childNodes.length === 1 && el.firstChild?.nodeName === 'BR';
-          if (!hasOnlyBr) {
-            text += htmlToPlainText(node);
-          }
-          isFirstChild = false;
-        } else if (el.tagName === 'SPAN') {
-          const spanContent = htmlToPlainText(node);
-          text += spanContent;
-          if (spanContent) {
-            isFirstChild = false;
-          }
-        } else {
-          const childContent = htmlToPlainText(node);
-          text += childContent;
-          if (childContent) {
-            isFirstChild = false;
-          }
-        }
-      }
-    });
-
-    return text;
-  }
-
-  function getTextBeforeCursor(element: HTMLDivElement): string {
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return '';
-
-    const range = selection.getRangeAt(0);
-    const preCaretRange = range.cloneRange();
-    preCaretRange.selectNodeContents(element);
-    preCaretRange.setEnd(range.startContainer, range.startOffset);
-
-    const tempDiv = document.createElement('div');
-    tempDiv.appendChild(preCaretRange.cloneContents());
-
-    return htmlToPlainText(tempDiv);
-  }
-
-  function updateContentFromComposer() {
-    if (!replyComposerEl) return;
-    const newText = htmlToPlainText(replyComposerEl);
-    lastRenderedReply = newText;
-    replyText = newText;
-  }
-
-  function handleBeforeInput(event: InputEvent) {
-    if (
-      event.isComposing ||
-      event.inputType === 'historyUndo' ||
-      event.inputType === 'historyRedo'
-    ) {
-      return;
-    }
-
-    const selection = window.getSelection();
-    if (!selection || !replyComposerEl) return;
-    const range = selection.getRangeAt(0);
-    let node: Node | null = range.startContainer;
-
-    while (node && node !== replyComposerEl) {
-      if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).dataset.mention) {
-        event.preventDefault();
-
-        if (event.inputType === 'insertText' || event.inputType === 'insertCompositionText') {
-          const newRange = document.createRange();
-          newRange.setStartAfter(node);
-          newRange.collapse(true);
-          selection.removeAllRanges();
-          selection.addRange(newRange);
-        }
-        return;
-      }
-      node = node.parentNode;
-    }
-  }
-
-  function handlePaste(event: ClipboardEvent) {
-    event.preventDefault();
-    const plainText = event.clipboardData?.getData('text/plain');
-    if (!plainText) return;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-    const range = selection.getRangeAt(0);
-
-    range.deleteContents();
-    const textNode = document.createTextNode(plainText);
-    range.insertNode(textNode);
-    range.setStartAfter(textNode);
-    range.collapse(true);
-    selection.removeAllRanges();
-    selection.addRange(range);
-
-    handleReplyInput();
-  }
-
-  function handleReplyInput() {
-    updateContentFromComposer();
-    if (!replyComposerEl) return;
-
-    const converted = convertRawMentionsToPills();
-    if (converted) {
-      updateContentFromComposer();
-    }
-
-    const textBeforeCursor = getTextBeforeCursor(replyComposerEl);
-    const mentionMatch = textBeforeCursor.match(/@([^@]*)$/);
-
-    if (mentionMatch) {
-      mentionQuery = mentionMatch[1] || '';
-      showMentionSuggestions = true;
-
-      if (mentionSearchTimeout) clearTimeout(mentionSearchTimeout);
-      mentionSearchTimeout = setTimeout(() => {
-        if (mentionQuery.length > 0) {
-          searchMentionUsers(mentionQuery);
-        } else {
-          mentionSuggestions = Array.from(mentionProfileCache.values()).slice(0, 8);
-          selectedMentionIndex = 0;
-        }
-      }, 150);
-    } else {
-      showMentionSuggestions = false;
-      mentionSuggestions = [];
-    }
-  }
-
-  function deleteCharsBeforeCursor(count: number) {
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-
-    const range = selection.getRangeAt(0);
-    let remaining = count;
-    let currentNode: Node | null = range.startContainer;
-    let currentOffset = range.startOffset;
-
-    if (currentNode.nodeType === Node.ELEMENT_NODE) {
-      const walker = document.createTreeWalker(currentNode, NodeFilter.SHOW_TEXT, null);
-      let lastText: Text | null = null;
-      while (walker.nextNode()) {
-        lastText = walker.currentNode as Text;
-      }
-      if (lastText) {
-        currentNode = lastText;
-        currentOffset = lastText.length;
-      }
-    }
-
-    while (remaining > 0 && currentNode) {
-      if (currentNode.nodeType === Node.TEXT_NODE) {
-        const textNode = currentNode as Text;
-        const deleteCount = Math.min(remaining, currentOffset);
-        if (deleteCount > 0) {
-          textNode.deleteData(currentOffset - deleteCount, deleteCount);
-          remaining -= deleteCount;
-          currentOffset -= deleteCount;
-        }
-
-        if (remaining > 0) {
-          let prev: Node | null = textNode.previousSibling;
-          while (prev && prev.nodeType !== Node.TEXT_NODE) {
-            prev = prev.previousSibling;
-          }
-          if (prev) {
-            currentNode = prev;
-            currentOffset = (prev as Text).length;
-          } else {
-            break;
-          }
-        }
-      } else {
-        break;
-      }
-    }
-  }
-
-  function createMentionPill(mention: string, displayName: string): HTMLSpanElement {
-    const pill = document.createElement('span');
-    pill.contentEditable = 'false';
-    pill.dataset.mention = mention;
-    pill.className = 'mention-pill';
-    pill.textContent = `@${displayName}`;
-    return pill;
-  }
-
-  function insertMentionNode(mention: string, displayName: string, addTrailingSpace = false) {
-    if (!replyComposerEl) return;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-    const range = selection.getRangeAt(0);
-
-    const pill = createMentionPill(mention, displayName);
-    const newRange = document.createRange();
-    newRange.setStart(range.startContainer, range.startOffset);
-    newRange.collapse(true);
-    newRange.insertNode(pill);
-
-    if (addTrailingSpace) {
-      const spacer = document.createTextNode(' ');
-      pill.after(spacer);
-      newRange.setStartAfter(spacer);
-    } else {
-      newRange.setStartAfter(pill);
-    }
-
-    newRange.collapse(true);
-    selection.removeAllRanges();
-    selection.addRange(newRange);
-  }
-
-  function convertRawMentionsToPills(): boolean {
-    if (!replyComposerEl) return false;
-
-    const rawText = replyComposerEl.textContent || '';
-    if (!rawText.includes('npub1')) return false;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0 || !selection.isCollapsed) return false;
-
-    const range = selection.getRangeAt(0);
-    const marker = document.createElement('span');
-    marker.dataset.mentionCaret = 'true';
-    marker.textContent = '\u200B';
-    range.insertNode(marker);
-
-    const textNodes: Text[] = [];
-    const walker = document.createTreeWalker(replyComposerEl, NodeFilter.SHOW_TEXT, {
-      acceptNode(node) {
-        const parent = node.parentElement;
-        if (!parent) return NodeFilter.FILTER_REJECT;
-        if (parent.dataset.mention || parent.dataset.mentionCaret) return NodeFilter.FILTER_REJECT;
-        return NodeFilter.FILTER_ACCEPT;
-      }
-    });
-
-    while (walker.nextNode()) {
-      textNodes.push(walker.currentNode as Text);
-    }
-
-    let converted = false;
-    for (const textNode of textNodes) {
-      const text = textNode.nodeValue;
-      if (!text || !text.includes('npub1')) continue;
-
-      const mentionRegex =
-        /@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)/g;
-      let lastIndex = 0;
-      let match: RegExpExecArray | null;
-      let hasMatch = false;
-      const fragment = document.createDocumentFragment();
-
-      while ((match = mentionRegex.exec(text)) !== null) {
-        hasMatch = true;
-        const before = text.slice(lastIndex, match.index);
-        if (before) {
-          fragment.appendChild(document.createTextNode(before));
-        }
-
-        const rawMention = match[0];
-        const mention = rawMention.startsWith('@') ? `nostr:${rawMention.slice(1)}` : rawMention;
-        const displayName = getDisplayNameForMention(mention);
-        fragment.appendChild(createMentionPill(mention, displayName));
-
-        lastIndex = match.index + rawMention.length;
-      }
-
-      if (!hasMatch) continue;
-      converted = true;
-
-      if (lastIndex < text.length) {
-        fragment.appendChild(document.createTextNode(text.slice(lastIndex)));
-      }
-
-      textNode.parentNode?.replaceChild(fragment, textNode);
-    }
-
-    const caretMarker = replyComposerEl.querySelector('[data-mention-caret]');
-    if (caretMarker) {
-      const newRange = document.createRange();
-      newRange.setStartAfter(caretMarker);
-      newRange.collapse(true);
-      selection.removeAllRanges();
-      selection.addRange(newRange);
-      caretMarker.remove();
-    }
-
-    return converted;
-  }
-
-  function insertMention(user: { name: string; npub: string; pubkey: string }) {
-    if (!replyComposerEl) return;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-    const textBeforeCursor = getTextBeforeCursor(replyComposerEl);
-    const mentionMatch = textBeforeCursor.match(/@([^@]*)$/);
-
-    if (mentionMatch?.[0]) {
-      deleteCharsBeforeCursor(mentionMatch[0].length);
-    }
-
-    const textAfterDeletion = getTextBeforeCursor(replyComposerEl);
-    const needsLeadingSpace = textAfterDeletion.length > 0 && !/\s$/.test(textAfterDeletion);
-    
-    if (needsLeadingSpace) {
-      const spaceNode = document.createTextNode(' ');
-      const range = selection.getRangeAt(0);
-      range.insertNode(spaceNode);
-      range.setStartAfter(spaceNode);
-      range.collapse(true);
-      selection.removeAllRanges();
-      selection.addRange(range);
-    }
-
-    const mention = `nostr:${user.npub}`;
-    insertMentionNode(mention, user.name, true);
-
-    mentionProfileCache.set(user.pubkey, user);
-    updateContentFromComposer();
-    showMentionSuggestions = false;
-    mentionSuggestions = [];
-  }
-
-  function replacePlainMentions(text: string): string {
-    let output = text;
-    output = output.replace(
-      /@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g,
-      (match) => `nostr:${match.slice(1)}`
-    );
-    for (const profile of mentionProfileCache.values()) {
-      if (!profile.name) continue;
-      const mentionText = `@${profile.name}`;
-      const mentionRegex = new RegExp(`${escapeRegex(mentionText)}(?=\\s|$|[.,!?;:])`, 'gi');
-      if (mentionRegex.test(output)) {
-        output = output.replace(mentionRegex, `nostr:${profile.npub}`);
-      }
-    }
-    return output;
-  }
-
-  function parseMentions(text: string): Map<string, string> {
-    const mentions = new Map<string, string>();
-    const mentionRegex =
-      /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)|@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g;
-    let match;
-
-    while ((match = mentionRegex.exec(text)) !== null) {
-      const mention = match[1] || match[0].slice(1);
-      try {
-        const decoded = nip19.decode(mention);
-        if (decoded.type === 'npub') {
-          mentions.set(mention, decoded.data);
-        } else if (decoded.type === 'nprofile') {
-          mentions.set(mention, decoded.data.pubkey);
-        }
-      } catch {}
-    }
-
-    return mentions;
-  }
-
-  function handleReplyKeydown(event: KeyboardEvent) {
-    const selection = window.getSelection();
-    if (selection && selection.rangeCount) {
-      const range = selection.getRangeAt(0);
-
-      if (event.key === 'Delete' && range.collapsed) {
-        const { startContainer, startOffset } = range;
-        if (startContainer.nodeType === Node.TEXT_NODE) {
-          const textNode = startContainer as Text;
-          if (startOffset === textNode.length) {
-            const nextSibling = startContainer.nextSibling;
-            if (
-              nextSibling &&
-              nextSibling.nodeType === Node.ELEMENT_NODE &&
-              (nextSibling as HTMLElement).dataset.mention
-            ) {
-              event.preventDefault();
-              nextSibling.remove();
-              updateContentFromComposer();
-              return;
-            }
-          }
-        }
-      }
-
-      if (event.key === 'Backspace') {
-        if (!range.collapsed) {
-          const container = range.commonAncestorContainer;
-          let mentionElement: HTMLElement | null = null;
-
-          if (container.nodeType === Node.ELEMENT_NODE) {
-            const el = container as HTMLElement;
-            if (el.dataset.mention) {
-              mentionElement = el;
-            }
-          } else if (container.parentElement?.dataset.mention) {
-            mentionElement = container.parentElement;
-          }
-
-          if (mentionElement) {
-            event.preventDefault();
-            mentionElement.remove();
-            updateContentFromComposer();
-            return;
-          }
-        }
-
-        if (range.collapsed) {
-          const { startContainer, startOffset } = range;
-          if (startContainer.nodeType === Node.TEXT_NODE && startOffset === 0) {
-            const prevSibling = startContainer.previousSibling;
-            if (
-              prevSibling &&
-              prevSibling.nodeType === Node.ELEMENT_NODE &&
-              (prevSibling as HTMLElement).dataset.mention
-            ) {
-              event.preventDefault();
-              prevSibling.remove();
-              updateContentFromComposer();
-              return;
-            }
-          }
-        }
-      }
-    }
-
-    if (showMentionSuggestions && mentionSuggestions.length > 0) {
-      if (event.key === 'ArrowDown') {
-        event.preventDefault();
-        selectedMentionIndex = (selectedMentionIndex + 1) % mentionSuggestions.length;
-      } else if (event.key === 'ArrowUp') {
-        event.preventDefault();
-        selectedMentionIndex =
-          selectedMentionIndex === 0 ? mentionSuggestions.length - 1 : selectedMentionIndex - 1;
-      } else if (event.key === 'Enter' || event.key === 'Tab') {
-        event.preventDefault();
-        insertMention(mentionSuggestions[selectedMentionIndex]);
-      } else if (event.key === 'Escape') {
-        showMentionSuggestions = false;
-        mentionSuggestions = [];
-      }
-      return;
-    }
-  }
-
   // Load profile and parent comment
   onMount(async () => {
     // Preload mention profiles in background
     if ($userPublickey) {
-      loadMentionFollowList();
+      mentionCtrl.preloadFollowList();
     }
 
     // Load author profile
@@ -954,11 +250,11 @@
     ev.kind = isRecipeReply ? 1111 : 1;
 
     if (replyComposerEl) {
-      replyText = htmlToPlainText(replyComposerEl);
+      replyText = mentionCtrl.extractText();
       lastRenderedReply = replyText;
     }
 
-    const replyContent = replacePlainMentions(replyText.trim());
+    const replyContent = mentionCtrl.replacePlainMentions(replyText.trim());
     ev.content = replyContent;
 
     // Reconstruct a minimal event object for the parent comment
@@ -1019,7 +315,7 @@
     }
 
     // Parse and add @ mention tags (p tags)
-    const mentions = parseMentions(replyContent);
+    const mentions = mentionCtrl.parseMentions(replyContent);
     for (const pubkey of mentions.values()) {
       if (!ev.tags.some((t) => t[0] === 'p' && t[1] === pubkey)) {
         ev.tags.push(['p', pubkey]);
@@ -1033,18 +329,14 @@
     if (replyComposerEl) {
       replyComposerEl.innerHTML = '';
     }
-    showMentionSuggestions = false;
-    mentionSuggestions = [];
-    mentionQuery = '';
+    mentionCtrl.resetMentionState();
     showReplyBox = false;
     postingReply = false;
     refresh();
   }
 
   onDestroy(() => {
-    if (mentionSearchTimeout) {
-      clearTimeout(mentionSearchTimeout);
-    }
+    mentionCtrl.destroy();
     if (likeSubscription) {
       likeSubscription.stop();
     }
@@ -1067,10 +359,6 @@
       .trim();
     if (cleaned.length <= maxLength) return cleaned;
     return cleaned.slice(0, maxLength).trim() + '...';
-  }
-
-  $: if (replyComposerEl && replyText !== lastRenderedReply) {
-    syncComposerContent(replyText);
   }
 </script>
 
@@ -1167,42 +455,20 @@
               role="textbox"
               aria-multiline="true"
               data-placeholder="Add a reply..."
-              on:input={handleReplyInput}
-              on:keydown={handleReplyKeydown}
-              on:beforeinput={handleBeforeInput}
-              on:paste={handlePaste}
+              on:input={() => mentionCtrl.handleInput()}
+              on:keydown={(e) => mentionCtrl.handleKeydown(e)}
+              on:beforeinput={(e) => mentionCtrl.handleBeforeInput(e)}
+              on:paste={(e) => mentionCtrl.handlePaste(e)}
             ></div>
 
-            <!-- Mention suggestions dropdown -->
-            {#if showMentionSuggestions}
-              <div class="mention-dropdown" style="border-color: var(--color-input-border);">
-                {#if mentionSuggestions.length > 0}
-                  <div class="mention-dropdown-content">
-                    {#each mentionSuggestions as suggestion, index}
-                      <button
-                        type="button"
-                        on:click={() => insertMention(suggestion)}
-                        on:mousedown|preventDefault={() => insertMention(suggestion)}
-                        class="mention-option"
-                        class:mention-selected={index === selectedMentionIndex}
-                      >
-                        <CustomAvatar pubkey={suggestion.pubkey} size={24} />
-                        <div class="mention-info">
-                          <span class="mention-name">{suggestion.name}</span>
-                          {#if suggestion.nip05}
-                            <span class="mention-nip05">{suggestion.nip05}</span>
-                          {/if}
-                        </div>
-                      </button>
-                    {/each}
-                  </div>
-                {:else if mentionSearching}
-                  <div class="mention-empty">Searching...</div>
-                {:else if mentionQuery.length > 0}
-                  <div class="mention-empty">No users found</div>
-                {/if}
-              </div>
-            {/if}
+            <MentionDropdown
+              show={mentionState.showMentionSuggestions}
+              suggestions={mentionState.mentionSuggestions}
+              selectedIndex={mentionState.selectedMentionIndex}
+              searching={mentionState.mentionSearching}
+              query={mentionState.mentionQuery}
+              on:select={(e) => mentionCtrl.insertMention(e.detail)}
+            />
           </div>
           <div class="reply-buttons">
             <button
@@ -1220,9 +486,7 @@
                 if (replyComposerEl) {
                   replyComposerEl.innerHTML = '';
                 }
-                showMentionSuggestions = false;
-                mentionSuggestions = [];
-                mentionQuery = '';
+                mentionCtrl.resetMentionState();
               }}
               class="btn-cancel"
             >
@@ -1435,107 +699,5 @@
 
   .btn-cancel:hover {
     opacity: 0.8;
-  }
-
-  /* Mention dropdown - compact and scrollable */
-  .mention-dropdown {
-    position: absolute;
-    z-index: 1000;
-    top: 100%;
-    left: 0;
-    margin-top: 0.25rem;
-    width: 280px;
-    max-width: calc(100vw - 2rem);
-    background: var(--color-input-bg);
-    border: 1px solid var(--color-input-border);
-    border-radius: 0.5rem;
-    box-shadow:
-      0 4px 6px -1px rgb(0 0 0 / 0.1),
-      0 2px 4px -1px rgb(0 0 0 / 0.06);
-    overflow: hidden;
-  }
-
-  .mention-dropdown-content {
-    max-height: 200px;
-    overflow-y: auto;
-    overflow-x: hidden;
-  }
-
-  .mention-dropdown-content::-webkit-scrollbar {
-    width: 6px;
-  }
-
-  .mention-dropdown-content::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  .mention-dropdown-content::-webkit-scrollbar-thumb {
-    background: var(--color-input-border);
-    border-radius: 3px;
-  }
-
-  .mention-dropdown-content::-webkit-scrollbar-thumb:hover {
-    background: var(--color-caption);
-  }
-
-  .mention-option {
-    width: 100%;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 0.75rem;
-    text-align: left;
-    transition: background-color 0.15s;
-    border: none;
-    background: transparent;
-  }
-
-  .mention-option:hover,
-  .mention-selected {
-    background: var(--color-accent-gray);
-  }
-
-  .mention-info {
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
-    flex: 1;
-  }
-
-  .mention-name {
-    font-size: 0.875rem;
-    font-weight: 500;
-    color: var(--color-text-primary);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .mention-nip05 {
-    font-size: 0.75rem;
-    color: var(--color-caption);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .mention-empty {
-    padding: 0.75rem;
-    text-align: center;
-    font-size: 0.875rem;
-    color: var(--color-caption);
-  }
-
-  :global(.mention-pill) {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-    padding: 0.1rem 0.45rem;
-    border-radius: 0.5rem;
-    background: rgba(247, 147, 26, 0.2);
-    color: #f7931a;
-    font-weight: 600;
-    user-select: all;
-    margin: 0 0.1rem;
   }
 </style>

--- a/src/components/CommentReplies.svelte
+++ b/src/components/CommentReplies.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte';
+  import { onDestroy } from 'svelte';
   import { ndk, userPublickey } from '$lib/nostr';
   import { NDKEvent } from '@nostr-dev-kit/ndk';
   import { mutedPubkeys } from '$lib/muteListStore';
@@ -13,7 +13,8 @@
   import CommentLikes from './CommentLikes.svelte';
   import NoteContent from './NoteContent.svelte';
   import { get } from 'svelte/store';
-  import { searchProfiles } from '$lib/profileSearchService';
+  import MentionDropdown from './MentionDropdown.svelte';
+  import { MentionComposerController, type MentionState } from '$lib/mentionComposer';
 
   export let parentComment: NDKEvent;
 
@@ -29,732 +30,30 @@
   let lastRenderedReply = '';
   let replySubscription: any = null;
 
-  // @ mention autocomplete state
-  let mentionQuery = '';
-  let showMentionSuggestions = false;
-  let mentionSuggestions: {
-    name: string;
-    npub: string;
-    picture?: string;
-    pubkey: string;
-    nip05?: string;
-  }[] = [];
-  let selectedMentionIndex = 0;
-  let mentionProfileCache: Map<
-    string,
-    { name: string; npub: string; picture?: string; pubkey: string; nip05?: string }
-  > = new Map();
-  let mentionFollowListLoaded = false;
-  let mentionSearchTimeout: ReturnType<typeof setTimeout>;
-  let mentionSearching = false;
+  // Mention autocomplete
+  let mentionState: MentionState = {
+    mentionQuery: '',
+    showMentionSuggestions: false,
+    mentionSuggestions: [],
+    selectedMentionIndex: 0,
+    mentionSearching: false
+  };
 
-  // Load follow list profiles for mention autocomplete
-  async function loadMentionFollowList() {
-    if (mentionFollowListLoaded) return;
-
-    const pubkey = get(userPublickey);
-    if (!pubkey || !$ndk) return;
-
-    try {
-      const contactEvent = await $ndk.fetchEvent({
-        kinds: [3],
-        authors: [pubkey],
-        limit: 1
-      });
-
-      if (!contactEvent) return;
-
-      const followPubkeys = contactEvent.tags.filter((t) => t[0] === 'p' && t[1]).map((t) => t[1]);
-
-      if (followPubkeys.length === 0) return;
-
-      const batchSize = 100;
-      for (let i = 0; i < followPubkeys.length; i += batchSize) {
-        const batch = followPubkeys.slice(i, i + batchSize);
-        try {
-          const events = await $ndk.fetchEvents({
-            kinds: [0],
-            authors: batch
-          });
-
-          for (const event of events) {
-            try {
-              const profile = JSON.parse(event.content);
-              const name = profile.display_name || profile.name || '';
-              if (name || profile.nip05) {
-                mentionProfileCache.set(event.pubkey, {
-                  name: name || profile.nip05?.split('@')[0] || 'Unknown',
-                  npub: nip19.npubEncode(event.pubkey),
-                  picture: profile.picture,
-                  pubkey: event.pubkey,
-                  nip05: profile.nip05
-                });
-              }
-            } catch {}
-          }
-        } catch (e) {
-          console.debug('Failed to fetch mention profile batch:', e);
-        }
-      }
-
-      mentionFollowListLoaded = true;
-    } catch (e) {
-      console.debug('Failed to load mention follow list:', e);
+  const mentionCtrl = new MentionComposerController(
+    (state) => {
+      mentionState = state;
+    },
+    (text) => {
+      replyText = text;
+      lastRenderedReply = text;
     }
-  }
+  );
 
-  // Search users for mention autocomplete
-  async function searchMentionUsers(query: string) {
-    loadMentionFollowList();
+  $: mentionCtrl.setComposerEl(replyComposerEl);
 
-    const queryLower = query.toLowerCase();
-    const matches: {
-      name: string;
-      npub: string;
-      picture?: string;
-      pubkey: string;
-      nip05?: string;
-    }[] = [];
-    const seenPubkeys = new Set<string>();
-
-    for (const profile of mentionProfileCache.values()) {
-      const nameMatch = profile.name.toLowerCase().includes(queryLower);
-      const nip05Match = profile.nip05?.toLowerCase().includes(queryLower);
-
-      if (nameMatch || nip05Match) {
-        matches.push(profile);
-        seenPubkeys.add(profile.pubkey);
-      }
-    }
-
-    if (matches.length > 0) {
-      mentionSuggestions = matches.slice(0, 10);
-      selectedMentionIndex = 0;
-    }
-
-    const shouldSearchPrimal = query.length >= 2;
-    const shouldSearchNdk = query.length >= 1 && $ndk;
-
-    if (shouldSearchPrimal || shouldSearchNdk) {
-      mentionSearching = true;
-      try {
-        if (shouldSearchPrimal) {
-          const primalResults = await searchProfiles(query, 25);
-          for (const profile of primalResults) {
-            if (seenPubkeys.has(profile.pubkey)) continue;
-
-            const name =
-              profile.displayName || profile.name || profile.nip05?.split('@')[0] || 'Unknown';
-            const profileData = {
-              name,
-              npub: profile.npub || nip19.npubEncode(profile.pubkey),
-              picture: profile.picture,
-              pubkey: profile.pubkey,
-              nip05: profile.nip05
-            };
-
-            matches.push(profileData);
-            seenPubkeys.add(profile.pubkey);
-            mentionProfileCache.set(profile.pubkey, profileData);
-          }
-        }
-
-        if (shouldSearchNdk && $ndk) {
-          const searchResults = await $ndk.fetchEvents({
-            kinds: [0],
-            search: query,
-            limit: 50
-          });
-
-          for (const event of searchResults) {
-            if (seenPubkeys.has(event.pubkey)) continue;
-
-            try {
-              const profile = JSON.parse(event.content);
-              const name = profile.display_name || profile.name || '';
-              const nip05 = profile.nip05;
-
-              const profileData = {
-                name: name || nip05?.split('@')[0] || profile.name || 'Unknown',
-                npub: nip19.npubEncode(event.pubkey),
-                picture: profile.picture,
-                pubkey: event.pubkey,
-                nip05
-              };
-
-              matches.push(profileData);
-              seenPubkeys.add(event.pubkey);
-              mentionProfileCache.set(event.pubkey, profileData);
-            } catch {}
-          }
-        }
-      } catch (e) {
-        console.debug('Network search failed:', e);
-      } finally {
-        mentionSearching = false;
-      }
-    }
-
-    matches.sort((a, b) => {
-      const aExact =
-        a.name.toLowerCase().startsWith(queryLower) ||
-        a.nip05?.toLowerCase().startsWith(queryLower);
-      const bExact =
-        b.name.toLowerCase().startsWith(queryLower) ||
-        b.nip05?.toLowerCase().startsWith(queryLower);
-      if (aExact && !bExact) return -1;
-      if (!aExact && bExact) return 1;
-      return a.name.localeCompare(b.name);
-    });
-
-    mentionSuggestions = matches.slice(0, 10);
-    selectedMentionIndex = 0;
-  }
-
-  function syncComposerContent(value: string) {
-    if (!replyComposerEl) return;
-    const html = renderTextWithMentions(value);
-    if (replyComposerEl.innerHTML !== html) {
-      replyComposerEl.innerHTML = html;
-    }
-    lastRenderedReply = value;
-  }
-
-  function escapeHtml(value: string): string {
-    return value
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#39;');
-  }
-
-  function escapeRegex(value: string): string {
-    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  }
-
-  function formatNpubShort(npub: string): string {
-    if (npub.length <= 16) return npub;
-    return `${npub.slice(0, 10)}...${npub.slice(-6)}`;
-  }
-
-  function getDisplayNameForMention(mention: string): string {
-    const identifier = mention.replace('nostr:', '');
-    try {
-      const decoded = nip19.decode(identifier);
-      if (decoded.type === 'npub') {
-        const profile = mentionProfileCache.get(decoded.data);
-        if (profile?.name) return profile.name;
-        return formatNpubShort(identifier);
-      }
-      if (decoded.type === 'nprofile') {
-        const profile = mentionProfileCache.get(decoded.data.pubkey);
-        if (profile?.name) return profile.name;
-        return formatNpubShort(nip19.npubEncode(decoded.data.pubkey));
-      }
-    } catch {}
-    return formatNpubShort(identifier);
-  }
-
-  function renderTextWithMentions(text: string): string {
-    if (!text) return '';
-    const mentionRegex =
-      /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)|@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g;
-    let html = '';
-    let lastIndex = 0;
-    let match: RegExpExecArray | null;
-
-    while ((match = mentionRegex.exec(text)) !== null) {
-      const beforeText = text.substring(lastIndex, match.index);
-      if (beforeText) {
-        html += escapeHtml(beforeText).replace(/\n/g, '<br>');
-      }
-
-      const rawMention = match[0];
-      const mention = rawMention.startsWith('@') ? `nostr:${rawMention.slice(1)}` : rawMention;
-      const displayName = getDisplayNameForMention(mention);
-      html += `<span class="mention-pill" contenteditable="false" data-mention="${mention}">@${escapeHtml(displayName)}</span>`;
-
-      lastIndex = match.index + rawMention.length;
-    }
-
-    if (lastIndex < text.length) {
-      html += escapeHtml(text.substring(lastIndex)).replace(/\n/g, '<br>');
-    }
-
-    return html;
-  }
-
-  function htmlToPlainText(element: Node): string {
-    let text = '';
-    let isFirstChild = true;
-
-    element.childNodes.forEach((node) => {
-      if (node.nodeType === Node.TEXT_NODE) {
-        const content = (node.textContent || '').replace(/\u200B/g, '');
-        text += content;
-        if (content) {
-          isFirstChild = false;
-        }
-      } else if (node.nodeType === Node.ELEMENT_NODE) {
-        const el = node as HTMLElement;
-
-        if (el.dataset.mention) {
-          text += el.dataset.mention;
-          isFirstChild = false;
-        } else if (el.tagName === 'BR') {
-          text += '\n';
-        } else if (el.tagName === 'DIV') {
-          if (!isFirstChild) {
-            text += '\n';
-          }
-
-          const hasOnlyBr = el.childNodes.length === 1 && el.firstChild?.nodeName === 'BR';
-          if (!hasOnlyBr) {
-            text += htmlToPlainText(node);
-          }
-          isFirstChild = false;
-        } else if (el.tagName === 'SPAN') {
-          const spanContent = htmlToPlainText(node);
-          text += spanContent;
-          if (spanContent) {
-            isFirstChild = false;
-          }
-        } else {
-          const childContent = htmlToPlainText(node);
-          text += childContent;
-          if (childContent) {
-            isFirstChild = false;
-          }
-        }
-      }
-    });
-
-    return text;
-  }
-
-  function getTextBeforeCursor(element: HTMLDivElement): string {
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return '';
-
-    const range = selection.getRangeAt(0);
-    const preCaretRange = range.cloneRange();
-    preCaretRange.selectNodeContents(element);
-    preCaretRange.setEnd(range.startContainer, range.startOffset);
-
-    const tempDiv = document.createElement('div');
-    tempDiv.appendChild(preCaretRange.cloneContents());
-
-    return htmlToPlainText(tempDiv);
-  }
-
-  function updateContentFromComposer() {
-    if (!replyComposerEl) return;
-    const newText = htmlToPlainText(replyComposerEl);
-    lastRenderedReply = newText;
-    replyText = newText;
-  }
-
-  function handleBeforeInput(event: InputEvent) {
-    if (
-      event.isComposing ||
-      event.inputType === 'historyUndo' ||
-      event.inputType === 'historyRedo'
-    ) {
-      return;
-    }
-
-    const selection = window.getSelection();
-    if (!selection || !replyComposerEl) return;
-    const range = selection.getRangeAt(0);
-    let node: Node | null = range.startContainer;
-
-    while (node && node !== replyComposerEl) {
-      if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).dataset.mention) {
-        event.preventDefault();
-
-        if (event.inputType === 'insertText' || event.inputType === 'insertCompositionText') {
-          const newRange = document.createRange();
-          newRange.setStartAfter(node);
-          newRange.collapse(true);
-          selection.removeAllRanges();
-          selection.addRange(newRange);
-        }
-        return;
-      }
-      node = node.parentNode;
-    }
-  }
-
-  function handlePaste(event: ClipboardEvent) {
-    event.preventDefault();
-    const plainText = event.clipboardData?.getData('text/plain');
-    if (!plainText) return;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-    const range = selection.getRangeAt(0);
-
-    range.deleteContents();
-    const textNode = document.createTextNode(plainText);
-    range.insertNode(textNode);
-    range.setStartAfter(textNode);
-    range.collapse(true);
-    selection.removeAllRanges();
-    selection.addRange(range);
-
-    handleReplyInput();
-  }
-
-  function handleReplyInput() {
-    updateContentFromComposer();
-    if (!replyComposerEl) return;
-
-    const converted = convertRawMentionsToPills();
-    if (converted) {
-      updateContentFromComposer();
-    }
-
-    const textBeforeCursor = getTextBeforeCursor(replyComposerEl);
-    const mentionMatch = textBeforeCursor.match(/@([^@]*)$/);
-
-    if (mentionMatch) {
-      mentionQuery = mentionMatch[1] || '';
-      showMentionSuggestions = true;
-
-      if (mentionSearchTimeout) clearTimeout(mentionSearchTimeout);
-      mentionSearchTimeout = setTimeout(() => {
-        if (mentionQuery.length > 0) {
-          searchMentionUsers(mentionQuery);
-        } else {
-          mentionSuggestions = Array.from(mentionProfileCache.values()).slice(0, 8);
-          selectedMentionIndex = 0;
-        }
-      }, 150);
-    } else {
-      showMentionSuggestions = false;
-      mentionSuggestions = [];
-    }
-  }
-
-  function deleteCharsBeforeCursor(count: number) {
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-
-    const range = selection.getRangeAt(0);
-    let remaining = count;
-    let currentNode: Node | null = range.startContainer;
-    let currentOffset = range.startOffset;
-
-    if (currentNode.nodeType === Node.ELEMENT_NODE) {
-      const walker = document.createTreeWalker(currentNode, NodeFilter.SHOW_TEXT, null);
-      let lastText: Text | null = null;
-      while (walker.nextNode()) {
-        lastText = walker.currentNode as Text;
-      }
-      if (lastText) {
-        currentNode = lastText;
-        currentOffset = lastText.length;
-      }
-    }
-
-    while (remaining > 0 && currentNode) {
-      if (currentNode.nodeType === Node.TEXT_NODE) {
-        const textNode = currentNode as Text;
-        const deleteCount = Math.min(remaining, currentOffset);
-        if (deleteCount > 0) {
-          textNode.deleteData(currentOffset - deleteCount, deleteCount);
-          remaining -= deleteCount;
-          currentOffset -= deleteCount;
-        }
-
-        if (remaining > 0) {
-          let prev: Node | null = textNode.previousSibling;
-          while (prev && prev.nodeType !== Node.TEXT_NODE) {
-            prev = prev.previousSibling;
-          }
-          if (prev) {
-            currentNode = prev;
-            currentOffset = (prev as Text).length;
-          } else {
-            break;
-          }
-        }
-      } else {
-        break;
-      }
-    }
-  }
-
-  function createMentionPill(mention: string, displayName: string): HTMLSpanElement {
-    const pill = document.createElement('span');
-    pill.contentEditable = 'false';
-    pill.dataset.mention = mention;
-    pill.className = 'mention-pill';
-    pill.textContent = `@${displayName}`;
-    return pill;
-  }
-
-  function insertMentionNode(mention: string, displayName: string, addTrailingSpace = false) {
-    if (!replyComposerEl) return;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-    const range = selection.getRangeAt(0);
-
-    const pill = createMentionPill(mention, displayName);
-    const newRange = document.createRange();
-    newRange.setStart(range.startContainer, range.startOffset);
-    newRange.collapse(true);
-    newRange.insertNode(pill);
-
-    if (addTrailingSpace) {
-      const spacer = document.createTextNode(' ');
-      pill.after(spacer);
-      newRange.setStartAfter(spacer);
-    } else {
-      newRange.setStartAfter(pill);
-    }
-
-    newRange.collapse(true);
-    selection.removeAllRanges();
-    selection.addRange(newRange);
-  }
-
-  function convertRawMentionsToPills(): boolean {
-    if (!replyComposerEl) return false;
-
-    const rawText = replyComposerEl.textContent || '';
-    if (!rawText.includes('npub1')) return false;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0 || !selection.isCollapsed) return false;
-
-    const range = selection.getRangeAt(0);
-    const marker = document.createElement('span');
-    marker.dataset.mentionCaret = 'true';
-    marker.textContent = '\u200B';
-    range.insertNode(marker);
-
-    const textNodes: Text[] = [];
-    const walker = document.createTreeWalker(replyComposerEl, NodeFilter.SHOW_TEXT, {
-      acceptNode(node) {
-        const parent = node.parentElement;
-        if (!parent) return NodeFilter.FILTER_REJECT;
-        if (parent.dataset.mention || parent.dataset.mentionCaret) return NodeFilter.FILTER_REJECT;
-        return NodeFilter.FILTER_ACCEPT;
-      }
-    });
-
-    while (walker.nextNode()) {
-      textNodes.push(walker.currentNode as Text);
-    }
-
-    let converted = false;
-    for (const textNode of textNodes) {
-      const text = textNode.nodeValue;
-      if (!text || !text.includes('npub1')) continue;
-
-      const mentionRegex =
-        /@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)/g;
-      let lastIndex = 0;
-      let match: RegExpExecArray | null;
-      let hasMatch = false;
-      const fragment = document.createDocumentFragment();
-
-      while ((match = mentionRegex.exec(text)) !== null) {
-        hasMatch = true;
-        const before = text.slice(lastIndex, match.index);
-        if (before) {
-          fragment.appendChild(document.createTextNode(before));
-        }
-
-        const rawMention = match[0];
-        const mention = rawMention.startsWith('@') ? `nostr:${rawMention.slice(1)}` : rawMention;
-        const displayName = getDisplayNameForMention(mention);
-        fragment.appendChild(createMentionPill(mention, displayName));
-
-        lastIndex = match.index + rawMention.length;
-      }
-
-      if (!hasMatch) continue;
-      converted = true;
-
-      if (lastIndex < text.length) {
-        fragment.appendChild(document.createTextNode(text.slice(lastIndex)));
-      }
-
-      textNode.parentNode?.replaceChild(fragment, textNode);
-    }
-
-    const caretMarker = replyComposerEl.querySelector('[data-mention-caret]');
-    if (caretMarker) {
-      const newRange = document.createRange();
-      newRange.setStartAfter(caretMarker);
-      newRange.collapse(true);
-      selection.removeAllRanges();
-      selection.addRange(newRange);
-      caretMarker.remove();
-    }
-
-    return converted;
-  }
-
-  function insertMention(user: { name: string; npub: string; pubkey: string }) {
-    if (!replyComposerEl) return;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-    const textBeforeCursor = getTextBeforeCursor(replyComposerEl);
-    const mentionMatch = textBeforeCursor.match(/@([^@]*)$/);
-
-    if (mentionMatch?.[0]) {
-      deleteCharsBeforeCursor(mentionMatch[0].length);
-    }
-
-    const textAfterDeletion = getTextBeforeCursor(replyComposerEl);
-    const needsLeadingSpace = textAfterDeletion.length > 0 && !/\s$/.test(textAfterDeletion);
-    
-    if (needsLeadingSpace) {
-      const spaceNode = document.createTextNode(' ');
-      const range = selection.getRangeAt(0);
-      range.insertNode(spaceNode);
-      range.setStartAfter(spaceNode);
-      range.collapse(true);
-      selection.removeAllRanges();
-      selection.addRange(range);
-    }
-
-    const mention = `nostr:${user.npub}`;
-    insertMentionNode(mention, user.name, true);
-
-    mentionProfileCache.set(user.pubkey, user);
-    updateContentFromComposer();
-    showMentionSuggestions = false;
-    mentionSuggestions = [];
-  }
-
-  function replacePlainMentions(text: string): string {
-    let output = text;
-    output = output.replace(
-      /@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g,
-      (match) => `nostr:${match.slice(1)}`
-    );
-    for (const profile of mentionProfileCache.values()) {
-      if (!profile.name) continue;
-      const mentionText = `@${profile.name}`;
-      const mentionRegex = new RegExp(`${escapeRegex(mentionText)}(?=\\s|$|[.,!?;:])`, 'gi');
-      if (mentionRegex.test(output)) {
-        output = output.replace(mentionRegex, `nostr:${profile.npub}`);
-      }
-    }
-    return output;
-  }
-
-  function parseMentions(text: string): Map<string, string> {
-    const mentions = new Map<string, string>();
-    const mentionRegex =
-      /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)|@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g;
-    let match;
-
-    while ((match = mentionRegex.exec(text)) !== null) {
-      const mention = match[1] || match[0].slice(1);
-      try {
-        const decoded = nip19.decode(mention);
-        if (decoded.type === 'npub') {
-          mentions.set(mention, decoded.data);
-        } else if (decoded.type === 'nprofile') {
-          mentions.set(mention, decoded.data.pubkey);
-        }
-      } catch {}
-    }
-
-    return mentions;
-  }
-
-  function handleReplyKeydown(event: KeyboardEvent) {
-    const selection = window.getSelection();
-    if (selection && selection.rangeCount) {
-      const range = selection.getRangeAt(0);
-
-      if (event.key === 'Delete' && range.collapsed) {
-        const { startContainer, startOffset } = range;
-        if (startContainer.nodeType === Node.TEXT_NODE) {
-          const textNode = startContainer as Text;
-          if (startOffset === textNode.length) {
-            const nextSibling = startContainer.nextSibling;
-            if (
-              nextSibling &&
-              nextSibling.nodeType === Node.ELEMENT_NODE &&
-              (nextSibling as HTMLElement).dataset.mention
-            ) {
-              event.preventDefault();
-              nextSibling.remove();
-              updateContentFromComposer();
-              return;
-            }
-          }
-        }
-      }
-
-      if (event.key === 'Backspace') {
-        if (!range.collapsed) {
-          const container = range.commonAncestorContainer;
-          let mentionElement: HTMLElement | null = null;
-
-          if (container.nodeType === Node.ELEMENT_NODE) {
-            const el = container as HTMLElement;
-            if (el.dataset.mention) {
-              mentionElement = el;
-            }
-          } else if (container.parentElement?.dataset.mention) {
-            mentionElement = container.parentElement;
-          }
-
-          if (mentionElement) {
-            event.preventDefault();
-            mentionElement.remove();
-            updateContentFromComposer();
-            return;
-          }
-        }
-
-        if (range.collapsed) {
-          const { startContainer, startOffset } = range;
-          if (startContainer.nodeType === Node.TEXT_NODE && startOffset === 0) {
-            const prevSibling = startContainer.previousSibling;
-            if (
-              prevSibling &&
-              prevSibling.nodeType === Node.ELEMENT_NODE &&
-              (prevSibling as HTMLElement).dataset.mention
-            ) {
-              event.preventDefault();
-              prevSibling.remove();
-              updateContentFromComposer();
-              return;
-            }
-          }
-        }
-      }
-    }
-
-    if (showMentionSuggestions && mentionSuggestions.length > 0) {
-      if (event.key === 'ArrowDown') {
-        event.preventDefault();
-        selectedMentionIndex = (selectedMentionIndex + 1) % mentionSuggestions.length;
-      } else if (event.key === 'ArrowUp') {
-        event.preventDefault();
-        selectedMentionIndex =
-          selectedMentionIndex === 0 ? mentionSuggestions.length - 1 : selectedMentionIndex - 1;
-      } else if (event.key === 'Enter' || event.key === 'Tab') {
-        event.preventDefault();
-        insertMention(mentionSuggestions[selectedMentionIndex]);
-      } else if (event.key === 'Escape') {
-        showMentionSuggestions = false;
-        mentionSuggestions = [];
-      }
-      return;
-    }
+  $: if (replyComposerEl && replyText !== lastRenderedReply) {
+    mentionCtrl.syncContent(replyText);
+    lastRenderedReply = replyText;
   }
 
   // Load replies for this comment
@@ -805,7 +104,7 @@
 
     try {
       if (replyComposerEl) {
-        replyText = htmlToPlainText(replyComposerEl);
+        replyText = mentionCtrl.extractText();
         lastRenderedReply = replyText;
       }
 
@@ -821,7 +120,7 @@
         (ATag && ATag[1]?.startsWith('30023:'));
       replyEvent.kind = isRecipeReply ? 1111 : 1;
 
-      const replyContent = replacePlainMentions(replyText.trim());
+      const replyContent = mentionCtrl.replacePlainMentions(replyText.trim());
       replyEvent.content = replyContent;
 
       // Reconstruct a minimal event object for the parent comment
@@ -870,7 +169,7 @@
       }
 
       // Parse and add @ mention tags (p tags)
-      const mentions = parseMentions(replyContent);
+      const mentions = mentionCtrl.parseMentions(replyContent);
       for (const pubkey of mentions.values()) {
         // Avoid duplicate p tags
         if (!replyEvent.tags.some((t) => t[0] === 'p' && t[1] === pubkey)) {
@@ -889,9 +188,7 @@
       if (replyComposerEl) {
         replyComposerEl.innerHTML = '';
       }
-      showMentionSuggestions = false;
-      mentionSuggestions = [];
-      mentionQuery = '';
+      mentionCtrl.resetMentionState();
       successMessage = 'Reply posted successfully!';
 
       // Reload replies to show the new one
@@ -917,22 +214,16 @@
     }
     // Preload mention profiles when opening replies
     if (showReplies && $userPublickey) {
-      loadMentionFollowList();
+      mentionCtrl.preloadFollowList();
     }
   }
 
   onDestroy(() => {
-    if (mentionSearchTimeout) {
-      clearTimeout(mentionSearchTimeout);
-    }
+    mentionCtrl.destroy();
     if (replySubscription) {
       replySubscription.stop();
     }
   });
-
-  $: if (replyComposerEl && replyText !== lastRenderedReply) {
-    syncComposerContent(replyText);
-  }
 </script>
 
 <div class="comment-replies" data-comment-id={parentComment.id}>
@@ -981,34 +272,20 @@
             aria-multiline="true"
             aria-disabled={!$ndk.signer || postingReply}
             data-placeholder={$ndk.signer ? 'Add a reply...' : 'Log in to reply...'}
-            on:input={handleReplyInput}
-            on:keydown={handleReplyKeydown}
-            on:beforeinput={handleBeforeInput}
-            on:paste={handlePaste}
+            on:input={() => mentionCtrl.handleInput()}
+            on:keydown={(e) => mentionCtrl.handleKeydown(e)}
+            on:beforeinput={(e) => mentionCtrl.handleBeforeInput(e)}
+            on:paste={(e) => mentionCtrl.handlePaste(e)}
           ></div>
 
-          <!-- Mention suggestions dropdown -->
-          {#if showMentionSuggestions && mentionSuggestions.length > 0}
-            <div
-              class="absolute z-50 mt-1 w-full max-w-md bg-input rounded-lg shadow-lg border overflow-hidden"
-              style="border-color: var(--color-input-border); max-height: 200px; overflow-y: auto;"
-            >
-              {#each mentionSuggestions as suggestion, index}
-                <button
-                  type="button"
-                  on:click={() => insertMention(suggestion)}
-                  on:mousedown|preventDefault={() => insertMention(suggestion)}
-                  class="w-full flex items-center gap-2 px-3 py-2 hover:bg-accent-gray transition-colors text-left"
-                  class:bg-accent-gray={index === selectedMentionIndex}
-                >
-                  <CustomAvatar pubkey={suggestion.pubkey} size={24} />
-                  <span class="text-sm" style="color: var(--color-text-primary)"
-                    >{suggestion.name}</span
-                  >
-                </button>
-              {/each}
-            </div>
-          {/if}
+          <MentionDropdown
+            show={mentionState.showMentionSuggestions}
+            suggestions={mentionState.mentionSuggestions}
+            selectedIndex={mentionState.selectedMentionIndex}
+            searching={mentionState.mentionSearching}
+            query={mentionState.mentionQuery}
+            on:select={(e) => mentionCtrl.insertMention(e.detail)}
+          />
         </div>
         <div class="flex justify-end">
           <Button
@@ -1130,18 +407,5 @@
     content: attr(data-placeholder);
     color: var(--color-caption);
     pointer-events: none;
-  }
-
-  :global(.mention-pill) {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-    padding: 0.1rem 0.45rem;
-    border-radius: 0.5rem;
-    background: rgba(247, 147, 26, 0.2);
-    color: #f7931a;
-    font-weight: 600;
-    user-select: all;
-    margin: 0 0.1rem;
   }
 </style>

--- a/src/components/Comments.svelte
+++ b/src/components/Comments.svelte
@@ -7,10 +7,9 @@
   import Comment from './Comment.svelte';
   import { onDestroy } from 'svelte';
   import { createCommentFilter } from '$lib/commentFilters';
-  import { nip19 } from 'nostr-tools';
   import { get } from 'svelte/store';
-  import CustomAvatar from './CustomAvatar.svelte';
-  import { searchProfiles } from '$lib/profileSearchService';
+  import MentionDropdown from './MentionDropdown.svelte';
+  import { MentionComposerController, type MentionState } from '$lib/mentionComposer';
 
   export let event: NDKEvent;
   let events = [];
@@ -21,24 +20,36 @@
   let subscribed = false;
   let commentSubscription: any = null;
 
-  // @ mention autocomplete state
-  let mentionQuery = '';
-  let showMentionSuggestions = false;
-  let mentionSuggestions: {
-    name: string;
-    npub: string;
-    picture?: string;
-    pubkey: string;
-    nip05?: string;
-  }[] = [];
-  let selectedMentionIndex = 0;
-  let mentionProfileCache: Map<
-    string,
-    { name: string; npub: string; picture?: string; pubkey: string; nip05?: string }
-  > = new Map();
-  let mentionFollowListLoaded = false;
-  let mentionSearchTimeout: ReturnType<typeof setTimeout>;
-  let mentionSearching = false;
+  // Mention autocomplete
+  let mentionState: MentionState = {
+    mentionQuery: '',
+    showMentionSuggestions: false,
+    mentionSuggestions: [],
+    selectedMentionIndex: 0,
+    mentionSearching: false
+  };
+
+  const mentionCtrl = new MentionComposerController(
+    (state) => {
+      mentionState = state;
+    },
+    (text) => {
+      commentText = text;
+      lastRenderedComment = text;
+    }
+  );
+
+  $: mentionCtrl.setComposerEl(commentComposerEl);
+
+  $: if (commentComposerEl && commentText !== lastRenderedComment) {
+    mentionCtrl.syncContent(commentText);
+    lastRenderedComment = commentText;
+  }
+
+  // Preload follow list when user is logged in
+  $: if ($userPublickey) {
+    mentionCtrl.preloadFollowList();
+  }
 
   // Create subscription once when ndk is ready
   $: if ($ndk && !subscribed) {
@@ -62,9 +73,7 @@
   }
 
   onDestroy(() => {
-    if (mentionSearchTimeout) {
-      clearTimeout(mentionSearchTimeout);
-    }
+    mentionCtrl.destroy();
     if (commentSubscription) {
       commentSubscription.stop();
     }
@@ -75,722 +84,13 @@
     // No-op: the subscription will automatically receive new events
   }
 
-  // Load follow list profiles for mention autocomplete
-  async function loadMentionFollowList() {
-    if (mentionFollowListLoaded) return;
-
-    const pubkey = get(userPublickey);
-    if (!pubkey || !$ndk) return;
-
-    try {
-      const contactEvent = await $ndk.fetchEvent({
-        kinds: [3],
-        authors: [pubkey],
-        limit: 1
-      });
-
-      if (!contactEvent) return;
-
-      const followPubkeys = contactEvent.tags.filter((t) => t[0] === 'p' && t[1]).map((t) => t[1]);
-
-      if (followPubkeys.length === 0) return;
-
-      const batchSize = 100;
-      for (let i = 0; i < followPubkeys.length; i += batchSize) {
-        const batch = followPubkeys.slice(i, i + batchSize);
-        try {
-          const events = await $ndk.fetchEvents({
-            kinds: [0],
-            authors: batch
-          });
-
-          for (const event of events) {
-            try {
-              const profile = JSON.parse(event.content);
-              const name = profile.display_name || profile.name || '';
-              if (name || profile.nip05) {
-                mentionProfileCache.set(event.pubkey, {
-                  name: name || profile.nip05?.split('@')[0] || 'Unknown',
-                  npub: nip19.npubEncode(event.pubkey),
-                  picture: profile.picture,
-                  pubkey: event.pubkey,
-                  nip05: profile.nip05
-                });
-              }
-            } catch {}
-          }
-        } catch (e) {
-          console.debug('Failed to fetch mention profile batch:', e);
-        }
-      }
-
-      mentionFollowListLoaded = true;
-    } catch (e) {
-      console.debug('Failed to load mention follow list:', e);
-    }
-  }
-
-  // Search users for mention autocomplete
-  async function searchMentionUsers(query: string) {
-    loadMentionFollowList();
-
-    const queryLower = query.toLowerCase();
-    const matches: {
-      name: string;
-      npub: string;
-      picture?: string;
-      pubkey: string;
-      nip05?: string;
-    }[] = [];
-    const seenPubkeys = new Set<string>();
-
-    for (const profile of mentionProfileCache.values()) {
-      const nameMatch = profile.name.toLowerCase().includes(queryLower);
-      const nip05Match = profile.nip05?.toLowerCase().includes(queryLower);
-
-      if (nameMatch || nip05Match) {
-        matches.push(profile);
-        seenPubkeys.add(profile.pubkey);
-      }
-    }
-
-    if (matches.length > 0) {
-      mentionSuggestions = matches.slice(0, 10);
-      selectedMentionIndex = 0;
-    }
-
-    const shouldSearchPrimal = query.length >= 2;
-    const shouldSearchNdk = query.length >= 1 && $ndk;
-
-    if (shouldSearchPrimal || shouldSearchNdk) {
-      mentionSearching = true;
-      try {
-        if (shouldSearchPrimal) {
-          const primalResults = await searchProfiles(query, 25);
-          for (const profile of primalResults) {
-            if (seenPubkeys.has(profile.pubkey)) continue;
-
-            const name =
-              profile.displayName || profile.name || profile.nip05?.split('@')[0] || 'Unknown';
-            const profileData = {
-              name,
-              npub: profile.npub || nip19.npubEncode(profile.pubkey),
-              picture: profile.picture,
-              pubkey: profile.pubkey,
-              nip05: profile.nip05
-            };
-
-            matches.push(profileData);
-            seenPubkeys.add(profile.pubkey);
-            mentionProfileCache.set(profile.pubkey, profileData);
-          }
-        }
-
-        if (shouldSearchNdk && $ndk) {
-          const searchResults = await $ndk.fetchEvents({
-            kinds: [0],
-            search: query,
-            limit: 50
-          });
-
-          for (const event of searchResults) {
-            if (seenPubkeys.has(event.pubkey)) continue;
-
-            try {
-              const profile = JSON.parse(event.content);
-              const name = profile.display_name || profile.name || '';
-              const nip05 = profile.nip05;
-
-              const profileData = {
-                name: name || nip05?.split('@')[0] || profile.name || 'Unknown',
-                npub: nip19.npubEncode(event.pubkey),
-                picture: profile.picture,
-                pubkey: event.pubkey,
-                nip05
-              };
-
-              matches.push(profileData);
-              seenPubkeys.add(event.pubkey);
-              mentionProfileCache.set(event.pubkey, profileData);
-            } catch {}
-          }
-        }
-      } catch (e) {
-        console.debug('Network search failed:', e);
-      } finally {
-        mentionSearching = false;
-      }
-    }
-
-    matches.sort((a, b) => {
-      const aExact =
-        a.name.toLowerCase().startsWith(queryLower) ||
-        a.nip05?.toLowerCase().startsWith(queryLower);
-      const bExact =
-        b.name.toLowerCase().startsWith(queryLower) ||
-        b.nip05?.toLowerCase().startsWith(queryLower);
-      if (aExact && !bExact) return -1;
-      if (!aExact && bExact) return 1;
-      return a.name.localeCompare(b.name);
-    });
-
-    mentionSuggestions = matches.slice(0, 10);
-    selectedMentionIndex = 0;
-  }
-
-  function syncComposerContent(value: string) {
-    if (!commentComposerEl) return;
-    const html = renderTextWithMentions(value);
-    if (commentComposerEl.innerHTML !== html) {
-      commentComposerEl.innerHTML = html;
-    }
-    lastRenderedComment = value;
-  }
-
-  function escapeHtml(value: string): string {
-    return value
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#39;');
-  }
-
-  function escapeRegex(value: string): string {
-    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  }
-
-  function formatNpubShort(npub: string): string {
-    if (npub.length <= 16) return npub;
-    return `${npub.slice(0, 10)}...${npub.slice(-6)}`;
-  }
-
-  function getDisplayNameForMention(mention: string): string {
-    const identifier = mention.replace('nostr:', '');
-    try {
-      const decoded = nip19.decode(identifier);
-      if (decoded.type === 'npub') {
-        const profile = mentionProfileCache.get(decoded.data);
-        if (profile?.name) return profile.name;
-        return formatNpubShort(identifier);
-      }
-      if (decoded.type === 'nprofile') {
-        const profile = mentionProfileCache.get(decoded.data.pubkey);
-        if (profile?.name) return profile.name;
-        return formatNpubShort(nip19.npubEncode(decoded.data.pubkey));
-      }
-    } catch {}
-    return formatNpubShort(identifier);
-  }
-
-  function renderTextWithMentions(text: string): string {
-    if (!text) return '';
-    const mentionRegex =
-      /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)|@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g;
-    let html = '';
-    let lastIndex = 0;
-    let match: RegExpExecArray | null;
-
-    while ((match = mentionRegex.exec(text)) !== null) {
-      const beforeText = text.substring(lastIndex, match.index);
-      if (beforeText) {
-        html += escapeHtml(beforeText).replace(/\n/g, '<br>');
-      }
-
-      const rawMention = match[0];
-      const mention = rawMention.startsWith('@') ? `nostr:${rawMention.slice(1)}` : rawMention;
-      const displayName = getDisplayNameForMention(mention);
-      html += `<span class="mention-pill" contenteditable="false" data-mention="${mention}">@${escapeHtml(displayName)}</span>`;
-
-      lastIndex = match.index + rawMention.length;
-    }
-
-    if (lastIndex < text.length) {
-      html += escapeHtml(text.substring(lastIndex)).replace(/\n/g, '<br>');
-    }
-
-    return html;
-  }
-
-  function htmlToPlainText(element: Node): string {
-    let text = '';
-    let isFirstChild = true;
-
-    element.childNodes.forEach((node) => {
-      if (node.nodeType === Node.TEXT_NODE) {
-        const content = (node.textContent || '').replace(/\u200B/g, '');
-        text += content;
-        if (content) {
-          isFirstChild = false;
-        }
-      } else if (node.nodeType === Node.ELEMENT_NODE) {
-        const el = node as HTMLElement;
-
-        if (el.dataset.mention) {
-          text += el.dataset.mention;
-          isFirstChild = false;
-        } else if (el.tagName === 'BR') {
-          text += '\n';
-        } else if (el.tagName === 'DIV') {
-          if (!isFirstChild) {
-            text += '\n';
-          }
-
-          const hasOnlyBr = el.childNodes.length === 1 && el.firstChild?.nodeName === 'BR';
-          if (!hasOnlyBr) {
-            text += htmlToPlainText(node);
-          }
-          isFirstChild = false;
-        } else if (el.tagName === 'SPAN') {
-          const spanContent = htmlToPlainText(node);
-          text += spanContent;
-          if (spanContent) {
-            isFirstChild = false;
-          }
-        } else {
-          const childContent = htmlToPlainText(node);
-          text += childContent;
-          if (childContent) {
-            isFirstChild = false;
-          }
-        }
-      }
-    });
-
-    return text;
-  }
-
-  function getTextBeforeCursor(element: HTMLDivElement): string {
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return '';
-
-    const range = selection.getRangeAt(0);
-    const preCaretRange = range.cloneRange();
-    preCaretRange.selectNodeContents(element);
-    preCaretRange.setEnd(range.startContainer, range.startOffset);
-
-    const tempDiv = document.createElement('div');
-    tempDiv.appendChild(preCaretRange.cloneContents());
-
-    return htmlToPlainText(tempDiv);
-  }
-
-  function updateContentFromComposer() {
-    if (!commentComposerEl) return;
-    const newText = htmlToPlainText(commentComposerEl);
-    lastRenderedComment = newText;
-    commentText = newText;
-  }
-
-  function handleBeforeInput(event: InputEvent) {
-    if (
-      event.isComposing ||
-      event.inputType === 'historyUndo' ||
-      event.inputType === 'historyRedo'
-    ) {
-      return;
-    }
-
-    const selection = window.getSelection();
-    if (!selection || !commentComposerEl) return;
-    const range = selection.getRangeAt(0);
-    let node: Node | null = range.startContainer;
-
-    while (node && node !== commentComposerEl) {
-      if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).dataset.mention) {
-        event.preventDefault();
-
-        if (event.inputType === 'insertText' || event.inputType === 'insertCompositionText') {
-          const newRange = document.createRange();
-          newRange.setStartAfter(node);
-          newRange.collapse(true);
-          selection.removeAllRanges();
-          selection.addRange(newRange);
-        }
-        return;
-      }
-      node = node.parentNode;
-    }
-  }
-
-  function handlePaste(event: ClipboardEvent) {
-    event.preventDefault();
-    const plainText = event.clipboardData?.getData('text/plain');
-    if (!plainText) return;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-    const range = selection.getRangeAt(0);
-
-    range.deleteContents();
-    const textNode = document.createTextNode(plainText);
-    range.insertNode(textNode);
-    range.setStartAfter(textNode);
-    range.collapse(true);
-    selection.removeAllRanges();
-    selection.addRange(range);
-
-    handleCommentInput();
-  }
-
-  function handleCommentInput() {
-    updateContentFromComposer();
-    if (!commentComposerEl) return;
-
-    const converted = convertRawMentionsToPills();
-    if (converted) {
-      updateContentFromComposer();
-    }
-
-    const textBeforeCursor = getTextBeforeCursor(commentComposerEl);
-    const mentionMatch = textBeforeCursor.match(/@([^@]*)$/);
-
-    if (mentionMatch) {
-      mentionQuery = mentionMatch[1] || '';
-      showMentionSuggestions = true;
-
-      if (mentionSearchTimeout) clearTimeout(mentionSearchTimeout);
-      mentionSearchTimeout = setTimeout(() => {
-        if (mentionQuery.length > 0) {
-          searchMentionUsers(mentionQuery);
-        } else {
-          mentionSuggestions = Array.from(mentionProfileCache.values()).slice(0, 8);
-          selectedMentionIndex = 0;
-        }
-      }, 150);
-    } else {
-      showMentionSuggestions = false;
-      mentionSuggestions = [];
-    }
-  }
-
-  function deleteCharsBeforeCursor(count: number) {
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-
-    const range = selection.getRangeAt(0);
-    let remaining = count;
-    let currentNode: Node | null = range.startContainer;
-    let currentOffset = range.startOffset;
-
-    if (currentNode.nodeType === Node.ELEMENT_NODE) {
-      const walker = document.createTreeWalker(currentNode, NodeFilter.SHOW_TEXT, null);
-      let lastText: Text | null = null;
-      while (walker.nextNode()) {
-        lastText = walker.currentNode as Text;
-      }
-      if (lastText) {
-        currentNode = lastText;
-        currentOffset = lastText.length;
-      }
-    }
-
-    while (remaining > 0 && currentNode) {
-      if (currentNode.nodeType === Node.TEXT_NODE) {
-        const textNode = currentNode as Text;
-        const deleteCount = Math.min(remaining, currentOffset);
-        if (deleteCount > 0) {
-          textNode.deleteData(currentOffset - deleteCount, deleteCount);
-          remaining -= deleteCount;
-          currentOffset -= deleteCount;
-        }
-
-        if (remaining > 0) {
-          let prev: Node | null = textNode.previousSibling;
-          while (prev && prev.nodeType !== Node.TEXT_NODE) {
-            prev = prev.previousSibling;
-          }
-          if (prev) {
-            currentNode = prev;
-            currentOffset = (prev as Text).length;
-          } else {
-            break;
-          }
-        }
-      } else {
-        break;
-      }
-    }
-  }
-
-  function createMentionPill(mention: string, displayName: string): HTMLSpanElement {
-    const pill = document.createElement('span');
-    pill.contentEditable = 'false';
-    pill.dataset.mention = mention;
-    pill.className = 'mention-pill';
-    pill.textContent = `@${displayName}`;
-    return pill;
-  }
-
-  function insertMentionNode(mention: string, displayName: string, addTrailingSpace = false) {
-    if (!commentComposerEl) return;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-    const range = selection.getRangeAt(0);
-
-    const pill = createMentionPill(mention, displayName);
-    const newRange = document.createRange();
-    newRange.setStart(range.startContainer, range.startOffset);
-    newRange.collapse(true);
-    newRange.insertNode(pill);
-
-    if (addTrailingSpace) {
-      const spacer = document.createTextNode(' ');
-      pill.after(spacer);
-      newRange.setStartAfter(spacer);
-    } else {
-      newRange.setStartAfter(pill);
-    }
-
-    newRange.collapse(true);
-    selection.removeAllRanges();
-    selection.addRange(newRange);
-  }
-
-  function convertRawMentionsToPills(): boolean {
-    if (!commentComposerEl) return false;
-
-    const rawText = commentComposerEl.textContent || '';
-    if (!rawText.includes('npub1')) return false;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0 || !selection.isCollapsed) return false;
-
-    const range = selection.getRangeAt(0);
-    const marker = document.createElement('span');
-    marker.dataset.mentionCaret = 'true';
-    marker.textContent = '\u200B';
-    range.insertNode(marker);
-
-    const textNodes: Text[] = [];
-    const walker = document.createTreeWalker(commentComposerEl, NodeFilter.SHOW_TEXT, {
-      acceptNode(node) {
-        const parent = node.parentElement;
-        if (!parent) return NodeFilter.FILTER_REJECT;
-        if (parent.dataset.mention || parent.dataset.mentionCaret) return NodeFilter.FILTER_REJECT;
-        return NodeFilter.FILTER_ACCEPT;
-      }
-    });
-
-    while (walker.nextNode()) {
-      textNodes.push(walker.currentNode as Text);
-    }
-
-    let converted = false;
-    for (const textNode of textNodes) {
-      const text = textNode.nodeValue;
-      if (!text || !text.includes('npub1')) continue;
-
-      const mentionRegex =
-        /@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)/g;
-      let lastIndex = 0;
-      let match: RegExpExecArray | null;
-      let hasMatch = false;
-      const fragment = document.createDocumentFragment();
-
-      while ((match = mentionRegex.exec(text)) !== null) {
-        hasMatch = true;
-        const before = text.slice(lastIndex, match.index);
-        if (before) {
-          fragment.appendChild(document.createTextNode(before));
-        }
-
-        const rawMention = match[0];
-        const mention = rawMention.startsWith('@') ? `nostr:${rawMention.slice(1)}` : rawMention;
-        const displayName = getDisplayNameForMention(mention);
-        fragment.appendChild(createMentionPill(mention, displayName));
-
-        lastIndex = match.index + rawMention.length;
-      }
-
-      if (!hasMatch) continue;
-      converted = true;
-
-      if (lastIndex < text.length) {
-        fragment.appendChild(document.createTextNode(text.slice(lastIndex)));
-      }
-
-      textNode.parentNode?.replaceChild(fragment, textNode);
-    }
-
-    const caretMarker = commentComposerEl.querySelector('[data-mention-caret]');
-    if (caretMarker) {
-      const newRange = document.createRange();
-      newRange.setStartAfter(caretMarker);
-      newRange.collapse(true);
-      selection.removeAllRanges();
-      selection.addRange(newRange);
-      caretMarker.remove();
-    }
-
-    return converted;
-  }
-
-  function insertMention(user: { name: string; npub: string; pubkey: string }) {
-    if (!commentComposerEl) return;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-    const textBeforeCursor = getTextBeforeCursor(commentComposerEl);
-    const mentionMatch = textBeforeCursor.match(/@([^@]*)$/);
-
-    if (mentionMatch?.[0]) {
-      deleteCharsBeforeCursor(mentionMatch[0].length);
-    }
-
-    const textAfterDeletion = getTextBeforeCursor(commentComposerEl);
-    const needsLeadingSpace = textAfterDeletion.length > 0 && !/\s$/.test(textAfterDeletion);
-    
-    if (needsLeadingSpace) {
-      const spaceNode = document.createTextNode(' ');
-      const range = selection.getRangeAt(0);
-      range.insertNode(spaceNode);
-      range.setStartAfter(spaceNode);
-      range.collapse(true);
-      selection.removeAllRanges();
-      selection.addRange(range);
-    }
-
-    const mention = `nostr:${user.npub}`;
-    insertMentionNode(mention, user.name, true);
-
-    mentionProfileCache.set(user.pubkey, user);
-    updateContentFromComposer();
-    showMentionSuggestions = false;
-    mentionSuggestions = [];
-  }
-
-  function replacePlainMentions(text: string): string {
-    let output = text;
-    output = output.replace(
-      /@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g,
-      (match) => `nostr:${match.slice(1)}`
-    );
-    for (const profile of mentionProfileCache.values()) {
-      if (!profile.name) continue;
-      const mentionText = `@${profile.name}`;
-      const mentionRegex = new RegExp(`${escapeRegex(mentionText)}(?=\\s|$|[.,!?;:])`, 'gi');
-      if (mentionRegex.test(output)) {
-        output = output.replace(mentionRegex, `nostr:${profile.npub}`);
-      }
-    }
-    return output;
-  }
-
-  function parseMentions(text: string): Map<string, string> {
-    const mentions = new Map<string, string>();
-    const mentionRegex =
-      /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)|@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g;
-    let match: RegExpExecArray | null;
-
-    while ((match = mentionRegex.exec(text)) !== null) {
-      const mention = match[1] || match[0].slice(1);
-      try {
-        const decoded = nip19.decode(mention);
-        if (decoded.type === 'npub') {
-          mentions.set(mention, decoded.data);
-        } else if (decoded.type === 'nprofile') {
-          mentions.set(mention, decoded.data.pubkey);
-        }
-      } catch {}
-    }
-
-    return mentions;
-  }
-
-  function handleCommentKeydown(event: KeyboardEvent) {
-    const selection = window.getSelection();
-    if (selection && selection.rangeCount) {
-      const range = selection.getRangeAt(0);
-
-      if (event.key === 'Delete' && range.collapsed) {
-        const { startContainer, startOffset } = range;
-        if (startContainer.nodeType === Node.TEXT_NODE) {
-          const textNode = startContainer as Text;
-          if (startOffset === textNode.length) {
-            const nextSibling = startContainer.nextSibling;
-            if (
-              nextSibling &&
-              nextSibling.nodeType === Node.ELEMENT_NODE &&
-              (nextSibling as HTMLElement).dataset.mention
-            ) {
-              event.preventDefault();
-              nextSibling.remove();
-              updateContentFromComposer();
-              return;
-            }
-          }
-        }
-      }
-
-      if (event.key === 'Backspace') {
-        if (!range.collapsed) {
-          const container = range.commonAncestorContainer;
-          let mentionElement: HTMLElement | null = null;
-
-          if (container.nodeType === Node.ELEMENT_NODE) {
-            const el = container as HTMLElement;
-            if (el.dataset.mention) {
-              mentionElement = el;
-            }
-          } else if (container.parentElement?.dataset.mention) {
-            mentionElement = container.parentElement;
-          }
-
-          if (mentionElement) {
-            event.preventDefault();
-            mentionElement.remove();
-            updateContentFromComposer();
-            return;
-          }
-        }
-
-        if (range.collapsed) {
-          const { startContainer, startOffset } = range;
-          if (startContainer.nodeType === Node.TEXT_NODE && startOffset === 0) {
-            const prevSibling = startContainer.previousSibling;
-            if (
-              prevSibling &&
-              prevSibling.nodeType === Node.ELEMENT_NODE &&
-              (prevSibling as HTMLElement).dataset.mention
-            ) {
-              event.preventDefault();
-              prevSibling.remove();
-              updateContentFromComposer();
-              return;
-            }
-          }
-        }
-      }
-    }
-
-    if (showMentionSuggestions && mentionSuggestions.length > 0) {
-      if (event.key === 'ArrowDown') {
-        event.preventDefault();
-        selectedMentionIndex = (selectedMentionIndex + 1) % mentionSuggestions.length;
-      } else if (event.key === 'ArrowUp') {
-        event.preventDefault();
-        selectedMentionIndex =
-          selectedMentionIndex === 0 ? mentionSuggestions.length - 1 : selectedMentionIndex - 1;
-      } else if (event.key === 'Enter' || event.key === 'Tab') {
-        event.preventDefault();
-        insertMention(mentionSuggestions[selectedMentionIndex]);
-      } else if (event.key === 'Escape') {
-        showMentionSuggestions = false;
-        mentionSuggestions = [];
-      }
-      return;
-    }
-  }
-
   async function postComment() {
     if (!commentText.trim()) {
       return;
     }
 
     if (commentComposerEl) {
-      commentText = htmlToPlainText(commentComposerEl);
+      commentText = mentionCtrl.extractText();
       lastRenderedComment = commentText;
     }
     if (!$ndk?.signer) {
@@ -803,7 +103,7 @@
     // Recipe replies should be kind 1111, not kind 1
     const isRecipe = event.kind === 30023;
     ev.kind = isRecipe ? 1111 : 1;
-    const commentContent = replacePlainMentions(commentText.trim());
+    const commentContent = mentionCtrl.replacePlainMentions(commentText.trim());
     ev.content = commentContent;
 
     // Use shared utility to build NIP-22 or NIP-10 tags
@@ -815,7 +115,7 @@
     });
 
     // Parse and add @ mention tags (p tags)
-    const mentions = parseMentions(commentContent);
+    const mentions = mentionCtrl.parseMentions(commentContent);
     for (const pubkey of mentions.values()) {
       if (!ev.tags.some((t) => t[0] === 'p' && t[1] === pubkey)) {
         ev.tags.push(['p', pubkey]);
@@ -860,9 +160,7 @@
       if (commentComposerEl) {
         commentComposerEl.innerHTML = '';
       }
-      showMentionSuggestions = false;
-      mentionSuggestions = [];
-      mentionQuery = '';
+      mentionCtrl.resetMentionState();
     } catch (error) {
       console.error('Error posting comment:', error);
       console.error('Error stack:', error instanceof Error ? error.stack : 'No stack trace');
@@ -873,9 +171,6 @@
 
   // Sort all comments chronologically (oldest first)
   $: sortedComments = [...events].sort((a, b) => (a.created_at || 0) - (b.created_at || 0));
-  $: if (commentComposerEl && commentText !== lastRenderedComment) {
-    syncComposerContent(commentText);
-  }
 </script>
 
 <div id="comments-section" class="space-y-6">
@@ -905,41 +200,20 @@
           role="textbox"
           aria-multiline="true"
           data-placeholder="Share your thoughts..."
-          on:input={handleCommentInput}
-          on:keydown={handleCommentKeydown}
-          on:beforeinput={handleBeforeInput}
-          on:paste={handlePaste}
+          on:input={() => mentionCtrl.handleInput()}
+          on:keydown={(e) => mentionCtrl.handleKeydown(e)}
+          on:beforeinput={(e) => mentionCtrl.handleBeforeInput(e)}
+          on:paste={(e) => mentionCtrl.handlePaste(e)}
         ></div>
 
-        {#if showMentionSuggestions}
-          <div class="mention-dropdown" style="border-color: var(--color-input-border);">
-            {#if mentionSuggestions.length > 0}
-              <div class="mention-dropdown-content">
-                {#each mentionSuggestions as suggestion, index}
-                  <button
-                    type="button"
-                    on:click={() => insertMention(suggestion)}
-                    on:mousedown|preventDefault={() => insertMention(suggestion)}
-                    class="mention-option"
-                    class:mention-selected={index === selectedMentionIndex}
-                  >
-                    <CustomAvatar pubkey={suggestion.pubkey} size={24} />
-                    <div class="mention-info">
-                      <span class="mention-name">{suggestion.name}</span>
-                      {#if suggestion.nip05}
-                        <span class="mention-nip05">{suggestion.nip05}</span>
-                      {/if}
-                    </div>
-                  </button>
-                {/each}
-              </div>
-            {:else if mentionSearching}
-              <div class="mention-empty">Searching...</div>
-            {:else if mentionQuery.length > 0}
-              <div class="mention-empty">No users found</div>
-            {/if}
-          </div>
-        {/if}
+        <MentionDropdown
+          show={mentionState.showMentionSuggestions}
+          suggestions={mentionState.mentionSuggestions}
+          selectedIndex={mentionState.selectedMentionIndex}
+          searching={mentionState.mentionSearching}
+          query={mentionState.mentionQuery}
+          on:select={(e) => mentionCtrl.insertMention(e.detail)}
+        />
       </div>
       <Button
         on:click={(e) => {
@@ -973,106 +247,5 @@
     content: attr(data-placeholder);
     color: var(--color-caption);
     pointer-events: none;
-  }
-
-  .mention-dropdown {
-    position: absolute;
-    z-index: 1000;
-    top: 100%;
-    left: 0;
-    margin-top: 0.25rem;
-    width: 280px;
-    max-width: calc(100vw - 2rem);
-    background: var(--color-input-bg);
-    border: 1px solid var(--color-input-border);
-    border-radius: 0.5rem;
-    box-shadow:
-      0 4px 6px -1px rgb(0 0 0 / 0.1),
-      0 2px 4px -1px rgb(0 0 0 / 0.06);
-    overflow: hidden;
-  }
-
-  .mention-dropdown-content {
-    max-height: 200px;
-    overflow-y: auto;
-    overflow-x: hidden;
-  }
-
-  .mention-dropdown-content::-webkit-scrollbar {
-    width: 6px;
-  }
-
-  .mention-dropdown-content::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  .mention-dropdown-content::-webkit-scrollbar-thumb {
-    background: var(--color-input-border);
-    border-radius: 3px;
-  }
-
-  .mention-dropdown-content::-webkit-scrollbar-thumb:hover {
-    background: var(--color-caption);
-  }
-
-  .mention-option {
-    width: 100%;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 0.75rem;
-    text-align: left;
-    transition: background-color 0.15s;
-    border: none;
-    background: transparent;
-  }
-
-  .mention-option:hover,
-  .mention-selected {
-    background: var(--color-accent-gray);
-  }
-
-  .mention-info {
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
-    flex: 1;
-  }
-
-  .mention-name {
-    font-size: 0.875rem;
-    font-weight: 500;
-    color: var(--color-text-primary);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .mention-nip05 {
-    font-size: 0.75rem;
-    color: var(--color-caption);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .mention-empty {
-    padding: 0.75rem;
-    text-align: center;
-    font-size: 0.875rem;
-    color: var(--color-caption);
-  }
-
-  :global(.mention-pill) {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-    padding: 0.1rem 0.45rem;
-    border-radius: 0.5rem;
-    background: rgba(247, 147, 26, 0.2);
-    color: #f7931a;
-    font-weight: 600;
-    user-select: all;
-    margin: 0 0.1rem;
   }
 </style>

--- a/src/components/FeedComment.svelte
+++ b/src/components/FeedComment.svelte
@@ -16,7 +16,8 @@
   import { onMount, onDestroy } from 'svelte';
   import { get } from 'svelte/store';
   import { decode } from '@gandlaf21/bolt11-decode';
-  import { searchProfiles } from '$lib/profileSearchService';
+  import MentionDropdown from './MentionDropdown.svelte';
+  import { MentionComposerController, type MentionState } from '$lib/mentionComposer';
 
   export let event: NDKEvent;
   export let allComments: NDKEvent[] = []; // All comments for finding parent
@@ -39,24 +40,31 @@
   let replyComposerEl: HTMLDivElement;
   let lastRenderedReply = '';
 
-  // @ mention autocomplete state
-  let mentionQuery = '';
-  let showMentionSuggestions = false;
-  let mentionSuggestions: {
-    name: string;
-    npub: string;
-    picture?: string;
-    pubkey: string;
-    nip05?: string;
-  }[] = [];
-  let selectedMentionIndex = 0;
-  let mentionProfileCache: Map<
-    string,
-    { name: string; npub: string; picture?: string; pubkey: string; nip05?: string }
-  > = new Map();
-  let mentionFollowListLoaded = false;
-  let mentionSearchTimeout: ReturnType<typeof setTimeout>;
-  let mentionSearching = false;
+  // Mention autocomplete
+  let mentionState: MentionState = {
+    mentionQuery: '',
+    showMentionSuggestions: false,
+    mentionSuggestions: [],
+    selectedMentionIndex: 0,
+    mentionSearching: false
+  };
+
+  const mentionCtrl = new MentionComposerController(
+    (state) => {
+      mentionState = state;
+    },
+    (text) => {
+      replyText = text;
+      lastRenderedReply = text;
+    }
+  );
+
+  $: mentionCtrl.setComposerEl(replyComposerEl);
+
+  $: if (replyComposerEl && replyText !== lastRenderedReply) {
+    mentionCtrl.syncContent(replyText);
+    lastRenderedReply = replyText;
+  }
 
   // Like state
   let liked = false;
@@ -87,714 +95,6 @@
     }
 
     return null;
-  }
-
-  // Load follow list profiles for mention autocomplete
-  async function loadMentionFollowList() {
-    if (mentionFollowListLoaded) return;
-
-    const pubkey = get(userPublickey);
-    if (!pubkey || !$ndk) return;
-
-    try {
-      const contactEvent = await $ndk.fetchEvent({
-        kinds: [3],
-        authors: [pubkey],
-        limit: 1
-      });
-
-      if (!contactEvent) return;
-
-      const followPubkeys = contactEvent.tags.filter((t) => t[0] === 'p' && t[1]).map((t) => t[1]);
-
-      if (followPubkeys.length === 0) return;
-
-      const batchSize = 100;
-      for (let i = 0; i < followPubkeys.length; i += batchSize) {
-        const batch = followPubkeys.slice(i, i + batchSize);
-        try {
-          const events = await $ndk.fetchEvents({
-            kinds: [0],
-            authors: batch
-          });
-
-          for (const event of events) {
-            try {
-              const profile = JSON.parse(event.content);
-              const name = profile.display_name || profile.name || '';
-              if (name || profile.nip05) {
-                mentionProfileCache.set(event.pubkey, {
-                  name: name || profile.nip05?.split('@')[0] || 'Unknown',
-                  npub: nip19.npubEncode(event.pubkey),
-                  picture: profile.picture,
-                  pubkey: event.pubkey,
-                  nip05: profile.nip05
-                });
-              }
-            } catch {}
-          }
-        } catch (e) {
-          console.debug('Failed to fetch mention profile batch:', e);
-        }
-      }
-
-      mentionFollowListLoaded = true;
-    } catch (e) {
-      console.debug('Failed to load mention follow list:', e);
-    }
-  }
-
-  // Search users for mention autocomplete
-  async function searchMentionUsers(query: string) {
-    loadMentionFollowList();
-
-    const queryLower = query.toLowerCase();
-    const matches: {
-      name: string;
-      npub: string;
-      picture?: string;
-      pubkey: string;
-      nip05?: string;
-    }[] = [];
-    const seenPubkeys = new Set<string>();
-
-    for (const profile of mentionProfileCache.values()) {
-      const nameMatch = profile.name.toLowerCase().includes(queryLower);
-      const nip05Match = profile.nip05?.toLowerCase().includes(queryLower);
-
-      if (nameMatch || nip05Match) {
-        matches.push(profile);
-        seenPubkeys.add(profile.pubkey);
-      }
-    }
-
-    if (matches.length > 0) {
-      mentionSuggestions = matches.slice(0, 10);
-      selectedMentionIndex = 0;
-    }
-
-    const shouldSearchPrimal = query.length >= 2;
-    const shouldSearchNdk = query.length >= 1 && $ndk;
-
-    if (shouldSearchPrimal || shouldSearchNdk) {
-      mentionSearching = true;
-      try {
-        if (shouldSearchPrimal) {
-          const primalResults = await searchProfiles(query, 25);
-          for (const profile of primalResults) {
-            if (seenPubkeys.has(profile.pubkey)) continue;
-
-            const name =
-              profile.displayName || profile.name || profile.nip05?.split('@')[0] || 'Unknown';
-            const profileData = {
-              name,
-              npub: profile.npub || nip19.npubEncode(profile.pubkey),
-              picture: profile.picture,
-              pubkey: profile.pubkey,
-              nip05: profile.nip05
-            };
-
-            matches.push(profileData);
-            seenPubkeys.add(profile.pubkey);
-            mentionProfileCache.set(profile.pubkey, profileData);
-          }
-        }
-
-        if (shouldSearchNdk && $ndk) {
-          const searchResults = await $ndk.fetchEvents({
-            kinds: [0],
-            search: query,
-            limit: 50
-          });
-
-          for (const event of searchResults) {
-            if (seenPubkeys.has(event.pubkey)) continue;
-
-            try {
-              const profile = JSON.parse(event.content);
-              const name = profile.display_name || profile.name || '';
-              const nip05 = profile.nip05;
-
-              const profileData = {
-                name: name || nip05?.split('@')[0] || profile.name || 'Unknown',
-                npub: nip19.npubEncode(event.pubkey),
-                picture: profile.picture,
-                pubkey: event.pubkey,
-                nip05
-              };
-
-              matches.push(profileData);
-              seenPubkeys.add(event.pubkey);
-              mentionProfileCache.set(event.pubkey, profileData);
-            } catch {}
-          }
-        }
-      } catch (e) {
-        console.debug('Network search failed:', e);
-      } finally {
-        mentionSearching = false;
-      }
-    }
-
-    matches.sort((a, b) => {
-      const aExact =
-        a.name.toLowerCase().startsWith(queryLower) ||
-        a.nip05?.toLowerCase().startsWith(queryLower);
-      const bExact =
-        b.name.toLowerCase().startsWith(queryLower) ||
-        b.nip05?.toLowerCase().startsWith(queryLower);
-      if (aExact && !bExact) return -1;
-      if (!aExact && bExact) return 1;
-      return a.name.localeCompare(b.name);
-    });
-
-    mentionSuggestions = matches.slice(0, 10);
-    selectedMentionIndex = 0;
-  }
-
-  function syncComposerContent(value: string) {
-    if (!replyComposerEl) return;
-    const html = renderTextWithMentions(value);
-    if (replyComposerEl.innerHTML !== html) {
-      replyComposerEl.innerHTML = html;
-    }
-    lastRenderedReply = value;
-  }
-
-  function escapeHtml(value: string): string {
-    return value
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#39;');
-  }
-
-  function escapeRegex(value: string): string {
-    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  }
-
-  function formatNpubShort(npub: string): string {
-    if (npub.length <= 16) return npub;
-    return `${npub.slice(0, 10)}...${npub.slice(-6)}`;
-  }
-
-  function getDisplayNameForMention(mention: string): string {
-    const identifier = mention.replace('nostr:', '');
-    try {
-      const decoded = nip19.decode(identifier);
-      if (decoded.type === 'npub') {
-        const profile = mentionProfileCache.get(decoded.data);
-        if (profile?.name) return profile.name;
-        return formatNpubShort(identifier);
-      }
-      if (decoded.type === 'nprofile') {
-        const profile = mentionProfileCache.get(decoded.data.pubkey);
-        if (profile?.name) return profile.name;
-        return formatNpubShort(nip19.npubEncode(decoded.data.pubkey));
-      }
-    } catch {}
-    return formatNpubShort(identifier);
-  }
-
-  function renderTextWithMentions(text: string): string {
-    if (!text) return '';
-    const mentionRegex =
-      /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)|@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g;
-    let html = '';
-    let lastIndex = 0;
-    let match: RegExpExecArray | null;
-
-    while ((match = mentionRegex.exec(text)) !== null) {
-      const beforeText = text.substring(lastIndex, match.index);
-      if (beforeText) {
-        html += escapeHtml(beforeText).replace(/\n/g, '<br>');
-      }
-
-      const rawMention = match[0];
-      const mention = rawMention.startsWith('@') ? `nostr:${rawMention.slice(1)}` : rawMention;
-      const displayName = getDisplayNameForMention(mention);
-      html += `<span class="mention-pill" contenteditable="false" data-mention="${mention}">@${escapeHtml(displayName)}</span>`;
-
-      lastIndex = match.index + rawMention.length;
-    }
-
-    if (lastIndex < text.length) {
-      html += escapeHtml(text.substring(lastIndex)).replace(/\n/g, '<br>');
-    }
-
-    return html;
-  }
-
-  function htmlToPlainText(element: Node): string {
-    let text = '';
-    let isFirstChild = true;
-
-    element.childNodes.forEach((node) => {
-      if (node.nodeType === Node.TEXT_NODE) {
-        const content = (node.textContent || '').replace(/\u200B/g, '');
-        text += content;
-        if (content) {
-          isFirstChild = false;
-        }
-      } else if (node.nodeType === Node.ELEMENT_NODE) {
-        const el = node as HTMLElement;
-
-        if (el.dataset.mention) {
-          text += el.dataset.mention;
-          isFirstChild = false;
-        } else if (el.tagName === 'BR') {
-          text += '\n';
-        } else if (el.tagName === 'DIV') {
-          if (!isFirstChild) {
-            text += '\n';
-          }
-
-          const hasOnlyBr = el.childNodes.length === 1 && el.firstChild?.nodeName === 'BR';
-          if (!hasOnlyBr) {
-            text += htmlToPlainText(node);
-          }
-          isFirstChild = false;
-        } else if (el.tagName === 'SPAN') {
-          const spanContent = htmlToPlainText(node);
-          text += spanContent;
-          if (spanContent) {
-            isFirstChild = false;
-          }
-        } else {
-          const childContent = htmlToPlainText(node);
-          text += childContent;
-          if (childContent) {
-            isFirstChild = false;
-          }
-        }
-      }
-    });
-
-    return text;
-  }
-
-  function getTextBeforeCursor(element: HTMLDivElement): string {
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return '';
-
-    const range = selection.getRangeAt(0);
-    const preCaretRange = range.cloneRange();
-    preCaretRange.selectNodeContents(element);
-    preCaretRange.setEnd(range.startContainer, range.startOffset);
-
-    const tempDiv = document.createElement('div');
-    tempDiv.appendChild(preCaretRange.cloneContents());
-
-    return htmlToPlainText(tempDiv);
-  }
-
-  function updateContentFromComposer() {
-    if (!replyComposerEl) return;
-    const newText = htmlToPlainText(replyComposerEl);
-    lastRenderedReply = newText;
-    replyText = newText;
-  }
-
-  function handleBeforeInput(event: InputEvent) {
-    if (
-      event.isComposing ||
-      event.inputType === 'historyUndo' ||
-      event.inputType === 'historyRedo'
-    ) {
-      return;
-    }
-
-    const selection = window.getSelection();
-    if (!selection || !replyComposerEl) return;
-    const range = selection.getRangeAt(0);
-    let node: Node | null = range.startContainer;
-
-    while (node && node !== replyComposerEl) {
-      if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).dataset.mention) {
-        event.preventDefault();
-
-        if (event.inputType === 'insertText' || event.inputType === 'insertCompositionText') {
-          const newRange = document.createRange();
-          newRange.setStartAfter(node);
-          newRange.collapse(true);
-          selection.removeAllRanges();
-          selection.addRange(newRange);
-        }
-        return;
-      }
-      node = node.parentNode;
-    }
-  }
-
-  function handlePaste(event: ClipboardEvent) {
-    event.preventDefault();
-    const plainText = event.clipboardData?.getData('text/plain');
-    if (!plainText) return;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-    const range = selection.getRangeAt(0);
-
-    range.deleteContents();
-    const textNode = document.createTextNode(plainText);
-    range.insertNode(textNode);
-    range.setStartAfter(textNode);
-    range.collapse(true);
-    selection.removeAllRanges();
-    selection.addRange(range);
-
-    handleReplyInput();
-  }
-
-  function handleReplyInput() {
-    updateContentFromComposer();
-    if (!replyComposerEl) return;
-
-    const converted = convertRawMentionsToPills();
-    if (converted) {
-      updateContentFromComposer();
-    }
-
-    const textBeforeCursor = getTextBeforeCursor(replyComposerEl);
-    const mentionMatch = textBeforeCursor.match(/@([^@]*)$/);
-
-    if (mentionMatch) {
-      mentionQuery = mentionMatch[1] || '';
-      showMentionSuggestions = true;
-
-      if (mentionSearchTimeout) clearTimeout(mentionSearchTimeout);
-      mentionSearchTimeout = setTimeout(() => {
-        if (mentionQuery.length > 0) {
-          searchMentionUsers(mentionQuery);
-        } else {
-          mentionSuggestions = Array.from(mentionProfileCache.values()).slice(0, 8);
-          selectedMentionIndex = 0;
-        }
-      }, 150);
-    } else {
-      showMentionSuggestions = false;
-      mentionSuggestions = [];
-    }
-  }
-
-  function deleteCharsBeforeCursor(count: number) {
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-
-    const range = selection.getRangeAt(0);
-    let remaining = count;
-    let currentNode: Node | null = range.startContainer;
-    let currentOffset = range.startOffset;
-
-    if (currentNode.nodeType === Node.ELEMENT_NODE) {
-      const walker = document.createTreeWalker(currentNode, NodeFilter.SHOW_TEXT, null);
-      let lastText: Text | null = null;
-      while (walker.nextNode()) {
-        lastText = walker.currentNode as Text;
-      }
-      if (lastText) {
-        currentNode = lastText;
-        currentOffset = lastText.length;
-      }
-    }
-
-    while (remaining > 0 && currentNode) {
-      if (currentNode.nodeType === Node.TEXT_NODE) {
-        const textNode = currentNode as Text;
-        const deleteCount = Math.min(remaining, currentOffset);
-        if (deleteCount > 0) {
-          textNode.deleteData(currentOffset - deleteCount, deleteCount);
-          remaining -= deleteCount;
-          currentOffset -= deleteCount;
-        }
-
-        if (remaining > 0) {
-          let prev: Node | null = textNode.previousSibling;
-          while (prev && prev.nodeType !== Node.TEXT_NODE) {
-            prev = prev.previousSibling;
-          }
-          if (prev) {
-            currentNode = prev;
-            currentOffset = (prev as Text).length;
-          } else {
-            break;
-          }
-        }
-      } else {
-        break;
-      }
-    }
-  }
-
-  function createMentionPill(mention: string, displayName: string): HTMLSpanElement {
-    const pill = document.createElement('span');
-    pill.contentEditable = 'false';
-    pill.dataset.mention = mention;
-    pill.className = 'mention-pill';
-    pill.textContent = `@${displayName}`;
-    return pill;
-  }
-
-  function insertMentionNode(mention: string, displayName: string, addTrailingSpace = false) {
-    if (!replyComposerEl) return;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-    const range = selection.getRangeAt(0);
-
-    const pill = createMentionPill(mention, displayName);
-    const newRange = document.createRange();
-    newRange.setStart(range.startContainer, range.startOffset);
-    newRange.collapse(true);
-    newRange.insertNode(pill);
-
-    if (addTrailingSpace) {
-      const spacer = document.createTextNode(' ');
-      pill.after(spacer);
-      newRange.setStartAfter(spacer);
-    } else {
-      newRange.setStartAfter(pill);
-    }
-
-    newRange.collapse(true);
-    selection.removeAllRanges();
-    selection.addRange(newRange);
-  }
-
-  function convertRawMentionsToPills(): boolean {
-    if (!replyComposerEl) return false;
-
-    const rawText = replyComposerEl.textContent || '';
-    if (!rawText.includes('npub1')) return false;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0 || !selection.isCollapsed) return false;
-
-    const range = selection.getRangeAt(0);
-    const marker = document.createElement('span');
-    marker.dataset.mentionCaret = 'true';
-    marker.textContent = '\u200B';
-    range.insertNode(marker);
-
-    const textNodes: Text[] = [];
-    const walker = document.createTreeWalker(replyComposerEl, NodeFilter.SHOW_TEXT, {
-      acceptNode(node) {
-        const parent = node.parentElement;
-        if (!parent) return NodeFilter.FILTER_REJECT;
-        if (parent.dataset.mention || parent.dataset.mentionCaret) return NodeFilter.FILTER_REJECT;
-        return NodeFilter.FILTER_ACCEPT;
-      }
-    });
-
-    while (walker.nextNode()) {
-      textNodes.push(walker.currentNode as Text);
-    }
-
-    let converted = false;
-    for (const textNode of textNodes) {
-      const text = textNode.nodeValue;
-      if (!text || !text.includes('npub1')) continue;
-
-      const mentionRegex =
-        /@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)/g;
-      let lastIndex = 0;
-      let match: RegExpExecArray | null;
-      let hasMatch = false;
-      const fragment = document.createDocumentFragment();
-
-      while ((match = mentionRegex.exec(text)) !== null) {
-        hasMatch = true;
-        const before = text.slice(lastIndex, match.index);
-        if (before) {
-          fragment.appendChild(document.createTextNode(before));
-        }
-
-        const rawMention = match[0];
-        const mention = rawMention.startsWith('@') ? `nostr:${rawMention.slice(1)}` : rawMention;
-        const displayName = getDisplayNameForMention(mention);
-        fragment.appendChild(createMentionPill(mention, displayName));
-
-        lastIndex = match.index + rawMention.length;
-      }
-
-      if (!hasMatch) continue;
-      converted = true;
-
-      if (lastIndex < text.length) {
-        fragment.appendChild(document.createTextNode(text.slice(lastIndex)));
-      }
-
-      textNode.parentNode?.replaceChild(fragment, textNode);
-    }
-
-    const caretMarker = replyComposerEl.querySelector('[data-mention-caret]');
-    if (caretMarker) {
-      const newRange = document.createRange();
-      newRange.setStartAfter(caretMarker);
-      newRange.collapse(true);
-      selection.removeAllRanges();
-      selection.addRange(newRange);
-      caretMarker.remove();
-    }
-
-    return converted;
-  }
-
-  function insertMention(user: { name: string; npub: string; pubkey: string }) {
-    if (!replyComposerEl) return;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-    const textBeforeCursor = getTextBeforeCursor(replyComposerEl);
-    const mentionMatch = textBeforeCursor.match(/@([^@]*)$/);
-
-    if (mentionMatch?.[0]) {
-      deleteCharsBeforeCursor(mentionMatch[0].length);
-    }
-
-    const textAfterDeletion = getTextBeforeCursor(replyComposerEl);
-    const needsLeadingSpace = textAfterDeletion.length > 0 && !/\s$/.test(textAfterDeletion);
-    
-    if (needsLeadingSpace) {
-      const spaceNode = document.createTextNode(' ');
-      const range = selection.getRangeAt(0);
-      range.insertNode(spaceNode);
-      range.setStartAfter(spaceNode);
-      range.collapse(true);
-      selection.removeAllRanges();
-      selection.addRange(range);
-    }
-
-    const mention = `nostr:${user.npub}`;
-    insertMentionNode(mention, user.name, true);
-
-    mentionProfileCache.set(user.pubkey, user);
-    updateContentFromComposer();
-    showMentionSuggestions = false;
-    mentionSuggestions = [];
-  }
-
-  function replacePlainMentions(text: string): string {
-    let output = text;
-    output = output.replace(
-      /@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g,
-      (match) => `nostr:${match.slice(1)}`
-    );
-    for (const profile of mentionProfileCache.values()) {
-      if (!profile.name) continue;
-      const mentionText = `@${profile.name}`;
-      const mentionRegex = new RegExp(`${escapeRegex(mentionText)}(?=\\s|$|[.,!?;:])`, 'gi');
-      if (mentionRegex.test(output)) {
-        output = output.replace(mentionRegex, `nostr:${profile.npub}`);
-      }
-    }
-    return output;
-  }
-
-  function parseMentions(text: string): Map<string, string> {
-    const mentions = new Map<string, string>();
-    const mentionRegex =
-      /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)|@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g;
-    let match: RegExpExecArray | null;
-
-    while ((match = mentionRegex.exec(text)) !== null) {
-      const mention = match[1] || match[0].slice(1);
-      try {
-        const decoded = nip19.decode(mention);
-        if (decoded.type === 'npub') {
-          mentions.set(mention, decoded.data);
-        } else if (decoded.type === 'nprofile') {
-          mentions.set(mention, decoded.data.pubkey);
-        }
-      } catch {}
-    }
-
-    return mentions;
-  }
-
-  function handleReplyKeydown(event: KeyboardEvent) {
-    const selection = window.getSelection();
-    if (selection && selection.rangeCount) {
-      const range = selection.getRangeAt(0);
-
-      if (event.key === 'Delete' && range.collapsed) {
-        const { startContainer, startOffset } = range;
-        if (startContainer.nodeType === Node.TEXT_NODE) {
-          const textNode = startContainer as Text;
-          if (startOffset === textNode.length) {
-            const nextSibling = startContainer.nextSibling;
-            if (
-              nextSibling &&
-              nextSibling.nodeType === Node.ELEMENT_NODE &&
-              (nextSibling as HTMLElement).dataset.mention
-            ) {
-              event.preventDefault();
-              nextSibling.remove();
-              updateContentFromComposer();
-              return;
-            }
-          }
-        }
-      }
-
-      if (event.key === 'Backspace') {
-        if (!range.collapsed) {
-          const container = range.commonAncestorContainer;
-          let mentionElement: HTMLElement | null = null;
-
-          if (container.nodeType === Node.ELEMENT_NODE) {
-            const el = container as HTMLElement;
-            if (el.dataset.mention) {
-              mentionElement = el;
-            }
-          } else if (container.parentElement?.dataset.mention) {
-            mentionElement = container.parentElement;
-          }
-
-          if (mentionElement) {
-            event.preventDefault();
-            mentionElement.remove();
-            updateContentFromComposer();
-            return;
-          }
-        }
-
-        if (range.collapsed) {
-          const { startContainer, startOffset } = range;
-          if (startContainer.nodeType === Node.TEXT_NODE && startOffset === 0) {
-            const prevSibling = startContainer.previousSibling;
-            if (
-              prevSibling &&
-              prevSibling.nodeType === Node.ELEMENT_NODE &&
-              (prevSibling as HTMLElement).dataset.mention
-            ) {
-              event.preventDefault();
-              prevSibling.remove();
-              updateContentFromComposer();
-              return;
-            }
-          }
-        }
-      }
-    }
-
-    if (showMentionSuggestions && mentionSuggestions.length > 0) {
-      if (event.key === 'ArrowDown') {
-        event.preventDefault();
-        selectedMentionIndex = (selectedMentionIndex + 1) % mentionSuggestions.length;
-      } else if (event.key === 'ArrowUp') {
-        event.preventDefault();
-        selectedMentionIndex =
-          selectedMentionIndex === 0 ? mentionSuggestions.length - 1 : selectedMentionIndex - 1;
-      } else if (event.key === 'Enter' || event.key === 'Tab') {
-        event.preventDefault();
-        insertMention(mentionSuggestions[selectedMentionIndex]);
-      } else if (event.key === 'Escape') {
-        showMentionSuggestions = false;
-        mentionSuggestions = [];
-      }
-    }
   }
 
   // Load zaps for this comment
@@ -839,6 +139,9 @@
 
   // Load profile and parent comment
   onMount(async () => {
+    // Preload follow list for mention autocomplete
+    mentionCtrl.preloadFollowList();
+
     // Load author profile
     if (event.pubkey && $ndk) {
       try {
@@ -910,9 +213,7 @@
   });
 
   onDestroy(() => {
-    if (mentionSearchTimeout) {
-      clearTimeout(mentionSearchTimeout);
-    }
+    mentionCtrl.destroy();
     if (likeSubscription) {
       likeSubscription.stop();
     }
@@ -949,7 +250,7 @@
     postingReply = true;
     try {
       if (replyComposerEl) {
-        replyText = htmlToPlainText(replyComposerEl);
+        replyText = mentionCtrl.extractText();
         lastRenderedReply = replyText;
       }
 
@@ -959,7 +260,7 @@
       // If the parent comment is kind 1111, use kind 1111 for nested reply
       const isRecipeReply = event.kind === 1111;
       ev.kind = isRecipeReply ? 1111 : 1;
-      const replyContent = replacePlainMentions(replyText.trim());
+      const replyContent = mentionCtrl.replacePlainMentions(replyText.trim());
       ev.content = replyContent;
 
       // Reconstruct a minimal event object for the parent comment
@@ -1012,7 +313,7 @@
         ev.tags = buildNip22CommentTags(rootEventObj, parentEventObj);
       }
 
-      const mentions = parseMentions(replyContent);
+      const mentions = mentionCtrl.parseMentions(replyContent);
       for (const pubkey of mentions.values()) {
         if (!ev.tags.some((t) => t[0] === 'p' && t[1] === pubkey)) {
           ev.tags.push(['p', pubkey]);
@@ -1026,9 +327,7 @@
       if (replyComposerEl) {
         replyComposerEl.innerHTML = '';
       }
-      showMentionSuggestions = false;
-      mentionSuggestions = [];
-      mentionQuery = '';
+      mentionCtrl.resetMentionState();
       showReplyBox = false;
       refresh();
     } catch {
@@ -1052,10 +351,6 @@
       .trim();
     if (cleaned.length <= maxLength) return cleaned;
     return cleaned.slice(0, maxLength).trim() + '...';
-  }
-
-  $: if (replyComposerEl && replyText !== lastRenderedReply) {
-    syncComposerContent(replyText);
   }
 </script>
 
@@ -1142,7 +437,7 @@
               on:click={() => {
                 showReplyBox = !showReplyBox;
                 if (showReplyBox && $userPublickey) {
-                  loadMentionFollowList();
+                  mentionCtrl.preloadFollowList();
                 }
               }}
               class="action-btn action-btn-text"
@@ -1163,41 +458,20 @@
                 role="textbox"
                 aria-multiline="true"
                 data-placeholder="Add a reply..."
-                on:input={handleReplyInput}
-                on:keydown={handleReplyKeydown}
-                on:beforeinput={handleBeforeInput}
-                on:paste={handlePaste}
+                on:input={() => mentionCtrl.handleInput()}
+                on:keydown={(e) => mentionCtrl.handleKeydown(e)}
+                on:beforeinput={(e) => mentionCtrl.handleBeforeInput(e)}
+                on:paste={(e) => mentionCtrl.handlePaste(e)}
               ></div>
 
-              {#if showMentionSuggestions}
-                <div class="mention-dropdown" style="border-color: var(--color-input-border);">
-                  {#if mentionSuggestions.length > 0}
-                    <div class="mention-dropdown-content">
-                      {#each mentionSuggestions as suggestion, index}
-                        <button
-                          type="button"
-                          on:click={() => insertMention(suggestion)}
-                          on:mousedown|preventDefault={() => insertMention(suggestion)}
-                          class="mention-option"
-                          class:mention-selected={index === selectedMentionIndex}
-                        >
-                          <CustomAvatar pubkey={suggestion.pubkey} size={24} />
-                          <div class="mention-info">
-                            <span class="mention-name">{suggestion.name}</span>
-                            {#if suggestion.nip05}
-                              <span class="mention-nip05">{suggestion.nip05}</span>
-                            {/if}
-                          </div>
-                        </button>
-                      {/each}
-                    </div>
-                  {:else if mentionSearching}
-                    <div class="mention-empty">Searching...</div>
-                  {:else if mentionQuery.length > 0}
-                    <div class="mention-empty">No users found</div>
-                  {/if}
-                </div>
-              {/if}
+              <MentionDropdown
+                show={mentionState.showMentionSuggestions}
+                suggestions={mentionState.mentionSuggestions}
+                selectedIndex={mentionState.selectedMentionIndex}
+                searching={mentionState.mentionSearching}
+                query={mentionState.mentionQuery}
+                on:select={(e) => mentionCtrl.insertMention(e.detail)}
+              />
             </div>
             <div class="reply-buttons">
               <button
@@ -1215,9 +489,7 @@
                   if (replyComposerEl) {
                     replyComposerEl.innerHTML = '';
                   }
-                  showMentionSuggestions = false;
-                  mentionSuggestions = [];
-                  mentionQuery = '';
+                  mentionCtrl.resetMentionState();
                 }}
                 class="btn-cancel"
               >
@@ -1432,106 +704,5 @@
 
   .btn-cancel:hover {
     opacity: 0.8;
-  }
-
-  .mention-dropdown {
-    position: absolute;
-    z-index: 1000;
-    top: 100%;
-    left: 0;
-    margin-top: 0.25rem;
-    width: 280px;
-    max-width: calc(100vw - 2rem);
-    background: var(--color-input-bg);
-    border: 1px solid var(--color-input-border);
-    border-radius: 0.5rem;
-    box-shadow:
-      0 4px 6px -1px rgb(0 0 0 / 0.1),
-      0 2px 4px -1px rgb(0 0 0 / 0.06);
-    overflow: hidden;
-  }
-
-  .mention-dropdown-content {
-    max-height: 200px;
-    overflow-y: auto;
-    overflow-x: hidden;
-  }
-
-  .mention-dropdown-content::-webkit-scrollbar {
-    width: 6px;
-  }
-
-  .mention-dropdown-content::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  .mention-dropdown-content::-webkit-scrollbar-thumb {
-    background: var(--color-input-border);
-    border-radius: 3px;
-  }
-
-  .mention-dropdown-content::-webkit-scrollbar-thumb:hover {
-    background: var(--color-caption);
-  }
-
-  .mention-option {
-    width: 100%;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 0.75rem;
-    text-align: left;
-    transition: background-color 0.15s;
-    border: none;
-    background: transparent;
-  }
-
-  .mention-option:hover,
-  .mention-selected {
-    background: var(--color-accent-gray);
-  }
-
-  .mention-info {
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
-    flex: 1;
-  }
-
-  .mention-name {
-    font-size: 0.875rem;
-    font-weight: 500;
-    color: var(--color-text-primary);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .mention-nip05 {
-    font-size: 0.75rem;
-    color: var(--color-caption);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .mention-empty {
-    padding: 0.75rem;
-    text-align: center;
-    font-size: 0.875rem;
-    color: var(--color-caption);
-  }
-
-  :global(.mention-pill) {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-    padding: 0.1rem 0.45rem;
-    border-radius: 0.5rem;
-    background: rgba(247, 147, 26, 0.2);
-    color: #f7931a;
-    font-weight: 600;
-    user-select: all;
-    margin: 0 0.1rem;
   }
 </style>

--- a/src/components/FeedComments.svelte
+++ b/src/components/FeedComments.svelte
@@ -6,12 +6,10 @@
   import { addClientTagToEvent } from '$lib/nip89';
   import { buildNip22CommentTags } from '$lib/tagUtils';
   import FeedComment from './FeedComment.svelte';
-  import CustomAvatar from './CustomAvatar.svelte';
-  import { nip19 } from 'nostr-tools';
-  import { get } from 'svelte/store';
   import { createCommentFilter } from '$lib/commentFilters';
-  import { searchProfiles } from '$lib/profileSearchService';
   import { mutedPubkeys } from '$lib/muteListStore';
+  import MentionDropdown from './MentionDropdown.svelte';
+  import { MentionComposerController, type MentionState } from '$lib/mentionComposer';
 
   export let event: NDKEvent;
   let events: NDKEvent[] = [];
@@ -23,739 +21,34 @@
   let lastRenderedComment = '';
   let feedCommentSubscription: any = null;
 
-  // @ mention autocomplete state
-  let mentionQuery = '';
-  let showMentionSuggestions = false;
-  let mentionSuggestions: {
-    name: string;
-    npub: string;
-    picture?: string;
-    pubkey: string;
-    nip05?: string;
-  }[] = [];
-  let selectedMentionIndex = 0;
-  let mentionProfileCache: Map<
-    string,
-    { name: string; npub: string; picture?: string; pubkey: string; nip05?: string }
-  > = new Map();
-  let mentionFollowListLoaded = false;
-  let mentionSearchTimeout: ReturnType<typeof setTimeout>;
-  let mentionSearching = false;
+  // Mention autocomplete
+  let mentionState: MentionState = {
+    mentionQuery: '',
+    showMentionSuggestions: false,
+    mentionSuggestions: [],
+    selectedMentionIndex: 0,
+    mentionSearching: false
+  };
 
-  // Load follow list profiles for mention autocomplete
-  async function loadMentionFollowList() {
-    if (mentionFollowListLoaded) return;
-
-    const pubkey = get(userPublickey);
-    if (!pubkey || !$ndk) return;
-
-    try {
-      const contactEvent = await $ndk.fetchEvent({
-        kinds: [3],
-        authors: [pubkey],
-        limit: 1
-      });
-
-      if (!contactEvent) return;
-
-      // Load ALL follows
-      const followPubkeys = contactEvent.tags.filter((t) => t[0] === 'p' && t[1]).map((t) => t[1]);
-
-      if (followPubkeys.length === 0) return;
-
-      const batchSize = 100;
-      for (let i = 0; i < followPubkeys.length; i += batchSize) {
-        const batch = followPubkeys.slice(i, i + batchSize);
-        try {
-          const events = await $ndk.fetchEvents({
-            kinds: [0],
-            authors: batch
-          });
-
-          for (const event of events) {
-            try {
-              const profile = JSON.parse(event.content);
-              const name = profile.display_name || profile.name || '';
-              if (name || profile.nip05) {
-                mentionProfileCache.set(event.pubkey, {
-                  name: name || profile.nip05?.split('@')[0] || 'Unknown',
-                  npub: nip19.npubEncode(event.pubkey),
-                  picture: profile.picture,
-                  pubkey: event.pubkey,
-                  nip05: profile.nip05
-                });
-              }
-            } catch {}
-          }
-        } catch (e) {
-          console.debug('Failed to fetch mention profile batch:', e);
-        }
-      }
-
-      mentionFollowListLoaded = true;
-    } catch (e) {
-      console.debug('Failed to load mention follow list:', e);
+  const mentionCtrl = new MentionComposerController(
+    (state) => {
+      mentionState = state;
+    },
+    (text) => {
+      commentText = text;
+      lastRenderedComment = text;
     }
+  );
+
+  $: mentionCtrl.setComposerEl(commentComposerEl);
+
+  $: if (commentComposerEl && commentText !== lastRenderedComment) {
+    mentionCtrl.syncContent(commentText);
+    lastRenderedComment = commentText;
   }
 
-  // Search users for mention autocomplete
-  async function searchMentionUsers(query: string) {
-    // Don't wait for follow list - search in parallel
-    loadMentionFollowList();
-
-    const queryLower = query.toLowerCase();
-    const matches: {
-      name: string;
-      npub: string;
-      picture?: string;
-      pubkey: string;
-      nip05?: string;
-    }[] = [];
-    const seenPubkeys = new Set<string>();
-
-    // Search local cache - by name AND NIP-05
-    for (const profile of mentionProfileCache.values()) {
-      const nameMatch = profile.name.toLowerCase().includes(queryLower);
-      const nip05Match = profile.nip05?.toLowerCase().includes(queryLower);
-
-      if (nameMatch || nip05Match) {
-        matches.push(profile);
-        seenPubkeys.add(profile.pubkey);
-      }
-    }
-
-    // Show local matches immediately
-    if (matches.length > 0) {
-      mentionSuggestions = matches.slice(0, 10);
-      selectedMentionIndex = 0;
-    }
-
-    const shouldSearchPrimal = query.length >= 2;
-    const shouldSearchNdk = query.length >= 1 && $ndk;
-
-    if (shouldSearchPrimal || shouldSearchNdk) {
-      mentionSearching = true;
-      try {
-        if (shouldSearchPrimal) {
-          const primalResults = await searchProfiles(query, 25);
-          for (const profile of primalResults) {
-            if (seenPubkeys.has(profile.pubkey)) continue;
-
-            const name =
-              profile.displayName || profile.name || profile.nip05?.split('@')[0] || 'Unknown';
-            const profileData = {
-              name,
-              npub: profile.npub || nip19.npubEncode(profile.pubkey),
-              picture: profile.picture,
-              pubkey: profile.pubkey,
-              nip05: profile.nip05
-            };
-            matches.push(profileData);
-            seenPubkeys.add(profile.pubkey);
-            mentionProfileCache.set(profile.pubkey, profileData);
-          }
-        }
-
-        if (shouldSearchNdk && $ndk) {
-          const searchResults = await $ndk.fetchEvents({
-            kinds: [0],
-            search: query,
-            limit: 50
-          });
-
-          for (const event of searchResults) {
-            if (seenPubkeys.has(event.pubkey)) continue;
-
-            try {
-              const profile = JSON.parse(event.content);
-              const name = profile.display_name || profile.name || '';
-              const nip05 = profile.nip05;
-
-              const profileData = {
-                name: name || nip05?.split('@')[0] || profile.name || 'Unknown',
-                npub: nip19.npubEncode(event.pubkey),
-                picture: profile.picture,
-                pubkey: event.pubkey,
-                nip05
-              };
-              matches.push(profileData);
-              seenPubkeys.add(event.pubkey);
-              mentionProfileCache.set(event.pubkey, profileData);
-            } catch {}
-          }
-        }
-      } catch (e) {
-        console.debug('Network search failed:', e);
-      } finally {
-        mentionSearching = false;
-      }
-    }
-
-    // Sort: prioritize exact matches
-    matches.sort((a, b) => {
-      const aExact =
-        a.name.toLowerCase().startsWith(queryLower) ||
-        a.nip05?.toLowerCase().startsWith(queryLower);
-      const bExact =
-        b.name.toLowerCase().startsWith(queryLower) ||
-        b.nip05?.toLowerCase().startsWith(queryLower);
-      if (aExact && !bExact) return -1;
-      if (!aExact && bExact) return 1;
-      return a.name.localeCompare(b.name);
-    });
-
-    mentionSuggestions = matches.slice(0, 10);
-    selectedMentionIndex = 0;
-  }
-
-  function syncComposerContent(value: string) {
-    if (!commentComposerEl) return;
-    const html = renderTextWithMentions(value);
-    if (commentComposerEl.innerHTML !== html) {
-      commentComposerEl.innerHTML = html;
-    }
-    lastRenderedComment = value;
-  }
-
-  function escapeHtml(value: string): string {
-    return value
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#39;');
-  }
-
-  function escapeRegex(value: string): string {
-    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  }
-
-  function formatNpubShort(npub: string): string {
-    if (npub.length <= 16) return npub;
-    return `${npub.slice(0, 10)}...${npub.slice(-6)}`;
-  }
-
-  function getDisplayNameForMention(mention: string): string {
-    const identifier = mention.replace('nostr:', '');
-    try {
-      const decoded = nip19.decode(identifier);
-      if (decoded.type === 'npub') {
-        const profile = mentionProfileCache.get(decoded.data);
-        if (profile?.name) return profile.name;
-        return formatNpubShort(identifier);
-      }
-      if (decoded.type === 'nprofile') {
-        const profile = mentionProfileCache.get(decoded.data.pubkey);
-        if (profile?.name) return profile.name;
-        return formatNpubShort(nip19.npubEncode(decoded.data.pubkey));
-      }
-    } catch {}
-    return formatNpubShort(identifier);
-  }
-
-  function renderTextWithMentions(text: string): string {
-    if (!text) return '';
-    const mentionRegex =
-      /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)|@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g;
-    let html = '';
-    let lastIndex = 0;
-    let match: RegExpExecArray | null;
-
-    while ((match = mentionRegex.exec(text)) !== null) {
-      const beforeText = text.substring(lastIndex, match.index);
-      if (beforeText) {
-        html += escapeHtml(beforeText).replace(/\n/g, '<br>');
-      }
-
-      const rawMention = match[0];
-      const mention = rawMention.startsWith('@') ? `nostr:${rawMention.slice(1)}` : rawMention;
-      const displayName = getDisplayNameForMention(mention);
-      html += `<span class="mention-pill" contenteditable="false" data-mention="${mention}">@${escapeHtml(displayName)}</span>`;
-
-      lastIndex = match.index + rawMention.length;
-    }
-
-    if (lastIndex < text.length) {
-      html += escapeHtml(text.substring(lastIndex)).replace(/\n/g, '<br>');
-    }
-
-    return html;
-  }
-
-  function htmlToPlainText(element: Node): string {
-    let text = '';
-    let isFirstChild = true;
-
-    element.childNodes.forEach((node) => {
-      if (node.nodeType === Node.TEXT_NODE) {
-        const content = (node.textContent || '').replace(/\u200B/g, '');
-        text += content;
-        if (content) {
-          isFirstChild = false;
-        }
-      } else if (node.nodeType === Node.ELEMENT_NODE) {
-        const el = node as HTMLElement;
-
-        if (el.dataset.mention) {
-          text += el.dataset.mention;
-          isFirstChild = false;
-        } else if (el.tagName === 'BR') {
-          text += '\n';
-        } else if (el.tagName === 'DIV') {
-          if (!isFirstChild) {
-            text += '\n';
-          }
-
-          const hasOnlyBr = el.childNodes.length === 1 && el.firstChild?.nodeName === 'BR';
-          if (!hasOnlyBr) {
-            text += htmlToPlainText(node);
-          }
-          isFirstChild = false;
-        } else if (el.tagName === 'SPAN') {
-          const spanContent = htmlToPlainText(node);
-          text += spanContent;
-          if (spanContent) {
-            isFirstChild = false;
-          }
-        } else {
-          const childContent = htmlToPlainText(node);
-          text += childContent;
-          if (childContent) {
-            isFirstChild = false;
-          }
-        }
-      }
-    });
-
-    return text;
-  }
-
-  function getTextBeforeCursor(element: HTMLDivElement): string {
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return '';
-
-    const range = selection.getRangeAt(0);
-    const preCaretRange = range.cloneRange();
-    preCaretRange.selectNodeContents(element);
-    preCaretRange.setEnd(range.startContainer, range.startOffset);
-
-    const tempDiv = document.createElement('div');
-    tempDiv.appendChild(preCaretRange.cloneContents());
-
-    return htmlToPlainText(tempDiv);
-  }
-
-  function updateContentFromComposer() {
-    if (!commentComposerEl) return;
-    const newText = htmlToPlainText(commentComposerEl);
-    lastRenderedComment = newText;
-    commentText = newText;
-  }
-
-  function handleBeforeInput(event: InputEvent) {
-    if (
-      event.isComposing ||
-      event.inputType === 'historyUndo' ||
-      event.inputType === 'historyRedo'
-    ) {
-      return;
-    }
-
-    const selection = window.getSelection();
-    if (!selection || !commentComposerEl) return;
-    const range = selection.getRangeAt(0);
-    let node: Node | null = range.startContainer;
-
-    while (node && node !== commentComposerEl) {
-      if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).dataset.mention) {
-        event.preventDefault();
-
-        if (event.inputType === 'insertText' || event.inputType === 'insertCompositionText') {
-          const newRange = document.createRange();
-          newRange.setStartAfter(node);
-          newRange.collapse(true);
-          selection.removeAllRanges();
-          selection.addRange(newRange);
-        }
-        return;
-      }
-      node = node.parentNode;
-    }
-  }
-
-  function handlePaste(event: ClipboardEvent) {
-    event.preventDefault();
-    const plainText = event.clipboardData?.getData('text/plain');
-    if (!plainText) return;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-    const range = selection.getRangeAt(0);
-
-    range.deleteContents();
-    const textNode = document.createTextNode(plainText);
-    range.insertNode(textNode);
-    range.setStartAfter(textNode);
-    range.collapse(true);
-    selection.removeAllRanges();
-    selection.addRange(range);
-
-    handleCommentInput();
-  }
-
-  // Handle composer input for @ mentions
-  function handleCommentInput() {
-    updateContentFromComposer();
-    if (!commentComposerEl) return;
-
-    const converted = convertRawMentionsToPills();
-    if (converted) {
-      updateContentFromComposer();
-    }
-
-    const textBeforeCursor = getTextBeforeCursor(commentComposerEl);
-    const mentionMatch = textBeforeCursor.match(/@([^@]*)$/);
-
-    if (mentionMatch) {
-      mentionQuery = mentionMatch[1] || '';
-      showMentionSuggestions = true;
-
-      if (mentionSearchTimeout) clearTimeout(mentionSearchTimeout);
-      mentionSearchTimeout = setTimeout(() => {
-        if (mentionQuery.length > 0) {
-          searchMentionUsers(mentionQuery);
-        } else {
-          mentionSuggestions = Array.from(mentionProfileCache.values()).slice(0, 8);
-          selectedMentionIndex = 0;
-        }
-      }, 150);
-    } else {
-      showMentionSuggestions = false;
-      mentionSuggestions = [];
-    }
-  }
-
-  function deleteCharsBeforeCursor(count: number) {
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-
-    const range = selection.getRangeAt(0);
-    let remaining = count;
-    let currentNode: Node | null = range.startContainer;
-    let currentOffset = range.startOffset;
-
-    if (currentNode.nodeType === Node.ELEMENT_NODE) {
-      const walker = document.createTreeWalker(currentNode, NodeFilter.SHOW_TEXT, null);
-      let lastText: Text | null = null;
-      while (walker.nextNode()) {
-        lastText = walker.currentNode as Text;
-      }
-      if (lastText) {
-        currentNode = lastText;
-        currentOffset = lastText.length;
-      }
-    }
-
-    while (remaining > 0 && currentNode) {
-      if (currentNode.nodeType === Node.TEXT_NODE) {
-        const textNode = currentNode as Text;
-        const deleteCount = Math.min(remaining, currentOffset);
-        if (deleteCount > 0) {
-          textNode.deleteData(currentOffset - deleteCount, deleteCount);
-          remaining -= deleteCount;
-          currentOffset -= deleteCount;
-        }
-
-        if (remaining > 0) {
-          let prev: Node | null = textNode.previousSibling;
-          while (prev && prev.nodeType !== Node.TEXT_NODE) {
-            prev = prev.previousSibling;
-          }
-          if (prev) {
-            currentNode = prev;
-            currentOffset = (prev as Text).length;
-          } else {
-            break;
-          }
-        }
-      } else {
-        break;
-      }
-    }
-  }
-
-  function createMentionPill(mention: string, displayName: string): HTMLSpanElement {
-    const pill = document.createElement('span');
-    pill.contentEditable = 'false';
-    pill.dataset.mention = mention;
-    pill.className = 'mention-pill';
-    pill.textContent = `@${displayName}`;
-    return pill;
-  }
-
-  function insertMentionNode(mention: string, displayName: string, addTrailingSpace = false) {
-    if (!commentComposerEl) return;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-    const range = selection.getRangeAt(0);
-
-    const pill = createMentionPill(mention, displayName);
-    const newRange = document.createRange();
-    newRange.setStart(range.startContainer, range.startOffset);
-    newRange.collapse(true);
-    newRange.insertNode(pill);
-
-    if (addTrailingSpace) {
-      const spacer = document.createTextNode(' ');
-      pill.after(spacer);
-      newRange.setStartAfter(spacer);
-    } else {
-      newRange.setStartAfter(pill);
-    }
-
-    newRange.collapse(true);
-    selection.removeAllRanges();
-    selection.addRange(newRange);
-  }
-
-  function convertRawMentionsToPills(): boolean {
-    if (!commentComposerEl) return false;
-
-    const rawText = commentComposerEl.textContent || '';
-    if (!rawText.includes('npub1')) return false;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0 || !selection.isCollapsed) return false;
-
-    const range = selection.getRangeAt(0);
-    const marker = document.createElement('span');
-    marker.dataset.mentionCaret = 'true';
-    marker.textContent = '\u200B';
-    range.insertNode(marker);
-
-    const textNodes: Text[] = [];
-    const walker = document.createTreeWalker(commentComposerEl, NodeFilter.SHOW_TEXT, {
-      acceptNode(node) {
-        const parent = node.parentElement;
-        if (!parent) return NodeFilter.FILTER_REJECT;
-        if (parent.dataset.mention || parent.dataset.mentionCaret) return NodeFilter.FILTER_REJECT;
-        return NodeFilter.FILTER_ACCEPT;
-      }
-    });
-
-    while (walker.nextNode()) {
-      textNodes.push(walker.currentNode as Text);
-    }
-
-    let converted = false;
-    for (const textNode of textNodes) {
-      const text = textNode.nodeValue;
-      if (!text || !text.includes('npub1')) continue;
-
-      const mentionRegex =
-        /@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)/g;
-      let lastIndex = 0;
-      let match: RegExpExecArray | null;
-      let hasMatch = false;
-      const fragment = document.createDocumentFragment();
-
-      while ((match = mentionRegex.exec(text)) !== null) {
-        hasMatch = true;
-        const before = text.slice(lastIndex, match.index);
-        if (before) {
-          fragment.appendChild(document.createTextNode(before));
-        }
-
-        const rawMention = match[0];
-        const mention = rawMention.startsWith('@') ? `nostr:${rawMention.slice(1)}` : rawMention;
-        const displayName = getDisplayNameForMention(mention);
-        fragment.appendChild(createMentionPill(mention, displayName));
-
-        lastIndex = match.index + rawMention.length;
-      }
-
-      if (!hasMatch) continue;
-      converted = true;
-
-      if (lastIndex < text.length) {
-        fragment.appendChild(document.createTextNode(text.slice(lastIndex)));
-      }
-
-      textNode.parentNode?.replaceChild(fragment, textNode);
-    }
-
-    const caretMarker = commentComposerEl.querySelector('[data-mention-caret]');
-    if (caretMarker) {
-      const newRange = document.createRange();
-      newRange.setStartAfter(caretMarker);
-      newRange.collapse(true);
-      selection.removeAllRanges();
-      selection.addRange(newRange);
-      caretMarker.remove();
-    }
-
-    return converted;
-  }
-
-  // Insert mention pill into composer
-  function insertMention(user: { name: string; npub: string; pubkey: string }) {
-    if (!commentComposerEl) return;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-    const textBeforeCursor = getTextBeforeCursor(commentComposerEl);
-    const mentionMatch = textBeforeCursor.match(/@([^@]*)$/);
-
-    if (mentionMatch?.[0]) {
-      deleteCharsBeforeCursor(mentionMatch[0].length);
-    }
-
-    const textAfterDeletion = getTextBeforeCursor(commentComposerEl);
-    const needsLeadingSpace = textAfterDeletion.length > 0 && !/\s$/.test(textAfterDeletion);
-    
-    if (needsLeadingSpace) {
-      const spaceNode = document.createTextNode(' ');
-      const range = selection.getRangeAt(0);
-      range.insertNode(spaceNode);
-      range.setStartAfter(spaceNode);
-      range.collapse(true);
-      selection.removeAllRanges();
-      selection.addRange(range);
-    }
-
-    const mention = `nostr:${user.npub}`;
-    insertMentionNode(mention, user.name, true);
-
-    mentionProfileCache.set(user.pubkey, user);
-    updateContentFromComposer();
-    showMentionSuggestions = false;
-    mentionSuggestions = [];
-  }
-
-  function replacePlainMentions(text: string): string {
-    let output = text;
-    output = output.replace(
-      /@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g,
-      (match) => `nostr:${match.slice(1)}`
-    );
-    for (const profile of mentionProfileCache.values()) {
-      if (!profile.name) continue;
-      const mentionText = `@${profile.name}`;
-      const mentionRegex = new RegExp(`${escapeRegex(mentionText)}(?=\\s|$|[.,!?;:])`, 'gi');
-      if (mentionRegex.test(output)) {
-        output = output.replace(mentionRegex, `nostr:${profile.npub}`);
-      }
-    }
-    return output;
-  }
-
-  // Parse nostr: mentions from content and return pubkeys
-  function parseMentions(text: string): Map<string, string> {
-    const mentions = new Map<string, string>();
-    const mentionRegex =
-      /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)|@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g;
-    let match: RegExpExecArray | null;
-
-    while ((match = mentionRegex.exec(text)) !== null) {
-      const mention = match[1] || match[0].slice(1);
-      try {
-        const decoded = nip19.decode(mention);
-        if (decoded.type === 'npub') {
-          mentions.set(mention, decoded.data);
-        } else if (decoded.type === 'nprofile') {
-          mentions.set(mention, decoded.data.pubkey);
-        }
-      } catch {}
-    }
-
-    return mentions;
-  }
-
-  // Handle keyboard navigation in mention suggestions and pill deletion
-  function handleCommentKeydown(event: KeyboardEvent) {
-    const selection = window.getSelection();
-    if (selection && selection.rangeCount) {
-      const range = selection.getRangeAt(0);
-
-      if (event.key === 'Delete' && range.collapsed) {
-        const { startContainer, startOffset } = range;
-        if (startContainer.nodeType === Node.TEXT_NODE) {
-          const textNode = startContainer as Text;
-          if (startOffset === textNode.length) {
-            const nextSibling = startContainer.nextSibling;
-            if (
-              nextSibling &&
-              nextSibling.nodeType === Node.ELEMENT_NODE &&
-              (nextSibling as HTMLElement).dataset.mention
-            ) {
-              event.preventDefault();
-              nextSibling.remove();
-              updateContentFromComposer();
-              return;
-            }
-          }
-        }
-      }
-
-      if (event.key === 'Backspace') {
-        if (!range.collapsed) {
-          const container = range.commonAncestorContainer;
-          let mentionElement: HTMLElement | null = null;
-
-          if (container.nodeType === Node.ELEMENT_NODE) {
-            const el = container as HTMLElement;
-            if (el.dataset.mention) {
-              mentionElement = el;
-            }
-          } else if (container.parentElement?.dataset.mention) {
-            mentionElement = container.parentElement;
-          }
-
-          if (mentionElement) {
-            event.preventDefault();
-            mentionElement.remove();
-            updateContentFromComposer();
-            return;
-          }
-        }
-
-        if (range.collapsed) {
-          const { startContainer, startOffset } = range;
-          if (startContainer.nodeType === Node.TEXT_NODE && startOffset === 0) {
-            const prevSibling = startContainer.previousSibling;
-            if (
-              prevSibling &&
-              prevSibling.nodeType === Node.ELEMENT_NODE &&
-              (prevSibling as HTMLElement).dataset.mention
-            ) {
-              event.preventDefault();
-              prevSibling.remove();
-              updateContentFromComposer();
-              return;
-            }
-          }
-        }
-      }
-    }
-
-    if (showMentionSuggestions && mentionSuggestions.length > 0) {
-      if (event.key === 'ArrowDown') {
-        event.preventDefault();
-        selectedMentionIndex = (selectedMentionIndex + 1) % mentionSuggestions.length;
-      } else if (event.key === 'ArrowUp') {
-        event.preventDefault();
-        selectedMentionIndex =
-          selectedMentionIndex === 0 ? mentionSuggestions.length - 1 : selectedMentionIndex - 1;
-      } else if (event.key === 'Enter' || event.key === 'Tab') {
-        event.preventDefault();
-        insertMention(mentionSuggestions[selectedMentionIndex]);
-      } else if (event.key === 'Escape') {
-        showMentionSuggestions = false;
-        mentionSuggestions = [];
-      }
-      return;
-    }
+  $: if ($userPublickey) {
+    mentionCtrl.preloadFollowList();
   }
 
   // Listen for toggle event from NoteTotalComments
@@ -773,17 +66,10 @@
         element.removeEventListener('toggleComments', handleToggleEvent);
       };
     }
-
-    // Preload mention profiles in background
-    if ($userPublickey) {
-      loadMentionFollowList();
-    }
   });
 
   onDestroy(() => {
-    if (mentionSearchTimeout) {
-      clearTimeout(mentionSearchTimeout);
-    }
+    mentionCtrl.destroy();
     if (feedCommentSubscription) {
       feedCommentSubscription.stop();
     }
@@ -816,7 +102,7 @@
 
     try {
       if (commentComposerEl) {
-        commentText = htmlToPlainText(commentComposerEl);
+        commentText = mentionCtrl.extractText();
         lastRenderedComment = commentText;
       }
 
@@ -827,7 +113,7 @@
       const isRecipe = event.kind === 30023;
       ev.kind = isRecipe ? 1111 : 1;
 
-      const commentContent = replacePlainMentions(commentText);
+      const commentContent = mentionCtrl.replacePlainMentions(commentText);
       ev.content = commentContent;
 
       // Use shared utility to build NIP-22 or NIP-10 tags
@@ -839,7 +125,7 @@
       });
 
       // Parse and add @ mention tags (p tags)
-      const mentions = parseMentions(commentContent);
+      const mentions = mentionCtrl.parseMentions(commentContent);
       for (const pubkey of mentions.values()) {
         // Avoid duplicate p tags
         if (!ev.tags.some((t) => t[0] === 'p' && t[1] === pubkey)) {
@@ -856,9 +142,7 @@
       if (commentComposerEl) {
         commentComposerEl.innerHTML = '';
       }
-      showMentionSuggestions = false;
-      mentionSuggestions = [];
-      mentionQuery = '';
+      mentionCtrl.resetMentionState();
     } catch {
       // Failed to post comment
     }
@@ -875,10 +159,6 @@
       return !authorKey || !$mutedPubkeys.has(authorKey);
     })
     .sort((a, b) => (a.created_at || 0) - (b.created_at || 0));
-
-  $: if (commentComposerEl && commentText !== lastRenderedComment) {
-    syncComposerContent(commentText);
-  }
 </script>
 
 <div class="inline-comments" data-event-id={event.id}>
@@ -907,42 +187,20 @@
               role="textbox"
               aria-multiline="true"
               data-placeholder="Add a comment..."
-              on:input={handleCommentInput}
-              on:keydown={handleCommentKeydown}
-              on:beforeinput={handleBeforeInput}
-              on:paste={handlePaste}
+              on:input={() => mentionCtrl.handleInput()}
+              on:keydown={(e) => mentionCtrl.handleKeydown(e)}
+              on:beforeinput={(e) => mentionCtrl.handleBeforeInput(e)}
+              on:paste={(e) => mentionCtrl.handlePaste(e)}
             ></div>
 
-            <!-- Mention suggestions dropdown -->
-            {#if showMentionSuggestions}
-              <div class="mention-dropdown" style="border-color: var(--color-input-border);">
-                {#if mentionSuggestions.length > 0}
-                  <div class="mention-dropdown-content">
-                    {#each mentionSuggestions as suggestion, index}
-                      <button
-                        type="button"
-                        on:click={() => insertMention(suggestion)}
-                        on:mousedown|preventDefault={() => insertMention(suggestion)}
-                        class="mention-option"
-                        class:mention-selected={index === selectedMentionIndex}
-                      >
-                        <CustomAvatar pubkey={suggestion.pubkey} size={24} />
-                        <div class="mention-info">
-                          <span class="mention-name">{suggestion.name}</span>
-                          {#if suggestion.nip05}
-                            <span class="mention-nip05">{suggestion.nip05}</span>
-                          {/if}
-                        </div>
-                      </button>
-                    {/each}
-                  </div>
-                {:else if mentionSearching}
-                  <div class="mention-empty">Searching...</div>
-                {:else if mentionQuery.length > 0}
-                  <div class="mention-empty">No users found</div>
-                {/if}
-              </div>
-            {/if}
+            <MentionDropdown
+              show={mentionState.showMentionSuggestions}
+              suggestions={mentionState.mentionSuggestions}
+              selectedIndex={mentionState.selectedMentionIndex}
+              searching={mentionState.mentionSearching}
+              query={mentionState.mentionQuery}
+              on:select={(e) => mentionCtrl.insertMention(e.detail)}
+            />
           </div>
           <div class="flex justify-end">
             <Button on:click={postComment} disabled={!commentText.trim()} class="text-sm px-4 py-2">
@@ -970,95 +228,6 @@
     gap: 1rem;
   }
 
-  /* Mention dropdown - compact and scrollable */
-  .mention-dropdown {
-    position: absolute;
-    z-index: 1000;
-    top: 100%;
-    left: 0;
-    margin-top: 0.25rem;
-    width: 280px;
-    max-width: calc(100vw - 2rem);
-    background: var(--color-input-bg);
-    border: 1px solid var(--color-input-border);
-    border-radius: 0.5rem;
-    box-shadow:
-      0 4px 6px -1px rgb(0 0 0 / 0.1),
-      0 2px 4px -1px rgb(0 0 0 / 0.06);
-    overflow: hidden;
-  }
-
-  .mention-dropdown-content {
-    max-height: 200px;
-    overflow-y: auto;
-    overflow-x: hidden;
-  }
-
-  .mention-dropdown-content::-webkit-scrollbar {
-    width: 6px;
-  }
-
-  .mention-dropdown-content::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  .mention-dropdown-content::-webkit-scrollbar-thumb {
-    background: var(--color-input-border);
-    border-radius: 3px;
-  }
-
-  .mention-dropdown-content::-webkit-scrollbar-thumb:hover {
-    background: var(--color-caption);
-  }
-
-  .mention-option {
-    width: 100%;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 0.75rem;
-    text-align: left;
-    transition: background-color 0.15s;
-    border: none;
-    background: transparent;
-  }
-
-  .mention-option:hover,
-  .mention-selected {
-    background: var(--color-accent-gray);
-  }
-
-  .mention-info {
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
-    flex: 1;
-  }
-
-  .mention-name {
-    font-size: 0.875rem;
-    font-weight: 500;
-    color: var(--color-text-primary);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .mention-nip05 {
-    font-size: 0.75rem;
-    color: var(--color-caption);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .mention-empty {
-    padding: 0.75rem;
-    text-align: center;
-    font-size: 0.875rem;
-    color: var(--color-caption);
-  }
-
   .comment-composer-input {
     white-space: pre-wrap;
     word-break: break-word;
@@ -1068,18 +237,5 @@
     content: attr(data-placeholder);
     color: var(--color-caption);
     pointer-events: none;
-  }
-
-  :global(.mention-pill) {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-    padding: 0.1rem 0.45rem;
-    border-radius: 0.5rem;
-    background: rgba(247, 147, 26, 0.2);
-    color: #f7931a;
-    font-weight: 600;
-    user-select: all;
-    margin: 0 0.1rem;
   }
 </style>

--- a/src/components/MentionDropdown.svelte
+++ b/src/components/MentionDropdown.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+	import CustomAvatar from './CustomAvatar.svelte';
+	import type { MentionSuggestion } from '$lib/mentionComposer';
+
+	export let show = false;
+	export let suggestions: MentionSuggestion[] = [];
+	export let selectedIndex = 0;
+	export let searching = false;
+	export let query = '';
+
+	const dispatch = createEventDispatcher<{ select: MentionSuggestion }>();
+</script>
+
+{#if show}
+	<div class="mention-dropdown" style="border-color: var(--color-input-border);">
+		{#if suggestions.length > 0}
+			<div class="mention-dropdown-content">
+				{#each suggestions as suggestion, index}
+					<button
+						type="button"
+						on:click={() => dispatch('select', suggestion)}
+						on:mousedown|preventDefault={() => dispatch('select', suggestion)}
+						class="mention-option"
+						class:mention-selected={index === selectedIndex}
+					>
+						<CustomAvatar pubkey={suggestion.pubkey} size={24} />
+						<div class="mention-info">
+							<span class="mention-name">{suggestion.name}</span>
+							{#if suggestion.nip05}
+								<span class="mention-nip05">{suggestion.nip05}</span>
+							{/if}
+						</div>
+					</button>
+				{/each}
+			</div>
+		{:else if searching}
+			<div class="mention-empty">Searching...</div>
+		{:else if query.length > 0}
+			<div class="mention-empty">No users found</div>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	/* PR #143 fix #3: z-index 50 -> 1000 */
+	.mention-dropdown {
+		position: absolute;
+		z-index: 1000;
+		top: 100%;
+		left: 0;
+		margin-top: 0.25rem;
+		width: 280px;
+		max-width: calc(100vw - 2rem);
+		background: var(--color-input-bg);
+		border: 1px solid var(--color-input-border);
+		border-radius: 0.5rem;
+		box-shadow:
+			0 4px 6px -1px rgb(0 0 0 / 0.1),
+			0 2px 4px -1px rgb(0 0 0 / 0.06);
+		overflow: hidden;
+	}
+
+	.mention-dropdown-content {
+		max-height: 200px;
+		overflow-y: auto;
+		overflow-x: hidden;
+	}
+
+	.mention-dropdown-content::-webkit-scrollbar {
+		width: 6px;
+	}
+
+	.mention-dropdown-content::-webkit-scrollbar-track {
+		background: transparent;
+	}
+
+	.mention-dropdown-content::-webkit-scrollbar-thumb {
+		background: var(--color-input-border);
+		border-radius: 3px;
+	}
+
+	.mention-dropdown-content::-webkit-scrollbar-thumb:hover {
+		background: var(--color-caption);
+	}
+
+	.mention-option {
+		width: 100%;
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.5rem 0.75rem;
+		text-align: left;
+		transition: background-color 0.15s;
+		border: none;
+		background: transparent;
+	}
+
+	.mention-option:hover,
+	.mention-selected {
+		background: var(--color-accent-gray);
+	}
+
+	.mention-info {
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+		flex: 1;
+	}
+
+	.mention-name {
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: var(--color-text-primary);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.mention-nip05 {
+		font-size: 0.75rem;
+		color: var(--color-caption);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.mention-empty {
+		padding: 0.75rem;
+		text-align: center;
+		font-size: 0.875rem;
+		color: var(--color-caption);
+	}
+
+	:global(.mention-pill) {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		padding: 0.1rem 0.45rem;
+		border-radius: 0.5rem;
+		background: rgba(247, 147, 26, 0.2);
+		color: #f7931a;
+		font-weight: 600;
+		user-select: all;
+		margin: 0 0.1rem;
+	}
+</style>

--- a/src/components/PostComposer.svelte
+++ b/src/components/PostComposer.svelte
@@ -11,10 +11,10 @@
   import NoteContent from './NoteContent.svelte';
   import { addClientTagToEvent } from '$lib/nip89';
   import type { NDKEvent as NDKEventType } from '@nostr-dev-kit/ndk';
-  import { get } from 'svelte/store';
-  import { searchProfiles } from '$lib/profileSearchService';
   import { clearQuotedNote } from '$lib/postComposerStore';
   import { publishQueue, publishQueueState } from '$lib/publishQueue';
+  import MentionDropdown from './MentionDropdown.svelte';
+  import { MentionComposerController, type MentionState } from '$lib/mentionComposer';
 
   // Clear stuck posts from the publish queue
   async function clearPendingQueue() {
@@ -52,24 +52,31 @@
   let videoInputEl: HTMLInputElement;
   let quotedNote: { nevent: string; event: NDKEventType } | null = null;
 
-  // @ mention autocomplete state
-  let mentionQuery = '';
-  let showMentionSuggestions = false;
-  let mentionSuggestions: {
-    name: string;
-    npub: string;
-    picture?: string;
-    pubkey: string;
-    nip05?: string;
-  }[] = [];
-  let selectedMentionIndex = 0;
-  let mentionProfileCache: Map<
-    string,
-    { name: string; npub: string; picture?: string; pubkey: string; nip05?: string }
-  > = new Map();
-  let mentionFollowListLoaded = false;
-  let mentionSearchTimeout: ReturnType<typeof setTimeout>;
-  let mentionSearching = false;
+  // Mention autocomplete (shared controller)
+  let mentionState: MentionState = {
+    mentionQuery: '',
+    showMentionSuggestions: false,
+    mentionSuggestions: [],
+    selectedMentionIndex: 0,
+    mentionSearching: false
+  };
+
+  const mentionCtrl = new MentionComposerController(
+    (state) => {
+      mentionState = state;
+    },
+    (text) => {
+      content = text;
+      lastRenderedContent = text;
+    }
+  );
+
+  $: mentionCtrl.setComposerEl(composerEl);
+
+  $: if (composerEl && content !== lastRenderedContent) {
+    mentionCtrl.syncContent(content);
+    lastRenderedContent = content;
+  }
 
   $: if (variant === 'modal') {
     isComposerOpen = true;
@@ -78,7 +85,7 @@
   function focusComposer() {
     setTimeout(() => {
       if (composerEl) {
-        syncComposerContent(content);
+        mentionCtrl.syncContent(content);
         composerEl.focus();
       }
     }, 50);
@@ -99,7 +106,7 @@
 
     // Preload mention profiles in background
     if ($userPublickey) {
-      loadMentionFollowList();
+      mentionCtrl.preloadFollowList();
     }
 
     if (variant === 'modal') {
@@ -115,9 +122,7 @@
     if (variant === 'inline') {
       window.removeEventListener('quote-note', handleQuoteNote as EventListener);
     }
-    if (mentionSearchTimeout) {
-      clearTimeout(mentionSearchTimeout);
-    }
+    mentionCtrl.destroy();
   });
 
   function openComposer() {
@@ -130,9 +135,7 @@
     lastRenderedContent = '';
     error = '';
     successQueued = false;
-    showMentionSuggestions = false;
-    mentionSuggestions = [];
-    mentionQuery = '';
+    mentionCtrl.resetMentionState();
     uploadedImages = [];
     uploadedVideos = [];
     quotedNote = null;
@@ -358,7 +361,7 @@
 
     try {
       if (composerEl) {
-        content = htmlToPlainText(composerEl);
+        content = mentionCtrl.extractText();
         lastRenderedContent = content;
         console.log('[PostComposer] Extracted content from composer:', content);
       }
@@ -400,8 +403,8 @@
           : `nostr:${quotedNote.nevent}`;
       }
 
-      postContent = replacePlainMentions(postContent);
-      const mentions = parseMentions(postContent);
+      postContent = mentionCtrl.replacePlainMentions(postContent);
+      const mentions = mentionCtrl.parseMentions(postContent);
 
       event.content = postContent;
       event.tags = [['t', 'zapcooking']];
@@ -483,718 +486,11 @@
     }
   }
 
-  // Load follow list profiles for mention autocomplete
-  async function loadMentionFollowList() {
-    if (mentionFollowListLoaded) return;
-
-    const pubkey = get(userPublickey);
-    if (!pubkey || !$ndk) return;
-
-    try {
-      const contactEvent = await $ndk.fetchEvent({
-        kinds: [3],
-        authors: [pubkey],
-        limit: 1
-      });
-
-      if (!contactEvent) return;
-
-      const followPubkeys = contactEvent.tags.filter((t) => t[0] === 'p' && t[1]).map((t) => t[1]);
-
-      if (followPubkeys.length === 0) return;
-
-      const batchSize = 100;
-      for (let i = 0; i < followPubkeys.length; i += batchSize) {
-        const batch = followPubkeys.slice(i, i + batchSize);
-        try {
-          const events = await $ndk.fetchEvents({
-            kinds: [0],
-            authors: batch
-          });
-
-          for (const event of events) {
-            try {
-              const profile = JSON.parse(event.content);
-              const name = profile.display_name || profile.name || '';
-              if (name || profile.nip05) {
-                mentionProfileCache.set(event.pubkey, {
-                  name: name || profile.nip05?.split('@')[0] || 'Unknown',
-                  npub: nip19.npubEncode(event.pubkey),
-                  picture: profile.picture,
-                  pubkey: event.pubkey,
-                  nip05: profile.nip05
-                });
-              }
-            } catch {}
-          }
-        } catch (e) {
-          console.debug('Failed to fetch mention profile batch:', e);
-        }
-      }
-
-      mentionFollowListLoaded = true;
-    } catch (e) {
-      console.debug('Failed to load mention follow list:', e);
-    }
-  }
-
-  // Search users for mention autocomplete
-  async function searchMentionUsers(query: string) {
-    loadMentionFollowList();
-
-    const queryLower = query.toLowerCase();
-    const matches: {
-      name: string;
-      npub: string;
-      picture?: string;
-      pubkey: string;
-      nip05?: string;
-    }[] = [];
-    const seenPubkeys = new Set<string>();
-
-    for (const profile of mentionProfileCache.values()) {
-      const nameMatch = profile.name.toLowerCase().includes(queryLower);
-      const nip05Match = profile.nip05?.toLowerCase().includes(queryLower);
-
-      if (nameMatch || nip05Match) {
-        matches.push(profile);
-        seenPubkeys.add(profile.pubkey);
-      }
-    }
-
-    if (matches.length > 0) {
-      mentionSuggestions = matches.slice(0, 10);
-      selectedMentionIndex = 0;
-    }
-
-    const shouldSearchPrimal = query.length >= 2;
-    const shouldSearchNdk = query.length >= 1 && $ndk;
-
-    if (shouldSearchPrimal || shouldSearchNdk) {
-      mentionSearching = true;
-
-      try {
-        if (shouldSearchPrimal) {
-          const primalResults = await searchProfiles(query, 25);
-          for (const profile of primalResults) {
-            if (seenPubkeys.has(profile.pubkey)) continue;
-
-            const name =
-              profile.displayName || profile.name || profile.nip05?.split('@')[0] || 'Unknown';
-            const profileData = {
-              name,
-              npub: profile.npub || nip19.npubEncode(profile.pubkey),
-              picture: profile.picture,
-              pubkey: profile.pubkey,
-              nip05: profile.nip05
-            };
-
-            matches.push(profileData);
-            seenPubkeys.add(profile.pubkey);
-            mentionProfileCache.set(profile.pubkey, profileData);
-          }
-        }
-
-        if (shouldSearchNdk && $ndk) {
-          const searchResults = await $ndk.fetchEvents({
-            kinds: [0],
-            search: query,
-            limit: 50
-          });
-
-          for (const event of searchResults) {
-            if (seenPubkeys.has(event.pubkey)) continue;
-
-            try {
-              const profile = JSON.parse(event.content);
-              const name = profile.display_name || profile.name || '';
-              const nip05 = profile.nip05;
-
-              const profileData = {
-                name: name || nip05?.split('@')[0] || profile.name || 'Unknown',
-                npub: nip19.npubEncode(event.pubkey),
-                picture: profile.picture,
-                pubkey: event.pubkey,
-                nip05
-              };
-
-              matches.push(profileData);
-              seenPubkeys.add(event.pubkey);
-              mentionProfileCache.set(event.pubkey, profileData);
-            } catch {}
-          }
-        }
-      } catch (e) {
-        console.debug('Network search failed:', e);
-      } finally {
-        mentionSearching = false;
-      }
-    }
-
-    matches.sort((a, b) => {
-      const aExact =
-        a.name.toLowerCase().startsWith(queryLower) ||
-        a.nip05?.toLowerCase().startsWith(queryLower);
-      const bExact =
-        b.name.toLowerCase().startsWith(queryLower) ||
-        b.nip05?.toLowerCase().startsWith(queryLower);
-      if (aExact && !bExact) return -1;
-      if (!aExact && bExact) return 1;
-      return a.name.localeCompare(b.name);
-    });
-
-    mentionSuggestions = matches.slice(0, 10);
-    selectedMentionIndex = 0;
-  }
-
-  function syncComposerContent(value: string) {
-    if (!composerEl) return;
-    const html = renderTextWithMentions(value);
-    if (composerEl.innerHTML !== html) {
-      composerEl.innerHTML = html;
-    }
-    lastRenderedContent = value;
-  }
-
-  function escapeHtml(value: string): string {
-    return value
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#39;');
-  }
-
-  function escapeRegex(value: string): string {
-    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  }
-
-  function formatNpubShort(npub: string): string {
-    if (npub.length <= 16) return npub;
-    return `${npub.slice(0, 10)}...${npub.slice(-6)}`;
-  }
-
-  function getDisplayNameForMention(mention: string): string {
-    const identifier = mention.replace('nostr:', '');
-    try {
-      const decoded = nip19.decode(identifier);
-      if (decoded.type === 'npub') {
-        const profile = mentionProfileCache.get(decoded.data);
-        if (profile?.name) return profile.name;
-        return formatNpubShort(identifier);
-      }
-      if (decoded.type === 'nprofile') {
-        const profile = mentionProfileCache.get(decoded.data.pubkey);
-        if (profile?.name) return profile.name;
-        return formatNpubShort(nip19.npubEncode(decoded.data.pubkey));
-      }
-    } catch {}
-    return formatNpubShort(identifier);
-  }
-
-  function renderTextWithMentions(text: string): string {
-    if (!text) return '';
-    const mentionRegex =
-      /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)|@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g;
-    let html = '';
-    let lastIndex = 0;
-    let match: RegExpExecArray | null;
-
-    while ((match = mentionRegex.exec(text)) !== null) {
-      const beforeText = text.substring(lastIndex, match.index);
-      if (beforeText) {
-        html += escapeHtml(beforeText).replace(/\n/g, '<br>');
-      }
-
-      const rawMention = match[0];
-      const mention = rawMention.startsWith('@') ? `nostr:${rawMention.slice(1)}` : rawMention;
-      const displayName = getDisplayNameForMention(mention);
-      html += `<span class="mention-pill" contenteditable="false" data-mention="${mention}">@${escapeHtml(displayName)}</span>`;
-
-      lastIndex = match.index + rawMention.length;
-    }
-
-    if (lastIndex < text.length) {
-      html += escapeHtml(text.substring(lastIndex)).replace(/\n/g, '<br>');
-    }
-
-    return html;
-  }
-
-  function htmlToPlainText(element: Node): string {
-    let text = '';
-    let isFirstChild = true;
-
-    element.childNodes.forEach((node) => {
-      if (node.nodeType === Node.TEXT_NODE) {
-        const content = (node.textContent || '').replace(/\u200B/g, '');
-        text += content;
-        if (content) {
-          isFirstChild = false;
-        }
-      } else if (node.nodeType === Node.ELEMENT_NODE) {
-        const el = node as HTMLElement;
-
-        if (el.dataset.mention) {
-          text += el.dataset.mention;
-          isFirstChild = false;
-        } else if (el.tagName === 'BR') {
-          text += '\n';
-        } else if (el.tagName === 'DIV') {
-          if (!isFirstChild) {
-            text += '\n';
-          }
-
-          const hasOnlyBr = el.childNodes.length === 1 && el.firstChild?.nodeName === 'BR';
-          if (!hasOnlyBr) {
-            text += htmlToPlainText(node);
-          }
-          isFirstChild = false;
-        } else if (el.tagName === 'SPAN') {
-          const spanContent = htmlToPlainText(node);
-          text += spanContent;
-          if (spanContent) {
-            isFirstChild = false;
-          }
-        } else {
-          const childContent = htmlToPlainText(node);
-          text += childContent;
-          if (childContent) {
-            isFirstChild = false;
-          }
-        }
-      }
-    });
-
-    return text;
-  }
-
-  function getTextBeforeCursor(element: HTMLDivElement): string {
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return '';
-
-    const range = selection.getRangeAt(0);
-    const preCaretRange = range.cloneRange();
-    preCaretRange.selectNodeContents(element);
-    preCaretRange.setEnd(range.startContainer, range.startOffset);
-
-    const tempDiv = document.createElement('div');
-    tempDiv.appendChild(preCaretRange.cloneContents());
-
-    return htmlToPlainText(tempDiv);
-  }
-
-  function updateContentFromComposer() {
-    if (!composerEl) return;
-    const newText = htmlToPlainText(composerEl);
-    lastRenderedContent = newText;
-    content = newText;
-  }
-
-  function handleBeforeInput(event: InputEvent) {
-    if (
-      event.isComposing ||
-      event.inputType === 'historyUndo' ||
-      event.inputType === 'historyRedo'
-    ) {
-      return;
-    }
-
-    const selection = window.getSelection();
-    if (!selection || !composerEl) return;
-    const range = selection.getRangeAt(0);
-    let node: Node | null = range.startContainer;
-
-    while (node && node !== composerEl) {
-      if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).dataset.mention) {
-        event.preventDefault();
-
-        if (event.inputType === 'insertText' || event.inputType === 'insertCompositionText') {
-          const newRange = document.createRange();
-          newRange.setStartAfter(node);
-          newRange.collapse(true);
-          selection.removeAllRanges();
-          selection.addRange(newRange);
-        }
-        return;
-      }
-      node = node.parentNode;
-    }
-  }
-
-  function handlePaste(event: ClipboardEvent) {
-    event.preventDefault();
-    const plainText = event.clipboardData?.getData('text/plain');
-    if (!plainText) return;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-    const range = selection.getRangeAt(0);
-
-    range.deleteContents();
-    const textNode = document.createTextNode(plainText);
-    range.insertNode(textNode);
-    range.setStartAfter(textNode);
-    range.collapse(true);
-    selection.removeAllRanges();
-    selection.addRange(range);
-
-    handleContentInput();
-  }
-
-  function handleContentInput() {
-    updateContentFromComposer();
-    if (!composerEl) return;
-
-    const converted = convertRawMentionsToPills();
-    if (converted) {
-      updateContentFromComposer();
-    }
-
-    const textBeforeCursor = getTextBeforeCursor(composerEl);
-    const mentionMatch = textBeforeCursor.match(/@([^@]*)$/);
-
-    if (mentionMatch) {
-      mentionQuery = mentionMatch[1] || '';
-      showMentionSuggestions = true;
-
-      if (mentionSearchTimeout) clearTimeout(mentionSearchTimeout);
-      mentionSearchTimeout = setTimeout(() => {
-        if (mentionQuery.length > 0) {
-          searchMentionUsers(mentionQuery);
-        } else {
-          mentionSuggestions = Array.from(mentionProfileCache.values()).slice(0, 8);
-          selectedMentionIndex = 0;
-        }
-      }, 150);
-    } else {
-      showMentionSuggestions = false;
-      mentionSuggestions = [];
-    }
-  }
-
-  function deleteCharsBeforeCursor(count: number) {
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-
-    const range = selection.getRangeAt(0);
-    let remaining = count;
-    let currentNode: Node | null = range.startContainer;
-    let currentOffset = range.startOffset;
-
-    if (currentNode.nodeType === Node.ELEMENT_NODE) {
-      const walker = document.createTreeWalker(currentNode, NodeFilter.SHOW_TEXT, null);
-      let lastText: Text | null = null;
-      while (walker.nextNode()) {
-        lastText = walker.currentNode as Text;
-      }
-      if (lastText) {
-        currentNode = lastText;
-        currentOffset = lastText.length;
-      }
-    }
-
-    while (remaining > 0 && currentNode) {
-      if (currentNode.nodeType === Node.TEXT_NODE) {
-        const textNode = currentNode as Text;
-        const deleteCount = Math.min(remaining, currentOffset);
-        if (deleteCount > 0) {
-          textNode.deleteData(currentOffset - deleteCount, deleteCount);
-          remaining -= deleteCount;
-          currentOffset -= deleteCount;
-        }
-
-        if (remaining > 0) {
-          let prev: Node | null = textNode.previousSibling;
-          while (prev && prev.nodeType !== Node.TEXT_NODE) {
-            prev = prev.previousSibling;
-          }
-          if (prev) {
-            currentNode = prev;
-            currentOffset = (prev as Text).length;
-          } else {
-            break;
-          }
-        }
-      } else {
-        break;
-      }
-    }
-  }
-
-  function createMentionPill(mention: string, displayName: string): HTMLSpanElement {
-    const pill = document.createElement('span');
-    pill.contentEditable = 'false';
-    pill.dataset.mention = mention;
-    pill.className = 'mention-pill';
-    pill.textContent = `@${displayName}`;
-    return pill;
-  }
-
-  function insertMentionNode(mention: string, displayName: string, addTrailingSpace = false) {
-    if (!composerEl) return;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-    const range = selection.getRangeAt(0);
-
-    const pill = createMentionPill(mention, displayName);
-    const newRange = document.createRange();
-    newRange.setStart(range.startContainer, range.startOffset);
-    newRange.collapse(true);
-    newRange.insertNode(pill);
-
-    if (addTrailingSpace) {
-      const spacer = document.createTextNode(' ');
-      pill.after(spacer);
-      newRange.setStartAfter(spacer);
-    } else {
-      newRange.setStartAfter(pill);
-    }
-
-    newRange.collapse(true);
-    selection.removeAllRanges();
-    selection.addRange(newRange);
-  }
-
-  function convertRawMentionsToPills(): boolean {
-    if (!composerEl) return false;
-
-    const rawText = composerEl.textContent || '';
-    if (!rawText.includes('npub1')) return false;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0 || !selection.isCollapsed) return false;
-
-    const range = selection.getRangeAt(0);
-    const marker = document.createElement('span');
-    marker.dataset.mentionCaret = 'true';
-    marker.textContent = '\u200B';
-    range.insertNode(marker);
-
-    const textNodes: Text[] = [];
-    const walker = document.createTreeWalker(composerEl, NodeFilter.SHOW_TEXT, {
-      acceptNode(node) {
-        const parent = node.parentElement;
-        if (!parent) return NodeFilter.FILTER_REJECT;
-        if (parent.dataset.mention || parent.dataset.mentionCaret) return NodeFilter.FILTER_REJECT;
-        return NodeFilter.FILTER_ACCEPT;
-      }
-    });
-
-    while (walker.nextNode()) {
-      textNodes.push(walker.currentNode as Text);
-    }
-
-    let converted = false;
-    for (const textNode of textNodes) {
-      const text = textNode.nodeValue;
-      if (!text || !text.includes('npub1')) continue;
-
-      const mentionRegex =
-        /@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)/g;
-      let lastIndex = 0;
-      let match: RegExpExecArray | null;
-      let hasMatch = false;
-      const fragment = document.createDocumentFragment();
-
-      while ((match = mentionRegex.exec(text)) !== null) {
-        hasMatch = true;
-        const before = text.slice(lastIndex, match.index);
-        if (before) {
-          fragment.appendChild(document.createTextNode(before));
-        }
-
-        const rawMention = match[0];
-        const mention = rawMention.startsWith('@') ? `nostr:${rawMention.slice(1)}` : rawMention;
-        const displayName = getDisplayNameForMention(mention);
-        fragment.appendChild(createMentionPill(mention, displayName));
-
-        lastIndex = match.index + rawMention.length;
-      }
-
-      if (!hasMatch) continue;
-      converted = true;
-
-      if (lastIndex < text.length) {
-        fragment.appendChild(document.createTextNode(text.slice(lastIndex)));
-      }
-
-      textNode.parentNode?.replaceChild(fragment, textNode);
-    }
-
-    const caretMarker = composerEl.querySelector('[data-mention-caret]');
-    if (caretMarker) {
-      const newRange = document.createRange();
-      newRange.setStartAfter(caretMarker);
-      newRange.collapse(true);
-      selection.removeAllRanges();
-      selection.addRange(newRange);
-      caretMarker.remove();
-    }
-
-    return converted;
-  }
-
-  function insertMention(user: { name: string; npub: string; pubkey: string }) {
-    if (!composerEl) return;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-    const textBeforeCursor = getTextBeforeCursor(composerEl);
-    const mentionMatch = textBeforeCursor.match(/@([^@]*)$/);
-
-    if (mentionMatch?.[0]) {
-      deleteCharsBeforeCursor(mentionMatch[0].length);
-    }
-
-    const textAfterDeletion = getTextBeforeCursor(composerEl);
-    const needsLeadingSpace = textAfterDeletion.length > 0 && !/\s$/.test(textAfterDeletion);
-    
-    if (needsLeadingSpace) {
-      const spaceNode = document.createTextNode(' ');
-      const range = selection.getRangeAt(0);
-      range.insertNode(spaceNode);
-      range.setStartAfter(spaceNode);
-      range.collapse(true);
-      selection.removeAllRanges();
-      selection.addRange(range);
-    }
-
-    const mention = `nostr:${user.npub}`;
-    insertMentionNode(mention, user.name, true);
-
-    mentionProfileCache.set(user.pubkey, user);
-    updateContentFromComposer();
-    showMentionSuggestions = false;
-    mentionSuggestions = [];
-  }
-
-  function replacePlainMentions(text: string): string {
-    let output = text;
-    output = output.replace(
-      /@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g,
-      (match) => `nostr:${match.slice(1)}`
-    );
-    for (const profile of mentionProfileCache.values()) {
-      if (!profile.name) continue;
-      const mentionText = `@${profile.name}`;
-      const mentionRegex = new RegExp(`${escapeRegex(mentionText)}(?=\\s|$|[.,!?;:])`, 'gi');
-      if (mentionRegex.test(output)) {
-        output = output.replace(mentionRegex, `nostr:${profile.npub}`);
-      }
-    }
-    return output;
-  }
-
-  function parseMentions(text: string): Map<string, string> {
-    const mentions = new Map<string, string>();
-    const mentionRegex =
-      /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)|@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g;
-    let match;
-
-    while ((match = mentionRegex.exec(text)) !== null) {
-      const mention = match[1] || match[0].slice(1);
-      try {
-        const decoded = nip19.decode(mention);
-        if (decoded.type === 'npub') {
-          mentions.set(mention, decoded.data);
-        } else if (decoded.type === 'nprofile') {
-          mentions.set(mention, decoded.data.pubkey);
-        }
-      } catch {}
-    }
-
-    return mentions;
-  }
-
   function handleKeydown(event: KeyboardEvent) {
-    const selection = window.getSelection();
-    if (selection && selection.rangeCount) {
-      const range = selection.getRangeAt(0);
+    // Let controller handle mention-related keys first
+    if (mentionCtrl.handleKeydown(event)) return;
 
-      if (event.key === 'Delete' && range.collapsed) {
-        const { startContainer, startOffset } = range;
-        if (startContainer.nodeType === Node.TEXT_NODE) {
-          const textNode = startContainer as Text;
-          if (startOffset === textNode.length) {
-            const nextSibling = startContainer.nextSibling;
-            if (
-              nextSibling &&
-              nextSibling.nodeType === Node.ELEMENT_NODE &&
-              (nextSibling as HTMLElement).dataset.mention
-            ) {
-              event.preventDefault();
-              nextSibling.remove();
-              updateContentFromComposer();
-              return;
-            }
-          }
-        }
-      }
-
-      if (event.key === 'Backspace') {
-        if (!range.collapsed) {
-          const container = range.commonAncestorContainer;
-          let mentionElement: HTMLElement | null = null;
-
-          if (container.nodeType === Node.ELEMENT_NODE) {
-            const el = container as HTMLElement;
-            if (el.dataset.mention) {
-              mentionElement = el;
-            }
-          } else if (container.parentElement?.dataset.mention) {
-            mentionElement = container.parentElement;
-          }
-
-          if (mentionElement) {
-            event.preventDefault();
-            mentionElement.remove();
-            updateContentFromComposer();
-            return;
-          }
-        }
-
-        if (range.collapsed) {
-          const { startContainer, startOffset } = range;
-          if (startContainer.nodeType === Node.TEXT_NODE && startOffset === 0) {
-            const prevSibling = startContainer.previousSibling;
-            if (
-              prevSibling &&
-              prevSibling.nodeType === Node.ELEMENT_NODE &&
-              (prevSibling as HTMLElement).dataset.mention
-            ) {
-              event.preventDefault();
-              prevSibling.remove();
-              updateContentFromComposer();
-              return;
-            }
-          }
-        }
-      }
-    }
-
-    if (showMentionSuggestions && mentionSuggestions.length > 0) {
-      if (event.key === 'ArrowDown') {
-        event.preventDefault();
-        selectedMentionIndex = (selectedMentionIndex + 1) % mentionSuggestions.length;
-      } else if (event.key === 'ArrowUp') {
-        event.preventDefault();
-        selectedMentionIndex =
-          selectedMentionIndex === 0 ? mentionSuggestions.length - 1 : selectedMentionIndex - 1;
-      } else if (event.key === 'Enter' || event.key === 'Tab') {
-        event.preventDefault();
-        insertMention(mentionSuggestions[selectedMentionIndex]);
-      } else if (event.key === 'Escape') {
-        showMentionSuggestions = false;
-        mentionSuggestions = [];
-      }
-      return;
-    }
-  }
-
-  $: if (composerEl && content !== lastRenderedContent) {
-    syncComposerContent(content);
+    // No additional non-mention keydown logic in PostComposer
   }
 </script>
 
@@ -1237,40 +533,19 @@
                 aria-multiline="true"
                 data-placeholder="What are you eating, cooking, or loving?"
                 on:keydown={handleKeydown}
-                on:input={handleContentInput}
-                on:beforeinput={handleBeforeInput}
-                on:paste={handlePaste}
+                on:input={() => mentionCtrl.handleInput()}
+                on:beforeinput={(e) => mentionCtrl.handleBeforeInput(e)}
+                on:paste={(e) => mentionCtrl.handlePaste(e)}
               ></div>
 
-              {#if showMentionSuggestions}
-                <div class="mention-dropdown" style="border-color: var(--color-input-border);">
-                  {#if mentionSuggestions.length > 0}
-                    <div class="mention-dropdown-content">
-                      {#each mentionSuggestions as suggestion, index}
-                        <button
-                          type="button"
-                          on:click={() => insertMention(suggestion)}
-                          on:mousedown|preventDefault={() => insertMention(suggestion)}
-                          class="mention-option"
-                          class:mention-selected={index === selectedMentionIndex}
-                        >
-                          <CustomAvatar pubkey={suggestion.pubkey} size={24} />
-                          <div class="mention-info">
-                            <span class="mention-name">{suggestion.name}</span>
-                            {#if suggestion.nip05}
-                              <span class="mention-nip05">{suggestion.nip05}</span>
-                            {/if}
-                          </div>
-                        </button>
-                      {/each}
-                    </div>
-                  {:else if mentionSearching}
-                    <div class="mention-empty">Searching...</div>
-                  {:else if mentionQuery.length > 0}
-                    <div class="mention-empty">No users found</div>
-                  {/if}
-                </div>
-              {/if}
+              <MentionDropdown
+                show={mentionState.showMentionSuggestions}
+                suggestions={mentionState.mentionSuggestions}
+                selectedIndex={mentionState.selectedMentionIndex}
+                searching={mentionState.mentionSearching}
+                query={mentionState.mentionQuery}
+                on:select={(e) => mentionCtrl.insertMention(e.detail)}
+              />
             </div>
 
             {#if error}
@@ -1525,63 +800,6 @@
 {/if}
 
 <style>
-  .mention-dropdown {
-    position: absolute;
-    z-index: 1000;
-    top: 100%;
-    left: 0;
-    margin-top: 0.25rem;
-    width: 280px;
-    max-width: calc(100vw - 2rem);
-    background: var(--color-input-bg);
-    border: 1px solid var(--color-input-border);
-    border-radius: 0.5rem;
-    box-shadow:
-      0 4px 6px -1px rgb(0 0 0 / 0.1),
-      0 2px 4px -1px rgb(0 0 0 / 0.06);
-    overflow: hidden;
-  }
-
-  .mention-dropdown-content {
-    max-height: 200px;
-    overflow-y: auto;
-    overflow-x: hidden;
-  }
-
-  .mention-dropdown-content::-webkit-scrollbar {
-    width: 6px;
-  }
-
-  .mention-dropdown-content::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  .mention-dropdown-content::-webkit-scrollbar-thumb {
-    background: var(--color-input-border);
-    border-radius: 3px;
-  }
-
-  .mention-dropdown-content::-webkit-scrollbar-thumb:hover {
-    background: var(--color-caption);
-  }
-
-  .mention-option {
-    width: 100%;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 0.75rem;
-    text-align: left;
-    transition: background-color 0.15s;
-    border: none;
-    background: transparent;
-  }
-
-  .mention-option:hover,
-  .mention-selected {
-    background: var(--color-accent-gray);
-  }
-
   .composer-input {
     white-space: pre-wrap;
     word-break: break-word;
@@ -1609,50 +827,6 @@
     content: attr(data-placeholder);
     color: var(--color-caption);
     pointer-events: none;
-  }
-
-  :global(.mention-pill) {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-    padding: 0.1rem 0.45rem;
-    border-radius: 0.5rem;
-    background: rgba(247, 147, 26, 0.2);
-    color: #f7931a;
-    font-weight: 600;
-    user-select: all;
-    margin: 0 0.1rem;
-  }
-
-  .mention-info {
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
-    flex: 1;
-  }
-
-  .mention-name {
-    font-size: 0.875rem;
-    font-weight: 500;
-    color: var(--color-text-primary);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .mention-nip05 {
-    font-size: 0.75rem;
-    color: var(--color-caption);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .mention-empty {
-    padding: 0.75rem;
-    text-align: center;
-    font-size: 0.875rem;
-    color: var(--color-caption);
   }
 
   /* Quoted note embed - orange bracket style matching feed */

--- a/src/components/TagsSearchAutocomplete.svelte
+++ b/src/components/TagsSearchAutocomplete.svelte
@@ -314,7 +314,7 @@
 
 <div class="relative flex-1 print:hidden">
   <form
-    class="flex rounded-xl shadow-sm bg-input"
+    class="flex"
     on:submit|preventDefault={() => {
       if (tagquery) {
         // If it's a note identifier, navigate directly

--- a/src/lib/components/messages/ConversationList.svelte
+++ b/src/lib/components/messages/ConversationList.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
   import { sortedConversations, messagesLoading } from '$lib/stores/messages';
-  import { mutedPubkeys } from '$lib/muteListStore';
+  import { mutedPubkeys, muteListStore } from '$lib/muteListStore';
   import { userPublickey } from '$lib/nostr';
   import CustomAvatar from '../../../components/CustomAvatar.svelte';
   import CustomName from '../../../components/CustomName.svelte';
   import PencilSimpleIcon from 'phosphor-svelte/lib/PencilSimple';
-  import { createEventDispatcher } from 'svelte';
+  import { createEventDispatcher, onMount } from 'svelte';
+
+  onMount(() => {
+    muteListStore.load();
+  });
 
   const dispatch = createEventDispatcher<{
     select: { pubkey: string };

--- a/src/lib/components/messages/ConversationList.svelte
+++ b/src/lib/components/messages/ConversationList.svelte
@@ -1,138 +1,136 @@
 <script lang="ts">
-	import { sortedConversations, messagesLoading } from '$lib/stores/messages';
-	import { userPublickey } from '$lib/nostr';
-	import CustomAvatar from '../../../components/CustomAvatar.svelte';
-	import CustomName from '../../../components/CustomName.svelte';
-	import PencilSimpleIcon from 'phosphor-svelte/lib/PencilSimple';
-	import { createEventDispatcher } from 'svelte';
+  import { sortedConversations, messagesLoading } from '$lib/stores/messages';
+  import { userPublickey } from '$lib/nostr';
+  import CustomAvatar from '../../../components/CustomAvatar.svelte';
+  import CustomName from '../../../components/CustomName.svelte';
+  import PencilSimpleIcon from 'phosphor-svelte/lib/PencilSimple';
+  import { createEventDispatcher } from 'svelte';
 
-	const dispatch = createEventDispatcher<{
-		select: { pubkey: string };
-		newMessage: void;
-	}>();
+  const dispatch = createEventDispatcher<{
+    select: { pubkey: string };
+    newMessage: void;
+  }>();
 
-	export let selectedPubkey: string | null = null;
+  export let selectedPubkey: string | null = null;
 
-	function truncate(text: string, maxLen: number): string {
-		if (!text) return '';
-		return text.length > maxLen ? text.slice(0, maxLen) + '...' : text;
-	}
+  function truncate(text: string, maxLen: number): string {
+    if (!text) return '';
+    return text.length > maxLen ? text.slice(0, maxLen) + '...' : text;
+  }
 
-	function formatRelativeTime(ts: number): string {
-		const now = Date.now() / 1000;
-		const diff = now - ts;
-		if (diff < 60) return 'now';
-		if (diff < 3600) return `${Math.floor(diff / 60)}m`;
-		if (diff < 86400) return `${Math.floor(diff / 3600)}h`;
-		if (diff < 604800) return `${Math.floor(diff / 86400)}d`;
-		return new Date(ts * 1000).toLocaleDateString([], { month: 'short', day: 'numeric' });
-	}
+  function formatRelativeTime(ts: number): string {
+    const now = Date.now() / 1000;
+    const diff = now - ts;
+    if (diff < 60) return 'now';
+    if (diff < 3600) return `${Math.floor(diff / 60)}m`;
+    if (diff < 86400) return `${Math.floor(diff / 3600)}h`;
+    if (diff < 604800) return `${Math.floor(diff / 86400)}d`;
+    return new Date(ts * 1000).toLocaleDateString([], { month: 'short', day: 'numeric' });
+  }
 
-	function getLastMessage(messages: { sender: string; content: string }[]) {
-		if (messages.length === 0) return '';
-		const last = messages[messages.length - 1];
-		const prefix = last.sender === $userPublickey ? 'You: ' : '';
-		return prefix + truncate(last.content, 40);
-	}
+  function getLastMessage(messages: { sender: string; content: string }[]) {
+    if (messages.length === 0) return '';
+    const last = messages[messages.length - 1];
+    const prefix = last.sender === $userPublickey ? 'You: ' : '';
+    return prefix + truncate(last.content, 40);
+  }
 
-	function getLastProtocol(messages: { protocol?: string }[]): string | null {
-		if (messages.length === 0) return null;
-		const last = messages[messages.length - 1];
-		return last.protocol === 'nip17' ? 'NIP-17' : 'NIP-04';
-	}
+  function getLastProtocol(messages: { protocol?: string }[]): string | null {
+    if (messages.length === 0) return null;
+    const last = messages[messages.length - 1];
+    return last.protocol === 'nip17' ? 'NIP-17' : 'NIP-04';
+  }
 </script>
 
-<div class="flex flex-col h-full">
-	<!-- Header -->
-	<div
-		class="flex items-center justify-between p-4 border-b"
-		style="border-color: var(--color-input-border);"
-	>
-		<h2 class="text-lg font-semibold" style="color: var(--color-text-primary);">Messages</h2>
-		<button
-			class="p-2 rounded-xl transition-colors hover:bg-accent-gray cursor-pointer"
-			style="color: var(--color-text-primary);"
-			on:click={() => dispatch('newMessage')}
-			title="New message"
-		>
-			<PencilSimpleIcon size={20} />
-		</button>
-	</div>
+<div class="relative h-full">
+  <!-- Header (frosted glass, floats over conversation list) -->
+  <div
+    class="absolute top-0 left-0 right-0 z-10 flex items-center justify-between px-4 h-[68px]"
+    style="background-color: color-mix(in srgb, var(--color-bg-secondary) 70%, transparent); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);"
+  >
+    <h2 class="text-lg font-semibold" style="color: var(--color-text-primary);">Messages</h2>
+    <button
+      class="p-2 rounded-full transition-colors cursor-pointer"
+      style="background-color: var(--color-primary); color: #ffffff;"
+      on:click={() => dispatch('newMessage')}
+      title="New message"
+    >
+      <PencilSimpleIcon size={18} weight="bold" />
+    </button>
+  </div>
 
-	<!-- Conversation list -->
-	<div class="flex-1 overflow-y-auto">
-		{#if $messagesLoading && $sortedConversations.length === 0}
-			<!-- Loading indicator while fetching historical messages -->
-			<div class="flex items-center gap-2 px-4 py-3" style="color: var(--color-caption);">
-				<div
-					class="w-4 h-4 border-2 border-t-transparent rounded-full animate-spin flex-shrink-0"
-					style="border-color: var(--color-primary); border-top-color: transparent;"
-				></div>
-				<span class="text-xs">Loading messages...</span>
-			</div>
-		{/if}
-		{#if $sortedConversations.length === 0 && !$messagesLoading}
-			<div class="flex flex-col items-center justify-center py-12 px-4 text-center">
-				<p class="text-sm mb-1" style="color: var(--color-caption);">No messages yet</p>
-				<p class="text-xs" style="color: var(--color-caption);">
-					Start a conversation by tapping the compose button.
-				</p>
-			</div>
-		{:else}
-			{#each $sortedConversations as convo (convo.pubkey)}
-				<button
-					class="w-full flex items-center gap-3 px-4 py-3 transition-colors cursor-pointer text-left"
-					class:bg-input={selectedPubkey === convo.pubkey}
-					style="border-bottom: 1px solid var(--color-input-border);"
-					on:click={() => dispatch('select', { pubkey: convo.pubkey })}
-				>
-					<div class="flex-shrink-0">
-						<CustomAvatar pubkey={convo.pubkey} size={44} />
-					</div>
-					<div class="flex-1 min-w-0">
-						<div class="flex items-center justify-between">
-							<span
-								class="font-medium text-sm truncate"
-								style="color: var(--color-text-primary);"
-							>
-								<CustomName pubkey={convo.pubkey} />
-							</span>
-							<span class="flex-shrink-0 ml-2 flex items-center gap-1.5">
-								{#if getLastProtocol(convo.messages)}
-									{@const proto = getLastProtocol(convo.messages)}
-									<span
-										class="text-[9px] px-1 py-0.5 rounded font-medium"
-										style={proto === 'NIP-17'
-											? 'background-color: rgba(124, 58, 237, 0.15); color: rgba(167, 139, 250, 1);'
-											: 'background-color: rgba(249, 115, 22, 0.12); color: rgba(249, 115, 22, 0.8);'}
-									>{proto}</span>
-								{/if}
-								<span class="text-xs" style="color: var(--color-caption);">
-									{formatRelativeTime(convo.lastMessageAt)}
-								</span>
-							</span>
-						</div>
-						<div class="flex items-center justify-between mt-0.5">
-							<p class="text-xs truncate" style="color: var(--color-caption);">
-								{getLastMessage(convo.messages)}
-							</p>
-							{#if convo.unreadCount > 0}
-								<span
-									class="flex-shrink-0 ml-2 min-w-[20px] h-5 rounded-full bg-red-500 text-white text-[10px] font-bold flex items-center justify-center px-1.5"
-								>
-									{convo.unreadCount > 99 ? '99+' : convo.unreadCount}
-								</span>
-							{/if}
-						</div>
-					</div>
-				</button>
-			{/each}
-			{#if $messagesLoading}
-				<!-- Subtle indicator at bottom while more messages are loading -->
-				<div class="flex items-center justify-center py-2">
-					<span class="text-xs" style="color: var(--color-caption);">Loading more...</span>
-				</div>
-			{/if}
-		{/if}
-	</div>
+  <!-- Conversation list -->
+  <div class="h-full overflow-y-auto pt-[68px]">
+    {#if $messagesLoading && $sortedConversations.length === 0}
+      <!-- Loading indicator while fetching historical messages -->
+      <div class="flex items-center gap-2 px-4 py-3" style="color: var(--color-caption);">
+        <div
+          class="w-4 h-4 border-2 border-t-transparent rounded-full animate-spin flex-shrink-0"
+          style="border-color: var(--color-primary); border-top-color: transparent;"
+        ></div>
+        <span class="text-xs">Loading messages...</span>
+      </div>
+    {/if}
+    {#if $sortedConversations.length === 0 && !$messagesLoading}
+      <div class="flex flex-col items-center justify-center py-12 px-4 text-center">
+        <p class="text-sm mb-1" style="color: var(--color-caption);">No messages yet</p>
+        <p class="text-xs" style="color: var(--color-caption);">
+          Start a conversation by tapping the compose button.
+        </p>
+      </div>
+    {:else}
+      {#each $sortedConversations as convo (convo.pubkey)}
+        <button
+          class="w-full flex items-center gap-3 px-4 py-3 transition-colors cursor-pointer text-left"
+          class:bg-input={selectedPubkey === convo.pubkey}
+          style="border-bottom: 1px solid color-mix(in srgb, var(--color-text-primary) 8%, transparent);"
+          on:click={() => dispatch('select', { pubkey: convo.pubkey })}
+        >
+          <div class="flex-shrink-0">
+            <CustomAvatar pubkey={convo.pubkey} size={44} />
+          </div>
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center justify-between">
+              <span class="font-medium text-sm truncate" style="color: var(--color-text-primary);">
+                <CustomName pubkey={convo.pubkey} />
+              </span>
+              <span class="flex-shrink-0 ml-2 flex items-center gap-1.5">
+                {#if getLastProtocol(convo.messages)}
+                  {@const proto = getLastProtocol(convo.messages)}
+                  <span
+                    class="text-[9px] px-1 py-0.5 rounded font-medium"
+                    style={proto === 'NIP-17'
+                      ? 'background-color: rgba(124, 58, 237, 0.15); color: rgba(167, 139, 250, 1);'
+                      : 'background-color: rgba(249, 115, 22, 0.12); color: rgba(249, 115, 22, 0.8);'}
+                    >{proto}</span
+                  >
+                {/if}
+                <span class="text-xs" style="color: var(--color-caption);">
+                  {formatRelativeTime(convo.lastMessageAt)}
+                </span>
+              </span>
+            </div>
+            <div class="flex items-center justify-between mt-0.5">
+              <p class="text-xs truncate" style="color: var(--color-caption);">
+                {getLastMessage(convo.messages)}
+              </p>
+              {#if convo.unreadCount > 0}
+                <span
+                  class="flex-shrink-0 ml-2 min-w-[20px] h-5 rounded-full bg-red-500 text-white text-[10px] font-bold flex items-center justify-center px-1.5"
+                >
+                  {convo.unreadCount > 99 ? '99+' : convo.unreadCount}
+                </span>
+              {/if}
+            </div>
+          </div>
+        </button>
+      {/each}
+      {#if $messagesLoading}
+        <!-- Subtle indicator at bottom while more messages are loading -->
+        <div class="flex items-center justify-center py-2">
+          <span class="text-xs" style="color: var(--color-caption);">Loading more...</span>
+        </div>
+      {/if}
+    {/if}
+  </div>
 </div>

--- a/src/lib/components/messages/ConversationList.svelte
+++ b/src/lib/components/messages/ConversationList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { sortedConversations, messagesLoading } from '$lib/stores/messages';
+  import { mutedPubkeys } from '$lib/muteListStore';
   import { userPublickey } from '$lib/nostr';
   import CustomAvatar from '../../../components/CustomAvatar.svelte';
   import CustomName from '../../../components/CustomName.svelte';
@@ -12,6 +13,8 @@
   }>();
 
   export let selectedPubkey: string | null = null;
+
+  $: filteredConversations = $sortedConversations.filter((c) => !$mutedPubkeys.has(c.pubkey));
 
   function truncate(text: string, maxLen: number): string {
     if (!text) return '';
@@ -61,7 +64,7 @@
 
   <!-- Conversation list -->
   <div class="h-full overflow-y-auto pt-[68px]">
-    {#if $messagesLoading && $sortedConversations.length === 0}
+    {#if $messagesLoading && filteredConversations.length === 0}
       <!-- Loading indicator while fetching historical messages -->
       <div class="flex items-center gap-2 px-4 py-3" style="color: var(--color-caption);">
         <div
@@ -71,7 +74,7 @@
         <span class="text-xs">Loading messages...</span>
       </div>
     {/if}
-    {#if $sortedConversations.length === 0 && !$messagesLoading}
+    {#if filteredConversations.length === 0 && !$messagesLoading}
       <div class="flex flex-col items-center justify-center py-12 px-4 text-center">
         <p class="text-sm mb-1" style="color: var(--color-caption);">No messages yet</p>
         <p class="text-xs" style="color: var(--color-caption);">
@@ -79,7 +82,7 @@
         </p>
       </div>
     {:else}
-      {#each $sortedConversations as convo (convo.pubkey)}
+      {#each filteredConversations as convo (convo.pubkey)}
         <button
           class="w-full flex items-center gap-3 px-4 py-3 transition-colors cursor-pointer text-left"
           class:bg-input={selectedPubkey === convo.pubkey}

--- a/src/lib/components/messages/ConversationList.svelte
+++ b/src/lib/components/messages/ConversationList.svelte
@@ -90,7 +90,7 @@
         <button
           class="w-full flex items-center gap-3 px-4 py-3 transition-colors cursor-pointer text-left"
           class:bg-input={selectedPubkey === convo.pubkey}
-          style="border-bottom: 1px solid color-mix(in srgb, var(--color-text-primary) 8%, transparent);"
+          style="border-bottom: 1px solid rgba(0, 0, 0, 0.08); border-bottom: 1px solid color-mix(in srgb, var(--color-text-primary) 8%, transparent);"
           on:click={() => dispatch('select', { pubkey: convo.pubkey })}
         >
           <div class="flex-shrink-0">

--- a/src/lib/components/messages/MessageBubble.svelte
+++ b/src/lib/components/messages/MessageBubble.svelte
@@ -72,6 +72,9 @@
   // Pill style adapts to bubble context
   $: pillClass = isMine ? 'msg-pill-sent' : 'msg-pill-received';
 
+  // Reactive HTML — re-renders when resolvedNames updates
+  $: renderedHtml = linkify(content, pillClass, resolvedNames);
+
   function renderNostrToken(raw: string, pillCls: string): string {
     const identifier = raw.startsWith('nostr:') ? raw.slice(6) : raw;
     try {
@@ -98,7 +101,7 @@
     return escapeHtml(raw);
   }
 
-  function linkify(text: string, pillCls: string): string {
+  function linkify(text: string, pillCls: string, _names: Record<string, string>): string {
     const parts = text.split(tokenRegex);
     return parts
       .map((part, i) => {
@@ -150,7 +153,7 @@
         ? 'background-color: rgba(124, 58, 237, 0.12); color: var(--color-text-primary);'
         : 'background-color: var(--color-input-bg); color: var(--color-text-primary);'}
   >
-    <p class="text-sm whitespace-pre-wrap break-words">{@html linkify(content, pillClass)}</p>
+    <p class="text-sm whitespace-pre-wrap break-words">{@html renderedHtml}</p>
     <p
       class="text-[10px] mt-1 {isMine ? 'text-right' : 'text-left'}"
       style={isMine ? 'color: rgba(255,255,255,0.7);' : 'color: var(--color-caption);'}

--- a/src/lib/components/messages/MessageBubble.svelte
+++ b/src/lib/components/messages/MessageBubble.svelte
@@ -1,70 +1,129 @@
 <script lang="ts">
-	import { userPublickey } from '$lib/nostr';
-	import LockSimpleIcon from 'phosphor-svelte/lib/LockSimple';
-	import LockSimpleOpenIcon from 'phosphor-svelte/lib/LockSimpleOpen';
+  import { userPublickey } from '$lib/nostr';
+  import { nip19 } from 'nostr-tools';
+  import LockSimpleIcon from 'phosphor-svelte/lib/LockSimple';
+  import LockSimpleOpenIcon from 'phosphor-svelte/lib/LockSimpleOpen';
 
-	export let sender: string;
-	export let content: string;
-	export let created_at: number;
-	export let protocol: 'nip17' | 'nip04' = 'nip04';
+  export let sender: string;
+  export let content: string;
+  export let created_at: number;
+  export let protocol: 'nip17' | 'nip04' = 'nip04';
 
-	$: isMine = sender === $userPublickey;
-	$: protocolTip = protocol === 'nip17'
-		? 'Private — metadata hidden'
-		: 'Compatible — metadata visible';
+  $: isMine = sender === $userPublickey;
 
-	$: timeString = formatTime(created_at);
+  // Matches URLs, nostr: identifiers, and bare npub/note/nevent/naddr/nprofile
+  const tokenRegex =
+    /(https?:\/\/[^\s<]+|nostr:(?:npub1|nprofile1|note1|nevent1|naddr1)[a-z0-9]+|(?:npub1|nprofile1|note1|nevent1|naddr1)[023456789acdefghjklmnpqrstuvwxyz]{6,})/g;
 
-	function formatTime(ts: number): string {
-		const date = new Date(ts * 1000);
-		const now = new Date();
-		const diff = now.getTime() - date.getTime();
-		const oneDay = 86400000;
+  function escapeHtml(text: string): string {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
 
-		if (diff < oneDay && date.getDate() === now.getDate()) {
-			return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-		}
-		if (diff < 7 * oneDay) {
-			return date.toLocaleDateString([], { weekday: 'short', hour: '2-digit', minute: '2-digit' });
-		}
-		return date.toLocaleDateString([], {
-			month: 'short',
-			day: 'numeric',
-			hour: '2-digit',
-			minute: '2-digit'
-		});
-	}
+  function formatNpubShort(id: string): string {
+    return id.length > 16 ? `${id.slice(0, 10)}...${id.slice(-6)}` : id;
+  }
+
+  function renderNostrToken(raw: string): string {
+    const identifier = raw.startsWith('nostr:') ? raw.slice(6) : raw;
+    try {
+      const decoded = nip19.decode(identifier);
+      if (decoded.type === 'npub' || decoded.type === 'nprofile') {
+        const label =
+          '@' +
+          formatNpubShort(
+            identifier.startsWith('npub')
+              ? identifier
+              : nip19.npubEncode(decoded.type === 'nprofile' ? decoded.data.pubkey : decoded.data)
+          );
+        const href = `/user/${identifier}`;
+        return `<a href="${href}" class="mention-pill" style="cursor: pointer; text-decoration: none;">${escapeHtml(label)}</a>`;
+      }
+      if (decoded.type === 'note' || decoded.type === 'nevent' || decoded.type === 'naddr') {
+        const label = formatNpubShort(identifier);
+        const href = `/${identifier}`;
+        return `<a href="${href}" class="mention-pill" style="cursor: pointer; text-decoration: none;">${escapeHtml(label)}</a>`;
+      }
+    } catch {}
+    return escapeHtml(raw);
+  }
+
+  function linkify(text: string): string {
+    const parts = text.split(tokenRegex);
+    return parts
+      .map((part, i) => {
+        if (i % 2 === 1) {
+          if (part.startsWith('http')) {
+            const escaped = escapeHtml(part);
+            return `<a href="${escaped}" target="_blank" rel="noopener noreferrer" class="underline break-all" style="color: inherit;">${escaped}</a>`;
+          }
+          return renderNostrToken(part);
+        }
+        return escapeHtml(part);
+      })
+      .join('');
+  }
+  $: protocolTip =
+    protocol === 'nip17' ? 'Private — metadata hidden' : 'Compatible — metadata visible';
+
+  $: timeString = formatTime(created_at);
+
+  function formatTime(ts: number): string {
+    const date = new Date(ts * 1000);
+    const now = new Date();
+    const diff = now.getTime() - date.getTime();
+    const oneDay = 86400000;
+
+    if (diff < oneDay && date.getDate() === now.getDate()) {
+      return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    }
+    if (diff < 7 * oneDay) {
+      return date.toLocaleDateString([], { weekday: 'short', hour: '2-digit', minute: '2-digit' });
+    }
+    return date.toLocaleDateString([], {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  }
 </script>
 
 <div class="flex {isMine ? 'justify-end' : 'justify-start'} mb-2">
-	<div
-		class="max-w-[75%] rounded-2xl px-4 py-2.5 {isMine
-			? 'rounded-br-md'
-			: 'rounded-bl-md'}"
-		style={isMine
-			? (protocol === 'nip17'
-				? 'background-color: rgba(124, 58, 237, 0.85); color: #ffffff;'
-				: 'background-color: var(--color-primary); color: #ffffff;')
-			: (protocol === 'nip17'
-				? 'background-color: rgba(124, 58, 237, 0.12); color: var(--color-text-primary);'
-				: 'background-color: var(--color-input-bg); color: var(--color-text-primary);')}
-	>
-		<p class="text-sm whitespace-pre-wrap break-words">{content}</p>
-		<p
-			class="text-[10px] mt-1 {isMine ? 'text-right' : 'text-left'}"
-			style={isMine ? 'color: rgba(255,255,255,0.7);' : 'color: var(--color-caption);'}
-		>
-			{timeString}
-			<span
-				class="inline-flex items-center gap-px ml-1"
-				title={protocolTip}
-			>
-				{#if protocol === 'nip17'}
-					<LockSimpleIcon class="w-2.5 h-2.5" weight="bold" style="color: rgba(167, 139, 250, 0.8);" />
-				{:else}
-					<LockSimpleOpenIcon class="w-2.5 h-2.5" weight="bold" style="color: rgba(249, 115, 22, 0.6);" />
-				{/if}
-			</span>
-		</p>
-	</div>
+  <div
+    class="max-w-[75%] rounded-2xl px-4 py-2.5 {isMine ? 'rounded-br-md' : 'rounded-bl-md'}"
+    style={isMine
+      ? protocol === 'nip17'
+        ? 'background-color: rgba(124, 58, 237, 0.85); color: #ffffff;'
+        : 'background-color: var(--color-primary); color: #ffffff;'
+      : protocol === 'nip17'
+        ? 'background-color: rgba(124, 58, 237, 0.12); color: var(--color-text-primary);'
+        : 'background-color: var(--color-input-bg); color: var(--color-text-primary);'}
+  >
+    <p class="text-sm whitespace-pre-wrap break-words">{@html linkify(content)}</p>
+    <p
+      class="text-[10px] mt-1 {isMine ? 'text-right' : 'text-left'}"
+      style={isMine ? 'color: rgba(255,255,255,0.7);' : 'color: var(--color-caption);'}
+    >
+      {timeString}
+      <span class="inline-flex items-center gap-px ml-1" title={protocolTip}>
+        {#if protocol === 'nip17'}
+          <LockSimpleIcon
+            class="w-2.5 h-2.5"
+            weight="bold"
+            style="color: rgba(167, 139, 250, 0.8);"
+          />
+        {:else}
+          <LockSimpleOpenIcon
+            class="w-2.5 h-2.5"
+            weight="bold"
+            style="color: rgba(249, 115, 22, 0.6);"
+          />
+        {/if}
+      </span>
+    </p>
+  </div>
 </div>

--- a/src/lib/components/messages/MessageThread.svelte
+++ b/src/lib/components/messages/MessageThread.svelte
@@ -1,208 +1,248 @@
 <script lang="ts">
-	import { onMount, afterUpdate, createEventDispatcher } from 'svelte';
-	import { userPublickey } from '$lib/nostr';
-	import { getConversation, setActiveConversation, addMessage } from '$lib/stores/messages';
-	import { sendDirectMessage, sendNip04DirectMessage } from '$lib/nip17';
-	import MessageBubble from './MessageBubble.svelte';
-	import CustomAvatar from '../../../components/CustomAvatar.svelte';
-	import CustomName from '../../../components/CustomName.svelte';
-	import ArrowLeftIcon from 'phosphor-svelte/lib/ArrowLeft';
-	import PaperPlaneTiltIcon from 'phosphor-svelte/lib/PaperPlaneTilt';
-	import LockSimpleIcon from 'phosphor-svelte/lib/LockSimple';
-	import LockSimpleOpenIcon from 'phosphor-svelte/lib/LockSimpleOpen';
-	import { nip19 } from 'nostr-tools';
+  import { onMount, afterUpdate, createEventDispatcher } from 'svelte';
+  import { userPublickey } from '$lib/nostr';
+  import { getConversation, setActiveConversation, addMessage } from '$lib/stores/messages';
+  import { sendDirectMessage, sendNip04DirectMessage } from '$lib/nip17';
+  import MessageBubble from './MessageBubble.svelte';
+  import CustomAvatar from '../../../components/CustomAvatar.svelte';
+  import CustomName from '../../../components/CustomName.svelte';
+  import ArrowLeftIcon from 'phosphor-svelte/lib/ArrowLeft';
+  import PaperPlaneTiltIcon from 'phosphor-svelte/lib/PaperPlaneTilt';
+  import LockSimpleIcon from 'phosphor-svelte/lib/LockSimple';
+  import LockSimpleOpenIcon from 'phosphor-svelte/lib/LockSimpleOpen';
+  import { nip19 } from 'nostr-tools';
 
-	export let partnerPubkey: string;
+  export let partnerPubkey: string;
 
-	const dispatch = createEventDispatcher<{ back: void }>();
+  const dispatch = createEventDispatcher<{ back: void }>();
 
-	let messageInput = '';
-	let sending = false;
-	let sendError = '';
-	let scrollContainer: HTMLDivElement;
-	let shouldAutoScroll = true;
-	let sendProtocol: 'nip04' | 'nip17' = 'nip04';
+  let messageInput = '';
+  let sending = false;
+  let sendError = '';
+  let scrollContainer: HTMLDivElement;
+  let shouldAutoScroll = true;
+  let sendProtocol: 'nip04' | 'nip17' = 'nip04';
 
-	$: conversation = getConversation(partnerPubkey);
-	$: messages = $conversation?.messages || [];
-	$: npub = nip19.npubEncode(partnerPubkey);
+  $: conversation = getConversation(partnerPubkey);
+  $: messages = $conversation?.messages || [];
+  $: npub = nip19.npubEncode(partnerPubkey);
 
-	// Mark as active on mount / when partner changes
-	$: {
-		if (partnerPubkey) {
-			setActiveConversation(partnerPubkey);
-		}
-	}
+  // Mark as active on mount / when partner changes
+  $: {
+    if (partnerPubkey) {
+      setActiveConversation(partnerPubkey);
+    }
+  }
 
-	onMount(() => {
-		setActiveConversation(partnerPubkey);
-		scrollToBottom();
-		return () => setActiveConversation(null);
-	});
+  onMount(() => {
+    setActiveConversation(partnerPubkey);
+    scrollToBottom();
+    return () => setActiveConversation(null);
+  });
 
-	afterUpdate(() => {
-		if (shouldAutoScroll) {
-			scrollToBottom();
-		}
-	});
+  afterUpdate(() => {
+    if (shouldAutoScroll) {
+      scrollToBottom();
+    }
+  });
 
-	function scrollToBottom() {
-		if (scrollContainer) {
-			scrollContainer.scrollTop = scrollContainer.scrollHeight;
-		}
-	}
+  function scrollToBottom() {
+    if (scrollContainer) {
+      scrollContainer.scrollTop = scrollContainer.scrollHeight;
+    }
+  }
 
-	function handleScroll() {
-		if (!scrollContainer) return;
-		const { scrollTop, scrollHeight, clientHeight } = scrollContainer;
-		shouldAutoScroll = scrollHeight - scrollTop - clientHeight < 100;
-	}
+  function handleScroll() {
+    if (!scrollContainer) return;
+    const { scrollTop, scrollHeight, clientHeight } = scrollContainer;
+    shouldAutoScroll = scrollHeight - scrollTop - clientHeight < 100;
+  }
 
-	function toggleProtocol() {
-		sendProtocol = sendProtocol === 'nip04' ? 'nip17' : 'nip04';
-	}
+  function toggleProtocol() {
+    sendProtocol = sendProtocol === 'nip04' ? 'nip17' : 'nip04';
+  }
 
-	async function handleSend() {
-		const text = messageInput.trim();
-		if (!text || sending) return;
+  async function handleSend() {
+    const text = messageInput.trim();
+    if (!text || sending) return;
 
-		sending = true;
-		sendError = '';
+    sending = true;
+    sendError = '';
 
-		try {
-			const msg = sendProtocol === 'nip04'
-				? await sendNip04DirectMessage(partnerPubkey, text)
-				: await sendDirectMessage(partnerPubkey, text);
-			addMessage(msg, $userPublickey);
-			messageInput = '';
-			shouldAutoScroll = true;
-		} catch (e) {
-			sendError = e instanceof Error ? e.message : 'Failed to send message';
-			console.error('[Messages] Send error:', e);
-		} finally {
-			sending = false;
-		}
-	}
+    try {
+      const msg =
+        sendProtocol === 'nip04'
+          ? await sendNip04DirectMessage(partnerPubkey, text)
+          : await sendDirectMessage(partnerPubkey, text);
+      addMessage(msg, $userPublickey);
+      messageInput = '';
+      shouldAutoScroll = true;
+    } catch (e) {
+      sendError = e instanceof Error ? e.message : 'Failed to send message';
+      console.error('[Messages] Send error:', e);
+    } finally {
+      sending = false;
+    }
+  }
 
-	function handleKeyDown(e: KeyboardEvent) {
-		if (e.key === 'Enter' && !e.shiftKey) {
-			e.preventDefault();
-			handleSend();
-		}
-	}
+  function handleKeyDown(e: KeyboardEvent) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  }
 </script>
 
-<div class="flex flex-col h-full">
-	<!-- Header -->
-	<div
-		class="flex items-center gap-3 p-4 border-b"
-		style="border-color: var(--color-input-border);"
-	>
-		<button
-			class="lg:hidden p-1 rounded-lg transition-colors hover:bg-accent-gray cursor-pointer"
-			style="color: var(--color-text-primary);"
-			on:click={() => dispatch('back')}
-		>
-			<ArrowLeftIcon size={20} />
-		</button>
-		<a href="/user/{npub}" class="flex items-center gap-3 min-w-0">
-			<CustomAvatar pubkey={partnerPubkey} size={36} />
-			<div class="min-w-0">
-				<span class="font-medium text-sm truncate block" style="color: var(--color-text-primary);">
-					<CustomName pubkey={partnerPubkey} />
-				</span>
-			</div>
-		</a>
-	</div>
+<div class="relative h-full overflow-hidden">
+  <!-- Header (frosted glass, floats over messages) -->
+  <div
+    class="absolute top-0 left-0 right-0 z-10 flex items-center gap-3 px-4 h-[68px]"
+    style="background-color: color-mix(in srgb, var(--color-bg-secondary) 70%, transparent); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);"
+  >
+    <button
+      class="lg:hidden p-1 rounded-lg transition-colors hover:bg-accent-gray cursor-pointer"
+      style="color: var(--color-text-primary);"
+      on:click={() => dispatch('back')}
+    >
+      <ArrowLeftIcon size={20} />
+    </button>
+    <a href="/user/{npub}" class="flex items-center gap-3 min-w-0">
+      <CustomAvatar pubkey={partnerPubkey} size={36} />
+      <div class="min-w-0">
+        <span class="font-medium text-sm truncate block" style="color: var(--color-text-primary);">
+          <CustomName pubkey={partnerPubkey} />
+        </span>
+      </div>
+    </a>
+  </div>
 
-	<!-- Messages -->
-	<div
-		bind:this={scrollContainer}
-		on:scroll={handleScroll}
-		class="flex-1 overflow-y-auto px-4 py-3"
-	>
-		{#if messages.length === 0}
-			<div class="flex items-center justify-center h-full">
-				<p class="text-sm" style="color: var(--color-caption);">
-					Send a message to start the conversation.
-				</p>
-			</div>
-		{:else}
-			{#each messages as msg (msg.id)}
-				<MessageBubble sender={msg.sender} content={msg.content} created_at={msg.created_at} protocol={msg.protocol} />
-			{/each}
-		{/if}
-	</div>
+  <!-- Messages (full height, padded top/bottom for header/input) -->
+  <div
+    bind:this={scrollContainer}
+    on:scroll={handleScroll}
+    class="h-full overflow-y-auto px-4 pt-[68px] pb-[120px]"
+  >
+    {#if messages.length === 0}
+      <div class="flex items-center justify-center h-full">
+        <p class="text-sm" style="color: var(--color-caption);">
+          Send a message to start the conversation.
+        </p>
+      </div>
+    {:else}
+      {#each messages as msg (msg.id)}
+        <MessageBubble
+          sender={msg.sender}
+          content={msg.content}
+          created_at={msg.created_at}
+          protocol={msg.protocol}
+        />
+      {/each}
+    {/if}
+  </div>
 
-	<!-- Error -->
-	{#if sendError}
-		<div class="px-4 py-2">
-			<p class="text-xs text-danger">{sendError}</p>
-		</div>
-	{/if}
-
-	<!-- Input -->
-	<div
-		class="p-3 border-t"
-		style="border-color: var(--color-input-border);"
-	>
-		<div class="flex items-center gap-1.5 mb-1.5 px-0.5 transition-all duration-200">
-			{#if sendProtocol === 'nip17'}
-				<LockSimpleIcon class="w-3 h-3 flex-shrink-0" weight="bold" style="color: rgba(167, 139, 250, 0.8);" />
-				<span class="text-[10px]" style="color: rgba(167, 139, 250, 0.8);">Private — metadata hidden</span>
-			{:else}
-				<LockSimpleOpenIcon class="w-3 h-3 flex-shrink-0" weight="bold" style="color: rgba(249, 115, 22, 0.6);" />
-				<span class="text-[10px]" style="color: rgba(249, 115, 22, 0.6);">Compatible — metadata visible</span>
-			{/if}
-		</div>
-		<div class="flex items-end gap-2">
-			<textarea
-				bind:value={messageInput}
-				on:keydown={handleKeyDown}
-				placeholder="Type a message..."
-				rows="1"
-				class="input flex-1 resize-none text-sm min-h-[42px] max-h-32"
-				style="background-color: var(--color-input-bg);"
-				disabled={sending}
-			></textarea>
-			<button
-				on:click={toggleProtocol}
-				class="relative flex items-center w-[72px] h-7 rounded-full cursor-pointer transition-colors duration-200 flex-shrink-0"
-				style={sendProtocol === 'nip17'
-					? 'background-color: rgba(124, 58, 237, 0.25);'
-					: 'background-color: rgba(249, 115, 22, 0.18);'}
-				title={sendProtocol === 'nip17'
-					? 'Private — metadata hidden (less compatible)'
-					: 'Compatible — metadata visible (less private)'}
-			>
-				<span
-					class="absolute top-0.5 h-6 w-9 rounded-full transition-all duration-200 shadow-sm"
-					style="left: {sendProtocol === 'nip17' ? '33px' : '2px'};
-						background-color: {sendProtocol === 'nip17' ? 'rgba(124, 58, 237, 0.9)' : 'rgba(249, 115, 22, 0.9)'};"
-				></span>
-				<span
-					class="relative z-10 w-1/2 text-center text-[9px] font-semibold transition-colors duration-200"
-					style="color: {sendProtocol === 'nip04' ? '#fff' : 'rgba(249, 115, 22, 0.6)'};"
-				>04</span>
-				<span
-					class="relative z-10 w-1/2 text-center text-[9px] font-semibold transition-colors duration-200"
-					style="color: {sendProtocol === 'nip17' ? '#fff' : 'rgba(167, 139, 250, 0.6)'};"
-				>17</span>
-			</button>
-			<button
-				on:click={handleSend}
-				disabled={!messageInput.trim() || sending}
-				class="p-2.5 rounded-xl transition-colors cursor-pointer disabled:opacity-40"
-				style="background-color: var(--color-primary); color: #ffffff;"
-			>
-				{#if sending}
-					<div
-						class="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin"
-					></div>
-				{:else}
-					<PaperPlaneTiltIcon size={20} weight="fill" />
-				{/if}
-			</button>
-		</div>
-	</div>
+  <!-- Input (frosted glass, floats over messages) -->
+  <div
+    class="absolute bottom-0 left-0 right-0 z-10 p-3"
+    style="background-color: color-mix(in srgb, var(--color-bg-secondary) 70%, transparent); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);"
+  >
+    {#if sendError}
+      <div class="pb-2">
+        <p class="text-xs text-danger">{sendError}</p>
+      </div>
+    {/if}
+    <!-- Protocol row -->
+    <div class="flex items-center justify-between mb-3 px-0.5 transition-all duration-200">
+      <div class="flex items-center gap-1.5">
+        {#if sendProtocol === 'nip17'}
+          <LockSimpleIcon
+            class="w-3 h-3 flex-shrink-0"
+            weight="bold"
+            style="color: rgba(167, 139, 250, 0.8);"
+          />
+          <span class="text-[10px]" style="color: rgba(167, 139, 250, 0.8);">More private</span>
+        {:else}
+          <LockSimpleOpenIcon
+            class="w-3 h-3 flex-shrink-0"
+            weight="bold"
+            style="color: rgba(249, 115, 22, 0.6);"
+          />
+          <span class="text-[10px]" style="color: rgba(249, 115, 22, 0.6);">More compatible</span>
+        {/if}
+      </div>
+      <div class="flex items-center gap-1.5">
+        <span
+          class="text-[8px] font-semibold uppercase tracking-[0.15em]"
+          style="color: var(--color-caption); opacity: 0.7;">NIP</span
+        >
+        <button
+          on:click={toggleProtocol}
+          class="relative flex items-center w-[72px] h-7 rounded-full cursor-pointer transition-colors duration-200"
+          style={sendProtocol === 'nip17'
+            ? 'background-color: rgba(124, 58, 237, 0.25);'
+            : 'background-color: rgba(249, 115, 22, 0.18);'}
+          title={sendProtocol === 'nip17'
+            ? 'More private (less compatible)'
+            : 'More compatible (less private)'}
+        >
+          <span
+            class="absolute top-0.5 h-6 w-9 rounded-full transition-all duration-200 shadow-sm"
+            style="left: {sendProtocol === 'nip17' ? '33px' : '2px'};
+							background-color: {sendProtocol === 'nip17'
+              ? 'rgba(124, 58, 237, 0.9)'
+              : 'rgba(249, 115, 22, 0.9)'};"
+          ></span>
+          <span
+            class="relative z-10 w-1/2 text-center text-[9px] font-semibold transition-colors duration-200"
+            style="color: {sendProtocol === 'nip04' ? '#fff' : 'rgba(249, 115, 22, 0.6)'};">04</span
+          >
+          <span
+            class="relative z-10 w-1/2 text-center text-[9px] font-semibold transition-colors duration-200"
+            style="color: {sendProtocol === 'nip17' ? '#fff' : 'rgba(167, 139, 250, 0.6)'};"
+            >17</span
+          >
+        </button>
+      </div>
+    </div>
+    <!-- Input row -->
+    <div class="flex items-end">
+      <textarea
+        bind:value={messageInput}
+        on:keydown={handleKeyDown}
+        placeholder="Type a message..."
+        rows="1"
+        class="message-input input flex-1 resize-none text-sm min-h-[42px] max-h-32 transition-colors duration-200"
+        style="background-color: var(--color-input-bg); border-radius: 0.75rem 0 0 0.75rem; border: 1px solid {sendProtocol ===
+        'nip17'
+          ? 'rgba(124, 58, 237, 0.35)'
+          : 'rgba(249, 115, 22, 0.35)'}; border-right: none; --msg-focus-color: {sendProtocol ===
+        'nip17'
+          ? 'rgba(124, 58, 237, 0.8)'
+          : 'rgba(249, 115, 22, 0.8)'};"
+        disabled={sending}
+      ></textarea>
+      <button
+        on:click={handleSend}
+        disabled={!messageInput.trim() || sending}
+        class="p-2.5 rounded-l-none rounded-r-xl transition-colors cursor-pointer disabled:opacity-40 self-stretch"
+        style="background-color: var(--color-primary); color: #ffffff;"
+      >
+        {#if sending}
+          <div
+            class="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin"
+          ></div>
+        {:else}
+          <PaperPlaneTiltIcon size={20} weight="fill" />
+        {/if}
+      </button>
+    </div>
+  </div>
 </div>
+
+<style>
+  .message-input:focus {
+    --tw-ring-shadow: none !important;
+    border-color: var(--msg-focus-color) !important;
+    box-shadow: inset 0 0 0 1px var(--msg-focus-color) !important;
+    outline: none !important;
+  }
+</style>

--- a/src/lib/components/messages/NewMessageModal.svelte
+++ b/src/lib/components/messages/NewMessageModal.svelte
@@ -1,162 +1,161 @@
 <script lang="ts">
-	import Modal from '../../../components/Modal.svelte';
-	import CustomAvatar from '../../../components/CustomAvatar.svelte';
-	import { searchProfiles, getDisplayName, formatNpub, type SearchProfile } from '$lib/profileSearchService';
-	import { createEventDispatcher } from 'svelte';
+  import Modal from '../../../components/Modal.svelte';
+  import CustomAvatar from '../../../components/CustomAvatar.svelte';
+  import {
+    searchProfiles,
+    getDisplayName,
+    formatNpub,
+    type SearchProfile
+  } from '$lib/profileSearchService';
+  import { createEventDispatcher } from 'svelte';
 
-	export let open = false;
+  export let open = false;
 
-	const dispatch = createEventDispatcher<{
-		select: { pubkey: string };
-	}>();
+  const dispatch = createEventDispatcher<{
+    select: { pubkey: string };
+  }>();
 
-	let input = '';
-	let error = '';
-	let searching = false;
-	let results: SearchProfile[] = [];
-	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-	let selectedIndex = -1;
+  let input = '';
+  let error = '';
+  let searching = false;
+  let results: SearchProfile[] = [];
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let selectedIndex = -1;
 
-	function cleanup() {
-		input = '';
-		error = '';
-		searching = false;
-		results = [];
-		selectedIndex = -1;
-		if (debounceTimer) clearTimeout(debounceTimer);
-	}
+  function cleanup() {
+    input = '';
+    error = '';
+    searching = false;
+    results = [];
+    selectedIndex = -1;
+    if (debounceTimer) clearTimeout(debounceTimer);
+  }
 
-	function selectUser(pubkey: string) {
-		open = false;
-		cleanup();
-		dispatch('select', { pubkey });
-	}
+  function selectUser(pubkey: string) {
+    open = false;
+    cleanup();
+    dispatch('select', { pubkey });
+  }
 
-	function handleInput() {
-		error = '';
-		selectedIndex = -1;
+  function handleInput() {
+    error = '';
+    selectedIndex = -1;
 
-		if (debounceTimer) clearTimeout(debounceTimer);
+    if (debounceTimer) clearTimeout(debounceTimer);
 
-		const query = input.trim();
-		if (!query) {
-			results = [];
-			searching = false;
-			return;
-		}
+    const query = input.trim();
+    if (!query) {
+      results = [];
+      searching = false;
+      return;
+    }
 
-		searching = true;
-		debounceTimer = setTimeout(async () => {
-			try {
-				results = await searchProfiles(query, 8);
-				// If the search resolved a direct identifier (npub/hex/nip05) to exactly 1 result, keep it
-				// Otherwise show the dropdown
-			} catch {
-				results = [];
-			} finally {
-				searching = false;
-			}
-		}, 300);
-	}
+    searching = true;
+    debounceTimer = setTimeout(async () => {
+      try {
+        results = await searchProfiles(query, 8);
+        // If the search resolved a direct identifier (npub/hex/nip05) to exactly 1 result, keep it
+        // Otherwise show the dropdown
+      } catch {
+        results = [];
+      } finally {
+        searching = false;
+      }
+    }, 300);
+  }
 
-	function handleKeyDown(e: KeyboardEvent) {
-		if (results.length > 0) {
-			if (e.key === 'ArrowDown') {
-				e.preventDefault();
-				selectedIndex = Math.min(selectedIndex + 1, results.length - 1);
-				return;
-			}
-			if (e.key === 'ArrowUp') {
-				e.preventDefault();
-				selectedIndex = Math.max(selectedIndex - 1, -1);
-				return;
-			}
-			if (e.key === 'Enter' && selectedIndex >= 0) {
-				e.preventDefault();
-				selectUser(results[selectedIndex].pubkey);
-				return;
-			}
-		}
-		// Enter with single result auto-selects it
-		if (e.key === 'Enter' && results.length === 1) {
-			e.preventDefault();
-			selectUser(results[0].pubkey);
-		}
-	}
+  function handleKeyDown(e: KeyboardEvent) {
+    if (results.length > 0) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        selectedIndex = Math.min(selectedIndex + 1, results.length - 1);
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        selectedIndex = Math.max(selectedIndex - 1, -1);
+        return;
+      }
+      if (e.key === 'Enter' && selectedIndex >= 0) {
+        e.preventDefault();
+        selectUser(results[selectedIndex].pubkey);
+        return;
+      }
+    }
+    // Enter with single result auto-selects it
+    if (e.key === 'Enter' && results.length === 1) {
+      e.preventDefault();
+      selectUser(results[0].pubkey);
+    }
+  }
 </script>
 
 <Modal bind:open {cleanup} compact>
-	<span slot="title">New Message</span>
+  <span slot="title">New Message</span>
 
-	<div class="flex flex-col gap-3">
-		<div>
-			<label
-				for="recipient-input"
-				class="block text-sm font-medium mb-1.5"
-				style="color: var(--color-text-secondary);"
-			>
-				To
-			</label>
-			<input
-				id="recipient-input"
-				bind:value={input}
-				on:input={handleInput}
-				on:keydown={handleKeyDown}
-				placeholder="Search by name, npub, or NIP-05..."
-				class="input w-full text-sm"
-				style="background-color: var(--color-input-bg);"
-				autocomplete="off"
-			/>
-		</div>
+  <div class="flex flex-col gap-3">
+    <div>
+      <input
+        bind:value={input}
+        on:input={handleInput}
+        on:keydown={handleKeyDown}
+        placeholder="Search by name, npub, or NIP-05..."
+        class="input w-full text-sm"
+        style="background-color: var(--color-input-bg);"
+        autocomplete="off"
+      />
+    </div>
 
-		{#if error}
-			<p class="text-xs text-danger">{error}</p>
-		{/if}
+    {#if error}
+      <p class="text-xs text-danger">{error}</p>
+    {/if}
 
-		<!-- Search results -->
-		{#if searching && results.length === 0}
-			<div class="flex items-center gap-2 py-3 px-1" style="color: var(--color-caption);">
-				<div
-					class="w-4 h-4 border-2 border-t-transparent rounded-full animate-spin flex-shrink-0"
-					style="border-color: var(--color-primary); border-top-color: transparent;"
-				></div>
-				<span class="text-xs">Searching...</span>
-			</div>
-		{/if}
+    <!-- Search results -->
+    {#if searching && results.length === 0}
+      <div class="flex items-center gap-2 py-3 px-1" style="color: var(--color-caption);">
+        <div
+          class="w-4 h-4 border-2 border-t-transparent rounded-full animate-spin flex-shrink-0"
+          style="border-color: var(--color-primary); border-top-color: transparent;"
+        ></div>
+        <span class="text-xs">Searching...</span>
+      </div>
+    {/if}
 
-		{#if results.length > 0}
-			<div
-				class="flex flex-col max-h-64 overflow-y-auto rounded-xl border"
-				style="border-color: var(--color-input-border);"
-			>
-				{#each results as profile, i (profile.pubkey)}
-					<button
-						class="flex items-center gap-3 px-3 py-2.5 text-left transition-colors cursor-pointer"
-						class:bg-input={selectedIndex === i}
-						style="color: var(--color-text-primary); {i > 0 ? `border-top: 1px solid var(--color-input-border);` : ''}"
-						on:click={() => selectUser(profile.pubkey)}
-						on:mouseenter={() => (selectedIndex = i)}
-					>
-						<div class="flex-shrink-0">
-							<CustomAvatar pubkey={profile.pubkey} size={36} />
-						</div>
-						<div class="flex-1 min-w-0">
-							<p class="text-sm font-medium truncate">
-								{getDisplayName(profile)}
-							</p>
-							<p class="text-xs truncate" style="color: var(--color-caption);">
-								{profile.nip05 || formatNpub(profile.pubkey)}
-							</p>
-						</div>
-					</button>
-				{/each}
-			</div>
-		{/if}
+    {#if results.length > 0}
+      <div
+        class="flex flex-col max-h-64 overflow-y-auto rounded-xl border"
+        style="border-color: var(--color-input-border);"
+      >
+        {#each results as profile, i (profile.pubkey)}
+          <button
+            class="flex items-center gap-3 px-3 py-2.5 text-left transition-colors cursor-pointer"
+            class:bg-input={selectedIndex === i}
+            style="color: var(--color-text-primary); {i > 0
+              ? `border-top: 1px solid var(--color-input-border);`
+              : ''}"
+            on:click={() => selectUser(profile.pubkey)}
+            on:mouseenter={() => (selectedIndex = i)}
+          >
+            <div class="flex-shrink-0">
+              <CustomAvatar pubkey={profile.pubkey} size={36} />
+            </div>
+            <div class="flex-1 min-w-0">
+              <p class="text-sm font-medium truncate">
+                {getDisplayName(profile)}
+              </p>
+              <p class="text-xs truncate" style="color: var(--color-caption);">
+                {profile.nip05 || formatNpub(profile.pubkey)}
+              </p>
+            </div>
+          </button>
+        {/each}
+      </div>
+    {/if}
 
-		{#if input.trim() && !searching && results.length === 0}
-			<p class="text-xs py-2" style="color: var(--color-caption);">
-				No users found. Try a name, npub, or NIP-05 address.
-			</p>
-		{/if}
-	</div>
+    {#if input.trim() && !searching && results.length === 0}
+      <p class="text-xs py-2" style="color: var(--color-caption);">
+        No users found. Try a name, npub, or NIP-05 address.
+      </p>
+    {/if}
+  </div>
 </Modal>

--- a/src/lib/mentionComposer.ts
+++ b/src/lib/mentionComposer.ts
@@ -1,0 +1,591 @@
+/**
+ * Stateful controller for the mention/autocomplete system.
+ * Each component creates one instance, passing callbacks for state and text changes.
+ * Uses the singleton followListCache for profile data.
+ */
+import { nip19 } from 'nostr-tools';
+import { get } from 'svelte/store';
+import { ndk } from '$lib/nostr';
+import { searchProfiles } from '$lib/profileSearchService';
+import {
+	loadFollowListProfiles,
+	getProfileCache,
+	addToCache,
+	type CachedProfile
+} from '$lib/followListCache';
+import {
+	htmlToPlainText,
+	getTextBeforeCursor,
+	deleteCharsBeforeCursor,
+	createMentionPill,
+	getDisplayNameForMention,
+	renderTextWithMentions,
+	replacePlainMentions as replacePlainMentionsUtil,
+	parseMentions as parseMentionsUtil,
+	escapeRegex
+} from '$lib/mentionUtils';
+
+export type { CachedProfile } from '$lib/followListCache';
+
+export interface MentionSuggestion {
+	name: string;
+	npub: string;
+	picture?: string;
+	pubkey: string;
+	nip05?: string;
+}
+
+export interface MentionState {
+	mentionQuery: string;
+	showMentionSuggestions: boolean;
+	mentionSuggestions: MentionSuggestion[];
+	selectedMentionIndex: number;
+	mentionSearching: boolean;
+}
+
+type StateChangeCallback = (state: MentionState) => void;
+type TextChangeCallback = (text: string) => void;
+
+// Regex to detect @mention trigger before cursor.
+// Uses [^@] instead of [^\s@] to allow spaces in names (PR #143 fix #1).
+const MENTION_TRIGGER_REGEX = /@([^@]*)$/;
+
+export class MentionComposerController {
+	private composerEl: HTMLDivElement | null = null;
+	private searchTimeout: ReturnType<typeof setTimeout> | null = null;
+	private onStateChange: StateChangeCallback;
+	private onTextChange: TextChangeCallback;
+
+	// Internal state
+	mentionQuery = '';
+	showMentionSuggestions = false;
+	mentionSuggestions: MentionSuggestion[] = [];
+	selectedMentionIndex = 0;
+	mentionSearching = false;
+
+	constructor(onStateChange: StateChangeCallback, onTextChange: TextChangeCallback) {
+		this.onStateChange = onStateChange;
+		this.onTextChange = onTextChange;
+	}
+
+	/** Call when bind:this resolves or changes */
+	setComposerEl(el: HTMLDivElement | null): void {
+		this.composerEl = el;
+	}
+
+	/** Preload follow list (call from onMount) */
+	preloadFollowList(): void {
+		loadFollowListProfiles();
+	}
+
+	/** Sync HTML into the composer from a text value */
+	syncContent(value: string): void {
+		if (!this.composerEl) return;
+		const html = renderTextWithMentions(value, getProfileCache());
+		if (this.composerEl.innerHTML !== html) {
+			this.composerEl.innerHTML = html;
+		}
+	}
+
+	/** Extract plain text from composer DOM */
+	extractText(): string {
+		if (!this.composerEl) return '';
+		return htmlToPlainText(this.composerEl);
+	}
+
+	/** Replace @name and @npub with nostr:npub format using the shared cache */
+	replacePlainMentions(text: string): string {
+		return replacePlainMentionsUtil(text, getProfileCache());
+	}
+
+	/** Parse mentions from text */
+	parseMentions(text: string): Map<string, string> {
+		return parseMentionsUtil(text);
+	}
+
+	/** Handle the input event on the composer — called from on:input */
+	handleInput(): string {
+		const text = this.updateContentFromComposer();
+		if (!this.composerEl) return text;
+
+		const converted = this.convertRawMentionsToPills();
+		let finalText = text;
+		if (converted) {
+			finalText = this.updateContentFromComposer();
+		}
+
+		const textBeforeCursor = getTextBeforeCursor(this.composerEl);
+		const mentionMatch = textBeforeCursor.match(MENTION_TRIGGER_REGEX);
+
+		if (mentionMatch) {
+			this.mentionQuery = mentionMatch[1] || '';
+			this.showMentionSuggestions = true;
+
+			if (this.searchTimeout) clearTimeout(this.searchTimeout);
+			this.searchTimeout = setTimeout(() => {
+				if (this.mentionQuery.length > 0) {
+					this.searchMentionUsers(this.mentionQuery);
+				} else {
+					this.mentionSuggestions = Array.from(getProfileCache().values()).slice(0, 8);
+					this.selectedMentionIndex = 0;
+					this.notifyStateChange();
+				}
+			}, 150);
+		} else {
+			this.showMentionSuggestions = false;
+			this.mentionSuggestions = [];
+		}
+
+		this.notifyStateChange();
+		return finalText;
+	}
+
+	/** Handle keydown — returns true if the event was consumed */
+	handleKeydown(event: KeyboardEvent): boolean {
+		const selection = window.getSelection();
+		if (selection && selection.rangeCount) {
+			const range = selection.getRangeAt(0);
+
+			// Delete key — remove mention pill ahead of cursor
+			if (event.key === 'Delete' && range.collapsed) {
+				const { startContainer, startOffset } = range;
+				if (startContainer.nodeType === Node.TEXT_NODE) {
+					const textNode = startContainer as Text;
+					if (startOffset === textNode.length) {
+						const nextSibling = startContainer.nextSibling;
+						if (
+							nextSibling &&
+							nextSibling.nodeType === Node.ELEMENT_NODE &&
+							(nextSibling as HTMLElement).dataset.mention
+						) {
+							event.preventDefault();
+							nextSibling.remove();
+							this.updateContentFromComposer();
+							return true;
+						}
+					}
+				}
+			}
+
+			// Backspace — remove mention pill behind cursor
+			if (event.key === 'Backspace') {
+				if (!range.collapsed) {
+					const container = range.commonAncestorContainer;
+					let mentionElement: HTMLElement | null = null;
+
+					if (container.nodeType === Node.ELEMENT_NODE) {
+						const el = container as HTMLElement;
+						if (el.dataset.mention) {
+							mentionElement = el;
+						}
+					} else if (container.parentElement?.dataset.mention) {
+						mentionElement = container.parentElement;
+					}
+
+					if (mentionElement) {
+						event.preventDefault();
+						mentionElement.remove();
+						this.updateContentFromComposer();
+						return true;
+					}
+				}
+
+				if (range.collapsed) {
+					const { startContainer, startOffset } = range;
+					if (startContainer.nodeType === Node.TEXT_NODE && startOffset === 0) {
+						const prevSibling = startContainer.previousSibling;
+						if (
+							prevSibling &&
+							prevSibling.nodeType === Node.ELEMENT_NODE &&
+							(prevSibling as HTMLElement).dataset.mention
+						) {
+							event.preventDefault();
+							prevSibling.remove();
+							this.updateContentFromComposer();
+							return true;
+						}
+					}
+				}
+			}
+		}
+
+		// Mention suggestion navigation
+		if (this.showMentionSuggestions && this.mentionSuggestions.length > 0) {
+			if (event.key === 'ArrowDown') {
+				event.preventDefault();
+				this.selectedMentionIndex =
+					(this.selectedMentionIndex + 1) % this.mentionSuggestions.length;
+				this.notifyStateChange();
+				return true;
+			} else if (event.key === 'ArrowUp') {
+				event.preventDefault();
+				this.selectedMentionIndex =
+					this.selectedMentionIndex === 0
+						? this.mentionSuggestions.length - 1
+						: this.selectedMentionIndex - 1;
+				this.notifyStateChange();
+				return true;
+			} else if (event.key === 'Enter' || event.key === 'Tab') {
+				event.preventDefault();
+				this.insertMention(this.mentionSuggestions[this.selectedMentionIndex]);
+				return true;
+			} else if (event.key === 'Escape') {
+				this.showMentionSuggestions = false;
+				this.mentionSuggestions = [];
+				this.notifyStateChange();
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/** Handle beforeinput event — prevents editing inside mention pills */
+	handleBeforeInput(event: InputEvent): void {
+		if (
+			event.isComposing ||
+			event.inputType === 'historyUndo' ||
+			event.inputType === 'historyRedo'
+		) {
+			return;
+		}
+
+		const selection = window.getSelection();
+		if (!selection || !this.composerEl) return;
+		const range = selection.getRangeAt(0);
+		let node: Node | null = range.startContainer;
+
+		while (node && node !== this.composerEl) {
+			if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).dataset.mention) {
+				event.preventDefault();
+
+				if (event.inputType === 'insertText' || event.inputType === 'insertCompositionText') {
+					const newRange = document.createRange();
+					newRange.setStartAfter(node);
+					newRange.collapse(true);
+					selection.removeAllRanges();
+					selection.addRange(newRange);
+				}
+				return;
+			}
+			node = node.parentNode;
+		}
+	}
+
+	/** Handle paste event — strips HTML, inserts plain text */
+	handlePaste(event: ClipboardEvent): void {
+		event.preventDefault();
+		const plainText = event.clipboardData?.getData('text/plain');
+		if (!plainText) return;
+
+		const selection = window.getSelection();
+		if (!selection || selection.rangeCount === 0) return;
+		const range = selection.getRangeAt(0);
+
+		range.deleteContents();
+		const textNode = document.createTextNode(plainText);
+		range.insertNode(textNode);
+		range.setStartAfter(textNode);
+		range.collapse(true);
+		selection.removeAllRanges();
+		selection.addRange(range);
+
+		this.handleInput();
+	}
+
+	/** Insert a selected mention user at the cursor position */
+	insertMention(user: MentionSuggestion): void {
+		if (!this.composerEl) return;
+
+		const selection = window.getSelection();
+		if (!selection || selection.rangeCount === 0) return;
+		const textBeforeCursor = getTextBeforeCursor(this.composerEl);
+		const mentionMatch = textBeforeCursor.match(MENTION_TRIGGER_REGEX);
+
+		if (mentionMatch?.[0]) {
+			deleteCharsBeforeCursor(mentionMatch[0].length);
+		}
+
+		// PR #143 fix #2: insert leading space if preceded by non-whitespace
+		const textAfterDeletion = getTextBeforeCursor(this.composerEl);
+		const needsLeadingSpace = textAfterDeletion.length > 0 && !/\s$/.test(textAfterDeletion);
+
+		if (needsLeadingSpace) {
+			const spaceNode = document.createTextNode(' ');
+			const sel = window.getSelection();
+			if (sel && sel.rangeCount > 0) {
+				const range = sel.getRangeAt(0);
+				range.insertNode(spaceNode);
+				range.setStartAfter(spaceNode);
+				range.collapse(true);
+				sel.removeAllRanges();
+				sel.addRange(range);
+			}
+		}
+
+		const mention = `nostr:${user.npub}`;
+		this.insertMentionNode(mention, user.name, true);
+
+		addToCache(user);
+		this.updateContentFromComposer();
+		this.showMentionSuggestions = false;
+		this.mentionSuggestions = [];
+		this.notifyStateChange();
+	}
+
+	/** Reset mention state (call after posting / clearing composer) */
+	resetMentionState(): void {
+		this.showMentionSuggestions = false;
+		this.mentionSuggestions = [];
+		this.mentionQuery = '';
+		this.selectedMentionIndex = 0;
+		if (this.searchTimeout) clearTimeout(this.searchTimeout);
+		this.notifyStateChange();
+	}
+
+	/** Cleanup (call from onDestroy) */
+	destroy(): void {
+		if (this.searchTimeout) clearTimeout(this.searchTimeout);
+	}
+
+	// --- Private methods ---
+
+	private notifyStateChange(): void {
+		this.onStateChange({
+			mentionQuery: this.mentionQuery,
+			showMentionSuggestions: this.showMentionSuggestions,
+			mentionSuggestions: this.mentionSuggestions,
+			selectedMentionIndex: this.selectedMentionIndex,
+			mentionSearching: this.mentionSearching
+		});
+	}
+
+	private updateContentFromComposer(): string {
+		if (!this.composerEl) return '';
+		const newText = htmlToPlainText(this.composerEl);
+		this.onTextChange(newText);
+		return newText;
+	}
+
+	private async searchMentionUsers(query: string): Promise<void> {
+		// Trigger follow list load (non-blocking)
+		loadFollowListProfiles();
+
+		const queryLower = query.toLowerCase();
+		const matches: MentionSuggestion[] = [];
+		const seenPubkeys = new Set<string>();
+		const cache = getProfileCache();
+
+		// Search local cache — by name AND NIP-05
+		for (const profile of cache.values()) {
+			const nameMatch = profile.name.toLowerCase().includes(queryLower);
+			const nip05Match = profile.nip05?.toLowerCase().includes(queryLower);
+
+			if (nameMatch || nip05Match) {
+				matches.push(profile);
+				seenPubkeys.add(profile.pubkey);
+			}
+		}
+
+		// Show local matches immediately
+		if (matches.length > 0) {
+			this.mentionSuggestions = matches.slice(0, 10);
+			this.selectedMentionIndex = 0;
+			this.notifyStateChange();
+		}
+
+		const shouldSearchPrimal = query.length >= 2;
+		const ndkInstance = get(ndk);
+		const shouldSearchNdk = query.length >= 1 && ndkInstance;
+
+		if (shouldSearchPrimal || shouldSearchNdk) {
+			this.mentionSearching = true;
+			this.notifyStateChange();
+			try {
+				if (shouldSearchPrimal) {
+					const primalResults = await searchProfiles(query, 25);
+					for (const profile of primalResults) {
+						if (seenPubkeys.has(profile.pubkey)) continue;
+
+						const name =
+							profile.displayName || profile.name || profile.nip05?.split('@')[0] || 'Unknown';
+						const profileData: MentionSuggestion = {
+							name,
+							npub: profile.npub || nip19.npubEncode(profile.pubkey),
+							picture: profile.picture,
+							pubkey: profile.pubkey,
+							nip05: profile.nip05
+						};
+						matches.push(profileData);
+						seenPubkeys.add(profile.pubkey);
+						addToCache(profileData);
+					}
+				}
+
+				if (shouldSearchNdk && ndkInstance) {
+					const searchResults = await ndkInstance.fetchEvents({
+						kinds: [0],
+						search: query,
+						limit: 50
+					});
+
+					for (const event of searchResults) {
+						if (seenPubkeys.has(event.pubkey)) continue;
+
+						try {
+							const profile = JSON.parse(event.content);
+							const name = profile.display_name || profile.name || '';
+							const nip05 = profile.nip05;
+
+							const profileData: MentionSuggestion = {
+								name: name || nip05?.split('@')[0] || profile.name || 'Unknown',
+								npub: nip19.npubEncode(event.pubkey),
+								picture: profile.picture,
+								pubkey: event.pubkey,
+								nip05
+							};
+							matches.push(profileData);
+							seenPubkeys.add(event.pubkey);
+							addToCache(profileData);
+						} catch {}
+					}
+				}
+			} catch (e) {
+				console.debug('Network search failed:', e);
+			} finally {
+				this.mentionSearching = false;
+			}
+		}
+
+		// Sort: prioritize exact matches
+		matches.sort((a, b) => {
+			const aExact =
+				a.name.toLowerCase().startsWith(queryLower) ||
+				a.nip05?.toLowerCase().startsWith(queryLower);
+			const bExact =
+				b.name.toLowerCase().startsWith(queryLower) ||
+				b.nip05?.toLowerCase().startsWith(queryLower);
+			if (aExact && !bExact) return -1;
+			if (!aExact && bExact) return 1;
+			return a.name.localeCompare(b.name);
+		});
+
+		this.mentionSuggestions = matches.slice(0, 10);
+		this.selectedMentionIndex = 0;
+		this.notifyStateChange();
+	}
+
+	private insertMentionNode(
+		mention: string,
+		displayName: string,
+		addTrailingSpace = false
+	): void {
+		if (!this.composerEl) return;
+
+		const selection = window.getSelection();
+		if (!selection || selection.rangeCount === 0) return;
+		const range = selection.getRangeAt(0);
+
+		const pill = createMentionPill(mention, displayName);
+		const newRange = document.createRange();
+		newRange.setStart(range.startContainer, range.startOffset);
+		newRange.collapse(true);
+		newRange.insertNode(pill);
+
+		if (addTrailingSpace) {
+			const spacer = document.createTextNode(' ');
+			pill.after(spacer);
+			newRange.setStartAfter(spacer);
+		} else {
+			newRange.setStartAfter(pill);
+		}
+
+		newRange.collapse(true);
+		selection.removeAllRanges();
+		selection.addRange(newRange);
+	}
+
+	private convertRawMentionsToPills(): boolean {
+		if (!this.composerEl) return false;
+
+		const rawText = this.composerEl.textContent || '';
+		if (!rawText.includes('npub1')) return false;
+
+		const selection = window.getSelection();
+		if (!selection || selection.rangeCount === 0 || !selection.isCollapsed) return false;
+
+		const range = selection.getRangeAt(0);
+		const marker = document.createElement('span');
+		marker.dataset.mentionCaret = 'true';
+		marker.textContent = '\u200B';
+		range.insertNode(marker);
+
+		const composerEl = this.composerEl;
+		const textNodes: Text[] = [];
+		const walker = document.createTreeWalker(composerEl, NodeFilter.SHOW_TEXT, {
+			acceptNode(node) {
+				const parent = node.parentElement;
+				if (!parent) return NodeFilter.FILTER_REJECT;
+				if (parent.dataset.mention || parent.dataset.mentionCaret)
+					return NodeFilter.FILTER_REJECT;
+				return NodeFilter.FILTER_ACCEPT;
+			}
+		});
+
+		while (walker.nextNode()) {
+			textNodes.push(walker.currentNode as Text);
+		}
+
+		const cache = getProfileCache();
+		let converted = false;
+		for (const textNode of textNodes) {
+			const text = textNode.nodeValue;
+			if (!text || !text.includes('npub1')) continue;
+
+			const mentionRegex =
+				/@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)/g;
+			let lastIndex = 0;
+			let match: RegExpExecArray | null;
+			let hasMatch = false;
+			const fragment = document.createDocumentFragment();
+
+			while ((match = mentionRegex.exec(text)) !== null) {
+				hasMatch = true;
+				const before = text.slice(lastIndex, match.index);
+				if (before) {
+					fragment.appendChild(document.createTextNode(before));
+				}
+
+				const rawMention = match[0];
+				const mention = rawMention.startsWith('@')
+					? `nostr:${rawMention.slice(1)}`
+					: rawMention;
+				const displayName = getDisplayNameForMention(mention, cache);
+				fragment.appendChild(createMentionPill(mention, displayName));
+
+				lastIndex = match.index + rawMention.length;
+			}
+
+			if (!hasMatch) continue;
+			converted = true;
+
+			if (lastIndex < text.length) {
+				fragment.appendChild(document.createTextNode(text.slice(lastIndex)));
+			}
+
+			textNode.parentNode?.replaceChild(fragment, textNode);
+		}
+
+		const caretMarker = composerEl.querySelector('[data-mention-caret]');
+		if (caretMarker) {
+			const newRange = document.createRange();
+			newRange.setStartAfter(caretMarker);
+			newRange.collapse(true);
+			selection.removeAllRanges();
+			selection.addRange(newRange);
+			caretMarker.remove();
+		}
+
+		return converted;
+	}
+}

--- a/src/lib/mentionUtils.ts
+++ b/src/lib/mentionUtils.ts
@@ -1,0 +1,246 @@
+/**
+ * Pure utility functions for the mention/autocomplete system.
+ * No state, no DOM element references stored — all dependencies passed as arguments.
+ */
+import { nip19 } from 'nostr-tools';
+import type { CachedProfile } from '$lib/followListCache';
+
+// --- String utilities ---
+
+export function escapeHtml(value: string): string {
+	return value
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;');
+}
+
+export function escapeRegex(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function formatNpubShort(npub: string): string {
+	if (npub.length <= 16) return npub;
+	return `${npub.slice(0, 10)}...${npub.slice(-6)}`;
+}
+
+// --- Mention display & parsing ---
+
+export function getDisplayNameForMention(
+	mention: string,
+	profileCache: Map<string, CachedProfile>
+): string {
+	const identifier = mention.replace('nostr:', '');
+	try {
+		const decoded = nip19.decode(identifier);
+		if (decoded.type === 'npub') {
+			const profile = profileCache.get(decoded.data);
+			if (profile?.name) return profile.name;
+			return formatNpubShort(identifier);
+		}
+		if (decoded.type === 'nprofile') {
+			const profile = profileCache.get(decoded.data.pubkey);
+			if (profile?.name) return profile.name;
+			return formatNpubShort(nip19.npubEncode(decoded.data.pubkey));
+		}
+	} catch {}
+	return formatNpubShort(identifier);
+}
+
+const MENTION_REGEX =
+	/nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)|@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g;
+
+export function renderTextWithMentions(
+	text: string,
+	profileCache: Map<string, CachedProfile>
+): string {
+	if (!text) return '';
+	const regex = new RegExp(MENTION_REGEX.source, MENTION_REGEX.flags);
+	let html = '';
+	let lastIndex = 0;
+	let match: RegExpExecArray | null;
+
+	while ((match = regex.exec(text)) !== null) {
+		const beforeText = text.substring(lastIndex, match.index);
+		if (beforeText) {
+			html += escapeHtml(beforeText).replace(/\n/g, '<br>');
+		}
+
+		const rawMention = match[0];
+		const mention = rawMention.startsWith('@') ? `nostr:${rawMention.slice(1)}` : rawMention;
+		const displayName = getDisplayNameForMention(mention, profileCache);
+		html += `<span class="mention-pill" contenteditable="false" data-mention="${mention}">@${escapeHtml(displayName)}</span>`;
+
+		lastIndex = match.index + rawMention.length;
+	}
+
+	if (lastIndex < text.length) {
+		html += escapeHtml(text.substring(lastIndex)).replace(/\n/g, '<br>');
+	}
+
+	return html;
+}
+
+export function parseMentions(text: string): Map<string, string> {
+	const mentions = new Map<string, string>();
+	const regex = new RegExp(MENTION_REGEX.source, MENTION_REGEX.flags);
+	let match;
+
+	while ((match = regex.exec(text)) !== null) {
+		const mention = match[1] || match[0].slice(1);
+		try {
+			const decoded = nip19.decode(mention);
+			if (decoded.type === 'npub') {
+				mentions.set(mention, decoded.data);
+			} else if (decoded.type === 'nprofile') {
+				mentions.set(mention, decoded.data.pubkey);
+			}
+		} catch {}
+	}
+
+	return mentions;
+}
+
+export function replacePlainMentions(
+	text: string,
+	profileCache: Map<string, CachedProfile>
+): string {
+	let output = text;
+	output = output.replace(
+		/@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g,
+		(match) => `nostr:${match.slice(1)}`
+	);
+	for (const profile of profileCache.values()) {
+		if (!profile.name) continue;
+		const mentionText = `@${profile.name}`;
+		const mentionRegex = new RegExp(`${escapeRegex(mentionText)}(?=\\s|$|[.,!?;:])`, 'gi');
+		if (mentionRegex.test(output)) {
+			output = output.replace(mentionRegex, `nostr:${profile.npub}`);
+		}
+	}
+	return output;
+}
+
+// --- DOM utilities ---
+
+export function htmlToPlainText(element: Node): string {
+	let text = '';
+	let isFirstChild = true;
+
+	element.childNodes.forEach((node) => {
+		if (node.nodeType === Node.TEXT_NODE) {
+			const content = (node.textContent || '').replace(/\u200B/g, '');
+			text += content;
+			if (content) {
+				isFirstChild = false;
+			}
+		} else if (node.nodeType === Node.ELEMENT_NODE) {
+			const el = node as HTMLElement;
+
+			if (el.dataset.mention) {
+				text += el.dataset.mention;
+				isFirstChild = false;
+			} else if (el.tagName === 'BR') {
+				text += '\n';
+			} else if (el.tagName === 'DIV') {
+				if (!isFirstChild) {
+					text += '\n';
+				}
+
+				const hasOnlyBr = el.childNodes.length === 1 && el.firstChild?.nodeName === 'BR';
+				if (!hasOnlyBr) {
+					text += htmlToPlainText(node);
+				}
+				isFirstChild = false;
+			} else if (el.tagName === 'SPAN') {
+				const spanContent = htmlToPlainText(node);
+				text += spanContent;
+				if (spanContent) {
+					isFirstChild = false;
+				}
+			} else {
+				const childContent = htmlToPlainText(node);
+				text += childContent;
+				if (childContent) {
+					isFirstChild = false;
+				}
+			}
+		}
+	});
+
+	return text;
+}
+
+export function createMentionPill(mention: string, displayName: string): HTMLSpanElement {
+	const pill = document.createElement('span');
+	pill.contentEditable = 'false';
+	pill.dataset.mention = mention;
+	pill.className = 'mention-pill';
+	pill.textContent = `@${displayName}`;
+	return pill;
+}
+
+export function getTextBeforeCursor(element: HTMLDivElement): string {
+	const selection = window.getSelection();
+	if (!selection || selection.rangeCount === 0) return '';
+
+	const range = selection.getRangeAt(0);
+	const preCaretRange = range.cloneRange();
+	preCaretRange.selectNodeContents(element);
+	preCaretRange.setEnd(range.startContainer, range.startOffset);
+
+	const tempDiv = document.createElement('div');
+	tempDiv.appendChild(preCaretRange.cloneContents());
+
+	return htmlToPlainText(tempDiv);
+}
+
+export function deleteCharsBeforeCursor(count: number): void {
+	const selection = window.getSelection();
+	if (!selection || selection.rangeCount === 0) return;
+
+	const range = selection.getRangeAt(0);
+	let remaining = count;
+	let currentNode: Node | null = range.startContainer;
+	let currentOffset = range.startOffset;
+
+	if (currentNode.nodeType === Node.ELEMENT_NODE) {
+		const walker = document.createTreeWalker(currentNode, NodeFilter.SHOW_TEXT, null);
+		let lastText: Text | null = null;
+		while (walker.nextNode()) {
+			lastText = walker.currentNode as Text;
+		}
+		if (lastText) {
+			currentNode = lastText;
+			currentOffset = lastText.length;
+		}
+	}
+
+	while (remaining > 0 && currentNode) {
+		if (currentNode.nodeType === Node.TEXT_NODE) {
+			const textNode = currentNode as Text;
+			const deleteCount = Math.min(remaining, currentOffset);
+			if (deleteCount > 0) {
+				textNode.deleteData(currentOffset - deleteCount, deleteCount);
+				remaining -= deleteCount;
+				currentOffset -= deleteCount;
+			}
+
+			if (remaining > 0) {
+				let prev: Node | null = textNode.previousSibling;
+				while (prev && prev.nodeType !== Node.TEXT_NODE) {
+					prev = prev.previousSibling;
+				}
+				if (prev) {
+					currentNode = prev;
+					currentOffset = (prev as Text).length;
+				} else {
+					break;
+				}
+			}
+		} else {
+			break;
+		}
+	}
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -15,7 +15,11 @@
   import LongformEditorModal from '../components/reads/LongformEditorModal.svelte';
   import WalletWelcomeModal from '../components/WalletWelcomeModal.svelte';
   import { createAuthManager, type AuthState } from '$lib/authManager';
-  import { initMessageSubscription, stopMessageSubscription, clearMessages } from '$lib/stores/messages';
+  import {
+    initMessageSubscription,
+    stopMessageSubscription,
+    clearMessages
+  } from '$lib/stores/messages';
   import { stopGroupSubscription, clearGroups } from '$lib/stores/groups';
   import type { LayoutData } from './$types';
   import ErrorBoundary from '../components/ErrorBoundary.svelte';
@@ -319,7 +323,11 @@
         <div class="header-blur sticky top-0 z-20 py-3 px-4">
           <Header />
         </div>
-        <div class="px-4 pb-16 lg:pb-8 min-w-0 max-w-full">
+        <div
+          class="px-4 min-w-0 max-w-full {$page.url.pathname.startsWith('/messages')
+            ? ''
+            : 'pb-16 lg:pb-8'}"
+        >
           <slot />
           {#if !$page.url.pathname.startsWith('/messages')}
             <Footer />

--- a/src/routes/[nip19]/+page.svelte
+++ b/src/routes/[nip19]/+page.svelte
@@ -24,7 +24,8 @@
   import type { PageData } from './$types';
   import { createCommentFilter } from '$lib/commentFilters';
   import PostActionsMenu from '../../components/PostActionsMenu.svelte';
-  import { searchProfiles } from '$lib/profileSearchService';
+  import MentionDropdown from '../../components/MentionDropdown.svelte';
+  import { MentionComposerController, type MentionState } from '$lib/mentionComposer';
 
   export const data: PageData = {} as PageData;
 
@@ -48,24 +49,24 @@
   let replyComposerEl: HTMLDivElement;
   let lastRenderedReply = '';
 
-  // @ mention autocomplete state
-  let mentionQuery = '';
-  let showMentionSuggestions = false;
-  let mentionSuggestions: {
-    name: string;
-    npub: string;
-    picture?: string;
-    pubkey: string;
-    nip05?: string;
-  }[] = [];
-  let selectedMentionIndex = 0;
-  let mentionProfileCache: Map<
-    string,
-    { name: string; npub: string; picture?: string; pubkey: string; nip05?: string }
-  > = new Map();
-  let mentionFollowListLoaded = false;
-  let mentionSearchTimeout: ReturnType<typeof setTimeout>;
-  let mentionSearching = false;
+  // @ mention autocomplete state (shared controller)
+  let mentionState: MentionState = {
+    mentionQuery: '',
+    showMentionSuggestions: false,
+    mentionSuggestions: [],
+    selectedMentionIndex: 0,
+    mentionSearching: false
+  };
+
+  const mentionCtrl = new MentionComposerController(
+    (state) => {
+      mentionState = state;
+    },
+    (text) => {
+      commentText = text;
+      lastRenderedReply = text;
+    }
+  );
 
   // Get the parent note ID from an event's e tags
   function getParentNoteId(evt: NDKEvent): string | null {
@@ -251,726 +252,24 @@
     zapModal = true;
   }
 
-  // Load follow list profiles for mention autocomplete
-  async function loadMentionFollowList() {
-    if (mentionFollowListLoaded) return;
-
-    const pubkey = get(userPublickey);
-    if (!pubkey || !$ndk) return;
-
-    try {
-      const contactEvent = await $ndk.fetchEvent({
-        kinds: [3],
-        authors: [pubkey],
-        limit: 1
-      });
-
-      if (!contactEvent) return;
-
-      const followPubkeys = contactEvent.tags.filter((t) => t[0] === 'p' && t[1]).map((t) => t[1]);
-
-      if (followPubkeys.length === 0) return;
-
-      const batchSize = 100;
-      for (let i = 0; i < followPubkeys.length; i += batchSize) {
-        const batch = followPubkeys.slice(i, i + batchSize);
-        try {
-          const events = await $ndk.fetchEvents({
-            kinds: [0],
-            authors: batch
-          });
-
-          for (const evt of events) {
-            try {
-              const profile = JSON.parse(evt.content);
-              const name = profile.display_name || profile.name || '';
-              if (name || profile.nip05) {
-                mentionProfileCache.set(evt.pubkey, {
-                  name: name || profile.nip05?.split('@')[0] || 'Unknown',
-                  npub: nip19.npubEncode(evt.pubkey),
-                  picture: profile.picture,
-                  pubkey: evt.pubkey,
-                  nip05: profile.nip05
-                });
-              }
-            } catch {}
-          }
-        } catch (e) {
-          console.debug('Failed to fetch mention profile batch:', e);
-        }
-      }
-
-      mentionFollowListLoaded = true;
-    } catch (e) {
-      console.debug('Failed to load mention follow list:', e);
-    }
-  }
-
-  // Search users for mention autocomplete
-  async function searchMentionUsers(query: string) {
-    loadMentionFollowList();
-
-    const queryLower = query.toLowerCase();
-    const matches: {
-      name: string;
-      npub: string;
-      picture?: string;
-      pubkey: string;
-      nip05?: string;
-    }[] = [];
-    const seenPubkeys = new Set<string>();
-
-    for (const profile of mentionProfileCache.values()) {
-      const nameMatch = profile.name.toLowerCase().includes(queryLower);
-      const nip05Match = profile.nip05?.toLowerCase().includes(queryLower);
-
-      if (nameMatch || nip05Match) {
-        matches.push(profile);
-        seenPubkeys.add(profile.pubkey);
-      }
-    }
-
-    if (matches.length > 0) {
-      mentionSuggestions = matches.slice(0, 10);
-      selectedMentionIndex = 0;
-    }
-
-    const shouldSearchPrimal = query.length >= 2;
-    const shouldSearchNdk = query.length >= 1 && $ndk;
-
-    if (shouldSearchPrimal || shouldSearchNdk) {
-      mentionSearching = true;
-      try {
-        if (shouldSearchPrimal) {
-          const primalResults = await searchProfiles(query, 25);
-          for (const profile of primalResults) {
-            if (seenPubkeys.has(profile.pubkey)) continue;
-
-            const name =
-              profile.displayName || profile.name || profile.nip05?.split('@')[0] || 'Unknown';
-            const profileData = {
-              name,
-              npub: profile.npub || nip19.npubEncode(profile.pubkey),
-              picture: profile.picture,
-              pubkey: profile.pubkey,
-              nip05: profile.nip05
-            };
-            matches.push(profileData);
-            seenPubkeys.add(profile.pubkey);
-            mentionProfileCache.set(profile.pubkey, profileData);
-          }
-        }
-
-        if (shouldSearchNdk && $ndk) {
-          const searchResults = await $ndk.fetchEvents({
-            kinds: [0],
-            search: query,
-            limit: 50
-          });
-
-          for (const evt of searchResults) {
-            if (seenPubkeys.has(evt.pubkey)) continue;
-
-            try {
-              const profile = JSON.parse(evt.content);
-              const name = profile.display_name || profile.name || '';
-              const nip05val = profile.nip05;
-
-              const profileData = {
-                name: name || nip05val?.split('@')[0] || profile.name || 'Unknown',
-                npub: nip19.npubEncode(evt.pubkey),
-                picture: profile.picture,
-                pubkey: evt.pubkey,
-                nip05: nip05val
-              };
-              matches.push(profileData);
-              seenPubkeys.add(evt.pubkey);
-              mentionProfileCache.set(evt.pubkey, profileData);
-            } catch {}
-          }
-        }
-      } catch (e) {
-        console.debug('Network search failed:', e);
-      } finally {
-        mentionSearching = false;
-      }
-    }
-
-    matches.sort((a, b) => {
-      const aExact =
-        a.name.toLowerCase().startsWith(queryLower) ||
-        a.nip05?.toLowerCase().startsWith(queryLower);
-      const bExact =
-        b.name.toLowerCase().startsWith(queryLower) ||
-        b.nip05?.toLowerCase().startsWith(queryLower);
-      if (aExact && !bExact) return -1;
-      if (!aExact && bExact) return 1;
-      return a.name.localeCompare(b.name);
-    });
-
-    mentionSuggestions = matches.slice(0, 10);
-    selectedMentionIndex = 0;
-  }
-
-  function escapeHtml(value: string): string {
-    return value
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#39;');
-  }
-
-  function escapeRegex(value: string): string {
-    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  }
-
-  function formatNpubShort(npub: string): string {
-    if (npub.length <= 16) return npub;
-    return `${npub.slice(0, 10)}...${npub.slice(-6)}`;
-  }
-
-  function getDisplayNameForMention(mention: string): string {
-    const identifier = mention.replace('nostr:', '');
-    try {
-      const decoded = nip19.decode(identifier);
-      if (decoded.type === 'npub') {
-        const profile = mentionProfileCache.get(decoded.data);
-        if (profile?.name) return profile.name;
-        return formatNpubShort(identifier);
-      }
-      if (decoded.type === 'nprofile') {
-        const profile = mentionProfileCache.get(decoded.data.pubkey);
-        if (profile?.name) return profile.name;
-        return formatNpubShort(nip19.npubEncode(decoded.data.pubkey));
-      }
-    } catch {}
-    return formatNpubShort(identifier);
-  }
-
-  function renderTextWithMentions(text: string): string {
-    if (!text) return '';
-    const mentionRegex =
-      /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)|@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g;
-    let html = '';
-    let lastIndex = 0;
-    let match: RegExpExecArray | null;
-
-    while ((match = mentionRegex.exec(text)) !== null) {
-      const beforeText = text.substring(lastIndex, match.index);
-      if (beforeText) {
-        html += escapeHtml(beforeText).replace(/\n/g, '<br>');
-      }
-
-      const rawMention = match[0];
-      const mention = rawMention.startsWith('@') ? `nostr:${rawMention.slice(1)}` : rawMention;
-      const displayName = getDisplayNameForMention(mention);
-      html += `<span class="mention-pill" contenteditable="false" data-mention="${mention}">@${escapeHtml(displayName)}</span>`;
-
-      lastIndex = match.index + rawMention.length;
-    }
-
-    if (lastIndex < text.length) {
-      html += escapeHtml(text.substring(lastIndex)).replace(/\n/g, '<br>');
-    }
-
-    return html;
-  }
-
-  function htmlToPlainText(element: Node): string {
-    let text = '';
-    let isFirstChild = true;
-
-    element.childNodes.forEach((node) => {
-      if (node.nodeType === Node.TEXT_NODE) {
-        const content = (node.textContent || '').replace(/\u200B/g, '');
-        text += content;
-        if (content) {
-          isFirstChild = false;
-        }
-      } else if (node.nodeType === Node.ELEMENT_NODE) {
-        const el = node as HTMLElement;
-
-        if (el.dataset.mention) {
-          text += el.dataset.mention;
-          isFirstChild = false;
-        } else if (el.tagName === 'BR') {
-          text += '\n';
-        } else if (el.tagName === 'DIV') {
-          if (!isFirstChild) {
-            text += '\n';
-          }
-
-          const hasOnlyBr = el.childNodes.length === 1 && el.firstChild?.nodeName === 'BR';
-          if (!hasOnlyBr) {
-            text += htmlToPlainText(node);
-          }
-          isFirstChild = false;
-        } else if (el.tagName === 'SPAN') {
-          const spanContent = htmlToPlainText(node);
-          text += spanContent;
-          if (spanContent) {
-            isFirstChild = false;
-          }
-        } else {
-          const childContent = htmlToPlainText(node);
-          text += childContent;
-          if (childContent) {
-            isFirstChild = false;
-          }
-        }
-      }
-    });
-
-    return text;
-  }
-
-  function getTextBeforeCursor(element: HTMLDivElement): string {
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return '';
-
-    const range = selection.getRangeAt(0);
-    const preCaretRange = range.cloneRange();
-    preCaretRange.selectNodeContents(element);
-    preCaretRange.setEnd(range.startContainer, range.startOffset);
-
-    const tempDiv = document.createElement('div');
-    tempDiv.appendChild(preCaretRange.cloneContents());
-
-    return htmlToPlainText(tempDiv);
-  }
-
-  function syncComposerContent(value: string) {
-    if (!replyComposerEl) return;
-    const html = renderTextWithMentions(value);
-    if (replyComposerEl.innerHTML !== html) {
-      replyComposerEl.innerHTML = html;
-    }
-    lastRenderedReply = value;
-  }
-
-  function updateContentFromComposer() {
-    if (!replyComposerEl) return;
-    const newText = htmlToPlainText(replyComposerEl);
-    lastRenderedReply = newText;
-    commentText = newText;
-  }
-
-  function handleBeforeInput(evt: InputEvent) {
-    if (evt.isComposing || evt.inputType === 'historyUndo' || evt.inputType === 'historyRedo') {
-      return;
-    }
-
-    const selection = window.getSelection();
-    if (!selection || !replyComposerEl) return;
-    const range = selection.getRangeAt(0);
-    let node: Node | null = range.startContainer;
-
-    while (node && node !== replyComposerEl) {
-      if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).dataset.mention) {
-        evt.preventDefault();
-
-        if (evt.inputType === 'insertText' || evt.inputType === 'insertCompositionText') {
-          const newRange = document.createRange();
-          newRange.setStartAfter(node);
-          newRange.collapse(true);
-          selection.removeAllRanges();
-          selection.addRange(newRange);
-        }
-        return;
-      }
-      node = node.parentNode;
-    }
-  }
-
-  function handlePaste(evt: ClipboardEvent) {
-    evt.preventDefault();
-    const plainText = evt.clipboardData?.getData('text/plain');
-    if (!plainText) return;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-    const range = selection.getRangeAt(0);
-
-    range.deleteContents();
-    const textNode = document.createTextNode(plainText);
-    range.insertNode(textNode);
-    range.setStartAfter(textNode);
-    range.collapse(true);
-    selection.removeAllRanges();
-    selection.addRange(range);
-
-    handleReplyInput();
-  }
-
-  function handleReplyInput() {
-    updateContentFromComposer();
-    if (!replyComposerEl) return;
-
-    const converted = convertRawMentionsToPills();
-    if (converted) {
-      updateContentFromComposer();
-    }
-
-    const textBeforeCursor = getTextBeforeCursor(replyComposerEl);
-    const mentionMatch = textBeforeCursor.match(/@([^@]*)$/);
-
-    if (mentionMatch) {
-      mentionQuery = mentionMatch[1] || '';
-      showMentionSuggestions = true;
-
-      if (mentionSearchTimeout) clearTimeout(mentionSearchTimeout);
-      mentionSearchTimeout = setTimeout(() => {
-        if (mentionQuery.length > 0) {
-          searchMentionUsers(mentionQuery);
-        } else {
-          mentionSuggestions = Array.from(mentionProfileCache.values()).slice(0, 8);
-          selectedMentionIndex = 0;
-        }
-      }, 150);
-    } else {
-      showMentionSuggestions = false;
-      mentionSuggestions = [];
-    }
-  }
-
-  function deleteCharsBeforeCursor(count: number) {
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-
-    const range = selection.getRangeAt(0);
-    let remaining = count;
-    let currentNode: Node | null = range.startContainer;
-    let currentOffset = range.startOffset;
-
-    if (currentNode.nodeType === Node.ELEMENT_NODE) {
-      const walker = document.createTreeWalker(currentNode, NodeFilter.SHOW_TEXT, null);
-      let lastText: Text | null = null;
-      while (walker.nextNode()) {
-        lastText = walker.currentNode as Text;
-      }
-      if (lastText) {
-        currentNode = lastText;
-        currentOffset = lastText.length;
-      }
-    }
-
-    while (remaining > 0 && currentNode) {
-      if (currentNode.nodeType === Node.TEXT_NODE) {
-        const textNode = currentNode as Text;
-        const deleteCount = Math.min(remaining, currentOffset);
-        if (deleteCount > 0) {
-          textNode.deleteData(currentOffset - deleteCount, deleteCount);
-          remaining -= deleteCount;
-          currentOffset -= deleteCount;
-        }
-
-        if (remaining > 0) {
-          let prev: Node | null = textNode.previousSibling;
-          while (prev && prev.nodeType !== Node.TEXT_NODE) {
-            prev = prev.previousSibling;
-          }
-          if (prev) {
-            currentNode = prev;
-            currentOffset = (prev as Text).length;
-          } else {
-            break;
-          }
-        }
-      } else {
-        break;
-      }
-    }
-  }
-
-  function createMentionPill(mention: string, displayName: string): HTMLSpanElement {
-    const pill = document.createElement('span');
-    pill.contentEditable = 'false';
-    pill.dataset.mention = mention;
-    pill.className = 'mention-pill';
-    pill.textContent = `@${displayName}`;
-    return pill;
-  }
-
-  function insertMentionNode(mention: string, displayName: string, addTrailingSpace = false) {
-    if (!replyComposerEl) return;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-    const range = selection.getRangeAt(0);
-
-    const pill = createMentionPill(mention, displayName);
-    const newRange = document.createRange();
-    newRange.setStart(range.startContainer, range.startOffset);
-    newRange.collapse(true);
-    newRange.insertNode(pill);
-
-    if (addTrailingSpace) {
-      const spacer = document.createTextNode(' ');
-      pill.after(spacer);
-      newRange.setStartAfter(spacer);
-    } else {
-      newRange.setStartAfter(pill);
-    }
-
-    newRange.collapse(true);
-    selection.removeAllRanges();
-    selection.addRange(newRange);
-  }
-
-  function convertRawMentionsToPills(): boolean {
-    if (!replyComposerEl) return false;
-
-    const rawText = replyComposerEl.textContent || '';
-    if (!rawText.includes('npub1')) return false;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0 || !selection.isCollapsed) return false;
-
-    const range = selection.getRangeAt(0);
-    const marker = document.createElement('span');
-    marker.dataset.mentionCaret = 'true';
-    marker.textContent = '\u200B';
-    range.insertNode(marker);
-
-    const textNodes: Text[] = [];
-    const walker = document.createTreeWalker(replyComposerEl, NodeFilter.SHOW_TEXT, {
-      acceptNode(node) {
-        const parent = node.parentElement;
-        if (!parent) return NodeFilter.FILTER_REJECT;
-        if (parent.dataset.mention || parent.dataset.mentionCaret) return NodeFilter.FILTER_REJECT;
-        return NodeFilter.FILTER_ACCEPT;
-      }
-    });
-
-    while (walker.nextNode()) {
-      textNodes.push(walker.currentNode as Text);
-    }
-
-    let converted = false;
-    for (const textNode of textNodes) {
-      const text = textNode.nodeValue;
-      if (!text || !text.includes('npub1')) continue;
-
-      const mentionRegex =
-        /@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)/g;
-      let lastIndex = 0;
-      let match: RegExpExecArray | null;
-      let hasMatch = false;
-      const fragment = document.createDocumentFragment();
-
-      while ((match = mentionRegex.exec(text)) !== null) {
-        hasMatch = true;
-        const before = text.slice(lastIndex, match.index);
-        if (before) {
-          fragment.appendChild(document.createTextNode(before));
-        }
-
-        const rawMention = match[0];
-        const mention = rawMention.startsWith('@') ? `nostr:${rawMention.slice(1)}` : rawMention;
-        const displayName = getDisplayNameForMention(mention);
-        fragment.appendChild(createMentionPill(mention, displayName));
-
-        lastIndex = match.index + rawMention.length;
-      }
-
-      if (!hasMatch) continue;
-      converted = true;
-
-      if (lastIndex < text.length) {
-        fragment.appendChild(document.createTextNode(text.slice(lastIndex)));
-      }
-
-      textNode.parentNode?.replaceChild(fragment, textNode);
-    }
-
-    const caretMarker = replyComposerEl.querySelector('[data-mention-caret]');
-    if (caretMarker) {
-      const newRange = document.createRange();
-      newRange.setStartAfter(caretMarker);
-      newRange.collapse(true);
-      selection.removeAllRanges();
-      selection.addRange(newRange);
-      caretMarker.remove();
-    }
-
-    return converted;
-  }
-
-  function insertMention(user: { name: string; npub: string; pubkey: string }) {
-    if (!replyComposerEl) return;
-
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-    const textBeforeCursor = getTextBeforeCursor(replyComposerEl);
-    const mentionMatch = textBeforeCursor.match(/@([^@]*)$/);
-
-    if (mentionMatch?.[0]) {
-      deleteCharsBeforeCursor(mentionMatch[0].length);
-    }
-
-    const textAfterDeletion = getTextBeforeCursor(replyComposerEl);
-    const needsLeadingSpace = textAfterDeletion.length > 0 && !/\s$/.test(textAfterDeletion);
-    
-    if (needsLeadingSpace) {
-      const spaceNode = document.createTextNode(' ');
-      const range = selection.getRangeAt(0);
-      range.insertNode(spaceNode);
-      range.setStartAfter(spaceNode);
-      range.collapse(true);
-      selection.removeAllRanges();
-      selection.addRange(range);
-    }
-
-    const mention = `nostr:${user.npub}`;
-    insertMentionNode(mention, user.name, true);
-
-    mentionProfileCache.set(user.pubkey, user);
-    updateContentFromComposer();
-    showMentionSuggestions = false;
-    mentionSuggestions = [];
-  }
-
-  function replacePlainMentions(text: string): string {
-    let output = text;
-    output = output.replace(
-      /@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g,
-      (match) => `nostr:${match.slice(1)}`
-    );
-    for (const profile of mentionProfileCache.values()) {
-      if (!profile.name) continue;
-      const mentionText = `@${profile.name}`;
-      const mentionRegex = new RegExp(`${escapeRegex(mentionText)}(?=\\s|$|[.,!?;:])`, 'gi');
-      if (mentionRegex.test(output)) {
-        output = output.replace(mentionRegex, `nostr:${profile.npub}`);
-      }
-    }
-    return output;
-  }
-
-  function parseMentions(text: string): Map<string, string> {
-    const mentions = new Map<string, string>();
-    const mentionRegex =
-      /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)|@npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g;
-    let match: RegExpExecArray | null;
-
-    while ((match = mentionRegex.exec(text)) !== null) {
-      const mentionVal = match[1] || match[0].slice(1);
-      try {
-        const decodedMention = nip19.decode(mentionVal);
-        if (decodedMention.type === 'npub') {
-          mentions.set(mentionVal, decodedMention.data);
-        } else if (decodedMention.type === 'nprofile') {
-          mentions.set(mentionVal, decodedMention.data.pubkey);
-        }
-      } catch {}
-    }
-
-    return mentions;
-  }
-
-  function handleReplyKeydown(evt: KeyboardEvent) {
-    const selection = window.getSelection();
-    if (selection && selection.rangeCount) {
-      const range = selection.getRangeAt(0);
-
-      if (evt.key === 'Delete' && range.collapsed) {
-        const { startContainer, startOffset } = range;
-        if (startContainer.nodeType === Node.TEXT_NODE) {
-          const textNode = startContainer as Text;
-          if (startOffset === textNode.length) {
-            const nextSibling = startContainer.nextSibling;
-            if (
-              nextSibling &&
-              nextSibling.nodeType === Node.ELEMENT_NODE &&
-              (nextSibling as HTMLElement).dataset.mention
-            ) {
-              evt.preventDefault();
-              nextSibling.remove();
-              updateContentFromComposer();
-              return;
-            }
-          }
-        }
-      }
-
-      if (evt.key === 'Backspace') {
-        if (!range.collapsed) {
-          const container = range.commonAncestorContainer;
-          let mentionElement: HTMLElement | null = null;
-
-          if (container.nodeType === Node.ELEMENT_NODE) {
-            const el = container as HTMLElement;
-            if (el.dataset.mention) {
-              mentionElement = el;
-            }
-          } else if (container.parentElement?.dataset.mention) {
-            mentionElement = container.parentElement;
-          }
-
-          if (mentionElement) {
-            evt.preventDefault();
-            mentionElement.remove();
-            updateContentFromComposer();
-            return;
-          }
-        }
-
-        if (range.collapsed) {
-          const { startContainer, startOffset } = range;
-          if (startContainer.nodeType === Node.TEXT_NODE && startOffset === 0) {
-            const prevSibling = startContainer.previousSibling;
-            if (
-              prevSibling &&
-              prevSibling.nodeType === Node.ELEMENT_NODE &&
-              (prevSibling as HTMLElement).dataset.mention
-            ) {
-              evt.preventDefault();
-              prevSibling.remove();
-              updateContentFromComposer();
-              return;
-            }
-          }
-        }
-      }
-    }
-
-    if (showMentionSuggestions && mentionSuggestions.length > 0) {
-      if (evt.key === 'ArrowDown') {
-        evt.preventDefault();
-        selectedMentionIndex = (selectedMentionIndex + 1) % mentionSuggestions.length;
-      } else if (evt.key === 'ArrowUp') {
-        evt.preventDefault();
-        selectedMentionIndex =
-          selectedMentionIndex === 0 ? mentionSuggestions.length - 1 : selectedMentionIndex - 1;
-      } else if (evt.key === 'Enter' || evt.key === 'Tab') {
-        evt.preventDefault();
-        insertMention(mentionSuggestions[selectedMentionIndex]);
-      } else if (evt.key === 'Escape') {
-        showMentionSuggestions = false;
-        mentionSuggestions = [];
-      }
-      return;
-    }
+  // Reactive statements for mention controller
+  $: mentionCtrl.setComposerEl(replyComposerEl);
+  $: if (replyComposerEl && commentText !== lastRenderedReply) {
+    mentionCtrl.syncContent(commentText);
+    lastRenderedReply = commentText;
   }
 
   // Load mute list when user is logged in
   onMount(() => {
     if ($userPublickey) {
       muteListStore.load();
+      mentionCtrl.preloadFollowList();
     }
   });
 
   onDestroy(() => {
-    if (mentionSearchTimeout) {
-      clearTimeout(mentionSearchTimeout);
-    }
+    mentionCtrl.destroy();
   });
-
-  // Sync composer content when commentText changes externally
-  $: if (replyComposerEl && commentText !== lastRenderedReply) {
-    syncComposerContent(commentText);
-  }
 
   // Post a reply
   async function postReply() {
@@ -978,7 +277,7 @@
 
     try {
       if (replyComposerEl) {
-        commentText = htmlToPlainText(replyComposerEl);
+        commentText = mentionCtrl.extractText();
         lastRenderedReply = commentText;
       }
 
@@ -989,7 +288,7 @@
       const isRecipe = event.kind === 30023;
       ev.kind = isRecipe ? 1111 : 1;
 
-      const replyContent = replacePlainMentions(commentText);
+      const replyContent = mentionCtrl.replacePlainMentions(commentText);
       ev.content = replyContent;
 
       // Use shared utility to build NIP-22 or NIP-10 tags
@@ -1001,7 +300,7 @@
       });
 
       // Parse and add @ mention tags (p tags)
-      const mentions = parseMentions(replyContent);
+      const mentions = mentionCtrl.parseMentions(replyContent);
       for (const pubkey of mentions.values()) {
         if (!ev.tags.some((t) => t[0] === 'p' && t[1] === pubkey)) {
           ev.tags.push(['p', pubkey]);
@@ -1017,9 +316,7 @@
       if (replyComposerEl) {
         replyComposerEl.innerHTML = '';
       }
-      showMentionSuggestions = false;
-      mentionSuggestions = [];
-      mentionQuery = '';
+      mentionCtrl.resetMentionState();
     } catch {
       // Failed to post reply
     }
@@ -1381,42 +678,21 @@
                   role="textbox"
                   aria-multiline="true"
                   data-placeholder="Write a reply..."
-                  on:input={handleReplyInput}
-                  on:keydown={handleReplyKeydown}
-                  on:beforeinput={handleBeforeInput}
-                  on:paste={handlePaste}
+                  on:input={() => mentionCtrl.handleInput()}
+                  on:keydown={(e) => mentionCtrl.handleKeydown(e)}
+                  on:beforeinput={(e) => mentionCtrl.handleBeforeInput(e)}
+                  on:paste={(e) => mentionCtrl.handlePaste(e)}
                 ></div>
 
                 <!-- Mention suggestions dropdown -->
-                {#if showMentionSuggestions}
-                  <div class="mention-dropdown" style="border-color: var(--color-input-border);">
-                    {#if mentionSuggestions.length > 0}
-                      <div class="mention-dropdown-content">
-                        {#each mentionSuggestions as suggestion, index}
-                          <button
-                            type="button"
-                            on:click={() => insertMention(suggestion)}
-                            on:mousedown|preventDefault={() => insertMention(suggestion)}
-                            class="mention-option"
-                            class:mention-selected={index === selectedMentionIndex}
-                          >
-                            <CustomAvatar pubkey={suggestion.pubkey} size={24} />
-                            <div class="mention-info">
-                              <span class="mention-name">{suggestion.name}</span>
-                              {#if suggestion.nip05}
-                                <span class="mention-nip05">{suggestion.nip05}</span>
-                              {/if}
-                            </div>
-                          </button>
-                        {/each}
-                      </div>
-                    {:else if mentionSearching}
-                      <div class="mention-empty">Searching...</div>
-                    {:else if mentionQuery.length > 0}
-                      <div class="mention-empty">No users found</div>
-                    {/if}
-                  </div>
-                {/if}
+                <MentionDropdown
+                  show={mentionState.showMentionSuggestions}
+                  suggestions={mentionState.mentionSuggestions}
+                  selectedIndex={mentionState.selectedMentionIndex}
+                  searching={mentionState.mentionSearching}
+                  query={mentionState.mentionQuery}
+                  on:select={(e) => mentionCtrl.insertMention(e.detail)}
+                />
               </div>
               {#if commentText.trim()}
                 <div class="flex justify-end mt-2">
@@ -1607,108 +883,5 @@
   .reply-composer-input:focus {
     outline: none;
     box-shadow: 0 0 0 2px var(--color-primary);
-  }
-
-  /* Mention dropdown */
-  .mention-dropdown {
-    position: absolute;
-    z-index: 1000;
-    top: 100%;
-    left: 0;
-    margin-top: 0.25rem;
-    width: 280px;
-    max-width: calc(100vw - 2rem);
-    background: var(--color-input-bg);
-    border: 1px solid var(--color-input-border);
-    border-radius: 0.5rem;
-    box-shadow:
-      0 4px 6px -1px rgb(0 0 0 / 0.1),
-      0 2px 4px -1px rgb(0 0 0 / 0.06);
-    overflow: hidden;
-  }
-
-  .mention-dropdown-content {
-    max-height: 200px;
-    overflow-y: auto;
-    overflow-x: hidden;
-  }
-
-  .mention-dropdown-content::-webkit-scrollbar {
-    width: 6px;
-  }
-
-  .mention-dropdown-content::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  .mention-dropdown-content::-webkit-scrollbar-thumb {
-    background: var(--color-input-border);
-    border-radius: 3px;
-  }
-
-  .mention-dropdown-content::-webkit-scrollbar-thumb:hover {
-    background: var(--color-caption);
-  }
-
-  .mention-option {
-    width: 100%;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 0.75rem;
-    text-align: left;
-    transition: background-color 0.15s;
-    border: none;
-    background: transparent;
-    cursor: pointer;
-  }
-
-  .mention-option:hover,
-  .mention-selected {
-    background: var(--color-accent-gray);
-  }
-
-  .mention-info {
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
-    flex: 1;
-  }
-
-  .mention-name {
-    font-size: 0.875rem;
-    font-weight: 500;
-    color: var(--color-text-primary);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .mention-nip05 {
-    font-size: 0.75rem;
-    color: var(--color-caption);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .mention-empty {
-    padding: 0.75rem;
-    text-align: center;
-    font-size: 0.875rem;
-    color: var(--color-caption);
-  }
-
-  :global(.mention-pill) {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-    padding: 0.1rem 0.45rem;
-    border-radius: 0.5rem;
-    background: rgba(247, 147, 26, 0.2);
-    color: #f7931a;
-    font-weight: 600;
-    user-select: all;
-    margin: 0 0.1rem;
   }
 </style>

--- a/src/routes/messages/+page.svelte
+++ b/src/routes/messages/+page.svelte
@@ -1,143 +1,144 @@
 <script lang="ts">
-	import { onMount, onDestroy } from 'svelte';
-	import { browser } from '$app/environment';
-	import { goto } from '$app/navigation';
-	import { page } from '$app/stores';
-	import { ndk, userPublickey } from '$lib/nostr';
-	import { hasEncryptionSupport } from '$lib/encryptionService';
-	import {
-		initMessageSubscription,
-		messagesInitialized,
-		messagesLoading,
-		setActiveConversation
-	} from '$lib/stores/messages';
-	import ConversationList from '$lib/components/messages/ConversationList.svelte';
-	import MessageThread from '$lib/components/messages/MessageThread.svelte';
-	import NewMessageModal from '$lib/components/messages/NewMessageModal.svelte';
-	import LockIcon from 'phosphor-svelte/lib/Lock';
+  import { onMount, onDestroy } from 'svelte';
+  import { browser } from '$app/environment';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import { ndk, userPublickey } from '$lib/nostr';
+  import { hasEncryptionSupport } from '$lib/encryptionService';
+  import {
+    initMessageSubscription,
+    messagesInitialized,
+    messagesLoading,
+    setActiveConversation
+  } from '$lib/stores/messages';
+  import ConversationList from '$lib/components/messages/ConversationList.svelte';
+  import MessageThread from '$lib/components/messages/MessageThread.svelte';
+  import NewMessageModal from '$lib/components/messages/NewMessageModal.svelte';
+  import LockIcon from 'phosphor-svelte/lib/Lock';
 
-	let selectedPubkey: string | null = null;
-	let newMessageOpen = false;
+  let selectedPubkey: string | null = null;
+  let newMessageOpen = false;
 
-	// Mobile: show thread or list
-	$: showThread = selectedPubkey !== null;
+  // Mobile: show thread or list
+  $: showThread = selectedPubkey !== null;
 
-	// Check auth and encryption support
-	$: isLoggedIn = !!$userPublickey;
-	$: canEncrypt = isLoggedIn && hasEncryptionSupport();
+  // Check auth and encryption support
+  $: isLoggedIn = !!$userPublickey;
+  $: canEncrypt = isLoggedIn && hasEncryptionSupport();
 
-	// Check URL params for deep-linking (e.g., /messages?pubkey=abc123)
-	$: {
-		const urlPubkey = $page.url.searchParams.get('pubkey');
-		if (urlPubkey && /^[0-9a-fA-F]{64}$/.test(urlPubkey)) {
-			selectedPubkey = urlPubkey;
-		}
-	}
+  // Check URL params for deep-linking (e.g., /messages?pubkey=abc123)
+  $: {
+    const urlPubkey = $page.url.searchParams.get('pubkey');
+    if (urlPubkey && /^[0-9a-fA-F]{64}$/.test(urlPubkey)) {
+      selectedPubkey = urlPubkey;
+    }
+  }
 
-	onMount(async () => {
-		if (!browser) return;
+  onMount(async () => {
+    if (!browser) return;
 
-		if (!$userPublickey) return;
+    if (!$userPublickey) return;
 
-		// Initialize messages if not already done
-		if (!$messagesInitialized && !$messagesLoading) {
-			await initMessageSubscription($ndk, $userPublickey);
-		}
-	});
+    // Initialize messages if not already done
+    if (!$messagesInitialized && !$messagesLoading) {
+      await initMessageSubscription($ndk, $userPublickey);
+    }
+  });
 
-	onDestroy(() => {
-		setActiveConversation(null);
-	});
+  onDestroy(() => {
+    setActiveConversation(null);
+  });
 
-	function handleSelectConversation(e: CustomEvent<{ pubkey: string }>) {
-		selectedPubkey = e.detail.pubkey;
-	}
+  function handleSelectConversation(e: CustomEvent<{ pubkey: string }>) {
+    selectedPubkey = e.detail.pubkey;
+  }
 
-	function handleBack() {
-		selectedPubkey = null;
-		setActiveConversation(null);
-	}
+  function handleBack() {
+    selectedPubkey = null;
+    setActiveConversation(null);
+  }
 
-	function handleNewMessage() {
-		newMessageOpen = true;
-	}
+  function handleNewMessage() {
+    newMessageOpen = true;
+  }
 
-	function handleNewMessageSelect(e: CustomEvent<{ pubkey: string }>) {
-		selectedPubkey = e.detail.pubkey;
-	}
+  function handleNewMessageSelect(e: CustomEvent<{ pubkey: string }>) {
+    selectedPubkey = e.detail.pubkey;
+  }
 </script>
 
 <svelte:head>
-	<title>Messages - Zap Cooking</title>
+  <title>Messages - Zap Cooking</title>
 </svelte:head>
 
 {#if !isLoggedIn}
-	<!-- Not logged in -->
-	<div class="flex flex-col items-center justify-center py-20 px-4 text-center">
-		<LockIcon size={48} weight="light" style="color: var(--color-caption);" />
-		<h2 class="text-lg font-semibold mt-4" style="color: var(--color-text-primary);">
-			Sign in to use Messages
-		</h2>
-		<p class="text-sm mt-2 max-w-sm" style="color: var(--color-caption);">
-			Private messages require authentication. Sign in with your Nostr key to send and receive
-			encrypted messages.
-		</p>
-		<a
-			href="/login"
-			class="mt-4 px-6 py-2.5 rounded-xl text-sm font-medium transition-colors"
-			style="background-color: var(--color-primary); color: #ffffff;"
-		>
-			Sign In
-		</a>
-	</div>
+  <!-- Not logged in -->
+  <div class="flex flex-col items-center justify-center py-20 px-4 text-center">
+    <LockIcon size={48} weight="light" style="color: var(--color-caption);" />
+    <h2 class="text-lg font-semibold mt-4" style="color: var(--color-text-primary);">
+      Sign in to use Messages
+    </h2>
+    <p class="text-sm mt-2 max-w-sm" style="color: var(--color-caption);">
+      Private messages require authentication. Sign in with your Nostr key to send and receive
+      encrypted messages.
+    </p>
+    <a
+      href="/login"
+      class="mt-4 px-6 py-2.5 rounded-xl text-sm font-medium transition-colors"
+      style="background-color: var(--color-primary); color: #ffffff;"
+    >
+      Sign In
+    </a>
+  </div>
 {:else if !canEncrypt}
-	<!-- Signer doesn't support encryption -->
-	<div class="flex flex-col items-center justify-center py-20 px-4 text-center">
-		<LockIcon size={48} weight="light" style="color: var(--color-caption);" />
-		<h2 class="text-lg font-semibold mt-4" style="color: var(--color-text-primary);">
-			Encryption Not Available
-		</h2>
-		<p class="text-sm mt-2 max-w-sm" style="color: var(--color-caption);">
-			Your login method does not support encryption. Please use a private key (nsec) or a browser extension that supports NIP-04 or NIP-44.
-		</p>
-	</div>
+  <!-- Signer doesn't support encryption -->
+  <div class="flex flex-col items-center justify-center py-20 px-4 text-center">
+    <LockIcon size={48} weight="light" style="color: var(--color-caption);" />
+    <h2 class="text-lg font-semibold mt-4" style="color: var(--color-text-primary);">
+      Encryption Not Available
+    </h2>
+    <p class="text-sm mt-2 max-w-sm" style="color: var(--color-caption);">
+      Your login method does not support encryption. Please use a private key (nsec) or a browser
+      extension that supports NIP-04 or NIP-44.
+    </p>
+  </div>
 {:else}
-	<!-- Messages UI -->
-	<div
-		class="flex h-[calc(100vh-8rem)] lg:h-[calc(100vh-6rem)] -mx-4 rounded-xl overflow-hidden border"
-		style="border-color: var(--color-input-border); background-color: var(--color-bg-secondary);"
-	>
-		<!-- Conversation List (left panel) -->
-		<div
-			class="w-full lg:w-80 xl:w-96 flex-shrink-0 border-r {showThread
-				? 'hidden lg:block'
-				: 'block'}"
-			style="border-color: var(--color-input-border); background-color: var(--color-bg-primary);"
-		>
-			<ConversationList
-				{selectedPubkey}
-				on:select={handleSelectConversation}
-				on:newMessage={handleNewMessage}
-			/>
-		</div>
+  <!-- Messages UI -->
+  <div
+    class="flex h-[calc(100vh-8rem)] lg:h-[calc(100vh-6rem)] rounded-xl overflow-hidden border"
+    style="border-color: var(--color-input-border); background-color: var(--color-bg-secondary);"
+  >
+    <!-- Conversation List (left panel) -->
+    <div
+      class="w-full lg:w-80 xl:w-96 flex-shrink-0 border-r {showThread
+        ? 'hidden lg:block'
+        : 'block'}"
+      style="border-color: var(--color-input-border); background-color: var(--color-bg-primary);"
+    >
+      <ConversationList
+        {selectedPubkey}
+        on:select={handleSelectConversation}
+        on:newMessage={handleNewMessage}
+      />
+    </div>
 
-		<!-- Message Thread (right panel) -->
-		<div
-			class="flex-1 min-w-0 {showThread ? 'block' : 'hidden lg:block'}"
-			style="background-color: var(--color-bg-primary);"
-		>
-			{#if selectedPubkey}
-				<MessageThread partnerPubkey={selectedPubkey} on:back={handleBack} />
-			{:else}
-				<div class="flex items-center justify-center h-full">
-					<p class="text-sm" style="color: var(--color-caption);">
-						Select a conversation or start a new one.
-					</p>
-				</div>
-			{/if}
-		</div>
-	</div>
+    <!-- Message Thread (right panel) -->
+    <div
+      class="flex-1 min-w-0 {showThread ? 'block' : 'hidden lg:block'}"
+      style="background-color: var(--color-bg-primary);"
+    >
+      {#if selectedPubkey}
+        <MessageThread partnerPubkey={selectedPubkey} on:back={handleBack} />
+      {:else}
+        <div class="flex items-center justify-center h-full">
+          <p class="text-sm" style="color: var(--color-caption);">
+            Select a conversation or start a new one.
+          </p>
+        </div>
+      {/if}
+    </div>
+  </div>
 
-	<!-- New message modal -->
-	<NewMessageModal bind:open={newMessageOpen} on:select={handleNewMessageSelect} />
+  <!-- New message modal -->
+  <NewMessageModal bind:open={newMessageOpen} on:select={handleNewMessageSelect} />
 {/if}

--- a/src/routes/user/[slug]/+page.svelte
+++ b/src/routes/user/[slug]/+page.svelte
@@ -15,6 +15,7 @@
   import CopyIcon from 'phosphor-svelte/lib/Copy';
   import CheckIcon from 'phosphor-svelte/lib/Check';
   import UserPlusIcon from 'phosphor-svelte/lib/UserPlus';
+  import ChatCircleIcon from 'phosphor-svelte/lib/ChatCircle';
   import SpeakerSlashIcon from 'phosphor-svelte/lib/SpeakerSlash';
   import SpeakerSimpleSlashIcon from 'phosphor-svelte/lib/SpeakerSimpleSlash';
   import SealCheckIcon from 'phosphor-svelte/lib/SealCheck';
@@ -1198,6 +1199,19 @@
           </button>
         {/if}
 
+        <!-- DM Button -->
+        {#if $userPublickey && hexpubkey && !$mutedPubkeys.has(hexpubkey)}
+          <a
+            href="/messages?pubkey={hexpubkey}"
+            class="w-full flex items-center justify-center gap-2 px-4 py-2 rounded-lg font-medium text-sm transition-colors bg-input hover:bg-accent-gray"
+            style="color: var(--color-text-primary)"
+            on:click={() => (qrModal = false)}
+          >
+            <ChatCircleIcon size={18} weight="bold" />
+            <span>Message</span>
+          </a>
+        {/if}
+
         <!-- Follow Button with mute indicator -->
         {#if $userPublickey}
           <button
@@ -1352,6 +1366,16 @@
             {/if}
 
             {#if $userPublickey}
+              <!-- DM button -->
+              <a
+                href="/messages?pubkey={hexpubkey}"
+                class="h-9 w-9 p-2 rounded-full transition-colors bg-input hover:bg-accent-gray flex items-center justify-center"
+                style="color: var(--color-text-primary)"
+                aria-label="Send message"
+              >
+                <ChatCircleIcon size={20} weight="bold" />
+              </a>
+
               <button
                 on:click={toggleFollow}
                 disabled={followLoading}


### PR DESCRIPTION
## Summary

### Messaging UI redesign
- Frosted glass headers and input bar with backdrop blur
- Background color hierarchy instead of border separators
- Mobile-friendly input layout: protocol controls on their own row, textarea gets full width
- Connected textarea + send button as a single unit
- Protocol-aware focus ring (purple for NIP-17, orange for NIP-04)
- Inset focus borders globally for all inputs
- Muted users hidden from conversation list
- NIP label above protocol toggle, streamlined descriptions ("More private" / "More compatible")
- Orange circle compose button, aligned panel headers

### Mention system refactor
Extracts the duplicated mention autocomplete logic (~2,260 lines across 7 files) into shared modules and redesigns the messaging UI.
- Extract shared `mentionUtils.ts`, `mentionComposer.ts`, and `MentionDropdown.svelte` from 7 copy-pasted implementations
- Apply PR #143 fixes (spaces in names, leading space insertion, z-index) in one place
- Use existing `followListCache.ts` singleton instead of per-component profile caches