### PR TITLE
feat: replace Explore with Polls, rename Community to Feed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.138",
+  "version": "4.2.139",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/BottomNav.svelte
+++ b/src/components/BottomNav.svelte
@@ -2,9 +2,9 @@
   import { onMount, onDestroy } from 'svelte';
   import { browser } from '$app/environment';
   import ForkKnifeIcon from 'phosphor-svelte/lib/ForkKnife';
-  import ChatCircleDotsIcon from 'phosphor-svelte/lib/ChatCircleDots';
+  import FlameIcon from 'phosphor-svelte/lib/Flame';
   import BellIcon from 'phosphor-svelte/lib/Bell';
-  import NewspaperIcon from 'phosphor-svelte/lib/Newspaper';
+  import ChartBarHorizontalIcon from 'phosphor-svelte/lib/ChartBarHorizontal';
   import StorefrontIcon from 'phosphor-svelte/lib/Storefront';
   import { page } from '$app/stores';
   import { unreadCount } from '$lib/notificationStore';
@@ -52,8 +52,8 @@
   style="color: var(--color-text-primary); border-top: 1px solid var(--color-input-border);"
 >
   <a href="/community" class="nav-tab" class:active={pathname === '/' || pathname.startsWith('/community')}>
-    <ChatCircleDotsIcon class="self-center" size={22} />
-    <span class="sr-only">Community</span>
+    <FlameIcon class="self-center" size={22} />
+    <span class="sr-only">Feed</span>
   </a>
   <a href="/recent" class="nav-tab" class:active={pathname.startsWith('/recent')}>
     <ForkKnifeIcon class="self-center" size={22} />
@@ -63,9 +63,9 @@
     <StorefrontIcon class="self-center" size={22} />
     <span class="sr-only">Market</span>
   </a>
-  <a href="/reads" class="nav-tab" class:active={pathname.startsWith('/reads')}>
-    <NewspaperIcon class="self-center" size={22} />
-    <span class="sr-only">Reads</span>
+  <a href="/polls" class="nav-tab" class:active={pathname.startsWith('/polls')}>
+    <ChartBarHorizontalIcon class="self-center" size={22} />
+    <span class="sr-only">Polls</span>
   </a>
   <a
     href="/notifications"

--- a/src/components/DesktopSideNav.svelte
+++ b/src/components/DesktopSideNav.svelte
@@ -10,11 +10,10 @@
   import { weblnConnected } from '$lib/wallet/webln';
   import { bitcoinConnectEnabled, bitcoinConnectWalletInfo } from '$lib/wallet/bitcoinConnect';
 
-  import ChatCircleDotsIcon from 'phosphor-svelte/lib/ChatCircleDots';
   import ForkKnifeIcon from 'phosphor-svelte/lib/ForkKnife';
-  import CompassIcon from 'phosphor-svelte/lib/Compass';
+  import ChartBarHorizontalIcon from 'phosphor-svelte/lib/ChartBarHorizontal';
+  import FlameIcon from 'phosphor-svelte/lib/Flame';
   import BellIcon from 'phosphor-svelte/lib/Bell';
-  import NewspaperIcon from 'phosphor-svelte/lib/Newspaper';
   import EnvelopeSimpleIcon from 'phosphor-svelte/lib/EnvelopeSimple';
 
   import CookbookIcon from 'phosphor-svelte/lib/BookOpen';
@@ -47,8 +46,8 @@
   const primary: NavItem[] = [
     {
       href: '/community',
-      label: 'Community',
-      icon: ChatCircleDotsIcon,
+      label: 'Feed',
+      icon: FlameIcon,
       match: (p) => p === '/' || p.startsWith('/community')
     },
     {
@@ -58,16 +57,10 @@
       match: (p) => p.startsWith('/recent')
     },
     {
-      href: '/explore',
-      label: 'Explore',
-      icon: CompassIcon,
-      match: (p) => p.startsWith('/explore')
-    },
-    {
-      href: '/reads',
-      label: 'Reads',
-      icon: NewspaperIcon,
-      match: (p) => p.startsWith('/reads')
+      href: '/polls',
+      label: 'Polls',
+      icon: ChartBarHorizontalIcon,
+      match: (p) => p.startsWith('/polls')
     },
     {
       href: '/market',

--- a/src/components/UserSidePanel.svelte
+++ b/src/components/UserSidePanel.svelte
@@ -29,6 +29,7 @@
   import CrownSimpleIcon from 'phosphor-svelte/lib/CrownSimple';
   import HandshakeIcon from 'phosphor-svelte/lib/Handshake';
   import EnvelopeSimpleIcon from 'phosphor-svelte/lib/EnvelopeSimple';
+  import NewspaperIcon from 'phosphor-svelte/lib/Newspaper';
   import LeafIcon from 'phosphor-svelte/lib/Leaf';
 
   // Components and stores
@@ -283,6 +284,16 @@
             >
               <EnvelopeSimpleIcon size={22} />
               <span class="font-medium">Messages</span>
+            </button>
+          </li>
+          <li>
+            <button
+              on:click={() => navigate('/reads')}
+              class="w-full flex items-center gap-4 px-4 py-3 rounded-xl hover:bg-opacity-50 transition-colors cursor-pointer"
+              style="color: var(--color-text-primary);"
+            >
+              <NewspaperIcon size={22} />
+              <span class="font-medium">Reads</span>
             </button>
           </li>
           <li>


### PR DESCRIPTION
## Summary
- **Desktop sidebar**: Replace Explore (Compass icon) with Polls (`/polls`, ChartBarHorizontal icon), rename Community to Feed (Flame icon), remove Reads from sidebar
- **Mobile bottom nav**: Replace Reads with Polls, rename Community to Feed with Flame icon
- **Mobile profile menu**: Add Reads (Newspaper icon) to user side panel so it remains accessible

## Test plan
- [ ] Desktop: verify Feed nav item links to `/community` and shows Flame icon
- [ ] Desktop: verify Polls nav item links to `/polls` and shows chart bar icon
- [ ] Desktop: verify Reads is no longer in the sidebar
- [ ] Mobile: verify bottom nav shows Feed, Recipes, Market, Polls, Notifications
- [ ] Mobile: verify Reads appears in the profile side panel menu and navigates to `/reads`

🤖 Generated with [Claude Code](https://claude.com/claude-code)