### PR TITLE
fix: resolve @mentions in OG descriptions, skip video URLs, disable reply button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,81 +1,212 @@
-⚡️ Zap Cooking
+# Zap Cooking
 
 Food is culture. Food is community.
 
-Zap Cooking is a Nostr-native cooking and recipe platform built around discovery, creativity, and value-for-value culture. It is not just a recipe app. It is a place where people share food, ideas, and inspiration without algorithms, ads, or extraction.
+Zap Cooking is a Nostr-native cooking and food culture platform built around discovery, creativity, and value-for-value. It is not just a recipe app. It is a place where people share food, ideas, and inspiration without algorithms, ads, or extraction.
 
 Built on open protocols. Powered by Nostr. Fueled by people who love to cook.
 
-⸻
+Check it out at [zap.cooking](https://zap.cooking)
 
-🌍 What Zap Cooking Is
+---
+
+## What Zap Cooking Is
 
 Zap Cooking is a decentralized recipe and food culture app where:
-	•	Recipes are shared as Nostr events
-	•	Identity is your Nostr key, not an account
-	•	Value flows peer-to-peer through Lightning zaps
-	•	Discovery comes from people, not algorithms
-	•	Creativity compounds through community feedback
 
-If you believe food connects people and culture matters more than clicks, you’re in the right place.
+- Recipes are shared as Nostr events
+- Identity is your Nostr key, not an account
+- Value flows peer-to-peer through Lightning zaps
+- Discovery comes from people, not algorithms
+- Creativity compounds through community feedback
 
-⸻
+If you believe food connects people and culture matters more than clicks, you're in the right place.
 
-🔑 Core Principles
-	•	Nostr-native
-Built directly on the Nostr protocol. No walled gardens.
-	•	Value for Value
-Support creators with Lightning zaps. No ads. No paywalls.
-	•	Human Discovery
-Explore recipes, cooks, and ideas organically.
-	•	Open and Experimental
-This project evolves in public and improves through iteration.
+---
 
-⸻
+## Core Principles
 
-✨ Current Features
-	•	🔍 Explore Page
-Browse recipe categories, discover new cooks, and surface recent additions.
-	•	🧑‍🍳 Creator Profiles
-Follow cooks and explore recipes tied to Nostr identities.
-	•	⚡ Lightning Zaps
-Support creators directly using Bitcoin Lightning.
-	•	🔐 Nostr Authentication
-Login via NIP-07 browser extensions, with fallback options.
-	•	📱 Responsive UI
-Designed to work smoothly across desktop and mobile.
-	•	🚀 Performance Focused
-Optimized relay usage, caching, and loading behavior.
-	•	💼 Integrated Wallet
-Built-in wallet supporting NWC (Nostr Wallet Connect) and Spark (Breez SDK).
-	•	₿ On-Chain Bitcoin
-Receive Bitcoin directly to on-chain addresses with deposit claiming.
-	•	🛡️ Branta Guardrail
-Payment address verification so users can confirm they're paying the right recipient.
+- **Nostr-native** — Built directly on the Nostr protocol. No walled gardens.
+- **Value for Value** — Support creators with Lightning zaps. No ads. No paywalls.
+- **Human Discovery** — Explore recipes, cooks, and ideas organically.
+- **Open and Experimental** — This project evolves in public and improves through iteration.
 
-⸻
+---
 
-🛠 Tech Stack
-	•	Frontend: Svelte / SvelteKit
-	•	Protocol: Nostr
-	•	Hosting: Cloudflare Pages
-	•	Auth: NIP-07, NIP-46 (Nostr Connect), nsec
-	•	Payments: Bitcoin Lightning (zaps), On-chain Bitcoin
-	•	Wallet: NWC, Spark (Breez SDK), WebLN
-	•	Verification: Branta Guardrail
+## Features
 
-⸻
+### Recipes & Content
 
-🚧 In Progress / Coming Soon
-	•	Improved onboarding and UX polish
-	•	Better recipe discovery and filtering
-	•	Enhanced performance monitoring
-	•	Mobile-first refinements
-	•	Additional creator and community features
+- **Recipe Publishing** — Create and share recipes with markdown, images, tags, servings, prep/cook times.
+- **Gated Recipes** — Publish premium recipes available only to members.
+- **Recipe Extraction** — Import recipes from URLs or paste raw content.
+- **Longform Articles** — Write and read food articles and stories (NIP-23 kind 30023) with a full editor and draft system.
+- **Food Culture Feed** — Post updates, thoughts, and food stories to a social feed with global, following, and community tabs.
 
-Zap Cooking is intentionally iterative. Small improvements shipped often.
-_A recipe-sharing client for nostr._
-Check it out at [zap.cooking](https://zap.cooking)!
+### Discovery
+
+- **Explore Page** — Curated collections, popular cooks, trending tags, recent recipes, and longform food articles.
+- **Mesh Visualization** — Interactive D3 force-directed network graph showing recipes, connections, and engagement relationships.
+- **Tag Browsing** — Browse recipes by category with trending tag discovery.
+- **Creator Profiles** — Follow cooks, explore their recipes and articles, and view profile badges.
+
+### Community & Messaging
+
+- **Direct Messages** — Encrypted private messaging (NIP-17) between users.
+- **Group Chat** — NIP-29 relay-based group conversations hosted on the Pantry relay (`wss://pantry.zap.cooking`). Create groups, manage members, share images.
+- **Comments & Reactions** — Comment on recipes and react with emoji reactions.
+- **Notifications** — Activity notifications with pull-to-refresh.
+
+### Organization
+
+- **Cookbooks** — Personal recipe collections you can create, edit, and share.
+- **Recipe Lists** — Curated lists of recipes (kind 30001).
+- **Bookmarks** — Save recipes and articles for later.
+- **Shopping Lists** — Manage grocery lists for meal planning.
+- **Drafts** — Save and manage unpublished article drafts with word count and reading time.
+
+### Payments & Wallet
+
+- **Lightning Zaps** — Support creators directly using Bitcoin Lightning with one-tap zap support.
+- **Integrated Wallet** — Built-in wallet supporting NWC (Nostr Wallet Connect), Spark (Breez SDK), Bitcoin Connect, and WebLN.
+- **On-Chain Bitcoin** — Receive Bitcoin directly to on-chain addresses with deposit claiming.
+- **Branta Guardrail** — Payment address verification so users can confirm they're paying the right recipient.
+
+### Membership
+
+- **Tiered Membership** — Cook, Cook+, Pro Kitchen, and Genesis Founders tiers.
+- **Member Benefits** — Access to gated recipes, group chat, marketplace, AI assistant, and community features.
+- **Invite Tree** — Visual referral and membership tree.
+
+### Marketplace
+
+- **P2P Marketplace** — Browse and list ingredients, kitchen tools, knowledge, and merch.
+- **Seller Dashboard** — Manage your marketplace products.
+
+### Kitchen Tools
+
+- **Zappy AI** — AI assistant for recipe ideas and cooking help (membership feature).
+- **Cooking Timer** — Integrated timer widget accessible from the header.
+- **Unit Converter** — Convert between cooking measurement units.
+
+### Settings & Personalization
+
+- **Theming** — Light, dark, and system-preference modes.
+- **Relay Management** — Configure and monitor Nostr relay connections.
+- **Currency Display** — Choose your preferred currency.
+- **One-Tap Zap** — Customize default zap amounts.
+
+---
+
+## Tech Stack
+
+- **Frontend:** SvelteKit (Svelte 4)
+- **Protocol:** Nostr (NDK, nostr-tools)
+- **Hosting:** Cloudflare Pages
+- **Auth:** NIP-07 (browser extensions), NIP-46 (Nostr Connect), nsec, key generation
+- **Payments:** Bitcoin Lightning (zaps), On-chain Bitcoin
+- **Wallet:** NWC, Spark (Breez SDK), Bitcoin Connect, WebLN
+- **Verification:** Branta Guardrail
+- **Visualization:** D3.js (Mesh network graph)
+
+---
+
+## App Structure
+
+```
+src/
+  routes/                    # SvelteKit page routes
+    (auth)/login/            # Authentication (NIP-07, NIP-46, nsec)
+    (auth)/onboarding/       # New user setup wizard
+    explore/                 # Discovery hub
+    recent/                  # Latest recipes
+    recipe/[slug]/           # Individual recipe view
+    r/[naddr]/               # Recipe view (NIP-19 address)
+    tag/[slug]/              # Tag-based browsing
+    create/                  # Recipe editor
+    create/gated/            # Gated recipe editor
+    extract/                 # Recipe import tool
+    reads/                   # Longform articles feed
+    reads/[naddr]/           # Individual article
+    drafts/                  # Article draft management
+    feed-post/               # Food culture post composer
+    community/               # Community feed
+    kitchen/                 # Kitchen relay feed
+    mesh/                    # Network visualization
+    cookbook/                 # Recipe collections
+    bookmarks/               # Saved content
+    grocery/                 # Shopping lists
+    messages/                # Direct messages (NIP-17)
+    groups/                  # Group chat (NIP-29)
+    user/[slug]/             # Creator profiles
+    wallet/                  # Wallet management
+    membership/              # Membership tiers & checkout
+    marketplace/             # P2P marketplace
+    my-store/                # Seller dashboard
+    garden/                  # Invite tree
+    pantry/                  # Community features
+    zappy/                   # AI assistant
+    settings/                # App settings
+    notifications/           # Activity feed
+    [nip19]/                 # Universal NIP-19 handler
+    s/[code]/                # Shortlinks
+
+  lib/                       # Shared utilities and modules
+    stores/                  # Svelte writable stores (messages, groups, etc.)
+    components/              # Shared components
+      messages/              # DM UI (ConversationList, MessageThread, etc.)
+      groups/                # Group chat UI (GroupList, GroupThread, etc.)
+    wallet/                  # Wallet integrations (NWC, Bitcoin Connect, WebLN)
+    spark/                   # Breez SDK / Spark wallet
+    mesh/                    # D3 network graph utilities
+    marketplace/             # Marketplace types and operations
+    relays/                  # Relay configuration and sets
+    perf/                    # Performance monitoring
+    types/                   # TypeScript interfaces
+    nostr.ts                 # NDK initialization, relay management
+    nip17.ts                 # Direct messaging protocol
+    nip29.ts                 # Group chat protocol
+    authManager.ts           # Authentication management
+    encryptionService.ts     # Message encryption
+    themeStore.ts            # Light/dark/system theming
+    profileResolver.ts       # Profile resolution with caching
+    profileSearchService.ts  # User search (Primal API + NDK)
+    followListCache.ts       # Contacts list caching
+    mentionComposer.ts       # @mention autocomplete controller
+    parser.ts                # Markdown template parsing
+    consts.ts                # Recipe tags and constants
+
+  components/                # Page-level components
+    Recipe/                  # Recipe display components
+    mesh/                    # Mesh visualization (canvas, nodes, controls)
+    marketplace/             # Product cards and filters
+    reads/                   # Article cards and feeds
+    grocery/                 # Shopping list components
+    Reactions/               # Emoji reactions
+    icons/                   # Branded icons
+```
+
+---
+
+## Nostr Event Kinds Used
+
+| Kind | Description |
+|------|-------------|
+| 0 | User metadata (profiles) |
+| 1 | Short text notes (food feed posts) |
+| 3 | Contact lists (follows) |
+| 7 | Reactions |
+| 9735 | Zap receipts |
+| 9802 | Recipe highlights |
+| 10009 | Group list |
+| 30001 | Recipe lists |
+| 30023 | Longform articles |
+| 30023 | Recipes (with structured tags) |
+| 39000-39003 | NIP-29 group metadata |
+| 9000-9022 | NIP-29 group moderation |
+| NIP-17 | Direct messages (encrypted) |
+
+---
 
 ## Contributing
 
@@ -83,3 +214,8 @@ Everyone is welcome to contribute.
 
 Note: The tag list is [here](https://github.com/github-tijlxyz/nostr.cooking/blob/main/src/lib/consts.ts#L22), please add useful tags to this list so they work with autocompletion.
 
+---
+
+## License
+
+This project is open source. See the repository for license details.

--- a/src/routes/[nip19]/+page.server.ts
+++ b/src/routes/[nip19]/+page.server.ts
@@ -28,6 +28,7 @@ const RELAYS = [
 
 // Image detection patterns (matching NoteContent.svelte)
 const IMAGE_EXTENSIONS = /\.(jpg|jpeg|png|gif|webp|svg|bmp|avif)(\?.*)?$/i;
+const VIDEO_EXTENSIONS = /\.(mp4|webm|mov|avi|mkv|ogv)(\?.*)?$/i;
 const IMAGE_HOSTS = [
 	'image.nostr.build',
 	'nostr.build',
@@ -45,6 +46,8 @@ function extractFirstImageUrl(content: string): string | null {
 	for (const url of urls) {
 		try {
 			const urlObj = new URL(url);
+			// Skip video URLs
+			if (VIDEO_EXTENSIONS.test(urlObj.pathname)) continue;
 			if (IMAGE_EXTENSIONS.test(urlObj.pathname)) return url;
 			if (IMAGE_HOSTS.some(host => urlObj.hostname.includes(host))) return url;
 		} catch {
@@ -54,10 +57,97 @@ function extractFirstImageUrl(content: string): string | null {
 	return null;
 }
 
-function cleanNoteContent(content: string): string {
-	let text = content
-		// Remove nostr: mentions
-		.replace(/nostr:[a-z0-9]+/gi, '')
+// Regex matching nostr:npub1... and nostr:nprofile1... mentions (bech32 charset)
+const MENTION_REGEX = /nostr:(npub1|nprofile1)([023456789acdefghjklmnpqrstuvwxyz]+)/g;
+const MAX_MENTION_RESOLVES = 5;
+
+/**
+ * Extract nostr:npub1/nprofile1 mentions from content, decode to pubkeys,
+ * fetch profiles, and return a map of original mention string -> @DisplayName.
+ */
+async function resolveMentions(content: string): Promise<Map<string, string>> {
+	const mentionMap = new Map<string, string>(); // full match -> pubkey
+	const seen = new Set<string>();
+
+	let match;
+	const regex = new RegExp(MENTION_REGEX);
+	while ((match = regex.exec(content)) !== null) {
+		const fullMatch = match[0]; // e.g. "nostr:npub1abc..."
+		if (mentionMap.has(fullMatch)) continue;
+
+		try {
+			const decoded = nip19.decode(fullMatch.replace('nostr:', ''));
+			let pubkey = '';
+			if (decoded.type === 'npub') {
+				pubkey = decoded.data as string;
+			} else if (decoded.type === 'nprofile') {
+				pubkey = (decoded.data as { pubkey: string }).pubkey;
+			}
+			if (pubkey && !seen.has(pubkey)) {
+				seen.add(pubkey);
+				mentionMap.set(fullMatch, pubkey);
+			}
+		} catch {
+			// Invalid nip19, skip
+		}
+
+		if (seen.size >= MAX_MENTION_RESOLVES) break;
+	}
+
+	if (mentionMap.size === 0) return new Map();
+
+	// Fetch all unique profiles in parallel
+	const pubkeys = [...new Set(mentionMap.values())];
+	const profileResults = await Promise.all(
+		pubkeys.map(async (pk) => {
+			try {
+				const timeout = new Promise<null>(resolve => setTimeout(() => resolve(null), 3000));
+				return { pk, profile: await Promise.race([fetchProfileMetadata(pk), timeout]) };
+			} catch {
+				return { pk, profile: null };
+			}
+		})
+	);
+
+	const profileMap = new Map<string, string>();
+	for (const { pk, profile } of profileResults) {
+		const name = profile?.display_name || profile?.name || null;
+		if (name) {
+			profileMap.set(pk, name);
+		} else {
+			// Fallback: truncated npub
+			try {
+				const npub = nip19.npubEncode(pk);
+				profileMap.set(pk, npub.slice(0, 8) + '...' + npub.slice(-4));
+			} catch {
+				profileMap.set(pk, 'unknown');
+			}
+		}
+	}
+
+	// Build final replacement map: full mention string -> @DisplayName
+	const result = new Map<string, string>();
+	for (const [mention, pubkey] of mentionMap) {
+		result.set(mention, '@' + (profileMap.get(pubkey) || 'unknown'));
+	}
+	return result;
+}
+
+function cleanNoteContent(content: string, mentionReplacements?: Map<string, string>): string {
+	let text = content;
+
+	// Replace nostr: mentions with @DisplayName (if resolved) or strip them
+	if (mentionReplacements && mentionReplacements.size > 0) {
+		for (const [mention, replacement] of mentionReplacements) {
+			text = text.replaceAll(mention, replacement);
+		}
+		// Strip any remaining unresolved nostr: references (notes, events, etc.)
+		text = text.replace(/nostr:[a-z0-9]+/gi, '');
+	} else {
+		text = text.replace(/nostr:[a-z0-9]+/gi, '');
+	}
+
+	text = text
 		// Remove image/video URLs
 		.replace(/https?:\/\/[^\s]+\.(jpg|jpeg|png|gif|webp|svg|bmp|avif|mp4|webm|mov)(\?[^\s]*)?/gi, '')
 		// Remove remaining standalone URLs
@@ -354,9 +444,17 @@ export const load: PageServerLoad = async ({ params, url }) => {
 			return { ogMeta: makeFallbackMeta() };
 		}
 
+		// Resolve @mentions in note content (parallel, with timeout)
+		let mentionReplacements: Map<string, string> | undefined;
+		try {
+			mentionReplacements = await resolveMentions(note.content);
+		} catch {
+			// Mention resolution failed, will fall back to stripping
+		}
+
 		const authorName = profile?.display_name || profile?.name || null;
 		const title = authorName ? `${authorName} on zap.cooking` : 'Note on zap.cooking';
-		const description = cleanNoteContent(note.content);
+		const description = cleanNoteContent(note.content, mentionReplacements);
 		const image = extractFirstImageUrl(note.content) || 'https://zap.cooking/social-share.png';
 
 		return {

--- a/src/routes/[nip19]/+page.svelte
+++ b/src/routes/[nip19]/+page.svelte
@@ -49,6 +49,7 @@
   let replies: NDKEvent[] = [];
   let loadingReplies = false;
   let commentText = '';
+  let postingReply = false;
   let processedReplies = new Set<string>();
 
   // Reply composer with mentions
@@ -279,8 +280,9 @@
 
   // Post a reply
   async function postReply() {
-    if (!commentText.trim() || !event) return;
+    if (!commentText.trim() || !event || postingReply) return;
 
+    postingReply = true;
     try {
       if (replyComposerEl) {
         commentText = mentionCtrl.extractText();
@@ -325,6 +327,8 @@
       mentionCtrl.resetMentionState();
     } catch {
       // Failed to post reply
+    } finally {
+      postingReply = false;
     }
   }
 
@@ -699,7 +703,7 @@
                   bind:this={replyComposerEl}
                   class="reply-composer-input w-full px-3 py-2 text-sm rounded-lg"
                   style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border); color: var(--color-text-primary); min-height: 60px;"
-                  contenteditable="true"
+                  contenteditable={!postingReply}
                   role="textbox"
                   tabindex="0"
                   aria-multiline="true"
@@ -720,9 +724,9 @@
                   on:select={(e) => mentionCtrl.insertMention(e.detail)}
                 />
               </div>
-              {#if commentText.trim()}
+              {#if commentText.trim() || postingReply}
                 <div class="flex justify-end mt-2">
-                  <Button on:click={postReply} class="text-sm px-4 py-1.5">Reply</Button>
+                  <Button on:click={postReply} disabled={postingReply} class="text-sm px-4 py-1.5">{postingReply ? 'Posting...' : 'Reply'}</Button>
                 </div>
               {/if}
             </div>


### PR DESCRIPTION
## Summary
- **OG mention resolution**: `nostr:npub1...` and `nostr:nprofile1...` mentions in note content are now resolved to `@DisplayName` in OG meta descriptions instead of being stripped. Fetches profiles server-side from relays (max 5 mentions, 3s timeout per relay, parallel execution).
- **OG image video skip**: Video URLs (mp4, webm, mov, etc.) on known image hosts like `nostr.build` are now skipped when extracting OG images, falling back to the default social share image instead of producing a broken preview.
- **Reply button disable**: The reply composer in the note thread view now disables the input field and shows "Posting..." on the button while the reply is publishing, preventing double-submission.
- **README update**: Comprehensive rewrite with organized feature sections, app structure directory tree, Nostr event kinds reference table, and updated tech stack.

## Test plan
- [ ] Share a note URL containing `nostr:npub1...` mentions — OG description should show `@DisplayName`
- [ ] Share a note URL containing a video from `nostr.build` — OG image should be the default social share image, not a broken video URL
- [ ] Reply to a note in the thread view — button should show "Posting..." and be disabled until publish completes
- [ ] Verify OG fallback works when profile resolution times out (shows truncated npub)

🤖 Generated with [Claude Code](https://claude.com/claude-code)