### PR TITLE
feat: Nostr backup section and security enhancements in settings

### DIFF
--- a/src/components/NostrBackupSection.svelte
+++ b/src/components/NostrBackupSection.svelte
@@ -1,0 +1,751 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { browser } from '$app/environment';
+	import { ndk, userPublickey } from '$lib/nostr';
+	import { hasEncryptionSupport } from '$lib/encryptionService';
+	import {
+		backupFollows,
+		listFollowsBackups,
+		restoreFollowsFromBackup,
+		backupMuteList,
+		listMuteListBackups,
+		restoreMuteListFromBackup,
+		checkBackupRelayStatus,
+		BACKUP_D_TAGS,
+		type BackupType,
+		type FollowsBackupData,
+		type MuteBackupData,
+		type BackupInfo,
+		type RelayBackupStatus
+	} from '$lib/nostrBackup';
+	import {
+		backupProfile,
+		restoreProfileFromBackup,
+		listProfileBackups,
+		type ProfileBackupData
+	} from '$lib/profileBackup';
+	import CheckCircleIcon from 'phosphor-svelte/lib/CheckCircle';
+	import XCircleIcon from 'phosphor-svelte/lib/XCircle';
+	import WarningIcon from 'phosphor-svelte/lib/Warning';
+	import CloudArrowUpIcon from 'phosphor-svelte/lib/CloudArrowUp';
+	import CloudArrowDownIcon from 'phosphor-svelte/lib/CloudArrowDown';
+	import CaretDownIcon from 'phosphor-svelte/lib/CaretDown';
+	import ArrowClockwiseIcon from 'phosphor-svelte/lib/ArrowClockwise';
+	import ClockCounterClockwiseIcon from 'phosphor-svelte/lib/ClockCounterClockwise';
+	import WalletIcon from 'phosphor-svelte/lib/Wallet';
+	import { activeWallet } from '$lib/wallet/walletStore';
+	import { checkRelayBackups as checkSparkRelayBackups } from '$lib/spark';
+	import { checkRelayBackups as checkNwcRelayBackups } from '$lib/wallet/nwcBackup';
+
+	// ── State ──
+
+	interface BackupStatus {
+		exists: boolean;
+		timestamp: number | null;
+		relayStatuses: RelayBackupStatus[];
+		loading: boolean;
+		error: string | null;
+		backupCount: number;
+		itemCount?: number;
+	}
+
+	let statuses: Record<BackupType, BackupStatus> = {
+		follows: { exists: false, timestamp: null, relayStatuses: [], loading: false, error: null, backupCount: 0 },
+		mute: { exists: false, timestamp: null, relayStatuses: [], loading: false, error: null, backupCount: 0 },
+		profile: { exists: false, timestamp: null, relayStatuses: [], loading: false, error: null, backupCount: 0 }
+	};
+
+	let backingUp: Record<BackupType, boolean> = { follows: false, mute: false, profile: false };
+	let restoring: Record<BackupType, boolean> = { follows: false, mute: false, profile: false };
+	let messages: Record<BackupType, { text: string; type: 'success' | 'error' } | null> = {
+		follows: null,
+		mute: null,
+		profile: null
+	};
+	let expandedType: BackupType | null = null;
+	let versionsExpanded: Record<BackupType, boolean> = { follows: false, mute: false, profile: false };
+
+	// Wallet backup state (view-only) — check both types independently
+	interface WalletBackupInfo {
+		loading: boolean;
+		exists: boolean;
+		timestamp: number | null;
+		relayStatuses: RelayBackupStatus[];
+		error: string | null;
+	}
+	const emptyWalletStatus: WalletBackupInfo = { loading: false, exists: false, timestamp: null, relayStatuses: [], error: null };
+	let sparkBackupStatus: WalletBackupInfo = { ...emptyWalletStatus };
+	let nwcBackupStatus: WalletBackupInfo = { ...emptyWalletStatus };
+	let walletRelaysExpanded: Record<string, boolean> = { spark: false, nwc: false };
+
+	// Cached backup lists for version picker
+	let followsBackups: BackupInfo<FollowsBackupData>[] = [];
+	let muteBackups: BackupInfo<MuteBackupData>[] = [];
+	let profileBackups: Array<{ timestamp: number; eventId: string; createdAt: number; data?: ProfileBackupData }> = [];
+
+	$: canEncrypt = browser ? hasEncryptionSupport() : false;
+
+	// ── Lifecycle ──
+
+	onMount(async () => {
+		if (!browser || !$userPublickey) return;
+		await checkAllStatuses();
+	});
+
+	// ── Status Checks ──
+
+	async function checkAllStatuses() {
+		await Promise.all([checkFollowsStatus(), checkMuteStatus(), checkProfileStatus(), checkWalletStatus()]);
+	}
+
+	async function checkFollowsStatus() {
+		statuses.follows.loading = true;
+		statuses.follows.error = null;
+		statuses = statuses;
+
+		try {
+			followsBackups = await listFollowsBackups($ndk, $userPublickey);
+			const newest = followsBackups.length > 0 && followsBackups[0].data ? followsBackups[0].data : null;
+
+			const relayStatuses = await checkBackupRelayStatus(
+				$ndk,
+				$userPublickey,
+				BACKUP_D_TAGS.follows as unknown as string[]
+			);
+
+			statuses.follows = {
+				exists: followsBackups.length > 0,
+				timestamp: newest?.timestamp || null,
+				relayStatuses,
+				loading: false,
+				error: null,
+				backupCount: followsBackups.length,
+				itemCount: newest?.follows.length
+			};
+		} catch (e: any) {
+			statuses.follows.loading = false;
+			statuses.follows.error = e.message || 'Failed to check follows backup';
+		}
+		statuses = statuses;
+	}
+
+	async function checkMuteStatus() {
+		statuses.mute.loading = true;
+		statuses.mute.error = null;
+		statuses = statuses;
+
+		try {
+			muteBackups = await listMuteListBackups($ndk, $userPublickey);
+			const newest = muteBackups.length > 0 && muteBackups[0].data ? muteBackups[0].data : null;
+
+			const relayStatuses = await checkBackupRelayStatus(
+				$ndk,
+				$userPublickey,
+				BACKUP_D_TAGS.mute as unknown as string[]
+			);
+
+			const itemCount = newest
+				? newest.muteList.pubkeys.length +
+					newest.muteList.words.length +
+					newest.muteList.tags.length +
+					newest.muteList.threads.length
+				: undefined;
+
+			statuses.mute = {
+				exists: muteBackups.length > 0,
+				timestamp: newest?.timestamp || null,
+				relayStatuses,
+				loading: false,
+				error: null,
+				backupCount: muteBackups.length,
+				itemCount
+			};
+		} catch (e: any) {
+			statuses.mute.loading = false;
+			statuses.mute.error = e.message || 'Failed to check mute list backup';
+		}
+		statuses = statuses;
+	}
+
+	async function checkProfileStatus() {
+		statuses.profile.loading = true;
+		statuses.profile.error = null;
+		statuses = statuses;
+
+		try {
+			profileBackups = await listProfileBackups($ndk, $userPublickey);
+
+			const relayStatuses = await checkBackupRelayStatus(
+				$ndk,
+				$userPublickey,
+				BACKUP_D_TAGS.profile as unknown as string[]
+			);
+
+			statuses.profile = {
+				exists: profileBackups.length > 0,
+				timestamp: profileBackups.length > 0 ? profileBackups[0].timestamp : null,
+				relayStatuses,
+				loading: false,
+				error: null,
+				backupCount: profileBackups.length
+			};
+		} catch (e: any) {
+			statuses.profile.loading = false;
+			statuses.profile.error = e.message || 'Failed to check profile backup';
+		}
+		statuses = statuses;
+	}
+
+	async function checkWalletStatus() {
+		await Promise.all([checkSparkBackupStatus(), checkNwcBackupStatus()]);
+	}
+
+	async function checkSingleWalletBackup(
+		checkFn: (pubkey: string) => Promise<RelayBackupStatus[]>
+	): Promise<WalletBackupInfo> {
+		try {
+			const relayStatuses = await checkFn($userPublickey);
+			const hasBackup = relayStatuses.some((r) => r.hasBackup);
+			let latestTimestamp: number | null = null;
+			for (const r of relayStatuses) {
+				if (r.hasBackup && r.timestamp && (!latestTimestamp || r.timestamp > latestTimestamp)) {
+					latestTimestamp = r.timestamp;
+				}
+			}
+			return { loading: false, exists: hasBackup, timestamp: latestTimestamp, relayStatuses, error: null };
+		} catch (e: any) {
+			return { loading: false, exists: false, timestamp: null, relayStatuses: [], error: e.message || 'Check failed' };
+		}
+	}
+
+	async function checkSparkBackupStatus() {
+		sparkBackupStatus = { ...emptyWalletStatus, loading: true };
+		sparkBackupStatus = await checkSingleWalletBackup(checkSparkRelayBackups);
+	}
+
+	async function checkNwcBackupStatus() {
+		nwcBackupStatus = { ...emptyWalletStatus, loading: true };
+		nwcBackupStatus = await checkSingleWalletBackup(checkNwcRelayBackups);
+	}
+
+	// ── Backup Actions ──
+
+	async function handleBackup(type: BackupType) {
+		backingUp[type] = true;
+		messages[type] = null;
+
+		try {
+			switch (type) {
+				case 'follows':
+					await backupFollows($ndk, $userPublickey);
+					break;
+				case 'mute':
+					await backupMuteList($ndk, $userPublickey);
+					break;
+				case 'profile': {
+					const profileEvent = await $ndk.fetchEvent({
+						kinds: [0],
+						authors: [$userPublickey]
+					});
+					if (profileEvent) {
+						await backupProfile($ndk, $userPublickey, JSON.parse(profileEvent.content));
+					} else {
+						throw new Error('No profile found to back up');
+					}
+					break;
+				}
+			}
+			messages[type] = { text: 'Backup created successfully', type: 'success' };
+			switch (type) {
+				case 'follows':
+					await checkFollowsStatus();
+					break;
+				case 'mute':
+					await checkMuteStatus();
+					break;
+				case 'profile':
+					await checkProfileStatus();
+					break;
+			}
+		} catch (e: any) {
+			messages[type] = { text: e.message || 'Backup failed', type: 'error' };
+		} finally {
+			backingUp[type] = false;
+		}
+	}
+
+	// ── Restore Actions ──
+
+	async function handleRestore(type: BackupType, index: number = 0) {
+		const labels: Record<BackupType, string> = {
+			follows: 'follow list',
+			mute: 'mute list',
+			profile: 'profile'
+		};
+		const versionLabel = index > 0 ? ` from backup #${index + 1}` : '';
+		if (!confirm(`Restore your ${labels[type]}${versionLabel}? This will replace your current ${labels[type]}.`))
+			return;
+
+		restoring[type] = true;
+		messages[type] = null;
+
+		try {
+			switch (type) {
+				case 'follows': {
+					const backup = followsBackups[index]?.data;
+					if (backup) {
+						await restoreFollowsFromBackup($ndk, $userPublickey, backup);
+					} else {
+						throw new Error('No backup data available to restore');
+					}
+					break;
+				}
+				case 'mute': {
+					const backup = muteBackups[index]?.data;
+					if (backup) {
+						await restoreMuteListFromBackup($ndk, $userPublickey, backup);
+					} else {
+						throw new Error('No backup data available to restore');
+					}
+					break;
+				}
+				case 'profile': {
+					const backup = profileBackups[index]?.data;
+					if (backup) {
+						await restoreProfileFromBackup($ndk, $userPublickey, backup);
+					} else {
+						throw new Error('No backup data available to restore');
+					}
+					break;
+				}
+			}
+			messages[type] = { text: 'Restored successfully', type: 'success' };
+		} catch (e: any) {
+			messages[type] = { text: e.message || 'Restore failed', type: 'error' };
+		} finally {
+			restoring[type] = false;
+		}
+	}
+
+	// ── Helpers ──
+
+	function toggleRelayDetails(type: BackupType) {
+		expandedType = expandedType === type ? null : type;
+	}
+
+	function toggleVersions(type: BackupType) {
+		versionsExpanded[type] = !versionsExpanded[type];
+	}
+
+	function formatTimestamp(ts: number | null): string {
+		if (!ts) return '';
+		const now = Date.now();
+		const diff = now - ts;
+
+		if (diff < 60 * 1000) return 'just now';
+		if (diff < 60 * 60 * 1000) return `${Math.floor(diff / 60000)}m ago`;
+		if (diff < 24 * 60 * 60 * 1000) return `${Math.floor(diff / 3600000)}h ago`;
+		if (diff < 7 * 24 * 60 * 60 * 1000) return `${Math.floor(diff / 86400000)}d ago`;
+		return new Date(ts).toLocaleDateString();
+	}
+
+	function formatFullTimestamp(ts: number): string {
+		const date = new Date(ts);
+		return date.toLocaleDateString() + ' ' + date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+	}
+
+	function formatRelayTimestamp(ts: number | undefined): string {
+		if (!ts) return '';
+		return new Date(ts).toLocaleDateString();
+	}
+
+	function getRelayDisplayName(relayUrl: string): string {
+		try {
+			return new URL(relayUrl).hostname;
+		} catch {
+			return relayUrl;
+		}
+	}
+
+	function relayBackupCount(statuses: RelayBackupStatus[]): number {
+		return statuses.filter((r) => r.hasBackup).length;
+	}
+
+	function getVersionSummary(type: BackupType, index: number): string {
+		switch (type) {
+			case 'follows': {
+				const b = followsBackups[index]?.data;
+				return b ? `${b.follows.length} follows` : '';
+			}
+			case 'mute': {
+				const b = muteBackups[index]?.data;
+				if (!b) return '';
+				const count = b.muteList.pubkeys.length + b.muteList.words.length + b.muteList.tags.length + b.muteList.threads.length;
+				return `${count} items`;
+			}
+			case 'profile':
+				return '';
+			default:
+				return '';
+		}
+	}
+
+	function getBackupList(type: BackupType): Array<{ timestamp: number; data?: any }> {
+		switch (type) {
+			case 'follows':
+				return followsBackups;
+			case 'mute':
+				return muteBackups;
+			case 'profile':
+				return profileBackups;
+		}
+	}
+
+	const typeLabels: Record<BackupType, { label: string; kind: string }> = {
+		follows: { label: 'Follows', kind: 'kind:3' },
+		mute: { label: 'Mute List', kind: 'kind:10000' },
+		profile: { label: 'Profile', kind: 'kind:0' }
+	};
+
+	const types: BackupType[] = ['follows', 'mute', 'profile'];
+</script>
+
+<div class="flex flex-col gap-4">
+	<p class="text-xs text-caption">
+		Back up your social graph to Nostr relays using encrypted NIP-78 events. Only you can decrypt
+		these backups.
+	</p>
+
+	{#if !canEncrypt}
+		<div
+			class="p-3 rounded-lg flex items-center gap-2 text-sm"
+			style="background-color: rgba(245, 158, 11, 0.1); border: 1px solid rgba(245, 158, 11, 0.3); color: var(--color-text-primary);"
+		>
+			<WarningIcon size={18} class="text-amber-500 flex-shrink-0" />
+			<span class="text-xs"
+				>Encryption is required for backups. Sign in with nsec, NIP-07, or NIP-46 to enable.</span
+			>
+		</div>
+	{/if}
+
+	{#each types as type}
+		{@const status = statuses[type]}
+		{@const info = typeLabels[type]}
+		{@const hasRelays = status.relayStatuses.length > 0}
+		{@const backupRelays = relayBackupCount(status.relayStatuses)}
+		{@const backupList = getBackupList(type)}
+
+		<div
+			class="rounded-lg border overflow-hidden"
+			style="border-color: var(--color-input-border); background-color: var(--color-bg-primary);"
+		>
+			<!-- Header -->
+			<div class="px-4 py-3">
+				<div class="flex items-center justify-between mb-1">
+					<div class="flex items-center gap-2">
+						<span class="text-sm font-medium" style="color: var(--color-text-primary)"
+							>{info.label}</span
+						>
+						<span class="text-xs text-caption font-mono">{info.kind}</span>
+					</div>
+				</div>
+
+				<!-- Status line -->
+				<div class="flex items-center gap-1.5 mb-3">
+					{#if status.loading}
+						<div
+							class="w-3 h-3 border-2 border-primary-color border-t-transparent rounded-full animate-spin"
+						></div>
+						<span class="text-xs text-caption">Checking...</span>
+					{:else if status.error}
+						<WarningIcon size={14} class="text-amber-500" />
+						<span class="text-xs text-amber-500">{status.error}</span>
+					{:else if status.exists}
+						<CheckCircleIcon size={14} class="text-green-500" weight="fill" />
+						<span class="text-xs text-caption">
+							{status.backupCount} backup{status.backupCount !== 1 ? 's' : ''}
+							{#if status.itemCount !== undefined}
+								&middot; {status.itemCount} items
+							{/if}
+							{#if status.timestamp}
+								&middot; {formatTimestamp(status.timestamp)}
+							{/if}
+							{#if hasRelays}
+								&middot; {backupRelays}/{status.relayStatuses.length} relays
+							{/if}
+						</span>
+					{:else}
+						<XCircleIcon size={14} class="text-caption" />
+						<span class="text-xs text-caption">No backup found</span>
+					{/if}
+				</div>
+
+				<!-- Actions -->
+				<div class="flex items-center gap-2 flex-wrap">
+					<button
+						class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors disabled:opacity-50"
+						style="background-color: var(--color-primary); color: #ffffff;"
+						disabled={!canEncrypt || backingUp[type]}
+						on:click={() => handleBackup(type)}
+					>
+						{#if backingUp[type]}
+							<div
+								class="w-3 h-3 border-2 border-white border-t-transparent rounded-full animate-spin"
+							></div>
+							Backing up...
+						{:else}
+							<CloudArrowUpIcon size={14} />
+							Backup Now
+						{/if}
+					</button>
+
+					<button
+						class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors disabled:opacity-50"
+						style="background-color: var(--color-bg-secondary); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+						disabled={!status.exists || !canEncrypt || restoring[type]}
+						on:click={() => handleRestore(type)}
+					>
+						{#if restoring[type]}
+							<div
+								class="w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin"
+							></div>
+							Restoring...
+						{:else}
+							<CloudArrowDownIcon size={14} />
+							Restore
+						{/if}
+					</button>
+
+					{#if status.backupCount > 1}
+						<button
+							class="flex items-center gap-1 px-2 py-1.5 rounded-lg text-xs transition-colors hover:bg-[var(--color-bg-secondary)]"
+							style="color: var(--color-caption);"
+							on:click={() => toggleVersions(type)}
+						>
+							<ClockCounterClockwiseIcon size={12} />
+							<CaretDownIcon
+								size={10}
+								class="transition-transform duration-200 {versionsExpanded[type]
+									? 'rotate-180'
+									: ''}"
+							/>
+							Versions
+						</button>
+					{/if}
+
+					{#if hasRelays}
+						<button
+							class="flex items-center gap-1 px-2 py-1.5 rounded-lg text-xs transition-colors hover:bg-[var(--color-bg-secondary)]"
+							style="color: var(--color-caption);"
+							on:click={() => toggleRelayDetails(type)}
+						>
+							<CaretDownIcon
+								size={12}
+								class="transition-transform duration-200 {expandedType === type
+									? 'rotate-180'
+									: ''}"
+							/>
+							Relays
+						</button>
+					{/if}
+				</div>
+
+				<!-- Message -->
+				{#if messages[type]}
+					<div
+						class="mt-2 text-xs px-2 py-1 rounded"
+						class:text-green-600={messages[type]?.type === 'success'}
+						class:text-red-500={messages[type]?.type === 'error'}
+						style="background-color: {messages[type]?.type === 'success'
+							? 'rgba(34, 197, 94, 0.1)'
+							: 'rgba(239, 68, 68, 0.1)'};"
+					>
+						{messages[type]?.text}
+					</div>
+				{/if}
+			</div>
+
+			<!-- Version List (expandable) -->
+			{#if versionsExpanded[type] && backupList.length > 0}
+				<div
+					class="px-4 pb-3 pt-2 border-t flex flex-col gap-1.5"
+					style="border-color: var(--color-input-border);"
+				>
+					{#each backupList as backup, i}
+						<div
+							class="flex items-center justify-between text-xs p-2 rounded-lg"
+							style="background-color: var(--color-bg-secondary);"
+						>
+							<div class="flex items-center gap-2 min-w-0">
+								<span class="text-caption flex-shrink-0">#{i + 1}</span>
+								<span class="truncate" style="color: var(--color-text-primary);">
+									{formatFullTimestamp(backup.timestamp)}
+								</span>
+								{#if getVersionSummary(type, i)}
+									<span class="text-caption flex-shrink-0">&middot; {getVersionSummary(type, i)}</span>
+								{/if}
+							</div>
+							<button
+								class="flex items-center gap-1 px-2 py-1 rounded text-xs transition-colors hover:opacity-80 flex-shrink-0 ml-2"
+								style="color: var(--color-primary);"
+								disabled={!backup.data || restoring[type]}
+								on:click={() => handleRestore(type, i)}
+							>
+								<CloudArrowDownIcon size={12} />
+								Restore
+							</button>
+						</div>
+					{/each}
+				</div>
+			{/if}
+
+			<!-- Relay Details (expandable) -->
+			{#if expandedType === type && hasRelays}
+				<div
+					class="px-4 pb-3 pt-2 border-t flex flex-col gap-1.5"
+					style="border-color: var(--color-input-border);"
+				>
+					{#each status.relayStatuses as relay}
+						<div class="flex items-center justify-between text-xs">
+							<div class="flex items-center gap-1.5 min-w-0">
+								{#if relay.hasBackup}
+									<CheckCircleIcon size={12} class="text-green-500 flex-shrink-0" weight="fill" />
+								{:else if relay.error}
+									<WarningIcon size={12} class="text-amber-500 flex-shrink-0" weight="fill" />
+								{:else}
+									<XCircleIcon size={12} class="text-caption flex-shrink-0" />
+								{/if}
+								<span class="truncate font-mono text-caption"
+									>{getRelayDisplayName(relay.relay)}</span
+								>
+							</div>
+							<span class="text-caption flex-shrink-0 ml-2">
+								{#if relay.hasBackup && relay.timestamp}
+									{formatRelayTimestamp(relay.timestamp)}
+								{:else if relay.error}
+									<span class="text-amber-500">{relay.error}</span>
+								{:else}
+									—
+								{/if}
+							</span>
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</div>
+	{/each}
+
+	<!-- Wallet Backups (view-only) — show each type that has a backup -->
+	{#each [{ key: 'spark', label: 'Spark Wallet', status: sparkBackupStatus }, { key: 'nwc', label: 'NWC Wallet', status: nwcBackupStatus }] as wallet (wallet.key)}
+		{#if wallet.status.loading || wallet.status.exists}
+			<div
+				class="rounded-lg border overflow-hidden"
+				style="border-color: var(--color-input-border); background-color: var(--color-bg-primary);"
+			>
+				<div class="px-4 py-3">
+					<div class="flex items-center justify-between mb-1">
+						<div class="flex items-center gap-2">
+							<span class="text-sm font-medium" style="color: var(--color-text-primary);"
+								>{wallet.label}</span
+							>
+						</div>
+					</div>
+
+					<!-- Status line -->
+					<div class="flex items-center gap-1.5 mb-3">
+						{#if wallet.status.loading}
+							<div
+								class="w-3 h-3 border-2 border-primary-color border-t-transparent rounded-full animate-spin"
+							></div>
+							<span class="text-xs text-caption">Checking...</span>
+						{:else if wallet.status.error}
+							<WarningIcon size={14} class="text-amber-500" />
+							<span class="text-xs text-amber-500">{wallet.status.error}</span>
+						{:else if wallet.status.exists}
+							<CheckCircleIcon size={14} class="text-green-500" weight="fill" />
+							<span class="text-xs text-caption">
+								Backed up
+								{#if wallet.status.timestamp}
+									&middot; {formatTimestamp(wallet.status.timestamp)}
+								{/if}
+								&middot; {relayBackupCount(wallet.status.relayStatuses)}/{wallet.status.relayStatuses.length} relays
+							</span>
+						{/if}
+					</div>
+
+					<!-- Info + relay toggle -->
+					<div class="flex items-center gap-2 flex-wrap">
+						<span class="text-xs text-caption flex items-center gap-1.5">
+							<WalletIcon size={14} />
+							Manage in Wallet
+						</span>
+
+						{#if wallet.status.relayStatuses.length > 0}
+							<button
+								class="flex items-center gap-1 px-2 py-1.5 rounded-lg text-xs transition-colors hover:bg-[var(--color-bg-secondary)]"
+								style="color: var(--color-caption);"
+								on:click={() => (walletRelaysExpanded[wallet.key] = !walletRelaysExpanded[wallet.key])}
+							>
+								<CaretDownIcon
+									size={12}
+									class="transition-transform duration-200 {walletRelaysExpanded[wallet.key] ? 'rotate-180' : ''}"
+								/>
+								Relays
+							</button>
+						{/if}
+					</div>
+				</div>
+
+				<!-- Relay Details (expandable) -->
+				{#if walletRelaysExpanded[wallet.key] && wallet.status.relayStatuses.length > 0}
+					<div
+						class="px-4 pb-3 pt-2 border-t flex flex-col gap-1.5"
+						style="border-color: var(--color-input-border);"
+					>
+						{#each wallet.status.relayStatuses as relay}
+							<div class="flex items-center justify-between text-xs">
+								<div class="flex items-center gap-1.5 min-w-0">
+									{#if relay.hasBackup}
+										<CheckCircleIcon size={12} class="text-green-500 flex-shrink-0" weight="fill" />
+									{:else if relay.error}
+										<WarningIcon size={12} class="text-amber-500 flex-shrink-0" weight="fill" />
+									{:else}
+										<XCircleIcon size={12} class="text-caption flex-shrink-0" />
+									{/if}
+									<span class="truncate font-mono text-caption"
+										>{getRelayDisplayName(relay.relay)}</span
+									>
+								</div>
+								<span class="text-caption flex-shrink-0 ml-2">
+									{#if relay.hasBackup && relay.timestamp}
+										{formatRelayTimestamp(relay.timestamp)}
+									{:else if relay.error}
+										<span class="text-amber-500">{relay.error}</span>
+									{:else}
+										—
+									{/if}
+								</span>
+							</div>
+						{/each}
+					</div>
+				{/if}
+			</div>
+		{/if}
+	{/each}
+
+	<!-- Refresh all -->
+	<button
+		class="flex items-center justify-center gap-2 px-4 py-2 rounded-lg text-xs transition-colors hover:opacity-80"
+		style="background-color: var(--color-bg-secondary); border: 1px solid var(--color-input-border); color: var(--color-text-primary);"
+		on:click={checkAllStatuses}
+		disabled={statuses.follows.loading || statuses.mute.loading || statuses.profile.loading}
+	>
+		<ArrowClockwiseIcon
+			size={14}
+			class={statuses.follows.loading || statuses.mute.loading || statuses.profile.loading
+				? 'animate-spin'
+				: ''}
+		/>
+		Refresh All
+	</button>
+</div>

--- a/src/components/NostrBackupSection.svelte
+++ b/src/components/NostrBackupSection.svelte
@@ -33,7 +33,6 @@
 	import ArrowClockwiseIcon from 'phosphor-svelte/lib/ArrowClockwise';
 	import ClockCounterClockwiseIcon from 'phosphor-svelte/lib/ClockCounterClockwise';
 	import WalletIcon from 'phosphor-svelte/lib/Wallet';
-	import { activeWallet } from '$lib/wallet/walletStore';
 	import { checkRelayBackups as checkSparkRelayBackups } from '$lib/spark';
 	import { checkRelayBackups as checkNwcRelayBackups } from '$lib/wallet/nwcBackup';
 

--- a/src/lib/nostrBackup.ts
+++ b/src/lib/nostrBackup.ts
@@ -1,0 +1,537 @@
+/**
+ * Nostr Backup Service
+ *
+ * Backup/restore follows (kind:3), mute list (kind:10000), and profile (kind:0)
+ * using NIP-78 (kind:30078) encrypted addressable events on Nostr relays.
+ *
+ * All backup types use rotating 3-slot systems with d-tags:
+ * - zapcooking:follows-backup:0/1/2
+ * - zapcooking:mute-backup:0/1/2
+ * - zapcooking:profile-backup:0/1/2 (managed by profileBackup.ts)
+ */
+
+import type NDK from '@nostr-dev-kit/ndk';
+import { NDKEvent, NDKRelaySet } from '@nostr-dev-kit/ndk';
+import { get } from 'svelte/store';
+import { ndk, getCurrentRelays } from '$lib/nostr';
+import { standardRelays } from '$lib/consts';
+import {
+	hasEncryptionSupport,
+	encrypt,
+	decrypt,
+	detectEncryptionMethod,
+	type EncryptionMethod
+} from '$lib/encryptionService';
+import { fetchMuteList, parseMuteListEvent, type MuteList } from '$lib/mutableIntegration';
+import { resetCache as resetFollowListCache } from '$lib/followListCache';
+
+// NIP-78 event kind
+const APP_DATA_KIND = 30078;
+
+// D-tag base constants
+const D_TAG_FOLLOWS_BASE = 'zapcooking:follows-backup';
+const D_TAG_MUTE_BASE = 'zapcooking:mute-backup';
+
+// Number of backup slots
+const MAX_BACKUP_SLOTS = 3;
+
+// Generate d-tag for a specific slot
+function getSlotDTag(base: string, slot: number): string {
+	return `${base}:${slot}`;
+}
+
+// Get all d-tags for a backup type (includes legacy non-slotted tag)
+function getAllDTags(base: string): string[] {
+	const tags = Array.from({ length: MAX_BACKUP_SLOTS }, (_, i) => getSlotDTag(base, i));
+	tags.push(base); // Include legacy for backwards compatibility
+	return tags;
+}
+
+// Re-export d-tags for relay status checking
+export const BACKUP_D_TAGS = {
+	follows: getAllDTags(D_TAG_FOLLOWS_BASE),
+	mute: getAllDTags(D_TAG_MUTE_BASE),
+	profile: [
+		'zapcooking:profile-backup:0',
+		'zapcooking:profile-backup:1',
+		'zapcooking:profile-backup:2',
+		'zapcooking:profile-backup'
+	]
+} as const;
+
+export type BackupType = 'follows' | 'mute' | 'profile';
+
+// ── Data Structures ──
+
+export interface FollowsBackupData {
+	version: number;
+	timestamp: number;
+	follows: string[];
+	relayHints?: Record<string, string>;
+	kind3Content?: string;
+}
+
+export interface MuteBackupData {
+	version: number;
+	timestamp: number;
+	muteList: {
+		pubkeys: Array<{ value: string; reason?: string; private: boolean }>;
+		words: Array<{ value: string; reason?: string; private: boolean }>;
+		tags: Array<{ value: string; reason?: string; private: boolean }>;
+		threads: Array<{ value: string; reason?: string; private: boolean }>;
+	};
+}
+
+export interface BackupInfo<T> {
+	timestamp: number;
+	createdAt: number;
+	eventId: string;
+	data?: T;
+}
+
+export interface RelayBackupStatus {
+	relay: string;
+	hasBackup: boolean;
+	timestamp?: number;
+	error?: string;
+}
+
+// ── Internal Helpers ──
+
+async function encryptBackupData(
+	data: FollowsBackupData | MuteBackupData,
+	userPubkey: string
+): Promise<{ content: string; method: EncryptionMethod }> {
+	if (!hasEncryptionSupport()) {
+		throw new Error('No encryption method available. Sign in with nsec, NIP-07, or NIP-46.');
+	}
+	const jsonString = JSON.stringify(data);
+	const result = await encrypt(userPubkey, jsonString, 'nip04');
+	return { content: result.ciphertext, method: result.method };
+}
+
+async function decryptBackupEvent<T>(event: NDKEvent): Promise<T | null> {
+	const encryptedTag = event.tags.find((t) => t[0] === 'encrypted');
+	const isEncrypted = encryptedTag?.[1] === 'true';
+
+	if (isEncrypted) {
+		if (!hasEncryptionSupport()) return null;
+		const encMethodTag = event.tags.find((t) => t[0] === 'encryption');
+		const method: EncryptionMethod =
+			encMethodTag?.[1] === 'nip44' || encMethodTag?.[1] === 'nip04'
+				? (encMethodTag[1] as EncryptionMethod)
+				: detectEncryptionMethod(event.content);
+		const decrypted = await decrypt(event.pubkey, event.content, method);
+		return JSON.parse(decrypted) as T;
+	} else {
+		return JSON.parse(event.content) as T;
+	}
+}
+
+async function publishBackupEvent(
+	ndkInstance: NDK,
+	dTag: string,
+	content: string,
+	isEncrypted: boolean,
+	encryptionMethod: EncryptionMethod
+): Promise<boolean> {
+	const event = new NDKEvent(ndkInstance);
+	event.kind = APP_DATA_KIND;
+	event.content = content;
+	event.tags = [
+		['d', dTag],
+		['encrypted', isEncrypted ? 'true' : 'false'],
+		...(encryptionMethod ? [['encryption', encryptionMethod]] : [])
+	];
+
+	await event.sign();
+	const publishedRelays = await event.publish();
+	return publishedRelays.size > 0;
+}
+
+/**
+ * Find the best slot to use for the next backup.
+ * Returns the first empty slot, or the oldest slot if all are used.
+ */
+async function findNextBackupSlot(
+	ndkInstance: NDK,
+	pubkey: string,
+	dTagBase: string
+): Promise<number> {
+	const dTags = Array.from({ length: MAX_BACKUP_SLOTS }, (_, i) => getSlotDTag(dTagBase, i));
+
+	const events = await ndkInstance.fetchEvents({
+		kinds: [APP_DATA_KIND],
+		authors: [pubkey],
+		'#d': dTags
+	});
+
+	const usedSlots = new Set<number>();
+	const slotTimestamps: Array<{ slot: number; timestamp: number }> = [];
+
+	for (const event of events) {
+		const dTag = event.tags.find((t) => t[0] === 'd')?.[1];
+		if (!dTag) continue;
+		const slotMatch = dTag.match(/:(\d+)$/);
+		if (!slotMatch) continue;
+		const slot = parseInt(slotMatch[1], 10);
+		usedSlots.add(slot);
+		slotTimestamps.push({ slot, timestamp: event.created_at || 0 });
+	}
+
+	// Use first empty slot
+	for (let i = 0; i < MAX_BACKUP_SLOTS; i++) {
+		if (!usedSlots.has(i)) return i;
+	}
+
+	// All used — overwrite oldest
+	slotTimestamps.sort((a, b) => a.timestamp - b.timestamp);
+	return slotTimestamps[0]?.slot ?? 0;
+}
+
+function getRelayUrls(): string[] {
+	const relays = getCurrentRelays();
+	return Array.isArray(relays) && relays.length > 0 ? relays : standardRelays;
+}
+
+// ── Follows Backup ──
+
+export async function backupFollows(
+	ndkInstance: NDK,
+	pubkey: string
+): Promise<boolean> {
+	const event = await ndkInstance.fetchEvent({
+		kinds: [3],
+		authors: [pubkey]
+	});
+
+	if (!event) {
+		throw new Error('No follow list found to back up');
+	}
+
+	const follows: string[] = [];
+	const relayHints: Record<string, string> = {};
+
+	for (const tag of event.tags) {
+		if (tag[0] === 'p' && tag[1]) {
+			follows.push(tag[1]);
+			if (tag[2]) {
+				relayHints[tag[1]] = tag[2];
+			}
+		}
+	}
+
+	const backupData: FollowsBackupData = {
+		version: 1,
+		timestamp: Date.now(),
+		follows,
+		relayHints: Object.keys(relayHints).length > 0 ? relayHints : undefined,
+		kind3Content: event.content || undefined
+	};
+
+	const slot = await findNextBackupSlot(ndkInstance, pubkey, D_TAG_FOLLOWS_BASE);
+	const dTag = getSlotDTag(D_TAG_FOLLOWS_BASE, slot);
+
+	const { content, method } = await encryptBackupData(backupData, pubkey);
+	return publishBackupEvent(ndkInstance, dTag, content, true, method);
+}
+
+export async function listFollowsBackups(
+	ndkInstance: NDK,
+	pubkey: string
+): Promise<BackupInfo<FollowsBackupData>[]> {
+	const events = await ndkInstance.fetchEvents({
+		kinds: [APP_DATA_KIND],
+		authors: [pubkey],
+		'#d': getAllDTags(D_TAG_FOLLOWS_BASE)
+	});
+
+	if (!events || events.size === 0) return [];
+
+	const backups: BackupInfo<FollowsBackupData>[] = [];
+
+	for (const event of events) {
+		try {
+			const data = await decryptBackupEvent<FollowsBackupData>(event);
+			if (data) {
+				backups.push({
+					timestamp: data.timestamp,
+					createdAt: event.created_at || 0,
+					eventId: event.id || '',
+					data
+				});
+			} else {
+				backups.push({
+					timestamp: (event.created_at || 0) * 1000,
+					createdAt: event.created_at || 0,
+					eventId: event.id || ''
+				});
+			}
+		} catch {
+			// Skip unparseable events
+		}
+	}
+
+	backups.sort((a, b) => b.timestamp - a.timestamp);
+	return backups.slice(0, MAX_BACKUP_SLOTS);
+}
+
+export async function fetchFollowsBackup(
+	ndkInstance: NDK,
+	pubkey: string
+): Promise<FollowsBackupData | null> {
+	const backups = await listFollowsBackups(ndkInstance, pubkey);
+	return backups.length > 0 && backups[0].data ? backups[0].data : null;
+}
+
+export async function restoreFollowsFromBackup(
+	ndkInstance: NDK,
+	pubkey: string,
+	backup: FollowsBackupData
+): Promise<boolean> {
+	const event = new NDKEvent(ndkInstance);
+	event.kind = 3;
+	event.content = backup.kind3Content || '';
+	event.tags = backup.follows.map((pk) => {
+		const tag = ['p', pk];
+		if (backup.relayHints?.[pk]) {
+			tag.push(backup.relayHints[pk]);
+		}
+		return tag;
+	});
+
+	await event.sign();
+	const publishedRelays = await event.publish();
+
+	if (publishedRelays.size > 0) {
+		resetFollowListCache();
+		return true;
+	}
+	return false;
+}
+
+// ── Mute List Backup ──
+
+export async function backupMuteList(
+	ndkInstance: NDK,
+	pubkey: string
+): Promise<boolean> {
+	const event = await fetchMuteList(pubkey);
+	if (!event) {
+		throw new Error('No mute list found to back up');
+	}
+
+	const muteList = await parseMuteListEvent(event);
+
+	const backupData: MuteBackupData = {
+		version: 1,
+		timestamp: Date.now(),
+		muteList: {
+			pubkeys: muteList.pubkeys.map((p) => ({
+				value: p.value,
+				reason: p.reason,
+				private: p.private || false
+			})),
+			words: muteList.words.map((w) => ({
+				value: w.value,
+				reason: w.reason,
+				private: w.private || false
+			})),
+			tags: muteList.tags.map((t) => ({
+				value: t.value,
+				reason: t.reason,
+				private: t.private || false
+			})),
+			threads: muteList.threads.map((t) => ({
+				value: t.value,
+				reason: t.reason,
+				private: t.private || false
+			}))
+		}
+	};
+
+	const slot = await findNextBackupSlot(ndkInstance, pubkey, D_TAG_MUTE_BASE);
+	const dTag = getSlotDTag(D_TAG_MUTE_BASE, slot);
+
+	const { content, method } = await encryptBackupData(backupData, pubkey);
+	return publishBackupEvent(ndkInstance, dTag, content, true, method);
+}
+
+export async function listMuteListBackups(
+	ndkInstance: NDK,
+	pubkey: string
+): Promise<BackupInfo<MuteBackupData>[]> {
+	const events = await ndkInstance.fetchEvents({
+		kinds: [APP_DATA_KIND],
+		authors: [pubkey],
+		'#d': getAllDTags(D_TAG_MUTE_BASE)
+	});
+
+	if (!events || events.size === 0) return [];
+
+	const backups: BackupInfo<MuteBackupData>[] = [];
+
+	for (const event of events) {
+		try {
+			const data = await decryptBackupEvent<MuteBackupData>(event);
+			if (data) {
+				backups.push({
+					timestamp: data.timestamp,
+					createdAt: event.created_at || 0,
+					eventId: event.id || '',
+					data
+				});
+			} else {
+				backups.push({
+					timestamp: (event.created_at || 0) * 1000,
+					createdAt: event.created_at || 0,
+					eventId: event.id || ''
+				});
+			}
+		} catch {
+			// Skip unparseable events
+		}
+	}
+
+	backups.sort((a, b) => b.timestamp - a.timestamp);
+	return backups.slice(0, MAX_BACKUP_SLOTS);
+}
+
+export async function fetchMuteListBackup(
+	ndkInstance: NDK,
+	pubkey: string
+): Promise<MuteBackupData | null> {
+	const backups = await listMuteListBackups(ndkInstance, pubkey);
+	return backups.length > 0 && backups[0].data ? backups[0].data : null;
+}
+
+export async function restoreMuteListFromBackup(
+	ndkInstance: NDK,
+	pubkey: string,
+	backup: MuteBackupData
+): Promise<boolean> {
+	const event = new NDKEvent(ndkInstance);
+	event.kind = 10000;
+	event.tags = [];
+
+	const privateItems: {
+		pubkeys?: Array<{ type: string; value: string; reason?: string }>;
+		words?: Array<{ type: string; value: string; reason?: string }>;
+		tags?: Array<{ type: string; value: string; reason?: string }>;
+		threads?: Array<{ type: string; value: string; reason?: string }>;
+	} = {};
+
+	for (const p of backup.muteList.pubkeys) {
+		if (p.private) {
+			if (!privateItems.pubkeys) privateItems.pubkeys = [];
+			privateItems.pubkeys.push({ type: 'pubkey', value: p.value, reason: p.reason });
+		} else {
+			const tag = ['p', p.value];
+			if (p.reason) tag.push(p.reason);
+			event.tags.push(tag);
+		}
+	}
+
+	for (const w of backup.muteList.words) {
+		if (w.private) {
+			if (!privateItems.words) privateItems.words = [];
+			privateItems.words.push({ type: 'word', value: w.value, reason: w.reason });
+		} else {
+			const tag = ['word', w.value];
+			if (w.reason) tag.push(w.reason);
+			event.tags.push(tag);
+		}
+	}
+
+	for (const t of backup.muteList.tags) {
+		if (t.private) {
+			if (!privateItems.tags) privateItems.tags = [];
+			privateItems.tags.push({ type: 'tag', value: t.value, reason: t.reason });
+		} else {
+			const tag = ['t', t.value];
+			if (t.reason) tag.push(t.reason);
+			event.tags.push(tag);
+		}
+	}
+
+	for (const t of backup.muteList.threads) {
+		if (t.private) {
+			if (!privateItems.threads) privateItems.threads = [];
+			privateItems.threads.push({ type: 'thread', value: t.value, reason: t.reason });
+		} else {
+			const tag = ['e', t.value];
+			if (t.reason) tag.push(t.reason);
+			event.tags.push(tag);
+		}
+	}
+
+	const hasPrivateItems = Object.values(privateItems).some((arr) => arr && arr.length > 0);
+	if (hasPrivateItems && hasEncryptionSupport()) {
+		const { ciphertext } = await encrypt(pubkey, JSON.stringify(privateItems), 'nip04');
+		event.content = ciphertext;
+	} else {
+		event.content = '';
+	}
+
+	await event.sign();
+	const publishedRelays = await event.publish();
+
+	if (publishedRelays.size > 0) {
+		const { muteListStore } = await import('$lib/muteListStore');
+		muteListStore.load(true);
+		return true;
+	}
+	return false;
+}
+
+// ── Per-Relay Status Check ──
+
+export async function checkBackupRelayStatus(
+	ndkInstance: NDK,
+	pubkey: string,
+	dTags: string | string[],
+	relayUrls?: string[]
+): Promise<RelayBackupStatus[]> {
+	const relays = relayUrls || getRelayUrls();
+	const dTagArray = Array.isArray(dTags) ? dTags : [dTags];
+
+	const checkPromises = relays.map(async (relayUrl): Promise<RelayBackupStatus> => {
+		try {
+			const relaySet = NDKRelaySet.fromRelayUrls([relayUrl], ndkInstance, true);
+
+			const events = await Promise.race([
+				ndkInstance.fetchEvents(
+					{
+						kinds: [APP_DATA_KIND],
+						authors: [pubkey],
+						'#d': dTagArray
+					},
+					{ closeOnEose: true },
+					relaySet
+				),
+				new Promise<Set<NDKEvent>>((resolve) => setTimeout(() => resolve(new Set()), 8000))
+			]);
+
+			if (events && events.size > 0) {
+				let latest: NDKEvent | null = null;
+				for (const event of events) {
+					if (!latest || (event.created_at || 0) > (latest.created_at || 0)) {
+						latest = event;
+					}
+				}
+
+				return {
+					relay: relayUrl,
+					hasBackup: true,
+					timestamp: latest?.created_at ? latest.created_at * 1000 : undefined
+				};
+			}
+
+			return { relay: relayUrl, hasBackup: false };
+		} catch {
+			return { relay: relayUrl, hasBackup: false, error: 'Connection failed' };
+		}
+	});
+
+	return Promise.all(checkPromises);
+}

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1215,10 +1215,10 @@
       <div class="text-xs" style="color: var(--color-text-primary);">
         <p class="font-medium text-red-500 mb-1">You will be signed out of zap.cooking</p>
         <p class="text-caption">
-          {#if authMethod === 'nip07'}
-            Your private key remains safe in your browser extension. You can sign back in anytime.
-          {:else if authMethod === 'nip46'}
+          {#if authMethod === 'nip46'}
             Your private key remains safe in your remote signer. You can reconnect anytime.
+          {:else}
+            Your private key remains safe in your Nostr signer (for example, your browser extension). You can sign back in anytime.
           {/if}
         </p>
       </div>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -9,8 +9,13 @@
   import CircleIcon from 'phosphor-svelte/lib/Circle';
   import BroadcastIcon from 'phosphor-svelte/lib/Broadcast';
   import PlugsIcon from 'phosphor-svelte/lib/Plugs';
+  import SignOutIcon from 'phosphor-svelte/lib/SignOut';
+  import ShieldCheckIcon from 'phosphor-svelte/lib/ShieldCheck';
+  import WarningIcon from 'phosphor-svelte/lib/Warning';
   import Button from '../../components/Button.svelte';
+  import Modal from '../../components/Modal.svelte';
   import Accordion from '../../components/Accordion.svelte';
+  import NostrBackupSection from '../../components/NostrBackupSection.svelte';
   import { nip19 } from 'nostr-tools';
   import { theme, type Theme } from '$lib/themeStore';
   import { displayCurrency, SUPPORTED_CURRENCIES, type CurrencyCode } from '$lib/currencyStore';
@@ -161,6 +166,8 @@
   let authMethod: string | null = null;
   let nip46Info: NIP46ConnectionInfo | null = null;
   let disconnectingBunker = false;
+  let disconnectingSession = false;
+  let showDisconnectConfirm = false;
   let privateKeyRevealed = false;
 
   if (browser) {
@@ -199,6 +206,24 @@
       console.error('Failed to disconnect bunker:', error);
     } finally {
       disconnectingBunker = false;
+    }
+  }
+
+  async function disconnectSession() {
+    if (!browser) return;
+    disconnectingSession = true;
+    try {
+      const authManager = getAuthManager();
+      if (authManager) {
+        await authManager.logout();
+      }
+      userPublickey.set('');
+      goto('/login');
+    } catch (error) {
+      console.error('Failed to disconnect session:', error);
+    } finally {
+      disconnectingSession = false;
+      showDisconnectConfirm = false;
     }
   }
 
@@ -988,6 +1013,11 @@
       </div>
     </Accordion>
 
+    <!-- Nostr Backup Section -->
+    <Accordion title="Nostr Backup" open={false}>
+      <NostrBackupSection />
+    </Accordion>
+
     <!-- Security Section -->
     <Accordion title="Security" open={false}>
       <div class="flex flex-col gap-5">
@@ -1097,9 +1127,36 @@
           </div>
         {:else if authMethod === 'nip46'}
           <div class="border-t border-[var(--color-input-border)] pt-5">
-            <p class="text-sm text-caption italic">
-              Using remote signer - no private key stored on this device
+            <div class="flex items-center gap-2 mb-2">
+              <ShieldCheckIcon size={18} class="text-green-500" weight="fill" />
+              <p class="text-sm font-medium" style="color: var(--color-text-primary)">
+                Remote Signer (NIP-46)
+              </p>
+            </div>
+            <p class="text-xs text-caption">
+              Your private key is securely held by your remote signer. It is never exposed to this app.
             </p>
+          </div>
+        {:else if pk}
+          <div class="border-t border-[var(--color-input-border)] pt-5">
+            <div class="flex items-center gap-2 mb-2">
+              <ShieldCheckIcon size={18} class="text-green-500" weight="fill" />
+              <p class="text-sm font-medium" style="color: var(--color-text-primary)">
+                Browser Extension (NIP-07)
+              </p>
+            </div>
+            <p class="text-xs text-caption mb-4">
+              Your private key is securely held by your browser extension. It is never exposed to this app.
+            </p>
+
+            <button
+              type="button"
+              on:click={() => (showDisconnectConfirm = true)}
+              class="flex items-center gap-1.5 px-4 py-2 bg-red-500/10 hover:bg-red-500/20 text-red-500 rounded-lg text-sm font-medium transition-colors"
+            >
+              <SignOutIcon size={16} />
+              Disconnect
+            </button>
           </div>
         {/if}
 
@@ -1107,7 +1164,7 @@
         {#if authMethod === 'nip46' && nip46Info}
           <div class="border-t border-[var(--color-input-border)] pt-5">
             <p class="text-sm font-medium mb-1" style="color: var(--color-text-primary)">
-              Remote Signer (NIP-46)
+              Bunker Connection
             </p>
             <div class="flex items-center gap-2 text-sm mb-3">
               <CircleIcon size={10} weight="fill" class="text-green-500" />
@@ -1131,10 +1188,11 @@
 
             <button
               type="button"
-              on:click={disconnectBunker}
+              on:click={() => (showDisconnectConfirm = true)}
               disabled={disconnectingBunker}
-              class="px-4 py-2 bg-red-500 hover:bg-red-600 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50"
+              class="flex items-center gap-1.5 px-4 py-2 bg-red-500 hover:bg-red-600 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50"
             >
+              <SignOutIcon size={16} />
               {disconnectingBunker ? 'Disconnecting...' : 'Disconnect Bunker'}
             </button>
           </div>
@@ -1143,3 +1201,53 @@
     </Accordion>
   </div>
 </div>
+
+<!-- Disconnect Confirmation Modal -->
+<Modal bind:open={showDisconnectConfirm} cleanup={() => (showDisconnectConfirm = false)}>
+  <span slot="title">Disconnect Session</span>
+
+  <div class="flex flex-col gap-4">
+    <div
+      class="p-3 rounded-lg flex items-start gap-2 text-sm"
+      style="background-color: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.3);"
+    >
+      <WarningIcon size={18} class="text-red-500 flex-shrink-0 mt-0.5" weight="fill" />
+      <div class="text-xs" style="color: var(--color-text-primary);">
+        <p class="font-medium text-red-500 mb-1">You will be signed out of zap.cooking</p>
+        <p class="text-caption">
+          {#if authMethod === 'nip07'}
+            Your private key remains safe in your browser extension. You can sign back in anytime.
+          {:else if authMethod === 'nip46'}
+            Your private key remains safe in your remote signer. You can reconnect anytime.
+          {/if}
+        </p>
+      </div>
+    </div>
+
+    <div class="flex gap-2">
+      <button
+        type="button"
+        class="flex-1 px-4 py-2.5 rounded-xl text-sm font-medium transition-colors"
+        style="background-color: var(--color-bg-secondary); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+        on:click={() => (showDisconnectConfirm = false)}
+      >
+        Cancel
+      </button>
+      <button
+        type="button"
+        class="flex-1 flex items-center justify-center gap-1.5 px-4 py-2.5 rounded-xl text-sm font-medium transition-colors bg-red-500 hover:bg-red-600 text-white disabled:opacity-50"
+        disabled={disconnectingSession || disconnectingBunker}
+        on:click={() => {
+          if (authMethod === 'nip46') {
+            disconnectBunker();
+          } else {
+            disconnectSession();
+          }
+        }}
+      >
+        <SignOutIcon size={16} />
+        {disconnectingSession || disconnectingBunker ? 'Disconnecting...' : 'Disconnect'}
+      </button>
+    </div>
+  </div>
+</Modal>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1237,11 +1237,15 @@
         type="button"
         class="flex-1 flex items-center justify-center gap-1.5 px-4 py-2.5 rounded-xl text-sm font-medium transition-colors bg-red-500 hover:bg-red-600 text-white disabled:opacity-50"
         disabled={disconnectingSession || disconnectingBunker}
-        on:click={() => {
-          if (authMethod === 'nip46') {
-            disconnectBunker();
-          } else {
-            disconnectSession();
+        on:click={async () => {
+          try {
+            if (authMethod === 'nip46') {
+              await disconnectBunker();
+            } else {
+              await disconnectSession();
+            }
+          } finally {
+            showDisconnectConfirm = false;
           }
         }}
       >


### PR DESCRIPTION
## Summary
- **Nostr Backup Section**: New accordion in Settings with backup/restore for follows (kind:3) and mute list (kind:10000) using NIP-78 encrypted storage with rotating 3-slot versioning
- **Version Picker**: Browse and restore from up to 3 previous backup versions per data type, with timestamps and item counts
- **Wallet Backup Info**: View-only cards showing Spark and NWC wallet backup status independently (not just the active wallet)
- **Security Enhancements**: NIP-07 and NIP-46 users see signer safety info with a disconnect button and confirmation modal

## Details
- Follows and mute list backups use rotating d-tags (`zapcooking:follows-backup:0/1/2`, `zapcooking:mute-backup:0/1/2`) matching the existing profile backup pattern
- Backups are NIP-04 encrypted to the user's own pubkey
- Wallet cards check both Spark and NWC relay backups in parallel, showing all that exist
- Disconnect modal warns users before signing out, with reassurance their key is safe in their signer

## New files
- `src/components/NostrBackupSection.svelte` — backup UI component
- `src/lib/nostrBackup.ts` — follows/mute backup service (rotating slots, encrypt/decrypt, list/restore)

## Modified files
- `src/routes/settings/+page.svelte` — added Nostr Backup accordion, security signer info, disconnect flow

## Test plan
- [ ] Open Settings → Nostr Backup: verify follows/mute/profile cards render
- [ ] Create a backup → verify it publishes to relay
- [ ] Expand "Versions" → verify version list with timestamps
- [ ] Restore from a previous version → verify data is restored
- [ ] Check wallet backup cards show both Spark and NWC when both exist
- [ ] NIP-07 user: verify signer info message and Disconnect button appear in Security
- [ ] NIP-46 user: verify signer info and Disconnect button with confirmation modal
- [ ] Click Disconnect → verify warning modal → confirm → verify logout and redirect to /login

🤖 Generated with [Claude Code](https://claude.com/claude-code)