### PR TITLE
perf: Global feed race, default tab, relay list timeout + fallback spread

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.181",
+  "version": "4.2.182",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.182",
+  "version": "4.2.183",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.181",
+  "version": "4.2.179",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.179",
+  "version": "4.2.180",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.180",
+  "version": "4.2.181",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -2482,13 +2482,25 @@
 
       const allFetchedEvents: NDKEvent[] = [...hashtagEvents];
 
-      // Only run expensive content-word scanning if hashtag results are insufficient
-      if (!authorPubkey && hashtagEvents.length < 30) {
-        try {
-          const contentEvents = await fetchNotesWithoutHashtags(timeWindow.since);
-          allFetchedEvents.push(...contentEvents);
-        } catch {
-          // Non-critical supplementary fetch
+      // Run content-word scanning if hashtag results are insufficient OR stale.
+      // Many food posts don't use hashtags, so hashtag-only results can have a
+      // freshness gap (e.g., newest is 3+ hours old while unhashtagged food posts
+      // exist from minutes ago).
+      if (!authorPubkey) {
+        const newestHashtagTime = hashtagEvents.length > 0
+          ? Math.max(...hashtagEvents.map((e) => e.created_at || 0))
+          : 0;
+        const THIRTY_MINUTES = 30 * 60;
+        const now = Math.floor(Date.now() / 1000);
+        const resultsAreStale = newestHashtagTime > 0 && (now - newestHashtagTime) > THIRTY_MINUTES;
+
+        if (hashtagEvents.length < 30 || resultsAreStale) {
+          try {
+            const contentEvents = await fetchNotesWithoutHashtags(timeWindow.since);
+            allFetchedEvents.push(...contentEvents);
+          } catch {
+            // Non-critical supplementary fetch
+          }
         }
       }
 

--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -2792,6 +2792,75 @@
     });
 
     activeSubscriptions.push(hashtagSub);
+
+    // For Global mode: start periodic content-scan to catch food posts without hashtags.
+    // The realtime subscription only sees hashtagged posts; this fills the gap.
+    if (!authorPubkey && filterMode === 'global') {
+      startPeriodicContentRefresh();
+    }
+  }
+
+  // ─── Periodic content refresh for Global feed ───────────────
+  let contentRefreshTimer: ReturnType<typeof setInterval> | null = null;
+  const CONTENT_REFRESH_INTERVAL_MS = 60_000; // every 60s
+
+  function startPeriodicContentRefresh() {
+    stopPeriodicContentRefresh();
+    contentRefreshTimer = setInterval(runContentRefresh, CONTENT_REFRESH_INTERVAL_MS);
+  }
+
+  function stopPeriodicContentRefresh() {
+    if (contentRefreshTimer) {
+      clearInterval(contentRefreshTimer);
+      contentRefreshTimer = null;
+    }
+  }
+
+  async function runContentRefresh() {
+    if (isDestroyed || filterMode !== 'global' || !$ndk) return;
+
+    try {
+      // Fetch recent notes (last 10 minutes) and client-side filter for food content
+      const tenMinutesAgo = Math.floor(Date.now() / 1000) - 600;
+      const since = Math.max(tenMinutesAgo, lastEventTime + 1);
+      const contentEvents = await fetchNotesWithoutHashtags(since);
+
+      if (isDestroyed || filterMode !== 'global') return;
+
+      // Get followed users to exclude from Global feed
+      const followedSet = new Set(followedPubkeysForRealtime);
+
+      const newEvents = contentEvents.filter((e) => {
+        if (seenEventIds.has(e.id)) return false;
+        if (isReply(e)) return false;
+        if (!shouldIncludeEvent(e)) return false;
+        if (followedSet.size > 0) {
+          const authorKey = e.author?.hexpubkey || e.pubkey;
+          if (authorKey && followedSet.has(authorKey)) return false;
+        }
+        return true;
+      });
+
+      if (newEvents.length > 0) {
+        for (const e of newEvents) {
+          seenEventIds.add(e.id);
+        }
+
+        if (isScrolledToTop) {
+          events = dedupeAndSort([...newEvents, ...events]);
+        } else {
+          pendingNewEvents = [...pendingNewEvents, ...newEvents];
+          showNewPostsButton = true;
+        }
+
+        const maxTime = Math.max(...newEvents.map((e) => e.created_at || 0));
+        if (maxTime > lastEventTime) lastEventTime = maxTime;
+
+        await cacheEvents();
+      }
+    } catch {
+      // Non-critical background refresh
+    }
   }
 
   function handleRealtimeEvent(event: NDKEvent) {
@@ -3489,6 +3558,7 @@
       }
     }
     activeSubscriptions = [];
+    stopPeriodicContentRefresh();
   }
 
   async function cleanup() {


### PR DESCRIPTION
## Summary

Follow-up to #285. Feed performance and freshness improvements based on production log analysis.

### Changes

**Performance**
- **Default to Global tab**: Changed default from 'following' to 'global' — faster load, more variety on login
- **Race Primal vs relay pools for Global feed**: Both start concurrently instead of sequential fallback. When Primal fails (common — its `explore_global_latest` API returns 'unknown api request'), relay pool results are already ready. Cuts worst-case from ~7s to ~3s.
- **Cap relay list fetch at 4s**: NIP-65 resolution for 1000+ follows could hang 15s+ on cold cache. Now proceeds with partial results after 4s.
- **Spread fallback authors across relays**: Round-robin distribution instead of dumping all into 1 relay (coverage-dedup was collapsing to single relay)

**Freshness**
- **Supplement stale hashtag results**: Content-word scanning now also runs when newest hashtag result is >30 min old (was: only when <30 results). Catches recent food posts without hashtags.
- **Periodic content refresh** (every 60s): Realtime subscription only sees hashtagged posts. New 60s interval fetches recent unhashtagged food posts via content-word scanning and merges them into the feed. Respects scroll position (auto-prepend vs "new posts" button).

**Bug fixes**
- Fix null crash: `fetchGlobalFromPrimal` returning null caused `Cannot destructure property 'events'`
- Align Primal `since` with 3-day `timeWindow.since` for following/replies (was using 7-day `sevenDaysAgo()`)
- Swallow outbox rejections in race patterns so outbox errors don't abort Primal fast path
- Guard `mergeOutboxInBackground` against stale mode / destroyed component

## Test plan

- [ ] Global feed loads quickly (~2-3s even when Primal is down)
- [ ] Global feed shows recent posts (not just 3+ hours old)
- [ ] New food posts appear within 60s of publishing (periodic refresh)
- [ ] "New posts" button appears when scrolled down, auto-prepends when at top
- [ ] Following feed uses 3-day window consistently (Primal + outbox aligned)
- [ ] Tab switching doesn't merge stale events from background processes
- [ ] Periodic refresh stops on tab switch / component destroy

🤖 Generated with [Claude Code](https://claude.com/claude-code)