### PR TITLE
Add Smoothie to selectable recipe tags

### DIFF
--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -158,6 +158,7 @@ export const recipeTags: recipeTagSimple[] = [
   { title: 'Shrimp', emoji: '🦐' },
   { title: 'Side' },
   { title: 'Slowcooked', emoji: '⏳' },
+  { title: 'Smoothie', emoji: '🥤' },
   { title: 'Snack', emoji: '🍿' },
   { title: 'Somali', emoji: '🇸🇴' },
   { title: 'Soup', emoji: '🍲' },


### PR DESCRIPTION
## Summary

- Add Smoothie (🥤) to the `recipeTags` array so it appears as a selectable tag in the recipe creation form. It was already in `RECIPE_TAGS` and the Meals category but missing from the selectable list.

## Test plan

- [ ] Open recipe creation form and verify "Smoothie" appears in the tag selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)