### PR TITLE
chore: update breez-sdk-spark to 0.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": "22.x"
   },
   "dependencies": {
-    "@breeztech/breez-sdk-spark": "0.7.12",
+    "@breeztech/breez-sdk-spark": "0.9.1",
     "@capacitor/android": "^8.0.0",
     "@capacitor/app": "^8.0.0",
     "@capacitor/cli": "^8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@breeztech/breez-sdk-spark':
-        specifier: 0.7.12
-        version: 0.7.12
+        specifier: 0.9.1
+        version: 0.9.1
       '@capacitor/android':
         specifier: ^8.0.0
         version: 8.0.0(@capacitor/core@8.0.0)
@@ -286,8 +286,8 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
-  '@breeztech/breez-sdk-spark@0.7.12':
-    resolution: {integrity: sha512-AdjvkgQFEQicfHEO7JEIMKq/v9T/sP8MTBHs/Jgwz6Dx8vnVjwCUKKBbsJtXBw9hpO8AT63QD6O7H0tq3KeeAQ==}
+  '@breeztech/breez-sdk-spark@0.9.1':
+    resolution: {integrity: sha512-cPyW9WdMewM0q2aDO9ioSVn2ud4FDTXQeE1r4yQMMzjsdFT/WUihuvwKjCwEB+Ot4d3wpQU+WHPcfLwj08Wo4A==}
     engines: {node: '>=22'}
 
   '@capacitor/android@8.0.0':
@@ -692,8 +692,8 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@floating-ui/core@1.7.3':
-    resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
+  '@floating-ui/core@1.7.4':
+    resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
 
   '@floating-ui/dom@1.7.4':
     resolution: {integrity: sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==}
@@ -5137,7 +5137,7 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
-  '@breeztech/breez-sdk-spark@0.7.12':
+  '@breeztech/breez-sdk-spark@0.9.1':
     optionalDependencies:
       better-sqlite3: 12.6.2
 
@@ -5437,13 +5437,13 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
-  '@floating-ui/core@1.7.3':
+  '@floating-ui/core@1.7.4':
     dependencies:
       '@floating-ui/utils': 0.2.10
 
   '@floating-ui/dom@1.7.4':
     dependencies:
-      '@floating-ui/core': 1.7.3
+      '@floating-ui/core': 1.7.4
       '@floating-ui/utils': 0.2.10
 
   '@floating-ui/utils@0.2.10': {}


### PR DESCRIPTION
## Summary
- Updates `@breeztech/breez-sdk-spark` from 0.7.12 to 0.9.1
- No breaking changes — all new fields are additive or set by `defaultConfig()`
- Tested on Vercel deployment with wallet functionality confirmed working

## Changes
- `package.json`: bump version
- `pnpm-lock.yaml`: updated lockfile

## Test plan
- [x] Build passes
- [x] Deployed and tested on Vercel
- [x] Wallet connect/disconnect works
- [x] No runtime errors