### PR TITLE
Unify note actions across thread view and add poll support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.116",
+  "version": "4.2.117",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.115",
+  "version": "4.2.116",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/NoteActionBar.svelte
+++ b/src/components/NoteActionBar.svelte
@@ -5,7 +5,8 @@
   import NoteRepost from './NoteRepost.svelte';
   import NoteTotalZaps from './NoteTotalZaps.svelte';
   import ZapModal from './ZapModal.svelte';
-  import { userPublickey } from '$lib/nostr';
+  import { ndk, userPublickey } from '$lib/nostr';
+  import { fetchEngagement, optimisticZapUpdate } from '$lib/engagementCache';
 
   export let event: NDKEvent;
 
@@ -34,6 +35,18 @@
     }
     zapModalOpen = true;
   }
+
+  function handleZapComplete(e: CustomEvent<{ amount: number }>) {
+    if (event) {
+      optimisticZapUpdate(event.id, (e.detail.amount || 0) * 1000, $userPublickey);
+      fetchEngagement($ndk, event.id, $userPublickey);
+    }
+  }
+
+  let isCompact: boolean;
+  let isFull: boolean;
+  let iconWrapClass: string;
+  let zapWrapClass: string;
 
   $: isCompact = variant === 'compact';
   $: isFull = variant === 'full';
@@ -84,7 +97,7 @@
 </div>
 
 {#if zapModalOpen}
-  <ZapModal bind:open={zapModalOpen} {event} />
+  <ZapModal bind:open={zapModalOpen} {event} on:zap-complete={handleZapComplete} />
 {/if}
 
 <style>

--- a/src/components/NoteActionBar.svelte
+++ b/src/components/NoteActionBar.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+  import type { NDKEvent } from '@nostr-dev-kit/ndk';
+  import NoteTotalLikes from './NoteTotalLikes.svelte';
+  import NoteTotalComments from './NoteTotalComments.svelte';
+  import NoteRepost from './NoteRepost.svelte';
+  import NoteTotalZaps from './NoteTotalZaps.svelte';
+  import ZapModal from './ZapModal.svelte';
+  import { userPublickey } from '$lib/nostr';
+
+  export let event: NDKEvent;
+
+  /**
+   * 'full'    — feed-style: all actions, hover wrappers, zap pills support
+   * 'compact' — thread parent/nested reply: smaller, tighter spacing
+   * 'default' — standard detail view
+   */
+  export let variant: 'full' | 'compact' | 'default' = 'default';
+
+  /** Show the zap pills row above the action icons (feed-style) */
+  export let showZapPills: boolean = false;
+
+  /** Show the comment count/toggle button */
+  export let showComments: boolean = true;
+
+  /** Show the repost/quote button */
+  export let showRepost: boolean = true;
+
+  let zapModalOpen = false;
+
+  function openZapModal() {
+    if (!$userPublickey) {
+      window.location.href = '/login';
+      return;
+    }
+    zapModalOpen = true;
+  }
+
+  $: isCompact = variant === 'compact';
+  $: isFull = variant === 'full';
+  $: iconWrapClass = isFull
+    ? 'hover:bg-accent-gray rounded-full p-1.5 transition-colors'
+    : isCompact
+      ? 'rounded p-0.5 transition-colors'
+      : 'hover:bg-accent-gray rounded px-1 py-0.5 transition-colors';
+  $: zapWrapClass = isFull
+    ? 'hover:bg-amber-50/50 rounded-full p-1 transition-colors'
+    : iconWrapClass;
+</script>
+
+<div class="note-action-bar" class:compact={isCompact} class:full={isFull}>
+  {#if showZapPills}
+    <div class="zap-pills-row">
+      <NoteTotalZaps
+        {event}
+        onZapClick={openZapModal}
+        showPills={true}
+        onlyPills={true}
+        maxPills={10}
+      />
+    </div>
+  {/if}
+
+  <div class="action-row">
+    <div class={iconWrapClass}>
+      <NoteTotalLikes {event} />
+    </div>
+
+    {#if showComments}
+      <div class={iconWrapClass}>
+        <NoteTotalComments {event} />
+      </div>
+    {/if}
+
+    {#if showRepost}
+      <div class={iconWrapClass}>
+        <NoteRepost {event} />
+      </div>
+    {/if}
+
+    <div class={zapWrapClass}>
+      <NoteTotalZaps {event} onZapClick={openZapModal} />
+    </div>
+  </div>
+</div>
+
+{#if zapModalOpen}
+  <ZapModal bind:open={zapModalOpen} {event} />
+{/if}
+
+<style>
+  .note-action-bar {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .action-row {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    color: var(--color-text-secondary);
+  }
+
+  .compact .action-row {
+    gap: 0.125rem;
+  }
+
+  .zap-pills-row {
+    padding: 0 0.5rem;
+  }
+
+  .full .zap-pills-row {
+    padding: 0;
+  }
+</style>

--- a/src/components/PollDisplay.svelte
+++ b/src/components/PollDisplay.svelte
@@ -227,16 +227,21 @@
         {/each}
       </div>
     {:else}
-      <!-- ═══ TEXT-ONLY LIST LAYOUT (unchanged) ═══ -->
-      <div class="space-y-2">
-        {#each pollData.options as option (option.id)}
+      <!-- ═══ TEXT GRID LAYOUT ═══ -->
+      <div class="poll-text-grid">
+        {#each pollData.options as option, i (option.id)}
           {@const voteCount = results.counts.get(option.id) || 0}
           {@const pct = results.totalVoters === 0 ? 0 : Math.round((voteCount / results.totalVoters) * 100)}
           {@const isUserChoice = userSelectedOptions.includes(option.id)}
           {@const isSelected = selectedOptions.has(option.id)}
+          {@const isLast = i === pollData.options.length - 1 && pollData.options.length % 2 !== 0}
 
           {#if displayResults}
-            <div class="poll-result-bar" class:poll-result-user={isUserChoice}>
+            <div
+              class="poll-result-bar"
+              class:poll-result-user={isUserChoice}
+              class:poll-text-card-last-odd={isLast}
+            >
               <div class="poll-result-fill" style="width: {pct}%"></div>
               <div class="poll-result-content">
                 <span class="poll-result-label">
@@ -245,13 +250,15 @@
                     <span class="poll-result-check">✓</span>
                   {/if}
                 </span>
-                <span class="poll-result-pct">{pct}% ({voteCount})</span>
+                <span class="poll-result-pct">{pct}%</span>
               </div>
+              <div class="poll-result-votes">{voteCount}</div>
             </div>
           {:else}
             <button
               class="poll-option-btn"
               class:poll-option-selected={isSelected}
+              class:poll-text-card-last-odd={isLast}
               on:click={() => toggleOption(option.id)}
               disabled={expired || voting}
             >
@@ -262,7 +269,7 @@
                   <span class="poll-checkbox" class:poll-checkbox-checked={isSelected}></span>
                 {/if}
               </span>
-              <span>{option.label}</span>
+              <span class="poll-option-label">{option.label}</span>
             </button>
           {/if}
         {/each}
@@ -514,24 +521,48 @@
   }
 
   /* ═══════════════════════════════════════════
-     TEXT-ONLY LIST LAYOUT
+     TEXT GRID LAYOUT
      ═══════════════════════════════════════════ */
+
+  .poll-text-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+  }
+
+  .poll-text-card-last-odd {
+    grid-column: 1 / -1;
+    max-width: 50%;
+    justify-self: center;
+  }
+
+  @media (max-width: 360px) {
+    .poll-text-grid {
+      grid-template-columns: 1fr;
+    }
+    .poll-text-card-last-odd {
+      max-width: 100%;
+    }
+  }
 
   /* Vote mode buttons */
   .poll-option-btn {
     display: flex;
+    flex-direction: column;
     align-items: center;
-    gap: 0.5rem;
+    justify-content: center;
+    gap: 0.375rem;
     width: 100%;
-    padding: 0.5rem 0.75rem;
-    border: 1px solid var(--color-input-border);
-    border-radius: 0.5rem;
+    padding: 0.75rem 0.5rem;
+    border: 2px solid var(--color-input-border);
+    border-radius: 0.625rem;
     background: transparent;
     color: var(--color-text-primary);
-    font-size: 0.875rem;
+    font-size: 0.8125rem;
     cursor: pointer;
     transition: all 0.15s;
-    text-align: left;
+    text-align: center;
+    min-height: 3.5rem;
   }
 
   .poll-option-btn:hover:not(:disabled) {
@@ -546,10 +577,16 @@
   .poll-option-selected {
     border-color: var(--color-primary, #f97316);
     background: rgba(249, 115, 22, 0.05);
+    box-shadow: 0 0 0 1px var(--color-primary, #f97316);
   }
 
   .poll-option-indicator {
     flex-shrink: 0;
+  }
+
+  .poll-option-label {
+    line-height: 1.3;
+    word-break: break-word;
   }
 
   .poll-radio,
@@ -583,10 +620,14 @@
   /* Results mode */
   .poll-result-bar {
     position: relative;
-    padding: 0.5rem 0.75rem;
-    border: 1px solid var(--color-input-border);
-    border-radius: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: 0.625rem 0.5rem;
+    border: 2px solid var(--color-input-border);
+    border-radius: 0.625rem;
     overflow: hidden;
+    min-height: 3.5rem;
   }
 
   .poll-result-user {
@@ -607,7 +648,8 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    font-size: 0.875rem;
+    font-size: 0.8125rem;
+    line-height: 1.3;
   }
 
   .poll-result-label {
@@ -615,6 +657,8 @@
     display: flex;
     align-items: center;
     gap: 0.25rem;
+    word-break: break-word;
+    min-width: 0;
   }
 
   .poll-result-check {
@@ -624,7 +668,16 @@
 
   .poll-result-pct {
     color: var(--color-caption);
-    font-size: 0.8125rem;
+    font-size: 0.75rem;
     flex-shrink: 0;
+    font-weight: 600;
+  }
+
+  .poll-result-votes {
+    position: relative;
+    font-size: 0.6875rem;
+    color: var(--color-caption);
+    text-align: center;
+    margin-top: 0.125rem;
   }
 </style>

--- a/src/routes/[nip19]/+page.svelte
+++ b/src/routes/[nip19]/+page.svelte
@@ -11,22 +11,19 @@
   import AuthorName from '../../components/AuthorName.svelte';
   import { formatDistanceToNow } from 'date-fns';
   import NoteContent from '../../components/NoteContent.svelte';
-  import NoteTotalLikes from '../../components/NoteTotalLikes.svelte';
-  import NoteTotalComments from '../../components/NoteTotalComments.svelte';
-  import NoteTotalZaps from '../../components/NoteTotalZaps.svelte';
-  import ZapModal from '../../components/ZapModal.svelte';
+  import PollDisplay from '../../components/PollDisplay.svelte';
+  import NoteActionBar from '../../components/NoteActionBar.svelte';
   import Button from '../../components/Button.svelte';
   import { addClientTagToEvent } from '$lib/nip89';
   import { buildNip22CommentTags } from '$lib/tagUtils';
   import ClientAttribution from '../../components/ClientAttribution.svelte';
-  import ThreadCommentActions from '../../components/ThreadCommentActions.svelte';
   import type { NDKEvent } from '@nostr-dev-kit/ndk';
   import type { PageData } from './$types';
   import { createCommentFilter } from '$lib/commentFilters';
   import PostActionsMenu from '../../components/PostActionsMenu.svelte';
   import MentionDropdown from '../../components/MentionDropdown.svelte';
   import { MentionComposerController, type MentionState } from '$lib/mentionComposer';
-  import { fetchEngagement, optimisticZapUpdate } from '$lib/engagementCache';
+  import { fetchEngagement } from '$lib/engagementCache';
 
   export let data: PageData;
 
@@ -40,7 +37,6 @@
   let event: NDKEvent | null = null;
   let loading = true;
   let error = false;
-  let zapModal = false;
 
   // Thread hierarchy
   let parentThread: NDKEvent[] = []; // Parent notes above this one
@@ -162,7 +158,6 @@
     replies = [];
     loading = true;
     error = false;
-    zapModal = false;
 
     if (!nip19Id) {
       error = true;
@@ -256,9 +251,6 @@
     return formatDistanceToNow(new Date(timestamp * 1000), { addSuffix: true });
   }
 
-  function openZapModal() {
-    zapModal = true;
-  }
 
   // Reactive statements for mention controller
   $: mentionCtrl.setComposerEl(replyComposerEl);
@@ -609,11 +601,15 @@
                     class="block text-sm leading-relaxed hover:opacity-80"
                     style="color: var(--color-text-secondary)"
                   >
-                    <NoteContent content={parentNote.content} />
+                    {#if parentNote.kind === 1068}
+                      <PollDisplay event={parentNote} />
+                    {:else}
+                      <NoteContent content={parentNote.content} />
+                    {/if}
                   </a>
                   <!-- Parent note actions -->
                   <div class="mt-2">
-                    <ThreadCommentActions event={parentNote} compact={true} />
+                    <NoteActionBar event={parentNote} variant="compact" />
                   </div>
                 </div>
               </div>
@@ -654,24 +650,16 @@
                 <ClientAttribution tags={event.tags} enableEnrichment={true} />
               </div>
               <div class="text-sm leading-relaxed mb-3" style="color: var(--color-text-primary)">
-                <NoteContent content={event.content} />
-              </div>
-              <div
-                class="flex items-center space-x-4 text-sm"
-                style="color: var(--color-text-secondary)"
-              >
-                <NoteTotalLikes {event} />
-                <NoteTotalComments {event} />
-                <button
-                  class="cursor-pointer hover:bg-accent-gray rounded px-1 py-0.5 transition duration-200"
-                  on:click={openZapModal}
-                >
-                  <NoteTotalZaps {event} />
-                </button>
+                {#if event.kind === 1068}
+                  <PollDisplay {event} />
+                {:else}
+                  <NoteContent content={event.content} />
+                {/if}
               </div>
             </div>
             <PostActionsMenu {event} />
           </div>
+          <NoteActionBar {event} />
         </div>
       </div>
     </article>
@@ -796,11 +784,15 @@
                         class="text-sm leading-relaxed"
                         style="color: var(--color-text-secondary)"
                       >
-                        <NoteContent content={reply.content} />
+                        {#if reply.kind === 1068}
+                          <PollDisplay event={reply} />
+                        {:else}
+                          <NoteContent content={reply.content} />
+                        {/if}
                       </div>
                       <!-- Reply actions -->
                       <div class="mt-2">
-                        <ThreadCommentActions event={reply} compact={false} />
+                        <NoteActionBar event={reply} />
                       </div>
                     </div>
                   </div>
@@ -850,11 +842,15 @@
                               class="text-xs leading-relaxed"
                               style="color: var(--color-text-secondary)"
                             >
-                              <NoteContent content={nestedReply.content} />
+                              {#if nestedReply.kind === 1068}
+                                <PollDisplay event={nestedReply} />
+                              {:else}
+                                <NoteContent content={nestedReply.content} />
+                              {/if}
                             </div>
                             <!-- Nested reply actions -->
                             <div class="mt-1.5">
-                              <ThreadCommentActions event={nestedReply} compact={true} />
+                              <NoteActionBar event={nestedReply} variant="compact" />
                             </div>
                           </div>
                         </div>
@@ -886,15 +882,6 @@
   {/if}
 </div>
 
-<!-- Zap Modal -->
-{#if zapModal && event}
-  <ZapModal {event} on:close={() => (zapModal = false)} on:zap-complete={(e) => {
-    if (event) {
-      optimisticZapUpdate(event.id, (e.detail.amount || 0) * 1000, $userPublickey);
-      fetchEngagement($ndk, event.id, $userPublickey);
-    }
-  }} />
-{/if}
 
 <style>
   /* Thread page styles */

--- a/src/routes/[nip19]/+page.svelte
+++ b/src/routes/[nip19]/+page.svelte
@@ -23,7 +23,6 @@
   import PostActionsMenu from '../../components/PostActionsMenu.svelte';
   import MentionDropdown from '../../components/MentionDropdown.svelte';
   import { MentionComposerController, type MentionState } from '$lib/mentionComposer';
-  import { fetchEngagement } from '$lib/engagementCache';
 
   export let data: PageData;
 
@@ -107,7 +106,7 @@
 
         seenIds.add(parentId);
 
-        const parentNote = await $ndk.fetchEvent({ kinds: [1, 1111] as any, ids: [parentId] });
+        const parentNote = await $ndk.fetchEvent({ kinds: [1, 1068, 1111] as any, ids: [parentId] });
         if (!parentNote) break;
 
         parents.unshift(parentNote); // Add to beginning for chronological order
@@ -596,17 +595,17 @@
                     </div>
                     <PostActionsMenu event={parentNote} />
                   </div>
-                  <a
-                    href="/{nip19.noteEncode(parentNote.id)}"
-                    class="block text-sm leading-relaxed hover:opacity-80"
-                    style="color: var(--color-text-secondary)"
-                  >
-                    {#if parentNote.kind === 1068}
-                      <PollDisplay event={parentNote} />
-                    {:else}
+                  {#if parentNote.kind === 1068}
+                    <PollDisplay event={parentNote} />
+                  {:else}
+                    <a
+                      href="/{nip19.noteEncode(parentNote.id)}"
+                      class="block text-sm leading-relaxed hover:opacity-80"
+                      style="color: var(--color-text-secondary)"
+                    >
                       <NoteContent content={parentNote.content} />
-                    {/if}
-                  </a>
+                    </a>
+                  {/if}
                   <!-- Parent note actions -->
                   <div class="mt-2">
                     <NoteActionBar event={parentNote} variant="compact" />


### PR DESCRIPTION
## Summary

- **New `NoteActionBar` component**: Shared action bar composing `NoteTotalLikes`, `NoteRepost`, `NoteTotalZaps`, `NoteTotalComments`, and `ZapModal` with `variant` prop (`default`, `compact`, `full`) for consistent actions everywhere
- **Thread view parity**: Main note, parent notes, replies, and nested replies all now use `NoteActionBar` — adds previously missing **Repost** action and fixes **Zap** wiring across all note surfaces
- **Poll rendering in threads**: Kind 1068 poll events now render via `PollDisplay` in the thread view (main note, parents, replies, nested replies) — previously showed blank content
- **Poll grid layout**: Text-only poll options now use a 2-column grid (quad) instead of a vertical stack for a more compact, scannable layout
- Removed `ThreadCommentActions` usage, page-level `ZapModal`, and dead state from `[nip19]` page (-58 lines)

## Test plan

- [ ] Open a note thread — verify React, Comment, **Repost**, Zap all appear on the main note
- [ ] Verify Repost dropdown (Repost + Quote options) works on main note, parent notes, and replies
- [ ] Verify Zap opens modal (or one-tap zaps) on all note surfaces in thread view
- [ ] Open a poll note via quoted note link (e.g. `note1c5uapegcyl9s6ktre5phm5ar6wrdgh9n5mtupuuueefhhrkmm2cqyh9h3h`) — verify poll renders with 2x2 grid options
- [ ] Vote on a poll in thread view — verify vote submits and results display in grid
- [ ] Verify poll results mode shows percentage bars in grid cells
- [ ] Check mobile layout — grid falls back to single column on very narrow screens
- [ ] Verify feed note actions are unchanged (NoteActionBar is not yet wired into feed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)