### PR TITLE
fix: preserve line breaks in recipe summary/abstract display

### DIFF
--- a/src/components/Recipe/Recipe.svelte
+++ b/src/components/Recipe/Recipe.svelte
@@ -892,7 +892,7 @@
 
       <!-- Recipe Summary -->
       {#if event.tags.find((e) => e[0] === 'summary')?.[1]}
-        <p class="text-lg text-caption leading-relaxed">
+        <p class="text-lg text-caption leading-relaxed whitespace-pre-line">
           {event.tags.find((e) => e[0] === 'summary')?.[1]}
         </p>
       {/if}


### PR DESCRIPTION
# Summary
- Adds `whitespace-pre-line` to the recipe summary/abstract `<p>` tag so newline characters (`\n`) in the `summary` tag are rendered as visible line breaks instead of being collapsed by HTML

## Test plan
- View a longform recipe with multi-paragraph summary (e.g. the no seed oil/tahini dressing recipe referenced in the issue)
- Confirm line breaks in the summary display match the author's intent

## Screenshots

Before
<img width="861" height="726" alt="image" src="https://github.com/user-attachments/assets/b55578e9-87ab-42f4-b0f5-feadbf6ce2bc" />

After
<img width="861" height="726" alt="image" src="https://github.com/user-attachments/assets/1fd6cc33-da98-4e32-80b9-59486cccf64b" />