### PR TITLE
fix: add server-side OG tags for user profiles

### DIFF
--- a/src/routes/user/[slug]/+page.server.ts
+++ b/src/routes/user/[slug]/+page.server.ts
@@ -1,0 +1,195 @@
+import type { PageServerLoad } from './$types';
+import { nip19 } from 'nostr-tools';
+
+interface ProfileMetadata {
+	name?: string;
+	display_name?: string;
+	picture?: string;
+	about?: string;
+	nip05?: string;
+}
+
+const RELAYS = [
+	'wss://relay.primal.net',
+	'wss://relay.damus.io',
+	'wss://nos.lol'
+];
+
+function fetchProfileFromRelay(relayUrl: string, pubkey: string): Promise<ProfileMetadata | null> {
+	if (typeof WebSocket === 'undefined') {
+		return Promise.resolve(null);
+	}
+
+	return new Promise((resolve) => {
+		let ws: WebSocket | null = null;
+		let resolved = false;
+
+		const cleanup = () => {
+			if (ws && ws.readyState === WebSocket.OPEN) {
+				try { ws.close(); } catch { /* ignore */ }
+			}
+		};
+
+		const safeResolve = (value: ProfileMetadata | null) => {
+			if (!resolved) {
+				resolved = true;
+				cleanup();
+				resolve(value);
+			}
+		};
+
+		const timeout = setTimeout(() => {
+			safeResolve(null);
+		}, 3000);
+
+		try {
+			ws = new WebSocket(relayUrl);
+		} catch {
+			clearTimeout(timeout);
+			safeResolve(null);
+			return;
+		}
+
+		const subId = `og-profile-${Date.now()}`;
+
+		ws.onopen = () => {
+			if (!ws || resolved) return;
+			try {
+				ws.send(JSON.stringify([
+					'REQ',
+					subId,
+					{ kinds: [0], authors: [pubkey], limit: 1 }
+				]));
+			} catch {
+				clearTimeout(timeout);
+				safeResolve(null);
+			}
+		};
+
+		ws.onmessage = (event) => {
+			if (!ws || resolved) return;
+			try {
+				const msg = JSON.parse(event.data);
+				if (msg[0] === 'EVENT' && msg[1] === subId && msg[2]) {
+					const evt = msg[2];
+					try {
+						const profile = JSON.parse(evt.content);
+						clearTimeout(timeout);
+						safeResolve({
+							name: profile.name || undefined,
+							display_name: profile.display_name || undefined,
+							picture: profile.picture || undefined,
+							about: profile.about || undefined,
+							nip05: profile.nip05 || undefined
+						});
+					} catch {
+						clearTimeout(timeout);
+						safeResolve(null);
+					}
+				} else if (msg[0] === 'EOSE' && msg[1] === subId) {
+					clearTimeout(timeout);
+					safeResolve(null);
+				}
+			} catch {
+				// Parse error, ignore
+			}
+		};
+
+		ws.onerror = () => {
+			clearTimeout(timeout);
+			safeResolve(null);
+		};
+
+		ws.onclose = () => {
+			clearTimeout(timeout);
+			if (!resolved) {
+				safeResolve(null);
+			}
+		};
+	});
+}
+
+async function fetchProfile(pubkey: string): Promise<ProfileMetadata | null> {
+	const results = await Promise.all(
+		RELAYS.map(relay => fetchProfileFromRelay(relay, pubkey))
+	);
+	return results.find(r => r !== null) || null;
+}
+
+function cleanBio(about: string): string {
+	let text = about
+		// Strip nostr: references
+		.replace(/nostr:[a-z0-9]+/gi, '')
+		// Strip URLs
+		.replace(/https?:\/\/[^\s]+/gi, '')
+		// Collapse whitespace
+		.replace(/\s+/g, ' ')
+		.trim();
+
+	if (text.length > 155) {
+		const truncated = text.slice(0, 155);
+		const lastSpace = truncated.lastIndexOf(' ');
+		return (lastSpace > 80 ? truncated.slice(0, lastSpace) : truncated) + '...';
+	}
+
+	return text;
+}
+
+export const prerender = false;
+
+export const load: PageServerLoad = async ({ params }) => {
+	const slug = params.slug;
+	if (!slug) return { ogMeta: null };
+
+	let pubkey = '';
+
+	try {
+		if (slug.startsWith('npub1')) {
+			const decoded = nip19.decode(slug);
+			if (decoded.type === 'npub') pubkey = decoded.data as string;
+		} else if (slug.startsWith('nprofile1')) {
+			const decoded = nip19.decode(slug);
+			if (decoded.type === 'nprofile') pubkey = (decoded.data as { pubkey: string }).pubkey;
+		} else if (/^[0-9a-f]{64}$/.test(slug)) {
+			pubkey = slug;
+		}
+	} catch {
+		return { ogMeta: null };
+	}
+
+	if (!pubkey) return { ogMeta: null };
+
+	if (typeof WebSocket === 'undefined') {
+		return {
+			ogMeta: {
+				title: 'User Profile - zap.cooking',
+				description: 'A user on zap.cooking - Food. Friends. Freedom.',
+				image: 'https://zap.cooking/social-share.png'
+			}
+		};
+	}
+
+	try {
+		const profilePromise = fetchProfile(pubkey);
+		const profileTimeout = new Promise<null>(resolve => setTimeout(() => resolve(null), 5000));
+		const profile = await Promise.race([profilePromise, profileTimeout]);
+
+		const displayName = profile?.display_name || profile?.name || null;
+		const title = displayName ? `${displayName} on zap.cooking` : 'User Profile - zap.cooking';
+
+		let description = 'A user on zap.cooking - Food. Friends. Freedom.';
+		if (profile?.about) {
+			const cleaned = cleanBio(profile.about);
+			if (cleaned) description = cleaned;
+		}
+
+		const image = profile?.picture || 'https://zap.cooking/social-share.png';
+
+		return {
+			ogMeta: { title, description, image }
+		};
+	} catch (e) {
+		console.error('[OG Meta] User profile error:', e);
+		return { ogMeta: null };
+	}
+};

--- a/src/routes/user/[slug]/+page.svelte
+++ b/src/routes/user/[slug]/+page.svelte
@@ -39,7 +39,7 @@
   import ArticleFeed from '../../../components/ArticleFeed.svelte';
   import MembershipBeltBadge from '../../../components/MembershipBeltBadge.svelte';
 
-  export const data: PageData = {} as PageData;
+  export let data: PageData;
 
   let hexpubkey: string | undefined = undefined;
   let events: NDKEvent[] = [];
@@ -1012,10 +1012,15 @@
     ? profile.name || (user ? user.npub.slice(0, 10) + '...' : 'Unknown User')
     : 'Unknown User';
 
+  // OG meta: prefer server-provided data (for crawlers), fall back to client data when loaded
   $: og_meta = {
-    title: `${profileTitleBase} - zap.cooking`,
-    description: "View this user's recipes on zap.cooking",
-    image: profile ? profile.picture : 'https://zap.cooking/social-share.png'
+    title: loaded ? `${profileTitleBase} - zap.cooking` : (data?.ogMeta?.title || 'User Profile - zap.cooking'),
+    description: loaded
+      ? (profile?.about ? profile.about.slice(0, 155) : "View this user's recipes on zap.cooking")
+      : (data?.ogMeta?.description || "A user on zap.cooking - Food. Friends. Freedom."),
+    image: loaded
+      ? (profile?.picture || 'https://zap.cooking/social-share.png')
+      : (data?.ogMeta?.image || 'https://zap.cooking/social-share.png')
   };
 
   // Setup IntersectionObserver for infinite scroll
@@ -1116,22 +1121,20 @@
 
 <svelte:head>
   <title>{og_meta.title}</title>
+  <meta name="description" content={og_meta.description} />
 
-  {#if loaded}
-    <meta name="description" content={og_meta.description} />
-    <meta property="og:url" content={`https://zap.cooking/user/${$page.params.slug}`} />
-    <meta property="og:type" content="profile" />
-    <meta property="og:title" content={og_meta.title} />
-    <meta property="og:description" content={og_meta.description} />
-    <meta property="og:image" content={String(og_meta.image)} />
+  <meta property="og:url" content={`https://zap.cooking/user/${$page.params.slug}`} />
+  <meta property="og:type" content="profile" />
+  <meta property="og:title" content={og_meta.title} />
+  <meta property="og:description" content={og_meta.description} />
+  <meta property="og:image" content={String(og_meta.image)} />
 
-    <meta name="twitter:card" content="summary" />
-    <meta property="twitter:domain" content="zap.cooking" />
-    <meta property="twitter:url" content={`https://zap.cooking/user/${$page.params.slug}`} />
-    <meta name="twitter:title" content={og_meta.title} />
-    <meta name="twitter:description" content={og_meta.description} />
-    <meta name="twitter:image" content={String(og_meta.image)} />
-  {/if}
+  <meta name="twitter:card" content="summary" />
+  <meta property="twitter:domain" content="zap.cooking" />
+  <meta property="twitter:url" content={`https://zap.cooking/user/${$page.params.slug}`} />
+  <meta name="twitter:title" content={og_meta.title} />
+  <meta name="twitter:description" content={og_meta.description} />
+  <meta name="twitter:image" content={String(og_meta.image)} />
 </svelte:head>
 
 {#if user}


### PR DESCRIPTION
## Summary
- User profile pages had no OG meta tags visible to crawlers/link preview bots because the tags were only rendered client-side after JavaScript loaded
- Add `+page.server.ts` that fetches the user's kind:0 profile from relays at request time, providing name, bio, and avatar for SSR

## Test plan
- [ ] `curl -s https://zap.cooking/user/npub1... | grep og:title` shows the user's name
- [ ] Share a user profile link on Discord/Telegram/iMessage — preview shows name, bio, and avatar
- [ ] Page still loads and functions normally in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)