### PR TITLE
refactor(marketplace): extract productPayment controller + PaymentActionPanel; rename ProductDetailModal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.207",
+  "version": "4.2.208",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.206",
+  "version": "4.2.207",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/marketplace/MessageSellerModal.svelte
+++ b/src/components/marketplace/MessageSellerModal.svelte
@@ -1,4 +1,13 @@
 <script lang="ts">
+	/**
+	 * MessageSellerModal — messaging-first product modal.
+	 *
+	 * Opened when the buyer clicks the 💬 icon on a product card, OR when
+	 * ProductViewModal dispatches `message` after a successful purchase. The
+	 * primary UI is a DM composer (NIP-04 by default, NIP-17 when supported);
+	 * an instant-buy action is available as a secondary affordance and, when
+	 * used, pre-fills a post-purchase DM with shipping ask/thanks.
+	 */
 	import { nip19 } from 'nostr-tools';
 	import { browser } from '$app/environment';
 	import { onMount, tick } from 'svelte';
@@ -6,26 +15,21 @@
 	import Button from '../Button.svelte';
 	import CustomAvatar from '../CustomAvatar.svelte';
 	import CustomName from '../CustomName.svelte';
-	import LightningIcon from 'phosphor-svelte/lib/Lightning';
-	import CopyIcon from 'phosphor-svelte/lib/Copy';
 	import CheckIcon from 'phosphor-svelte/lib/Check';
 	import PaperPlaneTiltIcon from 'phosphor-svelte/lib/PaperPlaneTilt';
-	import XIcon from 'phosphor-svelte/lib/X';
 	import LockSimpleIcon from 'phosphor-svelte/lib/LockSimple';
 	import LockSimpleOpenIcon from 'phosphor-svelte/lib/LockSimpleOpen';
 	import CaretDownIcon from 'phosphor-svelte/lib/CaretDown';
 	import TrustBadge from './TrustBadge.svelte';
 	import PriceDisplay from './PriceDisplay.svelte';
+	import PaymentActionPanel from './PaymentActionPanel.svelte';
 	import type { Product } from '$lib/marketplace/types';
-	import { resolveCommerceState, getCommerceConfig, isInstantCheckout } from '$lib/marketplace/commerceState';
+	import { resolveCommerceState, isInstantCheckout } from '$lib/marketplace/commerceState';
 	import { getImageOrPlaceholder } from '$lib/placeholderImages';
-	import { getInvoiceFromLightningAddress } from '$lib/marketplace/products';
-	import { formatPrice, formatSats, convertToSats } from '$lib/currencyConversion';
-	import { activeWallet } from '$lib/wallet';
-	import { sendPayment } from '$lib/wallet/walletManager';
-	import { lightningService } from '$lib/lightningService';
+	import { formatPrice, formatSats } from '$lib/currencyConversion';
 	import { userPublickey } from '$lib/nostr';
 	import { sendDirectMessage, sendNip04DirectMessage, isNip17Supported } from '$lib/nip17';
+	import { createProductPaymentController } from '$lib/marketplace/productPayment';
 
 	// Dynamic imports for browser-only modules
 	let hasEncryptionSupport: (() => boolean) | null = null;
@@ -57,71 +61,22 @@
 	export let trustRank: number | undefined = undefined;
 	export let personalized: boolean = false;
 
-	// Commerce state
+	const payment = createProductPaymentController();
+	const { paymentSats, paymentState, paymentError, resolvingLightning, resolvedLightningAddress, copiedLightning } = payment;
+
 	$: commerceState = resolveCommerceState(product);
-	$: stateConfig = getCommerceConfig(commerceState);
 	$: canInstantBuy = isInstantCheckout(commerceState);
 
-	// Sats amount for payment
-	let paymentSats: number | null = null;
-	$: {
-		if (open && product && product.price > 0) {
-			if (product.currency === 'SATS') {
-				paymentSats = Math.round(product.price);
-			} else {
-				paymentSats = null;
-				convertToSats(product.price, product.currency).then((s) => {
-					paymentSats = s;
-				});
-			}
-		} else {
-			paymentSats = null;
-		}
-	}
+	// Drive controller sync reactively from props.
+	$: payment.sync(product, open);
 
 	$: nativePriceDisplay = product ? formatPrice(product.price, product.currency) : '';
 	$: paymentLabel =
-		paymentSats !== null
-			? formatSats(paymentSats)
+		$paymentSats !== null
+			? formatSats($paymentSats)
 			: open && product && product.price > 0
 				? 'Calculating...'
 				: nativePriceDisplay;
-
-	// Lightning address resolution
-	let resolvedLightningAddress = '';
-	let resolvingLightning = false;
-
-	$: if (open && product) {
-		resolveLightningAddress(product);
-	}
-
-	async function resolveLightningAddress(p: Product) {
-		if (p.lightningAddress) {
-			resolvedLightningAddress = p.lightningAddress;
-			return;
-		}
-		resolvingLightning = true;
-		try {
-			const ndkModule = await import('$lib/nostr');
-			const { get } = await import('svelte/store');
-			const ndkInstance = get(ndkModule.ndk);
-			const user = ndkInstance.getUser({ pubkey: p.pubkey });
-			const profile = await user.fetchProfile();
-			resolvedLightningAddress = profile?.lud16 || '';
-		} catch {
-			resolvedLightningAddress = '';
-		} finally {
-			resolvingLightning = false;
-		}
-	}
-
-	// Copy states
-	let copiedLightning = false;
-
-	// Payment states
-	type PaymentState = 'idle' | 'loading' | 'success' | 'error';
-	let paymentState: PaymentState = 'idle';
-	let paymentError = '';
 
 	// DM states
 	let dmMessage = '';
@@ -141,7 +96,6 @@
 	}
 
 	$: npub = product?.pubkey ? nip19.npubEncode(product.pubkey) : '';
-	$: hasInAppWallet = $activeWallet && ($activeWallet.kind === 3 || $activeWallet.kind === 4);
 	$: canSendDm = browser && $userPublickey && encryptionServiceLoaded && hasEncryptionSupport?.();
 
 	$: imageUrl = product?.images?.[0]
@@ -154,10 +108,8 @@
 	// Track whether user has typed in the message box
 	let userEditedMessage = false;
 
-	// Reset / initialize on open/close
+	// Reset / initialize on open/close (payment state handled by controller.sync)
 	$: if (!open) {
-		paymentState = 'idle';
-		paymentError = '';
 		dmMessage = '';
 		dmSent = false;
 		dmError = '';
@@ -171,82 +123,24 @@
 		});
 	}
 
-	async function copyLightning() {
-		if (!resolvedLightningAddress) return;
-		try {
-			await navigator.clipboard.writeText(resolvedLightningAddress);
-			copiedLightning = true;
-			setTimeout(() => (copiedLightning = false), 2000);
-		} catch {
-			window.open(`lightning:${resolvedLightningAddress}`, '_blank');
-		}
-	}
-
-	async function handlePayment() {
-		if (!resolvedLightningAddress) {
-			paymentError = 'No lightning address available for this seller';
-			paymentState = 'error';
-			return;
-		}
-		if (!product?.price) {
-			paymentError = 'Product has no price set';
-			paymentState = 'error';
-			return;
-		}
-
-		paymentState = 'loading';
-		paymentError = '';
-
-		try {
-			let amountSats: number;
-			if (paymentSats) {
-				amountSats = paymentSats;
-			} else {
-				const converted = await convertToSats(product.price, product.currency);
-				if (!converted) throw new Error('Unable to convert price to sats.');
-				amountSats = converted;
-			}
-
-			const { invoice, verify } = await getInvoiceFromLightningAddress(
-				resolvedLightningAddress,
-				amountSats
-			);
-
-			if (hasInAppWallet) {
-				const result = await sendPayment(invoice, {
-					amount: amountSats,
-					description: `Purchase: ${product.title}`,
-					pubkey: product.pubkey
-				});
-
-				if (result.success) {
-					paymentState = 'success';
-					setTimeout(() => {
-						dmMessage = postPurchaseDmMessage;
-					}, 1000);
-				} else {
-					throw new Error(result.error || 'Payment failed');
-				}
-			} else {
+	function handlePayClick() {
+		payment.handlePayment(product, {
+			onSuccess: () => {
+				setTimeout(() => {
+					dmMessage = postPurchaseDmMessage;
+				}, 1000);
+			},
+			onExternalLaunch: () => {
 				open = false;
-				await lightningService.launchPayment({
-					invoice,
-					verify,
-					onPaid: () => {
-						open = true;
-						paymentState = 'success';
-						dmMessage = postPurchaseDmMessage;
-					},
-					onCancelled: () => {
-						open = true;
-						paymentState = 'idle';
-					}
-				});
+			},
+			onExternalPaid: () => {
+				open = true;
+				dmMessage = postPurchaseDmMessage;
+			},
+			onExternalCancelled: () => {
+				open = true;
 			}
-		} catch (e) {
-			paymentError = e instanceof Error ? e.message : 'Payment failed';
-			paymentState = 'error';
-		}
+		});
 	}
 
 	async function sendDm() {
@@ -422,58 +316,18 @@
 		{/if}
 
 		<!-- ═══ Payment (instant buy) ═══ -->
-		{#if canInstantBuy && (paymentState === 'idle' || paymentState === 'loading')}
-			<Button
-				class="w-full py-3"
-				on:click={handlePayment}
-				disabled={paymentState === 'loading' || resolvingLightning || !resolvedLightningAddress}
-			>
-				<span class="flex items-center justify-center gap-2">
-					{#if resolvingLightning || paymentState === 'loading'}
-						<svg class="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-							<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-							<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-						</svg>
-					{:else}
-						<LightningIcon size={20} weight="fill" />
-						Pay {paymentLabel}
-					{/if}
-				</span>
-			</Button>
-
-			{#if resolvedLightningAddress}
-				<button
-					type="button"
-					on:click={copyLightning}
-					class="flex items-center justify-center gap-2 py-1.5 text-xs transition-colors hover:opacity-80"
-					style="color: var(--color-text-secondary);"
-				>
-					{#if copiedLightning}
-						<CheckIcon size={12} class="text-emerald-400" />
-						<span class="text-emerald-400">Copied!</span>
-					{:else}
-						<CopyIcon size={12} />
-						Copy Lightning address
-					{/if}
-				</button>
-			{/if}
-		{/if}
-
-		{#if paymentState === 'success'}
-			<div class="flex flex-col items-center gap-3 py-4 rounded-xl" style="background-color: var(--color-bg-tertiary);">
-				<div class="w-12 h-12 rounded-full flex items-center justify-center bg-emerald-500/20">
-					<CheckIcon size={24} weight="bold" class="text-emerald-400" />
-				</div>
-				<p class="text-sm font-medium" style="color: var(--color-text-primary)">Payment sent!</p>
-				<p class="text-xs" style="color: var(--color-text-secondary)">{paymentLabel}</p>
-			</div>
-		{:else if paymentState === 'error'}
-			<div class="flex flex-col items-center gap-3 py-4 rounded-xl" style="background-color: rgba(239, 68, 68, 0.1);">
-				<XIcon size={24} weight="bold" class="text-red-400" />
-				<p class="text-sm text-red-400">{paymentError}</p>
-				<Button on:click={() => (paymentState = 'idle')}>Try Again</Button>
-			</div>
-		{/if}
+		<PaymentActionPanel
+			{canInstantBuy}
+			paymentState={$paymentState}
+			paymentError={$paymentError}
+			{paymentLabel}
+			resolvingLightning={$resolvingLightning}
+			resolvedLightningAddress={$resolvedLightningAddress}
+			copiedLightning={$copiedLightning}
+			on:pay={handlePayClick}
+			on:copy={() => payment.copyLightning()}
+			on:retry={() => payment.reset()}
+		/>
 
 		<!-- ═══ View full details (expandable) ═══ -->
 		<button

--- a/src/components/marketplace/PaymentActionPanel.svelte
+++ b/src/components/marketplace/PaymentActionPanel.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+	/**
+	 * PaymentActionPanel — shared visual block for product payment.
+	 *
+	 * Renders exactly one of: success panel, error panel, or the pay + copy-lightning
+	 * action buttons (when canInstantBuy and no terminal state reached). Events
+	 * `pay` / `copy` / `retry` are dispatched to the parent for handling.
+	 *
+	 * Success panel has a named slot `success-extra` for modal-specific follow-up
+	 * CTAs (e.g., ProductViewModal's "Message seller with order details").
+	 */
+	import { createEventDispatcher } from 'svelte';
+	import Button from '../Button.svelte';
+	import LightningIcon from 'phosphor-svelte/lib/Lightning';
+	import CopyIcon from 'phosphor-svelte/lib/Copy';
+	import CheckIcon from 'phosphor-svelte/lib/Check';
+	import XIcon from 'phosphor-svelte/lib/X';
+	import type { PaymentState } from '$lib/marketplace/productPayment';
+
+	export let canInstantBuy: boolean;
+	export let paymentState: PaymentState;
+	export let paymentError = '';
+	export let paymentLabel = '';
+	export let resolvingLightning = false;
+	export let resolvedLightningAddress = '';
+	export let copiedLightning = false;
+
+	/** Text beside the spinner while loading. `null` → spinner only (MessageSellerModal); string → shown (ProductViewModal: "Getting Invoice..."). */
+	export let loadingText: string | null = null;
+
+	/** Extra classes on the Pay button. MessageSellerModal uses the default; ProductViewModal passes `'w-full py-3 text-lg'`. */
+	export let payButtonClass = 'w-full py-3';
+
+	const dispatch = createEventDispatcher<{ pay: void; copy: void; retry: void }>();
+</script>
+
+{#if paymentState === 'success'}
+	<div
+		class="flex flex-col items-center gap-3 py-4 rounded-xl"
+		style="background-color: var(--color-bg-tertiary);"
+	>
+		<div class="w-12 h-12 rounded-full flex items-center justify-center bg-emerald-500/20">
+			<CheckIcon size={24} weight="bold" class="text-emerald-400" />
+		</div>
+		<p class="text-sm font-medium" style="color: var(--color-text-primary)">Payment sent!</p>
+		<p class="text-xs" style="color: var(--color-text-secondary)">{paymentLabel}</p>
+		<slot name="success-extra" />
+	</div>
+{:else if paymentState === 'error'}
+	<div
+		class="flex flex-col items-center gap-3 py-4 rounded-xl"
+		style="background-color: rgba(239, 68, 68, 0.1);"
+	>
+		<XIcon size={24} weight="bold" class="text-red-400" />
+		<p class="text-sm text-red-400">{paymentError}</p>
+		<Button on:click={() => dispatch('retry')}>Try Again</Button>
+	</div>
+{:else if canInstantBuy}
+	<Button
+		class={payButtonClass}
+		on:click={() => dispatch('pay')}
+		disabled={paymentState === 'loading' || resolvingLightning || !resolvedLightningAddress}
+	>
+		<span class="flex items-center justify-center gap-2">
+			{#if resolvingLightning || paymentState === 'loading'}
+				<svg
+					class="animate-spin h-5 w-5"
+					xmlns="http://www.w3.org/2000/svg"
+					fill="none"
+					viewBox="0 0 24 24"
+				>
+					<circle
+						class="opacity-25"
+						cx="12"
+						cy="12"
+						r="10"
+						stroke="currentColor"
+						stroke-width="4"
+					></circle>
+					<path
+						class="opacity-75"
+						fill="currentColor"
+						d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+					></path>
+				</svg>
+				{#if loadingText}
+					{loadingText}
+				{/if}
+			{:else}
+				<LightningIcon size={20} weight="fill" />
+				Pay {paymentLabel}
+			{/if}
+		</span>
+	</Button>
+
+	{#if resolvedLightningAddress}
+		<button
+			type="button"
+			on:click={() => dispatch('copy')}
+			class="flex items-center justify-center gap-2 py-1.5 text-xs transition-colors hover:opacity-80"
+			style="color: var(--color-text-secondary);"
+		>
+			{#if copiedLightning}
+				<CheckIcon size={12} class="text-emerald-400" />
+				<span class="text-emerald-400">Copied!</span>
+			{:else}
+				<CopyIcon size={12} />
+				Copy Lightning address
+			{/if}
+		</button>
+	{/if}
+{/if}

--- a/src/components/marketplace/ProductCard.svelte
+++ b/src/components/marketplace/ProductCard.svelte
@@ -15,7 +15,7 @@
 	import CustomAvatar from '../CustomAvatar.svelte';
 	import CustomName from '../CustomName.svelte';
 	import ProductViewModal from './ProductViewModal.svelte';
-	import ProductDetailModal from './ProductDetailModal.svelte';
+	import MessageSellerModal from './MessageSellerModal.svelte';
 	import TrustBadge from './TrustBadge.svelte';
 	import PriceDisplay from './PriceDisplay.svelte';
 
@@ -209,7 +209,7 @@
 
 <!-- Message Seller Modal (messaging-first) -->
 {#if product}
-	<ProductDetailModal bind:open={showMessageModal} {product} {trustRank} {personalized} />
+	<MessageSellerModal bind:open={showMessageModal} {product} {trustRank} {personalized} />
 {/if}
 {/if}
 

--- a/src/components/marketplace/ProductViewModal.svelte
+++ b/src/components/marketplace/ProductViewModal.svelte
@@ -8,29 +8,23 @@
 	 */
 	import { nip19 } from 'nostr-tools';
 	import Modal from '../Modal.svelte';
-	import Button from '../Button.svelte';
-	import CustomAvatar from '../CustomAvatar.svelte';
-	import CustomName from '../CustomName.svelte';
-	import LightningIcon from 'phosphor-svelte/lib/Lightning';
-	import CopyIcon from 'phosphor-svelte/lib/Copy';
-	import CheckIcon from 'phosphor-svelte/lib/Check';
 	import PackageIcon from 'phosphor-svelte/lib/Package';
 	import CloudArrowDownIcon from 'phosphor-svelte/lib/CloudArrowDown';
 	import MapPinIcon from 'phosphor-svelte/lib/MapPin';
 	import TagIcon from 'phosphor-svelte/lib/Tag';
 	import ChatCircleIcon from 'phosphor-svelte/lib/ChatCircle';
-	import XIcon from 'phosphor-svelte/lib/X';
 	import StorefrontIcon from 'phosphor-svelte/lib/Storefront';
+	import CustomAvatar from '../CustomAvatar.svelte';
+	import CustomName from '../CustomName.svelte';
 	import TrustBadge from './TrustBadge.svelte';
 	import PriceDisplay from './PriceDisplay.svelte';
+	import PaymentActionPanel from './PaymentActionPanel.svelte';
+	import Button from '../Button.svelte';
 	import { CATEGORY_LABELS, type Product } from '$lib/marketplace/types';
 	import { resolveCommerceState, getShippingText, isInstantCheckout } from '$lib/marketplace/commerceState';
 	import { getImageOrPlaceholder } from '$lib/placeholderImages';
-	import { getInvoiceFromLightningAddress } from '$lib/marketplace/products';
-	import { formatSats, convertToSats } from '$lib/currencyConversion';
-	import { activeWallet } from '$lib/wallet';
-	import { sendPayment } from '$lib/wallet/walletManager';
-	import { lightningService } from '$lib/lightningService';
+	import { formatSats } from '$lib/currencyConversion';
+	import { createProductPaymentController } from '$lib/marketplace/productPayment';
 	import { createEventDispatcher } from 'svelte';
 
 	const dispatch = createEventDispatcher<{ message: void }>();
@@ -40,76 +34,28 @@
 	export let trustRank: number | undefined = undefined;
 	export let personalized: boolean = false;
 
-	// Commerce state
+	const payment = createProductPaymentController();
+	const { paymentSats, paymentState, paymentError, resolvingLightning, resolvedLightningAddress, copiedLightning } = payment;
+
 	$: commerceState = resolveCommerceState(product);
 	$: canInstantBuy = isInstantCheckout(commerceState);
 	$: shippingText = getShippingText(product);
 
-	// Sats amount for payment
-	let paymentSats: number | null = null;
-	$: {
-		if (open && product && product.price > 0) {
-			if (product.currency === 'SATS') {
-				paymentSats = Math.round(product.price);
-			} else {
-				paymentSats = null;
-				convertToSats(product.price, product.currency).then((s) => {
-					paymentSats = s;
-				});
-			}
-		} else {
-			paymentSats = null;
-		}
-	}
+	// Drive controller sync reactively from props.
+	$: payment.sync(product, open);
+
 	$: paymentLabel =
-		paymentSats !== null
-			? formatSats(paymentSats)
+		$paymentSats !== null
+			? formatSats($paymentSats)
 			: open && product && product.price > 0
 				? 'Calculating...'
 				: '';
-
-	// Lightning address resolution
-	let resolvedLightningAddress = '';
-	let resolvingLightning = false;
-
-	$: if (open && product) {
-		resolveLightningAddress(product);
-	}
-
-	async function resolveLightningAddress(p: Product) {
-		if (p.lightningAddress) {
-			resolvedLightningAddress = p.lightningAddress;
-			return;
-		}
-		resolvingLightning = true;
-		try {
-			const ndkModule = await import('$lib/nostr');
-			const { get } = await import('svelte/store');
-			const ndkInstance = get(ndkModule.ndk);
-			const user = ndkInstance.getUser({ pubkey: p.pubkey });
-			const profile = await user.fetchProfile();
-			resolvedLightningAddress = profile?.lud16 || '';
-		} catch {
-			resolvedLightningAddress = '';
-		} finally {
-			resolvingLightning = false;
-		}
-	}
-
-	// Copy
-	let copiedLightning = false;
-
-	// Payment
-	type PaymentState = 'idle' | 'loading' | 'success' | 'error';
-	let paymentState: PaymentState = 'idle';
-	let paymentError = '';
 
 	// Image gallery
 	let activeImageIndex = 0;
 
 	$: npub = product?.pubkey ? nip19.npubEncode(product.pubkey) : '';
 	$: kitchenUrl = npub ? `/market/kitchen/${npub}` : '';
-	$: hasInAppWallet = $activeWallet && ($activeWallet.kind === 3 || $activeWallet.kind === 4);
 
 	$: allImages = (product?.images || []).map((img, i) =>
 		getImageOrPlaceholder(img, `${product.id}-${i}`)
@@ -122,76 +68,18 @@
 		activeImageIndex = 0;
 	}
 
-	$: if (!open) {
-		paymentState = 'idle';
-		paymentError = '';
-	}
-
-	async function copyLightning() {
-		if (!resolvedLightningAddress) return;
-		try {
-			await navigator.clipboard.writeText(resolvedLightningAddress);
-			copiedLightning = true;
-			setTimeout(() => (copiedLightning = false), 2000);
-		} catch {
-			window.open(`lightning:${resolvedLightningAddress}`, '_blank');
-		}
-	}
-
-	async function handlePayment() {
-		if (!resolvedLightningAddress) {
-			paymentError = 'No lightning address available';
-			paymentState = 'error';
-			return;
-		}
-		if (!product?.price) {
-			paymentError = 'No price set';
-			paymentState = 'error';
-			return;
-		}
-
-		paymentState = 'loading';
-		paymentError = '';
-
-		try {
-			let amountSats: number;
-			if (paymentSats) {
-				amountSats = paymentSats;
-			} else {
-				const converted = await convertToSats(product.price, product.currency);
-				if (!converted) throw new Error('Unable to convert price to sats.');
-				amountSats = converted;
-			}
-
-			const { invoice, verify } = await getInvoiceFromLightningAddress(
-				resolvedLightningAddress,
-				amountSats
-			);
-
-			if (hasInAppWallet) {
-				const result = await sendPayment(invoice, {
-					amount: amountSats,
-					description: `Purchase: ${product.title}`,
-					pubkey: product.pubkey
-				});
-				if (result.success) {
-					paymentState = 'success';
-				} else {
-					throw new Error(result.error || 'Payment failed');
-				}
-			} else {
+	function handlePayClick() {
+		payment.handlePayment(product, {
+			onExternalLaunch: () => {
 				open = false;
-				await lightningService.launchPayment({
-					invoice,
-					verify,
-					onPaid: () => { open = true; paymentState = 'success'; },
-					onCancelled: () => { open = true; paymentState = 'idle'; }
-				});
+			},
+			onExternalPaid: () => {
+				open = true;
+			},
+			onExternalCancelled: () => {
+				open = true;
 			}
-		} catch (e) {
-			paymentError = e instanceof Error ? e.message : 'Payment failed';
-			paymentState = 'error';
-		}
+		});
 	}
 
 	function openMessageModal() {
@@ -294,66 +182,44 @@
 
 		<!-- ═══ Actions ═══ -->
 
-		{#if paymentState === 'success'}
-			<div class="flex flex-col items-center gap-3 py-4 rounded-xl" style="background-color: var(--color-bg-tertiary);">
-				<div class="w-12 h-12 rounded-full flex items-center justify-center bg-emerald-500/20">
-					<CheckIcon size={24} weight="bold" class="text-emerald-400" />
-				</div>
-				<p class="text-sm font-medium" style="color: var(--color-text-primary)">Payment sent!</p>
-				<p class="text-xs" style="color: var(--color-text-secondary)">{paymentLabel}</p>
-				<!-- After payment, prompt to message seller -->
-				<Button on:click={openMessageModal} class="w-full mt-2">
+		{#if $paymentState === 'success' || $paymentState === 'error'}
+			<PaymentActionPanel
+				{canInstantBuy}
+				paymentState={$paymentState}
+				paymentError={$paymentError}
+				{paymentLabel}
+				resolvingLightning={$resolvingLightning}
+				resolvedLightningAddress={$resolvedLightningAddress}
+				copiedLightning={$copiedLightning}
+				loadingText="Getting Invoice..."
+				payButtonClass="w-full py-3 text-lg"
+				on:pay={handlePayClick}
+				on:copy={() => payment.copyLightning()}
+				on:retry={() => payment.reset()}
+			>
+				<Button on:click={openMessageModal} class="w-full mt-2" slot="success-extra">
 					<span class="flex items-center justify-center gap-2">
 						<ChatCircleIcon size={18} weight="fill" />
 						Message seller with order details
 					</span>
 				</Button>
-			</div>
-		{:else if paymentState === 'error'}
-			<div class="flex flex-col items-center gap-3 py-4 rounded-xl" style="background-color: rgba(239, 68, 68, 0.1);">
-				<XIcon size={24} weight="bold" class="text-red-400" />
-				<p class="text-sm text-red-400">{paymentError}</p>
-				<Button on:click={() => (paymentState = 'idle')}>Try Again</Button>
-			</div>
+			</PaymentActionPanel>
 		{:else}
 			<div class="flex flex-col gap-3">
-				{#if canInstantBuy}
-					<Button
-						class="w-full py-3 text-lg"
-						on:click={handlePayment}
-						disabled={paymentState === 'loading' || resolvingLightning || !resolvedLightningAddress}
-					>
-						<span class="flex items-center justify-center gap-2">
-							{#if resolvingLightning || paymentState === 'loading'}
-								<svg class="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-									<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-									<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-								</svg>
-								Getting Invoice...
-							{:else}
-								<LightningIcon size={20} weight="fill" />
-								Pay {paymentLabel}
-							{/if}
-						</span>
-					</Button>
-
-					{#if resolvedLightningAddress}
-						<button
-							type="button"
-							on:click={copyLightning}
-							class="flex items-center justify-center gap-2 py-1.5 text-xs transition-colors hover:opacity-80"
-							style="color: var(--color-text-secondary);"
-						>
-							{#if copiedLightning}
-								<CheckIcon size={12} class="text-emerald-400" />
-								<span class="text-emerald-400">Copied!</span>
-							{:else}
-								<CopyIcon size={12} />
-								Copy Lightning address
-							{/if}
-						</button>
-					{/if}
-				{/if}
+				<PaymentActionPanel
+					{canInstantBuy}
+					paymentState={$paymentState}
+					paymentError={$paymentError}
+					{paymentLabel}
+					resolvingLightning={$resolvingLightning}
+					resolvedLightningAddress={$resolvedLightningAddress}
+					copiedLightning={$copiedLightning}
+					loadingText="Getting Invoice..."
+					payButtonClass="w-full py-3 text-lg"
+					on:pay={handlePayClick}
+					on:copy={() => payment.copyLightning()}
+					on:retry={() => payment.reset()}
+				/>
 
 				<!-- Message seller (always at bottom) -->
 				<button

--- a/src/lib/marketplace/productPayment.ts
+++ b/src/lib/marketplace/productPayment.ts
@@ -1,0 +1,256 @@
+/**
+ * Product Payment Controller
+ *
+ * Shared state machine + actions for marketplace product modals. Encapsulates:
+ *  - Resolving a seller's lightning address (from product or profile lud16)
+ *  - Computing sats amount from product price/currency
+ *  - Running the instant-buy flow (in-app wallet OR external lightning launcher)
+ *  - Copy-to-clipboard for the lightning address
+ *  - Payment lifecycle state (idle → loading → success | error)
+ *
+ * One controller instance per modal. State is isolated; two modals that import
+ * this service do not share anything at runtime.
+ *
+ * Usage from a Svelte component:
+ *
+ *   const payment = createProductPaymentController();
+ *   const { paymentSats, paymentState, paymentError, ... } = payment;
+ *
+ *   // IMPORTANT: drive re-sync reactively. This `$:` is what keeps the
+ *   // controller's internal state aligned with prop changes — sats are
+ *   // recomputed when product changes, lightning address is resolved when
+ *   // the modal opens, and state is cleared when the modal closes.
+ *   $: payment.sync(product, open);
+ *
+ *   // User actions:
+ *   on:click={() => payment.handlePayment(product, { onSuccess })}
+ *   on:click={() => payment.copyLightning()}
+ *   on:click={() => payment.reset()}   // after error, to return to idle
+ */
+
+import { writable, derived, get, type Readable } from 'svelte/store';
+import type { Product } from './types';
+import { convertToSats } from '$lib/currencyConversion';
+import { getInvoiceFromLightningAddress } from './products';
+import { activeWallet } from '$lib/wallet';
+import { sendPayment } from '$lib/wallet/walletManager';
+import { lightningService } from '$lib/lightningService';
+
+export type PaymentState = 'idle' | 'loading' | 'success' | 'error';
+
+export interface PaymentCallbacks {
+  /** Fired once the in-app wallet reports a successful payment. */
+  onSuccess?: () => void;
+  /** Fired just before the external-wallet launcher opens — modal should close. */
+  onExternalLaunch?: () => void;
+  /** Fired when the external launcher reports the invoice was paid — modal can reopen. */
+  onExternalPaid?: () => void;
+  /** Fired when the external launcher is cancelled — modal can reopen. */
+  onExternalCancelled?: () => void;
+}
+
+export interface ProductPaymentController {
+  readonly paymentSats: Readable<number | null>;
+  readonly resolvedLightningAddress: Readable<string>;
+  readonly resolvingLightning: Readable<boolean>;
+  readonly paymentState: Readable<PaymentState>;
+  readonly paymentError: Readable<string>;
+  readonly copiedLightning: Readable<boolean>;
+  readonly hasInAppWallet: Readable<boolean>;
+
+  /**
+   * Drive this reactively from a Svelte component:
+   *   $: controller.sync(product, open);
+   *
+   * The `$:` label is what causes re-invocation whenever `product` or `open`
+   * changes — the controller itself has no hooks into the component's
+   * reactivity graph. Behaviour:
+   *  - Recomputes `paymentSats` based on the product's price/currency.
+   *  - On open (transition false → true), resolves the seller's lightning
+   *    address if not already cached.
+   *  - On close (transition true → false), resets paymentState + paymentError.
+   */
+  sync(product: Product | null, open: boolean): void;
+
+  /**
+   * Runs the instant-buy flow. Uses the in-app wallet if available, otherwise
+   * hands off to `lightningService.launchPayment` (external wallet/modal).
+   *
+   * Sets paymentState to 'loading' → 'success' | 'error'. Callers can hook
+   * into the transitions via `callbacks`.
+   */
+  handlePayment(product: Product, callbacks?: PaymentCallbacks): Promise<void>;
+
+  /** Copies the resolved lightning address to clipboard; falls back to `lightning:` URL. */
+  copyLightning(): Promise<void>;
+
+  /** Returns paymentState to 'idle' and clears paymentError. Used after "Try Again". */
+  reset(): void;
+}
+
+export function createProductPaymentController(): ProductPaymentController {
+  const paymentSats = writable<number | null>(null);
+  const resolvedLightningAddress = writable<string>('');
+  const resolvingLightning = writable<boolean>(false);
+  const paymentState = writable<PaymentState>('idle');
+  const paymentError = writable<string>('');
+  const copiedLightning = writable<boolean>(false);
+
+  const hasInAppWallet = derived(
+    activeWallet,
+    ($activeWallet) => !!$activeWallet && ($activeWallet.kind === 3 || $activeWallet.kind === 4)
+  );
+
+  let lastProductId: string | null = null;
+  let lastOpen = false;
+
+  function recomputeSats(product: Product | null, open: boolean) {
+    if (open && product && product.price > 0) {
+      if (product.currency === 'SATS') {
+        paymentSats.set(Math.round(product.price));
+      } else {
+        paymentSats.set(null);
+        convertToSats(product.price, product.currency).then((s) => {
+          paymentSats.set(s);
+        });
+      }
+    } else {
+      paymentSats.set(null);
+    }
+  }
+
+  async function resolveLightningAddress(product: Product) {
+    if (product.lightningAddress) {
+      resolvedLightningAddress.set(product.lightningAddress);
+      return;
+    }
+    resolvingLightning.set(true);
+    try {
+      const ndkModule = await import('$lib/nostr');
+      const ndkInstance = get(ndkModule.ndk);
+      const user = ndkInstance.getUser({ pubkey: product.pubkey });
+      const profile = await user.fetchProfile();
+      resolvedLightningAddress.set(profile?.lud16 || '');
+    } catch {
+      resolvedLightningAddress.set('');
+    } finally {
+      resolvingLightning.set(false);
+    }
+  }
+
+  function sync(product: Product | null, open: boolean): void {
+    recomputeSats(product, open);
+
+    if (open && product) {
+      resolveLightningAddress(product);
+    }
+
+    if (!open && lastOpen) {
+      paymentState.set('idle');
+      paymentError.set('');
+    }
+
+    lastProductId = product?.id ?? null;
+    lastOpen = open;
+  }
+
+  async function handlePayment(
+    product: Product,
+    callbacks: PaymentCallbacks = {}
+  ): Promise<void> {
+    const lightningAddr = get(resolvedLightningAddress);
+    if (!lightningAddr) {
+      paymentError.set('No lightning address available for this seller');
+      paymentState.set('error');
+      return;
+    }
+    if (!product?.price) {
+      paymentError.set('Product has no price set');
+      paymentState.set('error');
+      return;
+    }
+
+    paymentState.set('loading');
+    paymentError.set('');
+
+    try {
+      let amountSats: number;
+      const cached = get(paymentSats);
+      if (cached) {
+        amountSats = cached;
+      } else {
+        const converted = await convertToSats(product.price, product.currency);
+        if (!converted) throw new Error('Unable to convert price to sats.');
+        amountSats = converted;
+      }
+
+      const { invoice, verify } = await getInvoiceFromLightningAddress(
+        lightningAddr,
+        amountSats
+      );
+
+      if (get(hasInAppWallet)) {
+        const result = await sendPayment(invoice, {
+          amount: amountSats,
+          description: `Purchase: ${product.title}`,
+          pubkey: product.pubkey
+        });
+
+        if (result.success) {
+          paymentState.set('success');
+          callbacks.onSuccess?.();
+        } else {
+          throw new Error(result.error || 'Payment failed');
+        }
+      } else {
+        callbacks.onExternalLaunch?.();
+        await lightningService.launchPayment({
+          invoice,
+          verify,
+          onPaid: () => {
+            paymentState.set('success');
+            callbacks.onExternalPaid?.();
+          },
+          onCancelled: () => {
+            paymentState.set('idle');
+            callbacks.onExternalCancelled?.();
+          }
+        });
+      }
+    } catch (e) {
+      paymentError.set(e instanceof Error ? e.message : 'Payment failed');
+      paymentState.set('error');
+    }
+  }
+
+  async function copyLightning(): Promise<void> {
+    const addr = get(resolvedLightningAddress);
+    if (!addr) return;
+    try {
+      await navigator.clipboard.writeText(addr);
+      copiedLightning.set(true);
+      setTimeout(() => copiedLightning.set(false), 2000);
+    } catch {
+      window.open(`lightning:${addr}`, '_blank');
+    }
+  }
+
+  function reset(): void {
+    paymentState.set('idle');
+    paymentError.set('');
+  }
+
+  return {
+    paymentSats: { subscribe: paymentSats.subscribe },
+    resolvedLightningAddress: { subscribe: resolvedLightningAddress.subscribe },
+    resolvingLightning: { subscribe: resolvingLightning.subscribe },
+    paymentState: { subscribe: paymentState.subscribe },
+    paymentError: { subscribe: paymentError.subscribe },
+    copiedLightning: { subscribe: copiedLightning.subscribe },
+    hasInAppWallet,
+    sync,
+    handlePayment,
+    copyLightning,
+    reset
+  };
+}

--- a/src/lib/marketplace/productPayment.ts
+++ b/src/lib/marketplace/productPayment.ts
@@ -66,8 +66,9 @@ export interface ProductPaymentController {
    * changes — the controller itself has no hooks into the component's
    * reactivity graph. Behaviour:
    *  - Recomputes `paymentSats` based on the product's price/currency.
-   *  - On open (transition false → true), resolves the seller's lightning
-   *    address if not already cached.
+   *  - When `open && product`, resolves the seller's lightning address. There
+   *    is no caching; resolution fires on every such invocation (matching the
+   *    pre-refactor behaviour of the two modals).
    *  - On close (transition true → false), resets paymentState + paymentError.
    */
   sync(product: Product | null, open: boolean): void;
@@ -101,7 +102,6 @@ export function createProductPaymentController(): ProductPaymentController {
     ($activeWallet) => !!$activeWallet && ($activeWallet.kind === 3 || $activeWallet.kind === 4)
   );
 
-  let lastProductId: string | null = null;
   let lastOpen = false;
 
   function recomputeSats(product: Product | null, open: boolean) {
@@ -150,7 +150,6 @@ export function createProductPaymentController(): ProductPaymentController {
       paymentError.set('');
     }
 
-    lastProductId = product?.id ?? null;
     lastOpen = open;
   }
 


### PR DESCRIPTION
## Summary

`ProductDetailModal` and `ProductViewModal` are two distinct UX flows — product browsing vs seller messaging — that share a payment subsystem, not two modes of one modal. Investigation showed a consolidated `<ProductModal mode="...">` would require 7+ structural `{#if mode}` branches and produce a worse component than the originals. Instead, this PR extracts the shared payment logic into a service + a small presentational component, and renames `ProductDetailModal` to reflect what it actually is.

Net change: **+86 lines across 4 files**. Line-count isn't the win here — zero payment duplication across the two modals and a reusable controller for future marketplace surfaces are.

## Changes

### New — `src/lib/marketplace/productPayment.ts` (256 lines)

`createProductPaymentController()` factory returning:

- Readable Svelte stores: `paymentSats`, `resolvedLightningAddress`, `resolvingLightning`, `paymentState`, `paymentError`, `copiedLightning`, `hasInAppWallet`.
- Actions: `sync(product, open)` (called reactively via `$: controller.sync(...)`), `handlePayment(product, callbacks)`, `copyLightning()`, `reset()`.
- Per-call `PaymentCallbacks` hook into the lifecycle: `onSuccess`, `onExternalLaunch`, `onExternalPaid`, `onExternalCancelled`.

Matches the existing `createMembershipStore` / `createTierStore` factory pattern in `src/lib/membershipStore.ts`. One controller per modal instance; zero shared runtime state between modals.

### New — `src/components/marketplace/PaymentActionPanel.svelte` (112 lines)

Presentational component rendering the shared Pay button + Copy Lightning button + success/error panels. Accepts payment state as props; dispatches `pay` / `copy` / `retry` events. Named slot `success-extra` lets `ProductViewModal` inject its "Message seller with order details" button into the success panel without adding a mode prop.

### Renamed + rewritten — `ProductDetailModal.svelte` → `MessageSellerModal.svelte` (523 → 376 lines)

Previous name was actively misleading: this is the **messaging-focused** modal (opens when the user clicks 💬 on a product card, or after a successful ViewModal payment). Calling it "Detail" suggested it was the product-detail view, when in fact `ProductViewModal` plays that role.

Rewritten to use the new controller + panel. DM composer, NIP-04/NIP-17 protocol toggle, encryption detection (`hasEncryptionSupport`, `encryptionDebugInfo`), post-purchase DM pre-fill (with 1s setTimeout), external-wallet re-open flow, and the collapsible "View full details" section all preserved verbatim. ~140 lines of payment plumbing removed.

Cleanup: removed unused `stateConfig = getCommerceConfig(commerceState)` reactive declaration — it was computed but never referenced in the template.

### Modified — `ProductViewModal.svelte` (372 → 237 lines)

Rewritten to use the new controller + panel. Image gallery (activeImageIndex, allImages thumbnails), seller card with kitchen link, price/shipping/category/location rows, and the `message` event dispatch all preserved verbatim. ~130 lines of payment plumbing removed.

### Modified — `ProductCard.svelte` (2-line diff)

Import and tag renamed from `ProductDetailModal` → `MessageSellerModal` (line 18 and line 212). No other changes — props and event handlers unchanged.

## Line count

| | Lines |
|---|---:|
| **Before** (2 files): ProductDetailModal (523) + ProductViewModal (372) | 895 |
| **After** (4 files): productPayment (256) + PaymentActionPanel (112) + MessageSellerModal (376) + ProductViewModal (237) | 981 |
| **Net** | **+86** |

## Behaviors that stayed per-modal (deliberate, not extracted)

1. **`paymentLabel` computation.** The two modals differ in the fallback displayed when sats aren't yet computed and the price isn't active: `MessageSellerModal` shows the native-currency price (`formatPrice(product.price, product.currency)`), `ProductViewModal` shows `''`. Each modal derives its own `paymentLabel` from `$paymentSats` — cleaner than an injected fallback config.
2. **Reset-on-close for modal-local state.** The controller's `sync()` resets payment state on close; each modal resets its own non-payment state (DM state in MessageSellerModal, `activeImageIndex` in ProductViewModal) in its own `$:` block.

## Verification

- [x] `pnpm run check` — 0 errors / 0 warnings in the 5 touched files. 4 pre-existing errors elsewhere (marketplace/kitchens, nourish/nourishDiscovery, FoodstrFeedOptimized) — unchanged from `main`. Warning count unchanged at 129.
- [x] `pnpm run build` — passes.
- [x] `grep -rn "ProductDetailModal" src/` — zero matches.
- [x] Dev server — `/market` returns 200, no runtime errors.

## Test plan

- [ ] Click a product card on `/market` → ProductViewModal opens with full image, price/shipping row, seller card, description.
- [ ] Click the 💬 icon on a product card → MessageSellerModal opens with DM composer pre-filled with `Hey — is "<title>" still available?`, textarea focused.
- [ ] MessageSellerModal: click NIP-04/NIP-17 toggle — pill animates between the two states; disabled when `!nip17Available`.
- [ ] MessageSellerModal: type a message → "Send Message" button enables → click → message dispatches via correct protocol → "Message sent!" panel appears.
- [ ] MessageSellerModal: click "View full details" → expandable section reveals full image + summary + description + "Ships from" location. Caret rotates.
- [ ] ProductViewModal: click "Message seller" outline button → ViewModal closes, `message` event fires, parent opens MessageSellerModal.
- [ ] Both modals, instant-buy path with in-app wallet: click Pay → spinner while loading → success panel with `{paymentLabel}` → (ViewModal) "Message seller with order details" button; (MessageSellerModal) DM pre-fills with post-purchase text after 1s.
- [ ] Both modals, instant-buy path without in-app wallet: click Pay → modal closes → external lightning launcher opens → Paid → modal re-opens with success panel (and MessageSellerModal pre-fills DM).
- [ ] Both modals: payment error path → "Try Again" button returns state to idle.
- [ ] Both modals: copy-lightning button copies address, shows "Copied!" for 2s.
- [ ] ESC closes both modals; backdrop click closes both modals; focus returns to trigger on close.

## Unrelated cleanup noticed (not touched)

- `KitchenForm.svelte`, `ProductForm.svelte`, `TrustBadge.svelte` weren't inspected. Out of scope per task rule 5.
- `PriceDisplay` has its own sizing system that could potentially be simplified — separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)