### PR TITLE
polish: Nourish page UI — copy, spacing, chips, auto-grow, sparkle CTA

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.192",
+  "version": "4.2.193",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/nourish/NourishInputTabs.svelte
+++ b/src/components/nourish/NourishInputTabs.svelte
@@ -18,7 +18,7 @@
 
   const TABS: { id: TabId; label: string }[] = [
     { id: 'ingredients', label: 'Ingredients' },
-    { id: 'describe', label: 'Describe' },
+    { id: 'describe', label: 'Describe a Meal' },
     { id: 'photo', label: 'Photo' }
   ];
 
@@ -42,8 +42,20 @@
     photo: []
   };
 
+  let textareaEl: HTMLTextAreaElement;
+
   function useExample(example: string) {
     text = example;
+    // Trigger auto-resize after example is set
+    requestAnimationFrame(() => autoResize());
+  }
+
+  function autoResize() {
+    if (!textareaEl) return;
+    textareaEl.style.height = 'auto';
+    const lineHeight = 24; // ~1.5rem at 16px
+    const maxHeight = lineHeight * 5; // 5 lines
+    textareaEl.style.height = Math.min(textareaEl.scrollHeight, maxHeight) + 'px';
   }
 
   $: currentExamples = EXAMPLES[activeTab];
@@ -74,9 +86,11 @@
     {:else}
       <textarea
         class="nit-textarea"
+        bind:this={textareaEl}
         bind:value={text}
+        on:input={autoResize}
         placeholder={PLACEHOLDERS[activeTab]}
-        rows={4}
+        rows={2}
         {disabled}
       />
     {/if}
@@ -149,7 +163,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
 
-  /* Textarea */
+  /* Textarea — auto-grows from 2 lines to max 5, then scrolls */
   .nit-textarea {
     width: 100%;
     padding: 0.75rem;
@@ -160,7 +174,10 @@
     font-size: 1rem; /* 16px prevents iOS zoom */
     font-family: inherit;
     line-height: 1.5;
-    resize: vertical;
+    resize: none;
+    overflow-y: auto;
+    min-height: calc(1.5rem * 2 + 1.5rem); /* 2 lines + padding */
+    max-height: calc(1.5rem * 5 + 1.5rem); /* 5 lines + padding */
     transition: border-color 150ms;
   }
   .nit-textarea::placeholder {
@@ -190,17 +207,21 @@
     font-size: 0.75rem;
     padding: 0.25rem 0.625rem;
     border-radius: 9999px;
-    border: 1px solid var(--color-input-border, rgba(255, 255, 255, 0.08));
-    background: var(--color-input-bg, rgba(255, 255, 255, 0.02));
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    background: rgba(255, 255, 255, 0.04);
     color: var(--color-text-secondary);
     cursor: pointer;
     font-family: inherit;
-    transition: background 150ms, border-color 150ms, color 150ms;
+    transition: background 150ms, border-color 150ms, color 150ms, transform 100ms;
     white-space: nowrap;
   }
   .nit-example:hover {
-    background: rgba(34, 197, 94, 0.06);
-    border-color: rgba(34, 197, 94, 0.2);
+    background: rgba(34, 197, 94, 0.08);
+    border-color: rgba(34, 197, 94, 0.3);
     color: #22c55e;
+  }
+  .nit-example:active {
+    transform: scale(0.97);
+    background: rgba(34, 197, 94, 0.12);
   }
 </style>

--- a/src/routes/nourish/+page.svelte
+++ b/src/routes/nourish/+page.svelte
@@ -11,6 +11,7 @@
   import LeafIcon from 'phosphor-svelte/lib/Leaf';
   import LockIcon from 'phosphor-svelte/lib/Lock';
   import SpinnerIcon from 'phosphor-svelte/lib/SpinnerGap';
+  import SparkleIcon from 'phosphor-svelte/lib/Sparkle';
 
   // Membership check
   let membershipMap: Record<string, MembershipStatus> = {};
@@ -124,7 +125,7 @@
       <LeafIcon size={24} weight="fill" />
     </div>
     <h1 class="hero-title">Nourish</h1>
-    <p class="hero-subtitle">See what your food brings to the table.</p>
+    <p class="hero-subtitle">Get nutrition insights from your ingredients.</p>
     <p class="hero-note">Not a grade. Just guidance.</p>
   </div>
 
@@ -172,18 +173,22 @@
         <SpinnerIcon size={18} class="animate-spin" />
         Looking at your food...
       {:else}
-        <LeafIcon size={18} weight="fill" />
+        <SparkleIcon size={18} weight="fill" />
         See what's inside
       {/if}
     </button>
   {/if}
 
-  <!-- Footer -->
+  <!-- Member banner + disclaimer -->
+  {#if !hasMembership}
+    <div class="member-banner">
+      <LockIcon size={14} weight="fill" />
+      <span>Nourish is for <a href="/membership" class="banner-link">Zap Cooking members</a>.</span>
+      <a href="/membership" class="banner-cta">Join</a>
+    </div>
+  {/if}
   <div class="page-footer">
-    <p>
-      Nourish is for <a href="/membership" class="footer-link">Zap Cooking members</a>.
-      Profiles are estimates based on ingredients. Not medical advice.
-    </p>
+    <p>Profiles are estimates based on ingredients. Not medical advice.</p>
   </div>
 </div>
 
@@ -191,23 +196,23 @@
   .nourish-page {
     max-width: 480px;
     margin: 0 auto;
-    padding: 2rem 1rem 3rem;
+    padding: 1.5rem 1rem 2.5rem;
     display: flex;
     flex-direction: column;
-    gap: 1.5rem;
+    gap: 1rem;
   }
 
-  /* Hero */
+  /* Hero — tighter spacing */
   .hero {
     display: flex;
     flex-direction: column;
     align-items: center;
     text-align: center;
-    gap: 0.25rem;
+    gap: 0.125rem;
   }
   .hero-icon {
     color: #22c55e;
-    margin-bottom: 0.25rem;
+    margin-bottom: 0.125rem;
   }
   .hero-title {
     font-size: 1.5rem;
@@ -290,22 +295,50 @@
     cursor: not-allowed;
   }
 
+  /* Member banner */
+  .member-banner {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.625rem 0.75rem;
+    border-radius: 0.5rem;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+  }
+  .banner-link {
+    color: #22c55e;
+    text-decoration: none;
+  }
+  .banner-link:hover {
+    text-decoration: underline;
+  }
+  .banner-cta {
+    margin-left: auto;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #22c55e;
+    text-decoration: none;
+    padding: 0.25rem 0.625rem;
+    border-radius: 9999px;
+    border: 1px solid rgba(34, 197, 94, 0.3);
+    transition: background 150ms;
+    white-space: nowrap;
+  }
+  .banner-cta:hover {
+    background: rgba(34, 197, 94, 0.1);
+  }
+
   /* Footer */
   .page-footer {
     text-align: center;
-    padding-top: 1rem;
+    padding-top: 0.5rem;
   }
   .page-footer p {
     font-size: 0.6875rem;
     color: var(--color-text-secondary);
-    opacity: 0.5;
+    opacity: 0.4;
     margin: 0;
-  }
-  .footer-link {
-    color: #22c55e;
-    text-decoration: none;
-  }
-  .footer-link:hover {
-    text-decoration: underline;
   }
 </style>


### PR DESCRIPTION
## Summary

UI polish pass on the Nourish page. Seven targeted refinements to improve clarity, density, and premium feel.

### Changes

1. **Subheadline**: "See what your food brings to the table." → "Get nutrition insights from your ingredients."
2. **Auto-grow textarea**: Starts at 2 lines, expands as user types, max 5 lines before scrolling. No manual resize handle.
3. **Suggestion chips**: Added `border: 1px solid rgba(255,255,255,0.15)`, bumped background opacity, added `:active` press state (`scale(0.97)`)
4. **Tab label**: "Describe" → "Describe a Meal" (clearer differentiation from Ingredients tab)
5. **CTA icon**: Leaf → Sparkle (✨) to signal AI-powered analysis
6. **Member gate**: Footer text replaced with a subtle banner card — lock icon, light background, "Join" pill CTA. More visible conversion touchpoint.
7. **Spacing**: Reduced vertical gaps ~20-25% to keep full UI above the fold on standard laptops

## Test plan

- [ ] Textarea starts at 2 lines, grows to 5, then scrolls
- [ ] Example chips populate textarea and trigger auto-resize
- [ ] "Describe a Meal" tab label is clear
- [ ] Sparkle icon shows on CTA button
- [ ] Non-member sees member banner with lock icon and Join CTA
- [ ] Member does NOT see member banner
- [ ] Full input area fits above fold on 1080p laptop

🤖 Generated with [Claude Code](https://claude.com/claude-code)