### PR TITLE
QR Scan + Branta Verify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.123",
+  "version": "4.2.124",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": "22.x"
   },
   "dependencies": {
-    "@branta-ops/branta": "^0.0.3",
+    "@branta-ops/branta": "^0.0.9",
     "@breeztech/breez-sdk-spark": "0.11.0",
     "@capacitor/android": "^8.0.0",
     "@capacitor/app": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "google-translate-api-browser": "^3.0.1",
     "html2canvas": "^1.4.1",
     "hurdak": "^0.2.5",
+    "jsqr": "^1.4.0",
     "libretranslate": "^1.0.1",
     "light-bolt11-decoder": "^3.0.0",
     "markdown-it": "^13.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       hurdak:
         specifier: ^0.2.5
         version: 0.2.10
+      jsqr:
+        specifier: ^1.4.0
+        version: 1.4.0
       libretranslate:
         specifier: ^1.0.1
         version: 1.0.1
@@ -3197,6 +3200,9 @@ packages:
   jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
+
+  jsqr@1.4.0:
+    resolution: {integrity: sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -8307,6 +8313,8 @@ snapshots:
       graceful-fs: 4.2.11
 
   jsonparse@1.3.1: {}
+
+  jsqr@1.4.0: {}
 
   keyv@4.5.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@branta-ops/branta':
-        specifier: ^0.0.3
-        version: 0.0.3
+        specifier: ^0.0.9
+        version: 0.0.9
       '@breeztech/breez-sdk-spark':
         specifier: 0.11.0
         version: 0.11.0
@@ -298,8 +298,8 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
-  '@branta-ops/branta@0.0.3':
-    resolution: {integrity: sha512-BNiN8erGLVAVDC9laAgAkynsT/72dXFC1al9gnIJAvXC/F7wwLl4nsFYNVa/ys16RFmrwTUqx0M+oxrg+BSauw==}
+  '@branta-ops/branta@0.0.9':
+    resolution: {integrity: sha512-CLx8UUJQ5dLGWSUmxaFOBitw8C6DTNV0Hk/sm7jOhLOQPjgELLpcIwe/L2Tm3m9kkyKV8M9xdK9YClGRLf5Epw==}
 
   '@breeztech/breez-sdk-spark@0.11.0':
     resolution: {integrity: sha512-wX8ZdFfnXN9t2AuLYlZxslmdHlxqnvkU8kAmIL1GuI3LNV8F7bxMGxLV/WTaQTgd7BGW/pcejpBcNPe7jjCdfA==}
@@ -5218,7 +5218,7 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
-  '@branta-ops/branta@0.0.3': {}
+  '@branta-ops/branta@0.0.9': {}
 
   '@breeztech/breez-sdk-spark@0.11.0':
     optionalDependencies:

--- a/src/components/BrantaBadge.svelte
+++ b/src/components/BrantaBadge.svelte
@@ -1,67 +1,69 @@
 <!--
   Branta Verification Badge
 
-  Displays a "Verified by Branta" badge for payment addresses/invoices
+  Displays a Branta-verified platform card or a simple badge for payment addresses/invoices
   that are registered with Branta Guardrail.
 
   Usage:
     <BrantaBadge paymentString={invoiceOrAddress} />
+    <BrantaBadge paymentString={sendInput} rawQrText={rawQrText} />
 
   Props:
-    - paymentString: The address/invoice to verify
+    - paymentString: The address/invoice to verify (used when no rawQrText)
+    - rawQrText: Raw QR code text for QR-based verification (uses getPaymentsByQRCode)
     - autoVerify: Whether to verify on mount (default: true)
     - showUnverified: Whether to show badge when not verified (default: false)
 -->
 <script lang="ts">
   import { onMount } from 'svelte';
-  import CheckCircleIcon from 'phosphor-svelte/lib/CheckCircle';
   import ShieldCheckIcon from 'phosphor-svelte/lib/ShieldCheck';
   import CircleNotchIcon from 'phosphor-svelte/lib/CircleNotch';
 
   export let paymentString: string = '';
+  export let rawQrText: string = '';
   export let autoVerify: boolean = true;
   export let showUnverified: boolean = false;
 
   let verified: boolean | null = null;
-  let verifyLink: string | null = null;
+  let payment: Record<string, any> | null = null;
   let loading = false;
-  let error: string | null = null;
 
   async function verify() {
-    if (!paymentString || loading) return;
+    const input = rawQrText || paymentString;
+    if (!input || loading) return;
 
     loading = true;
-    error = null;
 
     try {
-      const res = await fetch(`/api/branta/verify?payment=${encodeURIComponent(paymentString)}`);
+      const param = rawQrText
+        ? `qr=${encodeURIComponent(rawQrText)}`
+        : `payment=${encodeURIComponent(paymentString)}`;
+      const res = await fetch(`/api/branta/verify?${param}`);
       const data = await res.json();
 
       if (res.status === 503) {
-        // Branta not configured - hide badge entirely
         verified = null;
         return;
       }
 
       verified = data.verified === true;
-      verifyLink = data.verifyLink;
+      payment = data.payment ?? null;
     } catch (e) {
       console.warn('[BrantaBadge] Verification failed:', e);
       verified = false;
-      error = e instanceof Error ? e.message : 'Verification failed';
     } finally {
       loading = false;
     }
   }
 
-  // Re-verify when paymentString changes
-  $: if (paymentString && autoVerify) {
+  $: if ((rawQrText || paymentString) && autoVerify) {
     verified = null;
+    payment = null;
     verify();
   }
 
   onMount(() => {
-    if (autoVerify && paymentString) {
+    if (autoVerify && (rawQrText || paymentString)) {
       verify();
     }
   });
@@ -74,9 +76,28 @@
     </span>
     <span>Verifying...</span>
   </div>
+{:else if verified === true && payment?.platform}
+  <a
+    href={payment.verify_url || 'https://branta.pro'}
+    target="_blank"
+    rel="noopener noreferrer"
+    class="flex items-center gap-2 px-3 py-2 rounded-lg border border-input hover:border-green-500/50 transition-colors w-fit"
+    title="Verified by Branta Guardrail"
+    style="width: 100%"
+  >
+    {#if payment.platform_logo_url}
+      <img src={payment.platform_logo_url} alt={payment.platform} class="w-10 h-10 rounded object-contain" />
+    {:else}
+      <ShieldCheckIcon size={16} weight="fill" class="text-green-500" />
+    {/if}
+    <div class="flex flex-col leading-tight">
+      <span class="text font-medium text-primary-color">{payment.platform}</span>
+      <span class="text-xs text-green-500">Verified by Branta</span>
+    </div>
+  </a>
 {:else if verified === true}
   <a
-    href={verifyLink || "https://branta.pro"}
+    href={payment?.verify_url || 'https://branta.pro'}
     target="_blank"
     rel="noopener noreferrer"
     class="flex items-center gap-1.5 text-xs text-green-500 hover:text-green-400 transition-colors"
@@ -85,9 +106,9 @@
     <ShieldCheckIcon size={14} weight="fill" />
     <span>Verified by Branta</span>
   </a>
-{:else if verified === false}
+{:else if verified === false && showUnverified}
   <a
-    href={verifyLink || "https://branta.pro"}
+    href="https://branta.pro"
     target="_blank"
     rel="noopener noreferrer"
     class="flex items-center gap-1.5 text-xs text-caption hover:text-primary-color transition-colors"

--- a/src/lib/brantaService.server.ts
+++ b/src/lib/brantaService.server.ts
@@ -15,17 +15,12 @@
 import { env } from '$env/dynamic/private';
 import { V2BrantaClient, type BrantaClientOptions, type Destination, type Payment } from '@branta-ops/branta';
 
+export type { Payment };
+
 export interface RegisterPaymentResult {
   success: boolean;
   verifyLink?: string;
   secret?: string;
-  error?: string;
-}
-
-export interface VerifyPaymentResult {
-  verified: boolean;
-  registeredAt?: string;
-  description?: string;
   error?: string;
 }
 
@@ -127,48 +122,43 @@ export async function registerPayment(
 }
 
 /**
- * Verify if a payment address/invoice is registered with Branta
- *
- * @param paymentString - The Bitcoin address, Lightning invoice, or Lightning address
- * @param platform - Optional platform object for Cloudflare Workers
+ * Get payment info for an address/invoice from Branta
  */
-export async function verifyPayment(
+export async function getPaymentInfo(
   paymentString: string,
   platform?: any
-): Promise<VerifyPaymentResult> {
+): Promise<Payment | null> {
   const config = getBrantaConfig(platform);
-
-  if (!config) {
-    return { verified: false, error: 'Branta not configured' };
-  }
-
-  if (!paymentString || paymentString.trim().length === 0) {
-    return { verified: false, error: 'Payment string is required' };
-  }
+  if (!config || !paymentString?.trim()) return null;
 
   try {
     const brantaClient = new V2BrantaClient(config);
-
     const response = await brantaClient.getPayments(paymentString.trim());
-
-    if (response.length === 0) {
-      return { verified: false };
-    }
-
-    return {
-      verified: true,
-      description: response[0].description
-    };
+    return response[0] ?? null;
   } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
-      console.warn('[Branta] Verification request timed out');
-      return { verified: false, error: 'Request timed out' };
-    }
-
-    console.warn('[Branta] Verification failed:', error);
-    return {
-      verified: false,
-      error: error instanceof Error ? error.message : 'Unknown error'
-    };
+    console.warn('[Branta] getPaymentInfo failed:', error);
+    return null;
   }
 }
+
+/**
+ * Get payment info from a raw QR code string using Branta
+ */
+export async function getPaymentInfoByQRCode(
+  qrText: string,
+  platform?: any
+): Promise<Payment | null> {
+  const config = getBrantaConfig(platform);
+  if (!config || !qrText?.trim()) return null;
+
+  try {
+    const brantaClient = new V2BrantaClient(config);
+    const response = await brantaClient.getPaymentsByQRCode(qrText.trim());
+
+    return response[0] ?? null;
+  } catch (error) {
+    console.warn('[Branta] getPaymentInfoByQRCode failed:', error);
+    return null;
+  }
+}
+

--- a/src/routes/api/branta/verify/+server.ts
+++ b/src/routes/api/branta/verify/+server.ts
@@ -2,12 +2,13 @@
  * Branta Payment Verification Endpoint
  *
  * GET /api/branta/verify?payment=<paymentString>
+ * GET /api/branta/verify?qr=<rawQrText>
  * Checks if a payment address/invoice is registered with Branta Guardrail
  */
 
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { verifyPayment, isBrantaConfigured, getBrantaConfig } from '$lib/brantaService.server';
+import { getPaymentInfo, getPaymentInfoByQRCode, isBrantaConfigured } from '$lib/brantaService.server';
 
 export const GET: RequestHandler = async ({ url, platform }) => {
 	// Check if Branta is configured
@@ -15,25 +16,19 @@ export const GET: RequestHandler = async ({ url, platform }) => {
 		return json({ verified: false, error: 'Branta not configured' }, { status: 503 });
 	}
 
+	const qrText = url.searchParams.get('qr');
 	const paymentString = url.searchParams.get('payment');
 
-	if (!paymentString) {
-		return json({ verified: false, error: 'payment query parameter is required' }, { status: 400 });
+	if (!qrText && !paymentString) {
+		return json({ verified: false, error: 'payment or qr query parameter is required' }, { status: 400 });
 	}
 
 	try {
-		const result = await verifyPayment(paymentString, platform);
+		const payment = qrText
+			? await getPaymentInfoByQRCode(qrText, platform)
+			: await getPaymentInfo(paymentString!, platform);
 
-		const response: Record<string, unknown> = {
-			verified: result.verified,
-			registeredAt: result.registeredAt,
-			description: result.description
-		};
-
-		const config = getBrantaConfig(platform);
-		response.verifyLink = config!.baseUrl + '/v2/verify/' + encodeURIComponent(paymentString);
-
-		return json(response);
+		return json({ verified: payment !== null, payment: payment ?? undefined });
 	} catch (error) {
 		console.error('[Branta API] Verification error:', error);
 		return json(

--- a/src/routes/wallet/+page.svelte
+++ b/src/routes/wallet/+page.svelte
@@ -370,6 +370,7 @@ import QrCodeIcon from 'phosphor-svelte/lib/QrCode';
   let showReceiveModal = false;
   let sendInput = ''; // Invoice or Lightning address
   let brantaVerifyTriggered = false;
+  let rawQrText = ''; // Raw QR text for QR-based branta verification
   let sendAmount = 0; // Amount for Lightning address sends
   let sendComment = ''; // Optional message for Lightning address sends
   let receiveAmount = 0;
@@ -1042,12 +1043,26 @@ import QrCodeIcon from 'phosphor-svelte/lib/QrCode';
       const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
       const result = jsQRModule(imageData.data, imageData.width, imageData.height);
       if (result) {
-        let decoded = result.data.trim();
-        if (decoded.toLowerCase().startsWith('lightning:')) decoded = decoded.slice('lightning:'.length);
-        else if (decoded.toLowerCase().startsWith('bitcoin:')) decoded = decoded.slice('bitcoin:'.length).split('?')[0];
+        const raw = result.data.trim();
+        let decoded = raw;
+        let shouldAutoVerify = false;
+
+        if (decoded.toLowerCase().startsWith('lightning:')) {
+          decoded = decoded.slice('lightning:'.length);
+          shouldAutoVerify = true;
+        } else if (decoded.toLowerCase().startsWith('bitcoin:')) {
+          const withoutPrefix = decoded.slice('bitcoin:'.length);
+          const params = new URLSearchParams(withoutPrefix.includes('?') ? withoutPrefix.split('?')[1] : '');
+          if (params.has('branta_id') && params.has('branta_secret')) {
+            shouldAutoVerify = true;
+          }
+          decoded = withoutPrefix.split('?')[0];
+        }
+
         sendInput = decoded;
+        rawQrText = shouldAutoVerify ? raw : '';
         sendingMaxBalance = false;
-        brantaVerifyTriggered = false;
+        brantaVerifyTriggered = shouldAutoVerify;
         if (onchainFeeQuote) { onchainFeeQuote = null; onchainPrepareResponse = null; }
         stopQrCamera();
         return;
@@ -4735,6 +4750,7 @@ import QrCodeIcon from 'phosphor-svelte/lib/QrCode';
                         // Reset on-chain state when input changes
                         sendingMaxBalance = false;
                         brantaVerifyTriggered = false;
+                        rawQrText = '';
                         if (onchainFeeQuote) {
                           onchainFeeQuote = null;
                           onchainPrepareResponse = null;
@@ -4743,7 +4759,7 @@ import QrCodeIcon from 'phosphor-svelte/lib/QrCode';
                     />
                     <button
                       type="button"
-                      class="absolute top-2 right-2 p-1 rounded text-caption hover:text-primary-color transition-colors disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+                      class="absolute top-2 right-3.5 p-1 rounded text-caption hover:text-primary-color transition-colors disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
                       on:click={startQrCamera}
                       disabled={isSending || isSendingOnchain || showQrCamera}
                       title="Scan QR code"
@@ -4759,7 +4775,7 @@ import QrCodeIcon from 'phosphor-svelte/lib/QrCode';
                   <div class="mt-1">
                     {#if sendInput.trim()}
                       {#if brantaVerifyTriggered}
-                        <BrantaBadge paymentString={sendInput.trim()} />
+                        <BrantaBadge paymentString={sendInput.trim()} rawQrText={rawQrText} />
                       {:else}
                         <button
                           type="button"

--- a/src/routes/wallet/+page.svelte
+++ b/src/routes/wallet/+page.svelte
@@ -119,6 +119,7 @@
   import CopyIcon from 'phosphor-svelte/lib/Copy';
   import InfoIcon from 'phosphor-svelte/lib/Info';
   import LinkIcon from 'phosphor-svelte/lib/Link';
+import QrCodeIcon from 'phosphor-svelte/lib/QrCode';
   import CheckIcon from 'phosphor-svelte/lib/Check';
   import XIcon from 'phosphor-svelte/lib/X';
   import UserCirclePlusIcon from 'phosphor-svelte/lib/UserCirclePlus';
@@ -429,6 +430,14 @@
   let isSendingOnchain = false;
   let showOnchainConfirmation = false; // Show address verification step before sending
   let sendingMaxBalance = false; // Track if user wants to send full balance (fee will be deducted)
+
+  // QR scan state
+  let showQrCamera = false;
+  let qrVideoElement: HTMLVideoElement;
+  let qrCameraStream: MediaStream | null = null;
+  let qrAnimFrame: number | null = null;
+  let jsQRModule: typeof import('jsqr').default | null = null;
+  let qrScanError = '';
 
   // Check if send input is a Bitcoin address
   $: isBtcAddress = isBitcoinAddress(sendInput);
@@ -999,8 +1008,58 @@
     sendError = '';
     sendSuccess = '';
     isSending = false;
+    qrScanError = '';
+    stopQrCamera();
     // Reset on-chain state
     resetOnchainSendState();
+  }
+
+  async function startQrCamera() {
+    qrScanError = '';
+    showQrCamera = true;
+    try {
+      if (!jsQRModule) jsQRModule = (await import('jsqr')).default;
+      qrCameraStream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: 'environment' }
+      });
+      qrVideoElement.srcObject = qrCameraStream;
+      await qrVideoElement.play();
+      scanQrFrame();
+    } catch {
+      qrScanError = 'Camera access denied.';
+      showQrCamera = false;
+    }
+  }
+
+  function scanQrFrame() {
+    if (!showQrCamera || !qrVideoElement || !jsQRModule) return;
+    if (qrVideoElement.readyState === qrVideoElement.HAVE_ENOUGH_DATA) {
+      const canvas = document.createElement('canvas');
+      canvas.width = qrVideoElement.videoWidth;
+      canvas.height = qrVideoElement.videoHeight;
+      const ctx = canvas.getContext('2d')!;
+      ctx.drawImage(qrVideoElement, 0, 0);
+      const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+      const result = jsQRModule(imageData.data, imageData.width, imageData.height);
+      if (result) {
+        let decoded = result.data.trim();
+        if (decoded.toLowerCase().startsWith('lightning:')) decoded = decoded.slice('lightning:'.length);
+        else if (decoded.toLowerCase().startsWith('bitcoin:')) decoded = decoded.slice('bitcoin:'.length).split('?')[0];
+        sendInput = decoded;
+        sendingMaxBalance = false;
+        brantaVerifyTriggered = false;
+        if (onchainFeeQuote) { onchainFeeQuote = null; onchainPrepareResponse = null; }
+        stopQrCamera();
+        return;
+      }
+    }
+    qrAnimFrame = requestAnimationFrame(scanQrFrame);
+  }
+
+  function stopQrCamera() {
+    showQrCamera = false;
+    if (qrAnimFrame) { cancelAnimationFrame(qrAnimFrame); qrAnimFrame = null; }
+    if (qrCameraStream) { qrCameraStream.getTracks().forEach(t => t.stop()); qrCameraStream = null; }
   }
 
   // Reset on-chain send state (defined above resetSendModal call)
@@ -4663,24 +4722,35 @@
                       Invoice or Lightning Address
                     {/if}
                   </label>
-                  <textarea
-                    bind:value={sendInput}
-                    placeholder={$activeWallet?.kind === 4
-                      ? 'lnbc..., user@example.com, or bc1...'
-                      : 'lnbc... or user@example.com'}
-                    class="w-full p-3 rounded-lg bg-input border border-input text-primary-color placeholder-caption resize-none focus:outline-none focus:ring-2 focus:ring-amber-500"
-                    rows="3"
-                    disabled={isSending || isSendingOnchain}
-                    on:input={() => {
-                      // Reset on-chain state when input changes
-                      sendingMaxBalance = false;
-                      brantaVerifyTriggered = false;
-                      if (onchainFeeQuote) {
-                        onchainFeeQuote = null;
-                        onchainPrepareResponse = null;
-                      }
-                    }}
-                  />
+                  <div class="relative">
+                    <textarea
+                      bind:value={sendInput}
+                      placeholder={$activeWallet?.kind === 4
+                        ? 'lnbc..., user@example.com, or bc1...'
+                        : 'lnbc... or user@example.com'}
+                      class="w-full p-3 pr-10 rounded-lg bg-input border border-input text-primary-color placeholder-caption resize-none focus:outline-none focus:ring-2 focus:ring-amber-500"
+                      rows="3"
+                      disabled={isSending || isSendingOnchain}
+                      on:input={() => {
+                        // Reset on-chain state when input changes
+                        sendingMaxBalance = false;
+                        brantaVerifyTriggered = false;
+                        if (onchainFeeQuote) {
+                          onchainFeeQuote = null;
+                          onchainPrepareResponse = null;
+                        }
+                      }}
+                    />
+                    <button
+                      type="button"
+                      class="absolute top-2 right-2 p-1 rounded text-caption hover:text-primary-color transition-colors disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+                      on:click={startQrCamera}
+                      disabled={isSending || isSendingOnchain || showQrCamera}
+                      title="Scan QR code"
+                    >
+                      <QrCodeIcon size={18} />
+                    </button>
+                  </div>
                   {#if isBtcAddress && $activeWallet?.kind === 4}
                     <div class="mt-1 text-xs text-amber-500 flex items-center gap-1">
                       ₿ Bitcoin address detected - on-chain payment
@@ -4702,6 +4772,12 @@
                       {/if}
                     {/if}
                   </div>
+                  {#if qrScanError}
+                    <div class="mt-1 text-xs text-red-400 flex items-center gap-1">
+                      <WarningIcon size={12} />
+                      {qrScanError}
+                    </div>
+                  {/if}
                 </div>
 
                 {#if isLightningAddress || isBtcAddress}
@@ -4926,8 +5002,23 @@
             </div>
           </div>
         </div>
-      </div>
-    {/if}
+      {#if showQrCamera}
+        <div class="fixed inset-0 bg-black z-[60] flex flex-col">
+          <div class="flex items-center justify-between p-4">
+            <span class="text-white text-sm font-medium">Point camera at QR code</span>
+            <button type="button" class="text-white p-1" on:click={stopQrCamera}>
+              <XIcon size={24} />
+            </button>
+          </div>
+          <div class="flex-1 flex items-center justify-center overflow-hidden">
+            <!-- svelte-ignore a11y-media-has-caption -->
+            <video bind:this={qrVideoElement} class="w-full h-full object-cover" playsinline />
+          </div>
+          <div class="p-4 text-center text-white/50 text-sm">Scanning for QR code...</div>
+        </div>
+      {/if}
+    </div>
+  {/if}
 
     <!-- Receive Modal -->
     {#if showReceiveModal && portalTarget}

--- a/src/routes/wallet/+page.svelte
+++ b/src/routes/wallet/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
-  import { onMount } from 'svelte';
+  import { onMount, tick } from 'svelte';
   import { browser } from '$app/environment';
   import { userPublickey } from '$lib/nostr';
   import { portal } from '../../components/Modal.svelte';
@@ -119,7 +119,7 @@
   import CopyIcon from 'phosphor-svelte/lib/Copy';
   import InfoIcon from 'phosphor-svelte/lib/Info';
   import LinkIcon from 'phosphor-svelte/lib/Link';
-import QrCodeIcon from 'phosphor-svelte/lib/QrCode';
+  import QrCodeIcon from 'phosphor-svelte/lib/QrCode';
   import CheckIcon from 'phosphor-svelte/lib/Check';
   import XIcon from 'phosphor-svelte/lib/X';
   import UserCirclePlusIcon from 'phosphor-svelte/lib/UserCirclePlus';
@@ -1018,6 +1018,7 @@ import QrCodeIcon from 'phosphor-svelte/lib/QrCode';
   async function startQrCamera() {
     qrScanError = '';
     showQrCamera = true;
+    await tick();
     try {
       if (!jsQRModule) jsQRModule = (await import('jsqr')).default;
       qrCameraStream = await navigator.mediaDevices.getUserMedia({
@@ -1027,20 +1028,27 @@ import QrCodeIcon from 'phosphor-svelte/lib/QrCode';
       await qrVideoElement.play();
       scanQrFrame();
     } catch {
+      stopQrCamera();
       qrScanError = 'Camera access denied.';
-      showQrCamera = false;
     }
   }
+
+  let qrCanvas: HTMLCanvasElement | null = null;
+  let qrCtx: CanvasRenderingContext2D | null = null;
 
   function scanQrFrame() {
     if (!showQrCamera || !qrVideoElement || !jsQRModule) return;
     if (qrVideoElement.readyState === qrVideoElement.HAVE_ENOUGH_DATA) {
-      const canvas = document.createElement('canvas');
-      canvas.width = qrVideoElement.videoWidth;
-      canvas.height = qrVideoElement.videoHeight;
-      const ctx = canvas.getContext('2d')!;
-      ctx.drawImage(qrVideoElement, 0, 0);
-      const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+      const w = qrVideoElement.videoWidth;
+      const h = qrVideoElement.videoHeight;
+      if (!qrCanvas) {
+        qrCanvas = document.createElement('canvas');
+        qrCtx = qrCanvas.getContext('2d')!;
+      }
+      if (qrCanvas.width !== w) qrCanvas.width = w;
+      if (qrCanvas.height !== h) qrCanvas.height = h;
+      qrCtx!.drawImage(qrVideoElement, 0, 0);
+      const imageData = qrCtx!.getImageData(0, 0, w, h);
       const result = jsQRModule(imageData.data, imageData.width, imageData.height);
       if (result) {
         const raw = result.data.trim();
@@ -1075,6 +1083,8 @@ import QrCodeIcon from 'phosphor-svelte/lib/QrCode';
     showQrCamera = false;
     if (qrAnimFrame) { cancelAnimationFrame(qrAnimFrame); qrAnimFrame = null; }
     if (qrCameraStream) { qrCameraStream.getTracks().forEach(t => t.stop()); qrCameraStream = null; }
+    qrCanvas = null;
+    qrCtx = null;
   }
 
   // Reset on-chain send state (defined above resetSendModal call)
@@ -4763,6 +4773,7 @@ import QrCodeIcon from 'phosphor-svelte/lib/QrCode';
                       on:click={startQrCamera}
                       disabled={isSending || isSendingOnchain || showQrCamera}
                       title="Scan QR code"
+                      aria-label="Scan QR code"
                     >
                       <QrCodeIcon size={18} />
                     </button>
@@ -5022,7 +5033,7 @@ import QrCodeIcon from 'phosphor-svelte/lib/QrCode';
         <div class="fixed inset-0 bg-black z-[60] flex flex-col">
           <div class="flex items-center justify-between p-4">
             <span class="text-white text-sm font-medium">Point camera at QR code</span>
-            <button type="button" class="text-white p-1" on:click={stopQrCamera}>
+            <button type="button" class="text-white p-1" on:click={stopQrCamera} aria-label="Close QR scanner">
               <XIcon size={24} />
             </button>
           </div>


### PR DESCRIPTION
## Summary
- Add QR code scanning to the Send Payment flow (camera-based via `jsqr`)
- Display Branta-verified platform logo and name in a clickable card on the verification badge
- Support QR-based Branta verification with `branta_id`/`branta_secret` params

Replaces #275 (rebased onto main, resolved conflicts, addressed Copilot review feedback).

## Changes from #275
- Fix `startQrCamera` race condition (`await tick()` before accessing conditionally-rendered video element)
- Clean up camera stream on error to prevent leaked media tracks
- Reuse canvas/context across `scanQrFrame` calls to reduce GC churn
- Add `aria-label` to icon-only QR scan and close buttons
- Fix `QrCodeIcon` import indentation

## Test plan
- [ ] Open wallet Send modal, tap QR icon, grant camera access, scan a Lightning/Bitcoin QR
- [ ] Deny camera access and verify error message appears
- [ ] Scan a Branta-enabled QR (`bitcoin:` URI with `branta_id`/`branta_secret`) and verify badge shows platform card
- [ ] Verify Branta badge on receive flow (Lightning invoice + on-chain address)
- [ ] Screen reader: verify QR scan and close buttons are announced

🤖 Generated with [Claude Code](https://claude.com/claude-code)