### PR TITLE
fix(marketplace): break circular dependency between commerceState and types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.202",
+  "version": "4.2.203",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/marketplace/commerceState.ts
+++ b/src/lib/marketplace/commerceState.ts
@@ -33,22 +33,15 @@
  * - External store links (Shopify, etc.) → external_checkout
  */
 
-import type { Product } from './types';
+import { COMMERCE_STATES, type CommerceState, type Product } from './types';
 import type { CurrencyCode } from '$lib/currencyStore';
 import { formatPrice } from '$lib/currencyConversion';
 
-// ── Commerce State Enum ─────────────────────────────────────────────
-
-export const COMMERCE_STATES = [
-	'instant_buy',
-	'starting_at',
-	'price_varies',
-	'message_to_order',
-	'custom_quote',
-	'external_checkout'
-] as const;
-
-export type CommerceState = (typeof COMMERCE_STATES)[number];
+// ── Commerce State Enum (re-exported from ./types) ──────────────────
+// Declared in types.ts to avoid a module cycle; re-exported here so existing
+// `import { COMMERCE_STATES, type CommerceState } from './commerceState'`
+// callers keep working.
+export { COMMERCE_STATES, type CommerceState };
 
 // ── Per-State Display Configuration ─────────────────────────────────
 

--- a/src/lib/marketplace/types.ts
+++ b/src/lib/marketplace/types.ts
@@ -6,8 +6,21 @@
 
 import type { NDKEvent } from '@nostr-dev-kit/ndk';
 import type { MembershipTier } from '$lib/membershipStore';
-import type { CommerceState } from './commerceState';
 import type { CurrencyCode } from '$lib/currencyStore';
+
+// Commerce state enum lives here (instead of commerceState.ts) so that the
+// Product / ProductFormData types can reference it without creating a module
+// cycle. commerceState.ts re-exports these for backward-compatible imports.
+export const COMMERCE_STATES = [
+	'instant_buy',
+	'starting_at',
+	'price_varies',
+	'message_to_order',
+	'custom_quote',
+	'external_checkout'
+] as const;
+
+export type CommerceState = (typeof COMMERCE_STATES)[number];
 
 // Maximum age for marketplace listings (in days). Listings older than this are hidden.
 export const MARKETPLACE_LISTING_MAX_AGE_DAYS = 270;


### PR DESCRIPTION
## Summary

- `madge --circular --extensions ts,svelte ./src` was reporting exactly one cycle: `commerceState.ts ⇄ types.ts`.
- Both imports were already `import type`, so there was no runtime cycle — but madge's default parser treats type-only imports identically to runtime imports, so the module graph still showed the loop.
- Moved `COMMERCE_STATES` + `CommerceState` into `types.ts` (where `Product.commerceState` already references them), and re-exported them from `commerceState.ts` to preserve the existing public API.

## What changed

```
src/lib/marketplace/types.ts          | +13 −1
src/lib/marketplace/commerceState.ts  | +4  −11
```

- `types.ts` — adds `COMMERCE_STATES` + `CommerceState`, drops its `import type { CommerceState } from './commerceState'`
- `commerceState.ts` — now imports `COMMERCE_STATES`, `CommerceState`, and `Product` from `./types`, and re-exports `COMMERCE_STATES` + `CommerceState` for backward compatibility

Every other consumer (`products.ts`, `ProductCard.svelte`, `ProductViewModal.svelte`, `ProductDetailModal.svelte`) keeps importing from `$lib/marketplace/commerceState` unchanged.

## Test plan

- [x] `npx madge --circular --extensions ts,svelte ./src` → `✔ No circular dependency found!`
- [x] `pnpm run build` → ✓ built in 33s (Cloudflare adapter)
- [x] `pnpm run check` — same 4 pre-existing errors (MembershipTier, NourishRelayResult, implicit any, NDKKind 1068); zero new errors touching marketplace
- [ ] Smoke-test marketplace: product card pricing, product detail modal, kitchen page — all use `resolveCommerceState`/`getCommerceConfig`/`getShippingText`/`isInstantCheckout` from `./commerceState` (unchanged surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)