### PR TITLE
Fix crashes, memory leaks, and premium recipe gate bypass

### DIFF
--- a/src/components/GatedRecipePayment.svelte
+++ b/src/components/GatedRecipePayment.svelte
@@ -141,6 +141,35 @@
 {:else if hasAccess && unlockedRecipe}
   <!-- Recipe is unlocked - show it -->
   <slot name="unlocked" {unlockedRecipe} />
+{:else if gatedMetadata.serverHasData === false}
+  <!-- Server store unavailable - cannot process payment -->
+  <div
+    class="flex flex-col gap-4 p-6 rounded-xl border"
+    style="border-color: var(--color-input-border); background-color: var(--color-input-bg);"
+  >
+    <div class="flex items-center gap-3">
+      <LockIcon size={24} class="text-gray-400" />
+      <div class="flex-1">
+        <h3 class="font-semibold text-lg">Premium Recipe</h3>
+        <p class="text-sm text-caption">This recipe is gated behind a Lightning payment</p>
+      </div>
+    </div>
+
+    {#if gatedMetadata.preview}
+      <div class="p-4 rounded-lg bg-input">
+        <p class="text-sm text-caption italic">"{gatedMetadata.preview}"</p>
+      </div>
+    {/if}
+
+    <div
+      class="flex flex-col items-center gap-3 p-4 rounded-lg bg-gray-50 dark:bg-gray-900/20 border border-gray-200 dark:border-gray-800"
+    >
+      <p class="text-sm font-medium" style="color: var(--color-text-secondary);">Content Unavailable</p>
+      <p class="text-xs text-center" style="color: var(--color-text-secondary);">
+        The encrypted recipe data is currently unavailable on the server. Please try again later.
+      </p>
+    </div>
+  </div>
 {:else}
   <!-- Gated content - show payment UI -->
   <div

--- a/src/routes/create/gated/+page.svelte
+++ b/src/routes/create/gated/+page.svelte
@@ -215,11 +215,14 @@
         );
         
         resultMessage = 'Publishing recipe...';
-        
+
         // Add gated tag to recipe with gatedNoteId and cost in sats (human readable)
         event.tags.push(['gated', gatedResult.gatedNoteId, gateCostSats.toString()]);
-        
-        // Publish the recipe with gated tag
+
+        // Replace content with preview-only for relay (full content is encrypted on server)
+        event.content = gatePreview || summary || 'This is a premium recipe. Visit zap.cooking to unlock.';
+
+        // Publish the recipe with gated tag (content is now preview-only)
         await event.publish();
         
         const naddr = nip19.naddrEncode({

--- a/src/routes/premium/recipe/[slug]/+page.svelte
+++ b/src/routes/premium/recipe/[slug]/+page.svelte
@@ -93,12 +93,8 @@
               hasAccess = true;
               unlockedRecipe = e;
             } else if (!metadata.serverHasData) {
-              // Server doesn't have the encrypted data (store was reset or
-              // recipe was never stored). The recipe content is already
-              // public on the relay, so show it directly rather than a
-              // non-functional paywall.
-              hasAccess = true;
-              unlockedRecipe = e;
+              // Server doesn't have the encrypted data - cannot unlock
+              // Keep gate shown, user will see locked state
             } else if ($userPublickey) {
               // Check if user has purchased access
               checkingAccess = true;
@@ -317,6 +313,24 @@
 
       <!-- Payment Section -->
       <div class="p-6">
+        {#if !gatedMetadata.serverHasData}
+          <!-- Server store unavailable -->
+          <div class="flex flex-col items-center gap-4 p-6 rounded-xl bg-gradient-to-br from-gray-500/10 to-gray-600/10 border border-gray-500/30">
+            <LockIcon size={32} class="text-gray-400" />
+            <div class="text-center">
+              <p class="font-semibold text-lg" style="color: var(--color-text-primary);">Content Unavailable</p>
+              <p class="text-sm mt-1" style="color: var(--color-text-secondary);">
+                The encrypted recipe data is currently unavailable. Please try again later.
+              </p>
+            </div>
+            <button
+              on:click={() => loadData()}
+              class="px-6 py-3 rounded-xl bg-gray-500 hover:bg-gray-600 text-white font-semibold transition-colors"
+            >
+              Try Again
+            </button>
+          </div>
+        {:else}
         <div class="flex flex-col md:flex-row items-center justify-between gap-6 p-6 rounded-xl bg-gradient-to-br from-amber-500/10 to-orange-500/10 border border-amber-500/30">
           <div class="text-center md:text-left">
             <p class="text-sm font-medium mb-1" style="color: var(--color-text-secondary);">
@@ -329,14 +343,14 @@
               </span>
             </div>
           </div>
-          
+
           <div class="flex flex-col gap-3 w-full md:w-auto">
             {#if purchaseError}
               <div class="px-4 py-2 rounded-lg bg-red-500/10 border border-red-500/30 text-red-600 dark:text-red-400 text-sm">
                 {purchaseError}
               </div>
             {/if}
-            
+
             <button
               on:click={handlePurchase}
               disabled={purchasing || !$userPublickey || checkingAccess}
@@ -355,10 +369,10 @@
                 <span>Pay & Unlock Recipe</span>
               {/if}
             </button>
-            
+
             {#if !$userPublickey}
-              <a 
-                href="/login" 
+              <a
+                href="/login"
                 class="text-center text-sm text-amber-600 dark:text-amber-400 hover:underline"
               >
                 Sign in with Nostr →
@@ -371,6 +385,7 @@
           <LockOpenIcon size={16} class="inline mr-1" />
           One-time payment. Permanent access to the full recipe.
         </p>
+        {/if}
       </div>
     </div>
 


### PR DESCRIPTION
## Summary

- **Fix premium recipe gate bypass**: Gated recipes were unlocking for ALL users after a single payment because full content was published unencrypted to relays and a `serverHasData: false` fallback bypassed the paywall. Now content is replaced with a preview before publishing, the fallback is removed, and kind 35000 events always show the paywall even on network errors.
- **Fix memory leaks in feed**: Early returns in `FoodstrFeedOptimized` were not resetting `loadInProgress`, causing the feed to get stuck. Added proper cleanup on all exit paths.
- **Fix crash-causing bugs**: Address multiple crash vectors including stale async results, missing null checks, and race conditions across feed, explore, recipe, and premium pages.
- **Improve premium recipe infrastructure**: Persisted dev store, author info display, build fixes for wrangler config and dynamic imports.

## Test plan

- [ ] Create a new premium recipe and verify the relay event contains only preview text, not the full recipe
- [ ] User A pays to unlock a recipe → User B should still see the locked paywall
- [ ] Clear the dev store and visit a premium recipe → should show "Content Unavailable" instead of the full recipe
- [ ] Access a premium recipe via `/recipe/[naddr]` → should show gated UI, not full content
- [ ] Verify feed loads correctly and doesn't get stuck on repeated navigation
- [ ] Verify explore page loads without crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)