### PR TITLE
feat: link previews and Nostr embeds in DMs and groups

### DIFF
--- a/src/components/NoteEmbed.svelte
+++ b/src/components/NoteEmbed.svelte
@@ -383,6 +383,7 @@
         }
         return url; // Keep other URLs (like marketplace links)
       })
+      .replace(/nostr:[^\s]+/g, '') // Remove nostr: references (shown as embeds or links, not raw text)
       .replace(/\s+/g, ' ')
       .trim(); // Clean up extra spaces
   }

--- a/src/lib/components/groups/GroupMessage.svelte
+++ b/src/lib/components/groups/GroupMessage.svelte
@@ -170,7 +170,7 @@
 			</button>
 		</div>
 		<div class="text-sm mt-0.5" style="color: var(--color-text-primary);">
-			<NoteContent {content} collapsible={false} showLinkPreviews={false} />
+			<NoteContent {content} collapsible={false} showLinkPreviews={true} />
 		</div>
 	</div>
 </div>

--- a/src/lib/components/messages/MessageBubble.svelte
+++ b/src/lib/components/messages/MessageBubble.svelte
@@ -4,6 +4,8 @@
   import { resolveProfileByPubkey, getDisplayName, type ProfileData } from '$lib/profileResolver';
   import LockSimpleIcon from 'phosphor-svelte/lib/LockSimple';
   import LockSimpleOpenIcon from 'phosphor-svelte/lib/LockSimpleOpen';
+  import LinkPreview from '../../../components/LinkPreview.svelte';
+  import NoteEmbed from '../../../components/NoteEmbed.svelte';
 
   export let sender: string;
   export let content: string;
@@ -116,6 +118,25 @@
       })
       .join('');
   }
+  // Extract URLs and nostr note/event references for previews below message text
+  function extractPreviewUrls(text: string): string[] {
+    const regex = /https?:\/\/[^\s<]+/g;
+    return (text.match(regex) || []).filter(url => {
+      // Skip image/video URLs (they'd clutter the bubble)
+      const lower = url.toLowerCase();
+      const mediaExt = ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.avif', '.svg', '.mp4', '.webm', '.mov'];
+      return !mediaExt.some(ext => lower.includes(ext));
+    });
+  }
+
+  function extractNostrEmbeds(text: string): string[] {
+    const regex = /nostr:(nevent1[023456789acdefghjklmnpqrstuvwxyz]+|note1[023456789acdefghjklmnpqrstuvwxyz]+|naddr1[023456789acdefghjklmnpqrstuvwxyz]+)/g;
+    return (text.match(regex) || []);
+  }
+
+  $: previewUrls = extractPreviewUrls(content);
+  $: nostrEmbeds = extractNostrEmbeds(content);
+
   $: protocolTip =
     protocol === 'nip17' ? 'Private — metadata hidden' : 'Compatible — metadata visible';
 
@@ -154,6 +175,16 @@
         : 'background-color: var(--color-input-bg); color: var(--color-text-primary);'}
   >
     <p class="text-sm whitespace-pre-wrap break-words">{@html renderedHtml}</p>
+    {#if nostrEmbeds.length > 0 || previewUrls.length > 0}
+      <div class="mt-1.5 flex flex-col gap-1.5">
+        {#each nostrEmbeds as nostrRef}
+          <NoteEmbed nostrString={nostrRef} depth={1} />
+        {/each}
+        {#each previewUrls as url}
+          <LinkPreview {url} />
+        {/each}
+      </div>
+    {/if}
     <p
       class="text-[10px] mt-1 {isMine ? 'text-right' : 'text-left'}"
       style={isMine ? 'color: rgba(255,255,255,0.7);' : 'color: var(--color-caption);'}


### PR DESCRIPTION
## Summary
- **Group messages**: Enable link previews, inline images, video embeds, and Nostr event embeds by flipping `showLinkPreviews` to `true` on the existing `NoteContent` component
- **DM messages**: Add `LinkPreview` and `NoteEmbed` components below message text to render rich previews for URLs (Instagram, YouTube, articles, etc.) and Nostr references (`nevent`, `note`, `naddr`)
- **NoteEmbed fix**: Strip `nostr:` references from quoted note content previews so second-level references don't display as raw bech32 text

## Changed files
- `src/lib/components/groups/GroupMessage.svelte` — enable `showLinkPreviews={true}`
- `src/lib/components/messages/MessageBubble.svelte` — add LinkPreview + NoteEmbed rendering
- `src/components/NoteEmbed.svelte` — strip `nostr:` refs from content preview text

## Test plan
- [ ] Send a URL (e.g. Instagram, YouTube, article) in a group message — verify preview card appears
- [ ] Send a `nostr:nevent1...` reference in a group message — verify embedded note renders
- [ ] Send a URL in a DM — verify link preview card appears inside the bubble
- [ ] Send a `nostr:nevent1...` in a DM — verify embedded note renders inside the bubble
- [ ] Verify quoted notes with nested `nostr:` references no longer show raw bech32 text
- [ ] Verify image/video URLs in DMs don't produce duplicate link preview cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)