### PR TITLE
chore: auto-increment patch version on every commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "private": true,
   "scripts": {
     "dev": "vite dev",
@@ -17,7 +17,8 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "prettier --plugin-search-dir . --check . && eslint .",
-    "format": "prettier --plugin-search-dir . --write ."
+    "format": "prettier --plugin-search-dir . --write .",
+    "prepare": "cp scripts/bump-version.sh .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit"
   },
   "type": "module",
   "engines": {

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Pre-commit hook: auto-increment patch version in package.json on every commit
+
+CURRENT=$(node -p "require('./package.json').version")
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+NEW_PATCH=$((PATCH + 1))
+NEW_VERSION="$MAJOR.$MINOR.$NEW_PATCH"
+
+# Update package.json in place (portable sed)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' "s/\"version\": \"$CURRENT\"/\"version\": \"$NEW_VERSION\"/" package.json
+else
+  sed -i "s/\"version\": \"$CURRENT\"/\"version\": \"$NEW_VERSION\"/" package.json
+fi
+
+git add package.json
+echo "[version] $CURRENT → $NEW_VERSION"


### PR DESCRIPTION
## Summary
- Add `scripts/bump-version.sh` pre-commit hook that increments the patch version in `package.json` on every commit (e.g. `4.2.0` → `4.2.1`)
- Add `prepare` script so the hook is installed automatically on `pnpm install` for all contributors

## How it works
- Every `git commit` triggers the hook, which reads the current version, bumps the patch number, updates `package.json`, and stages it
- The footer (`v4.2.1`, `v4.2.2`, etc.) updates automatically since it reads from `package.json` at build time via Vite's `define`
- For major/minor bumps, manually edit `package.json` to e.g. `4.3.0` and the hook will continue from there

## Test plan
- [ ] Run `pnpm install` → confirm `.git/hooks/pre-commit` is created
- [ ] Make a commit → confirm `[version] X.Y.Z → X.Y.(Z+1)` prints and `package.json` is updated
- [ ] Run `pnpm build` → confirm footer shows the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)