### PR TITLE
fix: clear wallet state on logout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.95",
+  "version": "4.2.96",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -27,7 +27,8 @@
   import ErrorBoundary from '../components/ErrorBoundary.svelte';
   import OfflineIndicator from '../components/OfflineIndicator.svelte';
   import { theme } from '$lib/themeStore';
-  import { initializeWalletManager, walletConnected } from '$lib/wallet';
+  import { initializeWalletManager, walletConnected, clearAllWallets } from '$lib/wallet';
+  import { disconnectWallet as disconnectSparkWallet, clearAllSparkWallets } from '$lib/spark';
   import { loadOneTapZapSettings } from '$lib/autoZapSettings';
   import { weblnConnected } from '$lib/wallet/webln';
   import { bitcoinConnectEnabled, bitcoinConnectWalletInfo } from '$lib/wallet/bitcoinConnect';
@@ -246,6 +247,9 @@
           clearUnwrapCache();
           stopGroupSubscription();
           clearGroups();
+          disconnectSparkWallet().catch(() => {});
+          clearAllWallets();
+          clearAllSparkWallets();
         }
 
         if (browser && state.isAuthenticated && state.publicKey) {


### PR DESCRIPTION
## Summary
- Disconnect Spark SDK, clear wallet list, and remove stored mnemonics on logout/account switch
- Prevents stale wallet data from previous account appearing after re-login or switching accounts

## Changes
- `src/routes/+layout.svelte` — Add `disconnectSparkWallet()`, `clearAllWallets()`, and `clearAllSparkWallets()` to the logout cleanup sequence alongside existing message/group/cache cleanup

## Test plan
- [ ] Log in with account A, create/connect a Spark wallet
- [ ] Log out
- [ ] Log in with account B — wallet page should show clean state, no leftover wallet from account A
- [ ] Log back in with account A — wallet should require reconnection

🤖 Generated with [Claude Code](https://claude.com/claude-code)