### PR TITLE
feat: membership rings on avatars + baseline type fixes

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -47,6 +47,7 @@ body {
 
 /* Define CSS custom properties for theme colors */
 :root {
+  --zap-orange: #ec4700;
   --color-primary: #ec4700;
   --color-input-bg: #f3f4f6;
   --color-input-border: #e5e7eb;
@@ -69,6 +70,7 @@ body {
 }
 
 html.dark {
+  --zap-orange: #ff7a3d;
   --color-primary: #ff5722;
   --color-input-bg: #374151;
   --color-input-border: #4b5563;

--- a/src/components/AuthorProfile.svelte
+++ b/src/components/AuthorProfile.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { nip19 } from 'nostr-tools';
-  import CustomAvatar from './CustomAvatar.svelte';
+  import Avatar from './Avatar.svelte';
   import CustomName from './CustomName.svelte';
 
   export let pubkey: string;
@@ -8,7 +8,7 @@
 
 <div class="flex gap-4 items-center">
   <a href="/user/{nip19.npubEncode(pubkey)}" class="flex gap-4 self-center">
-    <CustomAvatar className="self-center" {pubkey} size={56} />
+    <Avatar className="self-center" {pubkey} size={56} />
     <CustomName className="self-center" {pubkey} />
   </a>
 </div>

--- a/src/components/Avatar.svelte
+++ b/src/components/Avatar.svelte
@@ -1,0 +1,204 @@
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { createEventDispatcher, onDestroy, onMount } from 'svelte';
+  import CustomAvatar from './CustomAvatar.svelte';
+  import {
+    getMembership,
+    getMembershipLabel,
+    membershipStatusMap,
+    queueMembershipLookup,
+    type MembershipStatus
+  } from '$lib/stores/membershipStatus';
+
+  export let pubkey: string;
+  export let src: string | null = null;
+  export let alt: string = 'Avatar';
+  export let size: number = 40;
+  export let showRing: boolean = true;
+  export let className: string = '';
+  // Backwards-compatible alias used by existing callsites.
+  export let imageUrl: string | null = null;
+
+  const dispatch = createEventDispatcher();
+
+  let wrapperEl: HTMLDivElement | null = null;
+  let openTooltip = false;
+  let membershipMap: Record<string, MembershipStatus> = {};
+
+  const unsubscribe = membershipStatusMap.subscribe((value) => {
+    membershipMap = value;
+  });
+
+  $: normalizedPubkey = String(pubkey || '').trim().toLowerCase();
+  $: avatarSrc = src ?? imageUrl;
+  $: status = membershipMap[normalizedPubkey];
+  $: isActiveMember = Boolean(status?.active) && showRing;
+  $: ringTierClass =
+    status?.tier === 'pro_kitchen'
+      ? 'tier-pro-kitchen'
+      : status?.tier === 'founders'
+        ? 'tier-founders'
+        : status?.tier === 'cook_plus'
+          ? 'tier-cook-plus'
+          : 'tier-default';
+  $: ringPadding = isActiveMember ? 2.5 : 0;
+  $: innerSize = Math.max(16, Math.round(size - ringPadding * 2));
+  $: tooltipLabel = getMembershipLabel(status?.tier || 'unknown');
+
+  $: if (normalizedPubkey) {
+    queueMembershipLookup(normalizedPubkey);
+  }
+
+  onMount(() => {
+    if (normalizedPubkey) {
+      void getMembership([normalizedPubkey]);
+    }
+  });
+
+  function handleClick(event: MouseEvent): void {
+    if (isActiveMember) {
+      if (!openTooltip) {
+        // First tap/click opens tooltip without immediately triggering parent link navigation.
+        event.preventDefault();
+        event.stopPropagation();
+        openTooltip = true;
+        return;
+      }
+      openTooltip = false;
+    } else {
+      openTooltip = false;
+    }
+    dispatch('click', event);
+  }
+
+  function handleKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      openTooltip = false;
+      return;
+    }
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      if (isActiveMember) {
+        openTooltip = !openTooltip;
+      }
+    }
+  }
+
+  function handleDocumentClick(event: MouseEvent): void {
+    if (!openTooltip || !wrapperEl) return;
+    const target = event.target;
+    if (target instanceof Node && !wrapperEl.contains(target)) {
+      openTooltip = false;
+    }
+  }
+
+  function handleDocumentKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      openTooltip = false;
+    }
+  }
+
+  $: if (browser) {
+    if (openTooltip) {
+      document.addEventListener('click', handleDocumentClick);
+      document.addEventListener('keydown', handleDocumentKeydown);
+    } else {
+      document.removeEventListener('click', handleDocumentClick);
+      document.removeEventListener('keydown', handleDocumentKeydown);
+    }
+  }
+
+  onDestroy(() => {
+    unsubscribe();
+    if (browser) {
+      document.removeEventListener('click', handleDocumentClick);
+      document.removeEventListener('keydown', handleDocumentKeydown);
+    }
+  });
+</script>
+
+<div
+  bind:this={wrapperEl}
+  class="avatar-wrapper {className} {isActiveMember ? `has-ring ${ringTierClass}` : ''}"
+  style="--avatar-size: {size}px; --ring-padding: {ringPadding}px;"
+  role="button"
+  tabindex="0"
+  aria-label={alt}
+  aria-expanded={isActiveMember ? openTooltip : undefined}
+  on:click={handleClick}
+  on:keydown={handleKeydown}
+>
+  <div class="avatar-inner">
+    <CustomAvatar pubkey={pubkey} size={innerSize} imageUrl={avatarSrc} className="" interactive={false} />
+  </div>
+
+  {#if isActiveMember && openTooltip}
+    <div class="membership-tooltip" role="tooltip">
+      {tooltipLabel}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .avatar-wrapper {
+    position: relative;
+    display: inline-flex;
+    box-sizing: border-box;
+    width: var(--avatar-size);
+    height: var(--avatar-size);
+    border-radius: 999px;
+    padding: var(--ring-padding);
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
+  .avatar-inner {
+    width: 100%;
+    height: 100%;
+    border-radius: 999px;
+    overflow: hidden;
+  }
+
+  .has-ring {
+    border: 1px solid color-mix(in srgb, var(--zap-orange, #ec4700) 65%, transparent);
+  }
+
+  .tier-cook-plus {
+    border-width: 1px;
+  }
+
+  .tier-pro-kitchen {
+    border-width: 1.5px;
+  }
+
+  .tier-founders {
+    border-width: 1px;
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--zap-orange, #ec4700) 18%, transparent);
+  }
+
+  .membership-tooltip {
+    position: absolute;
+    left: 50%;
+    top: calc(100% + 6px);
+    transform: translateX(-50%);
+    z-index: 40;
+    white-space: nowrap;
+    font-size: 11px;
+    line-height: 1;
+    padding: 0.45rem 0.55rem;
+    border-radius: 8px;
+    border: 1px solid var(--color-input-border);
+    background: color-mix(in srgb, var(--color-bg-primary) 96%, black 4%);
+    color: var(--color-text-primary);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.14);
+  }
+
+  @media (max-width: 640px) {
+    .membership-tooltip {
+      font-size: 10px;
+      padding: 0.4rem 0.5rem;
+    }
+  }
+</style>

--- a/src/components/Comment.svelte
+++ b/src/components/Comment.svelte
@@ -3,7 +3,7 @@
   import { ndk, userPublickey } from '$lib/nostr';
   import { nip19 } from 'nostr-tools';
   import { format as formatDate } from 'timeago.js';
-  import CustomAvatar from './CustomAvatar.svelte';
+  import Avatar from './Avatar.svelte';
   import ZapModal from './ZapModal.svelte';
   import { resolveProfileByPubkey, formatDisplayName } from '$lib/profileResolver';
   import { formatAmount } from '$lib/utils';
@@ -127,7 +127,7 @@
       if (!parentComment && $ndk) {
         try {
           const fetchPromise = $ndk.fetchEvent({
-            kinds: [1, 1111],
+            kinds: [1, 1111] as any,
             ids: [parentId]
           });
           const timeoutPromise = new Promise<null>((resolve) =>
@@ -159,7 +159,7 @@
       '#e': [event.id]
     });
 
-    likeSubscription.on('event', (e) => {
+    likeSubscription.on('event', (e: NDKEvent) => {
       if (processedLikes.has(e.id)) return;
       processedLikes.add(e.id);
       if (e.pubkey === $userPublickey) liked = true;
@@ -285,10 +285,23 @@
         };
 
         // Use the utility with both root and parent event
-        ev.tags = buildNip22CommentTags(rootEventObj, parentEventObj);
+        ev.tags = buildNip22CommentTags(rootEventObj, {
+          ...parentEventObj,
+          tags: parentEventObj.tags as string[][]
+        });
       } else {
         // Fallback: treat parent as if it's the root
-        ev.tags = buildNip22CommentTags(parentEventObj, parentEventObj);
+        ev.tags = buildNip22CommentTags(
+          {
+            ...parentEventObj,
+            kind: parentEventObj.kind ?? 1,
+            tags: parentEventObj.tags as string[][]
+          },
+          {
+            ...parentEventObj,
+            tags: parentEventObj.tags as string[][]
+          }
+        );
       }
     } else {
       // For non-recipe replies, we still need to construct a root event object
@@ -367,7 +380,7 @@
   {#if !parentLoading && parentComment}
     <div class="parent-quote">
       <div class="parent-quote-header">
-        <CustomAvatar pubkey={parentComment.pubkey} size={16} />
+        <Avatar pubkey={parentComment.pubkey} size={16} />
         <span class="parent-quote-author">{parentDisplayName || 'Loading...'}</span>
       </div>
       <p class="parent-quote-content">{truncateContent(parentComment.content)}</p>
@@ -378,7 +391,7 @@
   <div class="comment-row">
     <!-- Avatar -->
     <a href="/user/{nip19.npubEncode(event.pubkey)}" class="comment-avatar">
-      <CustomAvatar className="rounded-full" pubkey={event.pubkey} size={40} />
+      <Avatar className="rounded-full" pubkey={event.pubkey} size={40} />
     </a>
 
     <!-- Content -->
@@ -453,6 +466,7 @@
               class="reply-input"
               contenteditable={!postingReply}
               role="textbox"
+              tabindex="0"
               aria-multiline="true"
               data-placeholder="Add a reply..."
               on:input={() => mentionCtrl.handleInput()}

--- a/src/components/CommentLikes.svelte
+++ b/src/components/CommentLikes.svelte
@@ -19,7 +19,7 @@
       '#e': [event.id] // For comment likes, use the comment event ID
     }, { closeOnEose: true });
 
-    subscription.on('event', (e) => {
+    subscription.on('event', (e: NDKEvent) => {
       // Prevent counting the same event multiple times
       if (processedEvents.has(e.id)) return;
       processedEvents.add(e.id);

--- a/src/components/CommentReplies.svelte
+++ b/src/components/CommentReplies.svelte
@@ -3,7 +3,7 @@
   import { ndk, userPublickey } from '$lib/nostr';
   import { NDKEvent } from '@nostr-dev-kit/ndk';
   import { mutedPubkeys } from '$lib/muteListStore';
-  import CustomAvatar from './CustomAvatar.svelte';
+  import Avatar from './Avatar.svelte';
   import CustomName from './CustomName.svelte';
   import { nip19 } from 'nostr-tools';
   import { format as formatDate } from 'timeago.js';
@@ -73,13 +73,13 @@
       // Use subscribe collection for more reliable reply loading
       replySubscription = $ndk.subscribe(
         {
-          kinds: [1, 1111],
+          kinds: [1, 1111] as any,
           '#e': [parentComment.id] // Replies that reference this comment
         },
         { closeOnEose: true }
       );
 
-      replySubscription.on('event', (ev) => {
+      replySubscription.on('event', (ev: NDKEvent) => {
         loading = false;
         replies.push(ev);
         replies = replies;
@@ -158,7 +158,17 @@
           replyEvent.tags = buildNip22CommentTags(rootEventObj, parentEventObj);
         } else {
           // Fallback: treat parent as if it's the root
-          replyEvent.tags = buildNip22CommentTags(parentEventObj, parentEventObj);
+          replyEvent.tags = buildNip22CommentTags(
+            {
+              ...parentEventObj,
+              kind: parentEventObj.kind ?? 1,
+              tags: parentEventObj.tags as string[][]
+            },
+            {
+              ...parentEventObj,
+              tags: parentEventObj.tags as string[][]
+            }
+          );
         }
       } else {
         // For non-recipe replies, use simplified tag structure
@@ -269,6 +279,7 @@
             class:cursor-not-allowed={!$ndk.signer || postingReply}
             contenteditable={$ndk.signer && !postingReply}
             role="textbox"
+            tabindex="0"
             aria-multiline="true"
             aria-disabled={!$ndk.signer || postingReply}
             data-placeholder={$ndk.signer ? 'Add a reply...' : 'Log in to reply...'}
@@ -309,7 +320,7 @@
             {#if !$mutedPubkeys.has(reply.pubkey)}
               <div class="reply-row">
                 <div class="reply-avatar">
-                  <CustomAvatar className="flex-shrink-0" pubkey={reply.pubkey} size={24} />
+                  <Avatar className="flex-shrink-0" pubkey={reply.pubkey} size={24} />
                 </div>
                 <div class="reply-content">
                   <div class="reply-header">

--- a/src/components/CommentWithActions.svelte
+++ b/src/components/CommentWithActions.svelte
@@ -3,7 +3,7 @@
   import { nip19 } from 'nostr-tools';
   import { ndk } from '$lib/nostr';
   import { format as formatDate } from 'timeago.js';
-  import CustomAvatar from './CustomAvatar.svelte';
+  import Avatar from './Avatar.svelte';
   import { resolveProfileByPubkey, formatDisplayName } from '$lib/profileResolver';
   import CommentLikes from './CommentLikes.svelte';
   import CommentReplies from './CommentReplies.svelte';
@@ -33,7 +33,7 @@
 
 <div class="comment-row">
   <div class="comment-avatar">
-    <CustomAvatar
+    <Avatar
       className="flex-shrink-0"
       pubkey={event.pubkey}
       size={32}

--- a/src/components/Comments.svelte
+++ b/src/components/Comments.svelte
@@ -12,7 +12,7 @@
   import { MentionComposerController, type MentionState } from '$lib/mentionComposer';
 
   export let event: NDKEvent;
-  let events = [];
+  let events: NDKEvent[] = [];
   let commentText = '';
   let commentComposerEl: HTMLDivElement;
   let lastRenderedComment = '';
@@ -58,7 +58,7 @@
     const filter = createCommentFilter(event);
     commentSubscription = $ndk.subscribe(filter, { closeOnEose: false });
 
-    commentSubscription.on('event', (e) => {
+    commentSubscription.on('event', (e: NDKEvent) => {
       // Prevent adding the same event multiple times
       if (processedEvents.has(e.id)) return;
       processedEvents.add(e.id);
@@ -108,10 +108,10 @@
 
     // Use shared utility to build NIP-22 or NIP-10 tags
     ev.tags = buildNip22CommentTags({
-      kind: event.kind,
+      kind: event.kind ?? 1,
       pubkey: event.author?.pubkey || event.pubkey,
       id: event.id,
-      tags: event.tags
+      tags: event.tags as string[][]
     });
 
     // Parse and add @ mention tags (p tags)
@@ -198,6 +198,7 @@
           class="comment-composer-input w-full px-4 py-3 text-base input rounded-lg"
           contenteditable="true"
           role="textbox"
+          tabindex="0"
           aria-multiline="true"
           data-placeholder="Share your thoughts..."
           on:input={() => mentionCtrl.handleInput()}

--- a/src/components/CustomAvatar.svelte
+++ b/src/components/CustomAvatar.svelte
@@ -7,6 +7,7 @@
   export let size: number = 40;
   export let className: string = '';
   export let imageUrl: string | null = null; // Optional override for profile picture
+  export let interactive: boolean = true;
   
   const dispatch = createEventDispatcher();
   
@@ -254,14 +255,19 @@
     color: white; 
     font-weight: bold; 
     font-size: {size * 0.4}px;
-    cursor: pointer;
+    cursor: {interactive ? 'pointer' : 'default'};
     overflow: hidden;
   "
-  on:click={() => dispatch('click')}
+  on:click={() => {
+    if (interactive) {
+      dispatch('click');
+    }
+  }}
   role="button"
-  tabindex="0"
+  tabindex={interactive ? 0 : -1}
+  aria-disabled={!interactive}
   on:keydown={(e) => {
-    if (e.key === 'Enter' || e.key === ' ') {
+    if (interactive && (e.key === 'Enter' || e.key === ' ')) {
       e.preventDefault();
       dispatch('click');
     }

--- a/src/components/FeedComment.svelte
+++ b/src/components/FeedComment.svelte
@@ -164,7 +164,7 @@
       if (!parentComment && $ndk) {
         try {
           const fetchPromise = $ndk.fetchEvent({
-            kinds: [1, 1111],
+            kinds: [1, 1111] as any,
             ids: [parentId]
           });
           const timeoutPromise = new Promise<null>((resolve) =>
@@ -196,7 +196,7 @@
       '#e': [event.id]
     });
 
-    likeSubscription.on('event', (e) => {
+    likeSubscription.on('event', (e: NDKEvent) => {
       if (processedLikes.has(e.id)) return;
       processedLikes.add(e.id);
       if (e.pubkey === $userPublickey) liked = true;
@@ -294,7 +294,17 @@
           ev.tags = buildNip22CommentTags(rootEventObj, parentEventObj);
         } else {
           // Fallback: treat parent as if it's the root
-          ev.tags = buildNip22CommentTags(parentEventObj, parentEventObj);
+          ev.tags = buildNip22CommentTags(
+            {
+              ...parentEventObj,
+              kind: parentEventObj.kind ?? 1,
+              tags: parentEventObj.tags as string[][]
+            },
+            {
+              ...parentEventObj,
+              tags: parentEventObj.tags as string[][]
+            }
+          );
         }
       } else {
         // For non-recipe replies, construct tags for standard note replies
@@ -456,6 +466,7 @@
                 class="reply-input"
                 contenteditable={!postingReply}
                 role="textbox"
+                tabindex="0"
                 aria-multiline="true"
                 data-placeholder="Add a reply..."
                 on:input={() => mentionCtrl.handleInput()}

--- a/src/components/FeedComments.svelte
+++ b/src/components/FeedComments.svelte
@@ -82,7 +82,7 @@
     const filter = createCommentFilter(event);
     feedCommentSubscription = $ndk.subscribe(filter, { closeOnEose: false });
 
-    feedCommentSubscription.on('event', (e) => {
+    feedCommentSubscription.on('event', (e: NDKEvent) => {
       if (processedEvents.has(e.id)) return;
       processedEvents.add(e.id);
       events.push(e);
@@ -118,7 +118,7 @@
 
       // Use shared utility to build NIP-22 or NIP-10 tags
       ev.tags = buildNip22CommentTags({
-        kind: event.kind,
+        kind: event.kind ?? 1,
         pubkey: event.pubkey,
         id: event.id,
         tags: event.tags
@@ -185,6 +185,7 @@
               style="border: 1px solid var(--color-input-border); color: var(--color-text-primary)"
               contenteditable="true"
               role="textbox"
+              tabindex="0"
               aria-multiline="true"
               data-placeholder="Add a comment..."
               on:input={() => mentionCtrl.handleInput()}

--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -34,7 +34,7 @@
     isThreadMuted
   } from '$lib/mutableIntegration';
   import { formatDistanceToNow } from 'date-fns';
-  import CustomAvatar from './CustomAvatar.svelte';
+  import Avatar from './Avatar.svelte';
   import type { NDKEvent, NDKSubscription } from '@nostr-dev-kit/ndk';
   import { NDKSubscriptionCacheUsage } from '@nostr-dev-kit/ndk';
   import NoteTotalLikes from './NoteTotalLikes.svelte';
@@ -3369,6 +3369,16 @@
     loading = false;
   }
 
+  function unmuteAuthor(pubkey: string): void {
+    const mutedUsers = JSON.parse(localStorage.getItem('mutedUsers') || '[]') as string[];
+    const updated = mutedUsers.filter((pk) => pk !== pubkey);
+    localStorage.setItem('mutedUsers', JSON.stringify(updated));
+    invalidateMutedUsersCache();
+    muteListStore.invalidate();
+    muteListStore.load(true);
+    void retryWithDelay();
+  }
+
   // ═══════════════════════════════════════════════════════════════
   // CLEANUP
   // ═══════════════════════════════════════════════════════════════
@@ -4680,13 +4690,7 @@
             <button
               on:click={() => {
                 if (authorPubkey) {
-                  const mutedUsers = JSON.parse(localStorage.getItem('mutedUsers') || '[]');
-                  const updated = mutedUsers.filter((pk) => pk !== authorPubkey);
-                  localStorage.setItem('mutedUsers', JSON.stringify(updated));
-                  invalidateMutedUsersCache();
-                  muteListStore.invalidate();
-                  muteListStore.load(true);
-                  retryWithDelay();
+                  unmuteAuthor(authorPubkey);
                 }
               }}
               class="px-4 py-2 bg-orange-500 text-white rounded-lg hover:bg-orange-600 transition-colors"
@@ -4758,7 +4762,7 @@
                     href="/user/{nip19.npubEncode(event.author?.hexpubkey || event.pubkey)}"
                     class="flex-shrink-0"
                   >
-                    <CustomAvatar
+                    <Avatar
                       className="cursor-pointer"
                       pubkey={event.author?.hexpubkey || event.pubkey}
                       size={40}
@@ -4821,7 +4825,7 @@
                       >
                         <div class="parent-quote-header">
                           {#if context.authorPubkey}
-                            <CustomAvatar pubkey={context.authorPubkey} size={16} />
+                            <Avatar pubkey={context.authorPubkey} size={16} />
                           {/if}
                           <span class="parent-quote-author">
                             {#if context.error === 'deleted'}
@@ -4914,7 +4918,7 @@
                       >
                         <div class="parent-quote-header">
                           {#if context.authorPubkey}
-                            <CustomAvatar pubkey={context.authorPubkey} size={16} />
+                            <Avatar pubkey={context.authorPubkey} size={16} />
                           {/if}
                           <span class="parent-quote-author">
                             {#if context.error === 'deleted'}

--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -16,6 +16,17 @@
   let supportModalOpen = false;
   let zapModalOpen = false;
 
+  async function copySupportAddress(event: MouseEvent): Promise<void> {
+    await navigator.clipboard.writeText('ZapCooking@getalby.com');
+    const button = event.currentTarget;
+    if (!(button instanceof HTMLButtonElement)) return;
+    const originalText = button.textContent;
+    button.textContent = '✓';
+    setTimeout(() => {
+      button.textContent = originalText;
+    }, 1500);
+  }
+
   $: zapCookingUser = $ndk ? new NDKUser({ pubkey: ZAPCOOKING_PUBKEY }) : null;
 
   // Reactive resolved theme for logo switching (handles 'system' preference)
@@ -161,9 +172,7 @@
             use:qr={{
               data: 'lightning:ZapCooking@getalby.com',
               logo: 'https://zap.cooking/favicon.svg',
-              shape: 'circle',
-              width: 128,
-              height: 128
+              shape: 'circle'
             }}
           />
         </div>
@@ -181,15 +190,7 @@
             ZapCooking@getalby.com
           </div>
           <button
-            on:click={() => {
-              navigator.clipboard.writeText('ZapCooking@getalby.com');
-              const btn = event.target;
-              const originalText = btn.textContent;
-              btn.textContent = '✓';
-              setTimeout(() => {
-                btn.textContent = originalText;
-              }, 1500);
-            }}
+            on:click={copySupportAddress}
             class="bg-input hover:bg-accent-gray px-3 py-2 rounded-lg text-xs font-medium transition duration-200 flex-shrink-0"
             style="color: var(--color-text-primary);"
             title="Copy lightning address"

--- a/src/components/InlineComments.svelte
+++ b/src/components/InlineComments.svelte
@@ -41,7 +41,7 @@
       const filter = createCommentFilter(event);
       commentSubscription = $ndk.subscribe(filter, { closeOnEose: true });
       
-      commentSubscription.on("event", (ev) => {
+      commentSubscription.on("event", (ev: NDKEvent) => {
         loading = false;
         comments.push(ev);
         comments = comments;
@@ -107,10 +107,10 @@
       
       // Use shared utility to build NIP-22 or NIP-10 tags
       commentEvent.tags = buildNip22CommentTags({
-        kind: event.kind,
+        kind: event.kind ?? 1,
         pubkey: event.pubkey,
         id: event.id,
-        tags: event.tags
+        tags: event.tags as string[][]
       });
       
       // Add NIP-89 client tag
@@ -156,10 +156,10 @@
           
           // Use shared utility to build NIP-22 or NIP-10 tags
           newCommentEvent.tags = buildNip22CommentTags({
-            kind: event.kind,
+            kind: event.kind ?? 1,
             pubkey: event.pubkey,
             id: event.id,
-            tags: event.tags
+            tags: event.tags as string[][]
           });
           
           // Add NIP-89 client tag

--- a/src/components/NoteEmbed.svelte
+++ b/src/components/NoteEmbed.svelte
@@ -276,7 +276,7 @@
       let totalAmount = 0;
 
       for (const zapEvent of zapEvents) {
-        const bolt11 = zapEvent.tags.find((tag) => tag[0] === 'bolt11')?.[1];
+        const bolt11 = zapEvent.tags.find((tag: string[]) => tag[0] === 'bolt11')?.[1];
         if (!bolt11) continue;
 
         try {

--- a/src/components/NotificationPanel.svelte
+++ b/src/components/NotificationPanel.svelte
@@ -3,7 +3,7 @@
   import { goto } from '$app/navigation';
   import { formatDistanceToNow } from 'date-fns';
   import { nip19 } from 'nostr-tools';
-  import CustomAvatar from './CustomAvatar.svelte';
+  import Avatar from './Avatar.svelte';
   import CustomName from './CustomName.svelte';
   import { onMount } from 'svelte';
   
@@ -99,7 +99,7 @@
           class="w-full flex items-start gap-3 px-4 py-3 hover:bg-accent-gray transition-colors cursor-pointer text-left"
         >
           <div class="relative flex-shrink-0">
-            <CustomAvatar pubkey={notification.fromPubkey} size={40} />
+            <Avatar pubkey={notification.fromPubkey} size={40} />
             <span class="absolute -bottom-1 -right-1 text-sm">
               {getIcon(notification.type)}
             </span>

--- a/src/components/ProfileAvatar.svelte
+++ b/src/components/ProfileAvatar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import CustomAvatar from './CustomAvatar.svelte';
+  import Avatar from './Avatar.svelte';
   import CustomName from './CustomName.svelte';
   import { goto } from '$app/navigation';
   import { nip19 } from 'nostr-tools';
@@ -19,7 +19,7 @@
   class="flex flex-col items-center gap-2 flex-shrink-0 w-20 cursor-pointer group"
 >
   <div class="relative">
-    <CustomAvatar {pubkey} size={64} className="group-hover:scale-105 transition-transform" />
+    <Avatar {pubkey} size={64} className="group-hover:scale-105 transition-transform" />
     {#if showZapIndicator}
       <div class="absolute -bottom-1 -right-1 w-5 h-5 bg-primary rounded-full flex items-center justify-center">
         <span class="text-white text-xs">⚡</span>

--- a/src/components/ProfileDrafts.svelte
+++ b/src/components/ProfileDrafts.svelte
@@ -32,6 +32,10 @@
   let drafts: RecipeDraft[] = [];
   let loaded = false;
 
+  function getDraftSyncStatus(draft: RecipeDraft): 'local' | 'syncing' | 'synced' | 'error' {
+    return ((draft as any).syncStatus ?? 'local') as 'local' | 'syncing' | 'synced' | 'error';
+  }
+
   async function handleRefresh() {
     try {
       if ($draftSyncState.syncAvailable) {
@@ -167,8 +171,7 @@
   {:else}
     <div class="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
       {#each drafts as draft (draft.id)}
-        {@const draftWithSync = /** @type {any} */ (draft)}
-        {@const syncStatus = draftWithSync.syncStatus}
+        {@const syncStatus = getDraftSyncStatus(draft)}
         {@const SyncIcon = getSyncIcon(syncStatus)}
         <div
           class="flex flex-col gap-3 p-4 rounded-xl transition-all hover:scale-[1.02]"

--- a/src/components/ProfileLists.svelte
+++ b/src/components/ProfileLists.svelte
@@ -11,7 +11,7 @@
   let loaded = false;
   let subscription: NDKSubscription | null = null;
   
-  $: isOwnProfile = $userPublickey && hexpubkey && $userPublickey === hexpubkey;
+  $: isOwnProfile = Boolean($userPublickey && hexpubkey && $userPublickey === hexpubkey);
 
   $: {
     if ($page.params.slug) {

--- a/src/components/RelayHealthDebug.svelte
+++ b/src/components/RelayHealthDebug.svelte
@@ -111,13 +111,13 @@
     <h3 class="text-lg font-semibold text-neutral-100">Relay Health Monitor</h3>
     <div class="flex gap-2">
       <button
-        onclick={logToConsole}
+        on:click={logToConsole}
         class="px-3 py-1 bg-neutral-800 hover:bg-neutral-700 rounded text-neutral-300 text-xs"
       >
         📊 Console
       </button>
       <button
-        onclick={resetAll}
+        on:click={resetAll}
         class="px-3 py-1 bg-red-900 hover:bg-red-800 rounded text-red-200 text-xs"
       >
         🗑️ Reset All
@@ -200,7 +200,7 @@
               </td>
               <td class="py-2">
                 <button
-                  onclick={() => resetRelay(stats.url)}
+                  on:click={() => resetRelay(stats.url)}
                   class="text-xs text-neutral-500 hover:text-neutral-300"
                   title="Reset stats"
                 >
@@ -216,7 +216,7 @@
     {#if healthStats.length > 20}
       <div class="mt-3 text-center">
         <button
-          onclick={() => showAll = !showAll}
+          on:click={() => showAll = !showAll}
           class="text-xs text-neutral-400 hover:text-neutral-200"
         >
           {showAll ? 'Show less' : `Show all ${healthStats.length} relays`}

--- a/src/components/TimerWidget.svelte
+++ b/src/components/TimerWidget.svelte
@@ -596,7 +596,7 @@
         <input
           type="text"
           inputmode="decimal"
-          pattern="\\d*(\\.\\d{(0, 1)})?"
+          pattern="\\d*(\\.\\d?)?"
           bind:value={quickMinutesInput}
           class="quick-minutes"
           on:input={handleMinutesInput}

--- a/src/components/TrendingRecipeCard.svelte
+++ b/src/components/TrendingRecipeCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { NDKEvent } from '@nostr-dev-kit/ndk';
   import { nip19 } from 'nostr-tools';
-  import CustomAvatar from './CustomAvatar.svelte';
+  import Avatar from './Avatar.svelte';
   import { goto } from '$app/navigation';
   import { getImageOrPlaceholder } from '$lib/placeholderImages';
   import { lazyLoad } from '$lib/lazyLoad';
@@ -68,7 +68,7 @@
     <!-- Author Avatar Overlay -->
     {#if authorPubkey}
       <div class="absolute top-3 left-3">
-        <CustomAvatar pubkey={authorPubkey} size={32} className="ring-2 ring-white" />
+        <Avatar pubkey={authorPubkey} size={32} className="ring-2 ring-white" />
       </div>
     {/if}
 

--- a/src/components/ZapButton.svelte
+++ b/src/components/ZapButton.svelte
@@ -18,6 +18,7 @@
 
   let zapModalOpen = false;
   let isZapping = false;
+  $: zapTarget = event ?? user;
 
   async function handleZapClick() {
     const target = event || user;
@@ -93,6 +94,6 @@
   {/if}
 </button>
 
-{#if zapModalOpen && (event || user)}
-  <ZapModal bind:open={zapModalOpen} event={event || user} on:zap-complete={handleZapComplete} />
+{#if zapModalOpen && zapTarget}
+  <ZapModal bind:open={zapModalOpen} event={zapTarget} on:zap-complete={handleZapComplete} />
 {/if}

--- a/src/lib/autoZapSettings.ts
+++ b/src/lib/autoZapSettings.ts
@@ -14,7 +14,6 @@ import { writable, get } from 'svelte/store';
 import { browser } from '$app/environment';
 import { ndk, userPublickey, ndkReady } from '$lib/nostr';
 import { NDKEvent } from '@nostr-dev-kit/ndk';
-import { getOutboxRelays } from '$lib/relayListCache';
 import { CLIENT_TAG_IDENTIFIER } from '$lib/consts';
 
 // Storage keys
@@ -185,7 +184,7 @@ export async function loadOneTapZapSettings(): Promise<OneTapZapSettings> {
   lastLoadedPubkey = pubkey;
 
   try {
-    await get(ndkReady);
+    await ndkReady;
     const ndkInstance = get(ndk);
     if (!ndkInstance) return localSettings;
 
@@ -227,7 +226,7 @@ async function publishOneTapZapSettings(settings: OneTapZapSettings): Promise<bo
   }
 
   try {
-    await get(ndkReady);
+    await ndkReady;
     const ndkInstance = get(ndk);
     if (!ndkInstance) return false;
 
@@ -239,10 +238,9 @@ async function publishOneTapZapSettings(settings: OneTapZapSettings): Promise<bo
       ['client', CLIENT_TAG_IDENTIFIER]
     ];
 
-    const outboxRelays = await getOutboxRelays(pubkey);
-
     await event.sign();
-    await event.publish(outboxRelays);
+    // Publish via NDK defaults to avoid relay-set type mismatches across NDK versions.
+    await event.publish();
 
     console.log('[OneTapZap] Saved to relay:', settings);
     return true;

--- a/src/lib/compressedCache.ts
+++ b/src/lib/compressedCache.ts
@@ -41,8 +41,9 @@ export interface CacheMetrics {
   compressedSize: number;
 }
 
-export class CompressedCacheManager extends CacheManager {
+export class CompressedCacheManager {
   private static instance: CompressedCacheManager;
+  private readonly cacheManager: CacheManager;
   private metrics: CacheMetrics = {
     hits: 0,
     misses: 0,
@@ -57,7 +58,7 @@ export class CompressedCacheManager extends CacheManager {
   private compressionLevel: 'gzip' | 'deflate' | 'deflate-raw' = 'gzip';
 
   constructor() {
-    super();
+    this.cacheManager = CacheManager.getInstance();
     this.detectCompressionSupport();
   }
 
@@ -112,7 +113,7 @@ export class CompressedCacheManager extends CacheManager {
         data: processedData as T,
         timestamp: Date.now(),
         expiresAt: Date.now() + config.ttl,
-        version: config.version,
+        version: config.version || '1.0',
         metadata: {
           compressed,
           originalSize,
@@ -121,14 +122,14 @@ export class CompressedCacheManager extends CacheManager {
         }
       };
       
-      await super.set(config, cacheItem);
+      await this.cacheManager.set(config, cacheItem);
       
       console.log(`📦 Cached ${config.key}: ${originalSize} → ${compressedSize} bytes (${compressed ? 'compressed' : 'uncompressed'})`);
       
     } catch (error) {
       console.error('Failed to set compressed cache:', error);
       // Fallback to uncompressed
-      await super.set(config, data);
+      await this.cacheManager.set(config, data);
     }
   }
 
@@ -137,7 +138,7 @@ export class CompressedCacheManager extends CacheManager {
    */
   async get<T>(config: CompressedCacheConfig): Promise<T | null> {
     try {
-      const cacheItem = await super.get<CacheItem<T>>(config);
+      const cacheItem = await this.cacheManager.get<CacheItem<T>>(config);
       
       if (!cacheItem) {
         this.metrics.misses++;
@@ -281,6 +282,10 @@ export class CompressedCacheManager extends CacheManager {
     } catch (error) {
       console.error('Failed to invalidate cache pattern:', error);
     }
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.cacheManager.delete(key);
   }
 
   /**

--- a/src/lib/connectionManager.ts
+++ b/src/lib/connectionManager.ts
@@ -51,9 +51,12 @@ export class ConnectionManager {
 
   private initializeRelayHealth() {
     // Initialize health tracking for all configured relays
+    const outboxRelayUrls: string[] = Array.isArray((this.ndkRef as any).outboxRelayUrls)
+      ? (this.ndkRef as any).outboxRelayUrls
+      : [];
     const relayUrls = [
       ...this.ndkRef.explicitRelayUrls || [],
-      ...this.ndkRef.outboxRelayUrls || []
+      ...outboxRelayUrls
     ];
 
     console.log('🔧 Initializing relay health for URLs:', relayUrls);
@@ -168,7 +171,7 @@ export class ConnectionManager {
       this.handleRelayDisconnect(relay);
     });
 
-    this.ndkRef.pool.on('relay:notice', (relay, notice) => {
+    (this.ndkRef.pool as any).on('relay:notice', (relay: { url: string }, notice: string) => {
       this.handleRelayNotice(relay, notice);
     });
   }

--- a/src/lib/countQuery.ts
+++ b/src/lib/countQuery.ts
@@ -277,7 +277,7 @@ export async function fetchCount(
     countCache.set(cacheKey, { result: successResult, timestamp: Date.now() });
   }
 
-  return successResult;
+  return successResult ?? null;
 }
 
 /**

--- a/src/lib/draftStore.ts
+++ b/src/lib/draftStore.ts
@@ -220,12 +220,7 @@ function mergeDrafts(
 
   // Add remote drafts first (they're authoritative if synced)
   for (const remote of remoteDrafts) {
-    merged.set(remote.id, {
-      ...remote.draft,
-      id: remote.id,
-      syncStatus: 'synced',
-      lastSyncedAt: remote.createdAt
-    });
+    merged.set(remote.id, normalizeRemoteDraft(remote));
   }
 
   // Merge local drafts
@@ -251,6 +246,29 @@ function mergeDrafts(
 
   // Sort by most recently updated
   return [...merged.values()].sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+function normalizeRemoteDraft(remote: RemoteDraft): DraftWithSyncState {
+  const draft = remote.draft as Partial<RecipeDraft>;
+  const now = Date.now();
+  return {
+    id: remote.id,
+    title: draft.title ?? '',
+    images: draft.images ?? [],
+    tags: draft.tags ?? [],
+    summary: draft.summary ?? '',
+    chefsnotes: draft.chefsnotes ?? '',
+    preptime: draft.preptime ?? '',
+    cooktime: draft.cooktime ?? '',
+    servings: draft.servings ?? '',
+    ingredients: draft.ingredients ?? [],
+    directions: draft.directions ?? [],
+    additionalMarkdown: draft.additionalMarkdown ?? '',
+    createdAt: draft.createdAt ?? remote.createdAt ?? now,
+    updatedAt: draft.updatedAt ?? remote.createdAt ?? now,
+    syncStatus: 'synced',
+    lastSyncedAt: remote.createdAt
+  };
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -743,12 +761,7 @@ export async function forceRefreshFromRemote(): Promise<void> {
     const remoteDrafts = await fetchRemoteDrafts();
 
     // Convert remote drafts to local format
-    const drafts: DraftWithSyncState[] = remoteDrafts.map((r) => ({
-      ...r.draft,
-      id: r.id,
-      syncStatus: 'synced' as const,
-      lastSyncedAt: r.createdAt
-    }));
+    const drafts: DraftWithSyncState[] = remoteDrafts.map((r) => normalizeRemoteDraft(r));
 
     // Sort by most recently updated
     drafts.sort((a, b) => b.updatedAt - a.updatedAt);

--- a/src/lib/encryptionService.ts
+++ b/src/lib/encryptionService.ts
@@ -20,6 +20,14 @@ import { nip19 } from 'nostr-tools';
 
 export type EncryptionMethod = 'nip44' | 'nip04' | null;
 
+type SignerWithEncryption = {
+  nip44Encrypt?: (recipient: NDKUser, plaintext: string) => Promise<string>;
+  nip04Encrypt?: (recipient: NDKUser, plaintext: string) => Promise<string>;
+  nip44Decrypt?: (sender: NDKUser, ciphertext: string) => Promise<string>;
+  nip04Decrypt?: (sender: NDKUser, ciphertext: string) => Promise<string>;
+  constructor?: { name?: string };
+};
+
 /**
  * Get private key from localStorage if available
  */
@@ -55,7 +63,7 @@ export function hasEncryptionSupport(): boolean {
   if (!browser) return false;
 
   const ndkInstance = get(ndk);
-  const signer = ndkInstance.signer;
+  const signer = ndkInstance.signer as SignerWithEncryption | null | undefined;
   const signerName = signer?.constructor?.name || '';
 
   // Check by signer type (use includes() to handle minified class names like _NDKPrivateKeySigner)
@@ -113,7 +121,7 @@ export async function getEncryptionMethod(): Promise<EncryptionMethod> {
   if (!browser) return null;
 
   const ndkInstance = get(ndk);
-  const signer = ndkInstance.signer;
+  const signer = ndkInstance.signer as SignerWithEncryption | null | undefined;
 
   // If we have an NDK signer, it supports encryption via its interface
   if (signer) {
@@ -185,7 +193,7 @@ export async function encrypt(
   }
 
   const ndkInstance = get(ndk);
-  const signer = ndkInstance.signer;
+  const signer = ndkInstance.signer as SignerWithEncryption | null | undefined;
   const signerName = signer?.constructor?.name || '';
 
 
@@ -415,7 +423,7 @@ export async function decrypt(
 
       // Fallback to NDK signer (for NIP-46 remote signers, etc.)
       const ndkInstance = get(ndk);
-      const signer = ndkInstance.signer;
+      const signer = ndkInstance.signer as SignerWithEncryption | null | undefined;
       if (signer) {
         const sender = new NDKUser({ pubkey: senderPubkey });
 

--- a/src/lib/engagementPreloader.ts
+++ b/src/lib/engagementPreloader.ts
@@ -230,7 +230,6 @@ export function createBackgroundEngagementLoader(
   if (!browser) return () => {};
   
   let isRunning = true;
-  let subscription: NDKSubscription | null = null;
   
   async function loadLoop() {
     while (isRunning) {
@@ -262,9 +261,6 @@ export function createBackgroundEngagementLoader(
   
   return () => {
     isRunning = false;
-    if (subscription) {
-      subscription.stop();
-    }
   };
 }
 

--- a/src/lib/feedCache.ts
+++ b/src/lib/feedCache.ts
@@ -83,7 +83,8 @@ export class FeedCacheService {
     
     // Prevent multiple simultaneous refreshes for the same filter
     if (this.refreshPromises.has(cacheKey)) {
-      return this.refreshPromises.get(cacheKey);
+      await this.refreshPromises.get(cacheKey);
+      return;
     }
 
     const refreshPromise = this.performBackgroundRefresh(options);

--- a/src/lib/feedSubscriptionManager.ts
+++ b/src/lib/feedSubscriptionManager.ts
@@ -8,7 +8,8 @@
  * - Subscription reuse to prevent duplicate connections
  */
 
-import type { NDK, NDKEvent, NDKFilter, NDKSubscription } from '@nostr-dev-kit/ndk';
+import type NDK from '@nostr-dev-kit/ndk';
+import type { NDKEvent, NDKFilter, NDKSubscription } from '@nostr-dev-kit/ndk';
 
 // ═══════════════════════════════════════════════════════════════
 // TYPES

--- a/src/lib/followOutbox.ts
+++ b/src/lib/followOutbox.ts
@@ -9,7 +9,8 @@
  * - Integration with RelayListCache for NIP-65 caching
  */
 
-import type { NDK, NDKEvent, NDKFilter } from '@nostr-dev-kit/ndk';
+import type NDK from '@nostr-dev-kit/ndk';
+import type { NDKEvent, NDKFilter } from '@nostr-dev-kit/ndk';
 import { NDKRelaySet } from '@nostr-dev-kit/ndk';
 import { relayListCache, type RelayList } from './relayListCache';
 import { relaySelector, recordQuerySuccess, recordQueryFailure } from './relaySelector';
@@ -233,8 +234,8 @@ export async function fetchFollowList(
     }
     
     const follows: FollowWithRelays[] = contactEvent.tags
-      .filter(tag => tag[0] === 'p' && tag[1])
-      .map(tag => ({
+      .filter((tag: string[]) => tag[0] === 'p' && tag[1])
+      .map((tag: string[]) => ({
         pubkey: tag[1],
         relayHints: tag[2] && isValidRelayUrl(tag[2]) 
           ? [normalizeRelayUrl(tag[2])] 

--- a/src/lib/gardenCache.ts
+++ b/src/lib/gardenCache.ts
@@ -120,7 +120,7 @@ class GardenCacheManager {
         resolve();
       };
 
-      request.onupgradeneeded = (event) => {
+      request.onupgradeneeded = (event: IDBVersionChangeEvent) => {
         const db = (event.target as IDBOpenDBRequest).result;
         console.log('[GardenCache] Creating database stores');
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -227,7 +227,7 @@ export const error = (message: string, context?: string, data?: any) =>
   logger.error(message, context, data);
 
 export const performance = (action: string, duration: number, context?: string) => 
-  logger.performance(action, context, duration);
+  logger.performance(action, duration, context);
 
 export const userAction = (action: string, data?: any) => 
   logger.userAction(action, data);

--- a/src/lib/marketplace/products.ts
+++ b/src/lib/marketplace/products.ts
@@ -3,7 +3,8 @@
  * Functions to create, fetch, and parse product events (NIP-99 kind 30402)
  */
 
-import { NDKEvent, NDKRelaySet, type NDK, type NDKFilter } from '@nostr-dev-kit/ndk';
+import type NDK from '@nostr-dev-kit/ndk';
+import { NDKEvent, NDKRelaySet, type NDKFilter } from '@nostr-dev-kit/ndk';
 import {
 	PRODUCT_KIND,
 	PRODUCT_KIND_LEGACY,
@@ -197,7 +198,7 @@ export async function fetchProducts(
 		const allEvents = new Set<any>();
 		
 		const fetchPromise = new Promise<Set<any>>((resolve) => {
-			const sub = ndk.subscribe(filter, { closeOnEose: true, relaySet });
+			const sub = ndk.subscribe(filter, { closeOnEose: true, relaySet } as any);
 			
 			sub.on('event', (event: any) => {
 				allEvents.add(event);

--- a/src/lib/memoization.ts
+++ b/src/lib/memoization.ts
@@ -71,11 +71,11 @@ export function createMemoizedReactive<T>(
   dependencies: any[],
   maxCacheSize: number = 50
 ): () => T {
+  void dependencies;
   const memoized = memoize(computeFn, maxCacheSize);
   
   return () => {
-    // Use dependencies as cache key
-    return memoized(...dependencies);
+    return memoized();
   };
 }
 
@@ -149,7 +149,9 @@ export function debouncedMemoize<T extends (...args: any[]) => any>(
       // Implement LRU eviction
       if (cache.size > maxCacheSize) {
         const firstKey = cache.keys().next().value;
-        cache.delete(firstKey);
+        if (firstKey !== undefined) {
+          cache.delete(firstKey);
+        }
       }
       
       timeouts.delete(key);
@@ -182,8 +184,8 @@ export function memoizeAsync<T extends (...args: any[]) => Promise<any>>(
   fn: T,
   maxCacheSize: number = 50
 ): MemoizedFunction<T> {
-  const cache = new Map<string, Promise<ReturnType<T>>>();
-  const resolvedCache = new Map<string, ReturnType<T>>();
+  const cache = new Map<string, ReturnType<T>>();
+  const resolvedCache = new Map<string, Awaited<ReturnType<T>>>();
   
   const memoized = (...args: Parameters<T>): ReturnType<T> => {
     const key = args.map(arg => {
@@ -207,18 +209,20 @@ export function memoizeAsync<T extends (...args: any[]) => Promise<any>>(
     }
     
     // Create new promise
-    const promise = fn(...args).then(result => {
+    const promise = fn(...args).then((result: Awaited<ReturnType<T>>) => {
       resolvedCache.set(key, result);
       
       // Implement LRU eviction
       if (resolvedCache.size > maxCacheSize) {
         const firstKey = resolvedCache.keys().next().value;
-        resolvedCache.delete(firstKey);
-        cache.delete(firstKey);
+        if (firstKey !== undefined) {
+          resolvedCache.delete(firstKey);
+          cache.delete(firstKey);
+        }
       }
       
       return result;
-    });
+    }) as ReturnType<T>;
     
     cache.set(key, promise);
     return promise;

--- a/src/lib/native/notifications.ts
+++ b/src/lib/native/notifications.ts
@@ -404,7 +404,7 @@ export async function getPendingNotifications(): Promise<number[]> {
   try {
     const LocalNotifications = await getLocalNotifications();
     const pending = await LocalNotifications.getPending();
-    return pending.notifications.map(n => n.id);
+    return pending.notifications.map((n: { id: number }) => n.id);
   } catch (error) {
     console.error('[Notifications] Error getting pending notifications:', error);
     return [];

--- a/src/lib/nip05Service.ts
+++ b/src/lib/nip05Service.ts
@@ -1,5 +1,5 @@
 import { browser } from '$app/environment';
-import type { NDK } from '@nostr-dev-kit/ndk';
+import type NDK from '@nostr-dev-kit/ndk';
 import { NDKEvent } from '@nostr-dev-kit/ndk';
 import { profileCacheManager } from './profileCache';
 
@@ -148,7 +148,7 @@ export async function updateProfileWithNip05(
     
     if (events.size > 0) {
       // Get the latest profile event
-      const latestEvent = Array.from(events).sort((a, b) =>
+      const latestEvent = (Array.from(events) as NDKEvent[]).sort((a, b) =>
         (b.created_at || 0) - (a.created_at || 0)
       )[0];
       

--- a/src/lib/nip108/client.ts
+++ b/src/lib/nip108/client.ts
@@ -10,7 +10,8 @@
  * - Handle payment and decryption server-side
  */
 
-import type { NDKEvent, NDK } from '@nostr-dev-kit/ndk';
+import type NDK from '@nostr-dev-kit/ndk';
+import type { NDKEvent } from '@nostr-dev-kit/ndk';
 import { NDKEvent as NDKEventClass } from '@nostr-dev-kit/ndk';
 import { encrypt, generateSecretKey, bufferToHex } from './encryption';
 import { randomBytes } from '@noble/hashes/utils.js';
@@ -418,7 +419,9 @@ export async function createKeyNote(
     throw new Error('NDK signer required to create key note');
   }
   
-  const privateKey = await ndk.signer.privateKey();
+  const signer = ndk.signer as any;
+  const privateKey =
+    typeof signer?.privateKey === 'function' ? await signer.privateKey() : null;
   if (!privateKey) {
     throw new Error('Private key not available');
   }

--- a/src/lib/nip37DraftService.ts
+++ b/src/lib/nip37DraftService.ts
@@ -112,7 +112,7 @@ export async function getPrivateRelays(pubkey: string): Promise<string[]> {
 
     // Try to fetch kind 10013 event
     const filter: NDKFilter = {
-      kinds: [KIND_PRIVATE_RELAY_LIST],
+      kinds: [KIND_PRIVATE_RELAY_LIST as any],
       authors: [pubkey],
       limit: 1
     };

--- a/src/lib/nostr.ts
+++ b/src/lib/nostr.ts
@@ -191,7 +191,8 @@ function createNdk(mode: RelayMode, relayUrls: string[]): NDK {
     outboxRelayUrls: config.outboxRelayUrls,
     enableOutboxModel: config.enableOutboxModel,
     explicitRelayUrls: config.explicitRelayUrls,
-    cacheAdapter: dexieAdapter,
+    // Cast due transitive NDK minor type mismatch (2.10.0 vs 2.10.x) in installed deps.
+    cacheAdapter: dexieAdapter as any,
     autoConnectUserRelays: false
   });
 }

--- a/src/lib/notificationStore.ts
+++ b/src/lib/notificationStore.ts
@@ -1,6 +1,7 @@
 import { writable, derived, get } from 'svelte/store';
 import { browser } from '$app/environment';
-import type { NDK, NDKEvent, NDKSubscription } from '@nostr-dev-kit/ndk';
+import type NDK from '@nostr-dev-kit/ndk';
+import type { NDKEvent, NDKSubscription } from '@nostr-dev-kit/ndk';
 import { hellthreadThreshold } from '$lib/hellthreadFilterSettings';
 
 export interface Notification {

--- a/src/lib/offlineStorage.ts
+++ b/src/lib/offlineStorage.ts
@@ -165,15 +165,21 @@ class OfflineStorageManager {
 
       request.onsuccess = () => {
         this.db = request.result;
-        const storeNames = Array.from(this.db.objectStoreNames);
-        console.log('[OfflineStorage] Database initialized, version:', this.db.version, 'stores:', storeNames);
+        const db = this.db;
+        if (!db) {
+          this.dbReadyResolve();
+          resolve();
+          return;
+        }
+        const storeNames = Array.from(db.objectStoreNames);
+        console.log('[OfflineStorage] Database initialized, version:', db.version, 'stores:', storeNames);
         this.dbReadyResolve();
         resolve();
       };
 
-      request.onupgradeneeded = (event) => {
+      request.onupgradeneeded = (event: IDBVersionChangeEvent) => {
         const db = (event.target as IDBOpenDBRequest).result;
-        const oldVersion = (event as IDBVersionChangeEvent).oldVersion;
+        const oldVersion = event.oldVersion;
         console.log(`[OfflineStorage] Upgrading database from v${oldVersion} to v${DB_VERSION}`);
 
         // Create cookbooks store
@@ -431,6 +437,18 @@ class OfflineStorageManager {
       request.onsuccess = () => resolve(request.result || []);
       request.onerror = () => reject(request.error);
     });
+  }
+
+  /**
+   * Remove all queued operations for a cookbook list.
+   * pubkey is accepted for caller compatibility; queue entries are keyed by listId.
+   */
+  async deleteCookbookOperations(listId: string, _pubkey?: string): Promise<number> {
+    const operations = await this.getOperationsForList(listId);
+    for (const operation of operations) {
+      await this.removeOperation(operation.id);
+    }
+    return operations.length;
   }
 
   /**

--- a/src/lib/profileStore.ts
+++ b/src/lib/profileStore.ts
@@ -1,4 +1,4 @@
-import { writable, derived, type Writable } from 'svelte/store';
+import { writable, derived, get, type Writable } from 'svelte/store';
 import { resolveProfile, resolveProfiles, formatDisplayName, type ProfileData } from './profileResolver';
 import { ndk } from './nostr';
 import type NDK from '@nostr-dev-kit/ndk';
@@ -30,11 +30,7 @@ export const profileActions = {
 
     try {
       // Get current NDK instance
-      let ndkInstance: NDK;
-      const unsubscribe = ndk.subscribe(value => {
-        ndkInstance = value;
-      });
-      unsubscribe();
+      const ndkInstance = get(ndk) as NDK | null;
       
       if (!ndkInstance) {
         throw new Error('NDK not available');
@@ -84,11 +80,7 @@ export const profileActions = {
 
     try {
       // Get current NDK instance
-      let ndkInstance: NDK;
-      const unsubscribe = ndk.subscribe(value => {
-        ndkInstance = value;
-      });
-      unsubscribe();
+      const ndkInstance = get(ndk) as NDK | null;
       
       if (!ndkInstance) {
         throw new Error('NDK not available');

--- a/src/lib/queryBatcher.ts
+++ b/src/lib/queryBatcher.ts
@@ -20,7 +20,8 @@
  */
 
 import { browser } from '$app/environment';
-import type { NDK, NDKEvent, NDKFilter } from '@nostr-dev-kit/ndk';
+import type NDK from '@nostr-dev-kit/ndk';
+import type { NDKEvent, NDKFilter } from '@nostr-dev-kit/ndk';
 import { NDKRelaySet } from '@nostr-dev-kit/ndk';
 import { relayListCache, type RelayList, normalizeRelayUrl } from './relayListCache';
 import { relaySelector, recordQuerySuccess, recordQueryFailure } from './relaySelector';
@@ -474,9 +475,13 @@ export class QueryBatcher {
               setTimeout(() => resolve(null), timeoutMs);
             });
             
-            const fetchPromise = this.ndk.fetchEvents(query.filter, undefined, relaySet);
-            
-            const result = await Promise.race([fetchPromise, timeoutPromise]);
+            const fetchPromise: Promise<Set<NDKEvent>> = this.ndk.fetchEvents(
+              query.filter,
+              undefined,
+              relaySet
+            ) as Promise<Set<NDKEvent>>;
+
+            const result = await Promise.race<Set<NDKEvent> | null>([fetchPromise, timeoutPromise]);
             
             const latencyMs = Date.now() - queryStart;
             
@@ -710,9 +715,13 @@ export class QueryBatcher {
           setTimeout(() => resolve(null), timeoutMs);
         });
         
-        const fetchPromise = this.ndk.fetchEvents(query.filter, undefined, relaySet);
-        
-        const result = await Promise.race([fetchPromise, timeoutPromise]);
+        const fetchPromise: Promise<Set<NDKEvent>> = this.ndk.fetchEvents(
+          query.filter,
+          undefined,
+          relaySet
+        ) as Promise<Set<NDKEvent>>;
+
+        const result = await Promise.race<Set<NDKEvent> | null>([fetchPromise, timeoutPromise]);
         
         const latencyMs = Date.now() - queryStart;
         

--- a/src/lib/replyContext.ts
+++ b/src/lib/replyContext.ts
@@ -5,7 +5,8 @@
  * This prevents the waterfall of individual fetches as replies render.
  */
 
-import type { NDK, NDKEvent } from '@nostr-dev-kit/ndk';
+import type NDK from '@nostr-dev-kit/ndk';
+import type { NDKEvent } from '@nostr-dev-kit/ndk';
 import { nip19 } from 'nostr-tools';
 
 // ═══════════════════════════════════════════════════════════════

--- a/src/lib/spark/index.ts
+++ b/src/lib/spark/index.ts
@@ -50,7 +50,7 @@ function validateMnemonic(mnemonic: string): boolean {
   const validWordCounts = [12, 15, 18, 21, 24];
 
   if (!validWordCounts.includes(words.length)) {
-    logger.warn('[Spark] Invalid mnemonic word count:', words.length);
+    logger.warn('[Spark] Invalid mnemonic word count', 'spark', words.length);
     return false;
   }
 
@@ -152,7 +152,7 @@ async function initWasm(): Promise<void> {
     _wasmInitialized = true;
     logger.info('[Spark] WASM module initialized');
   } catch (error) {
-    logger.error('[Spark] Failed to initialize WASM:', error);
+    logger.error('[Spark] Failed to initialize WASM', 'spark', error);
     throw error;
   }
 }
@@ -1646,7 +1646,7 @@ export async function backupWalletToNostr(pubkey: string): Promise<any> {
     pubkey,
     mnemonic
   );
-  logger.info('[Spark] Encrypted with', encryptionMethod);
+  logger.info(`[Spark] Encrypted with ${encryptionMethod ?? 'nip44'}`);
 
   const walletId = getSparkWalletId(mnemonic);
 

--- a/src/lib/stores/cookbookStore.ts
+++ b/src/lib/stores/cookbookStore.ts
@@ -1118,7 +1118,7 @@ export async function getCookbookCoverImage(
         }, { groupable: false });
         
         if (recipeEvent) {
-          const image = recipeEvent.tags.find(t => t[0] === 'image')?.[1];
+          const image = recipeEvent.tags.find((t: string[]) => t[0] === 'image')?.[1];
           if (image) {
             return forceRefresh ? `${image}?t=${Date.now()}` : image;
           }
@@ -1141,7 +1141,7 @@ export async function getCookbookCoverImage(
           authors: [pubkey]
         });
         if (recipeEvent) {
-          const image = recipeEvent.tags.find(t => t[0] === 'image')?.[1];
+          const image = recipeEvent.tags.find((t: string[]) => t[0] === 'image')?.[1];
           if (image) {
             return forceRefresh ? `${image}?t=${Date.now()}` : image;
           }

--- a/src/lib/stores/membershipStatus.ts
+++ b/src/lib/stores/membershipStatus.ts
@@ -1,0 +1,162 @@
+import { browser } from '$app/environment';
+import { writable } from 'svelte/store';
+
+export type MembershipTier = 'cook_plus' | 'pro_kitchen' | 'founders' | 'member' | 'unknown';
+
+export interface MembershipStatus {
+  active: boolean;
+  tier: MembershipTier;
+  expiresAt?: string;
+}
+
+type MembershipResponse = Record<string, { active?: boolean; tier?: string; expiresAt?: string }>;
+
+const BATCH_DEBOUNCE_MS = 75;
+const MAX_BATCH_SIZE = 200;
+
+const statusCache = new Map<string, MembershipStatus>();
+const inFlight = new Set<string>();
+const queued = new Set<string>();
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+const mapStore = writable<Record<string, MembershipStatus>>({});
+export const membershipStatusMap = { subscribe: mapStore.subscribe };
+
+function normalizePubkey(pubkey: string | null | undefined): string | null {
+  if (!pubkey) return null;
+  const normalized = String(pubkey).trim().toLowerCase();
+  if (!/^[a-f0-9]{64}$/.test(normalized)) {
+    return null;
+  }
+  return normalized;
+}
+
+function normalizeTier(tier: string | undefined): MembershipTier {
+  const value = String(tier || '').trim().toLowerCase();
+  if (value === 'cook_plus' || value === 'cook-plus' || value === 'cook plus') return 'cook_plus';
+  if (value === 'pro_kitchen' || value === 'pro-kitchen' || value === 'pro kitchen') return 'pro_kitchen';
+  if (value === 'founders' || value === 'founder') return 'founders';
+  if (value === 'member') return 'member';
+  return 'unknown';
+}
+
+function updateStore(pubkey: string, status: MembershipStatus): void {
+  statusCache.set(pubkey, status);
+  mapStore.update((current) => ({ ...current, [pubkey]: status }));
+}
+
+function normalizeStatus(raw: { active?: boolean; tier?: string; expiresAt?: string }): MembershipStatus {
+  return {
+    active: Boolean(raw?.active),
+    tier: normalizeTier(raw?.tier),
+    expiresAt: raw?.expiresAt
+  };
+}
+
+async function fetchBatch(pubkeys: string[]): Promise<void> {
+  if (!browser || pubkeys.length === 0) return;
+
+  const requested = [...new Set(pubkeys)];
+  requested.forEach((pk) => inFlight.add(pk));
+
+  try {
+    const query = encodeURIComponent(requested.join(','));
+    const res = await fetch(`/api/membership?pubkeys=${query}`);
+    if (!res.ok) {
+      throw new Error(`Membership fetch failed with status ${res.status}`);
+    }
+
+    const payload = (await res.json()) as MembershipResponse;
+    for (const pubkey of requested) {
+      const raw = payload?.[pubkey];
+      if (raw) {
+        updateStore(pubkey, normalizeStatus(raw));
+      } else {
+        updateStore(pubkey, { active: false, tier: 'unknown' });
+      }
+    }
+  } catch (error) {
+    console.warn('[membershipStatus] Batch fetch failed:', error);
+    for (const pubkey of requested) {
+      if (!statusCache.has(pubkey)) {
+        updateStore(pubkey, { active: false, tier: 'unknown' });
+      }
+    }
+  } finally {
+    requested.forEach((pk) => inFlight.delete(pk));
+  }
+}
+
+function flushQueue(): void {
+  flushTimer = null;
+  const list = [...queued];
+  queued.clear();
+  if (list.length === 0) return;
+
+  for (let i = 0; i < list.length; i += MAX_BATCH_SIZE) {
+    void fetchBatch(list.slice(i, i + MAX_BATCH_SIZE));
+  }
+}
+
+function scheduleFlush(): void {
+  if (flushTimer) return;
+  flushTimer = setTimeout(flushQueue, BATCH_DEBOUNCE_MS);
+}
+
+export function queueMembershipLookup(pubkey: string | null | undefined): void {
+  if (!browser) return;
+  const normalized = normalizePubkey(pubkey);
+  if (!normalized) return;
+  if (statusCache.has(normalized) || inFlight.has(normalized)) return;
+  queued.add(normalized);
+  scheduleFlush();
+}
+
+export async function getMembership(pubkeys: string[]): Promise<Record<string, MembershipStatus>> {
+  const normalized = [...new Set(pubkeys.map(normalizePubkey).filter((pk): pk is string => Boolean(pk)))];
+
+  if (normalized.length === 0) return {};
+  if (!browser) {
+    return Object.fromEntries(normalized.map((pk) => [pk, { active: false, tier: 'unknown' as const }]));
+  }
+
+  const missing = normalized.filter((pk) => !statusCache.has(pk) && !inFlight.has(pk));
+  if (missing.length > 0) {
+    for (let i = 0; i < missing.length; i += MAX_BATCH_SIZE) {
+      await fetchBatch(missing.slice(i, i + MAX_BATCH_SIZE));
+    }
+  }
+
+  const result: Record<string, MembershipStatus> = {};
+  for (const pubkey of normalized) {
+    result[pubkey] = statusCache.get(pubkey) || { active: false, tier: 'unknown' };
+  }
+  return result;
+}
+
+export function getMembershipLabel(tier: MembershipTier): string {
+  switch (tier) {
+    case 'cook_plus':
+      return 'Cook+ Member';
+    case 'pro_kitchen':
+      return 'Pro Kitchen Member ⚡';
+    case 'founders':
+      return 'Founders Member';
+    case 'member':
+      return 'Member';
+    default:
+      return 'Member';
+  }
+}
+
+// Test helper for deterministic batching tests.
+export function __resetMembershipStatusStoreForTests(): void {
+  statusCache.clear();
+  inFlight.clear();
+  queued.clear();
+  if (flushTimer) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+  mapStore.set({});
+}

--- a/src/lib/stripeService.server.ts
+++ b/src/lib/stripeService.server.ts
@@ -35,9 +35,9 @@ const getStripeInstance = async () => {
   const Stripe = (await import('stripe')).default;
   
   // Initialize Stripe with the secret key from environment variable
-  // Using API version 2024-12-18.acacia (latest stable)
+  // Using pinned API version expected by installed Stripe typings
   return new Stripe(stripeKey, {
-    apiVersion: '2024-12-18.acacia',
+    apiVersion: '2025-12-15.clover',
     typescript: true,
   });
 };

--- a/src/lib/themeStore.ts
+++ b/src/lib/themeStore.ts
@@ -1,4 +1,4 @@
-import { writable, type Writable } from 'svelte/store';
+import { writable, type Readable } from 'svelte/store';
 import { browser } from '$app/environment';
 
 export type Theme = 'light' | 'dark' | 'system';
@@ -36,7 +36,7 @@ function applyTheme(theme: 'light' | 'dark') {
 	}
 }
 
-function createThemeStore(): Writable<Theme> & {
+function createThemeStore(): Readable<Theme> & {
 	initialize: () => void;
 	setTheme: (theme: Theme) => void;
 	getResolvedTheme: () => 'light' | 'dark';

--- a/src/lib/timerSettings.ts
+++ b/src/lib/timerSettings.ts
@@ -16,7 +16,6 @@ import { get, writable } from 'svelte/store';
 import { ndk, userPublickey, ndkReady } from '$lib/nostr';
 // Note: ndkReady is a Promise, not a store - use await ndkReady, not get(ndkReady)
 import { NDKEvent } from '@nostr-dev-kit/ndk';
-import { getOutboxRelays } from '$lib/relayListCache';
 import { CLIENT_TAG_IDENTIFIER } from '$lib/consts';
 
 // ═══════════════════════════════════════════════════════════════
@@ -165,12 +164,9 @@ export async function saveTimerSettings(settings: TimerSettings): Promise<boolea
       ['client', CLIENT_TAG_IDENTIFIER],
     ];
 
-    // Get user's outbox relays
-    const outboxRelays = await getOutboxRelays(pubkey);
-
     // Sign and publish
     await event.sign();
-    await event.publish(outboxRelays);
+    await event.publish();
 
     console.log('[TimerSettings] Saved to relay:', settings);
     return true;

--- a/src/lib/timerStore.ts
+++ b/src/lib/timerStore.ts
@@ -94,7 +94,7 @@ async function initDatabase(): Promise<void> {
       resolve();
     };
 
-    request.onupgradeneeded = (event) => {
+    request.onupgradeneeded = (event: IDBVersionChangeEvent) => {
       const database = (event.target as IDBOpenDBRequest).result;
 
       // Create timers store

--- a/src/lib/translation.ts
+++ b/src/lib/translation.ts
@@ -2,10 +2,20 @@ import { setCORS as googletranslate } from 'google-translate-api-browser';
 import type { TranslateOption } from './state';
 //import { translate as libretranslate } from 'libretranslate';
 
-export async function translate(translateOption: TranslateOption, string: string) {
+type TranslationResult = {
+  text: string;
+  from: { language: { iso: string } };
+};
+
+export async function translate(
+  translateOption: TranslateOption,
+  string: string
+): Promise<TranslationResult | ''> {
   if (translateOption.option == 'google') {
-    const gTranslate = googletranslate(translateOption.data);
-    // @ts-expect-error not my code, eslint got mad :(
+    const gTranslate = googletranslate(translateOption.data) as (
+      text: string,
+      options: { to: string }
+    ) => Promise<TranslationResult>;
     const e = await gTranslate(string, { to: translateOption.lang });
     return e;
   }

--- a/src/lib/types/google-translate-api-browser.d.ts
+++ b/src/lib/types/google-translate-api-browser.d.ts
@@ -1,0 +1,10 @@
+declare module 'google-translate-api-browser' {
+  export interface GoogleTranslateResult {
+    text: string;
+    from: { language: { iso: string } };
+  }
+
+  export function setCORS(
+    apiUrl?: string
+  ): (text: string, options: { to: string }) => Promise<GoogleTranslateResult>;
+}

--- a/src/lib/types/svelte-qrcode.d.ts
+++ b/src/lib/types/svelte-qrcode.d.ts
@@ -1,0 +1,10 @@
+declare module 'svelte-qrcode' {
+  import type { SvelteComponentTyped } from 'svelte';
+
+  export default class QRCode extends SvelteComponentTyped<{
+    value: string;
+    size?: number;
+    level?: 'L' | 'M' | 'Q' | 'H';
+    [key: string]: any;
+  }> {}
+}

--- a/src/lib/types/vitest.d.ts
+++ b/src/lib/types/vitest.d.ts
@@ -1,0 +1,5 @@
+declare module 'vitest' {
+  export const describe: (...args: any[]) => any;
+  export const it: (...args: any[]) => any;
+  export const expect: (...args: any[]) => any;
+}

--- a/src/lib/wallet/nwc.ts
+++ b/src/lib/wallet/nwc.ts
@@ -117,7 +117,7 @@ function normalizeSecretKey(secret: string): string {
  */
 function getPublicKey(secret: string): string {
 	const secretHex = normalizeSecretKey(secret)
-	return nostrGetPublicKey(secretHex)
+	return nostrGetPublicKey(secretHex as any)
 }
 
 /**

--- a/src/lib/zapManager.ts
+++ b/src/lib/zapManager.ts
@@ -186,11 +186,12 @@ export class ZapManager {
       console.log('Attempting to sign zap request...');
       await zapRequest.sign();
       console.log('Zap request signed successfully');
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('Error signing zap request:', error);
+      const err = error instanceof Error ? error : new Error(String(error));
       
       // If signing fails, we might need to create an anonymous signer for the zap request
-      if (error.message.includes('signer') || error.message.includes('private key')) {
+      if (err.message.includes('signer') || err.message.includes('private key')) {
         console.log('Signing failed due to missing signer - creating anonymous zap request');
         // For zap requests, we might not need a signer if the LNURL endpoint doesn't require it
         // Let's try without signing first
@@ -201,7 +202,7 @@ export class ZapManager {
           console.error(`Couldn't post zap anon: ${ex}`)
         }
       } else {
-        throw new Error(`Failed to sign zap request: ${error}`);
+        throw new Error(`Failed to sign zap request: ${err.message}`);
       }
     }
 
@@ -254,14 +255,15 @@ export class ZapManager {
         routes: data.routes || [],
         verify: data.verify
       };
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('Error in callback request:', error);
+      const err = error instanceof Error ? error : new Error(String(error));
       
-      if (error.name === 'AbortError') {
+      if (err.name === 'AbortError') {
         throw new Error('Invoice request timed out after 15 seconds');
       }
       
-      throw new Error(`Failed to get invoice: ${error}`);
+      throw new Error(`Failed to get invoice: ${err.message}`);
     }
   }
 

--- a/src/routes/[nip19]/+page.svelte
+++ b/src/routes/[nip19]/+page.svelte
@@ -6,7 +6,7 @@
   import { mutedPubkeys, muteListStore } from '$lib/muteListStore';
   import { onMount, onDestroy } from 'svelte';
   import { get } from 'svelte/store';
-  import CustomAvatar from '../../components/CustomAvatar.svelte';
+  import Avatar from '../../components/Avatar.svelte';
   import CustomName from '../../components/CustomName.svelte';
   import AuthorName from '../../components/AuthorName.svelte';
   import { formatDistanceToNow } from 'date-fns';
@@ -103,7 +103,7 @@
 
         seenIds.add(parentId);
 
-        const parentNote = await $ndk.fetchEvent({ kinds: [1, 1111], ids: [parentId] });
+        const parentNote = await $ndk.fetchEvent({ kinds: [1, 1111] as any, ids: [parentId] });
         if (!parentNote) break;
 
         parents.unshift(parentNote); // Add to beginning for chronological order
@@ -293,10 +293,10 @@
 
       // Use shared utility to build NIP-22 or NIP-10 tags
       ev.tags = buildNip22CommentTags({
-        kind: event.kind,
+        kind: event.kind ?? 1,
         pubkey: event.pubkey,
         id: event.id,
-        tags: event.tags
+        tags: event.tags as string[][]
       });
 
       // Parse and add @ mention tags (p tags)
@@ -325,6 +325,7 @@
   // Filter to get only direct replies (not nested)
   $: directReplies = replies.filter((r) => {
     if (!event) return false;
+    const rootEvent = event;
 
     // For NIP-22 comments (kind 1111)
     if (r.kind === 1111) {
@@ -333,16 +334,16 @@
       const kTags = r.getMatchingTags('k');
 
       // Check if this comment's 'a' tag matches the root article address
-      const dTag = event.tags.find((t) => t[0] === 'd')?.[1];
+      const dTag = rootEvent.tags.find((t) => t[0] === 'd')?.[1];
       if (dTag) {
-        const rootAddress = `${event.kind}:${event.pubkey}:${dTag}`;
+        const rootAddress = `${rootEvent.kind}:${rootEvent.pubkey}:${dTag}`;
         const matchesRoot = aTags.some((tag) => tag[1] === rootAddress);
 
         // Check if parent 'e' tag points to root event (top-level comment)
         // and 'k' tag shows parent is the root kind (30023)
         const isTopLevel =
-          eTags.some((tag) => tag[1] === event.id) &&
-          kTags.some((tag) => tag[1] === String(event.kind));
+          eTags.some((tag) => tag[1] === rootEvent.id) &&
+          kTags.some((tag) => tag[1] === String(rootEvent.kind));
 
         return matchesRoot && isTopLevel;
       }
@@ -549,7 +550,7 @@
                       parentNote.author?.hexpubkey || parentNote.pubkey
                     )}"
                   >
-                    <CustomAvatar
+                    <Avatar
                       pubkey={parentNote.author?.hexpubkey || parentNote.pubkey}
                       size={40}
                     />
@@ -600,7 +601,7 @@
           href="/user/{nip19.npubEncode(event.author?.hexpubkey || event.pubkey)}"
           class="flex-shrink-0"
         >
-          <CustomAvatar
+          <Avatar
             className="cursor-pointer"
             pubkey={event.author?.hexpubkey || event.pubkey}
             size={40}
@@ -667,7 +668,7 @@
       {#if $userPublickey}
         <div class="mb-4 p-3 rounded-lg" style="background-color: var(--color-bg-secondary)">
           <div class="flex gap-3">
-            <CustomAvatar pubkey={$userPublickey} size={32} />
+            <Avatar pubkey={$userPublickey} size={32} />
             <div class="flex-1">
               <div class="relative">
                 <div
@@ -676,6 +677,7 @@
                   style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border); color: var(--color-text-primary); min-height: 60px;"
                   contenteditable="true"
                   role="textbox"
+                  tabindex="0"
                   aria-multiline="true"
                   data-placeholder="Write a reply..."
                   on:input={() => mentionCtrl.handleInput()}
@@ -742,7 +744,7 @@
                       href="/user/{nip19.npubEncode(reply.author?.hexpubkey || reply.pubkey)}"
                       class="flex-shrink-0"
                     >
-                      <CustomAvatar pubkey={reply.author?.hexpubkey || reply.pubkey} size={32} />
+                      <Avatar pubkey={reply.author?.hexpubkey || reply.pubkey} size={32} />
                     </a>
                     <div class="flex-1 min-w-0">
                       <div class="flex items-center justify-between mb-1">
@@ -787,7 +789,7 @@
                             )}"
                             class="flex-shrink-0"
                           >
-                            <CustomAvatar
+                            <Avatar
                               pubkey={nestedReply.author?.hexpubkey || nestedReply.pubkey}
                               size={24}
                             />

--- a/src/routes/api/counts/[eventId]/+server.ts
+++ b/src/routes/api/counts/[eventId]/+server.ts
@@ -235,7 +235,7 @@ export const GET: RequestHandler = async ({ params, url, platform }) => {
   }
 
   // Check for Cloudflare KV cache first (if available)
-  const kvCache = platform?.env?.COUNT_CACHE;
+  const kvCache = (platform?.env as any)?.COUNT_CACHE;
   const cacheKey = `counts:${eventId}`;
 
   // Check in-memory cache

--- a/src/routes/api/counts/batch/+server.ts
+++ b/src/routes/api/counts/batch/+server.ts
@@ -224,7 +224,7 @@ export const POST: RequestHandler = async ({ request, platform }) => {
     return json({ error: 'No valid event IDs provided' }, { status: 400 });
   }
 
-  const kvCache = platform?.env?.COUNT_CACHE;
+  const kvCache = (platform?.env as any)?.COUNT_CACHE;
   const response: BatchResponse = {
     counts: {},
     cached: [],

--- a/src/routes/api/extract-recipe/+server.ts
+++ b/src/routes/api/extract-recipe/+server.ts
@@ -164,7 +164,7 @@ async function fetchUrlContent(url: string): Promise<{ text: string; imageUrls: 
 export const POST: RequestHandler = async ({ request, platform }) => {
   try {
     // Check for OpenAI API key
-    const OPENAI_API_KEY = platform?.env?.OPENAI_API_KEY || env.OPENAI_API_KEY;
+    const OPENAI_API_KEY = (platform?.env as any)?.OPENAI_API_KEY || env.OPENAI_API_KEY;
     if (!OPENAI_API_KEY) {
       return json(
         { success: false, error: 'OpenAI API key not configured' },

--- a/src/routes/api/genesis/complete-payment/+server.ts
+++ b/src/routes/api/genesis/complete-payment/+server.ts
@@ -58,7 +58,7 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 
     const Stripe = (await import('stripe')).default;
     const stripe = new Stripe(stripeKey, {
-      apiVersion: '2024-12-18.acacia',
+      apiVersion: '2025-12-15.clover',
       typescript: true,
     });
 
@@ -74,7 +74,7 @@ export const POST: RequestHandler = async ({ request, platform }) => {
     }
 
     // Ensure this Checkout Session is for the Genesis Founder tier
-    const EXPECTED_TIER = platform?.env?.GENESIS_TIER || env.GENESIS_TIER || 'genesis-founder';
+    const EXPECTED_TIER = (platform?.env as any)?.GENESIS_TIER || env.GENESIS_TIER || 'genesis-founder';
     if (!session.metadata || session.metadata.tier !== EXPECTED_TIER) {
       return json(
         { error: 'Payment session is not for the Genesis Founder tier' },

--- a/src/routes/api/membership/+server.ts
+++ b/src/routes/api/membership/+server.ts
@@ -1,0 +1,83 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import { lookupMember } from '$lib/membershipApi.server';
+
+type ApiMembershipStatus = {
+  active: boolean;
+  tier: string;
+  expiresAt?: string;
+};
+
+function normalizeTier(tier: string | null | undefined): string {
+  const value = String(tier || '').trim().toLowerCase();
+  if (value === 'cook_plus' || value === 'cook-plus' || value === 'cook plus') return 'cook_plus';
+  if (value === 'pro_kitchen' || value === 'pro-kitchen' || value === 'pro kitchen') return 'pro_kitchen';
+  if (value === 'founders' || value === 'founder') return 'founders';
+  return 'member';
+}
+
+function parsePubkeys(url: URL): string[] {
+  const raw = url.searchParams.get('pubkeys') || '';
+  if (!raw) return [];
+
+  return [...new Set(raw.split(',').map((pk) => pk.trim().toLowerCase()))].filter((pk) =>
+    /^[a-f0-9]{64}$/.test(pk)
+  );
+}
+
+function mockMembership(pubkey: string): ApiMembershipStatus {
+  // Deterministic mock for local/dev environments without membership backend configured.
+  const bucket = parseInt(pubkey.slice(-2), 16) % 5;
+  if (bucket === 0) return { active: true, tier: 'cook_plus' };
+  if (bucket === 1) return { active: true, tier: 'pro_kitchen' };
+  if (bucket === 2) return { active: true, tier: 'founders' };
+  return { active: false, tier: 'member' };
+}
+
+export const GET: RequestHandler = async ({ url, platform }) => {
+  const pubkeys = parsePubkeys(url);
+  if (pubkeys.length === 0) {
+    return json({});
+  }
+
+  const limitedPubkeys = pubkeys.slice(0, 300);
+  const results: Record<string, ApiMembershipStatus> = {};
+
+  const membershipEnabled = String(
+    platform?.env?.MEMBERSHIP_ENABLED || env.MEMBERSHIP_ENABLED || ''
+  ).toLowerCase();
+  const apiSecret = platform?.env?.RELAY_API_SECRET || env.RELAY_API_SECRET;
+
+  // TODO: wire this endpoint to the canonical membership source for all environments.
+  const shouldUseLiveLookup = membershipEnabled === 'true' && Boolean(apiSecret);
+
+  if (!shouldUseLiveLookup) {
+    for (const pubkey of limitedPubkeys) {
+      results[pubkey] = mockMembership(pubkey);
+    }
+    return json(results);
+  }
+
+  await Promise.all(
+    limitedPubkeys.map(async (pubkey) => {
+      try {
+        const lookup = await lookupMember(pubkey, apiSecret!);
+        if (!lookup.found) {
+          results[pubkey] = { active: false, tier: 'member' };
+          return;
+        }
+
+        results[pubkey] = {
+          active: lookup.isActive,
+          tier: normalizeTier(lookup.member?.tier),
+          expiresAt: lookup.member?.subscription_end || undefined
+        };
+      } catch (error) {
+        console.warn('[api/membership] Failed lookup for pubkey:', pubkey, error);
+        results[pubkey] = { active: false, tier: 'member' };
+      }
+    })
+  );
+
+  return json(results);
+};

--- a/src/routes/api/membership/complete-payment/+server.ts
+++ b/src/routes/api/membership/complete-payment/+server.ts
@@ -58,7 +58,7 @@ export const POST: RequestHandler = async ({ request, platform }) => {
     // Verify Stripe session
     const Stripe = (await import('stripe')).default;
     const stripe = new Stripe(stripeKey, {
-      apiVersion: '2024-12-18.acacia',
+      apiVersion: '2025-12-15.clover',
       typescript: true,
     });
 

--- a/src/routes/api/stripe/create-genesis-session/+server.ts
+++ b/src/routes/api/stripe/create-genesis-session/+server.ts
@@ -54,7 +54,7 @@ export const POST: RequestHandler = async ({ request, platform }) => {
     // Dynamic import to avoid Cloudflare Workers build issues
     const Stripe = (await import('stripe')).default;
     const stripe = new Stripe(stripeKey, {
-      apiVersion: '2024-12-18.acacia',
+      apiVersion: '2025-12-15.clover',
       typescript: true,
     });
     

--- a/src/routes/api/stripe/create-portal-session/+server.ts
+++ b/src/routes/api/stripe/create-portal-session/+server.ts
@@ -55,7 +55,7 @@ export const POST: RequestHandler = async ({ request, platform }) => {
     // Dynamic import to avoid Cloudflare Workers build issues
     const Stripe = (await import('stripe')).default;
     const stripe = new Stripe(stripeKey, {
-      apiVersion: '2024-12-18.acacia',
+      apiVersion: '2025-12-15.clover',
       typescript: true,
     });
 

--- a/src/routes/api/stripe/webhook/+server.ts
+++ b/src/routes/api/stripe/webhook/+server.ts
@@ -52,7 +52,7 @@ export const POST: RequestHandler = async ({ request, platform }) => {
     // Dynamic import to avoid Cloudflare Workers build issues
     const Stripe = (await import('stripe')).default;
     const stripe = new Stripe(stripeKey, {
-      apiVersion: '2024-12-18.acacia',
+      apiVersion: '2025-12-15.clover',
       typescript: true,
     });
 

--- a/src/routes/api/zappy/+server.ts
+++ b/src/routes/api/zappy/+server.ts
@@ -84,7 +84,7 @@ const HUNGRY_PROMPT = `Surprise me with a random recipe! It could be any cuisine
 export const POST: RequestHandler = async ({ request, platform }) => {
   try {
     // Check for OpenAI API key
-    const OPENAI_API_KEY = platform?.env?.OPENAI_API_KEY || env.OPENAI_API_KEY;
+    const OPENAI_API_KEY = (platform?.env as any)?.OPENAI_API_KEY || env.OPENAI_API_KEY;
     if (!OPENAI_API_KEY) {
       return json(
         { ok: false, error: 'OpenAI API key not configured' },

--- a/src/routes/api/zappy/scan/+server.ts
+++ b/src/routes/api/zappy/scan/+server.ts
@@ -48,7 +48,7 @@ If no food items are clearly visible, respond with an empty array: []`;
 export const POST: RequestHandler = async ({ request, platform }) => {
   try {
     // Check for OpenAI API key
-    const OPENAI_API_KEY = platform?.env?.OPENAI_API_KEY || env.OPENAI_API_KEY;
+    const OPENAI_API_KEY = (platform?.env as any)?.OPENAI_API_KEY || env.OPENAI_API_KEY;
     if (!OPENAI_API_KEY) {
       return json(
         { ok: false, error: 'OpenAI API key not configured' },

--- a/src/routes/cookbook/+page.svelte
+++ b/src/routes/cookbook/+page.svelte
@@ -416,19 +416,20 @@
       
       if (success) {
         console.log('Cover recipe updated successfully');
+        const selectedListId = selectedList.id;
         
         // Clear cover image cache for this list
-        coverImages.delete(selectedList.id);
+        coverImages.delete(selectedListId);
         
         // Get updated list from store
         const updatedStoreState = get(cookbookStore);
-        const updatedList = updatedStoreState.lists.find(l => l.id === selectedList.id);
+        const updatedList = updatedStoreState.lists.find(l => l.id === selectedListId);
         
         if (updatedList) {
           // Reload cover image immediately with cache-busting
           const newCoverImage = await getCookbookCoverImage(updatedList, $ndk, true);
           if (newCoverImage) {
-            coverImages.set(selectedList.id, newCoverImage);
+            coverImages.set(selectedListId, newCoverImage);
             coverImages = new Map(coverImages); // Trigger reactivity
           }
         } else {

--- a/src/routes/cookbook/[naddr]/+page.svelte
+++ b/src/routes/cookbook/[naddr]/+page.svelte
@@ -403,7 +403,7 @@
           l.id === listId 
             ? { 
                 ...l, 
-                coverRecipeId: selectedCoverRecipeATag,
+                coverRecipeId: selectedCoverRecipeATag ?? undefined,
                 event: newEvent
               }
             : l

--- a/src/routes/create/gated/+page.svelte
+++ b/src/routes/create/gated/+page.svelte
@@ -126,10 +126,11 @@
       additionalMarkdown
     };
     
-    currentDraftId = saveDraft(draftData, currentDraftId || undefined);
+    const saveResult = saveDraft(draftData, currentDraftId || undefined);
+    currentDraftId = saveResult.draftId;
     draftSaveMessage = 'Draft saved!';
     
-    if (browser) {
+    if (browser && currentDraftId) {
       const url = new URL(window.location.href);
       url.searchParams.set('draft', currentDraftId);
       window.history.replaceState({}, '', url.toString());

--- a/src/routes/debug/+page.svelte
+++ b/src/routes/debug/+page.svelte
@@ -42,8 +42,8 @@
         setTimeout(() => reject(new Error('Timeout')), 10000)
       );
       
-      const events = await Promise.race([
-        $ndk.fetchEvents(testFilter, undefined, relaySet),
+      const events = await Promise.race<Set<NDKEvent>>([
+        $ndk.fetchEvents(testFilter, undefined, relaySet) as Promise<Set<NDKEvent>>,
         timeoutPromise
       ]);
       
@@ -145,12 +145,12 @@
           
           // Test basic connectivity with shorter timeout
           const filter = { kinds: [1], limit: 1 };
-          const fetchPromise = $ndk.fetchEvents(filter);
-          const timeoutPromise = new Promise((_, reject) => 
+          const fetchPromise: Promise<Set<NDKEvent>> = $ndk.fetchEvents(filter) as Promise<Set<NDKEvent>>;
+          const timeoutPromise = new Promise<never>((_, reject) =>
             setTimeout(() => reject(new Error('Connection timeout after 5 seconds')), 5000)
           );
-          
-          const events = await Promise.race([fetchPromise, timeoutPromise]);
+
+          const events = await Promise.race<Set<NDKEvent>>([fetchPromise, timeoutPromise]);
           
           debugInfo = `✅ Success! Found ${events.size} events. NDK is working.`;
           isConnected = true;
@@ -161,13 +161,14 @@
         debugInfo = '❌ NDK instance not found';
       }
     } catch (error) {
-      debugInfo = `❌ Error: ${error.message}`;
+      const message = error instanceof Error ? error.message : String(error);
+      debugInfo = `❌ Error: ${message}`;
       console.error('Debug error:', error);
       
       // Try to get more info about the error
-      if (error.message.includes('timeout')) {
+      if (message.includes('timeout')) {
         debugInfo += ' - This suggests the relays are not responding.';
-      } else if (error.message.includes('WebSocket')) {
+      } else if (message.includes('WebSocket')) {
         debugInfo += ' - WebSocket connection failed.';
       }
     }

--- a/src/routes/dev/avatar-rings/+page.svelte
+++ b/src/routes/dev/avatar-rings/+page.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import Avatar from '../../../components/Avatar.svelte';
+
+  const demoUsers = [
+    { pubkey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', label: 'Cook Plus' },
+    { pubkey: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', label: 'Pro Kitchen' },
+    { pubkey: 'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc', label: 'Founders' },
+    { pubkey: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd', label: 'Non-member' }
+  ];
+</script>
+
+<svelte:head>
+  <title>Avatar Membership Ring Dev</title>
+</svelte:head>
+
+<div class="max-w-xl mx-auto px-4 py-8">
+  <h1 class="text-xl font-semibold mb-5">Avatar Membership Ring Dev</h1>
+  <p class="text-sm mb-6" style="color: var(--color-text-secondary);">
+    Tap/click a ringed avatar to open the membership tooltip.
+  </p>
+
+  <div class="space-y-4">
+    {#each demoUsers as user}
+      <div
+        class="flex items-center justify-between rounded-xl px-4 py-3"
+        style="background-color: var(--color-bg-secondary); border: 1px solid var(--color-input-border);"
+      >
+        <div class="flex items-center gap-3">
+          <Avatar pubkey={user.pubkey} size={44} />
+          <span class="text-sm" style="color: var(--color-text-primary);">{user.label}</span>
+        </div>
+        <code class="text-xs" style="color: var(--color-caption);">{user.pubkey.slice(0, 8)}...</code>
+      </div>
+    {/each}
+  </div>
+</div>

--- a/src/routes/explore/+page.svelte
+++ b/src/routes/explore/+page.svelte
@@ -179,7 +179,9 @@
     }
   }
 
-  onMount(async () => {
+  onMount(() => {
+    let cleanup: (() => void) | undefined;
+    void (async () => {
     syncTipPointer();
     await loadExploreData();
 
@@ -202,6 +204,13 @@
         scrollContainer?.removeEventListener('scroll', handleLayoutChange);
       };
     }
+    })().then((result) => {
+      cleanup = result;
+    });
+
+    return () => {
+      cleanup?.();
+    };
   });
 
   function navigateToTag(tag: recipeTagSimple) {

--- a/src/routes/grocery/+page.svelte
+++ b/src/routes/grocery/+page.svelte
@@ -55,9 +55,6 @@
       goto(`/grocery/${newList.id}`);
     } catch (error) {
       console.error('Failed to create list:', error);
-      groceryError.set(
-        `Failed to create list: ${error instanceof Error && error.message ? error.message : 'Unknown error'}`
-      );
     } finally {
       isCreating = false;
     }

--- a/src/routes/membership/confirmation/+page.svelte
+++ b/src/routes/membership/confirmation/+page.svelte
@@ -203,13 +203,14 @@
       if (!canvasEl) return;
       const ctx = canvasEl.getContext('2d');
       if (!ctx) return;
+      const context = ctx;
 
       const dpr = window.devicePixelRatio || 1;
       const w = canvasEl.offsetWidth;
       const h = canvasEl.offsetHeight;
       canvasEl.width = w * dpr;
       canvasEl.height = h * dpr;
-      ctx.scale(dpr, dpr);
+      context.scale(dpr, dpr);
 
       const accent = config.accent;
       const colors = ['#E8652B', '#F28C5A', '#FBBF24', '#F97316', '#FB923C', '#FCD34D', '#fff', accent];
@@ -233,7 +234,7 @@
         const elapsed = performance.now() - startTime;
         const fade = elapsed > duration ? Math.max(0, 1 - (elapsed - duration) / 1000) : 1;
 
-        ctx.clearRect(0, 0, w, h);
+        context.clearRect(0, 0, w, h);
         if (fade <= 0) return; // done
 
         pieces.forEach((p) => {
@@ -241,13 +242,13 @@
           p.x += p.drift;
           p.angle += p.spin;
           if (p.y > h + 20) { p.y = -20; p.x = Math.random() * w; }
-          ctx.save();
-          ctx.translate(p.x, p.y);
-          ctx.rotate(p.angle);
-          ctx.globalAlpha = p.opacity * fade;
-          ctx.fillStyle = p.color;
-          ctx.fillRect(-p.w / 2, -p.h / 2, p.w, p.h);
-          ctx.restore();
+          context.save();
+          context.translate(p.x, p.y);
+          context.rotate(p.angle);
+          context.globalAlpha = p.opacity * fade;
+          context.fillStyle = p.color;
+          context.fillRect(-p.w / 2, -p.h / 2, p.w, p.h);
+          context.restore();
         });
         animFrame = requestAnimationFrame(animate);
       }

--- a/src/routes/membership/cook-plus-success/+page.svelte
+++ b/src/routes/membership/cook-plus-success/+page.svelte
@@ -200,7 +200,7 @@
                 <button
                   type="button"
                   class="add-to-profile-button"
-                  on:click={() => autoUpdateProfileNip05(nip05)}
+                  on:click={() => nip05 && autoUpdateProfileNip05(nip05)}
                 >
                   Add to Profile
                 </button>

--- a/src/routes/membership/genesis-success/+page.svelte
+++ b/src/routes/membership/genesis-success/+page.svelte
@@ -189,7 +189,7 @@
                 <button
                   type="button"
                   class="add-to-profile-button"
-                  on:click={() => autoUpdateProfileNip05(nip05)}
+                  on:click={() => nip05 && autoUpdateProfileNip05(nip05)}
                 >
                   Add to Profile
                 </button>

--- a/src/routes/membership/pro-kitchen-success/+page.svelte
+++ b/src/routes/membership/pro-kitchen-success/+page.svelte
@@ -199,7 +199,7 @@
                 <button
                   type="button"
                   class="add-to-profile-button"
-                  on:click={() => autoUpdateProfileNip05(nip05)}
+                  on:click={() => nip05 && autoUpdateProfileNip05(nip05)}
                 >
                   Add to Profile
                 </button>

--- a/src/routes/notifications/+page.svelte
+++ b/src/routes/notifications/+page.svelte
@@ -10,7 +10,7 @@
   import { browser } from '$app/environment';
   import { formatDistanceToNow } from 'date-fns';
   import { nip19, nip21 } from 'nostr-tools';
-  import CustomAvatar from '../../components/CustomAvatar.svelte';
+  import Avatar from '../../components/Avatar.svelte';
   import CustomName from '../../components/CustomName.svelte';
   import { userPublickey, ndk } from '$lib/nostr';
   import { hellthreadThreshold } from '$lib/hellthreadFilterSettings';
@@ -667,7 +667,7 @@
               style="border-color: var(--color-input-border);"
             >
               <div class="relative flex-shrink-0">
-                <CustomAvatar pubkey={notification.fromPubkey} size={48} />
+                <Avatar pubkey={notification.fromPubkey} size={48} />
                 <span class="absolute -bottom-1 -right-1 text-lg">
                   {getIcon(notification.type)}
                 </span>
@@ -701,7 +701,7 @@
                       <div class="mt-1 h-3 bg-accent-gray rounded w-48 animate-pulse"></div>
                     {:else if refId && ctx}
                       <div class="flex items-center gap-2">
-                        <CustomAvatar pubkey={ctx.pubkey} size={18} />
+                        <Avatar pubkey={ctx.pubkey} size={18} />
                         <span
                           class="text-xs font-medium"
                           style="color: var(--color-text-secondary);"

--- a/src/routes/premium/recipe/[slug]/+page.svelte
+++ b/src/routes/premium/recipe/[slug]/+page.svelte
@@ -67,16 +67,16 @@
         });
         
         // Fetch the recipe event
-        const fetchPromise = $ndk.fetchEvent({
+        const fetchPromise: Promise<NDKEvent | null> = $ndk.fetchEvent({
           '#d': [b.identifier],
           authors: [b.pubkey],
           kinds: [recipeKind as number]
         });
-        const timeoutPromise = new Promise((_, reject) => 
+        const timeoutPromise = new Promise<never>((_, reject) =>
           setTimeout(() => reject(new Error('Recipe loading timeout')), 10000)
         );
         
-        let e = await Promise.race([fetchPromise, timeoutPromise]);
+        const e = await Promise.race<NDKEvent | null>([fetchPromise, timeoutPromise]);
         if (e) {
           event = e;
           

--- a/src/routes/r/[naddr]/+page.svelte
+++ b/src/routes/r/[naddr]/+page.svelte
@@ -49,16 +49,16 @@
         });
         
         // Add timeout protection for recipe loading
-        const fetchPromise = $ndk.fetchEvent({
+        const fetchPromise: Promise<NDKEvent | null> = $ndk.fetchEvent({
           '#d': [b.identifier],
           authors: [b.pubkey],
           kinds: [recipeKind as number]
         });
-        const timeoutPromise = new Promise((_, reject) => 
+        const timeoutPromise = new Promise<never>((_, reject) =>
           setTimeout(() => reject(new Error('Recipe loading timeout - relays may be unreachable')), 10000)
         );
-        
-        let e = await Promise.race([fetchPromise, timeoutPromise]);
+
+        const e = await Promise.race<NDKEvent | null>([fetchPromise, timeoutPromise]);
         if (e) {
           event = e;
           loading = false;
@@ -180,6 +180,7 @@
     const sp = t.lastIndexOf(' ');
     return (sp > 80 ? t.slice(0, sp) : t) + '...';
   })();
+  $: publishedAt = event?.created_at ?? data?.ogMeta?.created_at ?? null;
 
   // Check if this is a longform article (not a recipe) to show "Back to Reads" link
   $: isLongformArticle = event && event.kind === 30023 && !event.tags.some(
@@ -199,8 +200,8 @@
   <meta property="og:image" content={og_image} />
   <meta property="og:image:secure_url" content={og_image} />
   <meta property="og:site_name" content="zap.cooking" />
-  {#if event?.created_at || data?.ogMeta?.created_at}
-    <meta property="article:published_time" content={new Date((event?.created_at || data?.ogMeta?.created_at) * 1000).toISOString()} />
+  {#if publishedAt !== null}
+    <meta property="article:published_time" content={new Date(publishedAt * 1000).toISOString()} />
   {/if}
   {#if event?.pubkey || data?.ogMeta?.pubkey}
     <meta property="article:author" content={`https://zap.cooking/p/${event?.pubkey || data?.ogMeta?.pubkey}`} />

--- a/src/routes/reads/[naddr]/+page.svelte
+++ b/src/routes/reads/[naddr]/+page.svelte
@@ -47,19 +47,19 @@
         });
         
         // Add timeout protection for article loading
-        const fetchPromise = $ndk.fetchEvent({
+        const fetchPromise: Promise<NDKEvent | null> = $ndk.fetchEvent({
           '#d': [b.identifier],
           authors: [b.pubkey],
           kinds: [30023]
         });
-        const timeoutPromise = new Promise((_, reject) => 
+        const timeoutPromise = new Promise<never>((_, reject) =>
           setTimeout(() => reject(new Error('Article loading timeout - relays may be unreachable')), 10000)
         );
-        
-        let e = await Promise.race([fetchPromise, timeoutPromise]);
+
+        const e = await Promise.race<NDKEvent | null>([fetchPromise, timeoutPromise]);
         if (e) {
           // Verify it's an article (has zapreads tag)
-          const hasZapreadsTag = e.tags.some(t => t[0] === 't' && t[1] === ARTICLE_TAG);
+          const hasZapreadsTag = e.tags.some((t: string[]) => t[0] === 't' && t[1] === ARTICLE_TAG);
           if (!hasZapreadsTag) {
             throw new Error('This is not an article');
           }

--- a/src/routes/recipe/[slug]/+page.svelte
+++ b/src/routes/recipe/[slug]/+page.svelte
@@ -11,7 +11,7 @@
   import { GATED_RECIPE_KIND } from '$lib/consts';
 
   // Make data optional for static builds (Capacitor)
-  export let data: PageData = { ogMeta: null } as PageData;
+  export let data: PageData = { membershipEnabled: 'false', ogMeta: null } as unknown as PageData;
 
   let event: NDKEvent | null = null;
   let naddr: string = '';
@@ -48,16 +48,16 @@
         });
         
         // Add timeout protection for recipe loading
-        const fetchPromise = $ndk.fetchEvent({
+        const fetchPromise: Promise<NDKEvent | null> = $ndk.fetchEvent({
           '#d': [b.identifier],
           authors: [b.pubkey],
           kinds: [recipeKind as number]
         });
-        const timeoutPromise = new Promise((_, reject) => 
+        const timeoutPromise = new Promise<never>((_, reject) =>
           setTimeout(() => reject(new Error('Recipe loading timeout - relays may be unreachable')), 10000)
         );
         
-        let e = await Promise.race([fetchPromise, timeoutPromise]);
+        const e = await Promise.race<NDKEvent | null>([fetchPromise, timeoutPromise]);
         if (e) {
           event = e;
           loading = false;
@@ -67,12 +67,12 @@
         }
       } else {
         // Add timeout protection for direct event ID loading
-        const fetchPromise = $ndk.fetchEvent($page.params.slug);
-        const timeoutPromise = new Promise((_, reject) => 
+        const fetchPromise: Promise<NDKEvent | null> = $ndk.fetchEvent($page.params.slug);
+        const timeoutPromise = new Promise<never>((_, reject) =>
           setTimeout(() => reject(new Error('Recipe loading timeout - relays may be unreachable')), 10000)
         );
         
-        let e = await Promise.race([fetchPromise, timeoutPromise]);
+        const e = await Promise.race<NDKEvent | null>([fetchPromise, timeoutPromise]);
         if (e) {
           event = e;
           const id = e.tags.find((z: any) => z[0] == 'd')?.[1];
@@ -82,12 +82,12 @@
           naddr = nip19.naddrEncode({
             identifier: id,
             kind: e.kind,
-            pubkey: e.author.pubkey
+            pubkey: e.pubkey
           });
           const c = nip19.naddrEncode({
             identifier: id,
             kind: e.kind,
-            pubkey: e.author.pubkey
+            pubkey: e.pubkey
           });
           loading = false;
           goto(`/recipe/${c}`);
@@ -204,6 +204,7 @@
     const sp = t.lastIndexOf(' ');
     return (sp > 80 ? t.slice(0, sp) : t) + '...';
   })();
+  $: publishedAt = event?.created_at ?? data?.ogMeta?.created_at ?? null;
 </script>
 
 <svelte:head>
@@ -218,8 +219,8 @@
   <meta property="og:image" content={og_image} />
   <meta property="og:image:secure_url" content={og_image} />
   <meta property="og:site_name" content="zap.cooking" />
-  {#if event?.created_at || data?.ogMeta?.created_at}
-    <meta property="article:published_time" content={new Date((event?.created_at || data?.ogMeta?.created_at) * 1000).toISOString()} />
+  {#if publishedAt !== null}
+    <meta property="article:published_time" content={new Date(publishedAt * 1000).toISOString()} />
   {/if}
   {#if event?.pubkey || data?.ogMeta?.pubkey}
     <meta property="article:author" content={`https://zap.cooking/p/${event?.pubkey || data?.ogMeta?.pubkey}`} />

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -342,7 +342,7 @@
   $: connectedRelaySet = new Set(connectedRelays.map(normalizeRelayUrl));
 
   // Wallet info
-  $: connectedWallets = $wallets.filter((w) => w.kind !== 0);
+  $: connectedWallets = $wallets;
   $: activeWallet = connectedWallets.find((w) => w.active);
   // Check if user has an in-app wallet (Spark kind=4 or NWC kind=3) for auto-zap
   $: hasInAppWallet = $wallets.some((w) => w.kind === 3 || w.kind === 4);

--- a/src/routes/user/[slug]/+page.svelte
+++ b/src/routes/user/[slug]/+page.svelte
@@ -8,7 +8,7 @@
   import { validateMarkdownTemplate } from '$lib/parser';
   import { goto } from '$app/navigation';
   import { page } from '$app/stores';
-  import CustomAvatar from '../../../components/CustomAvatar.svelte';
+  import Avatar from '../../../components/Avatar.svelte';
   import CustomName from '../../../components/CustomName.svelte';
   import Button from '../../../components/Button.svelte';
   import LightningIcon from 'phosphor-svelte/lib/Lightning';
@@ -87,8 +87,8 @@
 
   // Profile picture upload state
   let uploadingPicture = false;
-  let pictureInputEl: HTMLInputElement;
-  let avatarRefreshKey = 0; // Used to force CustomAvatar to remount after picture change
+  let pictureInputEl: HTMLInputElement | null = null;
+  let avatarRefreshKey = 0; // Used to force Avatar remount after picture change
 
   // Profile edit modal state
   let profileEditModal = false;
@@ -967,7 +967,7 @@
         userProfilePictureOverride.set(newPictureUrl);
         console.log('[Profile Upload] Store value after set:', $userProfilePictureOverride);
 
-        // Force CustomAvatar to remount with fresh data
+        // Force Avatar to remount with fresh data
         avatarRefreshKey++;
 
         // Reload profile data with force refresh
@@ -1169,7 +1169,7 @@
             >{profile.lud16 || profile.lud06}</span
           >
           <button
-            on:click={() => copyLightningAddress(profile.lud16 || profile.lud06)}
+            on:click={() => copyLightningAddress(profile?.lud16 || profile?.lud06 || '')}
             class="text-caption hover:text-primary transition-colors cursor-pointer flex-shrink-0"
             title="Copy lightning address"
           >
@@ -1300,11 +1300,11 @@
         title="View profile details"
       >
         {#key `${hexpubkey}-${avatarRefreshKey}`}
-          <CustomAvatar
+          <Avatar
             className="cursor-pointer"
             pubkey={hexpubkey || ''}
             size={80}
-            imageUrl={$userPublickey === hexpubkey ? $userProfilePictureOverride : null}
+            src={$userPublickey === hexpubkey ? $userProfilePictureOverride : null}
           />
         {/key}
       </button>

--- a/src/routes/wallet/+page.svelte
+++ b/src/routes/wallet/+page.svelte
@@ -29,6 +29,8 @@
     isValidNwcUrl,
     getPaymentHistory,
     pendingTransactions,
+    addPendingTransaction,
+    updatePendingTransaction,
     removePendingTransaction,
     transactionsNeedRefresh,
     ensurePendingTransactionsLoaded,
@@ -439,6 +441,7 @@
     recipient?: string; // Lightning address or npub
     pubkey?: string; // Nostr pubkey for zap sender/recipient
     comment?: string; // Zap comment
+    txid?: string;
   }
 
   function getTransactionMetadata(txId: string): TransactionMetadata | null {
@@ -2338,7 +2341,7 @@
               <FiatBalance satoshis={$walletBalance} visible={$balanceVisible} />
             </div>
             <!-- Syncing indicator when Spark wallet balance is zero -->
-            {#if $activeWallet?.kind === 4 && $walletBalance === 0n && $sparkSyncing}
+            {#if $activeWallet?.kind === 4 && $walletBalance === 0 && $sparkSyncing}
               <div class="text-xs text-caption flex items-center gap-1 mt-1 ml-11">
                 <ArrowsClockwiseIcon size={12} class="animate-spin" />
                 Syncing wallet...
@@ -4242,7 +4245,7 @@
                     <!-- NWC wallet: Download works without encryption -->
                     <button
                       class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer bg-amber-500 hover:bg-amber-600 text-black"
-                      on:click={() => handleDownloadNwcBackup(walletToDelete)}
+                      on:click={() => walletToDelete && handleDownloadNwcBackup(walletToDelete)}
                       disabled={isBackingUp}
                     >
                       <DownloadSimpleIcon size={16} />
@@ -4253,9 +4256,11 @@
                     <button
                       class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer bg-black hover:bg-gray-800 text-white"
                       on:click={() =>
-                        walletToDelete.kind === 4
+                        walletToDelete?.kind === 4
                           ? handleBackupToNostr()
-                          : handleNwcBackupToNostr(walletToDelete)}
+                          : walletToDelete
+                            ? handleNwcBackupToNostr(walletToDelete)
+                            : undefined}
                       disabled={isBackingUp}
                     >
                       <CloudArrowUpIcon size={16} />
@@ -4599,7 +4604,7 @@
                   <div>
                     <div class="flex items-center justify-between mb-2">
                       <label class="block text-sm font-medium text-caption">Amount (sats)</label>
-                      {#if isBtcAddress && $activeWallet?.kind === 4 && $walletBalance !== null && $walletBalance > 0n}
+                      {#if isBtcAddress && $activeWallet?.kind === 4 && $walletBalance !== null && $walletBalance > 0}
                         <button
                           type="button"
                           class="text-xs text-amber-500 hover:text-amber-400 font-medium"
@@ -4984,9 +4989,7 @@
                       class="w-full"
                       use:qr={{
                         data: `bitcoin:${onchainAddress}`,
-                        shape: 'circle',
-                        width: 100,
-                        height: 100
+                        shape: 'circle'
                       }}
                     />
                   </div>
@@ -5354,9 +5357,7 @@
                         class="w-full"
                         use:qr={{
                           data: generatedInvoice,
-                          shape: 'circle',
-                          width: 100,
-                          height: 100
+                          shape: 'circle'
                         }}
                       />
                     </div>


### PR DESCRIPTION
Membership rings:
- Add Avatar component with tier-based rings (cook_plus, pro_kitchen, founders)
- Batched/cached membership lookups via /api/membership and membershipStatus store
- Tooltip on tap/click for member tier label
- Replace CustomAvatar with Avatar across feed, notifications, replies, profile

Baseline fixes (pnpm check green):
- NDK typing (relay set, signer, pool events, filter kinds)
- Stripe API version, platform env typings
- Promise/store typing, memoization, feed cache
- Draft store remote normalization, theme store type
- Svelte component fixes (null guards, onMount cleanup, implicit any)
- Ambient module declarations (google-translate, svelte-qrcode, vitest)