### PR TITLE
feat: Sous Chef paste text formatting + rename to /souschef

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.172",
+  "version": "4.2.173",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.173",
+  "version": "4.2.174",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -154,7 +154,7 @@
     <!-- Sous Chef, Zappy & Nourish icons (logged in) -->
     {#if $userPublickey}
       <a
-        href="/extract"
+        href="/souschef"
         class="w-8 h-8 sm:w-9 sm:h-9 flex items-center justify-center rounded-full transition-colors cursor-pointer hover:bg-accent-gray"
         aria-label="Sous Chef"
       >

--- a/src/components/UserSidePanel.svelte
+++ b/src/components/UserSidePanel.svelte
@@ -364,7 +364,7 @@
           {#if SHOW_PRO_FEATURES}
             <li>
               <button
-                on:click={() => navigate('/extract')}
+                on:click={() => navigate('/souschef')}
                 class="w-full flex items-center gap-4 px-4 py-3 rounded-xl hover:bg-opacity-50 transition-colors cursor-pointer"
                 style="color: var(--color-text-primary);"
               >

--- a/src/routes/api/extract-recipe/+server.ts
+++ b/src/routes/api/extract-recipe/+server.ts
@@ -179,23 +179,37 @@ export const POST: RequestHandler = async ({ request, platform }) => {
     const { type, imageData, url, pubkey } = body;
     
     // Validate request
-    if (!type || (type !== 'image' && type !== 'url')) {
+    if (!type || (type !== 'image' && type !== 'url' && type !== 'text')) {
       return json(
-        { success: false, error: 'Invalid type. Must be "image" or "url"' },
+        { success: false, error: 'Invalid type. Must be "image", "url", or "text"' },
         { status: 400 }
       );
     }
-    
+
     if (type === 'image' && !imageData) {
       return json(
         { success: false, error: 'Image data is required for image extraction' },
         { status: 400 }
       );
     }
-    
+
     if (type === 'url' && !url) {
       return json(
         { success: false, error: 'URL is required for URL extraction' },
+        { status: 400 }
+      );
+    }
+
+    if (type === 'text' && !body.textData) {
+      return json(
+        { success: false, error: 'Recipe text is required' },
+        { status: 400 }
+      );
+    }
+
+    if (type === 'text' && body.textData && body.textData.length > 10000) {
+      return json(
+        { success: false, error: 'Recipe text is too long (max 10,000 characters)' },
         { status: 400 }
       );
     }
@@ -241,6 +255,12 @@ export const POST: RequestHandler = async ({ request, platform }) => {
             }
           }
         ]
+      });
+    } else if (type === 'text') {
+      // For text extraction, send the pasted text directly
+      messages.push({
+        role: 'user',
+        content: `Extract the recipe information from this text:\n\n${body.textData}`
       });
     } else {
       // For URL extraction, fetch the content first

--- a/src/routes/api/extract-recipe/+server.ts
+++ b/src/routes/api/extract-recipe/+server.ts
@@ -200,14 +200,14 @@ export const POST: RequestHandler = async ({ request, platform }) => {
       );
     }
 
-    if (type === 'text' && !body.textData) {
+    if (type === 'text' && (typeof body.textData !== 'string' || body.textData.trim().length === 0)) {
       return json(
         { success: false, error: 'Recipe text is required' },
         { status: 400 }
       );
     }
 
-    if (type === 'text' && body.textData && body.textData.length > 10000) {
+    if (type === 'text' && typeof body.textData === 'string' && body.textData.length > 10000) {
       return json(
         { success: false, error: 'Recipe text is too long (max 10,000 characters)' },
         { status: 400 }

--- a/src/routes/api/zappy/+server.ts
+++ b/src/routes/api/zappy/+server.ts
@@ -138,6 +138,15 @@ export const POST: RequestHandler = async ({ request, platform }) => {
     const body = await request.json();
     const { prompt, mode = 'prompt', pubkey } = body;
     
+    // Validate mode
+    const supportedModes = ['prompt', 'hungry', 'format'];
+    if (!supportedModes.includes(mode)) {
+      return json(
+        { ok: false, error: 'Invalid mode' },
+        { status: 400 }
+      );
+    }
+
     // Validate request
     if ((mode === 'prompt' || mode === 'format') && (!prompt || typeof prompt !== 'string')) {
       return json(

--- a/src/routes/api/zappy/+server.ts
+++ b/src/routes/api/zappy/+server.ts
@@ -78,6 +78,49 @@ You are Lightning-native. If a recipe is zapped, respond with a short, genuine t
 
 Above all: make cooking feel easier, lighter, and more fun.`;
 
+// System instruction for formatting pasted recipes
+const FORMAT_SYSTEM_INSTRUCTION = `You are Zappy, the friendly kitchen companion inside Zap Cooking. A user has pasted a recipe from an external source. Your job is to reformat it cleanly into the standard Zap Cooking format.
+
+ALWAYS format the recipe exactly like this:
+
+# [Recipe Title]
+
+[1-2 sentence summary describing the dish]
+
+## Time
+- Prep: [time]
+- Cook: [time]
+- Total: [time]
+
+## Servings
+[number] servings
+
+## Ingredients
+- [ingredient 1]
+- [ingredient 2]
+- [ingredient 3]
+...
+
+## Steps
+1. [Step 1]
+2. [Step 2]
+3. [Step 3]
+...
+
+## Notes (optional)
+- [Any helpful tips, substitutions, or variations from the original recipe]
+
+Rules:
+- Extract ALL information from the pasted recipe accurately
+- Clean up formatting: fix capitalization, remove unnecessary characters, standardize measurements
+- If prep/cook time isn't specified, estimate reasonable times based on the recipe
+- If servings aren't specified, estimate based on ingredient quantities
+- Keep ingredient quantities and measurements as provided
+- Make directions clear and concise
+- Include any tips, variations, or notes from the original
+- Do NOT add commentary or explanation outside the recipe format
+- Do NOT invent ingredients or steps that aren't in the original`;
+
 // Random recipe prompt for "Surprise Me" mode
 const HUNGRY_PROMPT = `Surprise me with a random recipe! It could be any cuisine, any meal type - breakfast, lunch, dinner, snack, or dessert. Make it practical, achievable for a home cook, and use ingredients most people have or can easily get. Let's cook something fun.`;
 
@@ -96,17 +139,18 @@ export const POST: RequestHandler = async ({ request, platform }) => {
     const { prompt, mode = 'prompt', pubkey } = body;
     
     // Validate request
-    if (mode === 'prompt' && (!prompt || typeof prompt !== 'string')) {
+    if ((mode === 'prompt' || mode === 'format') && (!prompt || typeof prompt !== 'string')) {
       return json(
-        { ok: false, error: 'Prompt is required' },
+        { ok: false, error: mode === 'format' ? 'Recipe text is required' : 'Prompt is required' },
         { status: 400 }
       );
     }
-    
-    // Limit prompt length (prevent abuse)
-    if (prompt && prompt.length > 2000) {
+
+    // Limit prompt length (format mode allows longer input for pasted recipes)
+    const maxPromptLength = mode === 'format' ? 10000 : 2000;
+    if (prompt && prompt.length > maxPromptLength) {
       return json(
-        { ok: false, error: 'Prompt is too long (max 2000 characters)' },
+        { ok: false, error: `Input is too long (max ${maxPromptLength} characters)` },
         { status: 400 }
       );
     }
@@ -132,9 +176,12 @@ export const POST: RequestHandler = async ({ request, platform }) => {
       }
     }
     
-    // Determine the user prompt based on mode
-    const userPrompt = mode === 'hungry' ? HUNGRY_PROMPT : prompt;
-    
+    // Determine the user prompt and system instruction based on mode
+    const isFormatMode = mode === 'format';
+    const userPrompt = mode === 'hungry' ? HUNGRY_PROMPT :
+                       isFormatMode ? `Please reformat this recipe:\n\n${prompt}` : prompt;
+    const systemInstruction = isFormatMode ? FORMAT_SYSTEM_INSTRUCTION : SYSTEM_INSTRUCTION;
+
     // Call OpenAI API
     const openaiResponse = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
@@ -145,11 +192,11 @@ export const POST: RequestHandler = async ({ request, platform }) => {
       body: JSON.stringify({
         model: 'gpt-4.1-mini',
         messages: [
-          { role: 'system', content: SYSTEM_INSTRUCTION },
+          { role: 'system', content: systemInstruction },
           { role: 'user', content: userPrompt }
         ],
         max_tokens: 2048,
-        temperature: 0.8
+        temperature: isFormatMode ? 0.3 : 0.8
       })
     });
     

--- a/src/routes/membership/+page.svelte
+++ b/src/routes/membership/+page.svelte
@@ -672,7 +672,7 @@
               <li>
                 <span class="feature-icon">✨</span>
                 <div class="feature-content">
-                  <a href="/extract" class="feature-link">Sous Chef - Extract recipes from any link or photo instantly</a>
+                  <a href="/souschef" class="feature-link">Sous Chef - Extract recipes from any link or photo instantly</a>
                   <span class="feature-subtext">Save time - let it do the work</span>
                 </div>
               </li>

--- a/src/routes/membership/+page.svelte
+++ b/src/routes/membership/+page.svelte
@@ -672,7 +672,7 @@
               <li>
                 <span class="feature-icon">✨</span>
                 <div class="feature-content">
-                  <a href="/souschef" class="feature-link">Sous Chef - Extract recipes from any link or photo instantly</a>
+                  <a href="/souschef" class="feature-link">Sous Chef - Extract recipes from any link, photo, or pasted text instantly</a>
                   <span class="feature-subtext">Save time - let it do the work</span>
                 </div>
               </li>

--- a/src/routes/membership/cook-plus-checkout/+page.svelte
+++ b/src/routes/membership/cook-plus-checkout/+page.svelte
@@ -378,7 +378,7 @@
             <li>
               <span class="feature-icon">✨</span>
               <div class="feature-content">
-                <span class="feature-text">Sous Chef - Extract recipes from any link or photo instantly</span>
+                <span class="feature-text">Sous Chef - Extract recipes from any link, photo, or pasted text instantly</span>
                 <span class="feature-subtext">Save time - let it do the work</span>
               </div>
             </li>

--- a/src/routes/souschef/+page.svelte
+++ b/src/routes/souschef/+page.svelte
@@ -40,13 +40,17 @@
   let errorMessage = '';
   
   // Input mode
-  type InputMode = 'image' | 'url';
-  let inputMode: InputMode = 'image';
+  type InputMode = 'image' | 'url' | 'text';
+  let inputMode: InputMode = 'text';
   const tabs = [
     { id: 'image', label: 'Upload Image' },
-    { id: 'url', label: 'Paste URL' }
+    { id: 'url', label: 'Paste URL' },
+    { id: 'text', label: 'Paste Text' }
   ];
-  
+
+  // Text input state
+  let textInput = '';
+
   // Image upload state
   let fileInput: HTMLInputElement;
   let isDragging = false;
@@ -97,6 +101,7 @@
     uploadedImagePreview = null;
     urlInput = '';
     urlError = '';
+    textInput = '';
     extractionError = '';
     extractionSuccess = false;
   }
@@ -174,9 +179,11 @@
   }
   
   // Check if we can extract
-  $: canExtract = inputMode === 'image' 
-    ? !!uploadedImageData 
-    : (!!urlInput && !urlError);
+  $: canExtract = inputMode === 'image'
+    ? !!uploadedImageData
+    : inputMode === 'url'
+      ? (!!urlInput && !urlError)
+      : !!textInput.trim();
   
   // Upload image to nostr.build
   async function uploadToNostrBuild(file: File): Promise<string | null> {
@@ -254,7 +261,7 @@
   // Extract recipe (requires login; redirect so reviewer can see upload UI first)
   async function extractRecipe() {
     if (!$userPublickey) {
-      goto('/login?redirect=/extract');
+      goto('/login?redirect=/souschef');
       return;
     }
     if (!canExtract || isExtracting) return;
@@ -272,6 +279,9 @@
       if (inputMode === 'image') {
         requestBody.imageData = uploadedImageData;
         extractionProgress = 'Extracting recipe from image...';
+      } else if (inputMode === 'text') {
+        requestBody.textData = textInput.trim();
+        extractionProgress = 'Formatting your recipe...';
       } else {
         requestBody.url = urlInput;
         extractionProgress = 'Fetching and extracting recipe from URL...';
@@ -359,7 +369,7 @@
   // Save as draft and navigate to drafts page
   function saveDraftOnly() {
     if (!$userPublickey) {
-      goto('/login?redirect=/extract');
+      goto('/login?redirect=/souschef');
       return;
     }
     const draftData = {
@@ -387,7 +397,7 @@
   // Publish recipe directly to relays
   async function publishRecipe() {
     if (!$userPublickey) {
-      goto('/login?redirect=/extract');
+      goto('/login?redirect=/souschef');
       return;
     }
 
@@ -503,7 +513,7 @@
       <h1>Sous Chef</h1>
     </div>
     <p class="text-caption">
-      Turn photos or links into ready-to-post recipes.
+      Turn photos, links, or pasted text into ready-to-post recipes.
     </p>
     <p class="text-caption">
       A little extra help in the kitchen.
@@ -594,7 +604,7 @@
               </div>
             {/if}
           </div>
-        {:else}
+        {:else if inputMode === 'url'}
           <!-- URL Input -->
           <div class="flex flex-col gap-2">
             <div class="flex items-center gap-2">
@@ -612,6 +622,22 @@
             {/if}
             <p class="text-xs text-caption">
               Paste a URL from any recipe website. The AI will extract the recipe details.
+            </p>
+          </div>
+        {:else}
+          <!-- Text Input -->
+          <div class="flex flex-col gap-2">
+            <label for="text-input" class="text-sm text-caption">Drop a recipe in here</label>
+            <textarea
+              id="text-input"
+              bind:value={textInput}
+              placeholder="Paste a URL, copy from a website, type it out, screenshot text — whatever you've got, Sous Chef will handle it."
+              rows="10"
+              class="input resize-none text-base"
+              disabled={isExtracting}
+            />
+            <p class="text-xs text-caption">
+              Paste any recipe text and Sous Chef will format it for zap.cooking.
             </p>
           </div>
         {/if}


### PR DESCRIPTION
## Summary
- Rename `/extract` route to `/souschef` across all nav links, header, side panel, and login redirects
- Add **Paste Text** tab to Sous Chef as the default landing tab — users can paste any recipe text and have it AI-formatted for zap.cooking
- Add `text` type support to the `extract-recipe` API (structured JSON output, 10K char limit)
- Add `format` mode to the Zappy API for future use

## Test plan
- [ ] Navigate to `/souschef` — should land on "Paste Text" tab by default
- [ ] Paste recipe text and click "Get Recipe" — should extract and populate the form
- [ ] Switch to "Upload Image" and "Paste URL" tabs — existing functionality works as before
- [ ] Verify header icon, side panel link, and membership page link all point to `/souschef`
- [ ] Verify `/extract` no longer resolves (or redirects if configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)