### PR TITLE
fix: send media_type field in profile image uploads per NIP-96

### DIFF
--- a/src/components/ProfileEditModal.svelte
+++ b/src/components/ProfileEditModal.svelte
@@ -166,6 +166,7 @@
 
     const body = new FormData();
     body.append('file[]', file);
+    body.append('media_type', type === 'picture' ? 'avatar' : 'banner');
 
     const result = await Fetch.fetchJson(url, {
       body,

--- a/src/routes/user/[slug]/+page.svelte
+++ b/src/routes/user/[slug]/+page.svelte
@@ -893,6 +893,7 @@
 
       const body = new FormData();
       body.append('file[]', file);
+      body.append('media_type', 'avatar');
 
       const result = await uploadProfilePicture(body);
       console.log('[Profile Upload] Upload complete, result:', result);


### PR DESCRIPTION
## Summary
- Profile image uploads now include the NIP-96 `media_type` form field (`"avatar"` or `"banner"`) so nostr.build applies the correct cropping dimensions for each type
- Previously the type parameter was accepted by `uploadImage()` but never sent to the server, causing banner uploads to be treated as generic uploads with no special handling

## Changes
- `ProfileEditModal.svelte` — append `media_type` (`avatar` or `banner`) to FormData
- `user/[slug]/+page.svelte` — append `media_type: avatar` to profile picture upload

## Test plan
- [ ] Upload a new profile picture via the profile edit modal — should crop as avatar
- [ ] Upload a new banner via the profile edit modal — should crop as banner (wide aspect ratio)
- [ ] Upload a profile picture from the user profile page — should crop as avatar

🤖 Generated with [Claude Code](https://claude.com/claude-code)