### PR TITLE
fix: polish groups UI to match messaging design

### DIFF
--- a/src/lib/components/groups/GroupList.svelte
+++ b/src/lib/components/groups/GroupList.svelte
@@ -69,12 +69,24 @@
 		return truncate(messages[messages.length - 1].content, 40);
 	}
 
+	let skipNextOutsideClose = false;
+
 	function toggleMenu(e: MouseEvent, groupId: string) {
 		e.stopPropagation();
-		openMenuId = openMenuId === groupId ? null : groupId;
+		if (openMenuId === groupId) {
+			openMenuId = null;
+		} else {
+			// Flag so the outgoing clickOutside from the previous menu doesn't reopen
+			skipNextOutsideClose = true;
+			openMenuId = groupId;
+		}
 	}
 
 	function closeMenu() {
+		if (skipNextOutsideClose) {
+			skipNextOutsideClose = false;
+			return;
+		}
 		openMenuId = null;
 	}
 
@@ -248,27 +260,27 @@
 	}
 </script>
 
-<div class="flex flex-col h-full">
-	<!-- Header -->
+<div class="relative h-full">
+	<!-- Header (frosted glass, floats over group list) -->
 	<div
-		class="flex items-center justify-between p-4 border-b"
-		style="border-color: var(--color-input-border);"
+		class="absolute top-0 left-0 right-0 z-10 flex items-center justify-between px-4 h-[68px]"
+		style="background-color: color-mix(in srgb, var(--color-bg-secondary) 70%, transparent); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);"
 	>
 		<h2 class="text-lg font-semibold" style="color: var(--color-text-primary);">Groups</h2>
 		{#if hasActiveMembership}
 			<button
-				class="p-2 rounded-xl transition-colors hover:bg-accent-gray cursor-pointer"
-				style="color: var(--color-text-primary);"
+				class="p-2 rounded-full transition-colors cursor-pointer"
+				style="background-color: var(--color-primary); color: #ffffff;"
 				on:click={() => dispatch('createGroup')}
 				title="Create group"
 			>
-				<PlusIcon size={20} />
+				<PlusIcon size={18} weight="bold" />
 			</button>
 		{/if}
 	</div>
 
 	<!-- Group list -->
-	<div class="flex-1 overflow-y-auto">
+	<div class="h-full overflow-y-auto pt-[68px]">
 		{#if $groupsLoading && $sortedGroups.length === 0}
 			<div class="flex items-center gap-2 px-4 py-3" style="color: var(--color-caption);">
 				<div
@@ -290,7 +302,7 @@
 				<div
 					class="relative flex items-start gap-3 px-4 py-3 transition-colors text-left"
 					class:bg-input={selectedGroupId === group.id}
-					style="border-bottom: 1px solid var(--color-input-border);"
+					style="border-bottom: 1px solid color-mix(in srgb, var(--color-text-primary) 8%, transparent);"
 				>
 					<button
 						class="flex items-start gap-3 flex-1 min-w-0 cursor-pointer text-left"
@@ -354,13 +366,13 @@
 
 						{#if openMenuId === group.id}
 							<div
-								class="absolute top-full right-0 mt-1 rounded-lg shadow-lg py-1 z-50 min-w-[150px]"
-								style="background-color: var(--color-input); border: 1px solid var(--color-input-border);"
+								class="absolute top-full right-0 mt-1 rounded-xl shadow-lg py-1 z-50 whitespace-nowrap"
+								style="background-color: var(--color-bg-secondary); border: 1px solid var(--color-input-border);"
 								use:clickOutside
 								on:click_outside={closeMenu}
 							>
 								<button
-									class="w-full px-4 py-2 text-left text-sm hover:bg-accent-gray flex items-center gap-2 cursor-pointer"
+									class="w-full px-4 py-2 text-left text-sm flex items-center gap-2 cursor-pointer transition-colors menu-item-hover"
 									style="color: var(--color-text-primary);"
 									on:click={(e) => openEdit(e, group.id, group.name)}
 								>
@@ -368,7 +380,7 @@
 									<span>Edit Name</span>
 								</button>
 								<button
-									class="w-full px-4 py-2 text-left text-sm hover:bg-accent-gray flex items-center gap-2 cursor-pointer"
+									class="w-full px-4 py-2 text-left text-sm flex items-center gap-2 cursor-pointer transition-colors menu-item-hover"
 									style="color: var(--color-text-primary);"
 									on:click={(e) => openPicture(e, group.id)}
 								>
@@ -376,7 +388,7 @@
 									<span>Picture</span>
 								</button>
 								<button
-									class="w-full px-4 py-2 text-left text-sm hover:bg-accent-gray flex items-center gap-2 cursor-pointer"
+									class="w-full px-4 py-2 text-left text-sm flex items-center gap-2 cursor-pointer transition-colors menu-item-hover"
 									style="color: var(--color-text-primary);"
 									disabled={togglingVisibility === group.id}
 									on:click={(e) => handleToggleVisibility(e, group)}
@@ -390,7 +402,7 @@
 									{/if}
 								</button>
 								<button
-									class="w-full px-4 py-2 text-left text-sm hover:bg-accent-gray flex items-center gap-2 cursor-pointer text-red-500"
+									class="w-full px-4 py-2 text-left text-sm flex items-center gap-2 cursor-pointer transition-colors text-red-500 menu-item-hover"
 									on:click={(e) => openDelete(e, group.id, group.name)}
 								>
 									<TrashIcon size={16} />
@@ -515,3 +527,9 @@
 		</div>
 	</div>
 </Modal>
+
+<style>
+	.menu-item-hover:hover {
+		background-color: color-mix(in srgb, var(--color-text-primary) 8%, transparent);
+	}
+</style>

--- a/src/lib/components/groups/GroupThread.svelte
+++ b/src/lib/components/groups/GroupThread.svelte
@@ -143,11 +143,11 @@
 	}
 </script>
 
-<div class="flex flex-col h-full">
-	<!-- Header -->
+<div class="relative h-full overflow-hidden">
+	<!-- Header (frosted glass, floats over messages) -->
 	<div
-		class="flex items-center gap-3 p-4 border-b"
-		style="border-color: var(--color-input-border);"
+		class="absolute top-0 left-0 right-0 z-10 flex items-center gap-3 px-4 h-[68px]"
+		style="background-color: color-mix(in srgb, var(--color-bg-secondary) 70%, transparent); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);"
 	>
 		<button
 			class="lg:hidden p-1 rounded-lg transition-colors hover:bg-accent-gray cursor-pointer"
@@ -223,7 +223,7 @@
 
 	{#if isLockedOut}
 		<!-- Locked out: members-only group for non-members -->
-		<div class="flex-1 flex flex-col items-center justify-center px-4 text-center">
+		<div class="h-full flex flex-col items-center justify-center px-4 text-center pt-[68px]">
 			<LockIcon size={40} weight="light" style="color: var(--color-caption);" />
 			<p class="text-sm font-medium mt-3" style="color: var(--color-text-primary);">
 				Members Only
@@ -240,11 +240,11 @@
 			</a>
 		</div>
 	{:else}
-		<!-- Messages -->
+		<!-- Messages (full height, padded top/bottom for header/input) -->
 		<div
 			bind:this={scrollContainer}
 			on:scroll={handleScroll}
-			class="flex-1 overflow-y-auto px-4 py-3"
+			class="h-full overflow-y-auto px-4 pt-[84px] pb-[80px]"
 		>
 			{#if messages.length === 0}
 				<div class="flex items-center justify-center h-full">
@@ -259,14 +259,7 @@
 			{/if}
 		</div>
 
-		<!-- Error -->
-		{#if sendError}
-			<div class="px-4 py-2">
-				<p class="text-xs text-danger">{sendError}</p>
-			</div>
-		{/if}
-
-		<!-- Input -->
+		<!-- Input (frosted glass, floats over messages) -->
 		<input
 			bind:this={fileInput}
 			type="file"
@@ -275,14 +268,19 @@
 			on:change={handleImageUpload}
 		/>
 		<div
-			class="p-3 border-t"
-			style="border-color: var(--color-input-border);"
+			class="absolute bottom-0 left-0 right-0 z-10 p-3"
+			style="background-color: color-mix(in srgb, var(--color-bg-secondary) 70%, transparent); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);"
 		>
-			<div class="flex items-end gap-2">
+			{#if sendError}
+				<div class="pb-2">
+					<p class="text-xs text-danger">{sendError}</p>
+				</div>
+			{/if}
+			<div class="flex items-end">
 				<button
 					on:click={() => fileInput?.click()}
 					disabled={uploading}
-					class="p-2.5 rounded-xl transition-colors cursor-pointer disabled:opacity-40"
+					class="p-2.5 rounded-xl transition-colors cursor-pointer disabled:opacity-40 self-stretch"
 					style="color: var(--color-caption);"
 					title="Attach image"
 				>
@@ -300,13 +298,13 @@
 					placeholder="Type a message..."
 					rows="1"
 					class="input flex-1 resize-none text-sm min-h-[42px] max-h-32"
-					style="background-color: var(--color-input-bg);"
+					style="background-color: var(--color-input-bg); border-radius: 0.75rem 0 0 0.75rem; border: 1px solid rgba(249, 115, 22, 0.35); border-right: none;"
 					disabled={sending}
 				></textarea>
 				<button
 					on:click={handleSend}
 					disabled={(!messageInput.trim() && !uploading) || sending}
-					class="p-2.5 rounded-xl transition-colors cursor-pointer disabled:opacity-40"
+					class="p-2.5 rounded-l-none rounded-r-xl transition-colors cursor-pointer disabled:opacity-40 self-stretch"
 					style="background-color: var(--color-primary); color: #ffffff;"
 				>
 					{#if sending}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -331,12 +331,12 @@
           <Header />
         </div>
         <div
-          class="px-4 min-w-0 max-w-full {$page.url.pathname.startsWith('/messages')
+          class="px-4 min-w-0 max-w-full {$page.url.pathname.startsWith('/messages') || $page.url.pathname.startsWith('/groups')
             ? ''
             : 'pb-16 lg:pb-8'}"
         >
           <slot />
-          {#if !$page.url.pathname.startsWith('/messages')}
+          {#if !$page.url.pathname.startsWith('/messages') && !$page.url.pathname.startsWith('/groups')}
             <Footer />
           {/if}
         </div>

--- a/src/routes/groups/+page.svelte
+++ b/src/routes/groups/+page.svelte
@@ -109,7 +109,7 @@
 {:else}
 	<!-- Groups UI -->
 	<div
-		class="flex h-[calc(100vh-8rem)] lg:h-[calc(100vh-6rem)] -mx-4 rounded-xl overflow-hidden border"
+		class="flex h-[calc(100vh-8rem)] lg:h-[calc(100vh-6rem)] rounded-xl overflow-hidden border"
 		style="border-color: var(--color-input-border); background-color: var(--color-bg-secondary);"
 	>
 		<!-- Group List (left panel) -->


### PR DESCRIPTION
## Summary
- Frosted glass effect on GroupList header and GroupThread header/input area, matching the messaging UI
- Connected textarea + send button with orange border styling
- Fixed kebab menu: opaque background, proper toggle close behavior, hover states, no text wrapping
- Matched groups page width/margins and scroll behavior to messages (removed `-mx-4`, excluded from footer/bottom padding)
- Subtle list separators using `color-mix` instead of hard borders

## Test plan
- [ ] Open Groups page — verify frosted glass header, no outer page scroll
- [ ] Open a group thread — verify frosted glass header and input area float over messages
- [ ] Test kebab menu (`...`): opens on click, closes on second click, closes on outside click
- [ ] Verify menu items have visible hover states and "Make Members Only" doesn't wrap
- [ ] Compare side-by-side with Messages page — width, margins, and borders should match
- [ ] Test on mobile viewport — back button, thread/list toggle still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)