### PR TITLE
fix: prevent avatar glow rings from being clipped in Popular Cooks section

### DIFF
--- a/src/routes/explore/+page.svelte
+++ b/src/routes/explore/+page.svelte
@@ -415,7 +415,7 @@
           <span>Popular Cooks</span>
         </h2>
         {#if loadingCooks}
-          <div class="flex gap-4 overflow-x-auto overflow-y-visible py-2 -mx-4 px-4">
+          <div class="flex gap-4 overflow-x-auto pt-8 pb-4 -mt-6 -mx-4 px-4">
             {#each Array(6) as _}
               <div class="flex-shrink-0 w-20 flex flex-col items-center gap-2">
                 <div class="w-16 h-16 rounded-full animate-pulse skeleton-bg"></div>
@@ -425,7 +425,7 @@
           </div>
         {:else if popularCooks.length > 0}
           <div
-            class="flex gap-4 overflow-x-auto overflow-y-visible py-2 -mx-4 px-4 scrollbar-hide touch-pan-x"
+            class="flex gap-4 overflow-x-auto pt-8 pb-4 -mt-6 -mx-4 px-4 scrollbar-hide touch-pan-x"
           >
             {#each popularCooks as cook}
               <ProfileAvatar pubkey={cook.pubkey} showZapIndicator={false} />


### PR DESCRIPTION
# Summary
- Fixes avatar glow rings being clipped at the top in the Popular Cooks horizontal scroll on the Explore page
- Replaces ineffective `overflow-y-visible` (browsers force both axes to clip when one is `auto`) with increased top padding and negative margin to preserve spacing

## Test plan
- View the Explore page and confirm membership glow rings (Genesis, Pro Kitchen, Cook+) on Popular Cooks avatars are fully visible without cropping

## Screenshots

Before
<img width="979" height="215" alt="image" src="https://github.com/user-attachments/assets/ae627120-c0f2-40c2-b048-8bd658e5add0" />

After
<img width="979" height="215" alt="image" src="https://github.com/user-attachments/assets/9f68101b-d57a-4e52-a025-cf77d9a70112" />