### PR TITLE
fix: replace NDK publisher with direct WebSocket (NDK fails on CF Workers)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.197",
+  "version": "4.2.198",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.198",
+  "version": "4.2.199",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/nourish/nourishPublisher.server.ts
+++ b/src/lib/nourish/nourishPublisher.server.ts
@@ -1,15 +1,12 @@
 /**
  * Nourish Event Publisher (Server-side only)
  *
- * Signs and publishes Nourish analysis events (kind 30078) to the pantry relay
- * using the Zap Cooking service account. This makes the analysis available to
- * all future viewers without a fresh GPT call.
- *
- * Mirrors the pattern in membershipNotificationService.ts for server-side signing.
+ * Signs and publishes Nourish analysis events (kind 30078) using
+ * nostr-tools directly (not NDK). NDK's WebSocket handling doesn't
+ * work reliably on Cloudflare Workers — direct WebSocket publish does.
  */
 
-import NDK, { NDKEvent, NDKPrivateKeySigner } from '@nostr-dev-kit/ndk';
-import { nip19 } from 'nostr-tools';
+import { nip19, getPublicKey, finalizeEvent } from 'nostr-tools';
 import {
   NOURISH_CACHE_VERSION,
   NOURISH_PROMPT_VERSION,
@@ -18,32 +15,64 @@ import {
 } from './types';
 import { buildNourishDTag } from './nourishRelay';
 
-const PANTRY_RELAY = 'wss://pantry.zap.cooking';
-const PUBLISH_RELAYS = [PANTRY_RELAY, 'wss://relay.damus.io', 'wss://nos.lol'];
-const CONNECT_TIMEOUT_MS = 5000;
+const PUBLISH_RELAYS = ['wss://nos.lol', 'wss://relay.damus.io', 'wss://relay.primal.net'];
 const PUBLISH_TIMEOUT_MS = 5000;
 
 /**
  * Resolve the private key from env var (supports both hex and nsec format).
+ * Returns a Uint8Array for nostr-tools.
  */
-function resolvePrivateKey(raw: string): string {
+function resolvePrivateKey(raw: string): Uint8Array {
   if (raw.startsWith('nsec1')) {
     const decoded = nip19.decode(raw);
-    const dataArray = Array.from(decoded.data as Uint8Array);
-    return dataArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+    return decoded.data as Uint8Array;
   }
   if (/^[0-9a-fA-F]{64}$/.test(raw)) {
-    return raw;
+    return Uint8Array.from(raw.match(/.{2}/g)!.map((b) => parseInt(b, 16)));
   }
   throw new Error('Invalid private key format — must be 64 hex chars or nsec');
 }
 
 /**
- * Publish a Nourish analysis event to the pantry relay.
- *
- * This is fire-and-forget from the API route's perspective — publish failures
- * don't block the response. The next viewer will trigger a fresh analysis if
- * no event is found on the relay.
+ * Publish an event to a single relay via raw WebSocket.
+ * Returns true if the relay accepted the event.
+ */
+function publishToRelay(relayUrl: string, event: any): Promise<boolean> {
+  return new Promise((resolve) => {
+    try {
+      const WebSocket = globalThis.WebSocket;
+      const ws = new WebSocket(relayUrl);
+      let settled = false;
+
+      const timer = setTimeout(() => {
+        if (!settled) { settled = true; ws.close(); resolve(false); }
+      }, PUBLISH_TIMEOUT_MS);
+
+      ws.onopen = () => {
+        ws.send(JSON.stringify(['EVENT', event]));
+      };
+
+      ws.onmessage = (msg: MessageEvent) => {
+        try {
+          const data = JSON.parse(typeof msg.data === 'string' ? msg.data : '');
+          if (data[0] === 'OK') {
+            const accepted = data[2] === true;
+            if (!settled) { settled = true; clearTimeout(timer); ws.close(); resolve(accepted); }
+          }
+        } catch {}
+      };
+
+      ws.onerror = () => {
+        if (!settled) { settled = true; clearTimeout(timer); resolve(false); }
+      };
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+/**
+ * Publish a Nourish analysis event to relays.
  */
 export async function publishNourishEvent(opts: {
   privateKey: string;
@@ -57,82 +86,49 @@ export async function publishNourishEvent(opts: {
   const { privateKey, recipePubkey, recipeDTag, contentHash, scores, improvements, ingredientSignals } = opts;
 
   try {
-    const hexKey = resolvePrivateKey(privateKey);
-    const signer = new NDKPrivateKeySigner(hexKey);
-
-    const ndk = new NDK({ explicitRelayUrls: PUBLISH_RELAYS });
-    ndk.signer = signer;
-    await ndk.connect();
-
-    // Wait for at least one relay to connect
-    const connected = await waitForConnection(ndk);
-    if (!connected) {
-      console.error('[Nourish Publisher] No relays connected after timeout');
-      return false;
-    }
-
+    const privKeyBytes = resolvePrivateKey(privateKey);
     const dTag = buildNourishDTag(recipePubkey, recipeDTag);
 
-    // Build the event
-    const event = new NDKEvent(ndk);
-    event.kind = 30078;
-    event.content = JSON.stringify({
-      gut: scores.gut,
-      protein: scores.protein,
-      realFood: scores.realFood,
-      overall: scores.overall,
-      summary: scores.summary,
-      improvements,
-      ingredient_signals: ingredientSignals,
-      version: scores.version
-    });
-    event.tags = [
-      // Identity
-      ['d', dTag],
-      ['client', 'zap.cooking'],
+    // Build and sign event using nostr-tools (works on CF Workers)
+    const event = finalizeEvent({
+      kind: 30078,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [
+        ['d', dTag],
+        ['client', 'zap.cooking'],
+        ['a', `30023:${recipePubkey}:${recipeDTag}`],
+        ['p', recipePubkey],
+        ['nourish_version', NOURISH_CACHE_VERSION],
+        ['content_hash', contentHash],
+        ['prompt_version', NOURISH_PROMPT_VERSION],
+        ['nourish_overall', String(scores.overall.score)],
+        ['nourish_gut', String(scores.gut.score)],
+        ['nourish_protein', String(scores.protein.score)],
+        ['nourish_realfood', String(scores.realFood.score)]
+      ],
+      content: JSON.stringify({
+        gut: scores.gut,
+        protein: scores.protein,
+        realFood: scores.realFood,
+        overall: scores.overall,
+        summary: scores.summary,
+        improvements,
+        ingredient_signals: ingredientSignals,
+        version: scores.version
+      })
+    }, privKeyBytes);
 
-      // Recipe reference
-      ['a', `30023:${recipePubkey}:${recipeDTag}`],
-      ['p', recipePubkey],
-
-      // Versioning
-      ['nourish_version', NOURISH_CACHE_VERSION],
-      ['content_hash', contentHash],
-      ['prompt_version', NOURISH_PROMPT_VERSION],
-
-      // Indexable scores (for future relay-side filtering)
-      ['nourish_overall', String(scores.overall.score)],
-      ['nourish_gut', String(scores.gut.score)],
-      ['nourish_protein', String(scores.protein.score)],
-      ['nourish_realfood', String(scores.realFood.score)]
-    ];
-    event.created_at = Math.floor(Date.now() / 1000);
-
-    await event.sign(signer);
-
-    // Publish with timeout
-    const publishPromise = event.publish();
-    const timeoutPromise = new Promise<void>((_, reject) =>
-      setTimeout(() => reject(new Error('Publish timeout')), PUBLISH_TIMEOUT_MS)
+    // Publish to all relays in parallel
+    const results = await Promise.all(
+      PUBLISH_RELAYS.map((relay) => publishToRelay(relay, event))
     );
 
-    await Promise.race([publishPromise, timeoutPromise]);
-    console.log(`[Nourish Publisher] Published analysis for ${recipeDTag} (${dTag})`);
-    return true;
+    const successCount = results.filter(Boolean).length;
+    console.log(`[Nourish Publisher] Published to ${successCount}/${PUBLISH_RELAYS.length} relays for ${recipeDTag}`);
+
+    return successCount > 0;
   } catch (err) {
-    console.error('[Nourish Publisher] Failed to publish:', err);
+    console.error('[Nourish Publisher] Failed:', err);
     return false;
   }
-}
-
-async function waitForConnection(ndk: NDK): Promise<boolean> {
-  const start = Date.now();
-  while (Date.now() - start < CONNECT_TIMEOUT_MS) {
-    const connected = Array.from(ndk.pool.relays.values()).filter(
-      (r) => r.status === 1
-    );
-    if (connected.length > 0) return true;
-    await new Promise((resolve) => setTimeout(resolve, 100));
-  }
-  return false;
 }

--- a/src/lib/nourish/nourishPublisher.server.ts
+++ b/src/lib/nourish/nourishPublisher.server.ts
@@ -6,7 +6,7 @@
  * work reliably on Cloudflare Workers — direct WebSocket publish does.
  */
 
-import { nip19, getPublicKey, finalizeEvent } from 'nostr-tools';
+import { nip19, finalizeEvent } from 'nostr-tools';
 import {
   NOURISH_CACHE_VERSION,
   NOURISH_PROMPT_VERSION,
@@ -49,7 +49,12 @@ function publishToRelay(relayUrl: string, event: any): Promise<boolean> {
       }, PUBLISH_TIMEOUT_MS);
 
       ws.onopen = () => {
-        ws.send(JSON.stringify(['EVENT', event]));
+        if (settled) return;
+        try {
+          ws.send(JSON.stringify(['EVENT', event]));
+        } catch {
+          if (!settled) { settled = true; clearTimeout(timer); ws.close(); resolve(false); }
+        }
       };
 
       ws.onmessage = (msg: MessageEvent) => {
@@ -63,6 +68,10 @@ function publishToRelay(relayUrl: string, event: any): Promise<boolean> {
       };
 
       ws.onerror = () => {
+        if (!settled) { settled = true; clearTimeout(timer); try { ws.close(); } catch {} resolve(false); }
+      };
+
+      ws.onclose = () => {
         if (!settled) { settled = true; clearTimeout(timer); resolve(false); }
       };
     } catch {


### PR DESCRIPTION
## Summary

**Critical fix**: Nourish events were never being published to any relay. The NDK-based publisher silently fails on Cloudflare Workers because NDK's WebSocket pool management doesn't work in the CF runtime.

### Root cause
NDK creates connection pools, monitors relay status, and manages subscriptions — none of which function correctly in CF Workers where WebSocket connections have a different lifecycle. Events were being signed but never sent.

### Fix
Replace the entire NDK-based publisher with direct WebSocket publish using `nostr-tools`:

```
Before (broken): NDK() → connect() → waitForConnection() → NDKEvent.publish()
After (works):   finalizeEvent() → new WebSocket(relay) → ws.send(['EVENT', event])
```

Publishes to nos.lol, relay.damus.io, and relay.primal.net in parallel. Returns true if at least one relay accepts.

### Verified
- Locally tested: nostr-tools signing + direct WebSocket publish → event lands on relay ✅
- Service pubkey matches NOTIFICATION_PRIVATE_KEY ✅

### After merge
Re-analyze any recipe to test. You should see `[Nourish Publisher] Published to 3/3 relays` in server logs, and the recipe will appear on `/nourish/explore`.

## Test plan
- [ ] Analyze a recipe → server logs show successful publish
- [ ] Query relay for kind 30078 events → Nourish event exists
- [ ] /nourish/explore shows the analyzed recipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)