### PR TITLE
fix: zap counts not showing on notes

### DIFF
--- a/src/components/NoteTotalZaps.svelte
+++ b/src/components/NoteTotalZaps.svelte
@@ -172,9 +172,11 @@
         if ('vibrate' in navigator) {
           navigator.vibrate([40, 50, 40]); // Two short pulses
         }
-        // The optimistic update already showed the zap, and the subscription will correct it
-        // when the real zap receipt arrives. No need to force refresh here.
         console.log('[NoteTotalZaps] One-tap zap completed successfully, amount:', result.amount);
+        // Re-fetch engagement to pick up the real zap receipt from relays
+        // (the optimistic update shows instantly, but this ensures the subscription
+        // is active and will reconcile with the actual zap receipt)
+        fetchEngagement($ndk, event.id, $userPublickey);
       } else {
         // Haptic feedback on failure - long vibration to indicate error
         if ('vibrate' in navigator) {

--- a/src/lib/engagementCache.ts
+++ b/src/lib/engagementCache.ts
@@ -1,9 +1,17 @@
 import { writable, type Writable, get } from 'svelte/store';
 import type { NDKEvent, NDKSubscription } from '@nostr-dev-kit/ndk';
-import type NDK from '@nostr-dev-kit/ndk';
+import NDK, { NDKRelaySet } from '@nostr-dev-kit/ndk';
 import { decode } from '@gandlaf21/bolt11-decode';
 import { browser } from '$app/environment';
 import { getEngagementCounts, batchFetchFromServerAPI } from './countQuery';
+
+// Aggregator relays that index zap receipts — LNURL providers publish kind:9735
+// to these relays, which may not overlap with the app's default relay set.
+const ZAP_AGGREGATOR_RELAYS = [
+  'wss://relay.damus.io',
+  'wss://nos.lol',
+  'wss://relay.primal.net'
+];
 
 // Individual zapper info
 export interface Zapper {
@@ -323,12 +331,38 @@ export async function fetchEngagement(
   
   // IMPORTANT: Reset counts to 0 before subscription to prevent double counting
   // The cache shows instant data, but subscription will provide accurate final counts
+  // Preserve any pending optimistic zap updates so they aren't wiped during re-fetch
+  let pendingOptimisticAmount = 0;
+  let pendingOptimisticCount = 0;
+  let pendingOptimisticZappers: Array<{ pubkey: string; amount: number; timestamp: number }> = [];
+  for (const [key, zap] of optimisticZaps.entries()) {
+    if (key.startsWith(`${eventId}:`)) {
+      pendingOptimisticAmount += zap.amountMillisats;
+      pendingOptimisticCount++;
+      const existingZapper = pendingOptimisticZappers.find(z => z.pubkey === zap.userPubkey);
+      if (existingZapper) {
+        existingZapper.amount += Math.floor(zap.amountMillisats / 1000);
+      } else {
+        pendingOptimisticZappers.push({
+          pubkey: zap.userPubkey,
+          amount: Math.floor(zap.amountMillisats / 1000),
+          timestamp: Math.floor(zap.timestamp / 1000)
+        });
+      }
+    }
+  }
   store.update(s => ({
     ...s,
     reactions: { count: 0, userReacted: false, groups: [], userReactions: new Set() },
     comments: { count: 0 },
     reposts: { count: 0, userReposted: false },
-    zaps: { ...s.zaps, count: 0, totalAmount: 0, topZappers: [] }, // Keep userZapped state
+    zaps: {
+      ...s.zaps,
+      count: pendingOptimisticCount,
+      totalAmount: pendingOptimisticAmount,
+      topZappers: pendingOptimisticZappers,
+      userZapped: s.zaps.userZapped || pendingOptimisticCount > 0
+    },
     loading: true
   }));
   
@@ -340,15 +374,39 @@ export async function fetchEngagement(
     kinds: [7, 6, 9735, 1],
     '#e': [eventId]
   };
-  
+
   let eoseReceived = false;
-  
+
+  // Pre-connect aggregator relays before subscribing.
+  // NDKRelaySet.fromRelayUrls creates temporary relays that connect asynchronously,
+  // so the subscription's initial REQ can miss them. By explicitly connecting first,
+  // we ensure the REQ reaches aggregator relays on the first try.
+  await Promise.all(
+    ZAP_AGGREGATOR_RELAYS.map(async (url) => {
+      try {
+        const relay = ndk.pool.getRelay(url, true, true);
+        if (relay.connectivity?.status !== 1) {
+          await relay.connect();
+        }
+      } catch {
+        // Non-fatal: subscription still works with other relays
+      }
+    })
+  );
+
+  // Build relay set: NDK's connected relays + zap aggregator relays
+  const relaySet = NDKRelaySet.fromRelayUrls(
+    [...(ndk.explicitRelayUrls || []), ...ZAP_AGGREGATOR_RELAYS],
+    ndk,
+    true // addConnectedRelays
+  );
+
   try {
     // Start subscription cleanup manager
     startSubscriptionCleanup();
-    
+
     // Create persistent subscription (stays open for real-time updates)
-    const sub = ndk.subscribe(filter, { closeOnEose: false });
+    const sub = ndk.subscribe(filter, { closeOnEose: false }, relaySet);
     
     // Register in persistent subscriptions map
     persistentSubscriptions.set(eventId, { sub, lastActivity: Date.now() });

--- a/src/routes/[nip19]/+page.svelte
+++ b/src/routes/[nip19]/+page.svelte
@@ -26,6 +26,7 @@
   import PostActionsMenu from '../../components/PostActionsMenu.svelte';
   import MentionDropdown from '../../components/MentionDropdown.svelte';
   import { MentionComposerController, type MentionState } from '$lib/mentionComposer';
+  import { fetchEngagement, optimisticZapUpdate } from '$lib/engagementCache';
 
   export let data: PageData;
 
@@ -887,7 +888,12 @@
 
 <!-- Zap Modal -->
 {#if zapModal && event}
-  <ZapModal {event} on:close={() => (zapModal = false)} />
+  <ZapModal {event} on:close={() => (zapModal = false)} on:zap-complete={(e) => {
+    if (event) {
+      optimisticZapUpdate(event.id, (e.detail.amount || 0) * 1000, $userPublickey);
+      fetchEngagement($ndk, event.id, $userPublickey);
+    }
+  }} />
 {/if}
 
 <style>


### PR DESCRIPTION
## Summary
- Zap counts were not appearing when loading previously-zapped notes, and not updating after sending a zap from the note page
- Root causes: note page ZapModal had no `on:zap-complete` handler, engagement subscription wasn't querying aggregator relays where LNURL providers publish zap receipts, and `fetchEngagement` reset was wiping optimistic updates

## Changes
- **Note page**: Add `on:zap-complete` handler to ZapModal that calls `optimisticZapUpdate` + `fetchEngagement`
- **engagementCache**: Pre-connect aggregator relays (relay.damus.io, nos.lol, relay.primal.net) before subscribing, use `NDKRelaySet` to include them in the engagement subscription, preserve pending optimistic zap amounts during reset
- **NoteTotalZaps**: Call `fetchEngagement` after one-tap zap success

## Test plan
- [ ] Open a previously-zapped note — zap count should show on first load
- [ ] Send a zap via the modal on a note page — count updates immediately
- [ ] Send a one-tap zap — count updates immediately
- [ ] Verify zap counts persist after page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)