### PR TITLE
refactor(comments): Stage 3 — extract ReplyComposer shared component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.213",
+  "version": "4.2.214",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.214",
+  "version": "4.2.215",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/Comment.svelte
+++ b/src/components/Comment.svelte
@@ -5,30 +5,24 @@
   import { format as formatDate } from 'timeago.js';
   import Avatar from './Avatar.svelte';
   import ZapModal from './ZapModal.svelte';
+  import ReplyComposer from './comments/ReplyComposer.svelte';
   import { resolveProfileByPubkey, formatDisplayName } from '$lib/profileResolver';
   import { formatAmount } from '$lib/utils';
   import { addClientTagToEvent } from '$lib/nip89';
-  import { buildNip22CommentTags } from '$lib/tagUtils';
   import HeartIcon from 'phosphor-svelte/lib/Heart';
   import LightningIcon from 'phosphor-svelte/lib/Lightning';
   import NoteContent from './NoteContent.svelte';
   import { onMount, onDestroy } from 'svelte';
-  import { get } from 'svelte/store';
   import { extractZapAmountSats } from '$lib/zapAmount';
-  import MentionDropdown from './MentionDropdown.svelte';
-  import { MentionComposerController, type MentionState } from '$lib/mentionComposer';
-  import GifIcon from 'phosphor-svelte/lib/Gif';
-  import ImageIcon from 'phosphor-svelte/lib/Image';
-  import VideoIcon from 'phosphor-svelte/lib/Video';
-  import GifPicker from './GifPicker.svelte';
-  import ChartBarHorizontalIcon from 'phosphor-svelte/lib/ChartBarHorizontal';
-  import PollCreator from './PollCreator.svelte';
-  import { buildPollTags, type PollConfig } from '$lib/polls';
-  import { uploadImage, uploadVideo } from '$lib/mediaUpload';
 
   export let event: NDKEvent;
   export let allReplies: NDKEvent[] = []; // All replies for finding parent
   export let refresh: () => void;
+  /**
+   * The root event (recipe) passed down from the Comments container. Used by
+   * the inline reply composer to build NIP-22 tags with the correct root-scope.
+   */
+  export let rootEvent: NDKEvent;
 
   // Display state
   let displayName = '';
@@ -39,48 +33,8 @@
   let parentDisplayName = '';
   let parentLoading = true;
 
-  // Reply box state
+  // Reply box state — the composer itself owns everything inside the form.
   let showReplyBox = false;
-  let showGifPicker = false;
-  let showPollCreator = false;
-  let pollConfig: PollConfig | null = null;
-  let replyText = '';
-  let postingReply = false;
-  let replyComposerEl: HTMLDivElement;
-  let lastRenderedReply = '';
-  let uploadedImages: string[] = [];
-  let uploadedVideos: string[] = [];
-  let uploadingImage = false;
-  let uploadingVideo = false;
-  let uploadError = '';
-  let imageInputEl: HTMLInputElement;
-  let videoInputEl: HTMLInputElement;
-
-  // Mention autocomplete
-  let mentionState: MentionState = {
-    mentionQuery: '',
-    showMentionSuggestions: false,
-    mentionSuggestions: [],
-    selectedMentionIndex: 0,
-    mentionSearching: false
-  };
-
-  const mentionCtrl = new MentionComposerController(
-    (state) => {
-      mentionState = state;
-    },
-    (text) => {
-      replyText = text;
-      lastRenderedReply = text;
-    }
-  );
-
-  $: mentionCtrl.setComposerEl(replyComposerEl);
-
-  $: if (replyComposerEl && replyText !== lastRenderedReply) {
-    mentionCtrl.syncContent(replyText);
-    lastRenderedReply = replyText;
-  }
 
   // Like state
   let liked = false;
@@ -103,8 +57,6 @@
     const replyTag = eTags.find((tag) => tag[3] === 'reply');
     if (replyTag) {
       // Check if this reply tag points to another comment (not the root recipe)
-      const aTag = event.getMatchingTags('a')[0];
-      // If it's a reply and there's another e tag, it might be a nested reply
       const parentEventTag = eTags.find((tag) => tag[3] !== 'reply' && tag[3] !== 'root');
       if (parentEventTag) return parentEventTag[1];
 
@@ -118,11 +70,6 @@
 
   // Load profile and parent comment
   onMount(async () => {
-    // Preload mention profiles in background
-    if ($userPublickey) {
-      mentionCtrl.preloadFollowList();
-    }
-
     // Load author profile
     if (event.pubkey && $ndk) {
       try {
@@ -238,182 +185,12 @@
     likeCount++;
   }
 
-  async function handleImageUpload(e: Event) {
-    const target = e.target as HTMLInputElement;
-    const files = target.files;
-    if (!files || files.length === 0) return;
-    uploadingImage = true;
-    uploadError = '';
-    try {
-      for (const file of Array.from(files)) {
-        const url = await uploadImage($ndk, file);
-        uploadedImages = [...uploadedImages, url];
-      }
-    } catch (err: any) {
-      uploadError = err?.message || 'Failed to upload image.';
-    } finally {
-      uploadingImage = false;
-      if (imageInputEl) imageInputEl.value = '';
-    }
-  }
-
-  async function handleVideoUpload(e: Event) {
-    const target = e.target as HTMLInputElement;
-    const files = target.files;
-    if (!files || files.length === 0) return;
-    uploadingVideo = true;
-    uploadError = '';
-    try {
-      for (const file of Array.from(files)) {
-        const url = await uploadVideo($ndk, file);
-        uploadedVideos = [...uploadedVideos, url];
-      }
-    } catch (err: any) {
-      uploadError = err?.message || 'Failed to upload video.';
-    } finally {
-      uploadingVideo = false;
-      if (videoInputEl) videoInputEl.value = '';
-    }
-  }
-
-  function removeImage(index: number) {
-    uploadedImages = uploadedImages.filter((_, i) => i !== index);
-  }
-
-  function removeVideo(index: number) {
-    uploadedVideos = uploadedVideos.filter((_, i) => i !== index);
-  }
-
-  // Post reply
-  async function postReply() {
-    if ((!replyText.trim() && uploadedImages.length === 0 && uploadedVideos.length === 0 && !pollConfig) || postingReply) return;
-
-    postingReply = true;
-    const ev = new NDKEvent($ndk);
-
-    // Check if this is a reply to a recipe comment
-    // If the parent comment is kind 1111 or has an 'a' tag referencing kind 30023, use kind 1111
-    const aTag = event.getMatchingTags('a')[0];
-    const ATag = event.getMatchingTags('A')[0];
-    const isRecipeReply =
-      event.kind === 1111 ||
-      (aTag && aTag[1]?.startsWith('30023:')) ||
-      (ATag && ATag[1]?.startsWith('30023:'));
-    ev.kind = pollConfig ? 1068 : (isRecipeReply ? 1111 : 1);
-
-    if (replyComposerEl) {
-      replyText = mentionCtrl.extractText();
-      lastRenderedReply = replyText;
-    }
-
-    let replyContent = mentionCtrl.replacePlainMentions(replyText.trim());
-    const mediaUrls = [...uploadedImages, ...uploadedVideos];
-    if (mediaUrls.length > 0) {
-      const mediaText = mediaUrls.join('\n');
-      replyContent = replyContent ? `${replyContent}\n\n${mediaText}` : mediaText;
-    }
-    ev.content = replyContent;
-
-    // Reconstruct a minimal event object for the parent comment
-    const parentEventObj = {
-      id: event.id,
-      pubkey: event.pubkey,
-      kind: event.kind,
-      tags: event.tags
-    };
-
-    // For recipe replies, we need to get the root event info from the parent's tags
-    if (isRecipeReply) {
-      // Get root event info from parent comment's tags
-      const rootATag = event.getMatchingTags('A')[0] || event.getMatchingTags('a')[0];
-
-      if (rootATag) {
-        // Parse the address tag to extract root event info
-        const [kind, pubkey, ...dTagParts] = rootATag[1].split(':');
-        const dTag = dTagParts.join(':');
-        const rootEventObj = {
-          kind: parseInt(kind),
-          pubkey: pubkey,
-          id: '', // We don't need the actual event ID for tag generation
-          tags: [
-            ['d', dTag],
-            ['relay', rootATag[2] || '']
-          ]
-        };
-
-        // Use the utility with both root and parent event
-        ev.tags = buildNip22CommentTags(rootEventObj, {
-          ...parentEventObj,
-          tags: parentEventObj.tags as string[][]
-        });
-      } else {
-        // Fallback: treat parent as if it's the root
-        ev.tags = buildNip22CommentTags(
-          {
-            ...parentEventObj,
-            kind: parentEventObj.kind ?? 1,
-            tags: parentEventObj.tags as string[][]
-          },
-          {
-            ...parentEventObj,
-            tags: parentEventObj.tags as string[][]
-          }
-        );
-      }
-    } else {
-      // For non-recipe replies, we still need to construct a root event object
-      // In this case, we need to find the root event ID from the parent's tags
-      const rootETag = event.getMatchingTags('e').find((t) => t[3] === 'root');
-      if (rootETag) {
-        // Derive the root author's pubkey from the parent's p-tags when possible
-        const rootPTags = event.getMatchingTags('p');
-        const rootPubkey = rootPTags && rootPTags.length > 0 ? rootPTags[0][1] : event.pubkey;
-        const rootEventObj = {
-          kind: 1,
-          pubkey: rootPubkey, // Use root author's pubkey when available, otherwise fall back to parent
-          id: rootETag[1], // Root event ID from the e tag
-          tags: []
-        };
-        ev.tags = buildNip22CommentTags(rootEventObj, parentEventObj);
-      } else {
-        // Use the simplified version for replies
-        ev.tags = [
-          ['e', event.id, '', 'reply'],
-          ['p', event.pubkey]
-        ];
-      }
-    }
-
-    // Parse and add @ mention tags (p tags)
-    const mentions = mentionCtrl.parseMentions(replyContent);
-    for (const pubkey of mentions.values()) {
-      if (!ev.tags.some((t) => t[0] === 'p' && t[1] === pubkey)) {
-        ev.tags.push(['p', pubkey]);
-      }
-    }
-
-    addClientTagToEvent(ev);
-    if (pollConfig) {
-      ev.tags.push(...buildPollTags(pollConfig));
-    }
-    await ev.publish();
-    replyText = '';
-    lastRenderedReply = '';
-    uploadedImages = [];
-    uploadedVideos = [];
-    pollConfig = null;
-    uploadError = '';
-    if (replyComposerEl) {
-      replyComposerEl.innerHTML = '';
-    }
-    mentionCtrl.resetMentionState();
+  function handleReplyPosted() {
     showReplyBox = false;
-    postingReply = false;
     refresh();
   }
 
   onDestroy(() => {
-    mentionCtrl.destroy();
     if (likeSubscription) {
       likeSubscription.stop();
     }
@@ -521,127 +298,19 @@
         </button>
       </div>
 
-      <!-- Inline Reply Box -->
+      <!-- Inline Reply Composer -->
       {#if showReplyBox}
-        <div class="reply-form">
-          <div class="relative">
-            <div
-              bind:this={replyComposerEl}
-              class="reply-input"
-              contenteditable={!postingReply}
-              role="textbox"
-              tabindex="0"
-              aria-multiline="true"
-              data-placeholder="Add a reply..."
-              on:input={() => mentionCtrl.handleInput()}
-              on:keydown={(e) => mentionCtrl.handleKeydown(e)}
-              on:beforeinput={(e) => mentionCtrl.handleBeforeInput(e)}
-              on:paste={(e) => mentionCtrl.handlePaste(e)}
-            ></div>
-
-            <MentionDropdown
-              show={mentionState.showMentionSuggestions}
-              suggestions={mentionState.mentionSuggestions}
-              selectedIndex={mentionState.selectedMentionIndex}
-              searching={mentionState.mentionSearching}
-              query={mentionState.mentionQuery}
-              on:select={(e) => mentionCtrl.insertMention(e.detail)}
-            />
-          </div>
-          {#if uploadError}
-            <p class="text-red-500 text-xs">{uploadError}</p>
-          {/if}
-
-          {#if uploadedImages.length > 0}
-            <div class="flex flex-wrap gap-2">
-              {#each uploadedImages as imageUrl, index}
-                <div class="relative group">
-                  <img src={imageUrl} alt="Upload preview" class="w-16 h-16 object-cover rounded-lg" style="border: 1px solid var(--color-input-border)" />
-                  <button type="button" on:click={() => removeImage(index)} class="absolute -top-2 -right-2 bg-red-500 hover:bg-red-600 text-white rounded-full p-0.5 shadow-lg" aria-label="Remove image">
-                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
-                  </button>
-                </div>
-              {/each}
-            </div>
-          {/if}
-
-          {#if uploadedVideos.length > 0}
-            <div class="flex flex-wrap gap-2">
-              {#each uploadedVideos as videoUrl, index}
-                <div class="relative group">
-                  <video src={videoUrl} class="w-24 h-16 object-cover rounded-lg" style="border: 1px solid var(--color-input-border)" preload="metadata" muted />
-                  <button type="button" on:click={() => removeVideo(index)} class="absolute -top-2 -right-2 bg-red-500 hover:bg-red-600 text-white rounded-full p-0.5 shadow-lg" aria-label="Remove video">
-                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
-                  </button>
-                </div>
-              {/each}
-            </div>
-          {/if}
-
-          <div class="reply-buttons">
-            <label class="btn-media" class:opacity-50={uploadingImage || uploadingVideo || postingReply} title="Upload image">
-              <ImageIcon size={16} />
-              <input bind:this={imageInputEl} type="file" accept="image/*" class="sr-only" on:change={handleImageUpload} disabled={postingReply || uploadingImage || uploadingVideo} />
-            </label>
-            <label class="btn-media" class:opacity-50={uploadingImage || uploadingVideo || postingReply} title="Upload video">
-              <VideoIcon size={16} />
-              <input bind:this={videoInputEl} type="file" accept="video/*" class="sr-only" on:change={handleVideoUpload} disabled={postingReply || uploadingImage || uploadingVideo} />
-            </label>
-            <button
-              on:click={() => (showGifPicker = true)}
-              class="btn-gif"
-              title="Add GIF"
-              disabled={postingReply || uploadingImage || uploadingVideo}
-            >
-              <GifIcon size={16} />
-            </button>
-            <button
-              on:click={() => (showPollCreator = true)}
-              class="btn-gif"
-              title="Create poll"
-              disabled={postingReply}
-              class:opacity-50={postingReply}
-            >
-              <ChartBarHorizontalIcon size={16} class={pollConfig ? 'text-primary' : ''} />
-            </button>
-            {#if uploadingImage}
-              <span class="text-xs text-caption">Uploading image...</span>
-            {:else if uploadingVideo}
-              <span class="text-xs text-caption">Uploading video...</span>
-            {/if}
-            {#if pollConfig}
-              <span class="text-xs text-orange-600 flex items-center gap-1">
-                <ChartBarHorizontalIcon size={12} />
-                Poll ({pollConfig.options.length})
-                <button type="button" on:click={() => (pollConfig = null)} class="hover:text-orange-800">×</button>
-              </span>
-            {/if}
-            <button
-              on:click={postReply}
-              disabled={(!replyText.trim() && uploadedImages.length === 0 && uploadedVideos.length === 0 && !pollConfig) || postingReply || uploadingImage || uploadingVideo}
-              class="btn-post"
-            >
-              {postingReply ? 'Posting...' : 'Post'}
-            </button>
-            <button
-              on:click={() => {
-                showReplyBox = false;
-                replyText = '';
-                lastRenderedReply = '';
-                uploadedImages = [];
-                uploadedVideos = [];
-                uploadError = '';
-                if (replyComposerEl) {
-                  replyComposerEl.innerHTML = '';
-                }
-                mentionCtrl.resetMentionState();
-              }}
-              class="btn-cancel"
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
+        <ReplyComposer
+          parentEvent={rootEvent}
+          replyTo={event}
+          placeholder="Add a reply..."
+          signingStrategy="explicit-with-timeout"
+          onErrorStrategy="alert"
+          compact
+          showCancel
+          onPosted={handleReplyPosted}
+          on:cancel={() => (showReplyBox = false)}
+        />
       {/if}
     </div>
   </div>
@@ -651,20 +320,6 @@
 {#if zapModalOpen}
   <ZapModal bind:open={zapModalOpen} {event} />
 {/if}
-
-<GifPicker
-  bind:open={showGifPicker}
-  on:select={(e) => {
-    uploadedImages = [...uploadedImages, e.detail.url];
-  }}
-/>
-
-<PollCreator
-  bind:open={showPollCreator}
-  on:create={(e) => {
-    pollConfig = e.detail;
-  }}
-/>
 
 <style>
   /* Comment card - full width, no nesting */
@@ -798,89 +453,5 @@
     align-items: center;
     gap: 0.25rem;
     color: var(--color-text-secondary);
-  }
-
-  /* Reply form */
-  .reply-form {
-    margin-top: 0.75rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-
-  .reply-input {
-    width: 100%;
-    padding: 0.5rem 0.75rem;
-    font-size: 1rem;
-    border-radius: 0.5rem;
-    background: var(--color-input-bg);
-    border: 1px solid var(--color-input-border);
-    color: var(--color-text-primary);
-    white-space: pre-wrap;
-    word-break: break-word;
-  }
-
-  .reply-input:focus {
-    outline: none;
-    box-shadow: 0 0 0 2px var(--color-primary);
-  }
-
-  .reply-input:empty:before {
-    content: attr(data-placeholder);
-    color: var(--color-caption);
-    pointer-events: none;
-  }
-
-  .reply-buttons {
-    display: flex;
-    gap: 0.5rem;
-  }
-
-  .btn-post {
-    padding: 0.5rem 1rem;
-    font-size: 0.875rem;
-    font-weight: 500;
-    color: white;
-    background: var(--color-primary);
-    border-radius: 0.5rem;
-  }
-
-  .btn-post:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  .btn-cancel {
-    padding: 0.5rem 1rem;
-    font-size: 0.875rem;
-    font-weight: 500;
-    color: var(--color-text-primary);
-    background: var(--color-input-bg);
-    border-radius: 0.5rem;
-  }
-
-  .btn-cancel:hover {
-    opacity: 0.8;
-  }
-
-  .btn-gif,
-  .btn-media {
-    padding: 0.375rem;
-    color: var(--color-caption);
-    border-radius: 0.375rem;
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    transition: opacity 0.15s;
-  }
-
-  .btn-gif:hover,
-  .btn-media:hover {
-    opacity: 0.7;
-  }
-
-  .btn-gif:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
   }
 </style>

--- a/src/components/Comments.svelte
+++ b/src/components/Comments.svelte
@@ -1,72 +1,18 @@
 <script lang="ts">
-  import { ndk, userPublickey } from '$lib/nostr';
+  import { ndk } from '$lib/nostr';
   import { NDKEvent } from '@nostr-dev-kit/ndk';
   import Button from './Button.svelte';
   import Comment from './Comment.svelte';
+  import ReplyComposer from './comments/ReplyComposer.svelte';
   import { onDestroy } from 'svelte';
-  import MentionDropdown from './MentionDropdown.svelte';
-  import { MentionComposerController, type MentionState } from '$lib/mentionComposer';
-  import GifIcon from 'phosphor-svelte/lib/Gif';
-  import ImageIcon from 'phosphor-svelte/lib/Image';
-  import VideoIcon from 'phosphor-svelte/lib/Video';
-  import GifPicker from './GifPicker.svelte';
-  import ChartBarHorizontalIcon from 'phosphor-svelte/lib/ChartBarHorizontal';
-  import PollCreator from './PollCreator.svelte';
-  import { buildPollTags, type PollConfig } from '$lib/polls';
-  import { uploadImage, uploadVideo } from '$lib/mediaUpload';
   import { writable, type Readable } from 'svelte/store';
   import {
     createCommentSubscription,
     type CommentSubscription
   } from '$lib/comments/subscription';
-  import { postComment as postCommentLib, PostCommentError } from '$lib/comments/postComment';
 
   export let event: NDKEvent;
   let sub: CommentSubscription | null = null;
-  let commentText = '';
-  let commentComposerEl: HTMLDivElement;
-  let lastRenderedComment = '';
-  let showGifPicker = false;
-  let showPollCreator = false;
-  let pollConfig: PollConfig | null = null;
-  let uploadedImages: string[] = [];
-  let uploadedVideos: string[] = [];
-  let uploadingImage = false;
-  let uploadingVideo = false;
-  let uploadError = '';
-  let imageInputEl: HTMLInputElement;
-  let videoInputEl: HTMLInputElement;
-
-  // Mention autocomplete
-  let mentionState: MentionState = {
-    mentionQuery: '',
-    showMentionSuggestions: false,
-    mentionSuggestions: [],
-    selectedMentionIndex: 0,
-    mentionSearching: false
-  };
-
-  const mentionCtrl = new MentionComposerController(
-    (state) => {
-      mentionState = state;
-    },
-    (text) => {
-      commentText = text;
-      lastRenderedComment = text;
-    }
-  );
-
-  $: mentionCtrl.setComposerEl(commentComposerEl);
-
-  $: if (commentComposerEl && commentText !== lastRenderedComment) {
-    mentionCtrl.syncContent(commentText);
-    lastRenderedComment = commentText;
-  }
-
-  // Preload follow list when user is logged in
-  $: if ($userPublickey) {
-    mentionCtrl.preloadFollowList();
-  }
 
   // Create subscription once ndk is ready. `sub` is nulled in onDestroy so
   // reconnection paths (if $ndk ever becomes null → non-null) re-subscribe.
@@ -80,7 +26,6 @@
   }
 
   onDestroy(() => {
-    mentionCtrl.destroy();
     sub?.stop();
     sub = null;
   });
@@ -92,119 +37,10 @@
     // intentionally empty
   }
 
-  async function handleImageUpload(e: Event) {
-    const target = e.target as HTMLInputElement;
-    const files = target.files;
-    if (!files || files.length === 0) return;
-    uploadingImage = true;
-    uploadError = '';
-    try {
-      for (const file of Array.from(files)) {
-        const url = await uploadImage($ndk, file);
-        uploadedImages = [...uploadedImages, url];
-      }
-    } catch (err: any) {
-      uploadError = err?.message || 'Failed to upload image.';
-    } finally {
-      uploadingImage = false;
-      if (imageInputEl) imageInputEl.value = '';
-    }
-  }
-
-  async function handleVideoUpload(e: Event) {
-    const target = e.target as HTMLInputElement;
-    const files = target.files;
-    if (!files || files.length === 0) return;
-    uploadingVideo = true;
-    uploadError = '';
-    try {
-      for (const file of Array.from(files)) {
-        const url = await uploadVideo($ndk, file);
-        uploadedVideos = [...uploadedVideos, url];
-      }
-    } catch (err: any) {
-      uploadError = err?.message || 'Failed to upload video.';
-    } finally {
-      uploadingVideo = false;
-      if (videoInputEl) videoInputEl.value = '';
-    }
-  }
-
-  function removeImage(index: number) {
-    uploadedImages = uploadedImages.filter((_, i) => i !== index);
-  }
-
-  function removeVideo(index: number) {
-    uploadedVideos = uploadedVideos.filter((_, i) => i !== index);
-  }
-
-  async function postComment() {
-    if (!commentText.trim() && uploadedImages.length === 0 && uploadedVideos.length === 0 && !pollConfig) {
-      return;
-    }
-
-    if (commentComposerEl) {
-      commentText = mentionCtrl.extractText();
-      lastRenderedComment = commentText;
-    }
-    if (!$ndk?.signer) {
-      console.error('No signer available - user must be logged in');
-      alert('Please log in to post comments');
-      return;
-    }
-
-    // Compose content: mention substitution + media URL append.
-    let commentContent = mentionCtrl.replacePlainMentions(commentText.trim());
-    const mediaUrls = [...uploadedImages, ...uploadedVideos];
-    if (mediaUrls.length > 0) {
-      const mediaText = mediaUrls.join('\n');
-      commentContent = commentContent ? `${commentContent}\n\n${mediaText}` : mediaText;
-    }
-
-    // Collect @-mention p-tags + optional poll tags to merge into the event.
-    const extraTags: string[][] = [];
-    const mentions = mentionCtrl.parseMentions(commentContent);
-    for (const pubkey of mentions.values()) {
-      extraTags.push(['p', pubkey]);
-    }
-    if (pollConfig) {
-      extraTags.push(...buildPollTags(pollConfig));
-    }
-
-    try {
-      const { event: posted } = await postCommentLib($ndk, {
-        parentEvent: event,
-        content: commentContent,
-        extraTags,
-        contentKind: pollConfig ? 1068 : undefined,
-        signingStrategy: 'explicit-with-timeout'
-      });
-
-      // Optimistic add — recipe comments want the new entry visible
-      // immediately rather than waiting for the subscription round-trip.
-      sub?.addLocal(posted);
-
-      // Clear the composer
-      commentText = '';
-      lastRenderedComment = '';
-      uploadedImages = [];
-      pollConfig = null;
-      uploadedVideos = [];
-      uploadError = '';
-      if (commentComposerEl) {
-        commentComposerEl.innerHTML = '';
-      }
-      mentionCtrl.resetMentionState();
-    } catch (error) {
-      console.error('Error posting comment:', error);
-      if (error instanceof PostCommentError && error.cause instanceof Error) {
-        console.error('Error stack:', error.cause.stack);
-      } else if (error instanceof Error) {
-        console.error('Error stack:', error.stack);
-      }
-      const errorMsg = error instanceof Error ? error.message : String(error);
-      alert('Error posting comment: ' + errorMsg);
-    }
+  function handlePosted(posted: NDKEvent) {
+    // Optimistic add — recipe comments want the new entry visible immediately
+    // rather than waiting for the subscription round-trip.
+    sub?.addLocal(posted);
   }
 </script>
 
@@ -217,7 +53,7 @@
       <p class="text-caption">No comments yet. Be the first to comment!</p>
     {:else}
       {#each $events as comment (comment.id)}
-        <Comment event={comment} allReplies={$events} {refresh} />
+        <Comment event={comment} allReplies={$events} {refresh} rootEvent={event} />
       {/each}
     {/if}
   </div>
@@ -226,110 +62,27 @@
   <div class="space-y-3 pt-4 border-t">
     <h3 class="text-lg font-semibold">Add a comment</h3>
     {#if $ndk?.signer}
-      <div class="relative">
-        <div
-          id="comment-input"
-          bind:this={commentComposerEl}
-          class="comment-composer-input w-full px-4 py-3 text-base input rounded-lg"
-          contenteditable="true"
-          role="textbox"
-          tabindex="0"
-          aria-multiline="true"
-          data-placeholder="Share your thoughts..."
-          on:input={() => mentionCtrl.handleInput()}
-          on:keydown={(e) => mentionCtrl.handleKeydown(e)}
-          on:beforeinput={(e) => mentionCtrl.handleBeforeInput(e)}
-          on:paste={(e) => mentionCtrl.handlePaste(e)}
-        ></div>
-
-        <MentionDropdown
-          show={mentionState.showMentionSuggestions}
-          suggestions={mentionState.mentionSuggestions}
-          selectedIndex={mentionState.selectedMentionIndex}
-          searching={mentionState.mentionSearching}
-          query={mentionState.mentionQuery}
-          on:select={(e) => mentionCtrl.insertMention(e.detail)}
-        />
-      </div>
-      {#if uploadError}
-        <p class="text-red-500 text-xs">{uploadError}</p>
-      {/if}
-
-      {#if uploadedImages.length > 0}
-        <div class="flex flex-wrap gap-2">
-          {#each uploadedImages as imageUrl, index}
-            <div class="relative group">
-              <img src={imageUrl} alt="Upload preview" class="w-20 h-20 object-cover rounded-lg" style="border: 1px solid var(--color-input-border)" />
-              <button type="button" on:click={() => removeImage(index)} class="absolute -top-2 -right-2 bg-red-500 hover:bg-red-600 text-white rounded-full p-1 shadow-lg" aria-label="Remove image">
-                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
-              </button>
-            </div>
-          {/each}
-        </div>
-      {/if}
-
-      {#if uploadedVideos.length > 0}
-        <div class="flex flex-wrap gap-2">
-          {#each uploadedVideos as videoUrl, index}
-            <div class="relative group">
-              <video src={videoUrl} class="w-32 h-20 object-cover rounded-lg" style="border: 1px solid var(--color-input-border)" preload="metadata" muted />
-              <button type="button" on:click={() => removeVideo(index)} class="absolute -top-2 -right-2 bg-red-500 hover:bg-red-600 text-white rounded-full p-1 shadow-lg" aria-label="Remove video">
-                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
-              </button>
-            </div>
-          {/each}
-        </div>
-      {/if}
-
-      <div class="flex items-center gap-2">
-        <label class="btn-media" class:opacity-50={uploadingImage || uploadingVideo} title="Upload image">
-          <ImageIcon size={18} />
-          <input bind:this={imageInputEl} type="file" accept="image/*" class="sr-only" on:change={handleImageUpload} disabled={uploadingImage || uploadingVideo} />
-        </label>
-        <label class="btn-media" class:opacity-50={uploadingImage || uploadingVideo} title="Upload video">
-          <VideoIcon size={18} />
-          <input bind:this={videoInputEl} type="file" accept="video/*" class="sr-only" on:change={handleVideoUpload} disabled={uploadingImage || uploadingVideo} />
-        </label>
-        <button
-          on:click={() => (showGifPicker = true)}
-          class="btn-gif"
-          title="Add GIF"
-          disabled={uploadingImage || uploadingVideo}
-          class:opacity-50={uploadingImage || uploadingVideo}
-        >
-          <GifIcon size={18} />
-        </button>
-        <button
-          on:click={() => (showPollCreator = true)}
-          class="btn-gif"
-          title="Create poll"
-          disabled={uploadingImage || uploadingVideo}
-          class:opacity-50={uploadingImage || uploadingVideo}
-        >
-          <ChartBarHorizontalIcon size={18} class={pollConfig ? 'text-primary' : ''} />
-        </button>
-        {#if uploadingImage}
-          <span class="text-xs text-caption">Uploading image...</span>
-        {:else if uploadingVideo}
-          <span class="text-xs text-caption">Uploading video...</span>
-        {/if}
-        {#if pollConfig}
-          <span class="text-xs text-orange-600 flex items-center gap-1">
-            <ChartBarHorizontalIcon size={12} />
-            Poll ({pollConfig.options.length})
-            <button type="button" on:click={() => (pollConfig = null)} class="hover:text-orange-800">×</button>
-          </span>
-        {/if}
+      <ReplyComposer
+        parentEvent={event}
+        placeholder="Share your thoughts..."
+        submitLabel="Post Comment"
+        signingStrategy="explicit-with-timeout"
+        onErrorStrategy="alert"
+        onPosted={handlePosted}
+      >
         <Button
+          slot="submit"
+          let:submit
+          let:disabled
           on:click={(e) => {
             e.preventDefault?.();
-            postComment();
+            submit();
           }}
-          disabled={uploadingImage || uploadingVideo || (!commentText.trim() && uploadedImages.length === 0 && uploadedVideos.length === 0 && !pollConfig)}
+          {disabled}
         >
           Post Comment
         </Button>
-      </div>
+      </ReplyComposer>
     {:else}
       <p class="text-sm text-caption">Sign in to comment.</p>
       <a href="/login" class="text-sm underline hover:opacity-80">Sign in</a>
@@ -337,51 +90,10 @@
   </div>
 </div>
 
-<GifPicker
-  bind:open={showGifPicker}
-  on:select={(e) => {
-    uploadedImages = [...uploadedImages, e.detail.url];
-  }}
-/>
-
-<PollCreator
-  bind:open={showPollCreator}
-  on:create={(e) => {
-    pollConfig = e.detail;
-  }}
-/>
-
 <style>
   .comments-list {
     display: flex;
     flex-direction: column;
     gap: 1rem;
-  }
-
-  .comment-composer-input {
-    white-space: pre-wrap;
-    word-break: break-word;
-  }
-
-  .comment-composer-input:empty:before {
-    content: attr(data-placeholder);
-    color: var(--color-caption);
-    pointer-events: none;
-  }
-
-  .btn-gif,
-  .btn-media {
-    padding: 0.375rem;
-    color: var(--color-caption);
-    border-radius: 0.375rem;
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    transition: opacity 0.15s;
-  }
-
-  .btn-gif:hover,
-  .btn-media:hover {
-    opacity: 0.7;
   }
 </style>

--- a/src/components/FeedComment.svelte
+++ b/src/components/FeedComment.svelte
@@ -7,30 +7,25 @@
   import CustomAvatar from './CustomAvatar.svelte';
   import NoteContent from './NoteContent.svelte';
   import ZapModal from './ZapModal.svelte';
+  import ReplyComposer from './comments/ReplyComposer.svelte';
   import { resolveProfileByPubkey, formatDisplayName } from '$lib/profileResolver';
   import { formatAmount } from '$lib/utils';
   import HeartIcon from 'phosphor-svelte/lib/Heart';
   import LightningIcon from 'phosphor-svelte/lib/Lightning';
   import { addClientTagToEvent } from '$lib/nip89';
-  import { buildNip22CommentTags } from '$lib/tagUtils';
   import { onMount, onDestroy } from 'svelte';
-  import { get } from 'svelte/store';
   import { extractZapAmountSats } from '$lib/zapAmount';
-  import MentionDropdown from './MentionDropdown.svelte';
-  import { MentionComposerController, type MentionState } from '$lib/mentionComposer';
-  import GifIcon from 'phosphor-svelte/lib/Gif';
-  import ImageIcon from 'phosphor-svelte/lib/Image';
-  import VideoIcon from 'phosphor-svelte/lib/Video';
-  import GifPicker from './GifPicker.svelte';
-  import ChartBarHorizontalIcon from 'phosphor-svelte/lib/ChartBarHorizontal';
-  import PollCreator from './PollCreator.svelte';
-  import { buildPollTags, type PollConfig } from '$lib/polls';
-  import { uploadImage, uploadVideo } from '$lib/mediaUpload';
 
   export let event: NDKEvent;
   export let allComments: NDKEvent[] = []; // All comments for finding parent
   export let refresh: () => void;
   export let mainEventId: string;
+  /**
+   * The root event (feed post) passed down from the FeedComments container.
+   * Used by the inline reply composer to build NIP-22/NIP-10 tags with the
+   * correct root-scope.
+   */
+  export let rootEvent: NDKEvent;
 
   // Display state
   let displayName = '';
@@ -41,48 +36,8 @@
   let parentDisplayName = '';
   let parentLoading = true;
 
-  // Reply box state
+  // Reply box state — the composer itself owns everything inside the form.
   let showReplyBox = false;
-  let showGifPicker = false;
-  let showPollCreator = false;
-  let pollConfig: PollConfig | null = null;
-  let replyText = '';
-  let postingReply = false;
-  let replyComposerEl: HTMLDivElement;
-  let lastRenderedReply = '';
-  let uploadedImages: string[] = [];
-  let uploadedVideos: string[] = [];
-  let uploadingImage = false;
-  let uploadingVideo = false;
-  let uploadError = '';
-  let imageInputEl: HTMLInputElement;
-  let videoInputEl: HTMLInputElement;
-
-  // Mention autocomplete
-  let mentionState: MentionState = {
-    mentionQuery: '',
-    showMentionSuggestions: false,
-    mentionSuggestions: [],
-    selectedMentionIndex: 0,
-    mentionSearching: false
-  };
-
-  const mentionCtrl = new MentionComposerController(
-    (state) => {
-      mentionState = state;
-    },
-    (text) => {
-      replyText = text;
-      lastRenderedReply = text;
-    }
-  );
-
-  $: mentionCtrl.setComposerEl(replyComposerEl);
-
-  $: if (replyComposerEl && replyText !== lastRenderedReply) {
-    mentionCtrl.syncContent(replyText);
-    lastRenderedReply = replyText;
-  }
 
   // Like state
   let liked = false;
@@ -145,9 +100,6 @@
 
   // Load profile and parent comment
   onMount(async () => {
-    // Preload follow list for mention autocomplete
-    mentionCtrl.preloadFollowList();
-
     // Load author profile
     if (event.pubkey && $ndk) {
       try {
@@ -219,7 +171,6 @@
   });
 
   onDestroy(() => {
-    mentionCtrl.destroy();
     if (likeSubscription) {
       likeSubscription.stop();
     }
@@ -249,171 +200,9 @@
     }
   }
 
-  async function handleImageUpload(e: Event) {
-    const target = e.target as HTMLInputElement;
-    const files = target.files;
-    if (!files || files.length === 0) return;
-    uploadingImage = true;
-    uploadError = '';
-    try {
-      for (const file of Array.from(files)) {
-        const url = await uploadImage($ndk, file);
-        uploadedImages = [...uploadedImages, url];
-      }
-    } catch (err: any) {
-      uploadError = err?.message || 'Failed to upload image.';
-    } finally {
-      uploadingImage = false;
-      if (imageInputEl) imageInputEl.value = '';
-    }
-  }
-
-  async function handleVideoUpload(e: Event) {
-    const target = e.target as HTMLInputElement;
-    const files = target.files;
-    if (!files || files.length === 0) return;
-    uploadingVideo = true;
-    uploadError = '';
-    try {
-      for (const file of Array.from(files)) {
-        const url = await uploadVideo($ndk, file);
-        uploadedVideos = [...uploadedVideos, url];
-      }
-    } catch (err: any) {
-      uploadError = err?.message || 'Failed to upload video.';
-    } finally {
-      uploadingVideo = false;
-      if (videoInputEl) videoInputEl.value = '';
-    }
-  }
-
-  function removeImage(index: number) {
-    uploadedImages = uploadedImages.filter((_, i) => i !== index);
-  }
-
-  function removeVideo(index: number) {
-    uploadedVideos = uploadedVideos.filter((_, i) => i !== index);
-  }
-
-  // Post reply
-  async function postReply() {
-    if ((!replyText.trim() && uploadedImages.length === 0 && uploadedVideos.length === 0 && !pollConfig) || postingReply) return;
-
-    postingReply = true;
-    try {
-      if (replyComposerEl) {
-        replyText = mentionCtrl.extractText();
-        lastRenderedReply = replyText;
-      }
-
-      const ev = new NDKEvent($ndk);
-
-      // Check if this is a reply to a recipe comment (kind 1111)
-      // If the parent comment is kind 1111, use kind 1111 for nested reply
-      const isRecipeReply = event.kind === 1111;
-      ev.kind = pollConfig ? 1068 : (isRecipeReply ? 1111 : 1);
-      let replyContent = mentionCtrl.replacePlainMentions(replyText.trim());
-      const mediaUrls = [...uploadedImages, ...uploadedVideos];
-      if (mediaUrls.length > 0) {
-        const mediaText = mediaUrls.join('\n');
-        replyContent = replyContent ? `${replyContent}\n\n${mediaText}` : mediaText;
-      }
-      ev.content = replyContent;
-
-      // Reconstruct a minimal event object for the parent comment
-      const parentEventObj = {
-        id: event.id,
-        pubkey: event.pubkey,
-        kind: event.kind,
-        tags: event.tags
-      };
-
-      // For recipe replies, we need to get the root event info from the parent's tags
-      if (isRecipeReply) {
-        // Get root event info from parent comment's NIP-22 tags
-        const rootATag = event.getMatchingTags('A')[0] || event.getMatchingTags('a')[0];
-
-        if (rootATag) {
-          // Parse the address tag to extract root event info
-          const [kind, pubkey, ...dTagParts] = rootATag[1].split(':');
-          const dTag = dTagParts.join(':');
-          // Find the root event's actual ID from the parent's e tags (look for the
-          // e tag that references the root, not another comment)
-          const rootETag = event.getMatchingTags('E')[0] ||
-            event.getMatchingTags('e').find((t) => t[1] && t[1] !== event.id);
-          const rootEventObj = {
-            kind: parseInt(kind),
-            pubkey: pubkey,
-            id: rootETag?.[1] || '',
-            tags: [
-              ['d', dTag],
-              ['relay', rootATag[2] || '']
-            ]
-          };
-
-          // Use the utility with both root and parent event
-          ev.tags = buildNip22CommentTags(rootEventObj, parentEventObj);
-        } else {
-          // Fallback: parent lacks NIP-22 structure — build tags treating
-          // the parent as both root and parent (best effort)
-          ev.tags = buildNip22CommentTags(
-            {
-              ...parentEventObj,
-              kind: parentEventObj.kind ?? 1,
-              tags: parentEventObj.tags as string[][]
-            },
-            {
-              ...parentEventObj,
-              tags: parentEventObj.tags as string[][]
-            }
-          );
-        }
-      } else {
-        // For non-recipe replies, construct tags for standard note replies
-        // Try to derive the root event's pubkey from the parent event's tags.
-        // Prefer any 'p'/'P' tag, which typically references the root author.
-        const rootPubkeyFromTags = event.tags.find(
-          (t) => (t[0] === 'p' || t[0] === 'P') && t[1]
-        )?.[1];
-
-        const rootEventObj = {
-          kind: 1,
-          pubkey: rootPubkeyFromTags || event.pubkey,
-          id: mainEventId,
-          tags: []
-        };
-        ev.tags = buildNip22CommentTags(rootEventObj, parentEventObj);
-      }
-
-      const mentions = mentionCtrl.parseMentions(replyContent);
-      for (const pubkey of mentions.values()) {
-        if (!ev.tags.some((t) => t[0] === 'p' && t[1] === pubkey)) {
-          ev.tags.push(['p', pubkey]);
-        }
-      }
-
-      addClientTagToEvent(ev);
-      if (pollConfig) {
-        ev.tags.push(...buildPollTags(pollConfig));
-      }
-      await ev.publish();
-      replyText = '';
-      lastRenderedReply = '';
-      uploadedImages = [];
-      uploadedVideos = [];
-      uploadError = '';
-      pollConfig = null;
-      if (replyComposerEl) {
-        replyComposerEl.innerHTML = '';
-      }
-      mentionCtrl.resetMentionState();
-      showReplyBox = false;
-      refresh();
-    } catch {
-      // Failed to post reply
-    } finally {
-      postingReply = false;
-    }
+  function handleReplyPosted() {
+    showReplyBox = false;
+    refresh();
   }
 
   // Open zap modal
@@ -513,12 +302,7 @@
           <!-- Reply Button -->
           {#if $userPublickey}
             <button
-              on:click={() => {
-                showReplyBox = !showReplyBox;
-                if (showReplyBox && $userPublickey) {
-                  mentionCtrl.preloadFollowList();
-                }
-              }}
+              on:click={() => (showReplyBox = !showReplyBox)}
               class="action-btn action-btn-text"
             >
               {showReplyBox ? 'Cancel' : 'Reply'}
@@ -526,127 +310,19 @@
           {/if}
         </div>
 
-        <!-- Inline Reply Box -->
+        <!-- Inline Reply Composer -->
         {#if showReplyBox}
-          <div class="reply-form">
-            <div class="relative">
-              <div
-                bind:this={replyComposerEl}
-                class="reply-input"
-                contenteditable={!postingReply}
-                role="textbox"
-                tabindex="0"
-                aria-multiline="true"
-                data-placeholder="Add a reply..."
-                on:input={() => mentionCtrl.handleInput()}
-                on:keydown={(e) => mentionCtrl.handleKeydown(e)}
-                on:beforeinput={(e) => mentionCtrl.handleBeforeInput(e)}
-                on:paste={(e) => mentionCtrl.handlePaste(e)}
-              ></div>
-
-              <MentionDropdown
-                show={mentionState.showMentionSuggestions}
-                suggestions={mentionState.mentionSuggestions}
-                selectedIndex={mentionState.selectedMentionIndex}
-                searching={mentionState.mentionSearching}
-                query={mentionState.mentionQuery}
-                on:select={(e) => mentionCtrl.insertMention(e.detail)}
-              />
-            </div>
-            {#if uploadError}
-              <p class="text-red-500 text-xs">{uploadError}</p>
-            {/if}
-
-            {#if uploadedImages.length > 0}
-              <div class="flex flex-wrap gap-2">
-                {#each uploadedImages as imageUrl, index}
-                  <div class="relative group">
-                    <img src={imageUrl} alt="Upload preview" class="w-16 h-16 object-cover rounded-lg" style="border: 1px solid var(--color-input-border)" />
-                    <button type="button" on:click={() => removeImage(index)} class="absolute -top-2 -right-2 bg-red-500 hover:bg-red-600 text-white rounded-full p-0.5 shadow-lg" aria-label="Remove image">
-                      <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
-                    </button>
-                  </div>
-                {/each}
-              </div>
-            {/if}
-
-            {#if uploadedVideos.length > 0}
-              <div class="flex flex-wrap gap-2">
-                {#each uploadedVideos as videoUrl, index}
-                  <div class="relative group">
-                    <video src={videoUrl} class="w-24 h-16 object-cover rounded-lg" style="border: 1px solid var(--color-input-border)" preload="metadata" muted />
-                    <button type="button" on:click={() => removeVideo(index)} class="absolute -top-2 -right-2 bg-red-500 hover:bg-red-600 text-white rounded-full p-0.5 shadow-lg" aria-label="Remove video">
-                      <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
-                    </button>
-                  </div>
-                {/each}
-              </div>
-            {/if}
-
-            <div class="reply-buttons">
-              <label class="btn-media" class:opacity-50={uploadingImage || uploadingVideo || postingReply} title="Upload image">
-                <ImageIcon size={16} />
-                <input bind:this={imageInputEl} type="file" accept="image/*" class="sr-only" on:change={handleImageUpload} disabled={postingReply || uploadingImage || uploadingVideo} />
-              </label>
-              <label class="btn-media" class:opacity-50={uploadingImage || uploadingVideo || postingReply} title="Upload video">
-                <VideoIcon size={16} />
-                <input bind:this={videoInputEl} type="file" accept="video/*" class="sr-only" on:change={handleVideoUpload} disabled={postingReply || uploadingImage || uploadingVideo} />
-              </label>
-              <button
-                on:click={() => (showGifPicker = true)}
-                class="btn-gif"
-                title="Add GIF"
-                disabled={postingReply || uploadingImage || uploadingVideo}
-              >
-                <GifIcon size={16} />
-              </button>
-              <button
-                on:click={() => (showPollCreator = true)}
-                class="btn-gif"
-                title="Create poll"
-                disabled={postingReply}
-                class:opacity-50={postingReply}
-              >
-                <ChartBarHorizontalIcon size={16} class={pollConfig ? 'text-primary' : ''} />
-              </button>
-              {#if uploadingImage}
-                <span class="text-xs text-caption">Uploading image...</span>
-              {:else if uploadingVideo}
-                <span class="text-xs text-caption">Uploading video...</span>
-              {/if}
-              {#if pollConfig}
-                <span class="text-xs text-orange-600 flex items-center gap-1">
-                  <ChartBarHorizontalIcon size={12} />
-                  Poll ({pollConfig.options.length})
-                  <button type="button" on:click={() => (pollConfig = null)} class="hover:text-orange-800">×</button>
-                </span>
-              {/if}
-              <button
-                on:click={postReply}
-                disabled={(!replyText.trim() && uploadedImages.length === 0 && uploadedVideos.length === 0 && !pollConfig) || postingReply || uploadingImage || uploadingVideo}
-                class="btn-post"
-              >
-                {postingReply ? 'Posting...' : 'Post'}
-              </button>
-              <button
-                on:click={() => {
-                  showReplyBox = false;
-                  replyText = '';
-                  lastRenderedReply = '';
-                  uploadedImages = [];
-                  uploadedVideos = [];
-                  uploadError = '';
-                  if (replyComposerEl) {
-                    replyComposerEl.innerHTML = '';
-                  }
-                  mentionCtrl.resetMentionState();
-                }}
-                class="btn-cancel"
-              >
-                Cancel
-              </button>
-            </div>
-          </div>
+          <ReplyComposer
+            parentEvent={rootEvent}
+            replyTo={event}
+            placeholder="Add a reply..."
+            signingStrategy="implicit"
+            onErrorStrategy="silent"
+            compact
+            showCancel
+            onPosted={handleReplyPosted}
+            on:cancel={() => (showReplyBox = false)}
+          />
         {/if}
       </div>
     </div>
@@ -657,20 +333,6 @@
     <ZapModal bind:open={zapModalOpen} {event} />
   {/if}
 {/if}
-
-<GifPicker
-  bind:open={showGifPicker}
-  on:select={(e) => {
-    uploadedImages = [...uploadedImages, e.detail.url];
-  }}
-/>
-
-<PollCreator
-  bind:open={showPollCreator}
-  on:create={(e) => {
-    pollConfig = e.detail;
-  }}
-/>
 
 <style>
   /* Comment card - full width, no nesting */
@@ -804,90 +466,5 @@
     align-items: center;
     gap: 0.25rem;
     color: var(--color-text-secondary);
-  }
-
-  /* Reply form */
-  .reply-form {
-    margin-top: 0.5rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-
-  .reply-input {
-    width: 100%;
-    padding: 0.375rem 0.5rem;
-    font-size: 0.875rem;
-    border-radius: 0.5rem;
-    background: var(--color-input-bg);
-    border: 1px solid var(--color-input-border);
-    color: var(--color-text-primary);
-    white-space: pre-wrap;
-    word-break: break-word;
-  }
-
-  .reply-input:focus {
-    outline: none;
-    ring: 2px;
-    ring-color: var(--color-primary);
-  }
-
-  .reply-input:empty:before {
-    content: attr(data-placeholder);
-    color: var(--color-caption);
-    pointer-events: none;
-  }
-
-  .reply-buttons {
-    display: flex;
-    gap: 0.5rem;
-  }
-
-  .btn-post {
-    padding: 0.375rem 0.75rem;
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: white;
-    background: var(--color-primary);
-    border-radius: 0.5rem;
-  }
-
-  .btn-post:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  .btn-cancel {
-    padding: 0.375rem 0.75rem;
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: var(--color-text-primary);
-    background: var(--color-input);
-    border-radius: 0.5rem;
-  }
-
-  .btn-cancel:hover {
-    opacity: 0.8;
-  }
-
-  .btn-gif,
-  .btn-media {
-    padding: 0.375rem;
-    color: var(--color-caption);
-    border-radius: 0.375rem;
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    transition: opacity 0.15s;
-  }
-
-  .btn-gif:hover,
-  .btn-media:hover {
-    opacity: 0.7;
-  }
-
-  .btn-gif:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
   }
 </style>

--- a/src/components/FeedComments.svelte
+++ b/src/components/FeedComments.svelte
@@ -3,71 +3,17 @@
   import { page } from '$app/stores';
   import { ndk, userPublickey } from '$lib/nostr';
   import { NDKEvent } from '@nostr-dev-kit/ndk';
-  import Button from './Button.svelte';
   import FeedComment from './FeedComment.svelte';
-  import MentionDropdown from './MentionDropdown.svelte';
-  import { MentionComposerController, type MentionState } from '$lib/mentionComposer';
-  import GifIcon from 'phosphor-svelte/lib/Gif';
-  import ImageIcon from 'phosphor-svelte/lib/Image';
-  import VideoIcon from 'phosphor-svelte/lib/Video';
-  import GifPicker from './GifPicker.svelte';
-  import ChartBarHorizontalIcon from 'phosphor-svelte/lib/ChartBarHorizontal';
-  import PollCreator from './PollCreator.svelte';
-  import { buildPollTags, type PollConfig } from '$lib/polls';
-  import { uploadImage, uploadVideo } from '$lib/mediaUpload';
+  import ReplyComposer from './comments/ReplyComposer.svelte';
   import { writable, type Readable } from 'svelte/store';
   import {
     createCommentSubscription,
     type CommentSubscription
   } from '$lib/comments/subscription';
-  import { postComment as postCommentLib } from '$lib/comments/postComment';
 
   export let event: NDKEvent;
   let sub: CommentSubscription | null = null;
-  let commentText = '';
   let showComments = false;
-  let commentComposerEl: HTMLDivElement;
-  let lastRenderedComment = '';
-  let showGifPicker = false;
-  let showPollCreator = false;
-  let pollConfig: PollConfig | null = null;
-  let uploadedImages: string[] = [];
-  let uploadedVideos: string[] = [];
-  let uploadingImage = false;
-  let uploadingVideo = false;
-  let uploadError = '';
-  let imageInputEl: HTMLInputElement;
-  let videoInputEl: HTMLInputElement;
-
-  // Mention autocomplete
-  let mentionState: MentionState = {
-    mentionQuery: '',
-    showMentionSuggestions: false,
-    mentionSuggestions: [],
-    selectedMentionIndex: 0,
-    mentionSearching: false
-  };
-
-  const mentionCtrl = new MentionComposerController(
-    (state) => {
-      mentionState = state;
-    },
-    (text) => {
-      commentText = text;
-      lastRenderedComment = text;
-    }
-  );
-
-  $: mentionCtrl.setComposerEl(commentComposerEl);
-
-  $: if (commentComposerEl && commentText !== lastRenderedComment) {
-    mentionCtrl.syncContent(commentText);
-    lastRenderedComment = commentText;
-  }
-
-  $: if ($userPublickey) {
-    mentionCtrl.preloadFollowList();
-  }
 
   // Listen for toggle event from NoteTotalComments
   onMount(() => {
@@ -87,7 +33,6 @@
   });
 
   onDestroy(() => {
-    mentionCtrl.destroy();
     sub?.stop();
     sub = null;
   });
@@ -109,103 +54,6 @@
     // intentionally empty
   }
 
-  async function handleImageUpload(e: Event) {
-    const target = e.target as HTMLInputElement;
-    const files = target.files;
-    if (!files || files.length === 0) return;
-    uploadingImage = true;
-    uploadError = '';
-    try {
-      for (const file of Array.from(files)) {
-        const url = await uploadImage($ndk, file);
-        uploadedImages = [...uploadedImages, url];
-      }
-    } catch (err: any) {
-      uploadError = err?.message || 'Failed to upload image.';
-    } finally {
-      uploadingImage = false;
-      if (imageInputEl) imageInputEl.value = '';
-    }
-  }
-
-  async function handleVideoUpload(e: Event) {
-    const target = e.target as HTMLInputElement;
-    const files = target.files;
-    if (!files || files.length === 0) return;
-    uploadingVideo = true;
-    uploadError = '';
-    try {
-      for (const file of Array.from(files)) {
-        const url = await uploadVideo($ndk, file);
-        uploadedVideos = [...uploadedVideos, url];
-      }
-    } catch (err: any) {
-      uploadError = err?.message || 'Failed to upload video.';
-    } finally {
-      uploadingVideo = false;
-      if (videoInputEl) videoInputEl.value = '';
-    }
-  }
-
-  function removeImage(index: number) {
-    uploadedImages = uploadedImages.filter((_, i) => i !== index);
-  }
-
-  function removeVideo(index: number) {
-    uploadedVideos = uploadedVideos.filter((_, i) => i !== index);
-  }
-
-  async function postComment() {
-    if (!commentText.trim() && uploadedImages.length === 0 && uploadedVideos.length === 0 && !pollConfig) return;
-
-    try {
-      if (commentComposerEl) {
-        commentText = mentionCtrl.extractText();
-        lastRenderedComment = commentText;
-      }
-
-      // Compose content: mention substitution + media URL append.
-      let commentContent = mentionCtrl.replacePlainMentions(commentText);
-      const mediaUrls = [...uploadedImages, ...uploadedVideos];
-      if (mediaUrls.length > 0) {
-        const mediaText = mediaUrls.join('\n');
-        commentContent = commentContent ? `${commentContent}\n\n${mediaText}` : mediaText;
-      }
-
-      // Collect @-mention p-tags + optional poll tags.
-      const extraTags: string[][] = [];
-      const mentions = mentionCtrl.parseMentions(commentContent);
-      for (const pubkey of mentions.values()) {
-        extraTags.push(['p', pubkey]);
-      }
-      if (pollConfig) {
-        extraTags.push(...buildPollTags(pollConfig));
-      }
-
-      await postCommentLib($ndk, {
-        parentEvent: event,
-        content: commentContent,
-        extraTags,
-        contentKind: pollConfig ? 1068 : undefined,
-        signingStrategy: 'implicit'
-      });
-
-      commentText = '';
-      lastRenderedComment = '';
-      uploadedImages = [];
-      pollConfig = null;
-      uploadedVideos = [];
-      uploadError = '';
-      if (commentComposerEl) {
-        commentComposerEl.innerHTML = '';
-      }
-      mentionCtrl.resetMentionState();
-    } catch {
-      // Failed to post comment — feed context swallows silently today.
-      // Stage 5 will unify to explicit + toast surface.
-    }
-  }
-
   function toggleComments() {
     showComments = !showComments;
   }
@@ -220,7 +68,13 @@
           <p class="text-sm text-caption">No comments yet. {#if !$userPublickey}<a href="/login?redirect={encodeURIComponent($page.url.pathname)}" class="underline hover:opacity-80">Sign in</a> to comment!{:else}Be the first to comment!{/if}</p>
         {:else}
           {#each $events as comment (comment.id)}
-            <FeedComment event={comment} allComments={$events} {refresh} mainEventId={event.id} />
+            <FeedComment
+              event={comment}
+              allComments={$events}
+              {refresh}
+              mainEventId={event.id}
+              rootEvent={event}
+            />
           {/each}
         {/if}
       </div>
@@ -228,104 +82,14 @@
       <!-- Add Comment Form -->
       {#if $userPublickey}
         <div class="space-y-2 pt-2" style="border-top: 1px solid var(--color-input-border)">
-          <div class="relative">
-            <div
-              bind:this={commentComposerEl}
-              class="comment-composer-input w-full px-3 py-2 text-sm rounded-lg bg-input"
-              style="border: 1px solid var(--color-input-border); color: var(--color-text-primary)"
-              contenteditable="true"
-              role="textbox"
-              tabindex="0"
-              aria-multiline="true"
-              data-placeholder="Add a comment..."
-              on:input={() => mentionCtrl.handleInput()}
-              on:keydown={(e) => mentionCtrl.handleKeydown(e)}
-              on:beforeinput={(e) => mentionCtrl.handleBeforeInput(e)}
-              on:paste={(e) => mentionCtrl.handlePaste(e)}
-            ></div>
-
-            <MentionDropdown
-              show={mentionState.showMentionSuggestions}
-              suggestions={mentionState.mentionSuggestions}
-              selectedIndex={mentionState.selectedMentionIndex}
-              searching={mentionState.mentionSearching}
-              query={mentionState.mentionQuery}
-              on:select={(e) => mentionCtrl.insertMention(e.detail)}
-            />
-          </div>
-          {#if uploadError}
-            <p class="text-red-500 text-xs">{uploadError}</p>
-          {/if}
-
-          {#if uploadedImages.length > 0}
-            <div class="flex flex-wrap gap-2">
-              {#each uploadedImages as imageUrl, index}
-                <div class="relative group">
-                  <img src={imageUrl} alt="Upload preview" class="w-16 h-16 object-cover rounded-lg" style="border: 1px solid var(--color-input-border)" />
-                  <button type="button" on:click={() => removeImage(index)} class="absolute -top-2 -right-2 bg-red-500 hover:bg-red-600 text-white rounded-full p-0.5 shadow-lg" aria-label="Remove image">
-                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
-                  </button>
-                </div>
-              {/each}
-            </div>
-          {/if}
-
-          {#if uploadedVideos.length > 0}
-            <div class="flex flex-wrap gap-2">
-              {#each uploadedVideos as videoUrl, index}
-                <div class="relative group">
-                  <video src={videoUrl} class="w-24 h-16 object-cover rounded-lg" style="border: 1px solid var(--color-input-border)" preload="metadata" muted />
-                  <button type="button" on:click={() => removeVideo(index)} class="absolute -top-2 -right-2 bg-red-500 hover:bg-red-600 text-white rounded-full p-0.5 shadow-lg" aria-label="Remove video">
-                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
-                  </button>
-                </div>
-              {/each}
-            </div>
-          {/if}
-
-          <div class="flex justify-end items-center gap-2">
-            <label class="btn-media" class:opacity-50={uploadingImage || uploadingVideo} title="Upload image">
-              <ImageIcon size={16} />
-              <input bind:this={imageInputEl} type="file" accept="image/*" class="sr-only" on:change={handleImageUpload} disabled={uploadingImage || uploadingVideo} />
-            </label>
-            <label class="btn-media" class:opacity-50={uploadingImage || uploadingVideo} title="Upload video">
-              <VideoIcon size={16} />
-              <input bind:this={videoInputEl} type="file" accept="video/*" class="sr-only" on:change={handleVideoUpload} disabled={uploadingImage || uploadingVideo} />
-            </label>
-            <button
-              on:click={() => (showGifPicker = true)}
-              class="btn-gif"
-              title="Add GIF"
-              disabled={uploadingImage || uploadingVideo}
-              class:opacity-50={uploadingImage || uploadingVideo}
-            >
-              <GifIcon size={16} />
-            </button>
-            <button
-              on:click={() => (showPollCreator = true)}
-              class="btn-gif"
-              title="Create poll"
-              disabled={uploadingImage || uploadingVideo}
-              class:opacity-50={uploadingImage || uploadingVideo}
-            >
-              <ChartBarHorizontalIcon size={16} class={pollConfig ? 'text-primary' : ''} />
-            </button>
-            {#if uploadingImage}
-              <span class="text-xs text-caption">Uploading image...</span>
-            {:else if uploadingVideo}
-              <span class="text-xs text-caption">Uploading video...</span>
-            {/if}
-            {#if pollConfig}
-              <span class="text-xs text-orange-600 flex items-center gap-1">
-                <ChartBarHorizontalIcon size={12} />
-                Poll ({pollConfig.options.length})
-                <button type="button" on:click={() => (pollConfig = null)} class="hover:text-orange-800">×</button>
-              </span>
-            {/if}
-            <Button on:click={postComment} disabled={uploadingImage || uploadingVideo || (!commentText.trim() && uploadedImages.length === 0 && uploadedVideos.length === 0 && !pollConfig)} class="text-sm px-4 py-2">
-              Post Comment
-            </Button>
-          </div>
+          <ReplyComposer
+            parentEvent={event}
+            placeholder="Add a comment..."
+            submitLabel="Post Comment"
+            signingStrategy="implicit"
+            onErrorStrategy="silent"
+            compact
+          />
         </div>
       {:else}
         <div
@@ -339,52 +103,11 @@
   {/if}
 </div>
 
-<GifPicker
-  bind:open={showGifPicker}
-  on:select={(e) => {
-    uploadedImages = [...uploadedImages, e.detail.url];
-  }}
-/>
-
-<PollCreator
-  bind:open={showPollCreator}
-  on:create={(e) => {
-    pollConfig = e.detail;
-  }}
-/>
-
 <style>
   /* Comments list - flat layout with spacing */
   .comments-list {
     display: flex;
     flex-direction: column;
     gap: 1rem;
-  }
-
-  .comment-composer-input {
-    white-space: pre-wrap;
-    word-break: break-word;
-  }
-
-  .comment-composer-input:empty:before {
-    content: attr(data-placeholder);
-    color: var(--color-caption);
-    pointer-events: none;
-  }
-
-  .btn-gif,
-  .btn-media {
-    padding: 0.375rem;
-    color: var(--color-caption);
-    border-radius: 0.375rem;
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    transition: opacity 0.15s;
-  }
-
-  .btn-gif:hover,
-  .btn-media:hover {
-    opacity: 0.7;
   }
 </style>

--- a/src/components/comments/ReplyComposer.svelte
+++ b/src/components/comments/ReplyComposer.svelte
@@ -20,7 +20,7 @@
 	 */
 	import { NDKEvent } from '@nostr-dev-kit/ndk';
 	import { ndk, userPublickey } from '$lib/nostr';
-	import { createEventDispatcher } from 'svelte';
+	import { createEventDispatcher, onDestroy } from 'svelte';
 	import MentionDropdown from '../MentionDropdown.svelte';
 	import { MentionComposerController, type MentionState } from '$lib/mentionComposer';
 	import GifIcon from 'phosphor-svelte/lib/Gif';
@@ -117,6 +117,12 @@
 	$: if ($userPublickey) {
 		mentionCtrl.preloadFollowList();
 	}
+
+	onDestroy(() => {
+		// Clears any pending mention-search timeout so it can't fire after
+		// unmount and trigger state updates on a destroyed component.
+		mentionCtrl.destroy();
+	});
 
 	async function handleImageUpload(e: Event) {
 		const target = e.target as HTMLInputElement;
@@ -258,6 +264,7 @@
 			role="textbox"
 			tabindex="0"
 			aria-multiline="true"
+			aria-label={placeholder}
 			data-placeholder={placeholder}
 			on:input={() => mentionCtrl.handleInput()}
 			on:keydown={(e) => mentionCtrl.handleKeydown(e)}
@@ -351,6 +358,7 @@
 			class="btn-media"
 			class:opacity-50={uploadingImage || uploadingVideo || posting}
 			title="Upload image"
+			aria-label="Upload image"
 		>
 			<ImageIcon size={compact ? 16 : 18} />
 			<input
@@ -366,6 +374,7 @@
 			class="btn-media"
 			class:opacity-50={uploadingImage || uploadingVideo || posting}
 			title="Upload video"
+			aria-label="Upload video"
 		>
 			<VideoIcon size={compact ? 16 : 18} />
 			<input
@@ -382,6 +391,7 @@
 			on:click={() => (showGifPicker = true)}
 			class="btn-gif"
 			title="Add GIF"
+			aria-label="Add GIF"
 			disabled={posting || uploadingImage || uploadingVideo}
 			class:opacity-50={uploadingImage || uploadingVideo}
 		>
@@ -392,6 +402,7 @@
 			on:click={() => (showPollCreator = true)}
 			class="btn-gif"
 			title="Create poll"
+			aria-label="Create poll"
 			disabled={posting || uploadingImage || uploadingVideo}
 			class:opacity-50={posting || uploadingImage || uploadingVideo}
 		>

--- a/src/components/comments/ReplyComposer.svelte
+++ b/src/components/comments/ReplyComposer.svelte
@@ -1,0 +1,547 @@
+<script lang="ts">
+	/**
+	 * ReplyComposer — shared contenteditable composer for Nostr comments and
+	 * inline replies.
+	 *
+	 * Owns: contenteditable wiring, @-mention autocomplete + dropdown, image /
+	 * video / GIF upload, poll creator integration, submit + cancel, calling
+	 * `postComment` from $lib/comments/postComment.
+	 *
+	 * Does NOT own: the surrounding comment card, subscription, caller-level
+	 * auth gating, reactions / likes / zaps, or deciding whether to render
+	 * itself (caller controls visibility).
+	 *
+	 * Caller variations flow through props:
+	 *   - Top-level composer (Comments/FeedComments): `parentEvent={root}`;
+	 *     no replyTo. showCancel=false.
+	 *   - Inline reply composer (Comment/FeedComment): `parentEvent={root}`
+	 *     (passed down from container) + `replyTo={parentComment}`.
+	 *     showCancel=true; compact=true.
+	 */
+	import { NDKEvent } from '@nostr-dev-kit/ndk';
+	import { ndk, userPublickey } from '$lib/nostr';
+	import { createEventDispatcher } from 'svelte';
+	import MentionDropdown from '../MentionDropdown.svelte';
+	import { MentionComposerController, type MentionState } from '$lib/mentionComposer';
+	import GifIcon from 'phosphor-svelte/lib/Gif';
+	import ImageIcon from 'phosphor-svelte/lib/Image';
+	import VideoIcon from 'phosphor-svelte/lib/Video';
+	import GifPicker from '../GifPicker.svelte';
+	import ChartBarHorizontalIcon from 'phosphor-svelte/lib/ChartBarHorizontal';
+	import PollCreator from '../PollCreator.svelte';
+	import { buildPollTags, type PollConfig } from '$lib/polls';
+	import { uploadImage, uploadVideo } from '$lib/mediaUpload';
+	import { postComment as postCommentLib } from '$lib/comments/postComment';
+
+	/**
+	 * Root event for NIP-22 / NIP-10 tag-building. Passed verbatim to
+	 * `postComment({ parentEvent })`.
+	 */
+	export let parentEvent: NDKEvent;
+
+	/**
+	 * Optional parent comment for nested replies. When set, the composer is
+	 * an inline reply to this comment rather than a top-level comment on
+	 * `parentEvent`. Passed as `postComment({ replyTo })`.
+	 */
+	export let replyTo: NDKEvent | undefined = undefined;
+
+	/** contenteditable placeholder. */
+	export let placeholder = 'Write a comment...';
+
+	/** Submit button label when idle. The pending state always reads "Posting...". */
+	export let submitLabel = 'Post';
+
+	/** Show a Cancel button next to Submit (inline-reply composers). */
+	export let showCancel = false;
+
+	/** Signing strategy passed through to `postComment`. Stage 5 unifies. */
+	export let signingStrategy: 'explicit-with-timeout' | 'implicit' = 'explicit-with-timeout';
+
+	/** Error surface preserved per caller. Stage 5 unifies. */
+	export let onErrorStrategy: 'alert' | 'silent' = 'alert';
+
+	/** Compact variant — smaller padding/font for inline-reply composers. */
+	export let compact = false;
+
+	/**
+	 * Fired after a successful post with the published event. Used by callers
+	 * that want optimistic add (`sub.addLocal(event)`) or a refresh hook.
+	 */
+	export let onPosted: ((event: NDKEvent) => void) | null = null;
+
+	const dispatch = createEventDispatcher<{ cancel: void }>();
+
+	// Composer state — local to this component.
+	let composerEl: HTMLDivElement;
+	let composerText = '';
+	let lastRendered = '';
+	let posting = false;
+	let showGifPicker = false;
+	let showPollCreator = false;
+	let pollConfig: PollConfig | null = null;
+	let uploadedImages: string[] = [];
+	let uploadedVideos: string[] = [];
+	let uploadingImage = false;
+	let uploadingVideo = false;
+	let uploadError = '';
+	let imageInputEl: HTMLInputElement;
+	let videoInputEl: HTMLInputElement;
+
+	let mentionState: MentionState = {
+		mentionQuery: '',
+		showMentionSuggestions: false,
+		mentionSuggestions: [],
+		selectedMentionIndex: 0,
+		mentionSearching: false
+	};
+
+	const mentionCtrl = new MentionComposerController(
+		(state) => {
+			mentionState = state;
+		},
+		(text) => {
+			composerText = text;
+			lastRendered = text;
+		}
+	);
+
+	$: mentionCtrl.setComposerEl(composerEl);
+
+	$: if (composerEl && composerText !== lastRendered) {
+		mentionCtrl.syncContent(composerText);
+		lastRendered = composerText;
+	}
+
+	// Preload follow list when user is logged in (for mention autocomplete).
+	$: if ($userPublickey) {
+		mentionCtrl.preloadFollowList();
+	}
+
+	async function handleImageUpload(e: Event) {
+		const target = e.target as HTMLInputElement;
+		const files = target.files;
+		if (!files || files.length === 0) return;
+		uploadingImage = true;
+		uploadError = '';
+		try {
+			for (const file of Array.from(files)) {
+				const url = await uploadImage($ndk, file);
+				uploadedImages = [...uploadedImages, url];
+			}
+		} catch (err: unknown) {
+			uploadError = (err as Error)?.message || 'Failed to upload image.';
+		} finally {
+			uploadingImage = false;
+			if (imageInputEl) imageInputEl.value = '';
+		}
+	}
+
+	async function handleVideoUpload(e: Event) {
+		const target = e.target as HTMLInputElement;
+		const files = target.files;
+		if (!files || files.length === 0) return;
+		uploadingVideo = true;
+		uploadError = '';
+		try {
+			for (const file of Array.from(files)) {
+				const url = await uploadVideo($ndk, file);
+				uploadedVideos = [...uploadedVideos, url];
+			}
+		} catch (err: unknown) {
+			uploadError = (err as Error)?.message || 'Failed to upload video.';
+		} finally {
+			uploadingVideo = false;
+			if (videoInputEl) videoInputEl.value = '';
+		}
+	}
+
+	function removeImage(index: number) {
+		uploadedImages = uploadedImages.filter((_, i) => i !== index);
+	}
+
+	function removeVideo(index: number) {
+		uploadedVideos = uploadedVideos.filter((_, i) => i !== index);
+	}
+
+	function clearState() {
+		composerText = '';
+		lastRendered = '';
+		uploadedImages = [];
+		uploadedVideos = [];
+		pollConfig = null;
+		uploadError = '';
+		if (composerEl) {
+			composerEl.innerHTML = '';
+		}
+		mentionCtrl.resetMentionState();
+	}
+
+	function handleCancel() {
+		clearState();
+		dispatch('cancel');
+	}
+
+	async function handleSubmit() {
+		if (
+			(!composerText.trim() &&
+				uploadedImages.length === 0 &&
+				uploadedVideos.length === 0 &&
+				!pollConfig) ||
+			posting
+		) {
+			return;
+		}
+
+		posting = true;
+		try {
+			if (composerEl) {
+				composerText = mentionCtrl.extractText();
+				lastRendered = composerText;
+			}
+
+			let content = mentionCtrl.replacePlainMentions(composerText.trim());
+			const mediaUrls = [...uploadedImages, ...uploadedVideos];
+			if (mediaUrls.length > 0) {
+				const mediaText = mediaUrls.join('\n');
+				content = content ? `${content}\n\n${mediaText}` : mediaText;
+			}
+
+			const extraTags: string[][] = [];
+			const mentions = mentionCtrl.parseMentions(content);
+			for (const pubkey of mentions.values()) {
+				extraTags.push(['p', pubkey]);
+			}
+			if (pollConfig) {
+				extraTags.push(...buildPollTags(pollConfig));
+			}
+
+			const { event: posted } = await postCommentLib($ndk, {
+				parentEvent,
+				replyTo,
+				content,
+				extraTags,
+				contentKind: pollConfig ? 1068 : undefined,
+				signingStrategy
+			});
+
+			clearState();
+			onPosted?.(posted);
+		} catch (error) {
+			if (onErrorStrategy === 'alert') {
+				console.error('Error posting comment:', error);
+				const errorMsg = error instanceof Error ? error.message : String(error);
+				alert('Error posting comment: ' + errorMsg);
+			}
+			// 'silent' — swallow. Stage 5 unifies to inline toast.
+		} finally {
+			posting = false;
+		}
+	}
+
+	$: isDisabled =
+		(!composerText.trim() &&
+			uploadedImages.length === 0 &&
+			uploadedVideos.length === 0 &&
+			!pollConfig) ||
+		posting ||
+		uploadingImage ||
+		uploadingVideo;
+</script>
+
+<div class="reply-composer" class:reply-composer--compact={compact}>
+	<div class="relative">
+		<div
+			bind:this={composerEl}
+			class="reply-composer-input"
+			contenteditable={!posting}
+			role="textbox"
+			tabindex="0"
+			aria-multiline="true"
+			data-placeholder={placeholder}
+			on:input={() => mentionCtrl.handleInput()}
+			on:keydown={(e) => mentionCtrl.handleKeydown(e)}
+			on:beforeinput={(e) => mentionCtrl.handleBeforeInput(e)}
+			on:paste={(e) => mentionCtrl.handlePaste(e)}
+		></div>
+
+		<MentionDropdown
+			show={mentionState.showMentionSuggestions}
+			suggestions={mentionState.mentionSuggestions}
+			selectedIndex={mentionState.selectedMentionIndex}
+			searching={mentionState.mentionSearching}
+			query={mentionState.mentionQuery}
+			on:select={(e) => mentionCtrl.insertMention(e.detail)}
+		/>
+	</div>
+
+	{#if uploadError}
+		<p class="text-red-500 text-xs">{uploadError}</p>
+	{/if}
+
+	{#if uploadedImages.length > 0}
+		<div class="flex flex-wrap gap-2">
+			{#each uploadedImages as imageUrl, index}
+				<div class="relative group">
+					<img
+						src={imageUrl}
+						alt="Upload preview"
+						class="w-16 h-16 object-cover rounded-lg"
+						class:w-20={!compact}
+						class:h-20={!compact}
+						style="border: 1px solid var(--color-input-border)"
+					/>
+					<button
+						type="button"
+						on:click={() => removeImage(index)}
+						class="absolute -top-2 -right-2 bg-red-500 hover:bg-red-600 text-white rounded-full p-0.5 shadow-lg"
+						class:p-1={!compact}
+						aria-label="Remove image"
+					>
+						<svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M6 18L18 6M6 6l12 12"
+							/>
+						</svg>
+					</button>
+				</div>
+			{/each}
+		</div>
+	{/if}
+
+	{#if uploadedVideos.length > 0}
+		<div class="flex flex-wrap gap-2">
+			{#each uploadedVideos as videoUrl, index}
+				<div class="relative group">
+					<video
+						src={videoUrl}
+						class="w-24 h-16 object-cover rounded-lg"
+						class:w-32={!compact}
+						class:h-20={!compact}
+						style="border: 1px solid var(--color-input-border)"
+						preload="metadata"
+						muted
+					></video>
+					<button
+						type="button"
+						on:click={() => removeVideo(index)}
+						class="absolute -top-2 -right-2 bg-red-500 hover:bg-red-600 text-white rounded-full p-0.5 shadow-lg"
+						class:p-1={!compact}
+						aria-label="Remove video"
+					>
+						<svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M6 18L18 6M6 6l12 12"
+							/>
+						</svg>
+					</button>
+				</div>
+			{/each}
+		</div>
+	{/if}
+
+	<div class="reply-composer-actions">
+		<label
+			class="btn-media"
+			class:opacity-50={uploadingImage || uploadingVideo || posting}
+			title="Upload image"
+		>
+			<ImageIcon size={compact ? 16 : 18} />
+			<input
+				bind:this={imageInputEl}
+				type="file"
+				accept="image/*"
+				class="sr-only"
+				on:change={handleImageUpload}
+				disabled={posting || uploadingImage || uploadingVideo}
+			/>
+		</label>
+		<label
+			class="btn-media"
+			class:opacity-50={uploadingImage || uploadingVideo || posting}
+			title="Upload video"
+		>
+			<VideoIcon size={compact ? 16 : 18} />
+			<input
+				bind:this={videoInputEl}
+				type="file"
+				accept="video/*"
+				class="sr-only"
+				on:change={handleVideoUpload}
+				disabled={posting || uploadingImage || uploadingVideo}
+			/>
+		</label>
+		<button
+			type="button"
+			on:click={() => (showGifPicker = true)}
+			class="btn-gif"
+			title="Add GIF"
+			disabled={posting || uploadingImage || uploadingVideo}
+			class:opacity-50={uploadingImage || uploadingVideo}
+		>
+			<GifIcon size={compact ? 16 : 18} />
+		</button>
+		<button
+			type="button"
+			on:click={() => (showPollCreator = true)}
+			class="btn-gif"
+			title="Create poll"
+			disabled={posting || uploadingImage || uploadingVideo}
+			class:opacity-50={posting || uploadingImage || uploadingVideo}
+		>
+			<ChartBarHorizontalIcon size={compact ? 16 : 18} class={pollConfig ? 'text-primary' : ''} />
+		</button>
+
+		{#if uploadingImage}
+			<span class="text-xs text-caption">Uploading image...</span>
+		{:else if uploadingVideo}
+			<span class="text-xs text-caption">Uploading video...</span>
+		{/if}
+		{#if pollConfig}
+			<span class="text-xs text-orange-600 flex items-center gap-1">
+				<ChartBarHorizontalIcon size={12} />
+				Poll ({pollConfig.options.length})
+				<button type="button" on:click={() => (pollConfig = null)} class="hover:text-orange-800"
+					>×</button
+				>
+			</span>
+		{/if}
+
+		<slot name="submit" submit={handleSubmit} disabled={isDisabled} {posting}>
+			<!-- Default submit button: callers can override via `slot="submit"`. -->
+			<button type="button" class="btn-post" on:click={handleSubmit} disabled={isDisabled}>
+				{posting ? 'Posting...' : submitLabel}
+			</button>
+		</slot>
+
+		{#if showCancel}
+			<button type="button" class="btn-cancel" on:click={handleCancel}>Cancel</button>
+		{/if}
+	</div>
+</div>
+
+<GifPicker
+	bind:open={showGifPicker}
+	on:select={(e) => {
+		uploadedImages = [...uploadedImages, e.detail.url];
+	}}
+/>
+
+<PollCreator
+	bind:open={showPollCreator}
+	on:create={(e) => {
+		pollConfig = e.detail;
+	}}
+/>
+
+<style>
+	.reply-composer {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		margin-top: 0.75rem;
+	}
+
+	.reply-composer--compact {
+		margin-top: 0.5rem;
+	}
+
+	.reply-composer-input {
+		width: 100%;
+		padding: 0.5rem 0.75rem;
+		font-size: 1rem;
+		border-radius: 0.5rem;
+		background: var(--color-input-bg);
+		border: 1px solid var(--color-input-border);
+		color: var(--color-text-primary);
+		white-space: pre-wrap;
+		word-break: break-word;
+	}
+
+	.reply-composer--compact .reply-composer-input {
+		padding: 0.375rem 0.5rem;
+		font-size: 0.875rem;
+	}
+
+	.reply-composer-input:focus {
+		outline: none;
+		box-shadow: 0 0 0 2px var(--color-primary);
+	}
+
+	.reply-composer-input:empty:before {
+		content: attr(data-placeholder);
+		color: var(--color-caption);
+		pointer-events: none;
+	}
+
+	.reply-composer-actions {
+		display: flex;
+		gap: 0.5rem;
+		align-items: center;
+		flex-wrap: wrap;
+	}
+
+	.btn-post {
+		padding: 0.5rem 1rem;
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: white;
+		background: var(--color-primary);
+		border-radius: 0.5rem;
+	}
+
+	.reply-composer--compact .btn-post {
+		padding: 0.375rem 0.75rem;
+		font-size: 0.75rem;
+	}
+
+	.btn-post:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.btn-cancel {
+		padding: 0.5rem 1rem;
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: var(--color-text-primary);
+		background: var(--color-input-bg);
+		border-radius: 0.5rem;
+	}
+
+	.reply-composer--compact .btn-cancel {
+		padding: 0.375rem 0.75rem;
+		font-size: 0.75rem;
+	}
+
+	.btn-cancel:hover {
+		opacity: 0.8;
+	}
+
+	.btn-gif,
+	.btn-media {
+		padding: 0.375rem;
+		color: var(--color-caption);
+		border-radius: 0.375rem;
+		display: flex;
+		align-items: center;
+		cursor: pointer;
+		transition: opacity 0.15s;
+	}
+
+	.btn-gif:hover,
+	.btn-media:hover {
+		opacity: 0.7;
+	}
+
+	.btn-gif:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+</style>


### PR DESCRIPTION
## Summary

Stage 3 of the comment-system refactor (Task 6). Extracts the composer UI (contenteditable + @mentions + media upload + GIF picker + poll creator + submit/cancel) previously duplicated across four components into a single `src/components/comments/ReplyComposer.svelte`.

**Net: −870 lines** (Stage 0 estimated −500; beat by 74%).

Cumulative Task 6 progress: Stage 1 (−1,293) + Stage 2 (+311) + Stage 3 (−870) = **−1,852 lines**. Stages 4 and 5 still ahead.

## Migration order (containers first, then inline composers)

1. `FeedComments.svelte` → ReplyComposer (implicit + silent + compact)
2. `Comments.svelte` → ReplyComposer (explicit + alert + optimistic add)
3. `FeedComment.svelte` → ReplyComposer (+ `replyTo`, `showCancel`, `rootEvent` prop)
4. `Comment.svelte` → ReplyComposer (+ `replyTo`, `showCancel`, `rootEvent` prop)

`pnpm run check` ran after each step; all 4 clean (zero introduced errors/warnings).

## Root-event plumbing

`Comment.svelte` and `FeedComment.svelte` gain a new `rootEvent: NDKEvent` prop, set by their containers (`Comments` / `FeedComments`). This lets the inline composers hand the root (recipe / feed post) to `postComment()` as `parentEvent`, with the comment-being-replied-to as `replyTo` — matching the spec-compliant Stage 2 API shape.

Previously the inline composers reconstructed a synthetic root-event object from the parent comment's `A`/`a` tags inline; that ~40-line reconstruction block is deleted along with the rest of the inlined composer logic.

## API

```svelte
<ReplyComposer
  parentEvent={rootEvent}          // always required; the NIP-22/NIP-10 root
  replyTo={parentComment}          // optional; set for inline replies
  placeholder="Write a comment..."
  submitLabel="Post"
  showCancel={false}               // inline composers pass true
  signingStrategy="explicit-with-timeout" | "implicit"
  onErrorStrategy="alert" | "silent"
  compact={false}                  // inline composers pass true
  onPosted={(event) => ...}        // optional optimistic-add / refresh hook
  on:cancel={...}                  // fired when user clicks Cancel
>
  <!-- optional: override the default submit button via named slot -->
  <Button slot="submit" let:submit let:disabled ...>Post Comment</Button>
</ReplyComposer>
```

## Behavior preserved per caller (Stage 5 unifies)

- **Comments** (top-level, recipe): optimistic add via `onPosted` callback; `alert()` on error; `<Button>` component via slot.
- **FeedComments** (top-level, feed): subscription round-trip only; silent errors; compact; plain `.btn-post` submit.
- **Comment** (inline reply, recipe): `alert()` on error; compact + showCancel.
- **FeedComment** (inline reply, feed): silent errors; compact + showCancel.

## Side-effect fixes landed as bonuses

1. **`Comment.svelte`'s `postingReply`-stuck-on-error bug** (Stage 0 finding, originally scheduled for Stage 4): eliminated. ReplyComposer's internal `posting` flag is managed via `try/finally` in the new code, which correctly resets on error. Stage 4's scope no longer includes this fix.
2. **`Comment.svelte` was silently broken on error** pre-Stage-3 (no alert, no state reset, button frozen). Now routes through `onErrorStrategy="alert"` matching the `Comments` container's stated recipe-context UX. Minor user-visible improvement exposed by the refactor.

## Spec compliance

`postComment` unchanged. All four callers pass `parentEvent` (root) + optional `replyTo` exactly as Stage 2 specified, so NIP-22 kind-1111 on kind-30023 recipes and NIP-10 kind-1 on kind-1 feed posts are byte-for-byte equivalent to Stage 2 output.

## Verification

| Check | Result |
|---|---|
| `pnpm run check` | 4 pre-existing errors / **127** warnings (down from 129 — deleting buggy `.ring:` / `.ring-color` CSS in `FeedComment` killed 2 "Unknown property" warnings). Zero new. |
| `pnpm run build` | passes (adapter-cloudflare successful). |
| Dev server HTTP sanity | `/`, `/polls`, `/reads` all 200; no runtime errors. |

## Line-count delta

| File | Before | After | Δ |
|---|---:|---:|---:|
| `Comment.svelte` | 886 | 457 | −429 |
| `FeedComment.svelte` | 893 | 470 | −423 |
| `Comments.svelte` | 387 | 99 | −288 |
| `FeedComments.svelte` | 390 | 113 | −277 |
| `comments/ReplyComposer.svelte` | — | 547 | +547 |
| **Total** | **2,556** | **1,686** | **−870** |

## Test plan

- [ ] Open a recipe page. Use the top-level composer to post a comment (text only). Appears via optimistic add. Inspect the published event JSON in devtools Network tab — confirm NIP-22 tag structure: `A` / `K` / `P` root-scope; `a` / `e` / `k` / `p` parent-scope; `client` tag appended.
- [ ] Same recipe page — click a comment's Reply. Inline composer shows with compact sizing. Post a reply. Verify the reply's event JSON has uppercase `A` / `K` / `P` pointing at the recipe (root-scope), lowercase `e` / `k: 1111` / `p` pointing at the parent comment (parent-scope). **This is the riskiest path** — `rootEvent` plumbing is new.
- [ ] On `/`, toggle comments on a feed post. Post a top-level comment. Verify NIP-10 kind 1 with single `["e", <id>, "", "root"]` + `p` + `client`.
- [ ] Same feed post — reply to a comment. Compact sizing. Verify NIP-10 kind 1 with marked `root` + `reply` e-tags, `p` for root author, `p` for parent author, `client`.
- [ ] On `/polls`, post a comment on a poll.
- [ ] Upload image → appears in preview tiles (full-size 80×80 in containers, compact 64×64 in inline composers). Remove works. Published event content has the image URL appended after 2 newlines.
- [ ] Upload video → same, but 128×80 / 96×64.
- [ ] Click GIF picker → select a GIF → appears as an image attachment.
- [ ] Click Poll creator → configure a poll → chip shows in the composer → submit. Published event is `kind: 1068` with poll tags merged in.
- [ ] Type `@` and a few chars → MentionDropdown shows → select a suggestion → content has `nostr:nprofile1...` inserted → published event has a deduplicated `p` tag for the mention.
- [ ] Inline reply composer: click Cancel → composer disappears, no event published, state cleared.
- [ ] Post recipe comment with network throttled → `alert()` shown with error; composer NOT frozen (side-effect fix works).
- [ ] Post feed comment with network throttled → no alert, silent fail (preserved).
- [ ] Screen-reader / keyboard: composer is focusable, mention dropdown navigates with arrow keys, Tab moves between composer and action buttons.

## Out of scope / deferred

- Toast UI (Stage 5 prep noted in `docs/dev/FOLLOWUPS.md`).
- `signingStrategy` / `onErrorStrategy` unification across callers — Stage 5.
- Merging `Comment` + `FeedComment` → `CommentCard` — Stage 4.
- Merging `Comments` + `FeedComments` → `CommentThread` — Stage 5.

## Preserved vestigial API

`refresh()` callback prop on `Comment.svelte` / `FeedComment.svelte`. Now a no-op passed from containers, kept as a stable API surface for the GifPicker/PollCreator events. Stage 4 deletes it when merging into `CommentCard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)