### PR TITLE
fix: UX improvements — dark mode, login redirects, wallet/settings cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "zap.cooking",
-  "version": "4.2.48",
+  "version": "4.2.139",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zap.cooking",
-      "version": "4.2.48",
+      "version": "4.2.139",
       "license": "MIT",
       "dependencies": {
-        "@branta-ops/branta": "^0.0.3",
+        "@branta-ops/branta": "^1.0.0",
         "@breeztech/breez-sdk-spark": "0.11.0",
         "@capacitor/android": "^8.0.0",
         "@capacitor/app": "^8.0.0",
@@ -50,6 +50,7 @@
         "google-translate-api-browser": "^3.0.1",
         "html2canvas": "^1.4.1",
         "hurdak": "^0.2.5",
+        "jsqr": "^1.4.0",
         "libretranslate": "^1.0.1",
         "light-bolt11-decoder": "^3.0.0",
         "markdown-it": "^13.0.1",
@@ -62,6 +63,7 @@
         "svelte-qrcode": "^1.0.0",
         "svelte-tags-input": "^5.0.0",
         "svelte-tiptap": "^3.0.1",
+        "syllable": "^5.0.1",
         "timeago.js": "^4.0.2",
         "turndown": "^7.2.2",
         "webln": "^0.3.2",
@@ -158,9 +160,9 @@
       }
     },
     "node_modules/@branta-ops/branta": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@branta-ops/branta/-/branta-0.0.3.tgz",
-      "integrity": "sha512-BNiN8erGLVAVDC9laAgAkynsT/72dXFC1al9gnIJAvXC/F7wwLl4nsFYNVa/ys16RFmrwTUqx0M+oxrg+BSauw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@branta-ops/branta/-/branta-1.0.1.tgz",
+      "integrity": "sha512-ACarzsYZFZTYnz1zloDS6FIFEW8OW2JAggBeQhAmI2y9F/2HH9voQFcw56Yy5AniTfiJDytol1UjUvznhU8ogg==",
       "license": "MIT"
     },
     "node_modules/@breeztech/breez-sdk-spark": {
@@ -3629,6 +3631,66 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
@@ -4453,6 +4515,12 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/pluralize": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.29.tgz",
+      "integrity": "sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA==",
       "license": "MIT"
     },
     "node_modules/@types/pug": {
@@ -9717,6 +9785,12 @@
         "node": "*"
       }
     },
+    "node_modules/jsqr": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==",
+      "license": "Apache-2.0"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -11661,6 +11735,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-strings": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-strings/-/normalize-strings-1.1.1.tgz",
+      "integrity": "sha512-fARPRdTwmrQDLYhmeh7j/eZwrCP6WzxD6uKOdK/hT/uKACAE9AG2Bc2dgqOZLkfmmctHpfcJ9w3AQnfLgg3GYg==",
+      "license": "MIT"
+    },
     "node_modules/nostr-tools": {
       "version": "2.19.4",
       "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-2.19.4.tgz",
@@ -12374,6 +12454,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -15114,6 +15203,24 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/syllable": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/syllable/-/syllable-5.0.1.tgz",
+      "integrity": "sha512-HWtNCp6v7J8H0lrT8j1HHjfOLltRoDcC7QRFVu25p4BE52JqetXG65nqC7CsatT8WQRfY4Qvh93BWJIUxbmXFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pluralize": "^0.0.29",
+        "normalize-strings": "^1.1.0",
+        "pluralize": "^8.0.0"
+      },
+      "bin": {
+        "syllable": "cli.js"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.167",
+  "version": "4.2.168",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.169",
+  "version": "4.2.170",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.170",
+  "version": "4.2.172",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.168",
+  "version": "4.2.169",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.139",
+  "version": "4.2.167",
   "private": true,
   "scripts": {
     "dev": "vite dev",
@@ -79,6 +79,7 @@
     "svelte-qrcode": "^1.0.0",
     "svelte-tags-input": "^5.0.0",
     "svelte-tiptap": "^3.0.1",
+    "syllable": "^5.0.1",
     "timeago.js": "^4.0.2",
     "turndown": "^7.2.2",
     "webln": "^0.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
       svelte-tiptap:
         specifier: ^3.0.1
         version: 3.0.1(@floating-ui/dom@1.7.4)(@tiptap/core@3.17.1(@tiptap/pm@3.17.1))(@tiptap/extension-bubble-menu@3.17.1(@tiptap/core@3.17.1(@tiptap/pm@3.17.1))(@tiptap/pm@3.17.1))(@tiptap/extension-floating-menu@3.17.1(@floating-ui/dom@1.7.4)(@tiptap/core@3.17.1(@tiptap/pm@3.17.1))(@tiptap/pm@3.17.1))(@tiptap/pm@3.17.1)(svelte@4.2.20)
+      syllable:
+        specifier: ^5.0.1
+        version: 5.0.1
       timeago.js:
         specifier: ^4.0.2
         version: 4.0.2
@@ -1617,6 +1620,9 @@ packages:
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/pluralize@0.0.29':
+    resolution: {integrity: sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA==}
 
   '@types/pug@2.0.10':
     resolution: {integrity: sha512-Sk/uYFOBAB7mb74XcpizmH0KOR2Pv3D2Hmrh1Dmy5BmK3MpdSa5kqZcg6EKBdklU0bFXX9gCfzvpnyUehrPIuA==}
@@ -3687,6 +3693,9 @@ packages:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
 
+  normalize-strings@1.1.1:
+    resolution: {integrity: sha512-fARPRdTwmrQDLYhmeh7j/eZwrCP6WzxD6uKOdK/hT/uKACAE9AG2Bc2dgqOZLkfmmctHpfcJ9w3AQnfLgg3GYg==}
+
   nostr-tools@2.16.2:
     resolution: {integrity: sha512-ZxH9EbSt5ypURZj2TGNJxZd0Omb5ag5KZSu8IyJMCdLyg2KKz+2GA0sP/cSawCQEkyviIN4eRT4G2gB/t9lMRw==}
     peerDependencies:
@@ -3942,6 +3951,10 @@ packages:
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
     engines: {node: '>=10.4.0'}
+
+  pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4636,6 +4649,10 @@ packages:
   svelte@4.2.20:
     resolution: {integrity: sha512-eeEgGc2DtiUil5ANdtd8vPwt9AgaMdnuUFnPft9F5oMvU/FHu5IHFic+p1dR/UOB7XU2mX2yHW+NcTch4DCh5Q==}
     engines: {node: '>=16'}
+
+  syllable@5.0.1:
+    resolution: {integrity: sha512-HWtNCp6v7J8H0lrT8j1HHjfOLltRoDcC7QRFVu25p4BE52JqetXG65nqC7CsatT8WQRfY4Qvh93BWJIUxbmXFg==}
+    hasBin: true
 
   tailwindcss@4.1.13:
     resolution: {integrity: sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==}
@@ -6545,6 +6562,8 @@ snapshots:
       undici-types: 5.26.5
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@types/pluralize@0.0.29': {}
 
   '@types/pug@2.0.10': {}
 
@@ -8818,6 +8837,8 @@ snapshots:
 
   normalize-range@0.1.2: {}
 
+  normalize-strings@1.1.1: {}
+
   nostr-tools@2.16.2(typescript@5.6.3):
     dependencies:
       '@noble/ciphers': 0.5.3
@@ -9078,6 +9099,8 @@ snapshots:
       '@xmldom/xmldom': 0.8.11
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
+
+  pluralize@8.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -9887,6 +9910,12 @@ snapshots:
       locate-character: 3.0.0
       magic-string: 0.30.19
       periscopic: 3.1.0
+
+  syllable@5.0.1:
+    dependencies:
+      '@types/pluralize': 0.0.29
+      normalize-strings: 1.1.1
+      pluralize: 8.0.0
 
   tailwindcss@4.1.13: {}
 

--- a/src/app.html
+++ b/src/app.html
@@ -6,9 +6,13 @@
     <!-- Apply dark mode before first paint to prevent flash -->
     <script>
       (function () {
-        var theme = localStorage.getItem('nostrcooking_theme') || 'system';
-        var dark = theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
-        if (dark) document.documentElement.classList.add('dark');
+        try {
+          var theme = localStorage.getItem('nostrcooking_theme') || 'system';
+          var dark = theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+          if (dark) document.documentElement.classList.add('dark');
+        } catch (e) {
+          // localStorage or matchMedia unavailable (Safari private mode, hardened browsers, etc.)
+        }
       })();
     </script>
 

--- a/src/app.html
+++ b/src/app.html
@@ -3,6 +3,15 @@
   <head>
     <meta charset="utf-8" />
 
+    <!-- Apply dark mode before first paint to prevent flash -->
+    <script>
+      (function () {
+        var theme = localStorage.getItem('nostrcooking_theme') || 'system';
+        var dark = theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (dark) document.documentElement.classList.add('dark');
+      })();
+    </script>
+
     <!-- Override fetch BEFORE anything else loads to intercept __data.json requests in static builds -->
     <script>
       (function () {

--- a/src/components/CommentLikes.svelte
+++ b/src/components/CommentLikes.svelte
@@ -51,14 +51,14 @@
     // Check if user is authenticated
     if (!$userPublickey) {
       console.log('User not authenticated - redirecting to login');
-      window.location.href = '/login';
+      window.location.href = '/login?redirect=' + encodeURIComponent(window.location.pathname);
       return;
     }
     
     // Check if NDK has a signer
     if (!$ndk.signer) {
       console.log('No signer available - redirecting to login');
-      window.location.href = '/login';
+      window.location.href = '/login?redirect=' + encodeURIComponent(window.location.pathname);
       return;
     }
     

--- a/src/components/DesktopSideNav.svelte
+++ b/src/components/DesktopSideNav.svelte
@@ -169,8 +169,13 @@
       class="block pl-2 py-2 cursor-pointer transition-transform duration-150 active:scale-95 active:opacity-80"
     >
       <img
-        src={isDarkMode ? '/zap_cooking_logo_white.svg' : SVGNostrCookingWithText}
-        class="w-40"
+        src={SVGNostrCookingWithText}
+        class="w-40 dark:hidden"
+        alt="Zap Cooking"
+      />
+      <img
+        src="/zap_cooking_logo_white.svg"
+        class="w-40 hidden dark:block"
         alt="Zap Cooking"
       />
     </button>

--- a/src/components/FeedComments.svelte
+++ b/src/components/FeedComments.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
+  import { page } from '$app/stores';
   import { ndk, userPublickey } from '$lib/nostr';
   import { NDKEvent } from '@nostr-dev-kit/ndk';
   import Button from './Button.svelte';
@@ -244,7 +245,7 @@
       <!-- Comments List - flat list with embedded parent quotes -->
       <div class="comments-list">
         {#if sortedComments.length === 0}
-          <p class="text-sm text-caption">No comments yet. {#if !$userPublickey}<a href="/login?redirect={encodeURIComponent(window.location.pathname)}" class="underline hover:opacity-80">Sign in</a> to comment!{:else}Be the first to comment!{/if}</p>
+          <p class="text-sm text-caption">No comments yet. {#if !$userPublickey}<a href="/login?redirect={encodeURIComponent($page.url.pathname)}" class="underline hover:opacity-80">Sign in</a> to comment!{:else}Be the first to comment!{/if}</p>
         {:else}
           {#each sortedComments as comment (comment.id)}
             <FeedComment event={comment} allComments={events} {refresh} mainEventId={event.id} />

--- a/src/components/FeedComments.svelte
+++ b/src/components/FeedComments.svelte
@@ -244,7 +244,7 @@
       <!-- Comments List - flat list with embedded parent quotes -->
       <div class="comments-list">
         {#if sortedComments.length === 0}
-          <p class="text-sm text-caption">No comments yet. Be the first to comment!</p>
+          <p class="text-sm text-caption">No comments yet. {#if !$userPublickey}<a href="/login?redirect={encodeURIComponent(window.location.pathname)}" class="underline hover:opacity-80">Sign in</a> to comment!{:else}Be the first to comment!{/if}</p>
         {:else}
           {#each sortedComments as comment (comment.id)}
             <FeedComment event={comment} allComments={events} {refresh} mainEventId={event.id} />

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -118,8 +118,13 @@
     class="flex-none lg:hidden cursor-pointer transition-transform duration-150 active:scale-95 active:opacity-80"
   >
     <img
-      src={isDarkMode ? '/zap_cooking_logo_white.svg' : SVGNostrCookingWithText}
-      class="w-28 sm:w-40 my-2 sm:my-3"
+      src={SVGNostrCookingWithText}
+      class="w-28 sm:w-40 my-2 sm:my-3 dark:hidden"
+      alt="zap.cooking Logo With Text"
+    />
+    <img
+      src="/zap_cooking_logo_white.svg"
+      class="w-28 sm:w-40 my-2 sm:my-3 hidden dark:block"
       alt="zap.cooking Logo With Text"
     />
   </button>

--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -16,7 +16,7 @@
 <script lang="ts">
   import { blur, scale } from 'svelte/transition';
   import CloseIcon from 'phosphor-svelte/lib/XCircle';
-  import { onMount } from 'svelte';
+  import { onMount, onDestroy } from 'svelte';
 
   export let open = false;
   export let cleanup: (() => void) | null = null;
@@ -29,6 +29,25 @@
 
   onMount(() => {
     portalTarget = document.body;
+  });
+
+  // Close on Escape key
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape' && open) close();
+  }
+
+  $: if (typeof window !== 'undefined') {
+    if (open) {
+      window.addEventListener('keydown', handleKeydown);
+    } else {
+      window.removeEventListener('keydown', handleKeydown);
+    }
+  }
+
+  onDestroy(() => {
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('keydown', handleKeydown);
+    }
   });
 
   // if some variables need to be erased when it's closed, we can do that here.

--- a/src/components/NoteActionBar.svelte
+++ b/src/components/NoteActionBar.svelte
@@ -30,7 +30,7 @@
 
   function openZapModal() {
     if (!$userPublickey) {
-      window.location.href = '/login';
+      window.location.href = '/login?redirect=' + encodeURIComponent(window.location.pathname);
       return;
     }
     zapModalOpen = true;

--- a/src/components/NoteRepost.svelte
+++ b/src/components/NoteRepost.svelte
@@ -30,7 +30,7 @@
     }
 
     if (!$userPublickey || !$ndk.signer) {
-      window.location.href = '/login';
+      window.location.href = '/login?redirect=' + encodeURIComponent(window.location.pathname);
       return;
     }
 
@@ -81,7 +81,7 @@
     showMenu = false;
 
     if (!$userPublickey) {
-      window.location.href = '/login';
+      window.location.href = '/login?redirect=' + encodeURIComponent(window.location.pathname);
       return;
     }
 

--- a/src/components/Reactions/ReactionButton.svelte
+++ b/src/components/Reactions/ReactionButton.svelte
@@ -105,7 +105,7 @@
     showFullPicker = false;
 
     if (!canPublishReaction($ndk, $userPublickey)) {
-      window.location.href = '/login';
+      window.location.href = '/login?redirect=' + encodeURIComponent(window.location.pathname);
       return;
     }
 
@@ -155,7 +155,7 @@
 
   function handleAddClick() {
     if (!canPublishReaction($ndk, $userPublickey)) {
-      window.location.href = '/login';
+      window.location.href = '/login?redirect=' + encodeURIComponent(window.location.pathname);
       return;
     }
     showPicker = !showPicker;

--- a/src/components/Reactions/ReactionPills.svelte
+++ b/src/components/Reactions/ReactionPills.svelte
@@ -24,7 +24,7 @@
 
   async function handlePillClick(emoji: string) {
     if (!canPublishReaction($ndk, $userPublickey)) {
-      window.location.href = '/login';
+      window.location.href = '/login?redirect=' + encodeURIComponent(window.location.pathname);
       return;
     }
 

--- a/src/components/Reactions/ReactionTrigger.svelte
+++ b/src/components/Reactions/ReactionTrigger.svelte
@@ -34,7 +34,7 @@
 
   function handleClick() {
     if (!canPublishReaction($ndk, $userPublickey)) {
-      window.location.href = '/login';
+      window.location.href = '/login?redirect=' + encodeURIComponent(window.location.pathname);
       return;
     }
     showPicker = !showPicker;
@@ -45,7 +45,7 @@
     showFullPicker = false;
 
     if (!canPublishReaction($ndk, $userPublickey)) {
-      window.location.href = '/login';
+      window.location.href = '/login?redirect=' + encodeURIComponent(window.location.pathname);
       return;
     }
 

--- a/src/components/TagsSearchAutocomplete.svelte
+++ b/src/components/TagsSearchAutocomplete.svelte
@@ -15,6 +15,12 @@
   let tagquery = '';
   let showAutocomplete = false;
   let inputFocused = false;
+  let inputEl: HTMLInputElement;
+
+  // Auto-focus on mount for mobile overlays where HTML autofocus is unreliable
+  $: if (autofocus && inputEl) {
+    inputEl.focus();
+  }
 
   // Multi-type search state
   let searchResults: {
@@ -348,13 +354,13 @@
   >
     <div class="flex mx-0.5 items-stretch flex-grow focus-within:z-10">
       <input
+        bind:this={inputEl}
         bind:value={tagquery}
         on:input={handleInputChange}
         on:focus={handleInputFocus}
         on:blur={handleInputBlur}
         class="block w-full input"
         placeholder={placeholderString}
-        {autofocus}
       />
     </div>
     <input type="submit" class="hidden" />

--- a/src/components/ThreadCommentActions.svelte
+++ b/src/components/ThreadCommentActions.svelte
@@ -39,7 +39,7 @@
 
   function handleReactionClick() {
     if (!canPublishReaction($ndk, $userPublickey)) {
-      window.location.href = '/login';
+      window.location.href = '/login?redirect=' + encodeURIComponent(window.location.pathname);
       return;
     }
     showPicker = !showPicker;
@@ -50,7 +50,7 @@
     showFullPicker = false;
 
     if (!canPublishReaction($ndk, $userPublickey)) {
-      window.location.href = '/login';
+      window.location.href = '/login?redirect=' + encodeURIComponent(window.location.pathname);
       return;
     }
 
@@ -110,7 +110,7 @@
 
   function openZapModal() {
     if (!$userPublickey) {
-      window.location.href = '/login';
+      window.location.href = '/login?redirect=' + encodeURIComponent(window.location.pathname);
       return;
     }
     zapModalOpen = true;

--- a/src/lib/haiku.ts
+++ b/src/lib/haiku.ts
@@ -1,62 +1,24 @@
-const EXACT_SYLLABLE_OVERRIDES: Record<string, number> = {
-  liked: 1
+import { syllable } from 'syllable';
+
+// Overrides for words the syllable library miscounts
+const OVERRIDES: Record<string, number> = {
+  poem: 2,
+  poems: 2,
+  poet: 2,
+  poets: 2,
+  poetry: 3,
+  fluid: 2
 };
 
 /**
- * Count syllables in an English word using a vowel-group heuristic.
- * Not perfect, but useful for detecting likely 5-7-5 structure.
+ * Count syllables in an English word using the `syllable` library
+ * with overrides for known miscounts.
  */
 export function countSyllables(word: string): number {
   const normalized = word.toLowerCase().trim();
   if (!normalized) return 0;
-  if (normalized in EXACT_SYLLABLE_OVERRIDES) return EXACT_SYLLABLE_OVERRIDES[normalized];
-  if (normalized.length <= 2) return 1;
-
-  const vowels = 'aeiouy';
-  let count = 0;
-  let prevVowel = false;
-
-  for (const char of normalized) {
-    const isVowel = vowels.includes(char);
-    if (isVowel && !prevVowel) count += 1;
-    prevVowel = isVowel;
-  }
-
-  // Silent trailing e (e.g. "make", "rice")
-  if (normalized.endsWith('e') && count > 1) count -= 1;
-
-  // Plural -es is often silent (e.g. "leaves", "waves") but pronounced as
-  // a syllable after sibilants (e.g. "roses", "changes", "boxes").
-  if (
-    normalized.endsWith('es') &&
-    count > 1 &&
-    !/(?:sh|ch|[szxgc])es$/i.test(normalized)
-  ) {
-    count -= 1;
-  }
-
-  // Many past-tense words ending in -ed keep the "e" silent (e.g. "liked").
-  // Exclude cases where the ending is typically pronounced as its own syllable.
-  if (
-    normalized.endsWith('ed') &&
-    count > 1 &&
-    normalized.length > 3 &&
-    !normalized.endsWith('ted') &&
-    !normalized.endsWith('ded')
-  ) {
-    count -= 1;
-  }
-
-  // -le ending counts as a syllable when preceded by a consonant (e.g. "little")
-  if (
-    normalized.endsWith('le') &&
-    normalized.length > 2 &&
-    !vowels.includes(normalized[normalized.length - 3])
-  ) {
-    count += 1;
-  }
-
-  return Math.max(count, 1);
+  if (normalized in OVERRIDES) return OVERRIDES[normalized];
+  return Math.max(syllable(normalized), 1);
 }
 
 /**

--- a/src/routes/[nip19]/+page.server.ts
+++ b/src/routes/[nip19]/+page.server.ts
@@ -386,6 +386,26 @@ export const load: PageServerLoad = async ({ params, url }) => {
 		throw redirect(301, `/${nip19Id}`);
 	}
 
+	// Check if this is a plain username (not a NIP-19 identifier)
+	// NIP-19 identifiers start with: npub1, nprofile1, note1, nevent1, naddr1
+	const isNip19 = /^(?:npub1|nprofile1|note1|nevent1|naddr1)/.test(nip19Id || '');
+	if (!isNip19 && nip19Id && /^[a-zA-Z0-9_]{3,20}$/.test(nip19Id)) {
+		// Try resolving as a zap.cooking NIP-05 username
+		try {
+			const res = await fetch('https://zap.cooking/.well-known/nostr.json?name=' + encodeURIComponent(nip19Id.toLowerCase()));
+			if (res.ok) {
+				const data = await res.json();
+				const pubkey = data?.names?.[nip19Id.toLowerCase()];
+				if (pubkey) {
+					const npub = nip19.npubEncode(pubkey);
+					throw redirect(302, `/user/${npub}`);
+				}
+			}
+		} catch (e) {
+			if (e && typeof e === 'object' && 'status' in e) throw e; // re-throw redirect
+		}
+	}
+
 	// Only handle note1/nevent1 identifiers for OG tags
 	if (!nip19Id?.startsWith('note1') && !nip19Id?.startsWith('nevent1')) {
 		return { ogMeta: null };

--- a/src/routes/[nip19]/+page.server.ts
+++ b/src/routes/[nip19]/+page.server.ts
@@ -392,7 +392,11 @@ export const load: PageServerLoad = async ({ params, url }) => {
 	if (!isNip19 && nip19Id && /^[a-zA-Z0-9_]{3,20}$/.test(nip19Id)) {
 		// Try resolving as a zap.cooking NIP-05 username
 		try {
-			const res = await fetch('https://zap.cooking/.well-known/nostr.json?name=' + encodeURIComponent(nip19Id.toLowerCase()));
+			const nostrJsonUrl = new URL('/.well-known/nostr.json?name=' + encodeURIComponent(nip19Id.toLowerCase()), url.origin);
+			const controller = new AbortController();
+			const timeout = setTimeout(() => controller.abort(), 5000);
+			const res = await fetch(nostrJsonUrl.toString(), { signal: controller.signal });
+			clearTimeout(timeout);
 			if (res.ok) {
 				const data = await res.json();
 				const pubkey = data?.names?.[nip19Id.toLowerCase()];

--- a/src/routes/[nip19]/+page.svelte
+++ b/src/routes/[nip19]/+page.svelte
@@ -756,7 +756,7 @@
         </div>
       {:else if directReplies.length === 0}
         <p class="text-sm py-4 text-center" style="color: var(--color-caption)">
-          No replies yet. Be the first to reply!
+          No replies yet. {#if !$userPublickey}<a href="/login?redirect={encodeURIComponent($page.url.pathname)}" class="underline hover:opacity-80" style="color: var(--color-primary)">Sign in</a> to reply!{:else}Be the first to reply!{/if}
         </p>
       {:else}
         <div class="space-y-0">

--- a/src/routes/drafts/+page.svelte
+++ b/src/routes/drafts/+page.svelte
@@ -23,7 +23,7 @@
 
 	// Redirect if not signed in
 	$: if (!isSignedIn && typeof window !== 'undefined') {
-		goto('/');
+		goto('/login?redirect=/drafts');
 	}
 
 	onMount(() => {

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -3,6 +3,7 @@
   import { ndk, userPublickey } from '$lib/nostr';
   import { browser } from '$app/environment';
   import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
   import Modal from '../../components/Modal.svelte';
   import type { PageData } from './$types';
   import QRCode from 'svelte-qrcode';
@@ -103,9 +104,10 @@
             userPublickey.set('');
           }
 
-          // Redirect to explore page if authenticated (skip during signup flow)
+          // Redirect after authenticated (skip during signup flow)
           if (state.isAuthenticated && !generateModal && !showSuggestedFollows) {
-            goto('/explore');
+            const redirectTo = $page.url.searchParams.get('redirect') || '/explore';
+            goto(redirectTo);
           }
         });
 
@@ -968,7 +970,8 @@
       if (browser) {
         localStorage.setItem('zapcooking_wallet_welcome_force', '1');
       }
-      goto('/explore');
+      const redirectTo = $page.url.searchParams.get('redirect') || '/explore';
+      goto(redirectTo);
     }}
   />
 

--- a/src/routes/membership/+page.svelte
+++ b/src/routes/membership/+page.svelte
@@ -153,8 +153,10 @@
   // Compute member since date from founders data or API status
   $: if (apiMembershipStatus && data.founders) {
     const founderRecord = data.founders.find((f: any) => f.pubkey === normalizedPubkey);
-    if (founderRecord?.created_at) {
-      memberSince = new Date(founderRecord.created_at).toLocaleDateString(undefined, { year: 'numeric', month: 'long' });
+    if (founderRecord?.joined) {
+      memberSince = new Date(founderRecord.joined).toLocaleDateString(undefined, { year: 'numeric', month: 'long' });
+    } else {
+      memberSince = null;
     }
   }
 

--- a/src/routes/membership/+page.svelte
+++ b/src/routes/membership/+page.svelte
@@ -136,6 +136,73 @@
     }
   }
 
+  // --- Member stats ---
+  import { ndk } from '$lib/nostr';
+  import { onMount } from 'svelte';
+  import CookingPotIcon from 'phosphor-svelte/lib/CookingPot';
+  import StarIcon from 'phosphor-svelte/lib/Star';
+  import ShieldCheckIcon from 'phosphor-svelte/lib/ShieldCheck';
+  import LightningIcon from 'phosphor-svelte/lib/Lightning';
+  import RobotIcon from 'phosphor-svelte/lib/Robot';
+  import StorefrontIcon from 'phosphor-svelte/lib/Storefront';
+  import CrownIcon from 'phosphor-svelte/lib/Crown';
+
+  let recipeCount: number | null = null;
+  let memberSince: string | null = null;
+
+  // Compute member since date from founders data or API status
+  $: if (apiMembershipStatus && data.founders) {
+    const founderRecord = data.founders.find((f: any) => f.pubkey === normalizedPubkey);
+    if (founderRecord?.created_at) {
+      memberSince = new Date(founderRecord.created_at).toLocaleDateString(undefined, { year: 'numeric', month: 'long' });
+    }
+  }
+
+  // Fetch recipe count for the user (kind 30023 = long-form recipes)
+  onMount(async () => {
+    if (!$userPublickey || !$ndk) return;
+    try {
+      const events = await $ndk.fetchEvents({
+        kinds: [30023],
+        authors: [$userPublickey]
+      });
+      recipeCount = events.size;
+    } catch (e) {
+      console.warn('[Membership] Failed to fetch recipe count:', e);
+    }
+  });
+
+  // Perks by tier
+  const TIER_PERKS: Record<string, { icon: typeof CookingPotIcon; label: string }[]> = {
+    cook_plus: [
+      { icon: RobotIcon, label: 'AI Recipe Extraction' },
+      { icon: ShieldCheckIcon, label: 'Verified NIP-05 Identity' },
+      { icon: StorefrontIcon, label: 'Market Access' },
+      { icon: StarIcon, label: 'Priority Relay Access' },
+    ],
+    pro_kitchen: [
+      { icon: RobotIcon, label: 'AI Recipe Extraction' },
+      { icon: LightningIcon, label: 'Lightning-Gated Recipes' },
+      { icon: ShieldCheckIcon, label: 'Verified NIP-05 Identity' },
+      { icon: StorefrontIcon, label: 'Market Access' },
+      { icon: StarIcon, label: 'Priority Relay Access' },
+      { icon: CookingPotIcon, label: 'Zappy AI Assistant' },
+    ],
+    founders: [
+      { icon: CrownIcon, label: 'Lifetime Access — All Features' },
+      { icon: RobotIcon, label: 'AI Recipe Extraction' },
+      { icon: LightningIcon, label: 'Lightning-Gated Recipes' },
+      { icon: ShieldCheckIcon, label: 'Verified NIP-05 Identity' },
+      { icon: StorefrontIcon, label: 'Market Access' },
+      { icon: StarIcon, label: 'Priority Relay Access' },
+      { icon: CookingPotIcon, label: 'Zappy AI Assistant' },
+    ],
+  };
+
+  $: currentPerks = isFoundersMember
+    ? TIER_PERKS['founders']
+    : TIER_PERKS[apiMembershipStatus?.tier || ''] || TIER_PERKS['cook_plus'];
+
   // Toggle for showing sales/pricing content when active member clicks "Upgrade"
   let showUpgradeOptions = false;
 
@@ -226,10 +293,12 @@
 <div class="membership-page">
   {#if $userPublickey && isActiveMemberApi}
     <section class="member-dashboard">
-      <h3 class="member-dashboard-title">Your Membership</h3>
+      <!-- Header with identity and badge -->
       <div class="member-dashboard-header">
         <div class="member-dashboard-identity">
-          <CustomAvatar pubkey={$userPublickey} size={48} interactive={false} />
+          <div class="member-avatar-glow" class:founders-glow={isFoundersMember}>
+            <CustomAvatar pubkey={$userPublickey} size={56} interactive={false} />
+          </div>
           <div class="member-dashboard-identity-text">
             <CustomName pubkey={$userPublickey} className="member-dashboard-display-name" />
             <span class="member-dashboard-tier">
@@ -247,12 +316,45 @@
         </div>
         <span class="member-dashboard-active-badge">Active</span>
       </div>
+
+      <!-- Stats row -->
       <div class="member-dashboard-stats">
         <div class="member-dashboard-stat">
           <span class="member-dashboard-stat-label">Expires</span>
           <span class="member-dashboard-stat-value">{formatExpiresAt(apiMembershipStatus?.expiresAt)}</span>
         </div>
+        {#if memberSince}
+          <div class="member-dashboard-stat">
+            <span class="member-dashboard-stat-label">Member Since</span>
+            <span class="member-dashboard-stat-value">{memberSince}</span>
+          </div>
+        {/if}
+        <div class="member-dashboard-stat">
+          <span class="member-dashboard-stat-label">Recipes Published</span>
+          <span class="member-dashboard-stat-value">
+            {#if recipeCount !== null}
+              {recipeCount}
+            {:else}
+              ...
+            {/if}
+          </span>
+        </div>
       </div>
+
+      <!-- Perks -->
+      <div class="member-dashboard-perks">
+        <h4 class="member-dashboard-perks-title">Your Perks</h4>
+        <div class="member-dashboard-perks-grid">
+          {#each currentPerks as perk}
+            <div class="member-dashboard-perk">
+              <svelte:component this={perk.icon} size={16} weight="bold" />
+              <span>{perk.label}</span>
+            </div>
+          {/each}
+        </div>
+      </div>
+
+      <!-- Actions -->
       <div class="member-dashboard-actions">
         {#if hasActiveCardMembership}
           {#if manageError}
@@ -270,7 +372,7 @@
             {/if}
           </button>
         {/if}
-        {#if !showUpgradeOptions}
+        {#if !showUpgradeOptions && !isLifetimeMember}
           <button class="member-dashboard-upgrade-button" on:click={handleShowUpgrade}>
             Upgrade Plan
           </button>
@@ -735,19 +837,10 @@
   .member-dashboard {
     background: var(--color-bg-secondary);
     border: 1px solid var(--color-input-border);
-    border-left: 3px solid var(--color-primary);
-    border-radius: 12px;
-    padding: 1.5rem;
+    border-radius: 16px;
+    padding: 1.75rem;
     margin-bottom: 2rem;
-  }
-
-  .member-dashboard-title {
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    color: var(--color-text-secondary);
-    margin-bottom: 1rem;
+    background-image: linear-gradient(135deg, rgba(249, 115, 22, 0.05) 0%, transparent 60%);
   }
 
   .member-dashboard-header {
@@ -761,6 +854,15 @@
     display: flex;
     align-items: center;
     gap: 0.75rem;
+  }
+
+  .member-avatar-glow {
+    border-radius: 9999px;
+    box-shadow: 0 0 12px rgba(245, 158, 11, 0.4), 0 0 24px rgba(249, 115, 22, 0.15);
+  }
+
+  .member-avatar-glow.founders-glow {
+    box-shadow: 0 0 14px rgba(245, 158, 11, 0.5), 0 0 28px rgba(249, 115, 22, 0.25), 0 0 48px rgba(249, 115, 22, 0.1);
   }
 
   .member-dashboard-identity-text {
@@ -797,15 +899,21 @@
   }
 
   .member-dashboard-stats {
-    margin-bottom: 1.25rem;
-    padding-top: 1.25rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+    padding: 1rem 0;
     border-top: 1px solid var(--color-input-border);
+    border-bottom: 1px solid var(--color-input-border);
   }
 
   .member-dashboard-stat {
     display: flex;
+    flex-direction: column;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.25rem;
+    text-align: center;
   }
 
   .member-dashboard-stat-value {
@@ -815,10 +923,48 @@
   }
 
   .member-dashboard-stat-label {
-    font-size: 0.75rem;
+    font-size: 0.7rem;
     color: var(--color-text-secondary);
     text-transform: uppercase;
     letter-spacing: 0.5px;
+  }
+
+  .member-dashboard-perks {
+    margin-bottom: 1.5rem;
+  }
+
+  .member-dashboard-perks-title {
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--color-text-secondary);
+    margin-bottom: 0.75rem;
+    text-align: center;
+  }
+
+  .member-dashboard-perks-grid {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.5rem;
+  }
+
+  .member-dashboard-perk {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.8rem;
+    color: var(--color-text-primary);
+    padding: 0.5rem 0.75rem;
+    border-radius: 8px;
+    background: rgba(249, 115, 22, 0.06);
+    border: 1px solid rgba(249, 115, 22, 0.12);
+  }
+
+  .member-dashboard-perk :global(svg) {
+    color: #f59e0b;
+    flex-shrink: 0;
   }
 
   .member-dashboard-actions {

--- a/src/routes/polls/+page.svelte
+++ b/src/routes/polls/+page.svelte
@@ -12,6 +12,7 @@
   import { formatDistanceToNow } from 'date-fns';
   import { nip19 } from 'nostr-tools';
   import { goto } from '$app/navigation';
+  import PostActionsMenu from '../../components/PostActionsMenu.svelte';
 
   let polls: NDKEvent[] = [];
   let loading = true;
@@ -205,12 +206,15 @@
                   <span class="zap-poll-badge">⚡ Zap Poll</span>
                 {/if}
               </div>
-              <button
-                class="poll-time"
-                on:click={() => navigateToNote(poll)}
-              >
-                {poll.created_at ? formatTime(poll.created_at) : ''}
-              </button>
+              <div class="flex items-center gap-2">
+                <button
+                  class="poll-time"
+                  on:click={() => navigateToNote(poll)}
+                >
+                  {poll.created_at ? formatTime(poll.created_at) : ''}
+                </button>
+                <PostActionsMenu event={poll} />
+              </div>
             </div>
           </div>
 

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -549,31 +549,17 @@
           {@const validTier = (['open', 'cook_plus', 'pro_kitchen', 'founders'].includes(member.tier) ? member.tier : 'cook_plus')}
           {@const expiryDate = new Date(member.subscription_end)}
 
-          <!-- Current Plan -->
-          <div
-            class="flex items-center justify-between p-4 rounded-xl"
-            style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
-          >
-            <div class="flex items-center gap-3">
-              <MembershipBadge tier={validTier} size="lg" showLabel />
-              <div>
-                {#if membershipData.isActive}
-                  <span
-                    class="text-xs px-2 py-0.5 rounded-full bg-green-500/20 text-green-600 dark:text-green-400"
-                    >Active</span
-                  >
-                {:else if membershipData.isExpired}
-                  <span class="text-xs px-2 py-0.5 rounded-full bg-red-500/20 text-red-500"
-                    >Expired</span
-                  >
-                {/if}
-              </div>
-            </div>
+          <!-- Current Plan + Details -->
+          <div class="flex items-center gap-3 mb-2">
+            <MembershipBadge tier={validTier} size="lg" showLabel />
+            {#if membershipData.isActive}
+              <span class="text-xs px-2 py-0.5 rounded-full bg-green-500/20 text-green-600 dark:text-green-400">Active</span>
+            {:else if membershipData.isExpired}
+              <span class="text-xs px-2 py-0.5 rounded-full bg-red-500/20 text-red-500">Expired</span>
+            {/if}
           </div>
 
-          <!-- Subscription Details -->
-          <div class="bg-secondary p-4 rounded-xl">
-            <div class="flex flex-col gap-2 text-sm">
+          <div class="flex flex-col gap-2 text-sm">
               <div class="flex justify-between">
                 <span class="text-caption">{membershipData.isExpired ? 'Expired' : 'Expires'}</span>
                 <span style="color: var(--color-text-primary)">
@@ -587,15 +573,14 @@
               <div class="flex justify-between">
                 <span class="text-caption">Payment</span>
                 <span style="color: var(--color-text-primary)">
-                  {member.payment_method === 'stripe'
+                  {member.payment_method === 'stripe' || member.payment_method === 'card'
                     ? 'Credit Card'
                     : member.payment_method === 'bitcoin'
                       ? 'Bitcoin'
-                      : member.payment_method}
+                      : member.payment_method || 'None'}
                 </span>
               </div>
             </div>
-          </div>
 
           <!-- Actions -->
           <div class="flex flex-col gap-2">
@@ -630,7 +615,7 @@
           <!-- No membership / Free tier -->
           <div
             class="p-4 rounded-xl text-center"
-            style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+            style="border: 1px solid var(--color-input-border);"
           >
             <p class="text-sm font-medium" style="color: var(--color-text-primary)">Welcome Table</p>
             <p class="text-xs text-caption mt-1">
@@ -791,8 +776,8 @@
             <input
               bind:value={newRelay}
               placeholder="wss://relay.example.com"
-              class="flex-1 p-3 bg-secondary rounded-lg border-none text-sm"
-              style="color: var(--color-text-primary);"
+              class="flex-1 p-3 rounded-lg text-sm"
+              style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
               on:keydown={(e) => e.key === 'Enter' && addRelay()}
             />
             <button
@@ -831,7 +816,7 @@
         {#if $weblnConnected}
           <div
             class="flex items-center gap-4 p-4 rounded-xl"
-            style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+            style="border: 1px solid var(--color-input-border);"
           >
             <div
               class="w-10 h-10 rounded-full bg-gradient-to-br from-orange-500 to-amber-500 flex items-center justify-center flex-shrink-0"
@@ -857,7 +842,7 @@
             {#each connectedWallets as wallet}
               <div
                 class="flex items-center gap-4 p-4 rounded-xl"
-                style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+                style="border: 1px solid var(--color-input-border);"
               >
                 {#if wallet.kind === 4}
                   <div
@@ -900,7 +885,7 @@
         {:else if $bitcoinConnectEnabled && !$weblnConnected}
           <div
             class="flex items-center gap-4 p-4 rounded-xl"
-            style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+            style="border: 1px solid var(--color-input-border);"
           >
             <div class="w-10 h-10 rounded-full bg-orange-500 flex items-center justify-center">
               <BitcoinConnectLogo size={20} className="text-white" />
@@ -917,7 +902,7 @@
         {:else if !$weblnConnected}
           <div
             class="p-4 rounded-xl text-center"
-            style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+            style="border: 1px solid var(--color-input-border);"
           >
             <p class="text-sm text-caption">No wallets connected</p>
           </div>
@@ -925,7 +910,7 @@
 
         <div
           class="p-4 rounded-xl {!hasNavWallet ? 'opacity-50' : ''}"
-          style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+          style="border: 1px solid var(--color-input-border);"
         >
           <div class="flex items-center justify-between">
             <div class="flex-1">
@@ -967,7 +952,7 @@
         <!-- One-Tap Zap Toggle -->
         <div
           class="p-4 rounded-xl {!hasInAppWallet ? 'opacity-50' : ''}"
-          style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+          style="border: 1px solid var(--color-input-border);"
         >
           <div class="flex items-center justify-between">
             <div class="flex-1">
@@ -1125,7 +1110,7 @@
           <p class="text-sm" style="color: var(--color-text-secondary)">Loading...</p>
         {:else}
           <!-- Current status -->
-          <div class="flex items-center gap-2 px-3 py-2 rounded-lg" style="background-color: var(--color-input-bg);">
+          <div class="flex items-center gap-2 px-3 py-2 rounded-lg" style="border: 1px solid var(--color-input-border);">
             {#if wotProvider}
               <ShieldCheckIcon size={16} weight="fill" class="text-green-500" />
               <span class="text-sm" style="color: var(--color-text-primary)">Personalized scoring active</span>
@@ -1137,7 +1122,7 @@
 
           <!-- Mode selection -->
           <div class="flex flex-col gap-2">
-            <label class="flex items-start gap-3 p-3 rounded-lg cursor-pointer" style="background-color: var(--color-input-bg); border: 1px solid {wotMode === 'global' ? 'var(--color-accent)' : 'transparent'};">
+            <label class="flex items-start gap-3 p-3 rounded-lg cursor-pointer">
               <input type="radio" bind:group={wotMode} value="global" class="mt-1" style="accent-color: var(--color-accent);" />
               <div>
                 <span class="block text-sm font-medium" style="color: var(--color-text-primary)">Global Web of Trust</span>
@@ -1145,7 +1130,7 @@
               </div>
             </label>
 
-            <label class="flex items-start gap-3 p-3 rounded-lg cursor-pointer" style="background-color: var(--color-input-bg); border: 1px solid {wotMode === 'custom' ? 'var(--color-accent)' : 'transparent'};">
+            <label class="flex items-start gap-3 p-3 rounded-lg cursor-pointer">
               <input type="radio" bind:group={wotMode} value="custom" class="mt-1" style="accent-color: var(--color-accent);" />
               <div>
                 <span class="block text-sm font-medium" style="color: var(--color-text-primary)">Personalized</span>
@@ -1162,7 +1147,7 @@
                 <button
                   type="button"
                   class="flex items-center gap-2 p-3 rounded-lg text-left transition-colors"
-                  style="background-color: var(--color-input-bg); border: 1px solid {wotPubkey === provider.pubkey ? 'var(--color-accent)' : 'transparent'};"
+                  style=""
                   on:click={() => selectWotProvider(provider)}
                 >
                   <ShieldCheckIcon size={16} weight="fill" class="text-green-500 flex-shrink-0" />

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1147,7 +1147,7 @@
                 <button
                   type="button"
                   class="flex items-center gap-2 p-3 rounded-lg text-left transition-colors"
-                  style=""
+                  style="background-color: var(--color-input-bg); border: 1px solid {wotPubkey === provider.pubkey ? 'var(--color-accent)' : 'transparent'};"
                   on:click={() => selectWotProvider(provider)}
                 >
                   <ShieldCheckIcon size={16} weight="fill" class="text-green-500 flex-shrink-0" />

--- a/src/routes/wallet/+page.svelte
+++ b/src/routes/wallet/+page.svelte
@@ -267,7 +267,7 @@
   // Check if an NWC wallet already exists (only one allowed at a time)
   $: hasExistingNwcWallet = $wallets.some((w) => w.kind === 3);
 
-  // Check if user has maximum wallets (2)
+  // Check if user has maximum wallets (1)
   $: hasMaxWallets = $wallets.length >= 1;
 
   async function checkSparkBackupStatus(pubkey: string) {

--- a/src/routes/wallet/+page.svelte
+++ b/src/routes/wallet/+page.svelte
@@ -268,7 +268,7 @@
   $: hasExistingNwcWallet = $wallets.some((w) => w.kind === 3);
 
   // Check if user has maximum wallets (2)
-  $: hasMaxWallets = $wallets.length >= 2;
+  $: hasMaxWallets = $wallets.length >= 1;
 
   async function checkSparkBackupStatus(pubkey: string) {
     if (sparkBackupChecking) return;
@@ -2468,13 +2468,13 @@
 
     <!-- Balance Overview -->
     {#if $walletConnected && $activeWallet && !$weblnConnected}
-      <div class="mb-8 p-6 rounded-2xl bg-input border border-input">
+      <div class="mb-8">
         <div class="flex items-start justify-between mb-2">
           <div>
             <div class="text-4xl font-bold text-primary-color flex items-center gap-3">
               <LightningIcon size={32} weight="fill" class="text-amber-500 flex-shrink-0" />
               {#if $walletLoading || $walletBalance === null}
-                <span class="animate-pulse">...</span>
+                <span class="inline-block w-32 h-9 rounded-lg animate-pulse" style="background: var(--color-input-bg);"></span>
               {:else if $balanceVisible}
                 {formatBalance($walletBalance)}
               {:else}
@@ -2545,6 +2545,15 @@
             </button>
           </div>
         {/if}
+      </div>
+    {/if}
+
+    <!-- Pending deposits alert -->
+    {#if $activeWallet?.kind === 4 && unclaimedDeposits.length > 0}
+      <div class="mb-4 p-3 rounded-xl flex items-center gap-2" style="background: rgba(245, 158, 11, 0.1); border: 1px solid rgba(245, 158, 11, 0.3);">
+        <WarningIcon size={18} class="text-amber-500 flex-shrink-0" />
+        <span class="text-sm font-medium" style="color: var(--color-text-primary);">{unclaimedDeposits.length} pending deposit{unclaimedDeposits.length > 1 ? 's' : ''} to claim</span>
+        <a href="#pending-deposits" class="ml-auto text-xs font-medium text-amber-500 hover:text-amber-400">View</a>
       </div>
     {/if}
 
@@ -2630,6 +2639,7 @@
     {/if}
 
     <!-- Pending On-Chain Deposits (Spark wallet only) -->
+    <div id="pending-deposits"></div>
     {#if $activeWallet?.kind === 4 && unclaimedDeposits.length > 0}
       <div
         class="mb-8 p-4 rounded-2xl"
@@ -2719,22 +2729,6 @@
 
     <!-- Connected Wallets -->
     <div class="mb-8">
-      <div class="flex items-center justify-between mb-4">
-        <h2 class="text-lg font-semibold" style="color: var(--color-text-primary)">
-          Connected Wallets
-        </h2>
-        {#if !hasMaxWallets && !$weblnConnected && !$bitcoinConnectEnabled}
-          <Button
-            on:click={() => {
-              showAddWallet = true;
-              selectedWalletType = null;
-            }}
-          >
-            <PlusIcon size={16} />
-            Add Wallet
-          </Button>
-        {/if}
-      </div>
 
       <!-- WebLN External Wallet Display -->
       {#if $weblnConnected}
@@ -2753,7 +2747,7 @@
           <p class="text-sm text-caption mb-4">Browser wallet connected via WebLN</p>
           <button
             class="px-5 py-2.5 rounded-full font-semibold text-sm text-caption hover:text-red-500 transition-colors cursor-pointer"
-            style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+            style="border: 1px solid var(--color-input-border);"
             on:click={handleDisconnectWebln}
           >
             Disconnect Browser Wallet
@@ -2763,8 +2757,7 @@
 
       {#if $wallets.length === 0 && !$weblnConnected}
         <div
-          class="p-8 rounded-2xl text-center flex flex-col items-center"
-          style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+          class="py-12 text-center flex flex-col items-center"
         >
           {#if $bitcoinConnectEnabled}
             <div
@@ -2811,7 +2804,7 @@
             <div class="flex gap-2">
               <button
                 class="px-4 py-2 rounded-full font-semibold text-sm transition-colors cursor-pointer"
-                style="background-color: var(--color-bg-primary); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+                style="color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
                 on:click={refreshBitcoinConnectBalance}
                 disabled={$bitcoinConnectBalanceLoading}
               >
@@ -2822,15 +2815,18 @@
               </button>
               <button
                 class="px-4 py-2 rounded-full font-semibold text-sm text-caption hover:text-red-500 transition-colors cursor-pointer"
-                style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+                style="border: 1px solid var(--color-input-border);"
                 on:click={() => (showRemoveBitcoinConnectModal = true)}
               >
                 Disconnect
               </button>
             </div>
           {:else}
-            <WalletIcon size={48} class="mb-4 text-caption" />
-            <p class="text-caption mb-4">No wallets connected yet</p>
+            <div class="w-16 h-16 rounded-full bg-gradient-to-br from-amber-500/20 to-orange-500/20 flex items-center justify-center mb-4">
+              <WalletIcon size={32} class="text-amber-500" />
+            </div>
+            <h3 class="font-semibold mb-1" style="color: var(--color-text-primary)">Get Started with Sats</h3>
+            <p class="text-caption text-sm mb-4 max-w-xs">Connect a Lightning wallet to send zaps, receive payments, and support creators.</p>
             <Button
               on:click={() => {
                 showAddWallet = true;
@@ -2861,7 +2857,7 @@
             </div>
             <button
               class="text-xs px-2 py-1 rounded-full text-caption hover:text-red-500 transition-colors cursor-pointer"
-              style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+              style="border: 1px solid var(--color-input-border);"
               on:click={handleDisconnectWebln}
             >
               Disconnect
@@ -2872,10 +2868,8 @@
           {#each $wallets.filter((w) => w.kind !== 1) as wallet}
             {@const isEffectivelyActive = wallet.active && !$weblnConnected}
             <div
-              class="rounded-xl overflow-hidden"
-              style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
-              class:ring-2={isEffectivelyActive}
-              class:ring-amber-500={isEffectivelyActive}
+              class="rounded-lg overflow-hidden border"
+              style="border-color: {isEffectivelyActive ? 'rgba(245, 158, 11, 0.5)' : 'var(--color-input-border)'};"
             >
               <div class="p-3 sm:p-4 flex items-center gap-2 sm:gap-4">
                 <!-- Wallet type icon -->
@@ -2894,23 +2888,6 @@
                         · {parsed.pubkey.slice(0, 8)}...{/if}{/if}
                   </div>
                 </div>
-                {#if isEffectivelyActive}
-                  <span class="text-xs px-2 py-1 rounded-full bg-amber-500 text-white flex-shrink-0"
-                    >Active</span
-                  >
-                {:else if $weblnConnected}
-                  <span
-                    class="text-xs px-2 py-1 rounded-full text-caption flex-shrink-0"
-                    style="background-color: var(--color-input-bg);">Inactive</span
-                  >
-                {:else}
-                  <button
-                    class="text-xs sm:text-sm text-caption hover:text-primary cursor-pointer flex-shrink-0 whitespace-nowrap"
-                    on:click={() => handleSetActive(wallet.id)}
-                  >
-                    Set Active
-                  </button>
-                {/if}
                 {#if wallet.kind === 4 || wallet.kind === 3}
                   <button
                     class="relative flex items-center gap-0.5 sm:gap-1 p-1.5 sm:px-2 sm:py-1 rounded-lg text-caption hover:text-primary hover:bg-black/5 dark:hover:bg-white/5 cursor-pointer transition-all flex-shrink-0"
@@ -2970,8 +2947,8 @@
                   </div>
                   <div class="grid grid-cols-2 gap-2 mb-4">
                     <button
-                      class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer"
-                      style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+                      class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer hover:bg-white/5 dark:hover:bg-white/5"
+                      style="color: var(--color-text-secondary); border: 1px solid var(--color-input-border);"
                       on:click={handleViewSparkInfo}
                       disabled={isLoadingSparkInfo}
                     >
@@ -2988,19 +2965,19 @@
                   </div>
                   <div class="grid grid-cols-2 gap-2">
                     <button
-                      class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer"
-                      style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+                      class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer hover:bg-white/5 dark:hover:bg-white/5"
+                      style="color: var(--color-text-secondary); border: 1px solid var(--color-input-border);"
                       on:click={handleRevealMnemonic}
                     >
                       <KeyIcon size={16} />
                       Recovery Phrase
                     </button>
                     <button
-                      class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors"
+                      class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors hover:bg-white/5 dark:hover:bg-white/5"
                       class:cursor-pointer={encryptionSupported}
                       class:cursor-not-allowed={!encryptionSupported}
                       class:opacity-50={!encryptionSupported}
-                      style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+                      style="color: var(--color-text-secondary); border: 1px solid var(--color-input-border);"
                       on:click={handleBackupToNostr}
                       disabled={isBackingUp || !encryptionSupported}
                       title={!encryptionSupported ? 'Your signer does not support encryption' : ''}
@@ -3009,8 +2986,8 @@
                       {isBackingUp ? 'Backing up...' : 'Backup to Nostr'}
                     </button>
                     <button
-                      class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer"
-                      style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+                      class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer hover:bg-white/5 dark:hover:bg-white/5"
+                      style="color: var(--color-text-secondary); border: 1px solid var(--color-input-border);"
                       on:click={() => {
                         checkRelayBackupsWalletType = 'spark';
                         showCheckRelayBackupsModal = true;
@@ -3020,8 +2997,8 @@
                       Check Backups
                     </button>
                     <button
-                      class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer"
-                      style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+                      class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer hover:bg-white/5 dark:hover:bg-white/5"
+                      style="color: var(--color-text-secondary); border: 1px solid var(--color-input-border);"
                       on:click={() => (showRecoveryHelpModal = true)}
                     >
                       <LifebuoyIcon size={16} />
@@ -3029,7 +3006,7 @@
                     </button>
                     <button
                       class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer text-red-500 hover:bg-red-500/10"
-                      style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+                      style="border: 1px solid var(--color-input-border);"
                       on:click={() =>
                         (walletToDelete = {
                           id: wallet.id,
@@ -3054,10 +3031,7 @@
 
                     {#if $sparkLightningAddressStore}
                       <!-- Has lightning address -->
-                      <div
-                        class="p-3 rounded-lg mb-3"
-                        style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
-                      >
+                      <div class="mb-3">
                         <div class="text-sm text-caption mb-1">Your lightning address:</div>
                         <div class="font-medium text-primary-color flex items-center gap-2">
                           {$sparkLightningAddressStore}
@@ -3143,7 +3117,7 @@
                           {:else}
                             <button
                               class="flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer"
-                              style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+                              style="border: 1px solid var(--color-input-border);"
                               on:click={() => (showSyncConfirmModal = true)}
                             >
                               <UserCirclePlusIcon size={16} />
@@ -3152,7 +3126,7 @@
                           {/if}
                           <button
                             class="flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-red-500 hover:bg-red-500/10 transition-colors cursor-pointer"
-                            style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+                            style="border: 1px solid var(--color-input-border);"
                             on:click={() => (showDeleteAddressConfirmModal = true)}
                           >
                             <TrashIcon size={16} />
@@ -3170,7 +3144,7 @@
                         <!-- Wallet is still initializing -->
                         <div
                           class="p-3 rounded-lg"
-                          style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+                          style="border: 1px solid var(--color-input-border);"
                         >
                           <div class="flex items-center gap-2 text-sm text-caption">
                             <div
@@ -3194,7 +3168,7 @@
                             <input
                               type="text"
                               class="w-full p-2 pr-20 rounded-lg text-sm"
-                              style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border); color: var(--color-text-primary);"
+                              style="border: 1px solid var(--color-input-border); color: var(--color-text-primary);"
                               placeholder="username"
                               value={newLightningUsername}
                               on:input={handleUsernameInput}
@@ -3228,7 +3202,7 @@
                         {/if}
                         <button
                           class="flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer disabled:opacity-50"
-                          style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+                          style="border: 1px solid var(--color-input-border);"
                           on:click={handleRegisterLightningAddress}
                           disabled={!isUsernameAvailable ||
                             isRegisteringAddress ||
@@ -3259,8 +3233,8 @@
                   </div>
                   <div class="grid grid-cols-2 gap-2 mb-4">
                     <button
-                      class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer"
-                      style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+                      class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer hover:bg-white/5 dark:hover:bg-white/5"
+                      style="color: var(--color-text-secondary); border: 1px solid var(--color-input-border);"
                       on:click={() => handleViewNwcInfo(wallet)}
                       disabled={isLoadingNwcInfo}
                     >
@@ -3269,8 +3243,8 @@
                       >
                     </button>
                     <button
-                      class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer"
-                      style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+                      class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer hover:bg-white/5 dark:hover:bg-white/5"
+                      style="color: var(--color-text-secondary); border: 1px solid var(--color-input-border);"
                       on:click={() => handleCopyNwcConnection(wallet)}
                     >
                       <CopyIcon size={16} />
@@ -3288,7 +3262,7 @@
                       class:cursor-pointer={encryptionSupported}
                       class:cursor-not-allowed={!encryptionSupported}
                       class:opacity-50={!encryptionSupported}
-                      style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+                      style="border: 1px solid var(--color-input-border);"
                       on:click={() => handleNwcBackupToNostr(wallet)}
                       disabled={isBackingUp || !encryptionSupported}
                       title={!encryptionSupported ? 'Your signer does not support encryption' : ''}
@@ -3299,16 +3273,16 @@
                       >
                     </button>
                     <button
-                      class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer"
-                      style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+                      class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer hover:bg-white/5 dark:hover:bg-white/5"
+                      style="color: var(--color-text-secondary); border: 1px solid var(--color-input-border);"
                       on:click={() => handleDownloadNwcBackup(wallet)}
                     >
                       <DownloadSimpleIcon size={16} />
                       <span class="truncate">Download</span>
                     </button>
                     <button
-                      class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer"
-                      style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+                      class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer hover:bg-white/5 dark:hover:bg-white/5"
+                      style="color: var(--color-text-secondary); border: 1px solid var(--color-input-border);"
                       on:click={() => {
                         checkRelayBackupsWalletType = 'nwc';
                         showCheckRelayBackupsModal = true;
@@ -3319,7 +3293,7 @@
                     </button>
                     <button
                       class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer text-red-500 hover:bg-red-500/10"
-                      style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+                      style="border: 1px solid var(--color-input-border);"
                       on:click={() =>
                         (walletToDelete = {
                           id: wallet.id,
@@ -3350,7 +3324,7 @@
 
                         <div
                           class="p-3 rounded-lg mb-3"
-                          style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+                          style="border: 1px solid var(--color-input-border);"
                         >
                           <div class="text-sm text-caption mb-1">From NWC connection:</div>
                           <div class="font-medium text-primary-color flex items-center gap-2">
@@ -3509,22 +3483,22 @@
           </div>
 
           {#if isLoadingHistory && transactions.length === 0 && filteredPendingTransactions.length === 0}
-            <div class="p-8 rounded-2xl text-center bg-input border border-input">
+            <div class="py-8 text-center">
               <div class="animate-pulse text-caption">Loading transactions...</div>
             </div>
           {:else if transactions.length === 0 && filteredPendingTransactions.length === 0}
-            <div class="p-8 rounded-2xl text-center bg-input border border-input">
+            <div class="py-8 text-center">
               <ClockIcon size={48} class="mx-auto mb-4 text-caption" />
               <p class="text-caption">No transactions yet</p>
             </div>
           {:else}
-            <div class="space-y-2">
+            <div>
               <!-- Pending/completed transactions shown first (filtered to active wallet) -->
               {#each filteredPendingTransactions as tx (tx.id)}
                 {#if tx.status === 'completed'}
                   <!-- Completed but not yet in history (outgoing = orange) -->
                   <div
-                    class="p-4 rounded-xl flex items-center gap-4 bg-input border border-orange-500/50"
+                    class="py-4 flex items-center gap-4 border-b border-l-2 border-orange-500/50 pl-3" style="border-bottom-color: var(--color-input-border);"
                   >
                     {#if tx.pubkey}
                       <a href="/user/{nip19.npubEncode(tx.pubkey)}" class="flex-shrink-0">
@@ -3568,7 +3542,7 @@
                 {:else}
                   <!-- Still pending -->
                   <div
-                    class="p-4 rounded-xl flex items-center gap-4 bg-input border border-amber-500/50 animate-pulse"
+                    class="py-4 flex items-center gap-4 border-b border-l-2 border-amber-500/50 pl-3 animate-pulse" style="border-bottom-color: var(--color-input-border);"
                   >
                     {#if tx.pubkey}
                       <a href="/user/{nip19.npubEncode(tx.pubkey)}" class="flex-shrink-0">
@@ -3617,7 +3591,7 @@
                 {#if tx.status === 'pending'}
                   <!-- Pending transaction from SDK -->
                   <div
-                    class="p-4 rounded-xl flex items-center gap-4 bg-input border border-amber-500/50 animate-pulse"
+                    class="py-4 flex items-center gap-4 border-b border-l-2 border-amber-500/50 pl-3 animate-pulse" style="border-bottom-color: var(--color-input-border);"
                   >
                     {#if tx.pubkey}
                       <a href="/user/{nip19.npubEncode(tx.pubkey)}" class="flex-shrink-0">
@@ -3669,7 +3643,7 @@
                   </div>
                 {:else}
                   <!-- Completed transaction -->
-                  <div class="p-4 rounded-xl flex items-center gap-4 bg-input border border-input">
+                  <div class="py-4 flex items-center gap-4 border-b" style="border-color: var(--color-input-border);">
                     {#if tx.pubkey}
                       <a href="/user/{nip19.npubEncode(tx.pubkey)}" class="flex-shrink-0">
                         <CustomAvatar pubkey={tx.pubkey} size={40} />
@@ -3739,6 +3713,8 @@
                   {isLoadingHistory ? 'Loading...' : 'Load More'}
                 </Button>
               </div>
+            {:else if transactions.length > 0}
+              <p class="mt-4 text-center text-xs text-caption">End of transaction history</p>
             {/if}
           {/if}
         {/if}
@@ -3773,7 +3749,7 @@
                 {#if $weblnConnected}
                   <div
                     class="p-4 rounded-xl text-center"
-                    style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+                    style="border: 1px solid var(--color-input-border);"
                   >
                     <p class="text-sm text-caption">
                       Disconnect your browser wallet to add embedded wallets
@@ -3786,7 +3762,7 @@
                     class:cursor-pointer={!hasExistingSparkWallet}
                     class:cursor-not-allowed={hasExistingSparkWallet}
                     class:opacity-50={hasExistingSparkWallet}
-                    style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+                    style="border: 1px solid var(--color-input-border);"
                     on:click={() => !hasExistingSparkWallet && (selectedWalletType = 4)}
                     disabled={hasExistingSparkWallet}
                   >
@@ -3816,7 +3792,7 @@
                     class:cursor-pointer={!hasExistingNwcWallet}
                     class:cursor-not-allowed={hasExistingNwcWallet}
                     class:opacity-50={hasExistingNwcWallet}
-                    style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+                    style="border: 1px solid var(--color-input-border);"
                     on:click={() => !hasExistingNwcWallet && (selectedWalletType = 3)}
                     disabled={hasExistingNwcWallet}
                   >
@@ -3858,7 +3834,7 @@
                 {#if $wallets.length > 0}
                   <div
                     class="p-4 rounded-xl text-center"
-                    style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+                    style="border: 1px solid var(--color-input-border);"
                   >
                     <p class="text-sm text-caption">
                       Backup and remove all embedded wallets if you want to connect a
@@ -3872,7 +3848,7 @@
                     class:cursor-pointer={!$bitcoinConnectEnabled && !$weblnConnected}
                     class:cursor-not-allowed={$bitcoinConnectEnabled || $weblnConnected}
                     class:opacity-50={$bitcoinConnectEnabled || $weblnConnected}
-                    style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+                    style="border: 1px solid var(--color-input-border);"
                     on:click={handleConnectBitcoinConnect}
                     disabled={$bitcoinConnectEnabled || $weblnConnected}
                   >
@@ -3904,7 +3880,7 @@
                       class:cursor-pointer={!$weblnConnected}
                       class:cursor-not-allowed={$weblnConnected}
                       class:opacity-50={$weblnConnected}
-                      style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+                      style="border: 1px solid var(--color-input-border);"
                       on:click={handleConnectWebln}
                       disabled={$weblnConnected}
                     >
@@ -3937,14 +3913,14 @@
                 {#if canCheckNwcBackup && nwcBackupChecking}
                   <div
                     class="mb-4 p-3 rounded-lg border text-sm"
-                    style="background-color: var(--color-input-bg); border-color: var(--color-input-border); color: var(--color-text-primary);"
+                    style="border-color: var(--color-input-border); color: var(--color-text-primary);"
                   >
                     Checking for Nostr backup...
                   </div>
                 {:else if canCheckNwcBackup && nwcBackupExists}
                   <div
                     class="mb-4 p-3 rounded-lg border text-sm"
-                    style="background-color: var(--color-input-bg); border-color: var(--color-input-border); color: var(--color-text-primary);"
+                    style="border-color: var(--color-input-border); color: var(--color-text-primary);"
                   >
                     Backup found on Nostr. You can restore it below.
                   </div>
@@ -4001,14 +3977,14 @@
                 {#if canCheckSparkBackup && sparkBackupChecking}
                   <div
                     class="mb-4 p-3 rounded-lg border text-sm"
-                    style="background-color: var(--color-input-bg); border-color: var(--color-input-border); color: var(--color-text-primary);"
+                    style="border-color: var(--color-input-border); color: var(--color-text-primary);"
                   >
                     Checking for Nostr backup...
                   </div>
                 {:else if canCheckSparkBackup && sparkBackupExists}
                   <div
                     class="mb-4 p-3 rounded-lg border text-sm"
-                    style="background-color: var(--color-input-bg); border-color: var(--color-input-border); color: var(--color-text-primary);"
+                    style="border-color: var(--color-input-border); color: var(--color-text-primary);"
                   >
                     Backup found on Nostr. You can restore it below.
                   </div>
@@ -4022,7 +3998,7 @@
                     <!-- Show loading state -->
                     <div
                       class="p-8 rounded-xl text-center"
-                      style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+                      style="border: 1px solid var(--color-input-border);"
                     >
                       <div
                         class="animate-spin w-8 h-8 border-2 border-amber-500 border-t-transparent rounded-full mx-auto mb-4"
@@ -4047,7 +4023,7 @@
                         {#if canCheckSparkBackup}
                           <button
                             class="flex items-center justify-center gap-2 w-full px-3 py-2.5 rounded-lg text-sm transition-colors cursor-pointer disabled:opacity-50"
-                            style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+                            style="border: 1px solid var(--color-input-border);"
                             on:click={handleRestoreFromNostr}
                             disabled={isConnecting}
                           >
@@ -4057,7 +4033,7 @@
                         {/if}
                         <button
                           class="flex items-center justify-center gap-2 w-full px-3 py-2.5 rounded-lg text-sm transition-colors cursor-pointer disabled:opacity-50"
-                          style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+                          style="border: 1px solid var(--color-input-border);"
                           on:click={() => (sparkRestoreMode = 'mnemonic')}
                           disabled={isConnecting}
                         >
@@ -4388,90 +4364,78 @@
             </p>
 
             {#if walletToDelete.kind === 4 || walletToDelete.kind === 3}
-              <!-- Backup options section -->
-              <div
-                class="p-4 rounded-xl mb-4"
-                style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
-              >
-                <div class="flex items-center gap-2 mb-3">
-                  <WarningIcon size={18} class="text-amber-500" />
-                  <span class="text-sm font-medium text-amber-500">Save a backup first</span>
-                </div>
-
-                <div
-                  class="grid gap-2"
-                  class:grid-cols-2={encryptionSupported}
-                  class:grid-cols-1={!encryptionSupported}
-                >
-                  {#if walletToDelete.kind === 4}
-                    <!-- Spark wallet: Recovery Phrase backup -->
-                    <button
-                      class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer bg-amber-500 hover:bg-amber-600 text-black"
-                      on:click={handleRevealMnemonic}
-                    >
-                      <KeyIcon size={16} />
-                      Recovery Phrase
-                    </button>
-                  {:else}
-                    <!-- NWC wallet: Download works without encryption -->
-                    <button
-                      class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer bg-amber-500 hover:bg-amber-600 text-black"
-                      on:click={() => walletToDelete && handleDownloadNwcBackup(walletToDelete)}
-                      disabled={isBackingUp}
-                    >
-                      <DownloadSimpleIcon size={16} />
-                      Download
-                    </button>
-                  {/if}
-                  {#if encryptionSupported}
-                    <button
-                      class="flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer bg-black hover:bg-gray-800 text-white"
-                      on:click={() =>
-                        walletToDelete?.kind === 4
-                          ? handleBackupToNostr()
-                          : walletToDelete
-                            ? handleNwcBackupToNostr(walletToDelete)
-                            : undefined}
-                      disabled={isBackingUp}
-                    >
-                      <CloudArrowUpIcon size={16} />
-                      {isBackingUp ? 'Saving...' : 'Backup to Nostr'}
-                    </button>
-                  {/if}
-                </div>
+              <!-- Backup warning -->
+              <div class="flex items-center gap-2 mb-3 pb-3 border-b" style="border-color: var(--color-input-border);">
+                <WarningIcon size={18} class="text-amber-500 flex-shrink-0" />
+                <span class="text-sm text-amber-500">Back up your wallet before removing</span>
               </div>
 
-              <!-- Delete relay backup toggle button -->
-              <button
-                class="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer mb-4"
-                class:bg-red-500={deleteRelayBackups}
-                class:hover:bg-red-600={deleteRelayBackups}
-                class:text-white={deleteRelayBackups}
-                style={deleteRelayBackups
-                  ? ''
-                  : 'background-color: var(--color-input-bg); border: 1px solid var(--color-input-border); color: var(--color-text-caption);'}
-                on:click={() => (deleteRelayBackups = !deleteRelayBackups)}
+              <div
+                class="grid gap-2 mb-4"
+                class:grid-cols-2={encryptionSupported}
+                class:grid-cols-1={!encryptionSupported}
               >
-                <TrashIcon size={14} />
-                {deleteRelayBackups ? 'Will delete relay backup' : 'Delete relay backup'}
-              </button>
+                {#if walletToDelete.kind === 4}
+                  <button
+                    class="flex items-center justify-center gap-2 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors cursor-pointer hover:bg-white/5"
+                    style="border: 1px solid var(--color-input-border); color: var(--color-text-primary);"
+                    on:click={handleRevealMnemonic}
+                  >
+                    <KeyIcon size={16} class="text-amber-500" />
+                    Recovery Phrase
+                  </button>
+                {:else}
+                  <button
+                    class="flex items-center justify-center gap-2 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors cursor-pointer hover:bg-white/5"
+                    style="border: 1px solid var(--color-input-border); color: var(--color-text-primary);"
+                    on:click={() => walletToDelete && handleDownloadNwcBackup(walletToDelete)}
+                    disabled={isBackingUp}
+                  >
+                    <DownloadSimpleIcon size={16} class="text-amber-500" />
+                    Download
+                  </button>
+                {/if}
+                {#if encryptionSupported}
+                  <button
+                    class="flex items-center justify-center gap-2 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors cursor-pointer hover:bg-white/5"
+                    style="border: 1px solid var(--color-input-border); color: var(--color-text-primary);"
+                    on:click={() =>
+                      walletToDelete?.kind === 4
+                        ? handleBackupToNostr()
+                        : walletToDelete
+                          ? handleNwcBackupToNostr(walletToDelete)
+                          : undefined}
+                    disabled={isBackingUp}
+                  >
+                    <CloudArrowUpIcon size={16} class="text-amber-500" />
+                    {isBackingUp ? 'Saving...' : 'Backup to Nostr'}
+                  </button>
+                {/if}
+              </div>
+
+              <!-- Delete relay backup toggle -->
+              <label class="flex items-center gap-2 mb-4 cursor-pointer text-sm" style="color: var(--color-text-secondary);">
+                <input type="checkbox" bind:checked={deleteRelayBackups} class="accent-red-500" />
+                Also delete relay backup
+              </label>
             {:else}
               <p class="text-caption text-sm mb-4">You can reconnect it later.</p>
             {/if}
 
             <div class="flex gap-3">
-              <Button
+              <button
+                class="flex-1 px-4 py-2.5 rounded-lg font-medium text-sm transition-colors cursor-pointer hover:bg-white/5"
+                style="border: 1px solid var(--color-input-border); color: var(--color-text-primary);"
                 on:click={() => {
                   walletToDelete = null;
                   deleteRelayBackups = false;
                 }}
                 disabled={isDeletingWallet}
-                class="flex-1"
               >
                 Cancel
-              </Button>
+              </button>
               <button
-                class="flex-1 px-4 py-2 rounded-full bg-red-500 hover:bg-red-600 text-white font-medium transition-colors cursor-pointer disabled:opacity-50"
+                class="flex-1 px-4 py-2.5 rounded-lg bg-red-500 hover:bg-red-600 text-white font-medium text-sm transition-colors cursor-pointer disabled:opacity-50"
                 disabled={isDeletingWallet}
                 on:click={async () => {
                   if (walletToDelete) {
@@ -4769,13 +4733,15 @@
                     />
                     <button
                       type="button"
-                      class="absolute top-2 right-3.5 p-1 rounded text-caption hover:text-primary-color transition-colors disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+                      class="absolute top-2 right-2 px-2 py-1 rounded-lg text-xs font-medium flex items-center gap-1 transition-colors disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+                      style="background: var(--color-input-bg); color: var(--color-text-secondary); border: 1px solid var(--color-input-border);"
                       on:click={startQrCamera}
                       disabled={isSending || isSendingOnchain || showQrCamera}
                       title="Scan QR code"
                       aria-label="Scan QR code"
                     >
-                      <QrCodeIcon size={18} />
+                      <QrCodeIcon size={14} />
+                      Scan
                     </button>
                   </div>
                   {#if isBtcAddress && $activeWallet?.kind === 4}
@@ -5131,7 +5097,7 @@
                   <!-- Current Network Fees -->
                   <div
                     class="p-3 rounded-lg text-left"
-                    style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+                    style="border: 1px solid var(--color-input-border);"
                   >
                     <div class="flex items-center justify-between mb-2">
                       <span class="text-xs font-medium text-caption">Current Network Fees</span>


### PR DESCRIPTION
## Summary

Broad UX pass addressing friction points, visual cleanup, and new features.

### Core UX Fixes
- **Dark mode flash prevention** — inline script in `<head>` applies dark class before first paint
- **Logo flash fix** — CSS-based dark/light toggle instead of Svelte reactivity
- **Login redirects preserve context** — all interaction buttons (zap, react, repost, comment) pass current path; login page returns user to where they were
- **Modal Escape key** — all modals close on Escape press
- **Search auto-focus** — reliable focus on mobile via `bind:this` instead of HTML autofocus
- **Empty states** — logged-out users see "Sign in" CTA instead of "Be the first"

### New Features
- **Short URL usernames** — `zap.cooking/daniel` resolves via NIP-05 lookup and redirects to profile
- **Haiku syllable library** — replaced hand-rolled counter with `syllable` npm package for accuracy
- **Enhanced membership dashboard** — stats row (expires, member since, recipes), perks grid, avatar glow, hide upgrade for lifetime members

### Visual Cleanup
- **Wallet page** — removed grey boxes from transaction rows, wallet cards, modals, and buttons; consistent bordered styling; better empty state, skeleton loader, QR scan button, pending deposits alert; limit to 1 wallet
- **Settings page** — removed grey backgrounds from all accordion sections; fixed dark mode on text inputs; cleaned up membership and WoT sections
- **Remove Wallet modal** — restyled with clean layout, checkbox for relay backup deletion

## Test plan
- [ ] Load app in dark mode — no flash of light theme or light logo
- [ ] Click zap/react/repost when logged out — should redirect to login then return to original page
- [ ] Visit `zap.cooking/username` for a user with NIP-05 — should redirect to their profile
- [ ] Type a haiku in post composer — should detect 5-7-5 pattern
- [ ] Check membership page as a member — should show stats, perks, glow
- [ ] Open wallet page — clean transaction list, no grey boxes
- [ ] Check settings page — no grey card backgrounds, inputs readable in dark mode
- [ ] Press Escape on any modal — should close