### PR TITLE
fix: reposts not sticking — missing relay hint in NIP-18 e tag

### DIFF
--- a/src/components/NoteRepost.svelte
+++ b/src/components/NoteRepost.svelte
@@ -45,12 +45,17 @@
         reposts: { count: s.reposts.count + 1, userReposted: true }
       }));
 
-      // Create kind 6 repost event
+      // Create kind 6 repost event (NIP-18)
       repostEvent = new NDKEvent($ndk);
       repostEvent.kind = 6;
       repostEvent.content = JSON.stringify(event.rawEvent());
+
+      // NIP-18: e tag MUST include a relay URL as its third entry
+      const relayUrl = event.relay?.url
+        || event.onRelays?.[0]?.url
+        || '';
       repostEvent.tags = [
-        ['e', event.id, '', 'mention'],
+        ['e', event.id, relayUrl],
         ['p', event.pubkey]
       ];
 


### PR DESCRIPTION
## Summary
Reposts (kind 6) were not persisting on relays because the `e` tag was non-compliant with NIP-18:

1. **Missing relay URL** — The `e` tag passed an empty string instead of a relay URL. NIP-18 states the `e` tag "MUST include a relay URL as its third entry to indicate where it can be fetched." Without this, relays may reject the event and other clients can't resolve the original.
2. **Incorrect `mention` marker** — The 4th positional value was `mention`, which per NIP-10 causes clients/relays to treat it as a mention rather than a repost reference. NIP-18 reposts should not have a marker.

### Before
```js
['e', event.id, '', 'mention']
```

### After
```js
['e', event.id, relayUrl]  // relayUrl from event.relay or event.onRelays
```

## Test plan
- [ ] Repost a note → confirm it appears on other clients (e.g. Primal, Amethyst)
- [ ] Check the raw event — `e` tag should have a valid relay URL as 3rd entry
- [ ] Repost count should increment and persist across page reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)