### PR TITLE
feat: dynamic OpenGraph previews for note/event URLs

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -53,9 +53,13 @@
   const ogImage = `${siteUrl}/social-share.png`;
   $: canonical = `${siteUrl}${$page.url.pathname === '/' ? '' : $page.url.pathname}`;
 
-  // Skip layout OG tags on pages that set their own (recipe pages)
+  // Skip layout OG tags on pages that set their own (recipe pages, note pages)
+  $: pathSegment = $page.url.pathname.split('/')[1] || '';
   $: hasCustomOgTags =
-    $page.url.pathname.startsWith('/recipe/') || $page.url.pathname.startsWith('/r/');
+    $page.url.pathname.startsWith('/recipe/') ||
+    $page.url.pathname.startsWith('/r/') ||
+    pathSegment.startsWith('note1') ||
+    pathSegment.startsWith('nevent1');
 
   let authManager: any = null;
   let authState: AuthState = {

--- a/src/routes/[nip19]/+page.server.ts
+++ b/src/routes/[nip19]/+page.server.ts
@@ -1,0 +1,375 @@
+import type { PageServerLoad } from './$types';
+import { nip19 } from 'nostr-tools';
+import { redirect } from '@sveltejs/kit';
+
+// Tracking parameters to strip
+const TRACKING_PARAMS = [
+	'fbclid', 'gclid', 'msclkid',
+	'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content',
+	'ref', 'source'
+];
+
+interface NoteMetadata {
+	content: string;
+	pubkey: string;
+	created_at?: number;
+}
+
+interface ProfileMetadata {
+	name?: string;
+	display_name?: string;
+}
+
+const RELAYS = [
+	'wss://relay.primal.net',
+	'wss://relay.damus.io',
+	'wss://nos.lol'
+];
+
+// Image detection patterns (matching NoteContent.svelte)
+const IMAGE_EXTENSIONS = /\.(jpg|jpeg|png|gif|webp|svg|bmp|avif)(\?.*)?$/i;
+const IMAGE_HOSTS = [
+	'image.nostr.build',
+	'nostr.build',
+	'imgur.com',
+	'imgproxy',
+	'primal.b-cdn.net',
+	'media.tenor.com',
+	'i.ibb.co'
+];
+
+function extractFirstImageUrl(content: string): string | null {
+	const urlRegex = /https?:\/\/[^\s<>"')\]]+/gi;
+	const urls = content.match(urlRegex) || [];
+
+	for (const url of urls) {
+		try {
+			const urlObj = new URL(url);
+			if (IMAGE_EXTENSIONS.test(urlObj.pathname)) return url;
+			if (IMAGE_HOSTS.some(host => urlObj.hostname.includes(host))) return url;
+		} catch {
+			continue;
+		}
+	}
+	return null;
+}
+
+function cleanNoteContent(content: string): string {
+	let text = content
+		// Remove nostr: mentions
+		.replace(/nostr:[a-z0-9]+/gi, '')
+		// Remove image/video URLs
+		.replace(/https?:\/\/[^\s]+\.(jpg|jpeg|png|gif|webp|svg|bmp|avif|mp4|webm|mov)(\?[^\s]*)?/gi, '')
+		// Remove remaining standalone URLs
+		.replace(/https?:\/\/[^\s]+/gi, '')
+		// Collapse whitespace
+		.replace(/\s+/g, ' ')
+		.trim();
+
+	if (text.length > 155) {
+		const truncated = text.slice(0, 155);
+		const lastSpace = truncated.lastIndexOf(' ');
+		const lastSentence = Math.max(
+			truncated.lastIndexOf('.'),
+			truncated.lastIndexOf('!'),
+			truncated.lastIndexOf('?')
+		);
+		if (lastSentence > 80) {
+			return text.slice(0, lastSentence + 1);
+		}
+		return (lastSpace > 80 ? truncated.slice(0, lastSpace) : truncated) + '...';
+	}
+
+	return text || 'A note shared on zap.cooking';
+}
+
+function fetchNoteFromRelay(relayUrl: string, eventId: string): Promise<NoteMetadata | null> {
+	if (typeof WebSocket === 'undefined') {
+		return Promise.resolve(null);
+	}
+
+	return new Promise((resolve) => {
+		let ws: WebSocket | null = null;
+		let resolved = false;
+
+		const cleanup = () => {
+			if (ws && ws.readyState === WebSocket.OPEN) {
+				try { ws.close(); } catch { /* ignore */ }
+			}
+		};
+
+		const safeResolve = (value: NoteMetadata | null) => {
+			if (!resolved) {
+				resolved = true;
+				cleanup();
+				resolve(value);
+			}
+		};
+
+		const timeout = setTimeout(() => {
+			safeResolve(null);
+		}, 3000);
+
+		try {
+			ws = new WebSocket(relayUrl);
+		} catch {
+			clearTimeout(timeout);
+			safeResolve(null);
+			return;
+		}
+
+		const subId = `og-note-${Date.now()}`;
+
+		ws.onopen = () => {
+			if (!ws || resolved) return;
+			try {
+				ws.send(JSON.stringify([
+					'REQ',
+					subId,
+					{ ids: [eventId], limit: 1 }
+				]));
+			} catch {
+				clearTimeout(timeout);
+				safeResolve(null);
+			}
+		};
+
+		ws.onmessage = (event) => {
+			if (!ws || resolved) return;
+			try {
+				const msg = JSON.parse(event.data);
+				if (msg[0] === 'EVENT' && msg[1] === subId && msg[2]) {
+					const evt = msg[2];
+					clearTimeout(timeout);
+					safeResolve({
+						content: evt.content || '',
+						pubkey: evt.pubkey || '',
+						created_at: evt.created_at
+					});
+				} else if (msg[0] === 'EOSE' && msg[1] === subId) {
+					clearTimeout(timeout);
+					safeResolve(null);
+				}
+			} catch {
+				// Parse error, ignore
+			}
+		};
+
+		ws.onerror = () => {
+			clearTimeout(timeout);
+			safeResolve(null);
+		};
+
+		ws.onclose = () => {
+			clearTimeout(timeout);
+			if (!resolved) {
+				safeResolve(null);
+			}
+		};
+	});
+}
+
+function fetchProfileFromRelay(relayUrl: string, pubkey: string): Promise<ProfileMetadata | null> {
+	if (typeof WebSocket === 'undefined') {
+		return Promise.resolve(null);
+	}
+
+	return new Promise((resolve) => {
+		let ws: WebSocket | null = null;
+		let resolved = false;
+
+		const cleanup = () => {
+			if (ws && ws.readyState === WebSocket.OPEN) {
+				try { ws.close(); } catch { /* ignore */ }
+			}
+		};
+
+		const safeResolve = (value: ProfileMetadata | null) => {
+			if (!resolved) {
+				resolved = true;
+				cleanup();
+				resolve(value);
+			}
+		};
+
+		const timeout = setTimeout(() => {
+			safeResolve(null);
+		}, 3000);
+
+		try {
+			ws = new WebSocket(relayUrl);
+		} catch {
+			clearTimeout(timeout);
+			safeResolve(null);
+			return;
+		}
+
+		const subId = `og-profile-${Date.now()}`;
+
+		ws.onopen = () => {
+			if (!ws || resolved) return;
+			try {
+				ws.send(JSON.stringify([
+					'REQ',
+					subId,
+					{ kinds: [0], authors: [pubkey], limit: 1 }
+				]));
+			} catch {
+				clearTimeout(timeout);
+				safeResolve(null);
+			}
+		};
+
+		ws.onmessage = (event) => {
+			if (!ws || resolved) return;
+			try {
+				const msg = JSON.parse(event.data);
+				if (msg[0] === 'EVENT' && msg[1] === subId && msg[2]) {
+					const evt = msg[2];
+					try {
+						const profile = JSON.parse(evt.content);
+						clearTimeout(timeout);
+						safeResolve({
+							name: profile.name || undefined,
+							display_name: profile.display_name || undefined
+						});
+					} catch {
+						clearTimeout(timeout);
+						safeResolve(null);
+					}
+				} else if (msg[0] === 'EOSE' && msg[1] === subId) {
+					clearTimeout(timeout);
+					safeResolve(null);
+				}
+			} catch {
+				// Parse error, ignore
+			}
+		};
+
+		ws.onerror = () => {
+			clearTimeout(timeout);
+			safeResolve(null);
+		};
+
+		ws.onclose = () => {
+			clearTimeout(timeout);
+			if (!resolved) {
+				safeResolve(null);
+			}
+		};
+	});
+}
+
+async function fetchNoteMetadata(eventId: string): Promise<NoteMetadata | null> {
+	const results = await Promise.all(
+		RELAYS.map(relay => fetchNoteFromRelay(relay, eventId))
+	);
+	return results.find(r => r !== null) || null;
+}
+
+async function fetchProfileMetadata(pubkey: string): Promise<ProfileMetadata | null> {
+	const results = await Promise.all(
+		RELAYS.map(relay => fetchProfileFromRelay(relay, pubkey))
+	);
+	return results.find(r => r !== null) || null;
+}
+
+function makeFallbackMeta() {
+	return {
+		title: 'Note - zap.cooking',
+		description: 'A note shared on zap.cooking - Food. Friends. Freedom.',
+		image: 'https://zap.cooking/social-share.png'
+	};
+}
+
+export const prerender = false;
+
+export const load: PageServerLoad = async ({ params, url }) => {
+	const nip19Id = params.nip19;
+
+	// Strip tracking parameters
+	const hasTrackingParams = TRACKING_PARAMS.some(param => url.searchParams.has(param));
+	if (hasTrackingParams) {
+		throw redirect(301, `/${nip19Id}`);
+	}
+
+	// Only handle note1/nevent1 identifiers for OG tags
+	if (!nip19Id?.startsWith('note1') && !nip19Id?.startsWith('nevent1')) {
+		return { ogMeta: null };
+	}
+
+	if (typeof WebSocket === 'undefined') {
+		return { ogMeta: makeFallbackMeta() };
+	}
+
+	try {
+		const decoded = nip19.decode(nip19Id);
+		let eventId = '';
+		let hintPubkey = '';
+
+		if (decoded.type === 'note') {
+			eventId = (decoded.data as string);
+		} else if (decoded.type === 'nevent') {
+			const data = decoded.data as { id: string; author?: string };
+			eventId = data.id;
+			hintPubkey = data.author || '';
+		} else {
+			return { ogMeta: null };
+		}
+
+		// Fetch note with 5s overall timeout
+		const notePromise = fetchNoteMetadata(eventId);
+		const noteTimeout = new Promise<null>(resolve => setTimeout(() => resolve(null), 5000));
+
+		let note: NoteMetadata | null;
+		let profile: ProfileMetadata | null = null;
+
+		if (hintPubkey) {
+			// nevent with author hint: fetch note and profile in parallel
+			const profilePromise = fetchProfileMetadata(hintPubkey);
+			const profileTimeout = new Promise<null>(resolve => setTimeout(() => resolve(null), 3000));
+
+			const [noteResult, profileResult] = await Promise.all([
+				Promise.race([notePromise, noteTimeout]),
+				Promise.race([profilePromise, profileTimeout])
+			]);
+			note = noteResult;
+			profile = profileResult;
+		} else {
+			// note1: fetch note first, then profile
+			note = await Promise.race([notePromise, noteTimeout]);
+
+			if (note?.pubkey) {
+				try {
+					const profilePromise = fetchProfileMetadata(note.pubkey);
+					const profileTimeout = new Promise<null>(resolve => setTimeout(() => resolve(null), 3000));
+					profile = await Promise.race([profilePromise, profileTimeout]);
+				} catch {
+					// Profile fetch failed, continue without it
+				}
+			}
+		}
+
+		if (!note) {
+			return { ogMeta: makeFallbackMeta() };
+		}
+
+		const authorName = profile?.display_name || profile?.name || null;
+		const title = authorName ? `${authorName} on zap.cooking` : 'Note on zap.cooking';
+		const description = cleanNoteContent(note.content);
+		const image = extractFirstImageUrl(note.content) || 'https://zap.cooking/social-share.png';
+
+		return {
+			ogMeta: {
+				title,
+				description,
+				image,
+				created_at: note.created_at,
+				pubkey: note.pubkey
+			}
+		};
+	} catch (e) {
+		console.error('[OG Meta] Error:', e);
+		return { ogMeta: makeFallbackMeta() };
+	}
+};

--- a/src/routes/[nip19]/+page.svelte
+++ b/src/routes/[nip19]/+page.svelte
@@ -27,7 +27,13 @@
   import MentionDropdown from '../../components/MentionDropdown.svelte';
   import { MentionComposerController, type MentionState } from '$lib/mentionComposer';
 
-  export const data: PageData = {} as PageData;
+  export let data: PageData;
+
+  // OG meta from server (for crawlers/SSR)
+  $: ogTitle = data?.ogMeta?.title || 'Note Thread - zap.cooking';
+  $: ogDescription = data?.ogMeta?.description || 'A note shared on zap.cooking - Food. Friends. Freedom.';
+  $: ogImage = data?.ogMeta?.image || 'https://zap.cooking/social-share.png';
+  $: ogCreatedAt = data?.ogMeta?.created_at ?? null;
 
   let decoded: any = null;
   let event: NDKEvent | null = null;
@@ -413,7 +419,25 @@
 </script>
 
 <svelte:head>
-  <title>Note Thread - zap.cooking</title>
+  <title>{ogTitle}</title>
+  <meta name="description" content={ogDescription} />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content={`https://zap.cooking/${$page.params.nip19}`} />
+  <meta property="og:title" content={ogTitle} />
+  <meta property="og:description" content={ogDescription} />
+  <meta property="og:image" content={ogImage} />
+  <meta property="og:site_name" content="zap.cooking" />
+  {#if ogCreatedAt}
+    <meta property="article:published_time" content={new Date(ogCreatedAt * 1000).toISOString()} />
+  {/if}
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content={ogImage !== 'https://zap.cooking/social-share.png' ? 'summary_large_image' : 'summary'} />
+  <meta name="twitter:title" content={ogTitle} />
+  <meta name="twitter:description" content={ogDescription} />
+  <meta name="twitter:image" content={ogImage} />
 </svelte:head>
 
 <div class="max-w-2xl mx-auto px-4">


### PR DESCRIPTION
## Summary
- Adds server-side OG meta tag generation for `note1` and `nevent1` URLs
- Fetches note content and author profile from Nostr relays at request time (same pattern as existing recipe OG tags)
- Shows author name, note text, and post images in social media previews instead of the generic site card

## How it works
- New `+page.server.ts` for the `[nip19]` route fetches the note event (kind:1) and author profile (kind:0) from 3 relays in parallel
- Extracts first image URL from note content using the same detection patterns as `NoteContent.svelte`
- Cleans note text for `og:description` (strips nostr mentions, media URLs, truncates at ~155 chars)
- Falls back gracefully on timeout, missing data, or WebSocket unavailability

## Files changed
- **`src/routes/[nip19]/+page.server.ts`** — New: server-side note + profile fetching
- **`src/routes/[nip19]/+page.svelte`** — Updated: dynamic `<svelte:head>` OG + Twitter Card tags
- **`src/routes/+layout.svelte`** — Updated: suppress default OG tags on note pages

## Test plan
- [ ] Verify recipe OG tags still work on `/r/` and `/recipe/` routes
- [ ] Test `note1` URL with text-only note — should show author name + note text
- [ ] Test `note1` URL with image in content — should show image as `og:image`
- [ ] Test `nevent1` URL — should work same as `note1`
- [ ] Test invalid/nonexistent note ID — should fall back to generic meta
- [ ] Verify with [opengraph.xyz](https://www.opengraph.xyz/) or Facebook debugger after deploy