### PR TITLE
feat: Nourish shared analysis layer — analyze once, serve all viewers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.189",
+  "version": "4.2.190",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.185",
+  "version": "4.2.186",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.190",
+  "version": "4.2.191",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.188",
+  "version": "4.2.189",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.187",
+  "version": "4.2.188",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.183",
+  "version": "4.2.184",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.186",
+  "version": "4.2.187",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.184",
+  "version": "4.2.185",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/Recipe/Recipe.svelte
+++ b/src/components/Recipe/Recipe.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { NDKEvent } from '@nostr-dev-kit/ndk';
+  import { browser } from '$app/environment';
   import TagLinks from './TagLinks.svelte';
   import { ndk, userPublickey } from '$lib/nostr';
   import BookmarkIcon from 'phosphor-svelte/lib/BookmarkSimple';
@@ -92,8 +93,10 @@
   let nourishProtein: number | null = null;
   let nourishRealFood: number | null = null;
 
-  // Load Nourish score preview (non-blocking)
-  $: if (event && isActualRecipe) {
+  // Load Nourish score preview (non-blocking, client-only)
+  let lastNourishEventId: string | null = null;
+
+  $: if (browser && event && isActualRecipe) {
     loadNourishPreview();
   }
 
@@ -105,8 +108,19 @@
   }
 
   function loadNourishPreview() {
+    // Reset when event changes (e.g., recipe prop swap) to avoid showing stale scores
+    if (lastNourishEventId !== event.id) {
+      lastNourishEventId = event.id;
+      nourishPreviewScore = null;
+      nourishGut = null;
+      nourishProtein = null;
+      nourishRealFood = null;
+    }
+
+    const targetEventId = event.id;
+
     // Check localStorage first (instant)
-    const cached = getNourishCache(event.id);
+    const cached = getNourishCache(targetEventId);
     if (cached) {
       applyNourishScores(cached.scores);
       return;
@@ -116,6 +130,8 @@
     const recipeDTag = event.tags.find((t: string[]) => t[0] === 'd')?.[1] || '';
     if (recipePubkey && recipeDTag && $ndk) {
       fetchNourishEvent($ndk, recipePubkey, recipeDTag).then((result) => {
+        // Ignore stale result if event changed while fetching
+        if (event.id !== targetEventId) return;
         if (result) applyNourishScores(result.scores);
       }).catch(() => {});
     }

--- a/src/components/Recipe/Recipe.svelte
+++ b/src/components/Recipe/Recipe.svelte
@@ -827,7 +827,7 @@
             </button>
           </div>
           <div class="flex items-center gap-2">
-          <!-- Nourish pill — first-class product layer, visually separated from actions -->
+          <!-- Nourish — first-class product layer, visually separated from actions -->
           {#if isActualRecipe}
             {#if nourishPreviewScore !== null}
               <NourishPill
@@ -835,14 +835,13 @@
                 gut={nourishGut}
                 protein={nourishProtein}
                 realFood={nourishRealFood}
-                mode="expand"
                 onClick={() => { nourishModalOpen = true; }}
               />
             {:else}
               <button
                 class="nourish-btn-empty"
                 on:click={() => { nourishModalOpen = true; }}
-                aria-label="Nourish — analyze this recipe"
+                aria-label="Nourish — explore this recipe's profile"
                 title="Nourish"
               >
                 <LeafIcon size={18} weight="regular" />

--- a/src/components/Recipe/Recipe.svelte
+++ b/src/components/Recipe/Recipe.svelte
@@ -57,6 +57,8 @@
   import { GATED_RECIPE_KIND } from '$lib/consts';
   import LeafIcon from 'phosphor-svelte/lib/Leaf';
   import NourishModal from '../nourish/NourishModal.svelte';
+  import { fetchNourishEvent } from '$lib/nourish/nourishRelay';
+  import { getNourishCache } from '$lib/nourish/cache';
   import { membershipStatusMap, queueMembershipLookup, type MembershipStatus } from '$lib/stores/membershipStatus';
 
   export let event: NDKEvent;
@@ -84,6 +86,29 @@
   let isDeleting = false;
   let isEditingRecipe = false;
   let nourishModalOpen = false;
+  let nourishPreviewScore: number | null = null;
+
+  // Load Nourish score preview (non-blocking)
+  $: if (event && isActualRecipe) {
+    loadNourishPreview();
+  }
+
+  function loadNourishPreview() {
+    // Check localStorage first (instant)
+    const cached = getNourishCache(event.id);
+    if (cached) {
+      nourishPreviewScore = cached.scores.overall.score;
+      return;
+    }
+    // Check relay in background
+    const recipePubkey = event.author?.hexpubkey || event.pubkey;
+    const recipeDTag = event.tags.find((t: string[]) => t[0] === 'd')?.[1] || '';
+    if (recipePubkey && recipeDTag && $ndk) {
+      fetchNourishEvent($ndk, recipePubkey, recipeDTag).then((result) => {
+        if (result) nourishPreviewScore = result.scores.overall.score;
+      }).catch(() => {});
+    }
+  }
 
   // Membership check for Nourish
   let membershipMap: Record<string, MembershipStatus> = {};
@@ -791,15 +816,18 @@
             </button>
           </div>
           <div class="flex items-center gap-1">
-          <!-- Nourish button -->
+          <!-- Nourish button with score preview -->
           {#if isActualRecipe}
             <button
-              class="cursor-pointer hover:bg-input rounded p-1 transition duration-300 text-green-500"
+              class="nourish-btn"
               on:click={() => { nourishModalOpen = true; }}
               aria-label="Nourish scores"
-              title="Nourish"
+              title={nourishPreviewScore !== null ? `Nourish ${nourishPreviewScore}/10` : 'Nourish'}
             >
               <LeafIcon size={24} />
+              {#if nourishPreviewScore !== null}
+                <span class="nourish-badge">{nourishPreviewScore}</span>
+              {/if}
             </button>
           {/if}
           <!-- 3-dot menu for recipe actions -->
@@ -1124,6 +1152,39 @@
 </article>
 
 <style>
+  /* Nourish button with score badge */
+  .nourish-btn {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    padding: 0.25rem;
+    border-radius: 0.375rem;
+    transition: background-color 300ms;
+    color: #22c55e;
+  }
+  .nourish-btn:hover {
+    background-color: var(--color-input-bg);
+  }
+  .nourish-badge {
+    position: absolute;
+    bottom: -2px;
+    right: -4px;
+    font-size: 0.625rem;
+    font-weight: 700;
+    line-height: 1;
+    min-width: 14px;
+    height: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 9999px;
+    background: #22c55e;
+    color: white;
+    pointer-events: none;
+  }
+
   /* Dark mode support for prose content */
   :global(.prose) {
     color: var(--color-text-primary);

--- a/src/components/Recipe/Recipe.svelte
+++ b/src/components/Recipe/Recipe.svelte
@@ -57,6 +57,7 @@
   import { GATED_RECIPE_KIND } from '$lib/consts';
   import LeafIcon from 'phosphor-svelte/lib/Leaf';
   import NourishModal from '../nourish/NourishModal.svelte';
+  import NourishPill from '../nourish/NourishPill.svelte';
   import { fetchNourishEvent } from '$lib/nourish/nourishRelay';
   import { getNourishCache } from '$lib/nourish/cache';
   import { membershipStatusMap, queueMembershipLookup, type MembershipStatus } from '$lib/stores/membershipStatus';
@@ -87,17 +88,27 @@
   let isEditingRecipe = false;
   let nourishModalOpen = false;
   let nourishPreviewScore: number | null = null;
+  let nourishGut: number | null = null;
+  let nourishProtein: number | null = null;
+  let nourishRealFood: number | null = null;
 
   // Load Nourish score preview (non-blocking)
   $: if (event && isActualRecipe) {
     loadNourishPreview();
   }
 
+  function applyNourishScores(scores: import('$lib/nourish/types').NourishScores) {
+    nourishPreviewScore = scores.overall.score;
+    nourishGut = scores.gut.score;
+    nourishProtein = scores.protein.score;
+    nourishRealFood = scores.realFood.score;
+  }
+
   function loadNourishPreview() {
     // Check localStorage first (instant)
     const cached = getNourishCache(event.id);
     if (cached) {
-      nourishPreviewScore = cached.scores.overall.score;
+      applyNourishScores(cached.scores);
       return;
     }
     // Check relay in background
@@ -105,7 +116,7 @@
     const recipeDTag = event.tags.find((t: string[]) => t[0] === 'd')?.[1] || '';
     if (recipePubkey && recipeDTag && $ndk) {
       fetchNourishEvent($ndk, recipePubkey, recipeDTag).then((result) => {
-        if (result) nourishPreviewScore = result.scores.overall.score;
+        if (result) applyNourishScores(result.scores);
       }).catch(() => {});
     }
   }
@@ -815,20 +826,28 @@
               {/if}
             </button>
           </div>
-          <div class="flex items-center gap-1">
-          <!-- Nourish button with score preview -->
+          <div class="flex items-center gap-2">
+          <!-- Nourish pill — first-class product layer, visually separated from actions -->
           {#if isActualRecipe}
-            <button
-              class="nourish-btn"
-              on:click={() => { nourishModalOpen = true; }}
-              aria-label="Nourish scores"
-              title={nourishPreviewScore !== null ? `Nourish ${nourishPreviewScore}/10` : 'Nourish'}
-            >
-              <LeafIcon size={24} />
-              {#if nourishPreviewScore !== null}
-                <span class="nourish-badge">{nourishPreviewScore}</span>
-              {/if}
-            </button>
+            {#if nourishPreviewScore !== null}
+              <NourishPill
+                overall={nourishPreviewScore}
+                gut={nourishGut}
+                protein={nourishProtein}
+                realFood={nourishRealFood}
+                mode="expand"
+                onClick={() => { nourishModalOpen = true; }}
+              />
+            {:else}
+              <button
+                class="nourish-btn-empty"
+                on:click={() => { nourishModalOpen = true; }}
+                aria-label="Nourish — analyze this recipe"
+                title="Nourish"
+              >
+                <LeafIcon size={18} weight="regular" />
+              </button>
+            {/if}
           {/if}
           <!-- 3-dot menu for recipe actions -->
           <div class="relative">
@@ -1152,37 +1171,22 @@
 </article>
 
 <style>
-  /* Nourish button with score badge */
-  .nourish-btn {
-    position: relative;
+  /* Nourish empty state — subtle leaf for un-analyzed recipes */
+  .nourish-btn-empty {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     cursor: pointer;
     padding: 0.25rem;
     border-radius: 0.375rem;
-    transition: background-color 300ms;
-    color: #22c55e;
+    transition: background-color 150ms, color 150ms;
+    color: var(--color-text-secondary);
+    opacity: 0.5;
   }
-  .nourish-btn:hover {
+  .nourish-btn-empty:hover {
     background-color: var(--color-input-bg);
-  }
-  .nourish-badge {
-    position: absolute;
-    bottom: -2px;
-    right: -4px;
-    font-size: 0.625rem;
-    font-weight: 700;
-    line-height: 1;
-    min-width: 14px;
-    height: 14px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 9999px;
-    background: #22c55e;
-    color: white;
-    pointer-events: none;
+    color: #22c55e;
+    opacity: 1;
   }
 
   /* Dark mode support for prose content */

--- a/src/components/nourish/NourishDimensionBar.svelte
+++ b/src/components/nourish/NourishDimensionBar.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+  /**
+   * NourishDimensionBar — single expandable dimension row.
+   *
+   * Shows icon + label + bar by default.
+   * Tap/click expands to reveal the reason text and numeric score.
+   * No numeric score visible in collapsed state — bars show the profile shape.
+   */
+
+  import CaretDownIcon from 'phosphor-svelte/lib/CaretDown';
+
+  export let icon: string = '🌱';
+  export let label: string = '';
+  export let score: number = 0;
+  export let reason: string = '';
+
+  let expanded = false;
+
+  function toggle() {
+    if (reason) expanded = !expanded;
+  }
+</script>
+
+<button
+  class="dim-row"
+  class:expandable={!!reason}
+  class:expanded
+  on:click={toggle}
+  aria-expanded={reason ? expanded : undefined}
+  aria-label="{label} — tap to learn more"
+>
+  <span class="dim-icon">{icon}</span>
+  <span class="dim-label">{label}</span>
+  <div class="dim-track">
+    <div class="dim-fill" style="width: {score * 10}%;" />
+  </div>
+  {#if reason}
+    <span class="dim-caret" class:expanded>
+      <CaretDownIcon size={10} weight="bold" />
+    </span>
+  {/if}
+</button>
+
+{#if expanded && reason}
+  <div class="dim-detail">
+    <span class="dim-score">{score}<span class="dim-score-max">/10</span></span>
+    <p class="dim-reason">{reason}</p>
+  </div>
+{/if}
+
+<style>
+  .dim-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0;
+    width: 100%;
+    border: none;
+    background: none;
+    cursor: default;
+    font-family: inherit;
+    text-align: left;
+    transition: opacity 150ms;
+  }
+  .dim-row.expandable {
+    cursor: pointer;
+  }
+  .dim-row.expandable:hover {
+    opacity: 0.85;
+  }
+
+  .dim-icon {
+    font-size: 0.875rem;
+    width: 20px;
+    text-align: center;
+    flex-shrink: 0;
+  }
+
+  .dim-label {
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--color-text-primary);
+    width: 72px;
+    flex-shrink: 0;
+  }
+
+  .dim-track {
+    flex: 1;
+    height: 6px;
+    border-radius: 3px;
+    background: var(--color-bg-tertiary, rgba(255, 255, 255, 0.06));
+    overflow: hidden;
+  }
+
+  .dim-fill {
+    height: 100%;
+    border-radius: 3px;
+    background: #22c55e;
+    opacity: 0.65;
+    transition: width 500ms ease-out;
+  }
+
+  .dim-caret {
+    display: flex;
+    color: var(--color-text-secondary);
+    opacity: 0.4;
+    transition: transform 200ms ease;
+    flex-shrink: 0;
+  }
+  .dim-caret.expanded {
+    transform: rotate(180deg);
+    opacity: 0.7;
+  }
+
+  .dim-detail {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    padding: 0 0 0.5rem 2rem;
+    animation: dim-expand 150ms ease-out;
+  }
+
+  @keyframes dim-expand {
+    from { opacity: 0; transform: translateY(-4px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  .dim-score {
+    font-size: 0.875rem;
+    font-weight: 700;
+    color: #22c55e;
+    flex-shrink: 0;
+    line-height: 1.4;
+  }
+  .dim-score-max {
+    font-size: 0.625rem;
+    font-weight: 400;
+    color: var(--color-text-secondary);
+  }
+
+  .dim-reason {
+    font-size: 0.75rem;
+    line-height: 1.5;
+    color: var(--color-text-secondary);
+    margin: 0;
+  }
+</style>

--- a/src/components/nourish/NourishInputTabs.svelte
+++ b/src/components/nourish/NourishInputTabs.svelte
@@ -1,0 +1,206 @@
+<script lang="ts">
+  /**
+   * NourishInputTabs — segmented input control.
+   *
+   * Three modes: Ingredients / Describe a Dish / Photo
+   * Each has contextual placeholder text and examples.
+   */
+
+  import NourishPhotoInput from './NourishPhotoInput.svelte';
+  import LeafIcon from 'phosphor-svelte/lib/Leaf';
+
+  export let text: string = '';
+  export let imageData: string | null = null;
+  export let disabled: boolean = false;
+
+  type TabId = 'ingredients' | 'describe' | 'photo';
+  export let activeTab: TabId = 'ingredients';
+
+  const TABS: { id: TabId; label: string }[] = [
+    { id: 'ingredients', label: 'Ingredients' },
+    { id: 'describe', label: 'Describe' },
+    { id: 'photo', label: 'Photo' }
+  ];
+
+  const PLACEHOLDERS: Record<TabId, string> = {
+    ingredients: 'chicken thighs, sweet potato, kale, olive oil, garlic...',
+    describe: 'A bowl of oatmeal with banana, walnuts, and honey...',
+    photo: ''
+  };
+
+  const EXAMPLES: Record<TabId, string[]> = {
+    ingredients: [
+      'Greek yogurt, berries, walnuts',
+      'Eggs, sourdough, avocado',
+      'Rice, beans, chicken, salsa'
+    ],
+    describe: [
+      'Homemade ramen with soft egg and greens',
+      'Sheet pan salmon with roasted vegetables',
+      'Smoothie bowl with fruit and granola'
+    ],
+    photo: []
+  };
+
+  function useExample(example: string) {
+    text = example;
+  }
+
+  $: currentExamples = EXAMPLES[activeTab];
+  $: hasInput = text.trim().length > 0 || imageData !== null;
+</script>
+
+<div class="nit-wrapper">
+  <!-- Segmented control -->
+  <div class="nit-tabs" role="tablist">
+    {#each TABS as tab}
+      <button
+        role="tab"
+        class="nit-tab"
+        class:active={activeTab === tab.id}
+        aria-selected={activeTab === tab.id}
+        on:click={() => { activeTab = tab.id; }}
+        {disabled}
+      >
+        {tab.label}
+      </button>
+    {/each}
+  </div>
+
+  <!-- Input area -->
+  <div class="nit-input" role="tabpanel">
+    {#if activeTab === 'photo'}
+      <NourishPhotoInput bind:imageData {disabled} />
+    {:else}
+      <textarea
+        class="nit-textarea"
+        bind:value={text}
+        placeholder={PLACEHOLDERS[activeTab]}
+        rows={4}
+        {disabled}
+      />
+    {/if}
+  </div>
+
+  <!-- Contextual examples -->
+  {#if currentExamples.length > 0 && !hasInput}
+    <div class="nit-examples">
+      <span class="nit-examples-label">Try:</span>
+      {#each currentExamples as example}
+        <button
+          class="nit-example"
+          on:click={() => useExample(example)}
+          {disabled}
+        >
+          {example}
+        </button>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .nit-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  /* Segmented control */
+  .nit-tabs {
+    display: flex;
+    border-radius: 0.5rem;
+    border: 1px solid var(--color-input-border, rgba(255, 255, 255, 0.08));
+    overflow: hidden;
+    background: var(--color-input-bg, rgba(255, 255, 255, 0.02));
+  }
+
+  .nit-tab {
+    flex: 1;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    font-family: inherit;
+    color: var(--color-text-secondary);
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    transition: background 150ms, color 150ms;
+    position: relative;
+  }
+  .nit-tab:not(:last-child)::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    top: 20%;
+    height: 60%;
+    width: 1px;
+    background: var(--color-input-border, rgba(255, 255, 255, 0.06));
+  }
+  .nit-tab.active {
+    background: rgba(34, 197, 94, 0.1);
+    color: #22c55e;
+    font-weight: 600;
+  }
+  .nit-tab.active::after {
+    display: none;
+  }
+  .nit-tab:hover:not(.active):not(:disabled) {
+    background: rgba(255, 255, 255, 0.03);
+  }
+
+  /* Textarea */
+  .nit-textarea {
+    width: 100%;
+    padding: 0.75rem;
+    border-radius: 0.5rem;
+    border: 1px solid var(--color-input-border, rgba(255, 255, 255, 0.08));
+    background: var(--color-input-bg, rgba(255, 255, 255, 0.02));
+    color: var(--color-text-primary);
+    font-size: 1rem; /* 16px prevents iOS zoom */
+    font-family: inherit;
+    line-height: 1.5;
+    resize: vertical;
+    transition: border-color 150ms;
+  }
+  .nit-textarea::placeholder {
+    color: var(--color-text-secondary);
+    opacity: 0.5;
+  }
+  .nit-textarea:focus {
+    outline: none;
+    border-color: rgba(34, 197, 94, 0.4);
+  }
+
+  /* Examples */
+  .nit-examples {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.375rem;
+  }
+
+  .nit-examples-label {
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+    opacity: 0.5;
+  }
+
+  .nit-example {
+    font-size: 0.75rem;
+    padding: 0.25rem 0.625rem;
+    border-radius: 9999px;
+    border: 1px solid var(--color-input-border, rgba(255, 255, 255, 0.08));
+    background: var(--color-input-bg, rgba(255, 255, 255, 0.02));
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    font-family: inherit;
+    transition: background 150ms, border-color 150ms, color 150ms;
+    white-space: nowrap;
+  }
+  .nit-example:hover {
+    background: rgba(34, 197, 94, 0.06);
+    border-color: rgba(34, 197, 94, 0.2);
+    color: #22c55e;
+  }
+</style>

--- a/src/components/nourish/NourishModal.svelte
+++ b/src/components/nourish/NourishModal.svelte
@@ -1,16 +1,18 @@
 <script lang="ts">
 	import type { NDKEvent } from '@nostr-dev-kit/ndk';
-	import { userPublickey } from '$lib/nostr';
+	import { ndk, userPublickey } from '$lib/nostr';
 	import Modal from '../Modal.svelte';
 	import Button from '../Button.svelte';
 	import LeafIcon from 'phosphor-svelte/lib/Leaf';
 	import LockIcon from 'phosphor-svelte/lib/Lock';
 	import SpinnerIcon from 'phosphor-svelte/lib/SpinnerGap';
 	import CaretDownIcon from 'phosphor-svelte/lib/CaretDown';
+	import ArrowClockwiseIcon from 'phosphor-svelte/lib/ArrowClockwise';
 	import { parseMarkdownForEditing } from '$lib/parser';
-	import { getNourishScores, setNourishScores } from '$lib/nourish/cache';
+	import { getNourishCache, setNourishScores } from '$lib/nourish/cache';
 	import { generateSuggestions, mergeImprovements } from '$lib/nourish/suggestions';
 	import { ingredientStore } from '$lib/nourish/ingredientStore';
+	import { fetchNourishEvent, isNourishStale, computeContentHash } from '$lib/nourish/nourishRelay';
 	import type { NourishScores } from '$lib/nourish/types';
 
 	export let open = false;
@@ -20,22 +22,89 @@
 	let scores: NourishScores | null = null;
 	let improvements: string[] = [];
 	let loading = false;
+	let checking = false;
+	let stale = false;
+	let analyzedAt = 0;
 	let error = '';
 	let expandedScore: string | null = null;
 
-	$: if (open && hasMembership && !scores && !loading) { fetchScores(); }
-	$: if (!open) { error = ''; expandedScore = null; }
+	// Open modal: anyone can VIEW existing scores, only members can GENERATE new ones
+	$: if (open && !scores && !loading && !checking) { fetchScores(); }
+	$: if (!open) { error = ''; expandedScore = null; stale = false; }
 
 	function toggleExpand(key: string) {
 		expandedScore = expandedScore === key ? null : key;
 	}
 
-	async function fetchScores() {
-		const cached = getNourishScores(event.id);
-		if (cached) { scores = cached; buildImprovements(cached); return; }
+	function getRecipeCoordinates() {
+		const recipePubkey = event.author?.hexpubkey || event.pubkey;
+		const recipeDTag = event.tags.find((t) => t[0] === 'd')?.[1] || '';
+		return { recipePubkey, recipeDTag };
+	}
 
+	async function fetchScores() {
+		// 1. Check localStorage cache (instant)
+		const cached = getNourishCache(event.id);
+		if (cached) {
+			scores = cached.scores;
+			improvements = [];
+			buildImprovements(cached.scores, cached.improvements);
+			// Check staleness against current content if we have a hash
+			if (cached.contentHash) {
+				computeContentHash(event.content || '').then((currentHash) => {
+					if (currentHash !== cached.contentHash) {
+						stale = true;
+					}
+				}).catch(() => {});
+			}
+			analyzedAt = cached.timestamp ? Math.floor(cached.timestamp / 1000) : 0;
+			return;
+		}
+
+		// 2. Check pantry relay for existing analysis (fast, ~200ms)
+		checking = true;
+		error = '';
+		try {
+			const { recipePubkey, recipeDTag } = getRecipeCoordinates();
+			if (recipePubkey && recipeDTag && $ndk) {
+				const relayResult = await fetchNourishEvent($ndk, recipePubkey, recipeDTag);
+				if (relayResult) {
+					scores = relayResult.scores;
+					buildImprovements(relayResult.scores, relayResult.improvements);
+					analyzedAt = relayResult.createdAt;
+
+					// Cache locally for next time
+					setNourishScores(event.id, relayResult.scores, {
+						contentHash: relayResult.contentHash,
+						improvements: relayResult.improvements,
+						ingredientSignals: relayResult.ingredientSignals
+					});
+
+					// Check staleness
+					const isStale = await isNourishStale(relayResult, event.content || '');
+					stale = isStale;
+
+					checking = false;
+					return;
+				}
+			}
+		} catch {
+			// Relay query failed — fall through to API
+		}
+		checking = false;
+
+		// 3. No existing analysis — call API (requires membership)
+		if (!hasMembership) {
+			// No cached score and no membership — show lock state
+			return;
+		}
+		await analyzeRecipe();
+	}
+
+	async function analyzeRecipe() {
 		loading = true;
 		error = '';
+		stale = false;
 		try {
 			const title = event.tags.find((t) => t[0] === 'title')?.[1] || event.tags.find((t) => t[0] === 'd')?.[1] || '';
 			const tags = event.tags.filter((t) => t[0] === 't' && t[1]).map((t) => t[1]);
@@ -44,16 +113,35 @@
 
 			if (info.ingredients.length === 0) { error = 'No ingredients found in this recipe.'; loading = false; return; }
 
+			// Compute content hash for staleness tracking
+			const contentHash = await computeContentHash(event.content || '');
+			const { recipePubkey, recipeDTag } = getRecipeCoordinates();
+
 			const res = await fetch('/api/nourish', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ pubkey: $userPublickey || '', eventId: event.id, title, ingredients: info.ingredients, tags, servings })
+				body: JSON.stringify({
+					pubkey: $userPublickey || '',
+					eventId: event.id,
+					title,
+					ingredients: info.ingredients,
+					tags,
+					servings,
+					recipePubkey,
+					recipeDTag,
+					contentHash
+				})
 			});
 			const data = await res.json();
 			if (!data.success) { error = data.error || 'Failed to analyze recipe.'; return; }
 
 			scores = data.scores;
-			setNourishScores(event.id, data.scores);
+			analyzedAt = Math.floor(Date.now() / 1000);
+			setNourishScores(event.id, data.scores, {
+				contentHash,
+				improvements: data.improvements,
+				ingredientSignals: data.ingredient_signals
+			});
 			buildImprovements(data.scores, data.improvements);
 
 			if (data.ingredient_signals?.length > 0) {
@@ -69,13 +157,24 @@
 		improvements = mergeImprovements(generateSuggestions(s), llm || []);
 	}
 
-	function retry() { scores = null; fetchScores(); }
+	function retry() { scores = null; analyzeRecipe(); }
+
+	function reanalyze() { scores = null; stale = false; analyzeRecipe(); }
+
+	function formatAnalyzedAt(ts: number): string {
+		if (!ts) return '';
+		const diff = Math.floor(Date.now() / 1000) - ts;
+		if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+		if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+		if (diff < 604800) return `${Math.floor(diff / 86400)}d ago`;
+		return new Date(ts * 1000).toLocaleDateString();
+	}
 </script>
 
 <Modal bind:open compact noHeader>
 	<h2 id="title" class="sr-only">Nourish analysis</h2>
-	{#if !hasMembership}
-		<!-- Lock state -->
+	{#if !hasMembership && !scores && !checking}
+		<!-- Lock state — only shown if no existing scores exist -->
 		<div class="lock-state">
 			<div class="lock-icon-wrap">
 				<LockIcon size={24} weight="fill" class="text-orange-500" />
@@ -83,6 +182,12 @@
 			<h3 class="lock-title">Unlock Nourish</h3>
 			<p class="lock-desc">See how this recipe scores for gut health, protein, and real food quality.</p>
 			<a href="/membership" class="w-full"><Button primary>View Membership</Button></a>
+		</div>
+
+	{:else if checking}
+		<div class="loading-state">
+			<SpinnerIcon size={28} class="animate-spin text-green-500" />
+			<p class="loading-text">Checking for analysis...</p>
 		</div>
 
 	{:else if loading}
@@ -98,6 +203,19 @@
 		</div>
 
 	{:else if scores}
+		<!-- ── Stale banner ── -->
+		{#if stale}
+			<div class="stale-banner">
+				<p class="stale-text">Recipe updated since this analysis</p>
+				{#if hasMembership}
+					<button class="stale-refresh" on:click={reanalyze}>
+						<ArrowClockwiseIcon size={14} />
+						Re-analyze
+					</button>
+				{/if}
+			</div>
+		{/if}
+
 		<!-- ── Hero: Overall Score ── -->
 		<div class="hero-score">
 			<div class="hero-icon">
@@ -159,6 +277,9 @@
 			<p class="footer-philosophy">Nourish helps you understand what a meal leans toward — so you can adjust, not judge.</p>
 			<p class="footer-disclaimer">
 				Estimates based on ingredients. Not medical advice.
+				{#if analyzedAt}
+					Analyzed {formatAnalyzedAt(analyzedAt)}.
+				{/if}
 				<a href="/nourish" class="footer-link">Learn more</a>
 			</p>
 		</div>
@@ -176,6 +297,21 @@
 	}
 	.lock-title { @apply text-lg font-semibold; color: var(--color-text-primary); }
 	.lock-desc { @apply text-sm; color: var(--color-text-secondary); }
+
+	/* ── Stale banner ── */
+	.stale-banner {
+		@apply flex items-center justify-between gap-2 px-3 py-2 rounded-lg mb-3 text-xs;
+		background-color: rgba(234, 179, 8, 0.1);
+		border: 1px solid rgba(234, 179, 8, 0.2);
+	}
+	.stale-text { color: var(--color-text-secondary); }
+	.stale-refresh {
+		@apply inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-medium cursor-pointer whitespace-nowrap;
+		color: #eab308;
+		background: rgba(234, 179, 8, 0.1);
+		border: none;
+	}
+	.stale-refresh:hover { background: rgba(234, 179, 8, 0.2); }
 
 	/* ── Loading / Error ── */
 	.loading-state { @apply flex flex-col items-center gap-3 py-8; }

--- a/src/components/nourish/NourishModal.svelte
+++ b/src/components/nourish/NourishModal.svelte
@@ -6,7 +6,7 @@
 	import LeafIcon from 'phosphor-svelte/lib/Leaf';
 	import LockIcon from 'phosphor-svelte/lib/Lock';
 	import SpinnerIcon from 'phosphor-svelte/lib/SpinnerGap';
-	import CaretDownIcon from 'phosphor-svelte/lib/CaretDown';
+	// CaretDownIcon no longer needed — NourishResult handles expand
 	import ArrowClockwiseIcon from 'phosphor-svelte/lib/ArrowClockwise';
 	import { parseMarkdownForEditing } from '$lib/parser';
 	import { getNourishCache, setNourishScores } from '$lib/nourish/cache';
@@ -14,6 +14,7 @@
 	import { ingredientStore } from '$lib/nourish/ingredientStore';
 	import { fetchNourishEvent, isNourishStale, computeContentHash } from '$lib/nourish/nourishRelay';
 	import type { NourishScores } from '$lib/nourish/types';
+	import NourishResult from './NourishResult.svelte';
 
 	export let open = false;
 	export let event: NDKEvent;
@@ -26,15 +27,9 @@
 	let stale = false;
 	let analyzedAt = 0;
 	let error = '';
-	let expandedScore: string | null = null;
-
 	// Open modal: anyone can VIEW existing scores, only members can GENERATE new ones
 	$: if (open && !scores && !loading && !checking) { fetchScores(); }
-	$: if (!open) { error = ''; expandedScore = null; stale = false; }
-
-	function toggleExpand(key: string) {
-		expandedScore = expandedScore === key ? null : key;
-	}
+	$: if (!open) { error = ''; stale = false; }
 
 	function getRecipeCoordinates() {
 		const recipePubkey = event.author?.hexpubkey || event.pubkey;
@@ -210,81 +205,28 @@
 		<!-- ── Stale banner ── -->
 		{#if stale}
 			<div class="stale-banner">
-				<p class="stale-text">Recipe updated since this analysis</p>
+				<p class="stale-text">This recipe has been updated since this profile was created.</p>
 				{#if hasMembership}
 					<button class="stale-refresh" on:click={reanalyze}>
 						<ArrowClockwiseIcon size={14} />
-						Re-analyze
+						Refresh
 					</button>
 				{/if}
 			</div>
 		{/if}
 
-		<!-- ── Hero: Overall Score ── -->
-		<div class="hero-score">
-			<div class="hero-icon">
-				<LeafIcon size={20} weight="fill" class="text-green-500" />
-			</div>
-			<div class="hero-number" style="color: #a855f7;">
-				{scores.overall?.score ?? '—'}<span class="hero-max">/10</span>
-			</div>
-			<div class="hero-label">{scores.overall?.label ?? ''}</div>
-			{#if scores.summary}
-				<p class="hero-summary">{scores.summary}</p>
-			{/if}
-		</div>
+		<NourishResult
+			{scores}
+			{improvements}
+			compact
+		/>
 
-		<!-- ── Subscores ── -->
-		<div class="subscores">
-			{#each [
-				{ key: 'realFood', label: 'Real Food', color: '#f97316', detail: scores.realFood },
-				{ key: 'gut', label: 'Gut', color: '#22c55e', detail: scores.gut },
-				{ key: 'protein', label: 'Protein', color: '#3b82f6', detail: scores.protein }
-			] as item}
-				<button
-					class="subscore-row"
-					on:click={() => toggleExpand(item.key)}
-					aria-expanded={expandedScore === item.key}
-				>
-					<div class="subscore-info">
-						<span class="subscore-label">{item.label}</span>
-						<span class="subscore-value" style="color: {item.color};">
-							{item.detail.score}<span class="subscore-max">/10</span>
-						</span>
-					</div>
-					<div class="subscore-bar-track">
-						<div class="subscore-bar-fill" style="width: {item.detail.score * 10}%; background: {item.color};" />
-					</div>
-					<div class="subscore-expand-hint">
-						<span class="subscore-tag">{item.detail.label}</span>
-						<span class="expand-caret" class:expanded={expandedScore === item.key}><CaretDownIcon size={12} /></span>
-					</div>
-				</button>
-				{#if expandedScore === item.key && item.detail.reason}
-					<p class="subscore-reason">{item.detail.reason}</p>
-				{/if}
-			{/each}
-		</div>
-
-		<!-- ── Improvements ── -->
-		{#if improvements.length > 0}
-			<div class="improvements">
-				<p class="improvements-title">Simple upgrades</p>
-				{#each improvements as s}
-					<div class="improvement-item">{s}</div>
-				{/each}
-			</div>
-		{/if}
-
-		<!-- ── Footer ── -->
 		<div class="modal-footer">
-			<p class="footer-philosophy">Nourish helps you understand what a meal leans toward — so you can adjust, not judge.</p>
 			<p class="footer-disclaimer">
-				Estimates based on ingredients. Not medical advice.
 				{#if analyzedAt}
 					Analyzed {formatAnalyzedAt(analyzedAt)}.
 				{/if}
-				<a href="/nourish" class="footer-link">Learn more</a>
+				<a href="/nourish" class="footer-link">Explore Nourish</a>
 			</p>
 		</div>
 	{/if}
@@ -323,108 +265,10 @@
 	.error-state { @apply flex flex-col items-center text-center gap-3 py-4; }
 	.error-text { @apply text-sm; color: var(--color-text-secondary); }
 
-	/* ── Hero score ── */
-	.hero-score {
-		@apply flex flex-col items-center text-center pb-4 mb-1;
-		border-bottom: 1px solid var(--color-bg-tertiary, rgba(255, 255, 255, 0.06));
-	}
-	.hero-icon { @apply mb-2; }
-	.hero-number {
-		@apply text-4xl font-bold leading-none;
-	}
-	.hero-max {
-		@apply text-base font-normal;
-		color: var(--color-text-secondary);
-	}
-	.hero-label {
-		@apply text-sm font-semibold mt-1;
-		color: var(--color-text-secondary);
-	}
-	.hero-summary {
-		@apply text-xs leading-relaxed mt-2 max-w-sm;
-		color: var(--color-text-secondary);
-		opacity: 0.8;
-	}
-
-	/* ── Subscores ── */
-	.subscores {
-		@apply flex flex-col py-2;
-	}
-	.subscore-row {
-		@apply w-full text-left py-2.5 cursor-pointer transition-colors;
-		border-bottom: 1px solid var(--color-bg-tertiary, rgba(255, 255, 255, 0.04));
-	}
-	.subscore-row:last-child { border-bottom: none; }
-	.subscore-row:hover { opacity: 0.9; }
-	.subscore-info {
-		@apply flex items-center justify-between mb-1.5;
-	}
-	.subscore-label {
-		@apply text-sm font-medium;
-		color: var(--color-text-primary);
-	}
-	.subscore-value {
-		@apply text-sm font-bold;
-	}
-	.subscore-max {
-		@apply text-xs font-normal;
-		color: var(--color-text-secondary);
-	}
-	.subscore-bar-track {
-		@apply w-full h-1 rounded-full mb-1.5;
-		background-color: var(--color-bg-tertiary, rgba(255, 255, 255, 0.06));
-	}
-	.subscore-bar-fill {
-		@apply h-full rounded-full transition-all duration-500 ease-out;
-	}
-	.subscore-expand-hint {
-		@apply flex items-center justify-between;
-	}
-	.subscore-tag {
-		@apply text-xs;
-		color: var(--color-text-secondary);
-		opacity: 0.7;
-	}
-	.expand-caret {
-		@apply inline-flex;
-		color: var(--color-text-secondary);
-		opacity: 0.4;
-		transition: transform 0.2s ease;
-	}
-	.expand-caret.expanded {
-		transform: rotate(180deg);
-	}
-	.subscore-reason {
-		@apply text-xs leading-relaxed pb-2 pl-0;
-		color: var(--color-text-secondary);
-		opacity: 0.8;
-		border-bottom: 1px solid var(--color-bg-tertiary, rgba(255, 255, 255, 0.04));
-	}
-
-	/* ── Improvements ── */
-	.improvements {
-		@apply pt-3 mt-1;
-		border-top: 1px solid var(--color-bg-tertiary, rgba(255, 255, 255, 0.06));
-	}
-	.improvements-title {
-		@apply text-sm font-semibold mb-2;
-		color: var(--color-text-primary);
-	}
-	.improvement-item {
-		@apply text-xs py-1.5 pl-3;
-		color: var(--color-text-secondary);
-		border-left: 2px solid var(--color-bg-tertiary, rgba(255, 255, 255, 0.1));
-	}
-
 	/* ── Footer ── */
 	.modal-footer {
 		@apply pt-3 mt-3 text-center;
 		border-top: 1px solid var(--color-bg-tertiary, rgba(255, 255, 255, 0.04));
-	}
-	.footer-philosophy {
-		@apply text-xs mb-1;
-		color: var(--color-text-secondary);
-		opacity: 0.6;
 	}
 	.footer-disclaimer {
 		@apply text-xs;

--- a/src/components/nourish/NourishModal.svelte
+++ b/src/components/nourish/NourishModal.svelte
@@ -76,9 +76,13 @@
 					// Cache locally for next time
 					setNourishScores(event.id, relayResult.scores, {
 						contentHash: relayResult.contentHash,
-						improvements: relayResult.improvements,
-						ingredientSignals: relayResult.ingredientSignals
+						improvements: relayResult.improvements
 					});
+
+					// Populate ingredient store from relay data (build dataset over time)
+					if (relayResult.ingredientSignals.length > 0) {
+						ingredientStore.saveIngredients(relayResult.ingredientSignals, 'recipe', event.id).catch(() => {});
+					}
 
 					// Check staleness
 					const isStale = await isNourishStale(relayResult, event.content || '');

--- a/src/components/nourish/NourishPhotoInput.svelte
+++ b/src/components/nourish/NourishPhotoInput.svelte
@@ -1,0 +1,209 @@
+<script lang="ts">
+  /**
+   * NourishPhotoInput — visual photo upload/capture card.
+   *
+   * Large drop zone with camera/gallery options.
+   * Shows preview with remove button when image is selected.
+   */
+
+  import CameraIcon from 'phosphor-svelte/lib/Camera';
+  import UploadIcon from 'phosphor-svelte/lib/UploadSimple';
+  import XIcon from 'phosphor-svelte/lib/X';
+  import ImageIcon from 'phosphor-svelte/lib/Image';
+
+  export let imageData: string | null = null;
+  export let disabled: boolean = false;
+
+  let fileInput: HTMLInputElement;
+  let cameraInput: HTMLInputElement;
+  let dragOver = false;
+
+  const MAX_SIZE = 20 * 1024 * 1024; // 20MB
+  const ACCEPT = 'image/jpeg,image/png,image/webp,image/gif';
+
+  function handleFile(file: File) {
+    if (!file.type.startsWith('image/')) return;
+    if (file.size > MAX_SIZE) return;
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      imageData = e.target?.result as string;
+    };
+    reader.readAsDataURL(file);
+  }
+
+  function handleFileInput(e: Event) {
+    const input = e.target as HTMLInputElement;
+    if (input.files?.[0]) handleFile(input.files[0]);
+  }
+
+  function handleDrop(e: DragEvent) {
+    e.preventDefault();
+    dragOver = false;
+    if (disabled) return;
+    const file = e.dataTransfer?.files[0];
+    if (file) handleFile(file);
+  }
+
+  function handleDragOver(e: DragEvent) {
+    e.preventDefault();
+    if (!disabled) dragOver = true;
+  }
+
+  function clear() {
+    imageData = null;
+    if (fileInput) fileInput.value = '';
+    if (cameraInput) cameraInput.value = '';
+  }
+</script>
+
+{#if imageData}
+  <!-- Preview state -->
+  <div class="photo-preview">
+    <img src={imageData} alt="Food to analyze" class="preview-image" />
+    <button class="preview-remove" on:click={clear} aria-label="Remove image" {disabled}>
+      <XIcon size={16} weight="bold" />
+    </button>
+  </div>
+{:else}
+  <!-- Upload state -->
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
+  <div
+    class="photo-dropzone"
+    class:dragOver
+    class:disabled
+    on:drop={handleDrop}
+    on:dragover={handleDragOver}
+    on:dragleave={() => { dragOver = false; }}
+  >
+    <div class="dropzone-icon">
+      <ImageIcon size={32} weight="light" />
+    </div>
+    <p class="dropzone-text">Take a photo or upload an image of your meal</p>
+    <div class="dropzone-actions">
+      <button class="dropzone-btn" on:click={() => cameraInput?.click()} {disabled}>
+        <CameraIcon size={16} />
+        Camera
+      </button>
+      <button class="dropzone-btn" on:click={() => fileInput?.click()} {disabled}>
+        <UploadIcon size={16} />
+        Upload
+      </button>
+    </div>
+  </div>
+{/if}
+
+<input
+  bind:this={cameraInput}
+  type="file"
+  accept={ACCEPT}
+  capture="environment"
+  on:change={handleFileInput}
+  class="hidden"
+/>
+<input
+  bind:this={fileInput}
+  type="file"
+  accept={ACCEPT}
+  on:change={handleFileInput}
+  class="hidden"
+/>
+
+<style>
+  .hidden { display: none; }
+
+  /* Drop zone */
+  .photo-dropzone {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 2rem 1.5rem;
+    border-radius: 0.75rem;
+    border: 2px dashed var(--color-input-border, rgba(255, 255, 255, 0.1));
+    background: var(--color-input-bg, rgba(255, 255, 255, 0.02));
+    transition: border-color 150ms, background 150ms;
+    cursor: pointer;
+  }
+  .photo-dropzone.dragOver {
+    border-color: #22c55e;
+    background: rgba(34, 197, 94, 0.04);
+  }
+  .photo-dropzone.disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .dropzone-icon {
+    color: var(--color-text-secondary);
+    opacity: 0.3;
+  }
+
+  .dropzone-text {
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
+    text-align: center;
+    margin: 0;
+  }
+
+  .dropzone-actions {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .dropzone-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.375rem 0.75rem;
+    border-radius: 9999px;
+    border: 1px solid var(--color-input-border, rgba(255, 255, 255, 0.1));
+    background: var(--color-input-bg, rgba(255, 255, 255, 0.04));
+    color: var(--color-text-primary);
+    font-size: 0.75rem;
+    font-weight: 500;
+    cursor: pointer;
+    font-family: inherit;
+    transition: background 150ms, border-color 150ms;
+  }
+  .dropzone-btn:hover {
+    background: rgba(34, 197, 94, 0.06);
+    border-color: rgba(34, 197, 94, 0.3);
+  }
+
+  /* Preview */
+  .photo-preview {
+    position: relative;
+    border-radius: 0.75rem;
+    overflow: hidden;
+    max-height: 240px;
+  }
+
+  .preview-image {
+    width: 100%;
+    max-height: 240px;
+    object-fit: cover;
+    display: block;
+    border-radius: 0.75rem;
+  }
+
+  .preview-remove {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    width: 28px;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 9999px;
+    background: rgba(0, 0, 0, 0.6);
+    color: white;
+    border: none;
+    cursor: pointer;
+    transition: background 150ms;
+  }
+  .preview-remove:hover {
+    background: rgba(0, 0, 0, 0.8);
+  }
+</style>

--- a/src/components/nourish/NourishPill.svelte
+++ b/src/components/nourish/NourishPill.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
   /**
-   * NourishPill — compact score presentation for recipe cards and headers.
+   * NourishPill — strengths-focused nutrition profile for recipe cards and headers.
    *
-   * Three display modes:
-   *   'pill'     — "🌿 Nourish 7"          (clean, minimal)
-   *   'labeled'  — "🌿 7 Strong"            (score + meaning)
-   *   'expand'   — "🌿 Nourish 7 ▸" → inline breakdown  (hybrid)
+   * Design philosophy:
+   *   - No judgment — no red/yellow/green, no "low/high" labels
+   *   - Highlight what a recipe brings to the table, not what it lacks
+   *   - Encourage curiosity, not evaluation
+   *   - "Nourish Profile" framing, not "Nourish Score"
    *
-   * Recommended: 'expand' — compact by default, rich on interaction.
+   * Compact by default, expands inline to show what this recipe is rich in.
    */
 
   import LeafIcon from 'phosphor-svelte/lib/Leaf';
@@ -17,27 +18,52 @@
   export let gut: number | null = null;
   export let protein: number | null = null;
   export let realFood: number | null = null;
-  export let mode: 'pill' | 'labeled' | 'expand' = 'expand';
+  export let compact: boolean = false;
   export let onClick: (() => void) | undefined = undefined;
 
   let expanded = false;
 
-  /** Map a 0–10 score to a human-readable label. */
-  function scoreLabel(score: number): string {
-    if (score <= 3) return 'Low';
-    if (score <= 6) return 'Moderate';
-    return 'Strong';
+  // Nourish brand color — consistent, non-judgmental
+  const NOURISH_COLOR = '#22c55e';
+
+  /**
+   * Describe what this recipe is rich in — strengths only.
+   * Returns up to 2 short positive descriptors.
+   */
+  function getStrengths(gut: number, protein: number, realFood: number): string[] {
+    const strengths: string[] = [];
+    // Only highlight dimensions that are genuinely strong (7+)
+    if (realFood >= 7) strengths.push('Whole foods');
+    if (gut >= 7) strengths.push('Gut-friendly');
+    if (protein >= 7) strengths.push('Protein-rich');
+    // If nothing hits 7+, mention whatever is highest as a softer positive
+    if (strengths.length === 0) {
+      const best = Math.max(gut, protein, realFood);
+      if (best >= 5) {
+        if (realFood === best) strengths.push('Real ingredients');
+        else if (gut === best) strengths.push('Plant diversity');
+        else strengths.push('Protein source');
+      }
+    }
+    return strengths.slice(0, 2);
   }
 
-  /** Color for the score badge based on value. */
-  function scoreColor(score: number): string {
-    if (score <= 3) return '#ef4444';  // red
-    if (score <= 6) return '#eab308';  // amber
-    return '#22c55e';                  // green
+  /** Dimension label for the expanded profile view. */
+  const DIMENSIONS = [
+    { key: 'realFood', label: 'Real Food', icon: '🥬' },
+    { key: 'gut',      label: 'Gut Health', icon: '🌱' },
+    { key: 'protein',  label: 'Protein',    icon: '💪' }
+  ] as const;
+
+  function getDimensionValue(key: string): number {
+    if (key === 'realFood') return realFood ?? 0;
+    if (key === 'gut') return gut ?? 0;
+    if (key === 'protein') return protein ?? 0;
+    return 0;
   }
 
-  function handleClick() {
-    if (mode === 'expand') {
+  function handlePillClick() {
+    if (!compact) {
       expanded = !expanded;
     }
     if (onClick) onClick();
@@ -46,179 +72,204 @@
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
-      handleClick();
+      handlePillClick();
     }
   }
 
-  $: label = overall !== null ? scoreLabel(overall) : '';
-  $: color = overall !== null ? scoreColor(overall) : '#22c55e';
   $: hasSubscores = gut !== null && protein !== null && realFood !== null;
+  $: strengths = hasSubscores ? getStrengths(gut!, protein!, realFood!) : [];
 </script>
 
 {#if overall !== null}
-  <div class="nourish-pill-wrapper">
+  <div class="nourish-wrapper">
     <button
       class="nourish-pill"
-      on:click={handleClick}
+      on:click={handlePillClick}
       on:keydown={handleKeydown}
-      aria-label="Nourish score {overall} out of 10 — {label}"
-      aria-expanded={mode === 'expand' ? expanded : undefined}
-      style="--pill-color: {color};"
+      aria-label="Nourish Profile{strengths.length > 0 ? ` — ${strengths.join(', ')}` : ''}"
+      aria-expanded={!compact ? expanded : undefined}
     >
-      <span class="pill-icon"><LeafIcon size={14} weight="fill" /></span>
-
-      {#if mode === 'pill'}
-        <span class="pill-text">Nourish</span>
-        <span class="pill-score">{overall}</span>
-      {:else if mode === 'labeled'}
-        <span class="pill-score">{overall}</span>
-        <span class="pill-label">{label}</span>
-      {:else}
-        <!-- expand mode -->
-        <span class="pill-text">Nourish</span>
-        <span class="pill-score">{overall}</span>
+      <span class="pill-leaf"><LeafIcon size={14} weight="fill" /></span>
+      <span class="pill-name">Nourish</span>
+      {#if !compact}
         <span class="pill-caret" class:expanded>
           <CaretRightIcon size={10} weight="bold" />
         </span>
       {/if}
     </button>
 
-    <!-- Expanded inline breakdown -->
-    {#if mode === 'expand' && expanded && hasSubscores}
-      <div class="nourish-breakdown" role="region" aria-label="Nourish score breakdown">
-        {#each [
-          { label: 'Real Food', score: realFood, color: '#f97316' },
-          { label: 'Gut', score: gut, color: '#22c55e' },
-          { label: 'Protein', score: protein, color: '#3b82f6' }
-        ] as item}
-          <div class="breakdown-row">
-            <span class="breakdown-label">{item.label}</span>
-            <div class="breakdown-track">
-              <div
-                class="breakdown-fill"
-                style="width: {(item.score ?? 0) * 10}%; background: {item.color};"
-              />
-            </div>
-            <span class="breakdown-value" style="color: {item.color};">{item.score}</span>
+    <!-- Expanded: strengths-focused profile -->
+    {#if !compact && expanded && hasSubscores}
+      <div class="nourish-profile" role="region" aria-label="Nourish Profile">
+        <!-- Strength tags -->
+        {#if strengths.length > 0}
+          <div class="profile-strengths">
+            {#each strengths as s}
+              <span class="strength-tag">{s}</span>
+            {/each}
           </div>
-        {/each}
+        {/if}
+
+        <!-- Dimension bars — neutral presentation, no color-coding by value -->
+        <div class="profile-dims">
+          {#each DIMENSIONS as dim}
+            {@const val = getDimensionValue(dim.key)}
+            <div class="dim-row">
+              <span class="dim-icon">{dim.icon}</span>
+              <span class="dim-label">{dim.label}</span>
+              <div class="dim-track">
+                <div class="dim-fill" style="width: {val * 10}%;" />
+              </div>
+            </div>
+          {/each}
+        </div>
+
+        <!-- Invite to learn more -->
+        <button class="profile-details" on:click={() => { if (onClick) onClick(); }}>
+          See full profile
+        </button>
       </div>
     {/if}
   </div>
 {/if}
 
 <style>
-  .nourish-pill-wrapper {
+  .nourish-wrapper {
     display: inline-flex;
     flex-direction: column;
     gap: 0.375rem;
   }
 
+  /* ── Pill ── */
   .nourish-pill {
     display: inline-flex;
     align-items: center;
     gap: 0.3rem;
-    padding: 0.25rem 0.625rem;
+    padding: 0.25rem 0.5rem;
     border-radius: 9999px;
-    border: 1px solid var(--pill-color, #22c55e);
-    background: color-mix(in srgb, var(--pill-color, #22c55e) 8%, transparent);
+    border: 1px solid rgba(34, 197, 94, 0.25);
+    background: rgba(34, 197, 94, 0.06);
     cursor: pointer;
-    transition: background 150ms, box-shadow 150ms;
+    transition: background 150ms, border-color 150ms;
     font-family: inherit;
     line-height: 1;
     white-space: nowrap;
   }
-
   .nourish-pill:hover {
-    background: color-mix(in srgb, var(--pill-color, #22c55e) 15%, transparent);
-    box-shadow: 0 0 0 2px color-mix(in srgb, var(--pill-color, #22c55e) 12%, transparent);
+    background: rgba(34, 197, 94, 0.12);
+    border-color: rgba(34, 197, 94, 0.4);
   }
-
   .nourish-pill:focus-visible {
-    outline: 2px solid var(--pill-color, #22c55e);
+    outline: 2px solid #22c55e;
     outline-offset: 2px;
   }
 
-  .pill-icon {
+  .pill-leaf {
     display: flex;
-    color: var(--pill-color, #22c55e);
+    color: #22c55e;
     flex-shrink: 0;
   }
-
-  .pill-text {
+  .pill-name {
     font-size: 0.6875rem;
-    font-weight: 500;
-    color: var(--color-text-secondary);
+    font-weight: 600;
+    color: #22c55e;
     letter-spacing: 0.01em;
   }
-
-  .pill-score {
-    font-size: 0.75rem;
-    font-weight: 700;
-    color: var(--pill-color, #22c55e);
-  }
-
-  .pill-label {
-    font-size: 0.6875rem;
-    font-weight: 500;
-    color: var(--color-text-secondary);
-  }
-
   .pill-caret {
     display: flex;
-    color: var(--color-text-secondary);
-    opacity: 0.5;
+    color: #22c55e;
+    opacity: 0.4;
     transition: transform 200ms ease;
   }
   .pill-caret.expanded {
     transform: rotate(90deg);
+    opacity: 0.7;
   }
 
-  /* ── Breakdown ── */
-  .nourish-breakdown {
+  /* ── Expanded profile ── */
+  .nourish-profile {
     display: flex;
     flex-direction: column;
-    gap: 0.3rem;
-    padding: 0.5rem 0.625rem;
-    border-radius: 0.5rem;
+    gap: 0.5rem;
+    padding: 0.625rem 0.75rem;
+    border-radius: 0.625rem;
     background: var(--color-input-bg, rgba(255, 255, 255, 0.04));
     border: 1px solid var(--color-input-border, rgba(255, 255, 255, 0.06));
-    min-width: 160px;
+    min-width: 180px;
+    max-width: 220px;
   }
 
-  .breakdown-row {
+  /* Strength tags */
+  .profile-strengths {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+  }
+  .strength-tag {
+    font-size: 0.625rem;
+    font-weight: 500;
+    padding: 0.125rem 0.375rem;
+    border-radius: 9999px;
+    background: rgba(34, 197, 94, 0.08);
+    color: #22c55e;
+    white-space: nowrap;
+  }
+
+  /* Dimension rows */
+  .profile-dims {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+  .dim-row {
     display: flex;
     align-items: center;
     gap: 0.375rem;
   }
-
-  .breakdown-label {
+  .dim-icon {
+    font-size: 0.625rem;
+    width: 14px;
+    text-align: center;
+    flex-shrink: 0;
+  }
+  .dim-label {
     font-size: 0.625rem;
     font-weight: 500;
     color: var(--color-text-secondary);
-    width: 52px;
+    width: 56px;
     flex-shrink: 0;
   }
-
-  .breakdown-track {
+  .dim-track {
     flex: 1;
-    height: 3px;
+    height: 4px;
     border-radius: 2px;
     background: var(--color-bg-tertiary, rgba(255, 255, 255, 0.06));
-    min-width: 48px;
+    overflow: hidden;
   }
-
-  .breakdown-fill {
+  .dim-fill {
     height: 100%;
     border-radius: 2px;
+    background: #22c55e;
+    opacity: 0.7;
     transition: width 400ms ease-out;
   }
 
-  .breakdown-value {
-    font-size: 0.6875rem;
-    font-weight: 700;
-    width: 16px;
-    text-align: right;
-    flex-shrink: 0;
+  /* Details link */
+  .profile-details {
+    font-size: 0.625rem;
+    font-weight: 500;
+    color: var(--color-text-secondary);
+    opacity: 0.6;
+    cursor: pointer;
+    text-align: left;
+    padding: 0;
+    border: none;
+    background: none;
+    font-family: inherit;
+    transition: opacity 150ms;
+  }
+  .profile-details:hover {
+    opacity: 1;
+    color: #22c55e;
   }
 </style>

--- a/src/components/nourish/NourishPill.svelte
+++ b/src/components/nourish/NourishPill.svelte
@@ -2,17 +2,11 @@
   /**
    * NourishPill — strengths-focused nutrition profile for recipe cards and headers.
    *
-   * Design philosophy:
-   *   - No judgment — no red/yellow/green, no "low/high" labels
-   *   - Highlight what a recipe brings to the table, not what it lacks
-   *   - Encourage curiosity, not evaluation
-   *   - "Nourish Profile" framing, not "Nourish Score"
-   *
-   * Compact by default, expands inline to show what this recipe is rich in.
+   * Hover/focus reveals the inline profile preview.
+   * Click opens the full Nourish modal.
    */
 
   import LeafIcon from 'phosphor-svelte/lib/Leaf';
-  import CaretRightIcon from 'phosphor-svelte/lib/CaretRight';
 
   export let overall: number | null = null;
   export let gut: number | null = null;
@@ -21,22 +15,18 @@
   export let compact: boolean = false;
   export let onClick: (() => void) | undefined = undefined;
 
-  let expanded = false;
-
-  // Nourish brand color — consistent, non-judgmental
-  const NOURISH_COLOR = '#22c55e';
+  let hovered = false;
+  let focused = false;
+  let hideTimeout: ReturnType<typeof setTimeout> | null = null;
 
   /**
    * Describe what this recipe is rich in — strengths only.
-   * Returns up to 2 short positive descriptors.
    */
   function getStrengths(gut: number, protein: number, realFood: number): string[] {
     const strengths: string[] = [];
-    // Only highlight dimensions that are genuinely strong (7+)
     if (realFood >= 7) strengths.push('Whole foods');
     if (gut >= 7) strengths.push('Gut-friendly');
     if (protein >= 7) strengths.push('Protein-rich');
-    // If nothing hits 7+, mention whatever is highest as a softer positive
     if (strengths.length === 0) {
       const best = Math.max(gut, protein, realFood);
       if (best >= 5) {
@@ -48,7 +38,6 @@
     return strengths.slice(0, 2);
   }
 
-  /** Dimension label for the expanded profile view. */
   const DIMENSIONS = [
     { key: 'realFood', label: 'Real Food', icon: '🥬' },
     { key: 'gut',      label: 'Gut Health', icon: '🌱' },
@@ -62,46 +51,51 @@
     return 0;
   }
 
-  function handlePillClick() {
-    if (!compact) {
-      expanded = !expanded;
-    }
+  function handleClick() {
     if (onClick) onClick();
   }
 
-  function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      handlePillClick();
-    }
+  function showPreview() {
+    if (hideTimeout) { clearTimeout(hideTimeout); hideTimeout = null; }
+    hovered = true;
   }
 
+  function scheduleHide() {
+    hideTimeout = setTimeout(() => { hovered = false; }, 200);
+  }
+
+  $: showProfile = !compact && (hovered || focused);
   $: hasSubscores = gut !== null && protein !== null && realFood !== null;
   $: strengths = hasSubscores ? getStrengths(gut!, protein!, realFood!) : [];
 </script>
 
 {#if overall !== null}
-  <div class="nourish-wrapper">
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
+  <div
+    class="nourish-wrapper"
+    on:mouseenter={showPreview}
+    on:mouseleave={scheduleHide}
+  >
     <button
       class="nourish-pill"
-      on:click={handlePillClick}
-      on:keydown={handleKeydown}
-      aria-label="Nourish Profile{strengths.length > 0 ? ` — ${strengths.join(', ')}` : ''}"
-      aria-expanded={!compact ? expanded : undefined}
+      on:click={handleClick}
+      on:focus={() => { focused = true; }}
+      on:blur={() => { focused = false; }}
+      aria-label="Nourish Profile — click for details{strengths.length > 0 ? `. ${strengths.join(', ')}` : ''}"
     >
       <span class="pill-leaf"><LeafIcon size={14} weight="fill" /></span>
       <span class="pill-name">Nourish</span>
-      {#if !compact}
-        <span class="pill-caret" class:expanded>
-          <CaretRightIcon size={10} weight="bold" />
-        </span>
-      {/if}
     </button>
 
-    <!-- Expanded: strengths-focused profile -->
-    {#if !compact && expanded && hasSubscores}
-      <div class="nourish-profile" role="region" aria-label="Nourish Profile">
-        <!-- Strength tags -->
+    <!-- Hover/focus preview — positioned as a floating card -->
+    {#if showProfile && hasSubscores}
+      <!-- svelte-ignore a11y-no-static-element-interactions -->
+      <div
+        class="nourish-profile"
+        role="tooltip"
+        on:mouseenter={showPreview}
+        on:mouseleave={scheduleHide}
+      >
         {#if strengths.length > 0}
           <div class="profile-strengths">
             {#each strengths as s}
@@ -110,7 +104,6 @@
           </div>
         {/if}
 
-        <!-- Dimension bars — neutral presentation, no color-coding by value -->
         <div class="profile-dims">
           {#each DIMENSIONS as dim}
             {@const val = getDimensionValue(dim.key)}
@@ -124,8 +117,7 @@
           {/each}
         </div>
 
-        <!-- Invite to learn more -->
-        <button class="profile-details" on:click={() => { if (onClick) onClick(); }}>
+        <button class="profile-details" on:click={handleClick}>
           See full profile
         </button>
       </div>
@@ -135,9 +127,8 @@
 
 <style>
   .nourish-wrapper {
+    position: relative;
     display: inline-flex;
-    flex-direction: column;
-    gap: 0.375rem;
   }
 
   /* ── Pill ── */
@@ -175,28 +166,29 @@
     color: #22c55e;
     letter-spacing: 0.01em;
   }
-  .pill-caret {
-    display: flex;
-    color: #22c55e;
-    opacity: 0.4;
-    transition: transform 200ms ease;
-  }
-  .pill-caret.expanded {
-    transform: rotate(90deg);
-    opacity: 0.7;
-  }
 
-  /* ── Expanded profile ── */
+  /* ── Floating profile card ── */
   .nourish-profile {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 6px);
+    z-index: 30;
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
     padding: 0.625rem 0.75rem;
     border-radius: 0.625rem;
-    background: var(--color-input-bg, rgba(255, 255, 255, 0.04));
-    border: 1px solid var(--color-input-border, rgba(255, 255, 255, 0.06));
+    background: var(--color-input-bg, #1a1a2e);
+    border: 1px solid var(--color-input-border, rgba(255, 255, 255, 0.08));
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
     min-width: 180px;
     max-width: 220px;
+    animation: nourish-fade-in 150ms ease-out;
+  }
+
+  @keyframes nourish-fade-in {
+    from { opacity: 0; transform: translateY(-4px); }
+    to   { opacity: 1; transform: translateY(0); }
   }
 
   /* Strength tags */
@@ -266,7 +258,7 @@
     border: none;
     background: none;
     font-family: inherit;
-    transition: opacity 150ms;
+    transition: opacity 150ms, color 150ms;
   }
   .profile-details:hover {
     opacity: 1;

--- a/src/components/nourish/NourishPill.svelte
+++ b/src/components/nourish/NourishPill.svelte
@@ -64,6 +64,10 @@
     hideTimeout = setTimeout(() => { hovered = false; }, 200);
   }
 
+  let showProfile = false;
+  let hasSubscores = false;
+  let strengths: string[] = [];
+
   $: showProfile = !compact && (hovered || focused);
   $: hasSubscores = gut !== null && protein !== null && realFood !== null;
   $: strengths = hasSubscores ? getStrengths(gut!, protein!, realFood!) : [];

--- a/src/components/nourish/NourishPill.svelte
+++ b/src/components/nourish/NourishPill.svelte
@@ -1,0 +1,224 @@
+<script lang="ts">
+  /**
+   * NourishPill — compact score presentation for recipe cards and headers.
+   *
+   * Three display modes:
+   *   'pill'     — "🌿 Nourish 7"          (clean, minimal)
+   *   'labeled'  — "🌿 7 Strong"            (score + meaning)
+   *   'expand'   — "🌿 Nourish 7 ▸" → inline breakdown  (hybrid)
+   *
+   * Recommended: 'expand' — compact by default, rich on interaction.
+   */
+
+  import LeafIcon from 'phosphor-svelte/lib/Leaf';
+  import CaretRightIcon from 'phosphor-svelte/lib/CaretRight';
+
+  export let overall: number | null = null;
+  export let gut: number | null = null;
+  export let protein: number | null = null;
+  export let realFood: number | null = null;
+  export let mode: 'pill' | 'labeled' | 'expand' = 'expand';
+  export let onClick: (() => void) | undefined = undefined;
+
+  let expanded = false;
+
+  /** Map a 0–10 score to a human-readable label. */
+  function scoreLabel(score: number): string {
+    if (score <= 3) return 'Low';
+    if (score <= 6) return 'Moderate';
+    return 'Strong';
+  }
+
+  /** Color for the score badge based on value. */
+  function scoreColor(score: number): string {
+    if (score <= 3) return '#ef4444';  // red
+    if (score <= 6) return '#eab308';  // amber
+    return '#22c55e';                  // green
+  }
+
+  function handleClick() {
+    if (mode === 'expand') {
+      expanded = !expanded;
+    }
+    if (onClick) onClick();
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleClick();
+    }
+  }
+
+  $: label = overall !== null ? scoreLabel(overall) : '';
+  $: color = overall !== null ? scoreColor(overall) : '#22c55e';
+  $: hasSubscores = gut !== null && protein !== null && realFood !== null;
+</script>
+
+{#if overall !== null}
+  <div class="nourish-pill-wrapper">
+    <button
+      class="nourish-pill"
+      on:click={handleClick}
+      on:keydown={handleKeydown}
+      aria-label="Nourish score {overall} out of 10 — {label}"
+      aria-expanded={mode === 'expand' ? expanded : undefined}
+      style="--pill-color: {color};"
+    >
+      <span class="pill-icon"><LeafIcon size={14} weight="fill" /></span>
+
+      {#if mode === 'pill'}
+        <span class="pill-text">Nourish</span>
+        <span class="pill-score">{overall}</span>
+      {:else if mode === 'labeled'}
+        <span class="pill-score">{overall}</span>
+        <span class="pill-label">{label}</span>
+      {:else}
+        <!-- expand mode -->
+        <span class="pill-text">Nourish</span>
+        <span class="pill-score">{overall}</span>
+        <span class="pill-caret" class:expanded>
+          <CaretRightIcon size={10} weight="bold" />
+        </span>
+      {/if}
+    </button>
+
+    <!-- Expanded inline breakdown -->
+    {#if mode === 'expand' && expanded && hasSubscores}
+      <div class="nourish-breakdown" role="region" aria-label="Nourish score breakdown">
+        {#each [
+          { label: 'Real Food', score: realFood, color: '#f97316' },
+          { label: 'Gut', score: gut, color: '#22c55e' },
+          { label: 'Protein', score: protein, color: '#3b82f6' }
+        ] as item}
+          <div class="breakdown-row">
+            <span class="breakdown-label">{item.label}</span>
+            <div class="breakdown-track">
+              <div
+                class="breakdown-fill"
+                style="width: {(item.score ?? 0) * 10}%; background: {item.color};"
+              />
+            </div>
+            <span class="breakdown-value" style="color: {item.color};">{item.score}</span>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .nourish-pill-wrapper {
+    display: inline-flex;
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+
+  .nourish-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.25rem 0.625rem;
+    border-radius: 9999px;
+    border: 1px solid var(--pill-color, #22c55e);
+    background: color-mix(in srgb, var(--pill-color, #22c55e) 8%, transparent);
+    cursor: pointer;
+    transition: background 150ms, box-shadow 150ms;
+    font-family: inherit;
+    line-height: 1;
+    white-space: nowrap;
+  }
+
+  .nourish-pill:hover {
+    background: color-mix(in srgb, var(--pill-color, #22c55e) 15%, transparent);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--pill-color, #22c55e) 12%, transparent);
+  }
+
+  .nourish-pill:focus-visible {
+    outline: 2px solid var(--pill-color, #22c55e);
+    outline-offset: 2px;
+  }
+
+  .pill-icon {
+    display: flex;
+    color: var(--pill-color, #22c55e);
+    flex-shrink: 0;
+  }
+
+  .pill-text {
+    font-size: 0.6875rem;
+    font-weight: 500;
+    color: var(--color-text-secondary);
+    letter-spacing: 0.01em;
+  }
+
+  .pill-score {
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: var(--pill-color, #22c55e);
+  }
+
+  .pill-label {
+    font-size: 0.6875rem;
+    font-weight: 500;
+    color: var(--color-text-secondary);
+  }
+
+  .pill-caret {
+    display: flex;
+    color: var(--color-text-secondary);
+    opacity: 0.5;
+    transition: transform 200ms ease;
+  }
+  .pill-caret.expanded {
+    transform: rotate(90deg);
+  }
+
+  /* ── Breakdown ── */
+  .nourish-breakdown {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    padding: 0.5rem 0.625rem;
+    border-radius: 0.5rem;
+    background: var(--color-input-bg, rgba(255, 255, 255, 0.04));
+    border: 1px solid var(--color-input-border, rgba(255, 255, 255, 0.06));
+    min-width: 160px;
+  }
+
+  .breakdown-row {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+  }
+
+  .breakdown-label {
+    font-size: 0.625rem;
+    font-weight: 500;
+    color: var(--color-text-secondary);
+    width: 52px;
+    flex-shrink: 0;
+  }
+
+  .breakdown-track {
+    flex: 1;
+    height: 3px;
+    border-radius: 2px;
+    background: var(--color-bg-tertiary, rgba(255, 255, 255, 0.06));
+    min-width: 48px;
+  }
+
+  .breakdown-fill {
+    height: 100%;
+    border-radius: 2px;
+    transition: width 400ms ease-out;
+  }
+
+  .breakdown-value {
+    font-size: 0.6875rem;
+    font-weight: 700;
+    width: 16px;
+    text-align: right;
+    flex-shrink: 0;
+  }
+</style>

--- a/src/components/nourish/NourishResult.svelte
+++ b/src/components/nourish/NourishResult.svelte
@@ -1,0 +1,240 @@
+<script lang="ts">
+  /**
+   * NourishResult — strengths-focused result presentation.
+   *
+   * Shared between the /nourish page and the NourishModal on recipe pages.
+   * Leads with what the food brings, not what it lacks.
+   */
+
+  import NourishDimensionBar from './NourishDimensionBar.svelte';
+  import LeafIcon from 'phosphor-svelte/lib/Leaf';
+  import type { NourishScores, IngredientSignal } from '$lib/nourish/types';
+
+  export let scores: NourishScores;
+  export let quickTake: string = '';
+  export let improvements: string[] = [];
+  export let ingredientSignals: IngredientSignal[] = [];
+  export let onReset: (() => void) | undefined = undefined;
+  export let compact: boolean = false;
+
+  /**
+   * Derive strength tags from scores — only highlight genuinely strong dimensions.
+   */
+  function getStrengths(s: NourishScores): string[] {
+    const tags: string[] = [];
+    if (s.realFood.score >= 7) tags.push('Whole foods');
+    if (s.gut.score >= 7) tags.push('Gut-friendly');
+    if (s.protein.score >= 7) tags.push('Protein-rich');
+    // If nothing hits 7, show the strongest as a softer positive
+    if (tags.length === 0) {
+      const best = Math.max(s.gut.score, s.protein.score, s.realFood.score);
+      if (best >= 5) {
+        if (s.realFood.score === best) tags.push('Real ingredients');
+        else if (s.gut.score === best) tags.push('Plant diversity');
+        else tags.push('Protein source');
+      }
+    }
+    return tags.slice(0, 3);
+  }
+
+  /**
+   * Get top positive ingredient contributors.
+   */
+  function getPositiveContributors(signals: IngredientSignal[]): string[] {
+    return signals
+      .filter((s) => s.contribution !== 'neutral')
+      .slice(0, 4)
+      .map((s) => s.name);
+  }
+
+  $: strengths = getStrengths(scores);
+  $: contributors = getPositiveContributors(ingredientSignals);
+</script>
+
+<div class="nr-result" class:compact>
+  <!-- Quick take -->
+  {#if quickTake || scores.summary}
+    <p class="nr-quicktake">{quickTake || scores.summary}</p>
+  {/if}
+
+  <!-- Strength tags -->
+  {#if strengths.length > 0}
+    <div class="nr-section">
+      <p class="nr-section-label">What this meal brings</p>
+      <div class="nr-strengths">
+        {#each strengths as tag}
+          <span class="nr-tag">
+            <LeafIcon size={10} weight="fill" />
+            {tag}
+          </span>
+        {/each}
+      </div>
+    </div>
+  {/if}
+
+  <!-- Nourish Profile — dimension bars -->
+  <div class="nr-section">
+    <p class="nr-section-label">Nourish Profile</p>
+    <div class="nr-dims">
+      <NourishDimensionBar icon="🥬" label="Real Food" score={scores.realFood.score} reason={scores.realFood.reason} />
+      <NourishDimensionBar icon="🌱" label="Gut Health" score={scores.gut.score} reason={scores.gut.reason} />
+      <NourishDimensionBar icon="💪" label="Protein" score={scores.protein.score} reason={scores.protein.reason} />
+    </div>
+  </div>
+
+  <!-- Top contributors -->
+  {#if contributors.length > 0}
+    <div class="nr-section">
+      <p class="nr-section-label">Key ingredients</p>
+      <div class="nr-contributors">
+        {#each contributors as name}
+          <span class="nr-contributor">{name}</span>
+        {/each}
+      </div>
+    </div>
+  {/if}
+
+  <!-- Simple upgrades -->
+  {#if improvements.length > 0}
+    <div class="nr-section">
+      <p class="nr-section-label">Simple upgrades</p>
+      <div class="nr-upgrades">
+        {#each improvements as item}
+          <p class="nr-upgrade">{item}</p>
+        {/each}
+      </div>
+    </div>
+  {/if}
+
+  <!-- Footer actions -->
+  <div class="nr-footer">
+    <p class="nr-disclaimer">Profiles are estimates based on ingredients. Not medical advice.</p>
+    {#if onReset}
+      <button class="nr-reset" on:click={onReset}>Try another</button>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .nr-result {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  .nr-result.compact {
+    gap: 0.5rem;
+  }
+
+  /* Quick take */
+  .nr-quicktake {
+    font-size: 0.875rem;
+    font-style: italic;
+    line-height: 1.5;
+    color: var(--color-text-primary);
+    margin: 0;
+    padding-bottom: 0.25rem;
+  }
+
+  /* Sections */
+  .nr-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+  .nr-section-label {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-secondary);
+    opacity: 0.6;
+    margin: 0;
+  }
+
+  /* Strength tags */
+  .nr-strengths {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+  }
+  .nr-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    padding: 0.25rem 0.5rem;
+    border-radius: 9999px;
+    background: rgba(34, 197, 94, 0.08);
+    color: #22c55e;
+    white-space: nowrap;
+  }
+
+  /* Dimension bars */
+  .nr-dims {
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* Contributors */
+  .nr-contributors {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+  }
+  .nr-contributor {
+    font-size: 0.75rem;
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.25rem;
+    background: var(--color-bg-tertiary, rgba(255, 255, 255, 0.04));
+    color: var(--color-text-secondary);
+    white-space: nowrap;
+  }
+
+  /* Upgrades */
+  .nr-upgrades {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+  .nr-upgrade {
+    font-size: 0.8125rem;
+    line-height: 1.4;
+    color: var(--color-text-secondary);
+    margin: 0;
+    padding-left: 0.75rem;
+    border-left: 2px solid rgba(34, 197, 94, 0.2);
+  }
+
+  /* Footer */
+  .nr-footer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid var(--color-bg-tertiary, rgba(255, 255, 255, 0.04));
+  }
+  .nr-disclaimer {
+    font-size: 0.6875rem;
+    color: var(--color-text-secondary);
+    opacity: 0.5;
+    margin: 0;
+    text-align: center;
+  }
+  .nr-reset {
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: #22c55e;
+    cursor: pointer;
+    background: none;
+    border: none;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    font-family: inherit;
+    transition: background 150ms;
+  }
+  .nr-reset:hover {
+    background: rgba(34, 197, 94, 0.08);
+  }
+</style>

--- a/src/lib/nourish/cache.ts
+++ b/src/lib/nourish/cache.ts
@@ -9,13 +9,16 @@ interface CacheEntry {
 	scores: NourishScores;
 	timestamp: number;
 	version: string;
+	contentHash?: string;
+	improvements?: string[];
+	ingredientSignals?: import('./types').IngredientSignal[];
 }
 
 function cacheKey(eventId: string): string {
 	return `nourish_${eventId}`;
 }
 
-export function getNourishScores(eventId: string): NourishScores | null {
+export function getNourishCache(eventId: string): CacheEntry | null {
 	if (!browser) return null;
 
 	try {
@@ -27,20 +30,32 @@ export function getNourishScores(eventId: string): NourishScores | null {
 		if (entry.version !== NOURISH_CACHE_VERSION) return null;
 		if (Date.now() - entry.timestamp > CACHE_TTL_MS) return null;
 
-		return entry.scores;
+		return entry;
 	} catch {
 		return null;
 	}
 }
 
-export function setNourishScores(eventId: string, scores: NourishScores): void {
+/** @deprecated Use getNourishCache for full entry with contentHash */
+export function getNourishScores(eventId: string): NourishScores | null {
+	return getNourishCache(eventId)?.scores ?? null;
+}
+
+export function setNourishScores(
+	eventId: string,
+	scores: NourishScores,
+	extra?: { contentHash?: string; improvements?: string[]; ingredientSignals?: import('./types').IngredientSignal[] }
+): void {
 	if (!browser) return;
 
 	try {
 		const entry: CacheEntry = {
 			scores,
 			timestamp: Date.now(),
-			version: NOURISH_CACHE_VERSION
+			version: NOURISH_CACHE_VERSION,
+			contentHash: extra?.contentHash,
+			improvements: extra?.improvements,
+			ingredientSignals: extra?.ingredientSignals
 		};
 		localStorage.setItem(cacheKey(eventId), JSON.stringify(entry));
 	} catch {

--- a/src/lib/nourish/nourishPublisher.server.ts
+++ b/src/lib/nourish/nourishPublisher.server.ts
@@ -106,6 +106,7 @@ export async function publishNourishEvent(opts: {
       ['nourish_protein', String(scores.protein.score)],
       ['nourish_realfood', String(scores.realFood.score)]
     ];
+    event.created_at = Math.floor(Date.now() / 1000);
 
     await event.sign(signer);
 

--- a/src/lib/nourish/nourishPublisher.server.ts
+++ b/src/lib/nourish/nourishPublisher.server.ts
@@ -1,0 +1,137 @@
+/**
+ * Nourish Event Publisher (Server-side only)
+ *
+ * Signs and publishes Nourish analysis events (kind 30078) to the pantry relay
+ * using the Zap Cooking service account. This makes the analysis available to
+ * all future viewers without a fresh GPT call.
+ *
+ * Mirrors the pattern in membershipNotificationService.ts for server-side signing.
+ */
+
+import NDK, { NDKEvent, NDKPrivateKeySigner } from '@nostr-dev-kit/ndk';
+import { nip19 } from 'nostr-tools';
+import {
+  NOURISH_CACHE_VERSION,
+  NOURISH_PROMPT_VERSION,
+  type NourishScores,
+  type IngredientSignal
+} from './types';
+import { buildNourishDTag } from './nourishRelay';
+
+const PANTRY_RELAY = 'wss://pantry.zap.cooking';
+const PUBLISH_RELAYS = [PANTRY_RELAY, 'wss://relay.damus.io', 'wss://nos.lol'];
+const CONNECT_TIMEOUT_MS = 5000;
+const PUBLISH_TIMEOUT_MS = 5000;
+
+/**
+ * Resolve the private key from env var (supports both hex and nsec format).
+ */
+function resolvePrivateKey(raw: string): string {
+  if (raw.startsWith('nsec1')) {
+    const decoded = nip19.decode(raw);
+    const dataArray = Array.from(decoded.data as Uint8Array);
+    return dataArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+  }
+  if (/^[0-9a-fA-F]{64}$/.test(raw)) {
+    return raw;
+  }
+  throw new Error('Invalid private key format — must be 64 hex chars or nsec');
+}
+
+/**
+ * Publish a Nourish analysis event to the pantry relay.
+ *
+ * This is fire-and-forget from the API route's perspective — publish failures
+ * don't block the response. The next viewer will trigger a fresh analysis if
+ * no event is found on the relay.
+ */
+export async function publishNourishEvent(opts: {
+  privateKey: string;
+  recipePubkey: string;
+  recipeDTag: string;
+  contentHash: string;
+  scores: NourishScores;
+  improvements: string[];
+  ingredientSignals: IngredientSignal[];
+}): Promise<boolean> {
+  const { privateKey, recipePubkey, recipeDTag, contentHash, scores, improvements, ingredientSignals } = opts;
+
+  try {
+    const hexKey = resolvePrivateKey(privateKey);
+    const signer = new NDKPrivateKeySigner(hexKey);
+
+    const ndk = new NDK({ explicitRelayUrls: PUBLISH_RELAYS });
+    ndk.signer = signer;
+    await ndk.connect();
+
+    // Wait for at least one relay to connect
+    const connected = await waitForConnection(ndk);
+    if (!connected) {
+      console.error('[Nourish Publisher] No relays connected after timeout');
+      return false;
+    }
+
+    const dTag = buildNourishDTag(recipePubkey, recipeDTag);
+
+    // Build the event
+    const event = new NDKEvent(ndk);
+    event.kind = 30078;
+    event.content = JSON.stringify({
+      gut: scores.gut,
+      protein: scores.protein,
+      realFood: scores.realFood,
+      overall: scores.overall,
+      summary: scores.summary,
+      improvements,
+      ingredient_signals: ingredientSignals,
+      version: scores.version
+    });
+    event.tags = [
+      // Identity
+      ['d', dTag],
+      ['client', 'zap.cooking'],
+
+      // Recipe reference
+      ['a', `30023:${recipePubkey}:${recipeDTag}`],
+      ['p', recipePubkey],
+
+      // Versioning
+      ['nourish_version', NOURISH_CACHE_VERSION],
+      ['content_hash', contentHash],
+      ['prompt_version', NOURISH_PROMPT_VERSION],
+
+      // Indexable scores (for future relay-side filtering)
+      ['nourish_overall', String(scores.overall.score)],
+      ['nourish_gut', String(scores.gut.score)],
+      ['nourish_protein', String(scores.protein.score)],
+      ['nourish_realfood', String(scores.realFood.score)]
+    ];
+
+    await event.sign(signer);
+
+    // Publish with timeout
+    const publishPromise = event.publish();
+    const timeoutPromise = new Promise<void>((_, reject) =>
+      setTimeout(() => reject(new Error('Publish timeout')), PUBLISH_TIMEOUT_MS)
+    );
+
+    await Promise.race([publishPromise, timeoutPromise]);
+    console.log(`[Nourish Publisher] Published analysis for ${recipeDTag} (${dTag})`);
+    return true;
+  } catch (err) {
+    console.error('[Nourish Publisher] Failed to publish:', err);
+    return false;
+  }
+}
+
+async function waitForConnection(ndk: NDK): Promise<boolean> {
+  const start = Date.now();
+  while (Date.now() - start < CONNECT_TIMEOUT_MS) {
+    const connected = Array.from(ndk.pool.relays.values()).filter(
+      (r) => r.status === 1
+    );
+    if (connected.length > 0) return true;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return false;
+}

--- a/src/lib/nourish/nourishRelay.ts
+++ b/src/lib/nourish/nourishRelay.ts
@@ -8,6 +8,7 @@
 
 import type NDK from '@nostr-dev-kit/ndk';
 import type { NDKEvent } from '@nostr-dev-kit/ndk';
+import { NDKRelaySet } from '@nostr-dev-kit/ndk';
 import {
   NOURISH_SERVICE_PUBKEY,
   NOURISH_CACHE_VERSION,
@@ -61,8 +62,11 @@ export async function fetchNourishEvent(
       '#d': [dTag]
     };
 
+    // Query the pantry relay specifically (where Nourish events are published)
+    const relaySet = NDKRelaySet.fromRelayUrls([PANTRY_RELAY], ndk, true);
+
     // Race against timeout
-    const eventPromise = ndk.fetchEvent(filter);
+    const eventPromise = ndk.fetchEvent(filter, undefined, relaySet);
     const timeoutPromise = new Promise<null>((resolve) =>
       setTimeout(() => resolve(null), QUERY_TIMEOUT_MS)
     );

--- a/src/lib/nourish/nourishRelay.ts
+++ b/src/lib/nourish/nourishRelay.ts
@@ -1,0 +1,158 @@
+/**
+ * Nourish Relay Module
+ *
+ * Queries the pantry relay for existing Nourish analysis events (kind 30078)
+ * published by the Zap Cooking service account. This enables share-once-read-many:
+ * one GPT analysis serves all future viewers of a recipe.
+ */
+
+import type NDK from '@nostr-dev-kit/ndk';
+import type { NDKEvent } from '@nostr-dev-kit/ndk';
+import {
+  NOURISH_SERVICE_PUBKEY,
+  NOURISH_CACHE_VERSION,
+  computeOverallScore,
+  type NourishScores,
+  type NourishRelayResult,
+  type IngredientSignal
+} from './types';
+
+const PANTRY_RELAY = 'wss://pantry.zap.cooking';
+const QUERY_TIMEOUT_MS = 4000;
+
+// ─── Content hashing ────────────────────────────────────────
+
+/**
+ * Compute SHA-256 hash of recipe content for staleness detection.
+ * Uses Web Crypto API (available in browser and Cloudflare Workers).
+ */
+export async function computeContentHash(content: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(content);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+// ─── D-tag construction ─────────────────────────────────────
+
+/** Build the d-tag for a Nourish event referencing a recipe. */
+export function buildNourishDTag(recipePubkey: string, recipeDTag: string): string {
+  return `nourish:30023:${recipePubkey}:${recipeDTag}`;
+}
+
+// ─── Relay query ────────────────────────────────────────────
+
+/**
+ * Fetch an existing Nourish analysis event from the pantry relay.
+ * Returns null if no analysis exists for this recipe.
+ */
+export async function fetchNourishEvent(
+  ndk: NDK,
+  recipePubkey: string,
+  recipeDTag: string
+): Promise<NourishRelayResult | null> {
+  const dTag = buildNourishDTag(recipePubkey, recipeDTag);
+
+  try {
+    const filter = {
+      kinds: [30078 as number],
+      authors: [NOURISH_SERVICE_PUBKEY],
+      '#d': [dTag]
+    };
+
+    // Race against timeout
+    const eventPromise = ndk.fetchEvent(filter);
+    const timeoutPromise = new Promise<null>((resolve) =>
+      setTimeout(() => resolve(null), QUERY_TIMEOUT_MS)
+    );
+
+    const event = await Promise.race([eventPromise, timeoutPromise]);
+    if (!event) return null;
+
+    return parseNourishEvent(event);
+  } catch {
+    return null;
+  }
+}
+
+// ─── Event parsing ──────────────────────────────────────────
+
+/** Parse a kind 30078 Nourish event into a typed result. */
+export function parseNourishEvent(event: NDKEvent): NourishRelayResult | null {
+  try {
+    const content = JSON.parse(event.content);
+
+    // Extract scores — recompute overall with current weights for forward compatibility
+    const gutScore = content.gut?.score ?? 0;
+    const proteinScore = content.protein?.score ?? 0;
+    const realFoodScore = content.realFood?.score ?? 0;
+    const overall = computeOverallScore(gutScore, proteinScore, realFoodScore);
+
+    const scores: NourishScores = {
+      gut: {
+        score: gutScore,
+        label: content.gut?.label || 'Moderate',
+        reason: content.gut?.reason || ''
+      },
+      protein: {
+        score: proteinScore,
+        label: content.protein?.label || 'Moderate',
+        reason: content.protein?.reason || ''
+      },
+      realFood: {
+        score: realFoodScore,
+        label: content.realFood?.label || 'Moderate',
+        reason: content.realFood?.reason || ''
+      },
+      overall: {
+        score: overall.score,
+        label: overall.label,
+        reason: content.overall?.reason || `Weighted: Real Food 45%, Gut 35%, Protein 20%`
+      },
+      summary: content.summary || '',
+      version: content.version || NOURISH_CACHE_VERSION
+    };
+
+    const improvements: string[] = Array.isArray(content.improvements)
+      ? content.improvements.filter((s: unknown) => typeof s === 'string')
+      : [];
+
+    const ingredientSignals: IngredientSignal[] = Array.isArray(content.ingredient_signals)
+      ? content.ingredient_signals.filter((i: any) => i && typeof i.name === 'string')
+      : [];
+
+    // Extract metadata from tags
+    const contentHash = event.tags.find((t) => t[0] === 'content_hash')?.[1] || '';
+    const promptVersion = event.tags.find((t) => t[0] === 'prompt_version')?.[1] || '1';
+    const nourishVersion = event.tags.find((t) => t[0] === 'nourish_version')?.[1] || NOURISH_CACHE_VERSION;
+
+    return {
+      scores,
+      improvements,
+      ingredientSignals,
+      contentHash,
+      promptVersion,
+      nourishVersion,
+      createdAt: event.created_at || 0,
+      eventId: event.id
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ─── Staleness detection ────────────────────────────────────
+
+/**
+ * Check if a Nourish analysis is stale (recipe content changed since analysis).
+ * Compares the stored content_hash against the current recipe content hash.
+ */
+export async function isNourishStale(
+  relayResult: NourishRelayResult,
+  currentRecipeContent: string
+): Promise<boolean> {
+  if (!relayResult.contentHash) return true; // No hash stored — assume stale
+  const currentHash = await computeContentHash(currentRecipeContent);
+  return currentHash !== relayResult.contentHash;
+}

--- a/src/lib/nourish/types.ts
+++ b/src/lib/nourish/types.ts
@@ -9,7 +9,7 @@ export const NOURISH_PROMPT_VERSION = '1';
  * This must match the pubkey derived from the NOTIFICATION_PRIVATE_KEY env var.
  * To find this value: new NDKPrivateKeySigner(hexKey).user().then(u => u.pubkey)
  */
-export const NOURISH_SERVICE_PUBKEY = '2cb95c7e3b3757e79b3fec757b92e1b8b2279a7f3b1a3d3b3f5a5e89c5e9f0a1';
+export const NOURISH_SERVICE_PUBKEY = 'fdd263f69f9e95a2a0a58ec3e7e8053011214fa66007d93b26d2f4717d31917b';
 
 /** Result from querying the pantry relay for an existing Nourish analysis event. */
 export interface NourishRelayResult {

--- a/src/lib/nourish/types.ts
+++ b/src/lib/nourish/types.ts
@@ -1,4 +1,27 @@
 export const NOURISH_CACHE_VERSION = '1.1';
+export const NOURISH_PROMPT_VERSION = '1';
+
+/**
+ * Public key of the Zap Cooking service account that publishes Nourish analysis events.
+ * Derived from NOTIFICATION_PRIVATE_KEY. Clients use this to filter relay queries
+ * so only official Zap Cooking analyses are trusted.
+ *
+ * This must match the pubkey derived from the NOTIFICATION_PRIVATE_KEY env var.
+ * To find this value: new NDKPrivateKeySigner(hexKey).user().then(u => u.pubkey)
+ */
+export const NOURISH_SERVICE_PUBKEY = '2cb95c7e3b3757e79b3fec757b92e1b8b2279a7f3b1a3d3b3f5a5e89c5e9f0a1';
+
+/** Result from querying the pantry relay for an existing Nourish analysis event. */
+export interface NourishRelayResult {
+  scores: NourishScores;
+  improvements: string[];
+  ingredientSignals: IngredientSignal[];
+  contentHash: string;
+  promptVersion: string;
+  nourishVersion: string;
+  createdAt: number;
+  eventId: string;
+}
 
 // ─── Recipe scoring (existing) ───────────────────────────────
 

--- a/src/routes/api/nourish/+server.ts
+++ b/src/routes/api/nourish/+server.ts
@@ -239,27 +239,36 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 					}))
 			: [];
 
-		// Publish Nourish event to pantry relay (fire-and-forget).
-		// If publishing fails, the analysis is still returned to the client —
-		// the next viewer will trigger a fresh analysis if no relay event is found.
-		if (recipePubkey && recipeDTag && contentHash) {
+		// Publish Nourish event to pantry relay.
+		// Uses waitUntil on Cloudflare Workers so the promise survives past the response.
+		const HEX_64_RE = /^[a-fA-F0-9]{64}$/;
+		const validRecipePubkey = typeof recipePubkey === 'string' && HEX_64_RE.test(recipePubkey.trim());
+		const validContentHash = typeof contentHash === 'string' && HEX_64_RE.test(contentHash.trim());
+		const validRecipeDTag = typeof recipeDTag === 'string' && recipeDTag.trim().length > 0 && recipeDTag.trim().length <= 200;
+
+		if (validRecipePubkey && validRecipeDTag && validContentHash) {
 			const NOTIFICATION_PRIVATE_KEY = (platform?.env as any)?.NOTIFICATION_PRIVATE_KEY || env.NOTIFICATION_PRIVATE_KEY;
 			if (NOTIFICATION_PRIVATE_KEY) {
-				import('$lib/nourish/nourishPublisher.server').then(({ publishNourishEvent }) => {
-					publishNourishEvent({
-						privateKey: NOTIFICATION_PRIVATE_KEY,
-						recipePubkey,
-						recipeDTag,
-						contentHash,
-						scores,
-						improvements,
-						ingredientSignals: ingredient_signals
-					}).catch((err) => {
+				const publishPromise = import('$lib/nourish/nourishPublisher.server')
+					.then(({ publishNourishEvent }) =>
+						publishNourishEvent({
+							privateKey: NOTIFICATION_PRIVATE_KEY,
+							recipePubkey: recipePubkey.trim(),
+							recipeDTag: recipeDTag.trim(),
+							contentHash: contentHash.trim(),
+							scores,
+							improvements,
+							ingredientSignals: ingredient_signals
+						})
+					)
+					.catch((err) => {
 						console.error('[Nourish] Failed to publish event:', err);
 					});
-				}).catch((err) => {
-					console.error('[Nourish] Failed to import publisher:', err);
-				});
+
+				// Cloudflare Workers: register with waitUntil so the promise survives past response
+				if ((platform as any)?.context?.waitUntil) {
+					(platform as any).context.waitUntil(publishPromise);
+				}
 			}
 		}
 

--- a/src/routes/api/nourish/+server.ts
+++ b/src/routes/api/nourish/+server.ts
@@ -107,7 +107,7 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 		}
 
 		const body = await request.json();
-		const { pubkey, eventId, title, ingredients, tags, servings } = body;
+		const { pubkey, eventId, title, ingredients, tags, servings, recipePubkey, recipeDTag, contentHash } = body;
 
 		// Validate request
 		if (!ingredients || !Array.isArray(ingredients) || ingredients.length === 0) {
@@ -238,6 +238,30 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 							: 'neutral'
 					}))
 			: [];
+
+		// Publish Nourish event to pantry relay (fire-and-forget).
+		// If publishing fails, the analysis is still returned to the client —
+		// the next viewer will trigger a fresh analysis if no relay event is found.
+		if (recipePubkey && recipeDTag && contentHash) {
+			const NOTIFICATION_PRIVATE_KEY = (platform?.env as any)?.NOTIFICATION_PRIVATE_KEY || env.NOTIFICATION_PRIVATE_KEY;
+			if (NOTIFICATION_PRIVATE_KEY) {
+				import('$lib/nourish/nourishPublisher.server').then(({ publishNourishEvent }) => {
+					publishNourishEvent({
+						privateKey: NOTIFICATION_PRIVATE_KEY,
+						recipePubkey,
+						recipeDTag,
+						contentHash,
+						scores,
+						improvements,
+						ingredientSignals: ingredient_signals
+					}).catch((err) => {
+						console.error('[Nourish] Failed to publish event:', err);
+					});
+				}).catch((err) => {
+					console.error('[Nourish] Failed to import publisher:', err);
+				});
+			}
+		}
 
 		return json({ success: true, scores, improvements, ingredient_signals });
 	} catch (error: any) {

--- a/src/routes/nourish/+page.svelte
+++ b/src/routes/nourish/+page.svelte
@@ -5,16 +5,12 @@
   import { generateSuggestions, mergeImprovements } from '$lib/nourish/suggestions';
   import { ingredientStore } from '$lib/nourish/ingredientStore';
   import type { ScanResponse } from '$lib/nourish/types';
-  import NourishScoreCard from '../../components/nourish/NourishScoreCard.svelte';
+  import NourishInputTabs from '../../components/nourish/NourishInputTabs.svelte';
+  import NourishResult from '../../components/nourish/NourishResult.svelte';
   import Button from '../../components/Button.svelte';
   import LeafIcon from 'phosphor-svelte/lib/Leaf';
   import LockIcon from 'phosphor-svelte/lib/Lock';
   import SpinnerIcon from 'phosphor-svelte/lib/SpinnerGap';
-  import ArrowLeftIcon from 'phosphor-svelte/lib/ArrowLeft';
-  import { clickOutside } from '$lib/clickOutside';
-  import CameraIcon from 'phosphor-svelte/lib/Camera';
-  import UploadIcon from 'phosphor-svelte/lib/UploadSimple';
-  import XCircleIcon from 'phosphor-svelte/lib/XCircle';
 
   // Membership check
   let membershipMap: Record<string, MembershipStatus> = {};
@@ -23,102 +19,94 @@
   $: normalizedPk = String($userPublickey || '').trim().toLowerCase();
   $: hasMembership = Boolean(membershipMap[normalizedPk]?.active);
 
-  // Scan state
+  // Input state (bound to NourishInputTabs)
   let scanText = '';
+  let imageData: string | null = null;
+  let activeTab: 'ingredients' | 'describe' | 'photo' = 'ingredients';
+
+  // Analysis state
   let scanning = false;
   let scanError = '';
   let scanResult: ScanResponse | null = null;
   let improvements: string[] = [];
-  let imageData: string | null = null;
-  let imagePreview: string | null = null;
-  let fileInput: HTMLInputElement;
-  let cameraInput: HTMLInputElement;
-  let showPhotoMenu = false;
 
-  const SCORE_COLORS = { gut: '#22c55e', protein: '#3b82f6', realFood: '#f97316' };
+  $: hasInput = scanText.trim().length > 0 || imageData !== null;
 
-  const EXAMPLES = [
-    'Greek yogurt, berries, walnuts, chia seeds',
-    'Chipotle bowl with rice, beans, chicken, salsa',
-    'Eggs, sourdough toast, avocado'
-  ];
-
-  function useExample(text: string) {
-    scanText = text;
-  }
-
-  function handleFileSelect(e: Event) {
-    const target = e.target as HTMLInputElement;
-    if (!target.files?.length) return;
-    const file = target.files[0];
-    if (!file.type.startsWith('image/')) {
-      scanError = 'Please upload an image file (JPG, PNG, WEBP, or GIF)';
-      return;
-    }
-    if (file.size > 20 * 1024 * 1024) {
-      scanError = 'Image is too large. Please use an image under 20MB.';
-      return;
-    }
-    const reader = new FileReader();
-    reader.onload = () => { imageData = reader.result as string; imagePreview = imageData; scanError = ''; };
-    reader.onerror = () => { scanError = 'Failed to read image'; };
-    reader.readAsDataURL(file);
-  }
-
-  function removeImage() {
-    imageData = null;
-    imagePreview = null;
-    if (fileInput) fileInput.value = '';
-    if (cameraInput) cameraInput.value = '';
-  }
-
-  function togglePhotoMenu() { showPhotoMenu = !showPhotoMenu; }
-  function openCamera() { showPhotoMenu = false; cameraInput?.click(); }
-  function openFilePicker() { showPhotoMenu = false; fileInput?.click(); }
-
-  async function handleScan() {
+  async function handleAnalyze() {
     const text = scanText.trim();
-    const hasText = text.length >= 3;
-    const hasImage = !!imageData;
-    if (!hasText && !hasImage) { scanError = 'Please enter some text or upload an image to analyze.'; return; }
 
-    if (hasText && !hasImage) {
+    if (!text && !imageData) {
+      scanError = 'Add some ingredients, describe a dish, or upload a photo.';
+      return;
+    }
+
+    // Check scan cache (text-only, not images)
+    if (text && !imageData) {
       const cached = getScanResult(text);
-      if (cached && cached.scores) {
+      if (cached?.scores) {
         scanResult = cached;
-        improvements = mergeImprovements(generateSuggestions(cached.scores), cached.improvements || []);
+        buildImprovements(cached);
         return;
       }
     }
 
     scanning = true;
     scanError = '';
+
     try {
-      const requestBody: any = { pubkey: $userPublickey || '', text: hasText ? text : '', title: '' };
-      if (hasImage) requestBody.imageData = imageData;
+      const body: any = {
+        pubkey: $userPublickey || '',
+        text: text || 'Analyze this food image'
+      };
+
+      if (imageData) {
+        body.imageData = imageData;
+      }
 
       const res = await fetch('/api/nourish/scan', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(requestBody)
+        body: JSON.stringify(body)
       });
+
       const data: ScanResponse = await res.json();
-      if (!data.success) { scanError = data.error || 'Failed to analyze. Please try again.'; return; }
+
+      if (!data.success) {
+        scanError = data.error || "Couldn't analyze this one. Try again or rephrase.";
+        return;
+      }
 
       scanResult = data;
-      if (hasText) { setScanResult(text, data); }
-      if (data.scores) { improvements = mergeImprovements(generateSuggestions(data.scores), data.improvements || []); }
-      if (data.ingredient_signals?.length) { ingredientStore.saveIngredients(data.ingredient_signals, 'scan').catch(() => {}); }
-    } catch { scanError = 'Could not connect. Please try again.'; }
-    finally { scanning = false; }
+      buildImprovements(data);
+
+      // Cache text-based results (not image-based — different images same text)
+      if (text && !imageData) {
+        setScanResult(text, data);
+      }
+
+      // Save ingredient signals to build dataset over time
+      if (data.ingredient_signals?.length) {
+        ingredientStore.saveIngredients(data.ingredient_signals, 'scan').catch(() => {});
+      }
+    } catch {
+      scanError = "Couldn't analyze this one. Try again or rephrase.";
+    } finally {
+      scanning = false;
+    }
+  }
+
+  function buildImprovements(data: ScanResponse) {
+    if (!data.scores) return;
+    improvements = mergeImprovements(
+      generateSuggestions(data.scores),
+      data.improvements || []
+    );
   }
 
   function resetScan() {
     scanResult = null;
     improvements = [];
     scanError = '';
-    removeImage();
-    scanText = '';
   }
 
   import { onDestroy } from 'svelte';
@@ -126,449 +114,198 @@
 </script>
 
 <svelte:head>
-  <title>Nourish — Recipe Intelligence - zap.cooking</title>
-  <meta name="description" content="Analyze any food with three simple signals: Real Food, Gut, and Protein." />
+  <title>Nourish | Zap Cooking</title>
 </svelte:head>
 
-<article class="max-w-2xl mx-auto">
-  <a href="/community" class="back-link">
-    <ArrowLeftIcon size={16} />
-    Back
-  </a>
-
-  <!-- ════════════════════════════════════════════════════════════ -->
-  <!-- HERO -->
-  <!-- ════════════════════════════════════════════════════════════ -->
+<div class="nourish-page">
+  <!-- Hero -->
   <div class="hero">
-    <div class="hero-title-row">
-      <LeafIcon size={28} weight="fill" class="text-green-500" />
-      <div>
-        <h1 class="text-2xl font-bold" style="color: var(--color-text-primary)">Nourish</h1>
-        <p class="text-xs font-medium" style="color: var(--color-text-secondary)">Recipe Intelligence</p>
-      </div>
+    <div class="hero-icon">
+      <LeafIcon size={24} weight="fill" />
     </div>
-    <h2 class="hero-heading">Understand what your food leans toward.</h2>
-    <p class="hero-sub">Three simple signals to help you make informed choices: Real Food, Gut, and Protein.</p>
-    <p class="hero-muted">Not a grade. Just guidance.</p>
+    <h1 class="hero-title">Nourish</h1>
+    <p class="hero-subtitle">See what your food brings to the table.</p>
+    <p class="hero-note">Not a grade. Just guidance.</p>
   </div>
 
-  <!-- ════════════════════════════════════════════════════════════ -->
-  <!-- SCAN CARD -->
-  <!-- ════════════════════════════════════════════════════════════ -->
-  <div class="scan-card">
-    {#if !hasMembership && !scanResult}
-      <div class="scan-lock">
-        <LockIcon size={22} class="text-orange-500" />
-        <div class="flex-1">
-          <p class="text-sm font-semibold" style="color: var(--color-text-primary);">Members Only</p>
-          <p class="text-xs" style="color: var(--color-text-secondary);">Analyze any food for instant Nourish scores.</p>
-        </div>
-        <a href="/membership"><Button primary>Join</Button></a>
+  {#if !hasMembership && !scanResult}
+    <!-- Lock state -->
+    <div class="lock-card">
+      <LockIcon size={22} weight="fill" class="text-orange-500" />
+      <div class="lock-content">
+        <p class="lock-title">Members Only</p>
+        <p class="lock-desc">Explore what your meals are made of with instant Nourish profiles.</p>
       </div>
+      <a href="/membership"><Button primary>Join</Button></a>
+    </div>
 
-    {:else if scanResult && scanResult.scores}
-      <!-- ── Results ── -->
-      {#if scanResult.quick_take}
-        <p class="text-sm font-medium mb-4" style="color: var(--color-text-primary);">{scanResult.quick_take}</p>
-      {/if}
+  {:else if scanResult?.scores}
+    <!-- Results -->
+    <NourishResult
+      scores={scanResult.scores}
+      quickTake={scanResult.quick_take || ''}
+      {improvements}
+      ingredientSignals={scanResult.ingredient_signals || []}
+      onReset={resetScan}
+    />
 
-      {#if scanResult.scores.overall}
-        <NourishScoreCard
-          label="Nourish Score"
-          subtitle="Overall food quality"
-          score={scanResult.scores.overall.score}
-          scoreLabel={scanResult.scores.overall.label}
-          reason={scanResult.scores.overall.reason}
-          color="#a855f7"
-        />
-      {/if}
+  {:else}
+    <!-- Input -->
+    <NourishInputTabs
+      bind:text={scanText}
+      bind:imageData
+      bind:activeTab
+      disabled={scanning}
+    />
 
-      <div class="flex flex-col">
-        <NourishScoreCard borderTop label="Real Food" subtitle="Whole food ingredients" score={scanResult.scores.realFood.score} scoreLabel={scanResult.scores.realFood.label} reason={scanResult.scores.realFood.reason} color={SCORE_COLORS.realFood} />
-        <NourishScoreCard borderTop label="Gut" subtitle="Digestive health potential" score={scanResult.scores.gut.score} scoreLabel={scanResult.scores.gut.label} reason={scanResult.scores.gut.reason} color={SCORE_COLORS.gut} />
-        <NourishScoreCard borderTop label="Protein" subtitle="Protein source quality" score={scanResult.scores.protein.score} scoreLabel={scanResult.scores.protein.label} reason={scanResult.scores.protein.reason} color={SCORE_COLORS.protein} />
-      </div>
-
-      {#if scanResult.scores.summary}
-        <p class="result-summary">{scanResult.scores.summary}</p>
-      {/if}
-
-      {#if improvements.length > 0}
-        <div class="result-upgrades">
-          <p class="text-sm font-semibold mb-1" style="color: var(--color-text-primary);">Upgrade It</p>
-          <ul class="text-sm pl-4 list-disc" style="color: var(--color-text-secondary);">
-            {#each improvements as s}<li class="py-0.5">{s}</li>{/each}
-          </ul>
-        </div>
-      {/if}
-
-      <button class="scan-again-btn" on:click={resetScan}>Analyze something else</button>
-
-    {:else}
-      <!-- ── Input ── -->
-      <p class="input-helper">Paste ingredients, describe a dish, or type anything food-related.</p>
-
-      <textarea
-        bind:value={scanText}
-        class="scan-input"
-        rows="4"
-        placeholder="e.g. chicken thighs, sweet potato, kale, olive oil, garlic..."
-        disabled={scanning}
-      ></textarea>
-
-      <!-- Hidden file inputs -->
-      <input bind:this={fileInput} type="file" accept="image/jpeg,image/png,image/webp,image/gif" class="hidden" on:change={handleFileSelect} />
-      <input bind:this={cameraInput} type="file" accept="image/jpeg,image/png,image/webp" capture="environment" class="hidden" on:change={handleFileSelect} />
-
-      {#if imagePreview}
-        <div class="image-preview-row">
-          <img src={imagePreview} alt="Upload preview" class="image-preview-thumb" />
-          <button class="remove-image-btn" on:click={removeImage} aria-label="Remove image"><XCircleIcon size={18} /></button>
-        </div>
-      {/if}
-
-      {#if scanError}
-        <p class="text-sm mt-2" style="color: #ef4444;">{scanError}</p>
-      {/if}
-
-      <!-- CTA row -->
-      <div class="cta-row">
-        {#if scanning}
-          <Button primary disabled>
-            <span class="flex items-center gap-2"><SpinnerIcon size={16} class="animate-spin" />Analyzing...</span>
-          </Button>
-        {:else}
-          <Button primary on:click={handleScan} disabled={!scanText.trim() && !imageData}>
-            <span class="flex items-center gap-2"><LeafIcon size={16} />Analyze with Nourish</span>
-          </Button>
-          <div class="relative" use:clickOutside on:click_outside={() => showPhotoMenu = false}>
-            <button class="photo-btn" on:click={togglePhotoMenu} aria-label="Add a photo" title="Add a photo">
-              <CameraIcon size={20} />
-            </button>
-            {#if showPhotoMenu}
-              <div class="photo-menu">
-                <button class="photo-menu-item" on:click={openCamera}><CameraIcon size={16} />Take Photo</button>
-                <button class="photo-menu-item" on:click={openFilePicker}><UploadIcon size={16} />Upload Image</button>
-              </div>
-            {/if}
-          </div>
-        {/if}
-      </div>
-
-      <!-- Example prompts -->
-      <div class="examples">
-        <p class="text-xs mb-2" style="color: var(--color-text-secondary);">Try an example:</p>
-        <div class="example-chips">
-          {#each EXAMPLES as ex}
-            <button class="example-chip" on:click={() => useExample(ex)}>{ex}</button>
-          {/each}
-        </div>
-      </div>
+    {#if scanError}
+      <p class="error-text">{scanError}</p>
     {/if}
-  </div>
 
-  <!-- ════════════════════════════════════════════════════════════ -->
-  <!-- SCORE PREVIEW (static mock) -->
-  <!-- ════════════════════════════════════════════════════════════ -->
-  {#if !scanResult}
-    <div class="preview-section">
-      <p class="text-xs font-medium mb-3" style="color: var(--color-text-secondary);">What you'll see:</p>
-      <div class="preview-grid">
-        <div class="preview-item">
-          <span class="preview-dot" style="background: #f97316;"></span>
-          <span class="preview-label">Real Food</span>
-          <span class="preview-score">8</span>
-        </div>
-        <div class="preview-item">
-          <span class="preview-dot" style="background: #22c55e;"></span>
-          <span class="preview-label">Gut</span>
-          <span class="preview-score">6</span>
-        </div>
-        <div class="preview-item">
-          <span class="preview-dot" style="background: #3b82f6;"></span>
-          <span class="preview-label">Protein</span>
-          <span class="preview-score">7</span>
-        </div>
-        <div class="preview-item">
-          <span class="preview-dot" style="background: #a855f7;"></span>
-          <span class="preview-label">Overall</span>
-          <span class="preview-score">7</span>
-        </div>
-      </div>
-    </div>
+    <!-- CTA -->
+    <button
+      class="analyze-btn"
+      on:click={handleAnalyze}
+      disabled={scanning || !hasInput}
+    >
+      {#if scanning}
+        <SpinnerIcon size={18} class="animate-spin" />
+        Looking at your food...
+      {:else}
+        <LeafIcon size={18} weight="fill" />
+        See what's inside
+      {/if}
+    </button>
   {/if}
 
-  <!-- ════════════════════════════════════════════════════════════ -->
-  <!-- SCORE CARDS -->
-  <!-- ════════════════════════════════════════════════════════════ -->
-  <div class="info-section">
-    <h2 class="info-heading">How Scores Work</h2>
-    <p class="info-muted">Scores help you understand what a recipe leans toward — so you can adjust, not judge.</p>
-
-    <div class="score-cards-grid">
-      <div class="score-card-info" style="border-color: #f97316;">
-        <h3 class="score-card-title" style="color: #f97316;">Real Food</h3>
-        <p class="score-card-desc">How close a meal is to whole, recognizable ingredients.</p>
-        <p class="score-card-weight">45% of overall</p>
-      </div>
-      <div class="score-card-info" style="border-color: #22c55e;">
-        <h3 class="score-card-title" style="color: #22c55e;">Gut</h3>
-        <p class="score-card-desc">Fiber, plant diversity, fermented foods, and prebiotic support.</p>
-        <p class="score-card-weight">35% of overall</p>
-      </div>
-      <div class="score-card-info" style="border-color: #3b82f6;">
-        <h3 class="score-card-title" style="color: #3b82f6;">Protein</h3>
-        <p class="score-card-desc">Protein density and contribution to fullness and recovery.</p>
-        <p class="score-card-weight">20% of overall</p>
-      </div>
-      <div class="score-card-info" style="border-color: #a855f7;">
-        <h3 class="score-card-title" style="color: #a855f7;">Overall</h3>
-        <p class="score-card-desc">A weighted signal based on Real Food, Gut, and Protein.</p>
-        <p class="score-card-weight">0–10 scale</p>
-      </div>
-    </div>
-
-    <!-- Scale -->
-    <div class="scale-row">
-      <div class="scale-item"><span class="scale-num">0–2</span><span class="scale-label">Low</span></div>
-      <div class="scale-item"><span class="scale-num">3–4</span><span class="scale-label">Fair</span></div>
-      <div class="scale-item"><span class="scale-num">5–6</span><span class="scale-label">Moderate</span></div>
-      <div class="scale-item"><span class="scale-num">7–8</span><span class="scale-label">Strong</span></div>
-      <div class="scale-item"><span class="scale-num">9–10</span><span class="scale-label">Excellent</span></div>
-    </div>
-  </div>
-
-  <!-- ════════════════════════════════════════════════════════════ -->
-  <!-- FOOTER -->
-  <!-- ════════════════════════════════════════════════════════════ -->
+  <!-- Footer -->
   <div class="page-footer">
-    <p>Nourish is available to <a href="/membership" class="footer-link">Zap Cooking members</a>.</p>
-    <p class="footer-notes">Scores are estimates based on ingredients. Not medical advice. Nourish is for awareness, not diagnosis.</p>
+    <p>
+      Nourish is for <a href="/membership" class="footer-link">Zap Cooking members</a>.
+      Profiles are estimates based on ingredients. Not medical advice.
+    </p>
   </div>
-</article>
+</div>
 
-<style lang="postcss">
-  @reference "../../app.css";
-
-  /* ── Back link ── */
-  .back-link {
-    @apply inline-flex items-center gap-2 mb-6 text-sm;
-    color: var(--color-text-secondary);
+<style>
+  .nourish-page {
+    max-width: 480px;
+    margin: 0 auto;
+    padding: 2rem 1rem 3rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
   }
-  .back-link:hover { text-decoration: underline; }
 
-  /* ── Hero ── */
+  /* Hero */
   .hero {
-    @apply mb-8;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 0.25rem;
   }
-  .hero-title-row {
-    @apply flex items-center gap-3 mb-4;
+  .hero-icon {
+    color: #22c55e;
+    margin-bottom: 0.25rem;
   }
-  .hero-heading {
-    @apply text-xl font-bold mb-2;
+  .hero-title {
+    font-size: 1.5rem;
+    font-weight: 700;
     color: var(--color-text-primary);
+    margin: 0;
   }
-  .hero-sub {
-    @apply text-sm leading-relaxed mb-1;
+  .hero-subtitle {
+    font-size: 0.9375rem;
     color: var(--color-text-secondary);
+    margin: 0;
   }
-  .hero-muted {
-    @apply text-xs;
-    color: var(--color-text-secondary);
-    opacity: 0.6;
-  }
-
-  /* ── Scan card ── */
-  .scan-card {
-    @apply p-5 rounded-2xl mb-8;
-    background-color: var(--color-bg-secondary);
-    border: 1px solid var(--color-bg-tertiary, rgba(255, 255, 255, 0.06));
-    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.15);
-  }
-  .scan-lock {
-    @apply flex items-center gap-4 p-4 rounded-xl;
-    background-color: var(--color-bg-tertiary, rgba(255, 255, 255, 0.04));
-  }
-  .input-helper {
-    @apply text-sm mb-3;
-    color: var(--color-text-secondary);
-  }
-  .scan-input {
-    @apply w-full rounded-xl p-4 text-sm border resize-none;
-    font-size: 16px;
-    background: var(--color-input-bg);
-    border-color: var(--color-input-border);
-    color: var(--color-text-primary);
-  }
-  .scan-input::placeholder {
+  .hero-note {
+    font-size: 0.75rem;
     color: var(--color-text-secondary);
     opacity: 0.5;
-  }
-  .scan-input:focus {
-    outline: none;
-    border-color: var(--color-accent, #f97316);
-    box-shadow: 0 0 0 2px rgba(249, 115, 22, 0.15);
-  }
-  .cta-row {
-    @apply mt-4 flex items-center gap-2;
-  }
-  .scan-again-btn {
-    @apply mt-4 text-sm font-medium cursor-pointer;
-    color: var(--color-accent, #f97316);
-  }
-  .scan-again-btn:hover { text-decoration: underline; }
-
-  .result-summary {
-    @apply text-sm leading-relaxed mt-3 pt-3;
-    color: var(--color-text-secondary);
-    border-top: 1px solid var(--color-bg-tertiary, rgba(255, 255, 255, 0.08));
-  }
-  .result-upgrades {
-    @apply mt-3 pt-3;
-    border-top: 1px solid var(--color-bg-tertiary, rgba(255, 255, 255, 0.08));
+    margin: 0;
   }
 
-  /* ── Examples ── */
-  .examples {
-    @apply mt-4 pt-4;
-    border-top: 1px solid var(--color-bg-tertiary, rgba(255, 255, 255, 0.06));
-  }
-  .example-chips {
-    @apply flex flex-wrap gap-2;
-  }
-  .example-chip {
-    @apply text-xs px-3 py-1.5 rounded-full cursor-pointer transition-colors;
-    background-color: var(--color-bg-tertiary, rgba(255, 255, 255, 0.05));
-    color: var(--color-text-secondary);
-    border: 1px solid transparent;
-  }
-  .example-chip:hover {
-    color: var(--color-text-primary);
-    border-color: var(--color-input-border);
-  }
-
-  /* ── Image ── */
-  .image-preview-row { @apply flex items-center gap-2 mt-3; }
-  .image-preview-thumb { @apply w-16 h-16 rounded-lg object-cover; }
-  .remove-image-btn {
-    @apply cursor-pointer transition-opacity;
-    color: var(--color-text-secondary);
-    opacity: 0.6;
-  }
-  .remove-image-btn:hover { opacity: 1; }
-
-  /* ── Photo menu ── */
-  .photo-btn {
-    @apply p-2.5 rounded-xl transition-colors cursor-pointer;
-    color: var(--color-text-secondary);
+  /* Lock */
+  .lock-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 0.75rem;
+    padding: 2rem 1.5rem;
+    border-radius: 0.75rem;
+    border: 1px solid var(--color-input-border);
     background: var(--color-input-bg);
-    border: 1px solid var(--color-input-border);
   }
-  .photo-btn:hover {
+  .lock-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+  .lock-title {
+    font-size: 1rem;
+    font-weight: 600;
     color: var(--color-text-primary);
-    background: var(--color-bg-tertiary, rgba(255, 255, 255, 0.08));
+    margin: 0;
   }
-  .photo-menu {
-    @apply absolute bottom-full left-0 mb-2 rounded-xl py-1 z-50;
-    min-width: 160px;
-    background-color: var(--color-bg-primary);
-    border: 1px solid var(--color-input-border);
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
-  }
-  .photo-menu-item {
-    @apply w-full flex items-center gap-3 px-4 py-2.5 text-sm text-left transition-colors cursor-pointer;
-    color: var(--color-text-primary);
-  }
-  .photo-menu-item:hover {
-    background-color: var(--color-bg-tertiary, rgba(255, 255, 255, 0.05));
+  .lock-desc {
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
+    margin: 0;
   }
 
-  /* ── Preview ── */
-  .preview-section {
-    @apply mb-8;
-  }
-  .preview-grid {
-    @apply grid grid-cols-4 gap-3;
-  }
-  .preview-item {
-    @apply flex flex-col items-center gap-1 p-3 rounded-xl text-center;
-    background-color: var(--color-bg-secondary);
-  }
-  .preview-dot {
-    @apply w-2 h-2 rounded-full;
-  }
-  .preview-label {
-    @apply text-xs;
-    color: var(--color-text-secondary);
-  }
-  .preview-score {
-    @apply text-lg font-bold;
-    color: var(--color-text-primary);
+  /* Error */
+  .error-text {
+    font-size: 0.8125rem;
+    color: #ef4444;
+    text-align: center;
+    margin: 0;
   }
 
-  /* ── Score info cards ── */
-  .info-section {
-    @apply mb-8;
+  /* CTA button */
+  .analyze-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.75rem 1.5rem;
+    border-radius: 0.625rem;
+    border: none;
+    background: #22c55e;
+    color: white;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    font-family: inherit;
+    cursor: pointer;
+    transition: background 150ms, opacity 150ms;
   }
-  .info-heading {
-    @apply text-lg font-bold mb-1;
-    color: var(--color-text-primary);
+  .analyze-btn:hover:not(:disabled) {
+    background: #16a34a;
   }
-  .info-muted {
-    @apply text-sm mb-5;
-    color: var(--color-text-secondary);
-  }
-  .score-cards-grid {
-    @apply grid grid-cols-2 gap-3 mb-5;
-  }
-  .score-card-info {
-    @apply p-4 rounded-xl;
-    background-color: var(--color-bg-secondary);
-    border-left: 3px solid;
-  }
-  .score-card-title {
-    @apply text-sm font-bold mb-1;
-  }
-  .score-card-desc {
-    @apply text-xs leading-relaxed;
-    color: var(--color-text-secondary);
-  }
-  .score-card-weight {
-    @apply text-xs mt-2 font-medium;
-    color: var(--color-text-secondary);
-    opacity: 0.6;
+  .analyze-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 
-  /* ── Scale ── */
-  .scale-row {
-    @apply grid grid-cols-5 gap-2 p-3 rounded-xl;
-    background-color: var(--color-bg-secondary);
-  }
-  .scale-item {
-    @apply flex flex-col items-center gap-0.5;
-  }
-  .scale-num {
-    @apply text-sm font-bold;
-    color: var(--color-text-primary);
-  }
-  .scale-label {
-    @apply text-xs;
-    color: var(--color-text-secondary);
-  }
-
-  /* ── Footer ── */
+  /* Footer */
   .page-footer {
-    @apply py-6 text-center text-xs;
+    text-align: center;
+    padding-top: 1rem;
+  }
+  .page-footer p {
+    font-size: 0.6875rem;
     color: var(--color-text-secondary);
-    opacity: 0.7;
+    opacity: 0.5;
+    margin: 0;
   }
   .footer-link {
-    color: var(--color-accent, #f97316);
-    font-weight: 500;
+    color: #22c55e;
+    text-decoration: none;
   }
-  .footer-link:hover { text-decoration: underline; }
-  .footer-notes {
-    @apply mt-1;
-    opacity: 0.6;
+  .footer-link:hover {
+    text-decoration: underline;
   }
 </style>


### PR DESCRIPTION
## Summary

Convert Nourish from per-user API calls to a shared persistent analysis layer using Nostr events. First analysis publishes results to the pantry relay — all future viewers read from the relay without a fresh GPT call.

### Before
- Every user click → fresh GPT-4o-mini API call (~$0.01-0.05)
- Scores cached only in viewer's localStorage (7-day TTL)
- 100 viewers = 100 identical API calls

### After
- First viewer → GPT analysis → published as kind 30078 event to pantry relay
- All subsequent viewers → read from relay (~200ms, no API call)
- 100 viewers = 1 API call + 99 relay reads

### Architecture

```
Client fetch chain:
1. localStorage cache (instant, <1ms)
2. Pantry relay query (~200ms)
3. POST /api/nourish + GPT (2-5s, membership-gated, publishes event)
```

**Nostr Event Model (kind 30078 / NIP-78):**
- d-tag: `nourish:30023:<recipe-author>:<recipe-d-tag>` (addressable/replaceable)
- Content: full scores, improvements, ingredient signals as JSON
- Tags: indexable scores (`nourish_overall`, `nourish_gut`, etc.), content hash, version tracking
- Published by Zap Cooking service account (NOTIFICATION_PRIVATE_KEY)

**Staleness detection:**
- SHA-256 content hash of recipe markdown stored in event tags
- Client compares against current recipe content on each view
- Stale scores shown with "Recipe updated" banner + re-analyze button

**Premium model shift:**
- Viewing scores: **free** (public Nostr events on pantry relay)
- Generating new analysis: **premium-gated** (the expensive GPT call)

### Files changed

| File | Change |
|------|--------|
| `src/lib/nourish/nourishRelay.ts` | **New** — relay query, content hashing, stale detection |
| `src/lib/nourish/nourishPublisher.server.ts` | **New** — server-side event signing + publishing |
| `src/routes/api/nourish/+server.ts` | Publishes Nourish event after GPT analysis (fire-and-forget) |
| `src/components/nourish/NourishModal.svelte` | Relay-first fetch chain, stale banner, re-analyze button, "analyzed at" timestamp |
| `src/lib/nourish/cache.ts` | Extended to store contentHash alongside scores |
| `src/lib/nourish/types.ts` | NOURISH_SERVICE_PUBKEY, NOURISH_PROMPT_VERSION, NourishRelayResult |

### Setup required

The `NOURISH_SERVICE_PUBKEY` constant in `types.ts` must be set to the pubkey derived from `NOTIFICATION_PRIVATE_KEY`. Run:
```js
new NDKPrivateKeySigner(hexKey).user().then(u => console.log(u.pubkey))
```

## Test plan

- [ ] Analyze a recipe → confirm kind 30078 event published to pantry relay
- [ ] Open same recipe in incognito → scores load from relay without API call
- [ ] Edit recipe content → stale banner appears with "Re-analyze" button
- [ ] Re-analyze → new event replaces old on relay
- [ ] Non-member views analyzed recipe → scores display (viewing is free)
- [ ] Non-member views un-analyzed recipe → lock state shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)