### PR TITLE
feat: mobile-first market controls & DM improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.101",
+  "version": "4.2.106",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.106",
+  "version": "4.2.107",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.107",
+  "version": "4.2.108",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/marketplace/CategoryFilter.svelte
+++ b/src/components/marketplace/CategoryFilter.svelte
@@ -1,87 +1,185 @@
 <script lang="ts">
 	import { PRODUCT_CATEGORIES, CATEGORY_LABELS, CATEGORY_EMOJIS, type ProductCategory } from '$lib/marketplace/types';
+	import CaretDownIcon from 'phosphor-svelte/lib/CaretDown';
 
 	export let selected: ProductCategory | null = null;
 	export let counts: Partial<Record<ProductCategory | 'all', number>> = {};
 	export let onChange: (category: ProductCategory | null) => void = () => {};
+
+	// Only show categories that have products
+	$: visibleCategories = PRODUCT_CATEGORIES.filter((c) => (counts[c] || 0) > 0);
+
+	// On mobile: show top 5 by count, rest behind "More"
+	$: topCategories = [...visibleCategories]
+		.sort((a, b) => (counts[b] || 0) - (counts[a] || 0))
+		.slice(0, 5);
+	$: moreCategories = visibleCategories.filter((c) => !topCategories.includes(c));
+	$: hasMore = moreCategories.length > 0;
+
+	let showMore = false;
 
 	function handleClick(category: ProductCategory | null) {
 		selected = category;
 		onChange(category);
 	}
 
-	// Only show categories that have products (plus always show "All")
-	$: visibleCategories = PRODUCT_CATEGORIES.filter((c) => (counts[c] || 0) > 0);
+	// If user selects a category that's in "more", keep it visible
+	$: selectedIsHidden = selected !== null && !topCategories.includes(selected) && moreCategories.includes(selected);
 </script>
 
-<div class="category-scroll flex gap-2 overflow-x-auto pb-2">
-	<!-- All button -->
-	<button
-		type="button"
-		on:click={() => handleClick(null)}
-		class="category-pill {selected === null ? 'active' : ''}"
-	>
-		<span class="text-base">✨</span>
-		<span>All</span>
-		{#if counts.all}
-			<span class="count">{counts.all}</span>
-		{/if}
-	</button>
-
-	<!-- Category buttons (only categories with products) -->
-	{#each visibleCategories as category}
+<!-- Mobile: compact horizontal scroll with overflow menu -->
+<div class="flex flex-col gap-2">
+	<div class="chip-scroll">
+		<!-- All -->
 		<button
 			type="button"
-			on:click={() => handleClick(category)}
-			class="category-pill {selected === category ? 'active' : ''}"
+			on:click={() => handleClick(null)}
+			class="chip {selected === null ? 'active' : ''}"
+			aria-label="All categories"
 		>
-			<span class="text-base">{CATEGORY_EMOJIS[category]}</span>
-			<span>{CATEGORY_LABELS[category]}</span>
-			{#if counts[category]}
-				<span class="count">{counts[category]}</span>
+			All
+			{#if counts.all}
+				<span class="chip-count">{counts.all}</span>
 			{/if}
 		</button>
-	{/each}
+
+		<!-- Top categories (always visible) -->
+		{#each topCategories as category}
+			<button
+				type="button"
+				on:click={() => handleClick(category)}
+				class="chip {selected === category ? 'active' : ''}"
+				aria-label="{CATEGORY_LABELS[category]} ({counts[category] || 0})"
+			>
+				<span class="chip-emoji">{CATEGORY_EMOJIS[category]}</span>
+				<span class="chip-label">{CATEGORY_LABELS[category]}</span>
+				{#if counts[category]}
+					<span class="chip-count">{counts[category]}</span>
+				{/if}
+			</button>
+		{/each}
+
+		<!-- Selected category from "more" (pinned when active) -->
+		{#if selectedIsHidden && selected}
+			<button
+				type="button"
+				on:click={() => handleClick(selected)}
+				class="chip active"
+				aria-label="{CATEGORY_LABELS[selected]} ({counts[selected] || 0})"
+			>
+				<span class="chip-emoji">{CATEGORY_EMOJIS[selected]}</span>
+				<span class="chip-label">{CATEGORY_LABELS[selected]}</span>
+				{#if counts[selected]}
+					<span class="chip-count">{counts[selected]}</span>
+				{/if}
+			</button>
+		{/if}
+
+		<!-- More button -->
+		{#if hasMore}
+			<button
+				type="button"
+				on:click={() => (showMore = !showMore)}
+				class="chip {showMore ? 'active' : ''}"
+				aria-label="More categories"
+			>
+				More
+				<CaretDownIcon
+					size={12}
+					class="transition-transform duration-200"
+					style="transform: rotate({showMore ? '180deg' : '0deg'});"
+				/>
+			</button>
+		{/if}
+	</div>
+
+	<!-- Expanded "More" categories -->
+	{#if showMore}
+		<div class="chip-more">
+			{#each moreCategories as category}
+				<button
+					type="button"
+					on:click={() => { handleClick(category); showMore = false; }}
+					class="chip {selected === category ? 'active' : ''}"
+					aria-label="{CATEGORY_LABELS[category]} ({counts[category] || 0})"
+				>
+					<span class="chip-emoji">{CATEGORY_EMOJIS[category]}</span>
+					<span class="chip-label">{CATEGORY_LABELS[category]}</span>
+					{#if counts[category]}
+						<span class="chip-count">{counts[category]}</span>
+					{/if}
+				</button>
+			{/each}
+		</div>
+	{/if}
 </div>
 
 <style lang="postcss">
 	@reference "../../app.css";
 
-	.category-scroll {
+	.chip-scroll {
+		@apply flex gap-1.5 overflow-x-auto;
 		-ms-overflow-style: none;
 		scrollbar-width: none;
 	}
 
-	.category-scroll::-webkit-scrollbar {
+	.chip-scroll::-webkit-scrollbar {
 		display: none;
 	}
 
-	.category-pill {
-		@apply flex items-center gap-2 px-4 py-2.5 rounded-full text-sm font-medium transition-all whitespace-nowrap;
+	.chip-more {
+		@apply flex flex-wrap gap-1.5;
+		animation: slideDown 0.15s ease-out;
+	}
+
+	@keyframes slideDown {
+		from { opacity: 0; transform: translateY(-4px); }
+		to { opacity: 1; transform: translateY(0); }
+	}
+
+	.chip {
+		@apply flex items-center gap-1.5 rounded-full text-xs font-medium whitespace-nowrap cursor-pointer;
 		background-color: var(--color-bg-secondary);
 		color: var(--color-text-secondary);
 		border: 1px solid transparent;
+		padding: 7px 12px;
+		transition: all 0.15s ease;
 	}
 
-	.category-pill:hover {
+	.chip:hover {
 		background-color: var(--color-bg-tertiary, var(--color-bg-secondary));
 		color: var(--color-text-primary);
 	}
 
-	.category-pill.active {
-		background-color: var(--color-accent);
-		color: white;
-		border-color: var(--color-accent);
-		box-shadow: 0 4px 12px rgba(249, 115, 22, 0.3);
-		transform: scale(1.02);
+	.chip.active {
+		background-color: rgba(249, 115, 22, 0.15);
+		color: #f97316;
+		border-color: rgba(249, 115, 22, 0.4);
 	}
 
-	.count {
-		@apply text-xs px-2 py-0.5 rounded-full;
-		background-color: rgba(255, 255, 255, 0.15);
+	.chip-emoji {
+		font-size: 13px;
+		line-height: 1;
 	}
 
-	.category-pill:not(.active) .count {
+	.chip-label {
+		/* Hide on very small screens, show on sm+ */
+		display: none;
+	}
+
+	@media (min-width: 480px) {
+		.chip-label {
+			display: inline;
+		}
+	}
+
+	.chip-count {
+		@apply text-[10px] font-semibold px-1.5 rounded-full;
 		background-color: var(--color-bg-tertiary, rgba(0, 0, 0, 0.2));
+		line-height: 1.5;
+	}
+
+	.chip.active .chip-count {
+		background-color: rgba(249, 115, 22, 0.2);
 	}
 </style>

--- a/src/components/marketplace/ProductDetailModal.svelte
+++ b/src/components/marketplace/ProductDetailModal.svelte
@@ -151,6 +151,9 @@
 	// Post-purchase DM
 	$: postPurchaseDmMessage = `Hey! I just paid for "${product?.title}" (${paymentLabel}).${product?.requiresShipping ? '\n\nShipping address:\n[Your address here]' : ''}\n\nThanks!`;
 
+	// Track whether user has typed in the message box
+	let userEditedMessage = false;
+
 	// Reset / initialize on open/close
 	$: if (!open) {
 		paymentState = 'idle';
@@ -159,10 +162,10 @@
 		dmSent = false;
 		dmError = '';
 		showFullDetails = false;
-	} else if (open && !dmMessage) {
-		// Pre-fill with casual inquiry
-		dmMessage = `Hey \u2014 is "${product?.title}" still available?`;
-		// Autofocus the textarea after the modal renders
+		userEditedMessage = false;
+	} else if (open && product?.title && !userEditedMessage) {
+		// Pre-fill once the product title is available
+		dmMessage = `Hey \u2014 is "${product.title}" still available?`;
 		tick().then(() => {
 			messageInput?.focus();
 		});
@@ -253,10 +256,11 @@
 		dmError = '';
 
 		try {
+			const fullMessage = dmMessage.trim() + '\n\nDiscovered on zap.cooking \uD83C\uDF73\u26A1\uFE0F';
 			if (sendProtocol === 'nip17') {
-				await sendDirectMessage(product.pubkey, dmMessage.trim());
+				await sendDirectMessage(product.pubkey, fullMessage);
 			} else {
-				await sendNip04DirectMessage(product.pubkey, dmMessage.trim());
+				await sendNip04DirectMessage(product.pubkey, fullMessage);
 			}
 			dmSent = true;
 			dmMessage = '';
@@ -334,6 +338,7 @@
 				<textarea
 					bind:this={messageInput}
 					bind:value={dmMessage}
+					on:input={() => (userEditedMessage = true)}
 					rows="3"
 					class="w-full p-3 rounded-xl text-sm resize-none"
 					style="background-color: var(--color-bg-secondary); color: var(--color-text-primary); border: 1px solid rgba(249, 115, 22, 0.25);"

--- a/src/routes/market/+page.svelte
+++ b/src/routes/market/+page.svelte
@@ -105,6 +105,12 @@
 			<PackageIcon size={16} />
 			Products
 		</a>
+		{#if $userPublickey}
+			<a href="/my-store" class="nav-pill">
+				<StorefrontIcon size={16} />
+				My Store
+			</a>
+		{/if}
 	</div>
 
 	<!-- Search & Filters -->

--- a/src/routes/market/products/+page.svelte
+++ b/src/routes/market/products/+page.svelte
@@ -170,6 +170,12 @@
 			<PackageIcon size={15} />
 			Products
 		</a>
+		{#if $userPublickey}
+			<a href="/my-store" class="nav-tab">
+				<StorefrontIcon size={15} />
+				My Store
+			</a>
+		{/if}
 	</div>
 
 	<!-- ═══ Row 2: Categories ═══ -->

--- a/src/routes/market/products/+page.svelte
+++ b/src/routes/market/products/+page.svelte
@@ -11,8 +11,9 @@
 	import StorefrontIcon from 'phosphor-svelte/lib/Storefront';
 	import PlusIcon from 'phosphor-svelte/lib/Plus';
 	import MagnifyingGlassIcon from 'phosphor-svelte/lib/MagnifyingGlass';
-	import FunnelIcon from 'phosphor-svelte/lib/Funnel';
+	import SlidersHorizontalIcon from 'phosphor-svelte/lib/SlidersHorizontal';
 	import PackageIcon from 'phosphor-svelte/lib/Package';
+	import XIcon from 'phosphor-svelte/lib/X';
 
 	let allProducts: Product[] = [];
 	let staleListingsHidden = 0;
@@ -25,8 +26,8 @@
 	let sortBy: 'latest' | 'price-low' | 'price-high' = 'latest';
 	let searchQuery = '';
 	let selectedCategory: ProductCategory | null = null;
+	let searchOpen = false;
 
-	// Compute category counts from loaded products
 	$: categoryCounts = computeCategoryCounts(allProducts);
 
 	function computeCategoryCounts(products: Product[]): Partial<Record<ProductCategory | 'all', number>> {
@@ -39,6 +40,9 @@
 
 	$: filteredProducts = filterAndSortProducts(allProducts, sortBy, searchQuery, membersOnly, selectedCategory);
 
+	// Count active filters for the badge
+	$: activeFilterCount = (membersOnly ? 1 : 0) + (selectedCategory ? 1 : 0) + (searchQuery.trim() ? 1 : 0);
+
 	function filterAndSortProducts(
 		products: Product[],
 		sort: string,
@@ -48,7 +52,6 @@
 	) {
 		let filtered = products;
 
-		// Category filter
 		if (category) {
 			filtered = filtered.filter((p) => p.category === category);
 		}
@@ -97,7 +100,6 @@
 
 			const sellerPubkeys = [...new Set(result.products.map((p) => p.pubkey))];
 
-			// Fetch trust ranks and membership in parallel (both background, non-blocking)
 			fetchTrustRanks($ndk, sellerPubkeys, $userPublickey || undefined).then(({ ranks, personalized }) => {
 				trustRanks = ranks;
 				trustPersonalized = personalized;
@@ -124,6 +126,13 @@
 	function removeProduct(eventId: string) {
 		allProducts = allProducts.filter((p) => p.event.id !== eventId);
 	}
+
+	function clearFilters() {
+		selectedCategory = null;
+		membersOnly = false;
+		searchQuery = '';
+		searchOpen = false;
+	}
 </script>
 
 <svelte:head>
@@ -132,59 +141,39 @@
 </svelte:head>
 
 <div class="products-page max-w-6xl mx-auto px-4 py-6">
-	<!-- Header -->
-	<div class="flex flex-col gap-2 mb-6">
-		<div class="flex items-center justify-between">
-			<div class="flex items-center gap-3">
-				<StorefrontIcon size={32} weight="duotone" class="text-orange-500" />
-				<h1 class="text-2xl font-bold" style="color: var(--color-text-primary)">The Market</h1>
-			</div>
-			<div class="flex items-center gap-2">
-				{#if $userPublickey}
-					<a
-						href="/my-store/new"
-						class="flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition-all hover:scale-105"
-						style="background: linear-gradient(135deg, #f97316, #ea580c); color: white;"
-					>
-						<PlusIcon size={18} weight="bold" />
-						<span class="hidden sm:inline">Create Listing</span>
-					</a>
-				{/if}
-			</div>
-		</div>
-		<p class="text-base" style="color: var(--color-text-secondary)">
-			Buy and sell cooking goods with Bitcoin. Direct Lightning payments, no middleman.
-		</p>
-	</div>
 
-	<!-- Navigation Tabs + Sort -->
-	<div class="flex items-center justify-between mb-6">
-		<div class="flex gap-2">
-			<a href="/market" class="nav-pill">
-				<StorefrontIcon size={16} />
-				Shops
-			</a>
-			<a href="/market/products" class="nav-pill active">
-				<PackageIcon size={16} />
-				Products
-			</a>
+	<!-- ═══ Header ═══ -->
+	<div class="flex items-center justify-between mb-5">
+		<div class="flex items-center gap-2.5">
+			<StorefrontIcon size={28} weight="duotone" class="text-orange-500" />
+			<h1 class="text-xl font-bold" style="color: var(--color-text-primary)">The Market</h1>
 		</div>
-
-		<div class="relative">
-			<FunnelIcon size={16} class="absolute left-3 top-1/2 -translate-y-1/2 opacity-50" />
-			<select
-				bind:value={sortBy}
-				class="sort-select pl-9 pr-4 py-2 rounded-lg text-sm"
+		{#if $userPublickey}
+			<a
+				href="/my-store/new"
+				class="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium transition-all hover:scale-105"
+				style="background: linear-gradient(135deg, #f97316, #ea580c); color: white;"
 			>
-				<option value="latest">Latest</option>
-				<option value="price-low">Price: Low to High</option>
-				<option value="price-high">Price: High to Low</option>
-			</select>
-		</div>
+				<PlusIcon size={16} weight="bold" />
+				<span class="hidden sm:inline">List</span>
+			</a>
+		{/if}
 	</div>
 
-	<!-- Category Filter -->
-	<div class="mb-6">
+	<!-- ═══ Row 1: Navigation Tabs ═══ -->
+	<div class="flex gap-2 mb-4">
+		<a href="/market" class="nav-tab">
+			<StorefrontIcon size={15} />
+			Shops
+		</a>
+		<a href="/market/products" class="nav-tab active">
+			<PackageIcon size={15} />
+			Products
+		</a>
+	</div>
+
+	<!-- ═══ Row 2: Categories ═══ -->
+	<div class="mb-3">
 		<CategoryFilter
 			selected={selectedCategory}
 			counts={categoryCounts}
@@ -192,32 +181,77 @@
 		/>
 	</div>
 
-	<!-- Search & Filter Bar -->
-	<div class="flex flex-col sm:flex-row gap-3 items-stretch sm:items-center justify-between mb-6">
+	<!-- ═══ Row 3: Modifiers (search, sort, members) ═══ -->
+	<div class="modifier-row">
+		<!-- Search (expandable) -->
+		{#if searchOpen}
+			<div class="search-container">
+				<MagnifyingGlassIcon size={14} class="search-icon" />
+				<input
+					type="text"
+					placeholder="Search..."
+					bind:value={searchQuery}
+					class="search-input"
+					autofocus
+				/>
+				<button
+					type="button"
+					on:click={() => { searchQuery = ''; searchOpen = false; }}
+					class="search-close"
+				>
+					<XIcon size={14} />
+				</button>
+			</div>
+		{:else}
+			<button
+				type="button"
+				on:click={() => (searchOpen = true)}
+				class="mod-btn"
+				aria-label="Search"
+			>
+				<MagnifyingGlassIcon size={14} />
+				<span class="hidden xs:inline">Search</span>
+			</button>
+		{/if}
+
+		<!-- Sort -->
+		<div class="relative">
+			<select
+				bind:value={sortBy}
+				class="mod-select"
+			>
+				<option value="latest">Latest</option>
+				<option value="price-low">Price: Low</option>
+				<option value="price-high">Price: High</option>
+			</select>
+		</div>
+
+		<!-- Members only toggle -->
 		<button
 			type="button"
-			class="members-pill"
-			class:active={membersOnly}
+			class="mod-btn {membersOnly ? 'mod-active' : ''}"
 			on:click={() => (membersOnly = !membersOnly)}
 		>
-			Members only
+			<span class="text-xs">Members</span>
 		</button>
 
-		<div class="relative w-full sm:w-64">
-			<MagnifyingGlassIcon size={16} class="absolute left-3 top-1/2 -translate-y-1/2 opacity-50" />
-			<input
-				type="text"
-				placeholder="Search products..."
-				bind:value={searchQuery}
-				class="search-input w-full pl-9 pr-4 py-2 rounded-lg text-sm"
-			/>
-		</div>
+		<!-- Clear all (shown when filters active) -->
+		{#if activeFilterCount > 0}
+			<button
+				type="button"
+				on:click={clearFilters}
+				class="mod-btn mod-clear"
+			>
+				<XIcon size={12} />
+				<span class="text-xs">Clear</span>
+			</button>
+		{/if}
 	</div>
 
 	<!-- Buyer Disclaimer Banner -->
 	<MarketBuyerBanner />
 
-	<!-- Content -->
+	<!-- ═══ Results ═══ -->
 	{#if loading}
 		<div class="products-grid">
 			{#each Array(8) as _, i}
@@ -285,7 +319,7 @@
 			</p>
 			{#if staleListingsHidden > 0}
 				<p class="text-xs" style="color: var(--color-text-secondary); opacity: 0.7;">
-					Some older listings have been hidden
+					Some older listings hidden
 				</p>
 			{/if}
 		</div>
@@ -301,77 +335,131 @@
 <style lang="postcss">
 	@reference "../../../app.css";
 
-	.nav-pill {
-		@apply flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium transition-all cursor-pointer;
+	/* ── Navigation Tabs ── */
+	.nav-tab {
+		@apply flex items-center gap-1.5 px-3.5 py-2 rounded-lg text-sm font-medium transition-all cursor-pointer;
 		background-color: var(--color-bg-secondary);
 		color: var(--color-text-secondary);
 		border: 1.5px solid transparent;
 		text-decoration: none;
 	}
 
-	.nav-pill:hover {
+	.nav-tab:hover {
 		color: var(--color-text-primary);
-		border-color: var(--color-accent, #f97316);
+		border-color: rgba(249, 115, 22, 0.3);
 	}
 
-	.nav-pill.active {
+	.nav-tab.active {
 		background-color: rgba(249, 115, 22, 0.12);
 		color: #f97316;
 		border-color: #f97316;
-		box-shadow: 0 0 8px rgba(249, 115, 22, 0.25);
 	}
 
+	/* ── Modifier Row ── */
+	.modifier-row {
+		@apply flex items-center gap-2 mb-5 flex-wrap;
+	}
+
+	.mod-btn {
+		@apply flex items-center gap-1.5 rounded-lg text-xs font-medium cursor-pointer;
+		background-color: var(--color-bg-secondary);
+		color: var(--color-text-secondary);
+		border: 1px solid transparent;
+		padding: 7px 10px;
+		transition: all 0.15s ease;
+		white-space: nowrap;
+	}
+
+	.mod-btn:hover {
+		color: var(--color-text-primary);
+		border-color: rgba(255, 255, 255, 0.1);
+	}
+
+	.mod-active {
+		background-color: rgba(249, 115, 22, 0.15);
+		color: #f97316;
+		border-color: rgba(249, 115, 22, 0.4);
+	}
+
+	.mod-clear {
+		color: var(--color-text-secondary);
+		opacity: 0.7;
+	}
+
+	.mod-clear:hover {
+		opacity: 1;
+		color: #ef4444;
+	}
+
+	.mod-select {
+		@apply text-xs font-medium rounded-lg cursor-pointer;
+		background-color: var(--color-bg-secondary);
+		color: var(--color-text-secondary);
+		border: 1px solid transparent;
+		padding: 7px 10px;
+		transition: all 0.15s ease;
+	}
+
+	.mod-select:focus {
+		outline: none;
+		border-color: rgba(249, 115, 22, 0.4);
+	}
+
+	/* ── Search ── */
+	.search-container {
+		@apply flex items-center gap-2 flex-1 min-w-0 rounded-lg;
+		background-color: var(--color-bg-secondary);
+		border: 1px solid rgba(249, 115, 22, 0.3);
+		padding: 5px 10px;
+		animation: expandIn 0.15s ease-out;
+	}
+
+	@keyframes expandIn {
+		from { opacity: 0; transform: scaleX(0.9); }
+		to { opacity: 1; transform: scaleX(1); }
+	}
+
+	.search-icon {
+		@apply flex-shrink-0 opacity-40;
+	}
+
+	.search-input {
+		@apply flex-1 min-w-0 text-xs bg-transparent outline-none;
+		color: var(--color-text-primary);
+	}
+
+	.search-close {
+		@apply flex-shrink-0 p-0.5 rounded opacity-50 cursor-pointer;
+		color: var(--color-text-secondary);
+		transition: opacity 0.1s ease;
+	}
+
+	.search-close:hover {
+		opacity: 1;
+	}
+
+	/* ── Product Grid ── */
 	.products-grid {
 		display: grid;
 		grid-template-columns: repeat(2, 1fr);
-		gap: 1rem;
+		gap: 0.75rem;
 	}
 
 	@media (min-width: 640px) {
 		.products-grid {
 			grid-template-columns: repeat(3, 1fr);
-			gap: 1.5rem;
+			gap: 1.25rem;
 		}
 	}
 
 	@media (min-width: 1024px) {
 		.products-grid {
 			grid-template-columns: repeat(4, 1fr);
+			gap: 1.5rem;
 		}
 	}
 
-	.sort-select,
-	.search-input {
-		background-color: var(--color-bg-secondary);
-		color: var(--color-text-primary);
-		border: 1px solid transparent;
-	}
-
-	.sort-select:focus,
-	.search-input:focus {
-		outline: none;
-		border-color: var(--color-accent);
-	}
-
-	.members-pill {
-		@apply px-4 py-2 rounded-lg text-sm font-medium transition-all flex-shrink-0 cursor-pointer;
-		background-color: var(--color-bg-secondary);
-		color: var(--color-text-secondary);
-		border: 1.5px solid transparent;
-	}
-
-	.members-pill:hover {
-		color: var(--color-text-primary);
-		border-color: var(--color-accent, #f97316);
-	}
-
-	.members-pill.active {
-		background-color: rgba(249, 115, 22, 0.12);
-		color: #f97316;
-		border-color: #f97316;
-		box-shadow: 0 0 8px rgba(249, 115, 22, 0.25);
-	}
-
+	/* ── Skeletons ── */
 	.skeleton-card {
 		@apply rounded-xl overflow-hidden;
 		background-color: var(--color-bg-secondary);
@@ -392,6 +480,7 @@
 		background-color: var(--color-bg-tertiary, rgba(0, 0, 0, 0.1));
 	}
 
+	/* ── Animations ── */
 	.animate-fade-in {
 		animation: fadeIn 0.5s ease-out;
 	}

--- a/src/routes/market/products/+page.svelte
+++ b/src/routes/market/products/+page.svelte
@@ -11,7 +11,6 @@
 	import StorefrontIcon from 'phosphor-svelte/lib/Storefront';
 	import PlusIcon from 'phosphor-svelte/lib/Plus';
 	import MagnifyingGlassIcon from 'phosphor-svelte/lib/MagnifyingGlass';
-	import SlidersHorizontalIcon from 'phosphor-svelte/lib/SlidersHorizontal';
 	import PackageIcon from 'phosphor-svelte/lib/Package';
 	import XIcon from 'phosphor-svelte/lib/X';
 
@@ -41,7 +40,7 @@
 	$: filteredProducts = filterAndSortProducts(allProducts, sortBy, searchQuery, membersOnly, selectedCategory);
 
 	// Count active filters for the badge
-	$: activeFilterCount = (membersOnly ? 1 : 0) + (selectedCategory ? 1 : 0) + (searchQuery.trim() ? 1 : 0);
+	$: activeFilterCount = (membersOnly ? 1 : 0) + (selectedCategory ? 1 : 0) + (searchQuery.trim() ? 1 : 0) + (sortBy !== 'latest' ? 1 : 0);
 
 	function filterAndSortProducts(
 		products: Product[],
@@ -132,6 +131,7 @@
 		membersOnly = false;
 		searchQuery = '';
 		searchOpen = false;
+		sortBy = 'latest';
 	}
 </script>
 
@@ -216,7 +216,7 @@
 				aria-label="Search"
 			>
 				<MagnifyingGlassIcon size={14} />
-				<span class="hidden xs:inline">Search</span>
+				<span class="hidden sm:inline">Search</span>
 			</button>
 		{/if}
 


### PR DESCRIPTION
## Summary
- **Market control bar redesign**: Three-tier mobile-first layout (nav tabs → category chips → modifiers). Top 5 categories shown by count with "More" expandable panel. Collapsible inline search. Compact sort, members toggle, and clear-all button.
- **Category chips**: Emoji + label on 480px+, emoji-only on smaller screens. Selected overflow category stays pinned in main row.
- **DM pre-fill fix**: Message now correctly includes product title (waits for prop to resolve instead of rendering empty quotes).
- **DM footer**: All marketplace DMs append "Discovered on zap.cooking" signature.

## Test plan
- [ ] Mobile (375px): all category chips fit without horizontal scroll
- [ ] Tap "More" to expand overflow categories, select one, verify it pins in main row
- [ ] Tap search icon → expands inline, type to filter, tap X to dismiss
- [ ] Sort dropdown works alongside category + search filters
- [ ] "Members" toggle highlights orange when active
- [ ] "Clear" button appears when any filter is active, resets all
- [ ] Message modal pre-fills with product title (not empty quotes)
- [ ] Sent DMs include "Discovered on zap.cooking" footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)