### PR TITLE
feat(nourish): flag mechanism for score disagreement

### DIFF
--- a/docs/dev/FOLLOWUPS.md
+++ b/docs/dev/FOLLOWUPS.md
@@ -61,3 +61,76 @@ priority — that's set per-sprint.
    appends the client tag unconditionally. Add a user setting
    ("Identify as zap.cooking on events I publish", default on) and gate
    the append. Affects every publish path.
+
+## Nourish flag mechanism (feat/nourish-flag)
+
+### Deferred UI placements
+
+7. **Flag affordance on NourishPill hover card + NourishModal summary.**
+   Phase 2 committed to these; commit 4 deferred because neither surface
+   currently receives the recipe FlagTarget as a prop. The three
+   NourishDimensionBar rows inside NourishResult cover the primary
+   engaged-user path. Adding the pill-preview and modal-summary flag
+   requires threading `{aTag, nourishEventId?}` into those components.
+   Low-effort once the Nourish event id starts being tracked alongside
+   scores — which is a separate open question below.
+
+8. **Track the Nourish event id alongside cached scores.**
+   `src/lib/nourish/cache.ts` stores scores keyed by recipe event id but
+   doesn't capture the kind 30078 Nourish event's own id returned from
+   the pantry relay or API. Capturing it would let flag events carry a
+   precise `["e", nourishEventId]` for admin triage ("which specific
+   scoring was flagged"). `flagSubmit.ts` already treats
+   `FlagTarget.nourishEventId` as optional; adding it is purely a
+   richer signal.
+
+### Admin auth + discoverability
+
+9. **NIP-98 signed HTTP-auth on admin endpoints.** Current pattern
+   (`x-admin-pubkey` header checked against `ADMIN_PUBKEY`) is the
+   existing codebase precedent (also in /sponsors) but weak — anyone who
+   knows the admin pubkey can spoof it. Upgrade path: require a NIP-98
+   signed Authorization header and verify the signature server-side.
+   Affects `/api/admin/nourish-flags` and `/api/sponsors`.
+
+10. **Admin nav entry for /admin/nourish-flags when usage patterns
+    justify.** v1 is unlinked — navigate manually. Once the page is
+    used regularly, add a nav link gated on `isAdmin($userPublickey)`.
+
+### Spam / abuse contingencies
+
+11. **Turnstile on anon flag endpoint if spam appears.** Not in v1.
+    Current limits (1/min, 10/hr, 30/day per ipHash) are an effective
+    floor. If anon flag volume grows disproportionate to legitimate
+    traffic growth, gate POST /api/nourish/flag behind a Cloudflare
+    Turnstile token. Two-hour change.
+
+12. **Per-pubkey rate cap for signed flags.** Currently unlimited on
+    the Nostr publish path (social pressure + public pubkey = self-
+    policing). If a user brigades from their own pubkey, add a 24h cap
+    (e.g., 50 signed flags per day per pubkey) at the client-side
+    `flagSubmit.submitSignedFlag` pre-check. Server can't easily enforce
+    this on a public relay; enforcement lives at the admin view where
+    per-pubkey concentration is visible.
+
+### Observability
+
+13. **Popover open-rate vs submit-rate analytics.** Measures how much
+    friction the popover adds. Currently no client-side analytics
+    infrastructure; when one lands, instrument
+    `NourishFlagButton.handleIconClick` (open) and `handleSubmit` (submit)
+    to emit events.
+
+14. **Progressive error back-off on repeated 429s.** The 429 response
+    already carries `{retryAfter, scope}`. Client could track rate-limit
+    hits locally and lengthen its cooldown before re-submitting. Not
+    needed for v1 — the UX tells the user to slow down.
+
+### Differentiated error messages
+
+15. **Signing-cancelled / network-timeout / generic error messages on
+    flag submission.** Currently all errors map to
+    "Couldn't submit your flag — please try again." Better granularity
+    helps users self-correct (e.g., "Please connect to the network and
+    try again" vs "You cancelled signing in your extension"). Also
+    applies to comment-post error path from Task 6 Stage 5.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.223",
+  "version": "4.2.224",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.226",
+  "version": "4.2.227",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.221",
+  "version": "4.2.222",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.225",
+  "version": "4.2.226",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.224",
+  "version": "4.2.225",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.218",
+  "version": "4.2.219",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.222",
+  "version": "4.2.223",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.220",
+  "version": "4.2.221",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.227",
+  "version": "4.2.228",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.219",
+  "version": "4.2.220",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -36,6 +36,13 @@ declare global {
             delete(key: string): Promise<void>;
             list(options?: { prefix?: string; limit?: number }): Promise<{ keys: { name: string }[] }>;
           };
+          /** KV namespace for anon Nourish-score flag submissions, rate-limit buckets, and daily IP-hash salts. */
+          NOURISH_FLAGS?: {
+            get(key: string, type?: 'text' | 'json'): Promise<string | unknown | null>;
+            put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>;
+            delete(key: string): Promise<void>;
+            list(options?: { prefix?: string; limit?: number }): Promise<{ keys: { name: string }[] }>;
+          };
         };
       }
   }

--- a/src/components/nourish/NourishDimensionBar.svelte
+++ b/src/components/nourish/NourishDimensionBar.svelte
@@ -5,20 +5,44 @@
    * Shows icon + label + bar by default.
    * Tap/click expands to reveal the reason text and numeric score.
    * No numeric score visible in collapsed state — bars show the profile shape.
+   *
+   * When `flagTarget` is provided, renders a small NourishFlagButton in
+   * the expanded detail row so users can contest the score.
    */
 
   import CaretDownIcon from 'phosphor-svelte/lib/CaretDown';
+  import NourishFlagButton from './NourishFlagButton.svelte';
+  import type { FlagTarget, NourishDimension } from '$lib/nourish/flagSubmit';
 
   export let icon: string = '🌱';
   export let label: string = '';
   export let score: number = 0;
   export let reason: string = '';
 
+  /**
+   * When present, the expanded detail row includes a flag affordance.
+   * Pass through from NourishResult's parent (NourishModal, /nourish page).
+   * Null/undefined → no flag button.
+   */
+  export let flagTarget: FlagTarget | null = null;
+
+  /**
+   * Machine-readable dimension key, required when `flagTarget` is set.
+   * Must be one of the NourishDimension values (gut / protein / realFood /
+   * overall). If omitted, the flag button is suppressed.
+   */
+  export let flagDimension: NourishDimension | null = null;
+
+  /** Nourish model/prompt version snapshot — required when flagTarget is set. */
+  export let nourishVer: string = '';
+
   let expanded = false;
 
   function toggle() {
     if (reason) expanded = !expanded;
   }
+
+  $: canFlag = !!flagTarget && !!flagDimension && !!nourishVer;
 </script>
 
 <button
@@ -45,6 +69,18 @@
   <div class="dim-detail">
     <span class="dim-score">{score}<span class="dim-score-max">/10</span></span>
     <p class="dim-reason">{reason}</p>
+    {#if canFlag && flagTarget && flagDimension}
+      <div class="dim-flag">
+        <NourishFlagButton
+          target={flagTarget}
+          dimension={flagDimension}
+          {score}
+          {nourishVer}
+          iconSize={12}
+          dimensionLabel={label.toLowerCase()}
+        />
+      </div>
+    {/if}
   </div>
 {/if}
 
@@ -143,5 +179,12 @@
     line-height: 1.5;
     color: var(--color-text-secondary);
     margin: 0;
+    flex: 1;
+  }
+
+  .dim-flag {
+    flex-shrink: 0;
+    align-self: flex-start;
+    margin-left: 0.25rem;
   }
 </style>

--- a/src/components/nourish/NourishFlagButton.svelte
+++ b/src/components/nourish/NourishFlagButton.svelte
@@ -1,0 +1,311 @@
+<script lang="ts">
+  /**
+   * NourishFlagButton — tiny flag icon + popover for submitting
+   * disagreement with a Nourish score.
+   *
+   * Popover uses the existing Modal primitive (portal-rendered,
+   * compact, with the same blur/scale transitions used elsewhere).
+   * No custom mobile bottom-sheet; Modal handles the desktop/mobile
+   * story uniformly.
+   *
+   * Pre-check: if the user has already flagged this target/dimension/
+   * direction-pair within 24h, the icon renders in filled state and
+   * clicking is a no-op. Prevents opening a popover the user can't
+   * meaningfully submit through.
+   */
+  import { onMount } from 'svelte';
+  import { get } from 'svelte/store';
+  import FlagIcon from 'phosphor-svelte/lib/Flag';
+  import Modal from '../Modal.svelte';
+  import Button from '../Button.svelte';
+  import { userPublickey } from '$lib/nostr';
+  import { showToast } from '$lib/toast';
+  import {
+    submitFlag,
+    hasAnonFlagStamp,
+    hasPriorSignedFlag,
+    type FlagTarget,
+    type NourishDimension,
+    type FlagDirection
+  } from '$lib/nourish/flagSubmit';
+
+  /** What's being flagged — either a recipe's Nourish event or a scan result. */
+  export let target: FlagTarget;
+
+  /** Which dimension this flag is about. */
+  export let dimension: NourishDimension;
+
+  /** Score at flag time (0..10). Stored in the flag record for admin triage. */
+  export let score: number;
+
+  /** Nourish model/prompt version (from $lib/nourish/types). */
+  export let nourishVer: string;
+
+  /** Icon size in px. Default 14 (matches NourishDimensionBar size scale). */
+  export let iconSize = 14;
+
+  /** For aria-label + popover dim name. Default derived from dimension. */
+  export let dimensionLabel: string = defaultDimensionLabel(dimension);
+
+  function defaultDimensionLabel(d: NourishDimension): string {
+    if (d === 'gut') return 'gut-health';
+    if (d === 'protein') return 'protein';
+    if (d === 'realFood') return 'real-food';
+    return 'overall';
+  }
+
+  let popoverOpen = false;
+  let submitting = false;
+  let selectedDirection: FlagDirection | null = null;
+  let reason = '';
+
+  // Filled state — user has previously flagged this.
+  let alreadyFlagged = false;
+
+  async function refreshFilledState() {
+    const pubkey = get(userPublickey);
+    if (pubkey) {
+      // Check signed flags for both directions; any prior flag fills the icon.
+      const high = await hasPriorSignedFlag(pubkey, target, dimension, 'too-high');
+      if (high) {
+        alreadyFlagged = true;
+        return;
+      }
+      const low = await hasPriorSignedFlag(pubkey, target, dimension, 'too-low');
+      alreadyFlagged = low;
+      return;
+    }
+    alreadyFlagged =
+      hasAnonFlagStamp(target, dimension, 'too-high') ||
+      hasAnonFlagStamp(target, dimension, 'too-low');
+  }
+
+  onMount(() => {
+    refreshFilledState();
+  });
+
+  function handleIconClick() {
+    if (alreadyFlagged) return; // no-op: no popover for already-flagged
+    popoverOpen = true;
+  }
+
+  function closePopover() {
+    popoverOpen = false;
+    selectedDirection = null;
+    reason = '';
+  }
+
+  async function handleSubmit() {
+    if (!selectedDirection || submitting) return;
+    submitting = true;
+
+    const result = await submitFlag({
+      target,
+      dimension,
+      direction: selectedDirection,
+      score,
+      nourishVer,
+      reason: reason.trim() || undefined
+    });
+
+    submitting = false;
+
+    if (!result.ok) {
+      if (result.error === 'rate_limited') {
+        showToast(
+          'error',
+          "You've flagged a few already — take a breather and try again in a minute."
+        );
+      } else {
+        showToast('error', "Couldn't submit your flag — please try again.");
+      }
+      return;
+    }
+
+    // Success OR duplicate both land here; both stamp the filled state.
+    alreadyFlagged = true;
+    closePopover();
+  }
+</script>
+
+<button
+  type="button"
+  class="flag-btn"
+  class:filled={alreadyFlagged}
+  aria-label={alreadyFlagged
+    ? `You flagged the ${dimensionLabel} score`
+    : `Flag the ${dimensionLabel} score`}
+  title={alreadyFlagged ? 'You flagged this' : 'Flag this score'}
+  on:click|stopPropagation={handleIconClick}
+>
+  <FlagIcon size={iconSize} weight={alreadyFlagged ? 'fill' : 'regular'} />
+</button>
+
+<Modal bind:open={popoverOpen} compact>
+  <span slot="title">Help us improve this score</span>
+
+  <div class="popover-body">
+    <p class="subhead">
+      The {dimensionLabel} score seems…
+    </p>
+
+    <div class="direction-row">
+      <button
+        type="button"
+        class="dir-btn"
+        class:selected={selectedDirection === 'too-high'}
+        on:click={() => (selectedDirection = 'too-high')}
+      >
+        ↑ too high
+      </button>
+      <button
+        type="button"
+        class="dir-btn"
+        class:selected={selectedDirection === 'too-low'}
+        on:click={() => (selectedDirection = 'too-low')}
+      >
+        ↓ too low
+      </button>
+    </div>
+
+    <label class="reason-label" for="flag-reason">Tell us more (optional)</label>
+    <textarea
+      id="flag-reason"
+      bind:value={reason}
+      rows="3"
+      maxlength="500"
+      placeholder="What seemed off?"
+      class="reason-input"
+    ></textarea>
+
+    <div class="actions">
+      <button
+        type="button"
+        class="btn-cancel"
+        on:click={closePopover}
+        disabled={submitting}
+      >
+        Cancel
+      </button>
+      <Button
+        on:click={handleSubmit}
+        disabled={!selectedDirection || submitting}
+      >
+        {submitting ? 'Submitting…' : 'Submit'}
+      </Button>
+    </div>
+  </div>
+</Modal>
+
+<style>
+  .flag-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem;
+    border-radius: 0.25rem;
+    color: var(--color-text-secondary);
+    transition:
+      color 0.15s,
+      opacity 0.15s;
+    cursor: pointer;
+  }
+
+  .flag-btn:hover {
+    color: var(--color-primary);
+  }
+
+  .flag-btn.filled {
+    color: var(--color-primary);
+    cursor: default;
+  }
+
+  .popover-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .subhead {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-text-primary);
+  }
+
+  .direction-row {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .dir-btn {
+    flex: 1 1 0%;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.5rem;
+    border: 1px solid var(--color-input-border);
+    background: var(--color-input-bg);
+    color: var(--color-text-primary);
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition:
+      border-color 0.15s,
+      background 0.15s;
+  }
+
+  .dir-btn:hover {
+    border-color: var(--color-primary);
+  }
+
+  .dir-btn.selected {
+    border-color: var(--color-primary);
+    background: rgba(249, 115, 22, 0.1);
+    color: var(--color-primary);
+  }
+
+  .reason-label {
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+  }
+
+  .reason-input {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.5rem;
+    background: var(--color-input-bg);
+    border: 1px solid var(--color-input-border);
+    color: var(--color-text-primary);
+    font-size: 0.875rem;
+    resize: vertical;
+    min-height: 4.5rem;
+  }
+
+  .reason-input:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--color-primary);
+  }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+
+  .btn-cancel {
+    padding: 0.5rem 1rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text-primary);
+    background: var(--color-input);
+    border-radius: 0.5rem;
+    cursor: pointer;
+  }
+
+  .btn-cancel:hover {
+    opacity: 0.8;
+  }
+
+  .btn-cancel:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>

--- a/src/components/nourish/NourishFlagButton.svelte
+++ b/src/components/nourish/NourishFlagButton.svelte
@@ -13,8 +13,6 @@
    * clicking is a no-op. Prevents opening a popover the user can't
    * meaningfully submit through.
    */
-  import { onMount } from 'svelte';
-  import { get } from 'svelte/store';
   import FlagIcon from 'phosphor-svelte/lib/Flag';
   import Modal from '../Modal.svelte';
   import Button from '../Button.svelte';
@@ -44,8 +42,12 @@
   /** Icon size in px. Default 14 (matches NourishDimensionBar size scale). */
   export let iconSize = 14;
 
-  /** For aria-label + popover dim name. Default derived from dimension. */
-  export let dimensionLabel: string = defaultDimensionLabel(dimension);
+  /**
+   * Optional human-readable dimension name override. When unset, derived
+   * reactively from `dimension` (so it stays in sync even if `dimension`
+   * arrives after component init, which is the common case).
+   */
+  export let dimensionLabel: string | undefined = undefined;
 
   function defaultDimensionLabel(d: NourishDimension): string {
     if (d === 'gut') return 'gut-health';
@@ -54,35 +56,42 @@
     return 'overall';
   }
 
+  $: resolvedDimensionLabel = dimensionLabel ?? defaultDimensionLabel(dimension);
+
+  // Unique id per instance so <label for="…"> never collides when the
+  // page renders multiple flag buttons (one per dimension bar).
+  const reasonInputId = `flag-reason-${Math.random().toString(36).slice(2, 10)}`;
+
   let popoverOpen = false;
   let submitting = false;
   let selectedDirection: FlagDirection | null = null;
   let reason = '';
 
-  // Filled state — user has previously flagged this.
+  // Filled state — user has previously flagged this. Reactive so that it
+  // re-runs when $userPublickey / target / dimension change (a common
+  // pattern: pubkey arrives after mount).
   let alreadyFlagged = false;
+  $: refreshFilledState($userPublickey, target, dimension);
 
-  async function refreshFilledState() {
-    const pubkey = get(userPublickey);
+  async function refreshFilledState(
+    pubkey: string | null,
+    t: FlagTarget,
+    dim: NourishDimension
+  ) {
     if (pubkey) {
       // Check signed flags for both directions; any prior flag fills the icon.
-      const high = await hasPriorSignedFlag(pubkey, target, dimension, 'too-high');
+      const high = await hasPriorSignedFlag(pubkey, t, dim, 'too-high');
       if (high) {
         alreadyFlagged = true;
         return;
       }
-      const low = await hasPriorSignedFlag(pubkey, target, dimension, 'too-low');
+      const low = await hasPriorSignedFlag(pubkey, t, dim, 'too-low');
       alreadyFlagged = low;
       return;
     }
     alreadyFlagged =
-      hasAnonFlagStamp(target, dimension, 'too-high') ||
-      hasAnonFlagStamp(target, dimension, 'too-low');
+      hasAnonFlagStamp(t, dim, 'too-high') || hasAnonFlagStamp(t, dim, 'too-low');
   }
-
-  onMount(() => {
-    refreshFilledState();
-  });
 
   function handleIconClick() {
     if (alreadyFlagged) return; // no-op: no popover for already-flagged
@@ -133,8 +142,8 @@
   class="flag-btn"
   class:filled={alreadyFlagged}
   aria-label={alreadyFlagged
-    ? `You flagged the ${dimensionLabel} score`
-    : `Flag the ${dimensionLabel} score`}
+    ? `You flagged the ${resolvedDimensionLabel} score`
+    : `Flag the ${resolvedDimensionLabel} score`}
   title={alreadyFlagged ? 'You flagged this' : 'Flag this score'}
   on:click|stopPropagation={handleIconClick}
 >
@@ -146,7 +155,7 @@
 
   <div class="popover-body">
     <p class="subhead">
-      The {dimensionLabel} score seems…
+      The {resolvedDimensionLabel} score seems…
     </p>
 
     <div class="direction-row">
@@ -168,9 +177,9 @@
       </button>
     </div>
 
-    <label class="reason-label" for="flag-reason">Tell us more (optional)</label>
+    <label class="reason-label" for={reasonInputId}>Tell us more (optional)</label>
     <textarea
-      id="flag-reason"
+      id={reasonInputId}
       bind:value={reason}
       rows="3"
       maxlength="500"

--- a/src/components/nourish/NourishModal.svelte
+++ b/src/components/nourish/NourishModal.svelte
@@ -14,11 +14,26 @@
 	import { ingredientStore } from '$lib/nourish/ingredientStore';
 	import { fetchNourishEvent, isNourishStale, computeContentHash } from '$lib/nourish/nourishRelay';
 	import type { NourishScores } from '$lib/nourish/types';
+	import { NOURISH_PROMPT_VERSION } from '$lib/nourish/types';
+	import type { FlagTarget } from '$lib/nourish/flagSubmit';
 	import NourishResult from './NourishResult.svelte';
 
 	export let open = false;
 	export let event: NDKEvent;
 	export let hasMembership = false;
+
+	// Flag target for the per-dimension flag affordance inside NourishResult.
+	// Derived from the recipe's NIP-01 addressable form. The Nourish event's
+	// own id isn't tracked on this component today, so the `a`-tag is the
+	// sole identifier in the flag; admin aggregation uses the a-tag to group.
+	$: flagTarget = scores
+		? ({
+				kind: 'recipe',
+				aTag: `${event.kind}:${event.author?.hexpubkey || event.pubkey}:${
+					event.tags.find((t) => t[0] === 'd')?.[1] || ''
+				}`
+			} satisfies FlagTarget)
+		: null;
 
 	let scores: NourishScores | null = null;
 	let improvements: string[] = [];
@@ -218,6 +233,8 @@
 		<NourishResult
 			{scores}
 			{improvements}
+			{flagTarget}
+			nourishVer={NOURISH_PROMPT_VERSION}
 			compact
 		/>
 

--- a/src/components/nourish/NourishResult.svelte
+++ b/src/components/nourish/NourishResult.svelte
@@ -9,6 +9,7 @@
   import NourishDimensionBar from './NourishDimensionBar.svelte';
   import LeafIcon from 'phosphor-svelte/lib/Leaf';
   import type { NourishScores, IngredientSignal } from '$lib/nourish/types';
+  import type { FlagTarget } from '$lib/nourish/flagSubmit';
 
   export let scores: NourishScores;
   export let quickTake: string = '';
@@ -16,6 +17,16 @@
   export let ingredientSignals: IngredientSignal[] = [];
   export let onReset: (() => void) | undefined = undefined;
   export let compact: boolean = false;
+
+  /**
+   * When provided, each NourishDimensionBar renders a flag affordance in
+   * its expanded detail area. Pass from the surrounding context (recipe
+   * modal or /nourish scan page). Null/undefined → no flag UI.
+   */
+  export let flagTarget: FlagTarget | null = null;
+
+  /** Nourish model/prompt version for the flag snapshot. */
+  export let nourishVer: string = '';
 
   /**
    * Derive strength tags from scores — only highlight genuinely strong dimensions.
@@ -76,9 +87,33 @@
   <div class="nr-section">
     <p class="nr-section-label">Nourish Profile</p>
     <div class="nr-dims">
-      <NourishDimensionBar icon="🥬" label="Real Food" score={scores.realFood.score} reason={scores.realFood.reason} />
-      <NourishDimensionBar icon="🌱" label="Gut Health" score={scores.gut.score} reason={scores.gut.reason} />
-      <NourishDimensionBar icon="💪" label="Protein" score={scores.protein.score} reason={scores.protein.reason} />
+      <NourishDimensionBar
+        icon="🥬"
+        label="Real Food"
+        score={scores.realFood.score}
+        reason={scores.realFood.reason}
+        {flagTarget}
+        flagDimension={flagTarget ? 'realFood' : null}
+        {nourishVer}
+      />
+      <NourishDimensionBar
+        icon="🌱"
+        label="Gut Health"
+        score={scores.gut.score}
+        reason={scores.gut.reason}
+        {flagTarget}
+        flagDimension={flagTarget ? 'gut' : null}
+        {nourishVer}
+      />
+      <NourishDimensionBar
+        icon="💪"
+        label="Protein"
+        score={scores.protein.score}
+        reason={scores.protein.reason}
+        {flagTarget}
+        flagDimension={flagTarget ? 'protein' : null}
+        {nourishVer}
+      />
     </div>
   </div>
 

--- a/src/lib/nourish/flagRateLimit.server.ts
+++ b/src/lib/nourish/flagRateLimit.server.ts
@@ -93,6 +93,27 @@ export async function getTodaySalt(kv: NourishFlagsKV): Promise<string> {
   return salt;
 }
 
+/**
+ * Look up the salt for a prior day (within SALT_RETENTION_DAYS). Returns
+ * null if the salt has aged out. Used by dedup to recompute yesterday's
+ * ipHash so a flag made at 23:59 UTC still deduplicates at 00:01 UTC.
+ */
+export async function getSaltForDay(
+  kv: NourishFlagsKV,
+  day: string
+): Promise<string | null> {
+  const key = `config:ip-salt:${day}`;
+  const existing = (await kv.get(key)) as string | null;
+  return existing ?? null;
+}
+
+/** YYYY-MM-DD of N days ago (UTC). */
+export function utcDayOffset(daysAgo: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - daysAgo);
+  return d.toISOString().slice(0, 10);
+}
+
 export async function hashIp(ip: string, salt: string): Promise<string> {
   return sha256Hex(`${ip}:${salt}`);
 }
@@ -172,17 +193,39 @@ export async function checkAndIncrementRateLimit(
  * Dedup grain: one anon flag per (ipHash × target × dimension × direction)
  * per 24 hours. Returns true if a prior flag exists (caller should
  * respond 200-no-op with {duplicate: true}).
+ *
+ * Midnight-race fix: the salt rotates daily, so the same IP produces a
+ * different `ipHash` across days. A naive lookup under today's ipHash
+ * alone would miss a flag made moments before UTC midnight. We therefore
+ * check dedup under today's AND yesterday's ipHash. Yesterday's salt is
+ * retained (SALT_RETENTION_DAYS) for exactly this.
  */
 export async function checkDedup(
   kv: NourishFlagsKV,
-  ipHash: string,
+  ip: string,
   target: string,
   dimension: string,
   direction: string
-): Promise<boolean> {
-  const key = `dedup:${ipHash}:${target}:${dimension}:${direction}`;
-  const existing = await kv.get(key);
-  return existing !== null;
+): Promise<{ hit: boolean; todayIpHash: string }> {
+  const todaySalt = await getTodaySalt(kv);
+  const todayIpHash = await hashIp(ip, todaySalt);
+
+  const todayKey = `dedup:${todayIpHash}:${target}:${dimension}:${direction}`;
+  if ((await kv.get(todayKey)) !== null) {
+    return { hit: true, todayIpHash };
+  }
+
+  // Also check yesterday's ipHash (if the salt is still in retention).
+  const yesterdaySalt = await getSaltForDay(kv, utcDayOffset(1));
+  if (yesterdaySalt) {
+    const yesterdayIpHash = await hashIp(ip, yesterdaySalt);
+    const yesterdayKey = `dedup:${yesterdayIpHash}:${target}:${dimension}:${direction}`;
+    if ((await kv.get(yesterdayKey)) !== null) {
+      return { hit: true, todayIpHash };
+    }
+  }
+
+  return { hit: false, todayIpHash };
 }
 
 export async function markDedup(

--- a/src/lib/nourish/flagRateLimit.server.ts
+++ b/src/lib/nourish/flagRateLimit.server.ts
@@ -1,0 +1,197 @@
+/**
+ * Rate-limiting + IP-hashing helpers for anon Nourish flag submissions.
+ *
+ * Runs server-side only (Cloudflare Workers / SvelteKit +server.ts). Per
+ * Task 6 Stage 5 conventions, errors surface to the client as structured
+ * 429 responses — the client maps them to a friendly toast.
+ *
+ * Rate-limit tiers (per ipHash):
+ *   - per-minute: 1
+ *   - per-hour:   10
+ *   - per-day:    30
+ *
+ * Dedup: one flag per (ipHash × target × dimension × direction) per 24h.
+ *
+ * IP privacy:
+ *   - IPs are hashed with a daily-rotated server-side salt.
+ *   - Salts are retained for 3 days to avoid midnight race conditions
+ *     (a dedup check just after rotation would otherwise miss yesterday's
+ *     submissions).
+ *   - Same IP across days becomes unlinkable — intentional.
+ */
+
+type NourishFlagsKV = {
+  get(key: string, type?: 'text' | 'json'): Promise<string | unknown | null>;
+  put(
+    key: string,
+    value: string,
+    options?: { expirationTtl?: number }
+  ): Promise<void>;
+};
+
+export type RateLimitScope = 'per-minute' | 'per-hour' | 'per-day';
+
+export interface RateLimitedError {
+  error: 'rate_limited';
+  retryAfter: number;
+  scope: RateLimitScope;
+}
+
+export interface DedupHit {
+  error: 'duplicate';
+}
+
+// Limits (public constants — referenced by tests/docs if they appear).
+export const LIMIT_PER_MINUTE = 1;
+export const LIMIT_PER_HOUR = 10;
+export const LIMIT_PER_DAY = 30;
+export const DEDUP_TTL_SECONDS = 24 * 60 * 60;
+export const SALT_RETENTION_DAYS = 3;
+
+function utcDay(d = new Date()): string {
+  return d.toISOString().slice(0, 10); // YYYY-MM-DD
+}
+
+function utcHour(d = new Date()): string {
+  return d.toISOString().slice(0, 13); // YYYY-MM-DDTHH
+}
+
+function utcMinute(d = new Date()): string {
+  return d.toISOString().slice(0, 16); // YYYY-MM-DDTHH:MM
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/**
+ * Return today's rotating salt, creating it on first call of the day.
+ * Past salts (up to SALT_RETENTION_DAYS back) are accessed via
+ * `getSaltForDay` for dedup lookups that span midnight.
+ */
+export async function getTodaySalt(kv: NourishFlagsKV): Promise<string> {
+  const day = utcDay();
+  const key = `config:ip-salt:${day}`;
+  const existing = (await kv.get(key)) as string | null;
+  if (existing) return existing;
+
+  // First call today — mint a fresh salt. 32 bytes of entropy.
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  const salt = Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+
+  // Salt TTL = 3 days. Yesterday's dedup still works the day after.
+  await kv.put(key, salt, {
+    expirationTtl: SALT_RETENTION_DAYS * 24 * 60 * 60
+  });
+  return salt;
+}
+
+export async function hashIp(ip: string, salt: string): Promise<string> {
+  return sha256Hex(`${ip}:${salt}`);
+}
+
+/**
+ * Increment the three rate-limit buckets for `ipHash`. Returns a
+ * RateLimitedError object if any tier is exceeded, otherwise null.
+ *
+ * Read-then-write is not atomic on Cloudflare KV, but the tiers are
+ * coarse enough that racing is acceptable — the worst case is one extra
+ * request squeezes through per bucket boundary.
+ */
+export async function checkAndIncrementRateLimit(
+  kv: NourishFlagsKV,
+  ipHash: string
+): Promise<RateLimitedError | null> {
+  const tiers: Array<{
+    scope: RateLimitScope;
+    bucket: string;
+    limit: number;
+    ttlSeconds: number;
+    retryAfter: number;
+  }> = [
+    {
+      scope: 'per-minute',
+      bucket: `rl:min:${ipHash}:${utcMinute()}`,
+      limit: LIMIT_PER_MINUTE,
+      ttlSeconds: 2 * 60,
+      retryAfter: 60
+    },
+    {
+      scope: 'per-hour',
+      bucket: `rl:hr:${ipHash}:${utcHour()}`,
+      limit: LIMIT_PER_HOUR,
+      ttlSeconds: 2 * 60 * 60,
+      retryAfter: 60 * 60
+    },
+    {
+      scope: 'per-day',
+      bucket: `rl:day:${ipHash}:${utcDay()}`,
+      limit: LIMIT_PER_DAY,
+      ttlSeconds: 26 * 60 * 60,
+      retryAfter: 24 * 60 * 60
+    }
+  ];
+
+  // First pass: read all counts. If any tier is already at limit, reject
+  // without bumping anything (fail-closed).
+  for (const tier of tiers) {
+    const raw = (await kv.get(tier.bucket)) as string | null;
+    const count = raw ? parseInt(raw, 10) : 0;
+    if (count >= tier.limit) {
+      return {
+        error: 'rate_limited',
+        retryAfter: tier.retryAfter,
+        scope: tier.scope
+      };
+    }
+  }
+
+  // Second pass: increment all buckets. KV writes are not transactional,
+  // but at this low rate the race-window is practically irrelevant.
+  await Promise.all(
+    tiers.map(async (tier) => {
+      const raw = (await kv.get(tier.bucket)) as string | null;
+      const count = raw ? parseInt(raw, 10) : 0;
+      await kv.put(tier.bucket, String(count + 1), {
+        expirationTtl: tier.ttlSeconds
+      });
+    })
+  );
+
+  return null;
+}
+
+/**
+ * Dedup grain: one anon flag per (ipHash × target × dimension × direction)
+ * per 24 hours. Returns true if a prior flag exists (caller should
+ * respond 200-no-op with {duplicate: true}).
+ */
+export async function checkDedup(
+  kv: NourishFlagsKV,
+  ipHash: string,
+  target: string,
+  dimension: string,
+  direction: string
+): Promise<boolean> {
+  const key = `dedup:${ipHash}:${target}:${dimension}:${direction}`;
+  const existing = await kv.get(key);
+  return existing !== null;
+}
+
+export async function markDedup(
+  kv: NourishFlagsKV,
+  ipHash: string,
+  target: string,
+  dimension: string,
+  direction: string
+): Promise<void> {
+  const key = `dedup:${ipHash}:${target}:${dimension}:${direction}`;
+  await kv.put(key, Date.now().toString(), { expirationTtl: DEDUP_TTL_SECONDS });
+}

--- a/src/lib/nourish/flagSubmit.ts
+++ b/src/lib/nourish/flagSubmit.ts
@@ -38,8 +38,14 @@ export type FlagTarget =
       kind: 'recipe';
       /** NIP-01 addressable tag value: "<kind>:<pubkey>:<d>" */
       aTag: string;
-      /** The kind 30078 Nourish event's id. */
-      nourishEventId: string;
+      /**
+       * The kind 30078 Nourish event's id, when the caller knows it.
+       * Optional because the recipe UI doesn't always track it today — the
+       * a-tag is the primary identifier for admin aggregation and the
+       * e-tag is auxiliary triage context (pinpoints the exact scoring
+       * event version that was flagged).
+       */
+      nourishEventId?: string;
     }
   | {
       kind: 'scan';
@@ -139,7 +145,14 @@ export async function hasPriorSignedFlag(
     '#l': [labelValue]
   };
   if (target.kind === 'recipe') {
-    (filter as Record<string, string[]>)['#e'] = [target.nourishEventId];
+    // Prefer the precise Nourish-event id when known; else fall back to
+    // matching by recipe address (a-tag). Either uniquely identifies a
+    // prior flag by this author for this dim/dir.
+    if (target.nourishEventId) {
+      (filter as Record<string, string[]>)['#e'] = [target.nourishEventId];
+    } else {
+      (filter as Record<string, string[]>)['#a'] = [target.aTag];
+    }
   } else {
     (filter as Record<string, string[]>)['#scan-hash'] = [target.contentHash];
   }
@@ -205,7 +218,9 @@ async function submitSignedFlag(
 
   if (target.kind === 'recipe') {
     ev.tags.push(['a', target.aTag, PANTRY_RELAY]);
-    ev.tags.push(['e', target.nourishEventId, PANTRY_RELAY]);
+    if (target.nourishEventId) {
+      ev.tags.push(['e', target.nourishEventId, PANTRY_RELAY]);
+    }
   } else {
     ev.tags.push(['scan-hash', target.contentHash]);
   }

--- a/src/lib/nourish/flagSubmit.ts
+++ b/src/lib/nourish/flagSubmit.ts
@@ -1,0 +1,281 @@
+/**
+ * Nourish-score flag submission — client-side helper.
+ *
+ * Two paths:
+ *   1. Logged-in (user has a Nostr signer) — publish a NIP-32 kind 1985
+ *      labeling event to the pantry relay, signed by the user's own pubkey.
+ *      Transparent, attributable, portable.
+ *   2. Anon (no signer) — POST to /api/nourish/flag, rate-limited per-IP
+ *      by the Cloudflare Worker (see flagRateLimit.server.ts).
+ *
+ * Both paths apply a dedup pre-check before opening any UI:
+ *   - Logged-in: reactive query for prior kind 1985 events from this pubkey
+ *     with matching l-tag + target tag.
+ *   - Anon: localStorage stamp `nourish-flagged:<target>:<dim>:<dir>` < 24h.
+ *
+ * NIP-32 tag structure (logged-in):
+ *   L = "cooking.zap.nourish-flag"
+ *   l = "<too-high|too-low>:<dimension>"    ← colon per NIP-73 precedent
+ *   target = ["a", "30023:<pk>:<d>", <relay>] + ["e", <nourishId>, <relay>]
+ *            OR ["scan-hash", <contentHash>]
+ *   score snapshot + model version for triage context.
+ */
+
+import { NDKEvent } from '@nostr-dev-kit/ndk';
+import { get, type Readable } from 'svelte/store';
+import { ndk, userPublickey } from '$lib/nostr';
+import { addClientTagToEvent } from '$lib/nip89';
+
+export const NOURISH_FLAG_NAMESPACE = 'cooking.zap.nourish-flag';
+export const NOURISH_FLAG_KIND = 1985;
+export const PANTRY_RELAY = 'wss://pantry.zap.cooking';
+
+export type NourishDimension = 'gut' | 'protein' | 'realFood' | 'overall';
+export type FlagDirection = 'too-high' | 'too-low';
+
+export type FlagTarget =
+  | {
+      kind: 'recipe';
+      /** NIP-01 addressable tag value: "<kind>:<pubkey>:<d>" */
+      aTag: string;
+      /** The kind 30078 Nourish event's id. */
+      nourishEventId: string;
+    }
+  | {
+      kind: 'scan';
+      /** Content hash of the scan input (from /lib/nourish/cache). */
+      contentHash: string;
+    };
+
+export interface FlagSubmission {
+  target: FlagTarget;
+  dimension: NourishDimension;
+  direction: FlagDirection;
+  /** Score at flag time (0..10). Stored as a snapshot for admin triage. */
+  score: number;
+  /** Nourish model/prompt version from $lib/nourish/types. */
+  nourishVer: string;
+  /** Optional free-text reason. Trimmed + truncated client-side to 500 chars. */
+  reason?: string;
+}
+
+export type FlagResult =
+  | { ok: true; source: 'nostr' | 'anon' }
+  | { ok: true; source: 'nostr' | 'anon'; duplicate: true }
+  | { ok: false; error: 'rate_limited'; retryAfter: number }
+  | { ok: false; error: 'no_signer' }
+  | { ok: false; error: 'network' }
+  | { ok: false; error: 'publish_failed' };
+
+const MAX_REASON_LEN = 500;
+
+// --------------------------- Target serialization ---------------------------
+
+/**
+ * Serialize a FlagTarget into the string form used by the anon Worker
+ * endpoint and by localStorage keys. Matches the server's `target` validation.
+ */
+export function serializeTarget(target: FlagTarget): string {
+  if (target.kind === 'recipe') return `a:${target.aTag}`;
+  return `scan:${target.contentHash}`;
+}
+
+// ---------------------------- Anon dedup (localStorage) ---------------------
+
+function anonStampKey(target: FlagTarget, dim: NourishDimension, dir: FlagDirection): string {
+  return `nourish-flagged:${serializeTarget(target)}:${dim}:${dir}`;
+}
+
+/** Returns true if the anon user has flagged this target/dim/dir in the last 24h. */
+export function hasAnonFlagStamp(
+  target: FlagTarget,
+  dimension: NourishDimension,
+  direction: FlagDirection
+): boolean {
+  if (typeof localStorage === 'undefined') return false;
+  const raw = localStorage.getItem(anonStampKey(target, dimension, direction));
+  if (!raw) return false;
+  const ts = parseInt(raw, 10);
+  if (!isFinite(ts)) return false;
+  return Date.now() - ts < 24 * 60 * 60 * 1000;
+}
+
+function setAnonFlagStamp(
+  target: FlagTarget,
+  dimension: NourishDimension,
+  direction: FlagDirection
+): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(anonStampKey(target, dimension, direction), Date.now().toString());
+  } catch {
+    // QuotaExceeded or privacy mode — non-fatal.
+  }
+}
+
+// ---------------------------- Signed dedup (Nostr) --------------------------
+
+/**
+ * Query the pantry relay for any kind 1985 flag event from `pubkey`
+ * matching this target + dimension + direction. Returns true if found.
+ * Fails open (returns false) on network error — worst case a user
+ * resubmits once; the relay will store both, admin view will dedup
+ * visually by pubkey.
+ */
+export async function hasPriorSignedFlag(
+  pubkey: string,
+  target: FlagTarget,
+  dimension: NourishDimension,
+  direction: FlagDirection
+): Promise<boolean> {
+  const ndkInstance = get(ndk);
+  if (!ndkInstance) return false;
+
+  const labelValue = `${direction}:${dimension}`;
+  const filter: Record<string, unknown> = {
+    kinds: [NOURISH_FLAG_KIND],
+    authors: [pubkey],
+    '#L': [NOURISH_FLAG_NAMESPACE],
+    '#l': [labelValue]
+  };
+  if (target.kind === 'recipe') {
+    (filter as Record<string, string[]>)['#e'] = [target.nourishEventId];
+  } else {
+    (filter as Record<string, string[]>)['#scan-hash'] = [target.contentHash];
+  }
+
+  try {
+    const results = await Promise.race([
+      ndkInstance.fetchEvents(filter as never),
+      new Promise<Set<NDKEvent>>((resolve) => setTimeout(() => resolve(new Set()), 3000))
+    ]);
+    return results.size > 0;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------- Public submit API -----------------------------
+
+/**
+ * Submit a flag. Auto-routes to Nostr (if signer present) or the anon
+ * Worker endpoint. Pre-checks dedup and returns `{ok, duplicate: true}`
+ * without attempting the write in that case.
+ *
+ * Errors surface as `{ok: false, error}` — callers map to a toast via
+ * Task 6 Stage 5's Toast primitive.
+ */
+export async function submitFlag(submission: FlagSubmission): Promise<FlagResult> {
+  const loggedInPubkey = get(userPublickey as Readable<string | null>);
+  const ndkInstance = get(ndk);
+  const hasSigner = !!ndkInstance?.signer;
+
+  if (loggedInPubkey && hasSigner) {
+    return submitSignedFlag(loggedInPubkey, submission);
+  }
+  return submitAnonFlag(submission);
+}
+
+async function submitSignedFlag(
+  pubkey: string,
+  submission: FlagSubmission
+): Promise<FlagResult> {
+  const { target, dimension, direction, score, nourishVer, reason } = submission;
+
+  const priorExists = await hasPriorSignedFlag(pubkey, target, dimension, direction);
+  if (priorExists) {
+    return { ok: true, source: 'nostr', duplicate: true };
+  }
+
+  const ndkInstance = get(ndk);
+  if (!ndkInstance) return { ok: false, error: 'no_signer' };
+
+  const ev = new NDKEvent(ndkInstance);
+  ev.kind = NOURISH_FLAG_KIND;
+  ev.content = (reason ?? '').trim().slice(0, MAX_REASON_LEN);
+  ev.created_at = Math.floor(Date.now() / 1000);
+
+  const labelValue = `${direction}:${dimension}`;
+  ev.tags = [
+    ['L', NOURISH_FLAG_NAMESPACE],
+    ['l', labelValue, NOURISH_FLAG_NAMESPACE],
+    ['score', score.toFixed(2)],
+    ['nourish-ver', nourishVer]
+  ];
+
+  if (target.kind === 'recipe') {
+    ev.tags.push(['a', target.aTag, PANTRY_RELAY]);
+    ev.tags.push(['e', target.nourishEventId, PANTRY_RELAY]);
+  } else {
+    ev.tags.push(['scan-hash', target.contentHash]);
+  }
+
+  addClientTagToEvent(ev);
+
+  try {
+    await ev.sign();
+    await ev.publish();
+    return { ok: true, source: 'nostr' };
+  } catch (err) {
+    console.error('[nourish-flag] publish failed:', err);
+    return { ok: false, error: 'publish_failed' };
+  }
+}
+
+async function submitAnonFlag(submission: FlagSubmission): Promise<FlagResult> {
+  const { target, dimension, direction, score, nourishVer, reason } = submission;
+
+  if (hasAnonFlagStamp(target, dimension, direction)) {
+    return { ok: true, source: 'anon', duplicate: true };
+  }
+
+  let response: Response;
+  try {
+    response = await fetch('/api/nourish/flag', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        target: serializeTarget(target),
+        dimension,
+        direction,
+        score,
+        nourishVer,
+        reason: (reason ?? '').trim().slice(0, MAX_REASON_LEN)
+      })
+    });
+  } catch (err) {
+    console.error('[nourish-flag] network failure:', err);
+    return { ok: false, error: 'network' };
+  }
+
+  if (response.status === 429) {
+    const body = (await response.json().catch(() => ({}))) as {
+      retryAfter?: number;
+    };
+    return {
+      ok: false,
+      error: 'rate_limited',
+      retryAfter: typeof body.retryAfter === 'number' ? body.retryAfter : 60
+    };
+  }
+
+  if (!response.ok) {
+    console.error('[nourish-flag] server error:', response.status);
+    return { ok: false, error: 'network' };
+  }
+
+  const body = (await response.json().catch(() => ({}))) as {
+    ok?: boolean;
+    duplicate?: boolean;
+  };
+
+  // Stamp localStorage BEFORE returning so subsequent pre-checks hit.
+  // (Even for duplicates — the server confirmed the flag exists, so our
+  // local stamp should match.)
+  setAnonFlagStamp(target, dimension, direction);
+
+  if (body.duplicate) {
+    return { ok: true, source: 'anon', duplicate: true };
+  }
+  return { ok: true, source: 'anon' };
+}

--- a/src/lib/nourish/flagSubmit.ts
+++ b/src/lib/nourish/flagSubmit.ts
@@ -16,12 +16,14 @@
  * NIP-32 tag structure (logged-in):
  *   L = "cooking.zap.nourish-flag"
  *   l = "<too-high|too-low>:<dimension>"    ← colon per NIP-73 precedent
- *   target = ["a", "30023:<pk>:<d>", <relay>] + ["e", <nourishId>, <relay>]
- *            OR ["scan-hash", <contentHash>]
+ *   target = ["a", "30023:<pk>:<d>", <relay>] + optional ["e", <nourishId>, <relay>]
+ *            OR ["i", "nourish-scan:<contentHash>"] + ["k", "nourish-scan"]
+ *            per NIP-73; single-letter `i` lets us query with a `#i` filter,
+ *            which Nostr requires for tag-based filtering.
  *   score snapshot + model version for triage context.
  */
 
-import { NDKEvent } from '@nostr-dev-kit/ndk';
+import { NDKEvent, NDKRelaySet } from '@nostr-dev-kit/ndk';
 import { get, type Readable } from 'svelte/store';
 import { ndk, userPublickey } from '$lib/nostr';
 import { addClientTagToEvent } from '$lib/nip89';
@@ -29,6 +31,10 @@ import { addClientTagToEvent } from '$lib/nip89';
 export const NOURISH_FLAG_NAMESPACE = 'cooking.zap.nourish-flag';
 export const NOURISH_FLAG_KIND = 1985;
 export const PANTRY_RELAY = 'wss://pantry.zap.cooking';
+/** NIP-73 `i` tag identifier for scan-target flags. Single-letter `i`
+ *  lets us filter via `#i`, which Nostr requires for tag-based queries. */
+export const SCAN_I_TAG_PREFIX = 'nourish-scan:';
+export const SCAN_K_TAG_VALUE = 'nourish-scan';
 
 export type NourishDimension = 'gut' | 'protein' | 'realFood' | 'overall';
 export type FlagDirection = 'too-high' | 'too-low';
@@ -154,12 +160,22 @@ export async function hasPriorSignedFlag(
       (filter as Record<string, string[]>)['#a'] = [target.aTag];
     }
   } else {
-    (filter as Record<string, string[]>)['#scan-hash'] = [target.contentHash];
+    // NIP-73: external content ID encoded in an `i` tag — single-letter so
+    // `#i` filtering works at the relay layer. Multi-letter filters like
+    // `#scan-hash` are not supported by Nostr.
+    (filter as Record<string, string[]>)['#i'] = [
+      `${SCAN_I_TAG_PREFIX}${target.contentHash}`
+    ];
   }
+
+  // Query the pantry relay specifically — that's where signed Nourish
+  // flags live. The app's default relay set doesn't include pantry, so
+  // omitting this would silently miss existing flags and re-post duplicates.
+  const relaySet = NDKRelaySet.fromRelayUrls([PANTRY_RELAY], ndkInstance, true);
 
   try {
     const results = await Promise.race([
-      ndkInstance.fetchEvents(filter as never),
+      ndkInstance.fetchEvents(filter as never, undefined, relaySet),
       new Promise<Set<NDKEvent>>((resolve) => setTimeout(() => resolve(new Set()), 3000))
     ]);
     return results.size > 0;
@@ -222,14 +238,22 @@ async function submitSignedFlag(
       ev.tags.push(['e', target.nourishEventId, PANTRY_RELAY]);
     }
   } else {
-    ev.tags.push(['scan-hash', target.contentHash]);
+    // NIP-73 external content id — single-letter tag so relay `#i`
+    // filtering works.
+    ev.tags.push(['i', `${SCAN_I_TAG_PREFIX}${target.contentHash}`]);
+    ev.tags.push(['k', SCAN_K_TAG_VALUE]);
   }
 
   addClientTagToEvent(ev);
 
+  // Publish to the pantry relay specifically — that's where admin
+  // aggregation queries look for signed flags. Publishing to the app's
+  // default relay set would route flags to the wrong place.
+  const relaySet = NDKRelaySet.fromRelayUrls([PANTRY_RELAY], ndkInstance, true);
+
   try {
     await ev.sign();
-    await ev.publish();
+    await ev.publish(relaySet);
     return { ok: true, source: 'nostr' };
   } catch (err) {
     console.error('[nourish-flag] publish failed:', err);

--- a/src/routes/admin/nourish-flags/+page.svelte
+++ b/src/routes/admin/nourish-flags/+page.svelte
@@ -18,8 +18,13 @@
   import { onMount } from 'svelte';
   import { ndk, userPublickey } from '$lib/nostr';
   import { isAdmin } from '$lib/adminAuth';
-  import { NOURISH_FLAG_KIND, NOURISH_FLAG_NAMESPACE } from '$lib/nourish/flagSubmit';
-  import type { NDKEvent } from '@nostr-dev-kit/ndk';
+  import {
+    NOURISH_FLAG_KIND,
+    NOURISH_FLAG_NAMESPACE,
+    PANTRY_RELAY,
+    SCAN_I_TAG_PREFIX
+  } from '$lib/nourish/flagSubmit';
+  import { NDKRelaySet, type NDKEvent } from '@nostr-dev-kit/ndk';
 
   interface AnonFlag {
     target: string;
@@ -69,11 +74,18 @@
 
   async function loadSigned() {
     if (!$ndk) return;
+    // Signed flags live on the pantry relay. The default relay set
+    // doesn't include pantry, so we target it explicitly.
+    const relaySet = NDKRelaySet.fromRelayUrls([PANTRY_RELAY], $ndk, true);
     const events = await Promise.race([
-      $ndk.fetchEvents({
-        kinds: [NOURISH_FLAG_KIND],
-        '#L': [NOURISH_FLAG_NAMESPACE]
-      } as never),
+      $ndk.fetchEvents(
+        {
+          kinds: [NOURISH_FLAG_KIND],
+          '#L': [NOURISH_FLAG_NAMESPACE]
+        } as never,
+        undefined,
+        relaySet
+      ),
       new Promise<Set<NDKEvent>>((resolve) =>
         setTimeout(() => resolve(new Set()), 6000)
       )
@@ -93,7 +105,10 @@
     if (!direction || !dimension) return null;
 
     const aTag = ev.tags.find((t) => t[0] === 'a')?.[1];
-    const scanHash = ev.tags.find((t) => t[0] === 'scan-hash')?.[1];
+    // NIP-73 `i` tag with "nourish-scan:<hash>" prefix.
+    const iTag = ev.tags
+      .find((t) => t[0] === 'i' && typeof t[1] === 'string' && t[1].startsWith(SCAN_I_TAG_PREFIX))?.[1];
+    const scanHash = iTag ? iTag.slice(SCAN_I_TAG_PREFIX.length) : undefined;
     const target = aTag ? `a:${aTag}` : scanHash ? `scan:${scanHash}` : '';
     if (!target) return null;
 
@@ -211,7 +226,9 @@
         f.dimension,
         f.direction,
         'signed',
-        `npub:${f.pubkey.slice(0, 8)}…`,
+        // Truncated hex pubkey — labelling as "pubkey" honestly rather than
+        // "npub" which would require nip19 encoding. Admin view.
+        `pubkey:${f.pubkey.slice(0, 8)}…`,
         f.reason,
         f.createdAt
       );

--- a/src/routes/admin/nourish-flags/+page.svelte
+++ b/src/routes/admin/nourish-flags/+page.svelte
@@ -1,0 +1,490 @@
+<script lang="ts">
+  /**
+   * /admin/nourish-flags — read-only list of Nourish score flags.
+   *
+   * First route under /admin/*. Gated client-side via isAdmin() from
+   * $lib/adminAuth (consistent with /sponsors). Merges two sources:
+   *
+   *   1. Signed flags (kind 1985 NIP-32) from wss://pantry.zap.cooking
+   *      — queried client-side via NDK. Author pubkey is visible.
+   *
+   *   2. Anon flags from /api/admin/nourish-flags (KV-backed). IP hash
+   *      shown (first 8 chars) for brigading detection; full IP is never
+   *      stored.
+   *
+   *  Tabs: Recipes (a-tag targets) vs Scans (scan-hash targets). Each
+   *  row expands to show sample reasons + per-source breakdown.
+   */
+  import { onMount } from 'svelte';
+  import { ndk, userPublickey } from '$lib/nostr';
+  import { isAdmin } from '$lib/adminAuth';
+  import { NOURISH_FLAG_KIND, NOURISH_FLAG_NAMESPACE } from '$lib/nourish/flagSubmit';
+  import type { NDKEvent } from '@nostr-dev-kit/ndk';
+
+  interface AnonFlag {
+    target: string;
+    dimension: string;
+    direction: string;
+    score: number;
+    nourishVer: string;
+    reason: string;
+    ipHash: string;
+    createdAt: string;
+  }
+
+  interface SignedFlag {
+    target: string;
+    dimension: string;
+    direction: string;
+    score: number | null;
+    nourishVer: string;
+    reason: string;
+    pubkey: string;
+    createdAt: string;
+  }
+
+  type Source = 'signed' | 'anon';
+  type TabKind = 'recipes' | 'scans';
+
+  let loading = true;
+  let loadError = '';
+  let anonFlags: AnonFlag[] = [];
+  let signedFlags: SignedFlag[] = [];
+  let activeTab: TabKind = 'recipes';
+  let expandedKey: string | null = null;
+
+  $: authed = isAdmin($userPublickey);
+
+  async function loadAnon() {
+    if (!$userPublickey) return;
+    const res = await fetch('/api/admin/nourish-flags', {
+      headers: { 'x-admin-pubkey': $userPublickey }
+    });
+    if (!res.ok) {
+      throw new Error(`anon flag fetch failed: ${res.status}`);
+    }
+    const body = (await res.json()) as { flags?: AnonFlag[] };
+    anonFlags = body.flags ?? [];
+  }
+
+  async function loadSigned() {
+    if (!$ndk) return;
+    const events = await Promise.race([
+      $ndk.fetchEvents({
+        kinds: [NOURISH_FLAG_KIND],
+        '#L': [NOURISH_FLAG_NAMESPACE]
+      } as never),
+      new Promise<Set<NDKEvent>>((resolve) =>
+        setTimeout(() => resolve(new Set()), 6000)
+      )
+    ]);
+    signedFlags = Array.from(events).map(parseSignedFlag).filter(notNull);
+  }
+
+  function notNull<T>(v: T | null): v is T {
+    return v !== null;
+  }
+
+  function parseSignedFlag(ev: NDKEvent): SignedFlag | null {
+    const lTag = ev.tags.find((t) => t[0] === 'l' && t[2] === NOURISH_FLAG_NAMESPACE);
+    if (!lTag) return null;
+    const labelValue = lTag[1];
+    const [direction, dimension] = labelValue.split(':');
+    if (!direction || !dimension) return null;
+
+    const aTag = ev.tags.find((t) => t[0] === 'a')?.[1];
+    const scanHash = ev.tags.find((t) => t[0] === 'scan-hash')?.[1];
+    const target = aTag ? `a:${aTag}` : scanHash ? `scan:${scanHash}` : '';
+    if (!target) return null;
+
+    const scoreRaw = ev.tags.find((t) => t[0] === 'score')?.[1];
+    const score = scoreRaw ? Number(scoreRaw) : null;
+    const nourishVer = ev.tags.find((t) => t[0] === 'nourish-ver')?.[1] ?? '';
+
+    return {
+      target,
+      dimension,
+      direction,
+      score: score !== null && isFinite(score) ? score : null,
+      nourishVer,
+      reason: ev.content ?? '',
+      pubkey: ev.pubkey,
+      createdAt: new Date((ev.created_at ?? 0) * 1000).toISOString()
+    };
+  }
+
+  async function loadAll() {
+    loading = true;
+    loadError = '';
+    try {
+      await Promise.all([loadAnon(), loadSigned()]);
+    } catch (err) {
+      loadError = err instanceof Error ? err.message : String(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  onMount(() => {
+    if (authed) loadAll();
+  });
+
+  // Re-load when pubkey arrives after mount (common in this app).
+  $: if (authed && loading && !loadError) loadAll();
+
+  // ── Aggregation ────────────────────────────────────────────────────
+
+  interface Group {
+    target: string;
+    dimension: string;
+    tooHighSigned: number;
+    tooHighAnon: number;
+    tooLowSigned: number;
+    tooLowAnon: number;
+    total: number;
+    lastAt: number;
+    samples: Array<{
+      source: Source;
+      author: string;
+      reason: string;
+      direction: string;
+      createdAt: string;
+    }>;
+  }
+
+  function keyOf(target: string, dimension: string): string {
+    return `${target}|${dimension}`;
+  }
+
+  function groupFlags(
+    signed: SignedFlag[],
+    anon: AnonFlag[],
+    kind: TabKind
+  ): Group[] {
+    const isRecipesTab = kind === 'recipes';
+    const map = new Map<string, Group>();
+    const push = (
+      target: string,
+      dimension: string,
+      direction: string,
+      source: Source,
+      author: string,
+      reason: string,
+      createdAt: string
+    ) => {
+      const matchesTab = isRecipesTab ? target.startsWith('a:') : target.startsWith('scan:');
+      if (!matchesTab) return;
+      const k = keyOf(target, dimension);
+      const ts = Date.parse(createdAt) || 0;
+      let g = map.get(k);
+      if (!g) {
+        g = {
+          target,
+          dimension,
+          tooHighSigned: 0,
+          tooHighAnon: 0,
+          tooLowSigned: 0,
+          tooLowAnon: 0,
+          total: 0,
+          lastAt: 0,
+          samples: []
+        };
+        map.set(k, g);
+      }
+      if (direction === 'too-high') {
+        if (source === 'signed') g.tooHighSigned++;
+        else g.tooHighAnon++;
+      } else {
+        if (source === 'signed') g.tooLowSigned++;
+        else g.tooLowAnon++;
+      }
+      g.total++;
+      if (ts > g.lastAt) g.lastAt = ts;
+      if (reason && g.samples.length < 5) {
+        g.samples.push({ source, author, reason, direction, createdAt });
+      }
+    };
+
+    for (const f of signed) {
+      push(
+        f.target,
+        f.dimension,
+        f.direction,
+        'signed',
+        `npub:${f.pubkey.slice(0, 8)}…`,
+        f.reason,
+        f.createdAt
+      );
+    }
+    for (const f of anon) {
+      push(
+        f.target,
+        f.dimension,
+        f.direction,
+        'anon',
+        `anon-${f.ipHash.slice(0, 4)}`,
+        f.reason,
+        f.createdAt
+      );
+    }
+
+    return Array.from(map.values()).sort((a, b) => b.total - a.total);
+  }
+
+  $: groups = groupFlags(signedFlags, anonFlags, activeTab);
+
+  function formatAgo(iso: number): string {
+    if (!iso) return '—';
+    const diff = Date.now() - iso;
+    const h = Math.floor(diff / 3_600_000);
+    if (h < 1) return `${Math.floor(diff / 60_000)}m ago`;
+    if (h < 24) return `${h}h ago`;
+    return `${Math.floor(h / 24)}d ago`;
+  }
+
+  function toggleExpand(key: string) {
+    expandedKey = expandedKey === key ? null : key;
+  }
+</script>
+
+<svelte:head>
+  <title>Nourish Flags — Admin</title>
+</svelte:head>
+
+<div class="page">
+  <h1>Nourish Flags</h1>
+
+  {#if !authed}
+    <div class="unauthorized">
+      <p>Not authorized.</p>
+    </div>
+  {:else if loading}
+    <p class="status">Loading flags…</p>
+  {:else if loadError}
+    <p class="status status-error">Couldn't load flags: {loadError}</p>
+  {:else}
+    <div class="tabs">
+      <button
+        class="tab"
+        class:active={activeTab === 'recipes'}
+        on:click={() => (activeTab = 'recipes')}
+      >
+        Recipes
+      </button>
+      <button
+        class="tab"
+        class:active={activeTab === 'scans'}
+        on:click={() => (activeTab = 'scans')}
+      >
+        Scans
+      </button>
+    </div>
+
+    {#if groups.length === 0}
+      <p class="status">No flags in this bucket yet.</p>
+    {:else}
+      <div class="list">
+        {#each groups as g (keyOf(g.target, g.dimension))}
+          {@const k = keyOf(g.target, g.dimension)}
+          <div class="row" class:expanded={expandedKey === k}>
+            <button
+              type="button"
+              class="row-header"
+              on:click={() => toggleExpand(k)}
+            >
+              <span class="target">{g.target}</span>
+              <span class="dim">{g.dimension}</span>
+              <span class="counts">
+                <span class="count high">↑ {g.tooHighSigned + g.tooHighAnon}</span>
+                <span class="count low">↓ {g.tooLowSigned + g.tooLowAnon}</span>
+              </span>
+              <span class="ago">{formatAgo(g.lastAt)}</span>
+            </button>
+            {#if expandedKey === k}
+              <div class="row-detail">
+                <p class="breakdown">
+                  Signed: {g.tooHighSigned + g.tooLowSigned} · Anon: {g.tooHighAnon +
+                    g.tooLowAnon}
+                </p>
+                {#if g.samples.length === 0}
+                  <p class="no-samples">No free-text reasons on these flags.</p>
+                {:else}
+                  <ul class="samples">
+                    {#each g.samples as s}
+                      <li class="sample">
+                        <span class="sample-meta">
+                          [{s.source}] {s.author} · {s.direction}
+                        </span>
+                        <p class="sample-text">{s.reason}</p>
+                      </li>
+                    {/each}
+                  </ul>
+                {/if}
+              </div>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .page {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 2rem 1.25rem;
+    color: var(--color-text-primary);
+  }
+
+  h1 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin: 0 0 1rem;
+  }
+
+  .unauthorized,
+  .status {
+    padding: 2rem;
+    text-align: center;
+    color: var(--color-text-secondary);
+  }
+
+  .status-error {
+    color: #ef4444;
+  }
+
+  .tabs {
+    display: flex;
+    gap: 0.5rem;
+    border-bottom: 1px solid var(--color-input-border);
+    margin-bottom: 1rem;
+  }
+
+  .tab {
+    padding: 0.5rem 1rem;
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+
+  .tab.active {
+    color: var(--color-text-primary);
+    border-bottom-color: var(--color-primary);
+  }
+
+  .list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .row {
+    border: 1px solid var(--color-input-border);
+    border-radius: 0.5rem;
+    background: var(--color-bg-secondary);
+  }
+
+  .row-header {
+    display: grid;
+    grid-template-columns: 1fr auto auto auto;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.75rem 1rem;
+    width: 100%;
+    background: none;
+    border: none;
+    color: inherit;
+    text-align: left;
+    cursor: pointer;
+    font-family: inherit;
+  }
+
+  .row-header:hover {
+    background: var(--color-bg-tertiary);
+  }
+
+  .target {
+    font-family: ui-monospace, monospace;
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .dim {
+    font-size: 0.875rem;
+    font-weight: 500;
+    text-transform: capitalize;
+  }
+
+  .counts {
+    display: flex;
+    gap: 0.5rem;
+    font-size: 0.8125rem;
+  }
+
+  .count.high {
+    color: #ef4444;
+  }
+
+  .count.low {
+    color: #3b82f6;
+  }
+
+  .ago {
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+    white-space: nowrap;
+  }
+
+  .row-detail {
+    padding: 0.5rem 1rem 1rem;
+    border-top: 1px solid var(--color-input-border);
+  }
+
+  .breakdown {
+    margin: 0 0 0.5rem;
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
+  }
+
+  .no-samples {
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
+    font-style: italic;
+  }
+
+  .samples {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .sample {
+    border-left: 2px solid var(--color-input-border);
+    padding-left: 0.75rem;
+  }
+
+  .sample-meta {
+    display: block;
+    font-family: ui-monospace, monospace;
+    font-size: 0.6875rem;
+    color: var(--color-text-secondary);
+    margin-bottom: 0.1875rem;
+  }
+
+  .sample-text {
+    margin: 0;
+    font-size: 0.8125rem;
+    line-height: 1.4;
+  }
+</style>

--- a/src/routes/api/admin/nourish-flags/+server.ts
+++ b/src/routes/api/admin/nourish-flags/+server.ts
@@ -29,7 +29,16 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { ADMIN_PUBKEY } from '$lib/adminAuth';
 
-const LIST_PAGE_LIMIT = 1000; // KV list per-call cap; plenty for v1 volume.
+const LIST_PAGE_LIMIT = 1000; // KV list per-call cap.
+const GET_CONCURRENCY = 16; // max in-flight kv.get calls — bounds memory + CPU.
+
+// KV list response shape — extends what we declared in app.d.ts with the
+// pagination fields that actually ship.
+interface KvListResult {
+  keys: Array<{ name: string }>;
+  list_complete?: boolean;
+  cursor?: string;
+}
 
 export const GET: RequestHandler = async ({ request, platform }) => {
   const adminPubkey = request.headers.get('x-admin-pubkey');
@@ -43,17 +52,39 @@ export const GET: RequestHandler = async ({ request, platform }) => {
   }
 
   try {
-    const { keys } = await kv.list({ prefix: 'flag:', limit: LIST_PAGE_LIMIT });
+    // Page through all flag:* keys via cursor so volume past 1000 entries
+    // doesn't silently truncate the admin view.
+    const allKeys: Array<{ name: string }> = [];
+    let cursor: string | undefined;
+    do {
+      const page = (await (kv.list as (opts?: unknown) => Promise<KvListResult>)({
+        prefix: 'flag:',
+        limit: LIST_PAGE_LIMIT,
+        cursor
+      })) as KvListResult;
+      allKeys.push(...page.keys);
+      cursor = page.list_complete === false ? page.cursor : undefined;
+    } while (cursor);
+
+    // Parallelize KV reads in bounded batches. Sequential awaiting (the
+    // prior implementation) scales linearly with flag count and is the
+    // dominant latency for the admin page at higher volumes.
     const flags: unknown[] = [];
-    for (const { name } of keys) {
-      const raw = (await kv.get(name)) as string | null;
-      if (!raw) continue;
-      try {
-        flags.push(JSON.parse(raw));
-      } catch {
-        // Skip malformed entries; admin surface just shows what parses.
+    for (let i = 0; i < allKeys.length; i += GET_CONCURRENCY) {
+      const batch = allKeys.slice(i, i + GET_CONCURRENCY);
+      const results = await Promise.all(
+        batch.map((k) => kv.get(k.name) as Promise<string | null>)
+      );
+      for (const raw of results) {
+        if (!raw) continue;
+        try {
+          flags.push(JSON.parse(raw));
+        } catch {
+          // Skip malformed entries; admin surface just shows what parses.
+        }
       }
     }
+
     return json({ flags, count: flags.length });
   } catch (err) {
     console.error('[admin/nourish-flags] KV list failed:', err);

--- a/src/routes/api/admin/nourish-flags/+server.ts
+++ b/src/routes/api/admin/nourish-flags/+server.ts
@@ -1,0 +1,62 @@
+/**
+ * GET /api/admin/nourish-flags — admin-only aggregate of anon flag records.
+ *
+ * Returns every flag:* record currently stored in the NOURISH_FLAGS KV
+ * namespace (90-day TTL enforces bounded storage). Signed kind 1985
+ * flags live on the pantry relay and are queried client-side by the
+ * admin page — this endpoint covers only the anon-via-Worker path.
+ *
+ * Auth: `x-admin-pubkey` header must match ADMIN_PUBKEY from
+ * $lib/adminAuth. Same weak-but-consistent pattern as /sponsors.
+ * A future FOLLOWUPS item formalizes this with NIP-98 HTTP-Auth.
+ *
+ * Response:
+ *   {
+ *     flags: Array<{
+ *       target: string,
+ *       dimension: string,
+ *       direction: string,
+ *       score: number,
+ *       nourishVer: string,
+ *       reason: string,
+ *       ipHash: string,       // full hash, so admin can spot brigading
+ *       createdAt: string,
+ *     }>,
+ *     count: number
+ *   }
+ */
+
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { ADMIN_PUBKEY } from '$lib/adminAuth';
+
+const LIST_PAGE_LIMIT = 1000; // KV list per-call cap; plenty for v1 volume.
+
+export const GET: RequestHandler = async ({ request, platform }) => {
+  const adminPubkey = request.headers.get('x-admin-pubkey');
+  if (!adminPubkey || adminPubkey !== ADMIN_PUBKEY) {
+    return json({ error: 'forbidden' }, { status: 403 });
+  }
+
+  const kv = platform?.env?.NOURISH_FLAGS;
+  if (!kv) {
+    return json({ error: 'kv_unavailable' }, { status: 503 });
+  }
+
+  try {
+    const { keys } = await kv.list({ prefix: 'flag:', limit: LIST_PAGE_LIMIT });
+    const flags: unknown[] = [];
+    for (const { name } of keys) {
+      const raw = (await kv.get(name)) as string | null;
+      if (!raw) continue;
+      try {
+        flags.push(JSON.parse(raw));
+      } catch {
+        // Skip malformed entries; admin surface just shows what parses.
+      }
+    }
+    return json({ flags, count: flags.length });
+  } catch (err) {
+    console.error('[admin/nourish-flags] KV list failed:', err);
+    return json({ error: 'server_error' }, { status: 500 });
+  }
+};

--- a/src/routes/api/nourish/flag/+server.ts
+++ b/src/routes/api/nourish/flag/+server.ts
@@ -36,8 +36,6 @@ import { json, type RequestHandler } from '@sveltejs/kit';
 import {
   checkAndIncrementRateLimit,
   checkDedup,
-  getTodaySalt,
-  hashIp,
   markDedup
 } from '$lib/nourish/flagRateLimit.server';
 
@@ -94,12 +92,17 @@ export const POST: RequestHandler = async ({ request, getClientAddress, platform
     ip = '127.0.0.1';
   }
 
-  const salt = await getTodaySalt(kv);
-  const ipHash = await hashIp(ip, salt);
-
-  // Dedup pre-check. Duplicate is a 200 no-op so the client UI can show the
-  // "you've already flagged this" state without surfacing an error toast.
-  const already = await checkDedup(kv, ipHash, target, dimension, direction);
+  // Dedup pre-check — spans yesterday + today so a flag made just before
+  // UTC midnight still deduplicates the minute after. Duplicate is a 200
+  // no-op so the client UI can show the "you've already flagged this"
+  // state without surfacing an error toast.
+  const { hit: already, todayIpHash: ipHash } = await checkDedup(
+    kv,
+    ip,
+    target,
+    dimension,
+    direction
+  );
   if (already) {
     return json({ ok: true, duplicate: true });
   }

--- a/src/routes/api/nourish/flag/+server.ts
+++ b/src/routes/api/nourish/flag/+server.ts
@@ -1,0 +1,137 @@
+/**
+ * POST /api/nourish/flag — anon Nourish-score flag submission endpoint.
+ *
+ * Logged-in users bypass this endpoint entirely and publish a NIP-32
+ * kind 1985 labeling event to the pantry relay directly (see
+ * $lib/nourish/flagSubmit.ts). This endpoint exists to let ANONYMOUS
+ * users contribute flags without needing a Nostr signer, with
+ * per-IP rate limiting + dedup + daily-rotated IP hashing for privacy.
+ *
+ * Storage: Cloudflare KV namespace `NOURISH_FLAGS`. See flagRateLimit.server.ts
+ * for the key schema.
+ *
+ * Rate limits: 1/min, 10/hr, 30/day per ipHash. Dedup: 1/24h per
+ * (ipHash × target × dimension × direction).
+ *
+ * Request body:
+ *   {
+ *     target:     "a:<kind>:<pubkey>:<d>" | "scan:<content-hash>",
+ *     dimension:  "gut" | "protein" | "realFood" | "overall",
+ *     direction:  "too-high" | "too-low",
+ *     score:      number,          // 0..10, score at flag time
+ *     nourishVer: string,          // Nourish model/prompt version
+ *     reason?:    string           // optional free-text, <= 500 chars
+ *   }
+ *
+ * Responses:
+ *   200 { ok: true }
+ *   200 { ok: true, duplicate: true }             — already flagged (no-op)
+ *   400 { error: "bad_request", detail?: string } — payload validation
+ *   429 { error: "rate_limited", retryAfter, scope }
+ *   500 { error: "server_error" }
+ *   503 { error: "kv_unavailable" }               — platform.env.NOURISH_FLAGS missing
+ */
+
+import { json, type RequestHandler } from '@sveltejs/kit';
+import {
+  checkAndIncrementRateLimit,
+  checkDedup,
+  getTodaySalt,
+  hashIp,
+  markDedup
+} from '$lib/nourish/flagRateLimit.server';
+
+const ALLOWED_DIMENSIONS = new Set(['gut', 'protein', 'realFood', 'overall']);
+const ALLOWED_DIRECTIONS = new Set(['too-high', 'too-low']);
+const MAX_REASON_LEN = 500;
+const FLAG_RECORD_TTL_SECONDS = 90 * 24 * 60 * 60; // 90 days
+
+function isValidTarget(target: unknown): target is string {
+  if (typeof target !== 'string' || target.length > 256) return false;
+  return target.startsWith('a:') || target.startsWith('scan:');
+}
+
+export const POST: RequestHandler = async ({ request, getClientAddress, platform }) => {
+  const kv = platform?.env?.NOURISH_FLAGS;
+  if (!kv) {
+    return json({ error: 'kv_unavailable' }, { status: 503 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'bad_request', detail: 'invalid JSON' }, { status: 400 });
+  }
+
+  const { target, dimension, direction, score, nourishVer, reason } =
+    (body as Record<string, unknown>) ?? {};
+
+  if (!isValidTarget(target)) {
+    return json({ error: 'bad_request', detail: 'target' }, { status: 400 });
+  }
+  if (typeof dimension !== 'string' || !ALLOWED_DIMENSIONS.has(dimension)) {
+    return json({ error: 'bad_request', detail: 'dimension' }, { status: 400 });
+  }
+  if (typeof direction !== 'string' || !ALLOWED_DIRECTIONS.has(direction)) {
+    return json({ error: 'bad_request', detail: 'direction' }, { status: 400 });
+  }
+  if (typeof score !== 'number' || !isFinite(score) || score < 0 || score > 10) {
+    return json({ error: 'bad_request', detail: 'score' }, { status: 400 });
+  }
+  if (typeof nourishVer !== 'string' || nourishVer.length === 0 || nourishVer.length > 32) {
+    return json({ error: 'bad_request', detail: 'nourishVer' }, { status: 400 });
+  }
+  const reasonStr =
+    typeof reason === 'string' ? reason.slice(0, MAX_REASON_LEN) : '';
+
+  let ip: string;
+  try {
+    ip = getClientAddress();
+  } catch {
+    // Local dev without a real request addr; synthesize one so the endpoint
+    // still works in `pnpm run dev`.
+    ip = '127.0.0.1';
+  }
+
+  const salt = await getTodaySalt(kv);
+  const ipHash = await hashIp(ip, salt);
+
+  // Dedup pre-check. Duplicate is a 200 no-op so the client UI can show the
+  // "you've already flagged this" state without surfacing an error toast.
+  const already = await checkDedup(kv, ipHash, target, dimension, direction);
+  if (already) {
+    return json({ ok: true, duplicate: true });
+  }
+
+  const limited = await checkAndIncrementRateLimit(kv, ipHash);
+  if (limited) {
+    return json(limited, { status: 429 });
+  }
+
+  // Record the flag.
+  const createdAtIso = new Date().toISOString();
+  const flagKey = `flag:${target}:${dimension}:${direction}:${createdAtIso}:${ipHash.slice(0, 8)}`;
+  const flagRecord = {
+    target,
+    dimension,
+    direction,
+    score: Number(score.toFixed(2)),
+    nourishVer,
+    reason: reasonStr,
+    ipHash,
+    createdAt: createdAtIso
+  };
+
+  try {
+    await kv.put(flagKey, JSON.stringify(flagRecord), {
+      expirationTtl: FLAG_RECORD_TTL_SECONDS
+    });
+    await markDedup(kv, ipHash, target, dimension, direction);
+  } catch (err) {
+    console.error('[nourish-flag] KV write failed:', err);
+    return json({ error: 'server_error' }, { status: 500 });
+  }
+
+  return json({ ok: true });
+};

--- a/src/routes/nourish/+page.svelte
+++ b/src/routes/nourish/+page.svelte
@@ -5,6 +5,9 @@
   import { generateSuggestions, mergeImprovements } from '$lib/nourish/suggestions';
   import { ingredientStore } from '$lib/nourish/ingredientStore';
   import type { ScanResponse } from '$lib/nourish/types';
+  import { NOURISH_PROMPT_VERSION } from '$lib/nourish/types';
+  import { computeContentHash } from '$lib/nourish/nourishRelay';
+  import type { FlagTarget } from '$lib/nourish/flagSubmit';
   import NourishInputTabs from '../../components/nourish/NourishInputTabs.svelte';
   import NourishResult from '../../components/nourish/NourishResult.svelte';
   import Button from '../../components/Button.svelte';
@@ -30,6 +33,20 @@
   let scanError = '';
   let scanResult: ScanResponse | null = null;
   let improvements: string[] = [];
+
+  // Flag target — text scans can be referenced by content hash. Image-only
+  // scans don't have a stable identifier, so the flag affordance is
+  // suppressed there.
+  let flagTarget: FlagTarget | null = null;
+  $: updateFlagTarget(scanResult, scanText);
+  async function updateFlagTarget(_result: ScanResponse | null, text: string) {
+    if (!_result?.scores || !text.trim()) {
+      flagTarget = null;
+      return;
+    }
+    const hash = await computeContentHash(text.trim());
+    flagTarget = { kind: 'scan', contentHash: hash };
+  }
 
   $: hasInput = scanText.trim().length > 0 || imageData !== null;
 
@@ -151,6 +168,8 @@
       {improvements}
       ingredientSignals={scanResult.ingredient_signals || []}
       onReset={resetScan}
+      {flagTarget}
+      nourishVer={NOURISH_PROMPT_VERSION}
     />
 
   {:else}

--- a/src/routes/nourish/+page.svelte
+++ b/src/routes/nourish/+page.svelte
@@ -37,14 +37,27 @@
   // Flag target — text scans can be referenced by content hash. Image-only
   // scans don't have a stable identifier, so the flag affordance is
   // suppressed there.
+  //
+  // `computeContentHash` is async, and `scanText` can change before a
+  // prior hash resolves. The request-seq guard + text re-check discard
+  // any resolution that's no longer current — otherwise a slow earlier
+  // hash would overwrite a fast newer one with a stale value.
   let flagTarget: FlagTarget | null = null;
+  let flagTargetRequestSeq = 0;
   $: updateFlagTarget(scanResult, scanText);
   async function updateFlagTarget(_result: ScanResponse | null, text: string) {
-    if (!_result?.scores || !text.trim()) {
+    const trimmed = text.trim();
+    const seq = ++flagTargetRequestSeq;
+
+    if (!_result?.scores || !trimmed) {
       flagTarget = null;
       return;
     }
-    const hash = await computeContentHash(text.trim());
+
+    const hash = await computeContentHash(trimmed);
+    // If a newer request started while we were hashing, or the text has
+    // changed, drop this result.
+    if (seq !== flagTargetRequestSeq || trimmed !== scanText.trim()) return;
     flagTarget = { kind: 'scan', contentHash: hash };
   }
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,11 +17,8 @@
       "id": "e373fff5cddb4db885eb4f027c307545"
     },
     {
-      // Anon Nourish-score flag submissions + rate-limit buckets + daily IP-hash salts.
-      // TODO(deploy): replace `id` with the production namespace id created via
-      // `wrangler kv:namespace create NOURISH_FLAGS`, then remove this comment.
       "binding": "NOURISH_FLAGS",
-      "id": "REPLACE_ME_WITH_PRODUCTION_KV_ID"
+      "id": "3f66fd6ea3304241b93584e284e36738"
     }
   ]
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -18,7 +18,7 @@
     },
     {
       "binding": "NOURISH_FLAGS",
-      "id": "3f66fd6ea3304241b93584e284e36738"
+      "id": "62b1fc47ff274697923fc65e51592734"
     }
   ]
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -15,6 +15,13 @@
     {
       "binding": "GATED_CONTENT",
       "id": "e373fff5cddb4db885eb4f027c307545"
+    },
+    {
+      // Anon Nourish-score flag submissions + rate-limit buckets + daily IP-hash salts.
+      // TODO(deploy): replace `id` with the production namespace id created via
+      // `wrangler kv:namespace create NOURISH_FLAGS`, then remove this comment.
+      "binding": "NOURISH_FLAGS",
+      "id": "REPLACE_ME_WITH_PRODUCTION_KV_ID"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Introduces a lightweight way for users to indicate they disagree with a Nourish score. Captures:

- **Per-dimension flagging** (gut / protein / realFood / overall) with direction (too-high / too-low)
- **Score snapshot** at flag time + **Nourish model version** for triage context
- **Optional free-text reason** (500 char cap)
- **Hybrid storage**: logged-in users publish **NIP-32 kind 1985** labeling events to the pantry relay (public, attributable); anon users POST to a **Cloudflare Worker endpoint** with per-IP rate limiting (never logs IPs in cleartext — SHA-256 + daily-rotated salt)
- **Rate limits**: 1/min, 10/hr, 30/day per anon ipHash; dedup 1 per (ipHash × target × dim × dir) per 24h
- Admin view at **`/admin/nourish-flags`** (gated via existing `isAdmin()` + `ADMIN_PUBKEY`) merges both sources, tabs Recipes vs Scans, read-only

Anyone can submit, including anon users. Submissions surface in the admin list for triage and inform future rescoring prioritization.

**This is foundation work — no behavioral change to displayed Nourish scores yet.** Subsequent features (score caching/versioning, explanation modal, amplification features like sort-by-top-gut-health) build on the signal this feature collects.

## Storage decision — hybrid, NIP-73 colon-separated compound labels

Recommended and approved in Phase 2:

- **Logged-in**: NIP-32 kind 1985, signed by the user's pubkey, to `wss://pantry.zap.cooking`. Transparent, Nostr-native, auditable.
- **Anon**: POST `/api/nourish/flag` → Cloudflare KV. Anon users don't have a Nostr signer loaded; requiring ephemeral keys just for this signal is over-engineering.
- **Admin aggregation**: merges both sources client-side.

**Compound label separator: colon**, following NIP-73 precedent (`podcast:item:guid`, `bitcoin:tx`, `ethereum:1:address`). NIP-32 doesn't specify a separator; following adjacent precedent.

Example label: `["l", "too-high:gut", "cooking.zap.nourish-flag"]`.

## Example event JSON

### Signed flag — kind 1985 (logged-in user)

```jsonc
{
  "kind": 1985,
  "created_at": 1713456789,
  "pubkey": "<flagger-hex>",
  "tags": [
    ["L", "cooking.zap.nourish-flag"],
    ["l", "too-high:gut", "cooking.zap.nourish-flag"],
    ["score", "7.20"],
    ["nourish-ver", "1"],
    ["a", "30023:<recipe-author>:<d-tag>", "wss://pantry.zap.cooking"],
    ["client", "zap.cooking", "31990:<app-pubkey>:<d>", "wss://relay.zap.cooking"]
  ],
  "content": "Recipe has a lot of cured meat — gut-health score seems generous."
}
```

### Anon flag — KV record (JSON value at `flag:a:30023:…:gut:too-high:2026-04-18T15:30:00Z:a1b2c3d4`)

```jsonc
{
  "target": "a:30023:<recipe-author>:<d-tag>",
  "dimension": "gut",
  "direction": "too-high",
  "score": 7.2,
  "nourishVer": "1",
  "reason": "",
  "ipHash": "<sha256(ip+dailySalt)>",
  "createdAt": "2026-04-18T15:30:00.000Z"
}
```

## Rate-limit numbers (per anon ipHash)

| Scope | Limit | Reset |
|---|---:|---|
| per-minute | **1** | 60s |
| per-hour | **10** | 1h |
| per-day | **30** | 24h |
| **Dedup** | 1 per (target × dimension × direction) | 24h |

429 response shape:
```json
{ "error": "rate_limited", "retryAfter": 60, "scope": "per-minute" }
```

IP hashing: SHA-256(IP + daily-rotated server-side salt). Salts retained 3 days to avoid midnight-race dedup misses. Raw IPs never stored.

## UI

- **Flag icon** appears in the expanded-state detail row of each `NourishDimensionBar` (3 bars per result view: Real Food / Gut Health / Protein). Covers both recipe context (via `NourishModal`) and scan context (via `/nourish` page).
- **Popover** opens on click via the existing `Modal` primitive (portal-rendered, same desktop/mobile story as GifPicker / PollCreator). Title: "Help us improve this score". Direction picker (↑ too high / ↓ too low) + optional reason textarea + Submit.
- **Persistent filled state**: the icon renders filled (and click becomes no-op) if the user has previously flagged this dimension — pantry relay query for signed users, localStorage stamp for anon.
- **Error UX**: `showToast('error', …)` via Task 6 Stage 5's Toast primitive. Rate-limit → `"You've flagged a few already — take a breather and try again in a minute."` Generic → `"Couldn't submit your flag — please try again."`
- **No success toast** (matches the Stage 5 convention).

## Admin view — `/admin/nourish-flags`

First route under `/admin/*`. Gated client-side via `isAdmin($userPublickey)` using the existing `$lib/adminAuth` module.

**Merges two data sources**:
1. Signed flags: NDK `fetchEvents` against pantry relay for kind 1985 events with `#L = "cooking.zap.nourish-flag"`.
2. Anon flags: `GET /api/admin/nourish-flags` with `x-admin-pubkey` header check against `ADMIN_PUBKEY`.

**Tabs**: Recipes (a-tag targets) vs Scans (scan-hash targets) — per Phase 2, these inform different things (recipe scoring quality vs scan model behaviour). Sort by total flag count descending.

**Row detail**: per-source breakdown + up to 5 sample reasons, source-tagged (`[signed] npub:abcd…` or `[anon] anon-a1b2`).

**Unlinked in v1** — navigate manually. A nav entry is deferred to FOLLOWUPS.

## Files touched

**New** (8):
- `src/lib/nourish/flagRateLimit.server.ts` — rate-limit + IP-hash helpers
- `src/lib/nourish/flagSubmit.ts` — client submission helper (Nostr + anon routing)
- `src/components/nourish/NourishFlagButton.svelte` — icon + popover component
- `src/routes/api/nourish/flag/+server.ts` — anon submission endpoint
- `src/routes/api/admin/nourish-flags/+server.ts` — admin aggregation endpoint
- `src/routes/admin/nourish-flags/+page.svelte` — admin list view

**Modified** (5):
- `wrangler.jsonc` — `NOURISH_FLAGS` KV binding (with deploy TODO for the real id)
- `src/app.d.ts` — `NOURISH_FLAGS` platform typing
- `src/components/nourish/NourishDimensionBar.svelte` — flag affordance in expanded detail
- `src/components/nourish/NourishResult.svelte` — threads `flagTarget` + `nourishVer` to bars
- `src/components/nourish/NourishModal.svelte` — constructs recipe `flagTarget` from the recipe event
- `src/routes/nourish/+page.svelte` — constructs scan `flagTarget` from text content hash
- `docs/dev/FOLLOWUPS.md` — 9 new follow-up items

## Verification

| Check | Result |
|---|---|
| `pnpm run check` | 4 pre-existing errors / 127 warnings — unchanged from `main`. Zero introduced. |
| `pnpm run build` | passes (adapter-cloudflare). |
| Dev server — `/nourish`, `/reads` | 200, no runtime errors. |
| Endpoint validation — invalid JSON / dimension / target | 400 with structured `{error, detail}` per expected shape. |

## Deploy checklist

Before the first deploy this PR needs:

1. Create the production KV namespace:
   ```
   wrangler kv:namespace create NOURISH_FLAGS
   ```
2. Replace `REPLACE_ME_WITH_PRODUCTION_KV_ID` in `wrangler.jsonc` with the returned namespace id, then remove the `TODO(deploy)` comment.

Everything else deploys cleanly. The Worker endpoint fails closed (503 `kv_unavailable`) until the binding is real.

## Rollout

**Full-bore, no feature flag.** Per Phase 2 reasoning:
- Purely additive — no existing Nourish rendering changes.
- Flag UI is opt-in (user must click the icon).
- Rate limiting from day 1.
- Mitigations are cheap (CSS-hide the button if noisy; tighten rate limits if spammed).

## Commit list

7 atomic commits, each `pnpm run check` + `pnpm run build` clean:

1. Anon flag endpoint + rate-limit + KV binding
2. `flagSubmit` client helper (Nostr + anon routing)
3. `NourishFlagButton` popover component
4. Wire `NourishFlagButton` into `NourishDimensionBar` (both contexts)
5. Admin API endpoint for anon flag aggregation
6. Admin route `/admin/nourish-flags`
7. FOLLOWUPS — 9 new items

## Scope trims (filed as follow-ups)

- Flag affordance on `NourishPill` hover card + `NourishModal` summary area (requires threading `FlagTarget` through those components).
- Tracking the specific kind-30078 Nourish event id alongside cached scores (enables precise `["e", nourishEventId]` in flag events).
- NIP-98 signed HTTP-auth on admin endpoints (upgrade from header-based).
- Admin nav entry (unlinked in v1 by design).
- Turnstile contingency for anon abuse (not needed v1).
- Per-pubkey rate cap for signed flags.
- Popover open-rate vs submit-rate analytics.
- Progressive 429 back-off.
- Differentiated error messages (signing cancelled / network / generic).

## Test plan

- [ ] Deploy checklist above completed (KV namespace id in `wrangler.jsonc`).
- [ ] As logged-in user: open a recipe with Nourish analysis → click 🌱 Gut bar → read reason → click flag icon → popover opens.
- [ ] Pick "too high" → type "test reason" → Submit → popover closes → icon is now filled → re-click = no popover.
- [ ] Verify the published event JSON at pantry relay matches the spec (uppercase `L` / lowercase `l` with colon-separated value, `a` tag, `score` + `nourish-ver` snapshot, `client` tag).
- [ ] Sign out. Open same recipe → flag icon is outlined (no signed record found for anon). Click → popover opens.
- [ ] Pick "too low" → Submit → icon fills. Verify `nourish-flagged:a:…:gut:too-low` localStorage key exists and is within 24h.
- [ ] Same anon user re-submits same (target, dim, dir) within 24h → server returns 200 `{ok: true, duplicate: true}` → no new KV record.
- [ ] Trigger 11 rapid anon submits (different targets to bypass dedup) → 11th should 429 with `{error: "rate_limited", retryAfter, scope: "per-hour"}` → toast renders.
- [ ] Load `/nourish` → scan "kale pasta garlic" → expand Gut Health → click flag → submit. Verify the published event has `["scan-hash", "<sha256>"]` instead of `a`.
- [ ] Load `/admin/nourish-flags` as admin → list shows both signed + anon flags, source-tagged.
- [ ] Load `/admin/nourish-flags` as non-admin → "Not authorized." message.

## Cumulative file list touched

- `wrangler.jsonc`
- `src/app.d.ts`
- `src/lib/nourish/flagRateLimit.server.ts` (new)
- `src/lib/nourish/flagSubmit.ts` (new)
- `src/components/nourish/NourishFlagButton.svelte` (new)
- `src/components/nourish/NourishDimensionBar.svelte`
- `src/components/nourish/NourishResult.svelte`
- `src/components/nourish/NourishModal.svelte`
- `src/routes/nourish/+page.svelte`
- `src/routes/api/nourish/flag/+server.ts` (new)
- `src/routes/api/admin/nourish-flags/+server.ts` (new)
- `src/routes/admin/nourish-flags/+page.svelte` (new)
- `docs/dev/FOLLOWUPS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)