### PR TITLE
Poll voter lists + Zap polls (kind 6969)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.125",
+  "version": "4.2.126",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.124",
+  "version": "4.2.125",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.126",
+  "version": "4.2.127",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/PollCreator.svelte
+++ b/src/components/PollCreator.svelte
@@ -25,8 +25,8 @@
 
   // Zap poll state
   let isZapPoll = false;
-  let minSats = 1;
-  let maxSats = 0;
+  let minSats = 21;
+  let maxSats = 21000;
 
   // Image upload state
   let uploadingIndex: number | null = null;
@@ -124,8 +124,8 @@
     uploadError = '';
     fileInputs = {};
     isZapPoll = false;
-    minSats = 1;
-    maxSats = 0;
+    minSats = 21;
+    maxSats = 21000;
   }
 
   function setPreset(d: number, h: number, m: number) {

--- a/src/components/PollCreator.svelte
+++ b/src/components/PollCreator.svelte
@@ -4,13 +4,13 @@
   import PlusIcon from 'phosphor-svelte/lib/Plus';
   import TrashIcon from 'phosphor-svelte/lib/Trash';
   import ImageIcon from 'phosphor-svelte/lib/Image';
-  import { generateOptionId, type PollConfig, type PollOption, type PollType } from '$lib/polls';
+  import { generateOptionId, type PollConfig, type PollOption, type PollType, type ZapPollConfig, type ZapPollOption } from '$lib/polls';
   import { ndk } from '$lib/nostr';
   import { uploadImage } from '$lib/mediaUpload';
 
   export let open = false;
 
-  const dispatch = createEventDispatcher<{ create: PollConfig }>();
+  const dispatch = createEventDispatcher<{ create: PollConfig; createZapPoll: ZapPollConfig }>();
 
   let pollType: PollType = 'singlechoice';
   let options: PollOption[] = [
@@ -22,6 +22,11 @@
   let days = 1;
   let hours = 0;
   let minutes = 0;
+
+  // Zap poll state
+  let isZapPoll = false;
+  let minSats = 1;
+  let maxSats = 0;
 
   // Image upload state
   let uploadingIndex: number | null = null;
@@ -83,11 +88,21 @@
       endsAt = Math.floor(Date.now() / 1000) + totalMinutes * 60;
     }
 
-    dispatch('create', {
-      options: validOptions,
-      pollType,
-      endsAt
-    });
+    if (isZapPoll) {
+      dispatch('createZapPoll', {
+        options: validOptions.map(o => ({ id: o.id, label: o.label })),
+        pollType,
+        closedAt: endsAt,
+        valueMinimum: minSats,
+        ...(maxSats > 0 && { valueMaximum: maxSats })
+      });
+    } else {
+      dispatch('create', {
+        options: validOptions,
+        pollType,
+        endsAt
+      });
+    }
     close();
   }
 
@@ -108,6 +123,9 @@
     uploadingIndex = null;
     uploadError = '';
     fileInputs = {};
+    isZapPoll = false;
+    minSats = 1;
+    maxSats = 0;
   }
 
   function setPreset(d: number, h: number, m: number) {
@@ -137,6 +155,26 @@
       >
         Multiple choice
       </button>
+    </div>
+
+    <!-- Zap poll toggle -->
+    <div class="mb-4">
+      <label class="flex items-center gap-2 cursor-pointer">
+        <input type="checkbox" bind:checked={isZapPoll} style="accent-color: #facc15; width: 1rem; height: 1rem; cursor: pointer;" />
+        <span class="text-sm" style="color: var(--color-text-primary);">⚡ Zap Poll <span class="text-xs" style="color: var(--color-caption);">(vote with sats)</span></span>
+      </label>
+      {#if isZapPoll}
+        <div class="flex gap-3 mt-2 ml-6">
+          <div class="flex flex-col gap-1">
+            <label class="text-xs" style="color: var(--color-caption);">Min sats</label>
+            <input type="number" bind:value={minSats} min="1" class="poll-option-input" style="width: 5rem;" />
+          </div>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs" style="color: var(--color-caption);">Max sats <span>(0 = no limit)</span></label>
+            <input type="number" bind:value={maxSats} min="0" class="poll-option-input" style="width: 5rem;" />
+          </div>
+        </div>
+      {/if}
     </div>
 
     <!-- Options -->

--- a/src/components/PollDisplay.svelte
+++ b/src/components/PollDisplay.svelte
@@ -5,6 +5,8 @@
   import { addClientTagToEvent } from '$lib/nip89';
   import { publishQueue } from '$lib/publishQueue';
   import NoteContent from './NoteContent.svelte';
+  import CustomAvatar from './CustomAvatar.svelte';
+  import CustomName from './CustomName.svelte';
   import { formatDistanceToNow } from 'date-fns';
   import {
     parsePollFromEvent,
@@ -31,6 +33,19 @@
   let voteError = '';
   let voteHandle: VoteHandle | null = null;
   let unsubResults: (() => void) | null = null;
+  let expandedOption: string | null = null;
+
+  function getVotersForOption(optionId: string): string[] {
+    const pubkeys: string[] = [];
+    for (const [pubkey, optionIds] of results.votesByPubkey) {
+      if (optionIds.includes(optionId)) pubkeys.push(pubkey);
+    }
+    return pubkeys;
+  }
+
+  function toggleVoterList(optionId: string) {
+    expandedOption = expandedOption === optionId ? null : optionId;
+  }
 
   $: expired = pollData ? isPollExpired(pollData.endsAt) : false;
   $: userVoted = $userPublickey ? results.voters.has($userPublickey) : false;
@@ -126,34 +141,50 @@
         {@const isWinner = displayResults && voteCount > 0 && voteCount === maxVoteCount}
 
         {#if displayResults}
-          <div
-            class="poll-card"
-            class:poll-card-winner={isWinner}
-            class:poll-card-user={isUserChoice}
-          >
-            <div class="poll-card-img-wrap">
-              {#if option.image}
-                <img src={option.image} alt={option.label || `Option ${i + 1}`} class="poll-card-img" />
-              {:else}
-                <div class="poll-card-img-placeholder"></div>
-              {/if}
-              <div class="poll-card-overlay">
-                <span class="poll-card-pct">{pct}%</span>
-                {#if option.label}
-                  <span class="poll-card-label">{option.label}</span>
+          {@const voters = getVotersForOption(option.id)}
+          {@const isExpanded = expandedOption === option.id}
+          <div class="poll-card-wrapper" class:poll-card-expanded={isExpanded}>
+            <button
+              class="poll-card"
+              class:poll-card-winner={isWinner}
+              class:poll-card-user={isUserChoice}
+              on:click={() => voters.length > 0 && toggleVoterList(option.id)}
+              disabled={voters.length === 0}
+            >
+              <div class="poll-card-img-wrap">
+                {#if option.image}
+                  <img src={option.image} alt={option.label || `Option ${i + 1}`} class="poll-card-img" />
+                {:else}
+                  <div class="poll-card-img-placeholder"></div>
                 {/if}
-                <div class="poll-card-bar">
-                  <div class="poll-card-bar-fill" style="width: {pct}%"></div>
+                <div class="poll-card-overlay">
+                  <span class="poll-card-pct">{pct}%</span>
+                  {#if option.label}
+                    <span class="poll-card-label">{option.label}</span>
+                  {/if}
+                  <div class="poll-card-bar">
+                    <div class="poll-card-bar-fill" style="width: {pct}%"></div>
+                  </div>
                 </div>
+                {#if isUserChoice}
+                  <span class="poll-check-badge">
+                    <svg viewBox="0 0 12 12" fill="none">
+                      <path d="M2.5 6L5 8.5L9.5 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    </svg>
+                  </span>
+                {/if}
               </div>
-              {#if isUserChoice}
-                <span class="poll-check-badge">
-                  <svg viewBox="0 0 12 12" fill="none">
-                    <path d="M2.5 6L5 8.5L9.5 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                </span>
-              {/if}
-            </div>
+            </button>
+            {#if isExpanded && voters.length > 0}
+              <div class="poll-voters poll-voters-card">
+                {#each voters as pubkey (pubkey)}
+                  <a href="/user/{pubkey}" class="poll-voter">
+                    <CustomAvatar pubkey={pubkey} size={24} />
+                    <CustomName {pubkey} className="poll-voter-name" />
+                  </a>
+                {/each}
+              </div>
+            {/if}
           </div>
         {:else}
           <button
@@ -197,17 +228,37 @@
         {@const isSelected = selectedOptions.has(option.id)}
 
         {#if displayResults}
-          <div class="poll-row poll-row-result" class:poll-row-user={isUserChoice}>
-            <div class="poll-row-fill" style="width: {pct}%"></div>
-            <span class="poll-row-label">
-              {option.label}
-              {#if isUserChoice}
-                <svg class="poll-row-check" viewBox="0 0 12 12" fill="none">
-                  <path d="M2.5 6L5 8.5L9.5 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-              {/if}
-            </span>
-            <span class="poll-row-pct">{pct}%</span>
+          {@const voters = getVotersForOption(option.id)}
+          {@const isExpanded = expandedOption === option.id}
+          <div>
+            <button
+              class="poll-row poll-row-result"
+              class:poll-row-user={isUserChoice}
+              class:poll-row-expanded={isExpanded}
+              on:click={() => voters.length > 0 && toggleVoterList(option.id)}
+              disabled={voters.length === 0}
+            >
+              <div class="poll-row-fill" style="width: {pct}%"></div>
+              <span class="poll-row-label">
+                {option.label}
+                {#if isUserChoice}
+                  <svg class="poll-row-check" viewBox="0 0 12 12" fill="none">
+                    <path d="M2.5 6L5 8.5L9.5 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                {/if}
+              </span>
+              <span class="poll-row-pct">{pct}%</span>
+            </button>
+            {#if isExpanded && voters.length > 0}
+              <div class="poll-voters">
+                {#each voters as pubkey (pubkey)}
+                  <a href="/user/{pubkey}" class="poll-voter">
+                    <CustomAvatar pubkey={pubkey} size={24} />
+                    <CustomName {pubkey} className="poll-voter-name" />
+                  </a>
+                {/each}
+              </div>
+            {/if}
           </div>
         {:else}
           <button
@@ -255,7 +306,7 @@
           </button>
         {/if}
       {:else if displayResults && $userPublickey && !userVoted && !expired && !voted}
-        <button class="poll-results-link" on:click={() => (showResults = false)}>
+        <button class="poll-results-link" on:click={() => { showResults = false; expandedOption = null; }}>
           Back to vote
         </button>
       {/if}
@@ -488,7 +539,12 @@
     background: rgba(255, 122, 61, 0.08);
   }
 
-  .poll-row-result {
+  .poll-row-result:not(:disabled) {
+    cursor: pointer;
+  }
+
+  .poll-row-result:disabled {
+    opacity: 1;
     cursor: default;
   }
 
@@ -623,5 +679,75 @@
 
   @keyframes fillGrow {
     from { width: 0; }
+  }
+
+  /* ═══════════════════════════════════════════
+     VOTER LIST
+     ═══════════════════════════════════════════ */
+
+  .poll-row-expanded {
+    border-color: var(--color-primary);
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  .poll-voters {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--color-primary);
+    border-top: none;
+    border-radius: 0 0 0.625rem 0.625rem;
+    background: rgba(249, 115, 22, 0.03);
+    max-height: 11rem;
+    overflow-y: auto;
+  }
+
+  :global(.dark) .poll-voters {
+    background: rgba(255, 122, 61, 0.05);
+  }
+
+  .poll-voters-card {
+    border-radius: 0 0 0.75rem 0.75rem;
+  }
+
+  .poll-voter {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.25rem 0;
+    text-decoration: none;
+    color: var(--color-text-primary);
+    transition: opacity 0.15s;
+  }
+
+  .poll-voter:hover {
+    opacity: 0.8;
+  }
+
+  :global(.poll-voter-name) {
+    font-size: 0.8125rem;
+    font-weight: 500;
+  }
+
+  .poll-card-wrapper {
+    display: contents;
+  }
+
+  .poll-card-wrapper.poll-card-expanded {
+    display: flex;
+    flex-direction: column;
+    grid-column: 1 / -1;
+  }
+
+  .poll-card-wrapper.poll-card-expanded .poll-card {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  .poll-card-wrapper button.poll-card:disabled {
+    opacity: 1;
+    cursor: default;
   }
 </style>

--- a/src/components/PostComposer.svelte
+++ b/src/components/PostComposer.svelte
@@ -9,7 +9,7 @@
   import ChartBarHorizontalIcon from 'phosphor-svelte/lib/ChartBarHorizontal';
   import GifPicker from './GifPicker.svelte';
   import PollCreator from './PollCreator.svelte';
-  import { buildPollTags, type PollConfig } from '$lib/polls';
+  import { buildPollTags, buildZapPollTags, type PollConfig, type ZapPollConfig } from '$lib/polls';
   import CustomAvatar from './CustomAvatar.svelte';
   import ProfileLink from './ProfileLink.svelte';
   import { nip19 } from 'nostr-tools';
@@ -60,6 +60,7 @@
   let showGifPicker = false;
   let showPollCreator = false;
   let pollConfig: PollConfig | null = null;
+  let zapPollConfig: ZapPollConfig | null = null;
 
   // Mention autocomplete (shared controller)
   let mentionState: MentionState = {
@@ -149,6 +150,7 @@
     uploadedVideos = [];
     quotedNote = null;
     pollConfig = null;
+    zapPollConfig = null;
     if (composerEl) {
       composerEl.innerHTML = '';
     }
@@ -233,7 +235,8 @@
       !quotedNote &&
       uploadedImages.length === 0 &&
       uploadedVideos.length === 0 &&
-      !pollConfig
+      !pollConfig &&
+      !zapPollConfig
     ) {
       console.log('[PostComposer] No content to post');
       error = 'Please enter some content';
@@ -269,7 +272,7 @@
 
       console.log('[PostComposer] Creating NDKEvent...');
       const event = new NDKEvent($ndk);
-      event.kind = pollConfig ? 1068 : 1;
+      event.kind = zapPollConfig ? 6969 : pollConfig ? 1068 : 1;
 
       // Build content with text, image URLs, and video URLs
       let postContent = content.trim();
@@ -316,7 +319,14 @@
 
       addClientTagToEvent(event);
 
-      if (pollConfig) {
+      if (zapPollConfig) {
+        // Zap polls need a p tag with creator's pubkey for Lightning routing
+        if ($userPublickey) {
+          const relay = $ndk.explicitRelayUrls?.[0] || '';
+          event.tags.push(relay ? ['p', $userPublickey, relay] : ['p', $userPublickey]);
+        }
+        event.tags.push(...buildZapPollTags(zapPollConfig));
+      } else if (pollConfig) {
         event.tags.push(...buildPollTags(pollConfig));
       }
 
@@ -554,15 +564,19 @@
                 </div>
               {/if}
 
-              {#if pollConfig}
+              {#if pollConfig || zapPollConfig}
                 <div class="mb-2 flex items-center gap-2 px-3 py-1.5 rounded-lg bg-orange-50 dark:bg-orange-900/20 border border-orange-200 dark:border-orange-800">
                   <ChartBarHorizontalIcon size={14} class="text-orange-600 dark:text-orange-400" />
                   <span class="text-xs font-medium text-orange-700 dark:text-orange-300">
-                    Poll: {pollConfig.options.length} options
+                    {#if zapPollConfig}
+                      ⚡ Zap Poll: {zapPollConfig.options.length} options (min {zapPollConfig.valueMinimum} sats)
+                    {:else if pollConfig}
+                      Poll: {pollConfig.options.length} options
+                    {/if}
                   </span>
                   <button
                     type="button"
-                    on:click={() => (pollConfig = null)}
+                    on:click={() => { pollConfig = null; zapPollConfig = null; }}
                     class="ml-auto text-orange-500 hover:text-orange-700 p-0.5"
                     aria-label="Remove poll"
                   >
@@ -671,7 +685,7 @@
               disabled={posting}
               title="Create poll"
             >
-              <ChartBarHorizontalIcon size={18} class={pollConfig ? 'text-primary' : 'text-caption'} />
+              <ChartBarHorizontalIcon size={18} class={pollConfig || zapPollConfig ? 'text-primary' : 'text-caption'} />
             </button>
 
             {#if uploadingImage}
@@ -728,7 +742,8 @@
                   uploadedImages.length === 0 &&
                   uploadedVideos.length === 0 &&
                   !quotedNote &&
-                  !pollConfig)}
+                  !pollConfig &&
+                  !zapPollConfig)}
               class="px-4 py-1.5 text-xs font-medium text-white bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 rounded-full disabled:opacity-50 disabled:cursor-not-allowed transition-all"
             >
               {posting ? 'Posting...' : 'Post'}
@@ -751,6 +766,11 @@
   bind:open={showPollCreator}
   on:create={(e) => {
     pollConfig = e.detail;
+    zapPollConfig = null;
+  }}
+  on:createZapPoll={(e) => {
+    zapPollConfig = e.detail;
+    pollConfig = null;
   }}
 />
 

--- a/src/components/ZapModal.svelte
+++ b/src/components/ZapModal.svelte
@@ -17,7 +17,7 @@
   import { displayCurrency } from '$lib/currencyStore';
   import { convertSatsToFiat, formatFiatValue } from '$lib/currencyConversion';
 
-  const dispatch = createEventDispatcher<{ 'zap-complete': { amount: number } }>();
+  const dispatch = createEventDispatcher<{ 'zap-complete': { amount: number; pollOptionId?: string } }>();
   import { activeWallet, getWalletKindName } from '$lib/wallet';
   import { sendPayment } from '$lib/wallet/walletManager';
 
@@ -37,8 +37,41 @@
 
   export let open = false;
   export let event: NDKEvent | NDKUser;
+  export let pollOptionId: string | undefined = undefined;
+  export let pollOptionLabel: string | undefined = undefined;
+  export let pollMinSats: number | undefined = undefined;
+  export let pollMaxSats: number | undefined = undefined;
+  export let pollEventKind: number | undefined = undefined;
 
   let amount: number = 21;
+
+  // Generate dynamic presets for zap polls — linear interpolation (matches Primal)
+  function getZapPollPresets(min: number, max: number | undefined): { amount: number; label: string }[] {
+    const lo = min || 1;
+    const hi = max && max > 0 ? max : 21_000;
+    let count = 6;
+    if (hi - lo < 6) count = hi - lo + 1;
+    if (count <= 0) count = 1;
+
+    const presets: number[] = count === 1
+      ? [lo]
+      : Array.from({ length: count }, (_, i) => Math.round(lo + (i * (hi - lo)) / (count - 1)));
+
+    return presets.map(a => ({
+      amount: a,
+      label: a >= 1_000_000 ? `${(a / 1_000_000).toFixed(1)}M`
+           : a >= 1_000 ? `${a % 1_000 === 0 ? `${a / 1_000}K` : a.toLocaleString()}`
+           : String(a)
+    }));
+  }
+
+  $: isPollMode = pollOptionId != null;
+  $: pollPresets = isPollMode ? getZapPollPresets(pollMinSats || 1, pollMaxSats) : [];
+
+  // Set default amount to min sats when entering poll mode
+  $: if (isPollMode && pollMinSats && amount === 21) {
+    amount = pollMinSats;
+  }
   let message: string = '';
 
   let state: 'pre' | 'pending' | 'success' | 'error' = 'pre';
@@ -130,11 +163,15 @@
       recipientPubkeyForDisplay = recipientPubkey;
 
       // Get the invoice from zapManager
+      const extraTags = pollOptionId
+        ? [['poll_option', pollOptionId], ...(pollEventKind ? [['k', String(pollEventKind)]] : [])]
+        : undefined;
       const zapResult = await zapManager.createZap(
         recipientPubkey,
         amount * 1000,
         message,
-        eventId
+        eventId,
+        extraTags
       );
 
       // Use the unified wallet manager to send payment (handles both Spark and NWC)
@@ -154,7 +191,7 @@
       hapticSuccess();
 
       // Notify parent that zap completed so it can refresh zap totals
-      dispatch('zap-complete', { amount });
+      dispatch('zap-complete', { amount, pollOptionId });
 
       // Auto-close modal after 2.5s; user can also tap anywhere to dismiss
       successTimeout = setTimeout(() => {
@@ -199,11 +236,15 @@
       recipientPubkeyForDisplay = recipientPubkey;
 
       // Get the invoice from zapManager
+      const extraTags = pollOptionId
+        ? [['poll_option', pollOptionId], ...(pollEventKind ? [['k', String(pollEventKind)]] : [])]
+        : undefined;
       const zapResult = await zapManager.createZap(
         recipientPubkey,
         amount * 1000,
         message,
-        eventId
+        eventId,
+        extraTags
       );
 
       isCreatingInvoice = false;
@@ -217,7 +258,7 @@
         invoice: zapResult.invoice,
         verify: zapResult.verify,
         onPaid: () => {
-          dispatch('zap-complete', { amount });
+          dispatch('zap-complete', { amount, pollOptionId });
         },
         onCancelled: () => {
           // User cancelled - reopen our modal
@@ -276,20 +317,49 @@
       </div>
     {:else if state == 'pre'}
       <div class="flex flex-col gap-3">
+        {#if pollOptionLabel}
+          <div class="flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium" style="background: rgba(250, 204, 21, 0.1); color: var(--color-text-primary); border: 1px solid rgba(250, 204, 21, 0.3);">
+            <span>⚡</span>
+            <span>Voting for: <strong>{pollOptionLabel}</strong></span>
+          </div>
+          {#if pollMinSats || pollMaxSats}
+            <p class="text-xs text-caption px-1">
+              {#if pollMinSats}Min: {pollMinSats} sats{/if}
+              {#if pollMinSats && pollMaxSats} · {/if}
+              {#if pollMaxSats}Max: {pollMaxSats} sats{/if}
+            </p>
+          {/if}
+        {/if}
         <div class="grid grid-cols-4 gap-2">
-          {#each defaultZapSatsAmounts as zapOption}
-            <button
-              on:click={() => handlePresetClick(zapOption.amount)}
-              class="flex flex-col items-center justify-center py-3 px-2 rounded-xl transition-all duration-200 cursor-pointer
-                {amount === zapOption.amount
-                ? 'bg-gradient-to-r from-orange-500 to-amber-500 text-white shadow-md scale-105'
-                : 'bg-input hover:bg-accent-gray'}"
-              style={amount !== zapOption.amount ? 'color: var(--color-text-primary)' : ''}
-            >
-              <span class="text-xl">{zapOption.emoji}</span>
-              <span class="text-sm font-semibold">{zapOption.label}</span>
-            </button>
-          {/each}
+          {#if isPollMode && pollPresets.length > 0}
+            {#each pollPresets as preset}
+              <button
+                on:click={() => handlePresetClick(preset.amount)}
+                class="flex flex-col items-center justify-center py-3 px-2 rounded-xl transition-all duration-200 cursor-pointer
+                  {amount === preset.amount
+                  ? 'bg-gradient-to-r from-yellow-500 to-amber-500 text-white shadow-md scale-105'
+                  : 'bg-input hover:bg-accent-gray'}"
+                style={amount !== preset.amount ? 'color: var(--color-text-primary)' : ''}
+              >
+                <span class="text-xl">⚡</span>
+                <span class="text-sm font-semibold">{preset.label}</span>
+              </button>
+            {/each}
+          {:else}
+            {#each defaultZapSatsAmounts as zapOption}
+              <button
+                on:click={() => handlePresetClick(zapOption.amount)}
+                class="flex flex-col items-center justify-center py-3 px-2 rounded-xl transition-all duration-200 cursor-pointer
+                  {amount === zapOption.amount
+                  ? 'bg-gradient-to-r from-orange-500 to-amber-500 text-white shadow-md scale-105'
+                  : 'bg-input hover:bg-accent-gray'}"
+                style={amount !== zapOption.amount ? 'color: var(--color-text-primary)' : ''}
+              >
+                <span class="text-xl">{zapOption.emoji}</span>
+                <span class="text-sm font-semibold">{zapOption.label}</span>
+              </button>
+            {/each}
+          {/if}
         </div>
         <input type="text" class="input" bind:value={amount} />
         <textarea rows="2" class="input" bind:value={message} placeholder="Message (optional)" />
@@ -318,7 +388,7 @@
             <p class="text-xs text-caption mt-1">Scan QR code or connect wallet</p>
           </div>
         {/if}
-        <Button class="w-full py-3 text-lg" on:click={submitZap} disabled={isCreatingInvoice}>
+        <Button class="w-full py-3 text-lg" on:click={submitZap} disabled={isCreatingInvoice || (pollMinSats != null && amount < pollMinSats) || (pollMaxSats != null && pollMaxSats > 0 && amount > pollMaxSats)}>
           {#if isCreatingInvoice}
             <span class="flex items-center justify-center gap-2">
               <svg
@@ -344,7 +414,7 @@
               Creating Invoice...
             </span>
           {:else}
-            ⚡ Send {amount.toLocaleString()} sats
+            ⚡ {pollOptionId ? 'Zap Vote' : 'Send'} {amount.toLocaleString()} sats
           {/if}
         </Button>
       </div>

--- a/src/components/ZapModal.svelte
+++ b/src/components/ZapModal.svelte
@@ -47,7 +47,7 @@
 
   // Generate dynamic presets for zap polls — linear interpolation (matches Primal)
   function getZapPollPresets(min: number, max: number | undefined): { amount: number; label: string }[] {
-    const lo = min || 1;
+    const lo = min || 21;
     const hi = max && max > 0 ? max : 21_000;
     let count = 6;
     if (hi - lo < 6) count = hi - lo + 1;

--- a/src/components/ZapPollDisplay.svelte
+++ b/src/components/ZapPollDisplay.svelte
@@ -1,0 +1,386 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { userPublickey } from '$lib/nostr';
+  import { NDKEvent } from '@nostr-dev-kit/ndk';
+  import NoteContent from './NoteContent.svelte';
+  import CustomAvatar from './CustomAvatar.svelte';
+  import CustomName from './CustomName.svelte';
+  import ZapModal from './ZapModal.svelte';
+  import LightningIcon from 'phosphor-svelte/lib/Lightning';
+  import { formatDistanceToNow } from 'date-fns';
+  import {
+    parseZapPollFromEvent,
+    isPollExpired,
+    type ZapPollData,
+    type ZapPollResults
+  } from '$lib/polls';
+  import { getZapPollResults, type ZapPollHandle } from '$lib/zapPollCache';
+
+  export let event: NDKEvent;
+
+  let pollData: ZapPollData | null = null;
+  let results: ZapPollResults = {
+    satsByOption: new Map(),
+    totalSats: 0,
+    totalVoters: 0,
+    voters: new Set(),
+    votesByPubkey: new Map()
+  };
+  let zapPollHandle: ZapPollHandle | null = null;
+  let unsubResults: (() => void) | null = null;
+  let voted = false;
+  let expandedOption: string | null = null;
+
+  // Zap modal state
+  let zapModalOpen = false;
+  let zapVoteOptionId: string | null = null;
+  let zapVoteOptionLabel: string | null = null;
+
+  $: expired = pollData ? isPollExpired(pollData.closedAt) : false;
+  $: userVoted = $userPublickey ? results.voters.has($userPublickey) : false;
+  $: displayResults = userVoted || expired || voted || !$userPublickey;
+  $: maxSats = pollData
+    ? Math.max(...pollData.options.map(o => results.satsByOption.get(o.id) || 0), 0)
+    : 0;
+  $: endDateText = pollData?.closedAt
+    ? expired
+      ? `Ended ${formatDistanceToNow(new Date(pollData.closedAt * 1000), { addSuffix: true })}`
+      : `Ends ${formatDistanceToNow(new Date(pollData.closedAt * 1000), { addSuffix: true })}`
+    : '';
+
+  onMount(() => {
+    pollData = parseZapPollFromEvent(event);
+    if (pollData) {
+      zapPollHandle = getZapPollResults(event.id);
+      unsubResults = zapPollHandle.results.subscribe(r => { results = r; });
+    }
+  });
+
+  onDestroy(() => {
+    if (unsubResults) unsubResults();
+    if (zapPollHandle) zapPollHandle.cleanup();
+  });
+
+  function handleZapVote(option: { id: string; label: string }) {
+    if (!$userPublickey || expired) return;
+    zapVoteOptionId = option.id;
+    zapVoteOptionLabel = option.label;
+    zapModalOpen = true;
+  }
+
+  function handleZapComplete(e: CustomEvent<{ amount: number; pollOptionId?: string }>) {
+    if (e.detail.pollOptionId && zapPollHandle && $userPublickey) {
+      zapPollHandle.addLocalZap(e.detail.pollOptionId, e.detail.amount, $userPublickey);
+    }
+    voted = true;
+    zapModalOpen = false;
+  }
+
+  function getVotersForOption(optionId: string): string[] {
+    const pubkeys: string[] = [];
+    for (const [pubkey, votes] of results.votesByPubkey) {
+      if (votes.some(v => v.optionId === optionId)) pubkeys.push(pubkey);
+    }
+    return pubkeys;
+  }
+
+  function toggleVoterList(optionId: string) {
+    expandedOption = expandedOption === optionId ? null : optionId;
+  }
+
+  function formatSats(sats: number): string {
+    if (sats >= 1_000_000) return `${(sats / 1_000_000).toFixed(1)}M`;
+    if (sats >= 1_000) return `${(sats / 1_000).toFixed(sats >= 10_000 ? 0 : 1)}K`;
+    return sats.toLocaleString();
+  }
+</script>
+
+{#if pollData}
+  {#if pollData.question}
+    <div class="zp-question">
+      <NoteContent content={pollData.question} />
+    </div>
+  {/if}
+
+  <div class="zp-list">
+    {#each pollData.options as option (option.id)}
+      {@const sats = results.satsByOption.get(option.id) || 0}
+      {@const pct = results.totalSats === 0 ? 0 : Math.round((sats / results.totalSats) * 100)}
+      {@const isUserChoice = results.votesByPubkey.get($userPublickey || '')?.some(v => v.optionId === option.id) || false}
+      {@const isWinner = displayResults && sats > 0 && sats === maxSats}
+
+      {#if displayResults}
+        {@const voters = getVotersForOption(option.id)}
+        {@const isExpanded = expandedOption === option.id}
+        <div>
+          <button
+            class="zp-row zp-row-result"
+            class:zp-row-user={isUserChoice}
+            class:zp-row-winner={isWinner}
+            class:zp-row-expanded={isExpanded}
+            on:click={() => voters.length > 0 && toggleVoterList(option.id)}
+            disabled={voters.length === 0}
+          >
+            <div class="zp-row-fill" style="width: {pct}%"></div>
+            <span class="zp-row-label">
+              {option.label}
+              {#if isUserChoice}
+                <svg class="zp-row-check" viewBox="0 0 12 12" fill="none">
+                  <path d="M2.5 6L5 8.5L9.5 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              {/if}
+            </span>
+            <span class="zp-row-sats">{formatSats(sats)} sats</span>
+          </button>
+          {#if isExpanded && voters.length > 0}
+            <div class="zp-voters">
+              {#each voters as pubkey (pubkey)}
+                <a href="/user/{pubkey}" class="zp-voter">
+                  <CustomAvatar pubkey={pubkey} size={24} />
+                  <CustomName {pubkey} className="zp-voter-name" />
+                </a>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      {:else}
+        <button
+          class="zp-row"
+          on:click={() => handleZapVote(option)}
+          disabled={expired}
+        >
+          <span class="zp-row-label">
+            {option.label}
+            <LightningIcon size={14} weight="fill" class="zp-zap-icon" />
+          </span>
+        </button>
+      {/if}
+    {/each}
+  </div>
+
+  <!-- Footer -->
+  <div class="zp-footer">
+    <span class="zp-meta">
+      {formatSats(results.totalSats)} sats
+      <span class="zp-meta-dot">&middot;</span>
+      {results.totalVoters} voter{results.totalVoters !== 1 ? 's' : ''}
+      {#if endDateText}
+        <span class="zp-meta-dot">&middot;</span>
+        <span class:zp-meta-expired={expired}>{endDateText}</span>
+      {/if}
+      <span class="zp-meta-dot">&middot;</span>
+      <span class="zp-meta-zap">⚡ Zap Poll</span>
+    </span>
+    <div class="zp-footer-actions">
+      {#if pollData.valueMinimum}
+        <span class="zp-meta">min {pollData.valueMinimum} sats</span>
+      {/if}
+    </div>
+  </div>
+
+  {#if zapModalOpen && pollData}
+    <ZapModal
+      bind:open={zapModalOpen}
+      event={event}
+      pollOptionId={zapVoteOptionId ?? undefined}
+      pollOptionLabel={zapVoteOptionLabel ?? undefined}
+      pollMinSats={pollData.valueMinimum}
+      pollMaxSats={pollData.valueMaximum}
+      pollEventKind={6969}
+      on:zap-complete={handleZapComplete}
+    />
+  {/if}
+{/if}
+
+<style>
+  .zp-question {
+    font-size: 0.9375rem;
+    font-weight: 500;
+    line-height: 1.5;
+    color: var(--color-text-primary);
+    margin-bottom: 0.75rem;
+  }
+
+  .zp-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+
+  .zp-row {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.625rem 0.75rem;
+    min-height: 2.75rem;
+    border: 1px solid var(--color-input-border);
+    border-radius: 0.625rem;
+    background: transparent;
+    color: var(--color-text-primary);
+    font-size: 0.875rem;
+    line-height: 1.4;
+    cursor: pointer;
+    transition: border-color 0.15s ease, background-color 0.15s ease;
+    overflow: hidden;
+    text-align: left;
+    font: inherit;
+  }
+
+  button.zp-row:hover:not(:disabled) {
+    border-color: #facc15;
+    background: rgba(250, 204, 21, 0.04);
+  }
+
+  button.zp-row:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .zp-row-result:not(:disabled) {
+    cursor: pointer;
+  }
+
+  .zp-row-result:disabled {
+    opacity: 1;
+    cursor: default;
+  }
+
+  .zp-row-user {
+    border-color: #facc15;
+  }
+
+  .zp-row-winner {
+    border-color: #facc15;
+    box-shadow: 0 0 0 1px rgba(250, 204, 21, 0.5);
+  }
+
+  .zp-row-expanded {
+    border-color: #facc15;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  .zp-row-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    background: rgba(250, 204, 21, 0.08);
+    animation: fillGrow 0.4s ease;
+    transition: width 0.3s ease;
+    pointer-events: none;
+  }
+
+  :global(.dark) .zp-row-fill {
+    background: rgba(250, 204, 21, 0.12);
+  }
+
+  .zp-row-label {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    min-width: 0;
+    word-break: break-word;
+  }
+
+  .zp-row-check {
+    flex-shrink: 0;
+    width: 14px;
+    height: 14px;
+    color: #facc15;
+  }
+
+  .zp-row-sats {
+    position: relative;
+    flex-shrink: 0;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--color-caption);
+  }
+
+  :global(.zp-zap-icon) {
+    color: #facc15;
+    flex-shrink: 0;
+  }
+
+  /* Voter list */
+  .zp-voters {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid #facc15;
+    border-top: none;
+    border-radius: 0 0 0.625rem 0.625rem;
+    background: rgba(250, 204, 21, 0.03);
+    max-height: 11rem;
+    overflow-y: auto;
+  }
+
+  :global(.dark) .zp-voters {
+    background: rgba(250, 204, 21, 0.05);
+  }
+
+  .zp-voter {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.25rem 0;
+    text-decoration: none;
+    color: var(--color-text-primary);
+    transition: opacity 0.15s;
+  }
+
+  .zp-voter:hover {
+    opacity: 0.8;
+  }
+
+  :global(.zp-voter-name) {
+    font-size: 0.8125rem;
+    font-weight: 500;
+  }
+
+  /* Footer */
+  .zp-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 0.625rem;
+    gap: 0.5rem;
+  }
+
+  .zp-meta {
+    font-size: 0.75rem;
+    color: var(--color-caption);
+    line-height: 1.4;
+  }
+
+  .zp-meta-dot {
+    margin: 0 0.125rem;
+    opacity: 0.5;
+  }
+
+  .zp-meta-expired {
+    color: var(--color-danger);
+  }
+
+  .zp-meta-zap {
+    color: #facc15;
+    font-weight: 600;
+  }
+
+  .zp-footer-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    flex-shrink: 0;
+  }
+
+  @keyframes fillGrow {
+    from { width: 0; }
+  }
+</style>

--- a/src/lib/polls.ts
+++ b/src/lib/polls.ts
@@ -185,3 +185,129 @@ export function countVotes(voteEvents: NDKEvent[], pollType: PollType): PollResu
 
   return { counts, totalVoters: voters.size, voters, votesByPubkey };
 }
+
+// ═══════════════════════════════════════════════════════════════
+// KIND 6969 — ZAP POLLS (Primal convention)
+// ═══════════════════════════════════════════════════════════════
+
+export interface ZapPollOption {
+  id: string;
+  label: string;
+}
+
+export interface ZapPollData {
+  question: string;
+  options: ZapPollOption[];
+  pollType: PollType;
+  closedAt?: number;
+  valueMinimum?: number;
+  valueMaximum?: number;
+}
+
+export interface ZapPollConfig {
+  options: ZapPollOption[];
+  pollType: PollType;
+  closedAt?: number;
+  valueMinimum?: number;
+  valueMaximum?: number;
+}
+
+export interface ZapPollResults {
+  /** Map of option id → total sats */
+  satsByOption: Map<string, number>;
+  /** Total sats across all options */
+  totalSats: number;
+  /** Total unique zap voters */
+  totalVoters: number;
+  /** Set of pubkeys that voted */
+  voters: Set<string>;
+  /** Map of pubkey → array of { optionId, sats } */
+  votesByPubkey: Map<string, { optionId: string; sats: number }[]>;
+}
+
+export interface ParsedZapVote {
+  zapperPubkey: string;
+  optionId: string;
+  amountSats: number;
+  receiptId: string;
+}
+
+/** Extract zap poll data from a kind:6969 event */
+export function parseZapPollFromEvent(event: NDKEvent): ZapPollData | null {
+  if (event.kind !== 6969) return null;
+
+  const options: ZapPollOption[] = [];
+  let pollType: PollType = 'singlechoice';
+  let closedAt: number | undefined;
+  let valueMinimum: number | undefined;
+  let valueMaximum: number | undefined;
+
+  for (const tag of event.tags) {
+    if (tag[0] === 'poll_option' && tag[1] && tag[2]) {
+      options.push({ id: tag[1], label: tag[2] });
+    } else if (tag[0] === 'polltype' && tag[1]) {
+      pollType = tag[1] === 'multiplechoice' ? 'multiplechoice' : 'singlechoice';
+    } else if (tag[0] === 'closed_at' && tag[1]) {
+      closedAt = parseInt(tag[1], 10);
+      if (isNaN(closedAt)) closedAt = undefined;
+    } else if (tag[0] === 'value_minimum' && tag[1]) {
+      valueMinimum = parseInt(tag[1], 10);
+      if (isNaN(valueMinimum)) valueMinimum = undefined;
+    } else if (tag[0] === 'value_maximum' && tag[1]) {
+      valueMaximum = parseInt(tag[1], 10);
+      if (isNaN(valueMaximum)) valueMaximum = undefined;
+    }
+  }
+
+  if (options.length < 2) return null;
+
+  return { question: event.content, options, pollType, closedAt, valueMinimum, valueMaximum };
+}
+
+/** Build tags for a kind:6969 zap poll event */
+export function buildZapPollTags(config: ZapPollConfig): string[][] {
+  const tags: string[][] = [];
+
+  for (const option of config.options) {
+    tags.push(['poll_option', option.id, option.label]);
+  }
+
+  tags.push(['polltype', config.pollType]);
+
+  if (config.closedAt) {
+    tags.push(['closed_at', String(config.closedAt)]);
+  }
+  if (config.valueMinimum != null) {
+    tags.push(['value_minimum', String(config.valueMinimum)]);
+  }
+  if (config.valueMaximum != null && config.valueMaximum > 0) {
+    tags.push(['value_maximum', String(config.valueMaximum)]);
+  }
+
+  return tags;
+}
+
+/** Aggregate parsed zap votes into ZapPollResults */
+export function countZapVotes(votes: ParsedZapVote[]): ZapPollResults {
+  const satsByOption = new Map<string, number>();
+  const voters = new Set<string>();
+  const votesByPubkey = new Map<string, { optionId: string; sats: number }[]>();
+  const seen = new Set<string>();
+
+  for (const vote of votes) {
+    if (seen.has(vote.receiptId)) continue;
+    seen.add(vote.receiptId);
+
+    voters.add(vote.zapperPubkey);
+    satsByOption.set(vote.optionId, (satsByOption.get(vote.optionId) || 0) + vote.amountSats);
+
+    const existing = votesByPubkey.get(vote.zapperPubkey) || [];
+    existing.push({ optionId: vote.optionId, sats: vote.amountSats });
+    votesByPubkey.set(vote.zapperPubkey, existing);
+  }
+
+  let totalSats = 0;
+  for (const sats of satsByOption.values()) totalSats += sats;
+
+  return { satsByOption, totalSats, totalVoters: voters.size, voters, votesByPubkey };
+}

--- a/src/lib/zapManager.ts
+++ b/src/lib/zapManager.ts
@@ -12,6 +12,7 @@ export interface ZapRequest {
   amount: number; // in millisatoshis
   comment?: string;
   relays?: string[];
+  extraTags?: string[][];
 }
 
 export interface ZapReceipt {
@@ -111,12 +112,13 @@ export class ZapManager {
     zapRequest.kind = 9734;
     zapRequest.content = request.comment || '';
 
-    // Add p tag for recipient pubkey
-    zapRequest.tags.push(['p', request.pubkey]);
+    // Add p tag for recipient pubkey (with relay hint)
+    const relayHint = request.relays?.[0] || '';
+    zapRequest.tags.push(relayHint ? ['p', request.pubkey, relayHint] : ['p', request.pubkey]);
 
-    // Add e tag for event being zapped (if applicable)
+    // Add e tag for event being zapped (with relay hint)
     if (request.eventId) {
-      zapRequest.tags.push(['e', request.eventId]);
+      zapRequest.tags.push(relayHint ? ['e', request.eventId, relayHint] : ['e', request.eventId]);
     }
 
     // Add relays tag (NIP-57: single tag with all relay URLs as values)
@@ -129,6 +131,13 @@ export class ZapManager {
 
     // Add lnurl tag (will be populated when we get the LNURL)
     zapRequest.tags.push(['lnurl', '']);
+
+    // Add any extra tags (e.g., poll_option for zap polls)
+    if (request.extraTags) {
+      for (const tag of request.extraTags) {
+        zapRequest.tags.push(tag);
+      }
+    }
 
     // Add NIP-89 client tag
     zapRequest.tags = ensureClientTag(zapRequest.tags);
@@ -272,7 +281,8 @@ export class ZapManager {
     recipient: NDKUser | string,
     amount: number,
     comment?: string,
-    eventId?: string
+    eventId?: string,
+    extraTags?: string[][]
   ): Promise<{ invoice: string; verify?: string; zapRequest: NDKEvent; zapPubkey: string }> {
     // Check if user is authenticated (required for zap requests)
     if (!this.ndk.signer) {
@@ -355,7 +365,8 @@ export class ZapManager {
       pubkey,
       amount,
       comment,
-      relays: this.ndk.explicitRelayUrls || []
+      relays: this.ndk.explicitRelayUrls || [],
+      extraTags
     });
 
     // Get invoice

--- a/src/lib/zapPollCache.ts
+++ b/src/lib/zapPollCache.ts
@@ -1,0 +1,280 @@
+/**
+ * Zap Poll Cache (kind 6969)
+ *
+ * Fetches kind:9735 zap receipts for zap polls and parses the embedded
+ * kind:9734 zap request to extract the poll_option tag (choice ID).
+ * Aggregates sats per option.
+ *
+ * Follows the Primal convention:
+ *   - poll_option tag value = choice ID string (not index)
+ *   - Zap polls use kind 6969
+ */
+
+import { writable, get, type Readable } from 'svelte/store';
+import type { NDKEvent, NDKSubscription } from '@nostr-dev-kit/ndk';
+import { ndk } from '$lib/nostr';
+import { decode } from '@gandlaf21/bolt11-decode';
+import { countZapVotes, type ZapPollResults, type ParsedZapVote } from '$lib/polls';
+
+// ═══════════════════════════════════════════════════════════════
+// TYPES
+// ═══════════════════════════════════════════════════════════════
+
+export interface ZapPollHandle {
+  results: Readable<ZapPollResults>;
+  addLocalZap: (optionId: string, amountSats: number, pubkey: string) => void;
+  cleanup: () => void;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// INTERNAL STATE
+// ═══════════════════════════════════════════════════════════════
+
+const votesByPoll = new Map<string, ParsedZapVote[]>();
+const resultStores = new Map<string, ReturnType<typeof writable<ZapPollResults>>>();
+const refCounts = new Map<string, number>();
+const fetchedPolls = new Set<string>();
+
+let pendingBatch: Set<string> | null = null;
+let liveSub: NDKSubscription | null = null;
+let liveSubPollIds = new Set<string>();
+
+const CLEANUP_DELAY_MS = 60_000;
+const RELAY_TIMEOUT_MS = 10_000;
+const BATCH_CHUNK_SIZE = 30;
+
+function emptyResults(): ZapPollResults {
+  return {
+    satsByOption: new Map(),
+    totalSats: 0,
+    totalVoters: 0,
+    voters: new Set(),
+    votesByPubkey: new Map()
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════
+// PUBLIC API
+// ═══════════════════════════════════════════════════════════════
+
+export function getZapPollResults(pollId: string): ZapPollHandle {
+  if (!resultStores.has(pollId)) {
+    resultStores.set(pollId, writable(emptyResults()));
+    votesByPoll.set(pollId, []);
+  }
+  refCounts.set(pollId, (refCounts.get(pollId) || 0) + 1);
+
+  if (!fetchedPolls.has(pollId)) {
+    scheduleBatchFetch(pollId);
+  }
+
+  const store = resultStores.get(pollId)!;
+
+  return {
+    results: { subscribe: store.subscribe },
+
+    addLocalZap(optionId: string, amountSats: number, pubkey: string) {
+      const votes = votesByPoll.get(pollId);
+      if (!votes) return;
+      const localId = `local-${Date.now()}-${Math.random()}`;
+      votes.push({ zapperPubkey: pubkey, optionId, amountSats, receiptId: localId });
+      recount(pollId);
+    },
+
+    cleanup() {
+      const count = (refCounts.get(pollId) || 0) - 1;
+      if (count <= 0) {
+        refCounts.delete(pollId);
+        setTimeout(() => {
+          if (!refCounts.has(pollId)) {
+            votesByPoll.delete(pollId);
+            resultStores.delete(pollId);
+            fetchedPolls.delete(pollId);
+            refreshLiveSubscription();
+          }
+        }, CLEANUP_DELAY_MS);
+      } else {
+        refCounts.set(pollId, count);
+      }
+    }
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════
+// INTERNAL — event processing
+// ═══════════════════════════════════════════════════════════════
+
+function parseZapReceipt(event: NDKEvent): ParsedZapVote | null {
+  const bolt11 = event.tags.find(t => t[0] === 'bolt11')?.[1];
+  if (!bolt11) return null;
+
+  let amountSats = 0;
+  try {
+    const decoded = decode(bolt11);
+    const amountSection = decoded.sections.find((s: { name: string }) => s.name === 'amount');
+    if (amountSection?.value) {
+      amountSats = Math.floor(Number(amountSection.value) / 1000);
+    }
+  } catch {
+    return null;
+  }
+  if (amountSats <= 0) return null;
+
+  const descTag = event.tags.find(t => t[0] === 'description')?.[1];
+  if (!descTag) return null;
+
+  let zapRequest: { pubkey?: string; tags?: string[][] };
+  try {
+    zapRequest = JSON.parse(descTag);
+  } catch {
+    return null;
+  }
+
+  // Extract poll_option — this is the choice ID string (Primal convention)
+  const pollOptionTag = zapRequest.tags?.find(t => t[0] === 'poll_option');
+  if (!pollOptionTag?.[1]) return null;
+
+  const zapperPubkey = zapRequest.pubkey || event.pubkey;
+
+  return {
+    zapperPubkey,
+    optionId: pollOptionTag[1],
+    amountSats,
+    receiptId: event.id
+  };
+}
+
+function addZapReceipt(pollId: string, event: NDKEvent) {
+  const votes = votesByPoll.get(pollId);
+  if (!votes) return;
+  if (votes.some(v => v.receiptId === event.id)) return;
+
+  const parsed = parseZapReceipt(event);
+  if (parsed) {
+    votes.push(parsed);
+    recount(pollId);
+  }
+}
+
+function recount(pollId: string) {
+  const votes = votesByPoll.get(pollId);
+  const store = resultStores.get(pollId);
+  if (!votes || !store) return;
+  store.set(countZapVotes(votes));
+}
+
+function routeZapReceipt(event: NDKEvent) {
+  for (const tag of event.tags) {
+    if (tag[0] === 'e' && tag[1] && votesByPoll.has(tag[1])) {
+      addZapReceipt(tag[1], event);
+      return;
+    }
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// INTERNAL — batch fetching
+// ═══════════════════════════════════════════════════════════════
+
+function scheduleBatchFetch(pollId: string) {
+  if (!pendingBatch) {
+    pendingBatch = new Set();
+    queueMicrotask(() => {
+      const batch = pendingBatch!;
+      pendingBatch = null;
+      executeBatch(batch);
+    });
+  }
+  pendingBatch.add(pollId);
+}
+
+async function executeBatch(pollIds: Set<string>) {
+  const ndkInstance = get(ndk);
+  if (!ndkInstance || pollIds.size === 0) return;
+
+  const idsToFetch = [...pollIds].filter(id => !fetchedPolls.has(id));
+  if (idsToFetch.length === 0) return;
+
+  for (const id of idsToFetch) {
+    if (!votesByPoll.has(id)) votesByPoll.set(id, []);
+  }
+
+  const chunks: string[][] = [];
+  for (let i = 0; i < idsToFetch.length; i += BATCH_CHUNK_SIZE) {
+    chunks.push(idsToFetch.slice(i, i + BATCH_CHUNK_SIZE));
+  }
+
+  for (const chunk of chunks) {
+    let success = false;
+    try {
+      await new Promise<void>((resolve) => {
+        const sub = ndkInstance.subscribe(
+          { kinds: [9735 as number], '#e': chunk },
+          { closeOnEose: true }
+        );
+
+        let settled = false;
+        let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+        const finish = () => {
+          if (settled) return;
+          settled = true;
+          if (timeoutId !== null) clearTimeout(timeoutId);
+          success = true;
+          resolve();
+        };
+
+        sub.on('event', (e: NDKEvent) => routeZapReceipt(e));
+        sub.on('eose', finish);
+
+        timeoutId = setTimeout(() => {
+          try { sub.stop(); } catch {}
+          if (!settled) { settled = true; resolve(); }
+        }, RELAY_TIMEOUT_MS);
+      });
+    } catch (err) {
+      console.debug('[ZapPollCache] Relay fetch failed:', err);
+    }
+
+    if (success) {
+      for (const id of chunk) fetchedPolls.add(id);
+    }
+  }
+
+  refreshLiveSubscription();
+}
+
+// ═══════════════════════════════════════════════════════════════
+// INTERNAL — live subscription
+// ═══════════════════════════════════════════════════════════════
+
+function refreshLiveSubscription() {
+  const ndkInstance = get(ndk);
+  if (!ndkInstance) return;
+
+  const activePollIds = [...refCounts.keys()];
+
+  if (activePollIds.length === 0) {
+    if (liveSub) { try { liveSub.stop(); } catch {} liveSub = null; }
+    liveSubPollIds.clear();
+    return;
+  }
+
+  const newIds = new Set(activePollIds);
+  if (liveSub && setsEqual(newIds, liveSubPollIds)) return;
+
+  if (liveSub) { try { liveSub.stop(); } catch {} }
+  liveSubPollIds = newIds;
+
+  liveSub = ndkInstance.subscribe(
+    { kinds: [9735 as number], '#e': activePollIds, since: Math.floor(Date.now() / 1000) },
+    { closeOnEose: false }
+  );
+  liveSub.on('event', (e: NDKEvent) => routeZapReceipt(e));
+}
+
+function setsEqual<T>(a: Set<T>, b: Set<T>): boolean {
+  if (a.size !== b.size) return false;
+  for (const item of a) { if (!b.has(item)) return false; }
+  return true;
+}

--- a/src/routes/polls/+page.svelte
+++ b/src/routes/polls/+page.svelte
@@ -4,6 +4,7 @@
   import { NDKRelaySet } from '@nostr-dev-kit/ndk';
   import type { NDKEvent, NDKSubscription } from '@nostr-dev-kit/ndk';
   import PollDisplay from '../../components/PollDisplay.svelte';
+  import ZapPollDisplay from '../../components/ZapPollDisplay.svelte';
   import Avatar from '../../components/Avatar.svelte';
   import CustomName from '../../components/CustomName.svelte';
   import NoteActionBar from '../../components/NoteActionBar.svelte';
@@ -80,7 +81,7 @@
 
       subscription = $ndk.subscribe(
         {
-          kinds: [1068 as number],
+          kinds: [1068 as number, 6969 as number],
           limit: 200,
           since: Math.floor(Date.now() / 1000) - (365 * 24 * 60 * 60)
         },
@@ -95,9 +96,12 @@
         // Block known spammers
         if (BLACKLISTED_PUBKEYS.has(event.pubkey)) return;
 
-        // Must have option tags to be a valid poll
-        const hasOptions = event.tags.some((t) => t[0] === 'option');
-        if (!hasOptions) return;
+        // Validate: kind 1068 needs 'option' tags, kind 6969 needs 'poll_option' tags
+        if (event.kind === 1068) {
+          if (!event.tags.some((t) => t[0] === 'option')) return;
+        } else if (event.kind === 6969) {
+          if (!event.tags.some((t) => t[0] === 'poll_option')) return;
+        }
 
         // Rate limit: max 5 polls per hour per author
         if (exceedsRateLimit(event, polls)) return;
@@ -181,20 +185,26 @@
     <div>
       {#each polls as poll, i (poll.id)}
         {@const pubkey = poll.author?.hexpubkey || poll.pubkey}
-        <article class="poll-item" class:poll-item-border={i > 0}>
+        {@const isZapPoll = poll.kind === 6969}
+        <article class="poll-item" class:poll-item-border={i > 0} class:poll-item-zap={isZapPoll}>
           <!-- Author row -->
           <div class="flex items-center gap-3 mb-3">
             <a href="/user/{nip19.npubEncode(pubkey)}" class="flex-shrink-0">
               <Avatar {pubkey} size={40} />
             </a>
             <div class="flex-1 min-w-0">
-              <a
-                href="/user/{nip19.npubEncode(pubkey)}"
-                class="font-semibold text-sm hover:opacity-80 transition-opacity block"
-                style="color: var(--color-text-primary);"
-              >
-                <CustomName {pubkey} />
-              </a>
+              <div class="flex items-center gap-2">
+                <a
+                  href="/user/{nip19.npubEncode(pubkey)}"
+                  class="font-semibold text-sm hover:opacity-80 transition-opacity block"
+                  style="color: var(--color-text-primary);"
+                >
+                  <CustomName {pubkey} />
+                </a>
+                {#if isZapPoll}
+                  <span class="zap-poll-badge">⚡ Zap Poll</span>
+                {/if}
+              </div>
               <button
                 class="poll-time"
                 on:click={() => navigateToNote(poll)}
@@ -204,8 +214,12 @@
             </div>
           </div>
 
-          <!-- Poll content (flows directly into the feed item) -->
-          <PollDisplay event={poll} />
+          <!-- Poll content -->
+          {#if isZapPoll}
+            <ZapPollDisplay event={poll} />
+          {:else}
+            <PollDisplay event={poll} />
+          {/if}
 
           <!-- Actions -->
           <div class="mt-2">
@@ -249,5 +263,28 @@
   .poll-time:hover {
     text-decoration: underline;
     color: var(--color-text-primary);
+  }
+
+  .poll-item-zap {
+    background: rgba(250, 204, 21, 0.06);
+    border-left: 3px solid rgba(250, 204, 21, 0.5);
+    padding-left: 1rem;
+    border-radius: 0.5rem;
+    margin: 0.25rem 0;
+  }
+
+  :global(.dark) .poll-item-zap {
+    background: rgba(250, 204, 21, 0.04);
+    border-left-color: rgba(250, 204, 21, 0.3);
+  }
+
+  .zap-poll-badge {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    color: #facc15;
+    background: rgba(250, 204, 21, 0.1);
+    padding: 0.0625rem 0.375rem;
+    border-radius: 9999px;
+    white-space: nowrap;
   }
 </style>


### PR DESCRIPTION
## Summary
- **Poll voter lists**: Click any poll result to see who voted with profile pictures and names. Scrollable when >5 voters. Works for both text and image polls.
- **Zap polls (kind 6969)**: Primal-compatible zap poll support — vote on polls with Lightning zaps instead of free votes.

## Zap Polls
- New event kind 6969 with `poll_option`, `closed_at`, `value_minimum`/`value_maximum` tags
- Fully interoperable with Primal's zap poll implementation
- ZapPollDisplay component with sats-based results, yellow accent theme
- Dynamic preset amounts (linear interpolation between min/max, default 21–21K sats)
- `poll_option` + `k` tag in kind 9734 zap requests using choice ID strings
- `p` tag with creator pubkey + relay hint on poll events for Lightning routing
- Yellow highlight + "⚡ Zap Poll" badge in the poll feed
- Zap poll creation toggle in PollCreator

## New files
- `src/components/ZapPollDisplay.svelte` — Zap poll rendering component
- `src/lib/zapPollCache.ts` — Kind 9735 receipt aggregation cache

## Test plan
- [ ] Regular polls: vote, view results, click result to expand voter list with pfps
- [ ] Image polls: same voter list behavior
- [ ] Create a zap poll (toggle in poll creator, 21–21K defaults)
- [ ] Zap poll shows in feed with yellow highlight and badge
- [ ] Click option → ZapModal with dynamic presets → zap vote → results update
- [ ] Verify zap polls from Primal display correctly on our feed
- [ ] Verify our zap polls display correctly on Primal

🤖 Generated with [Claude Code](https://claude.com/claude-code)