### PR TITLE
Recipe editor UX: auto-save, add-by-URL, drag-reorder, markdown links

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -16,6 +16,12 @@
       })();
     </script>
 
+    <!-- Logo visibility rule inlined so it applies before the Tailwind bundle loads (prevents light-logo flash in dark mode) -->
+    <style>
+      html.dark .logo-light { display: none !important; }
+      html:not(.dark) .logo-dark { display: none !important; }
+    </style>
+
     <!-- Override fetch BEFORE anything else loads to intercept __data.json requests in static builds -->
     <script>
       (function () {

--- a/src/components/DesktopSideNav.svelte
+++ b/src/components/DesktopSideNav.svelte
@@ -170,12 +170,12 @@
     >
       <img
         src={SVGNostrCookingWithText}
-        class="w-40 dark:hidden"
+        class="logo-light w-40 dark:hidden"
         alt="Zap Cooking"
       />
       <img
         src="/zap_cooking_logo_white.svg"
-        class="w-40 hidden dark:block"
+        class="logo-dark w-40 hidden dark:block"
         alt="Zap Cooking"
       />
     </button>

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -119,12 +119,12 @@
   >
     <img
       src={SVGNostrCookingWithText}
-      class="w-28 sm:w-40 my-2 sm:my-3 dark:hidden"
+      class="logo-light w-28 sm:w-40 my-2 sm:my-3 dark:hidden"
       alt="zap.cooking Logo With Text"
     />
     <img
       src="/zap_cooking_logo_white.svg"
-      class="w-28 sm:w-40 my-2 sm:my-3 hidden dark:block"
+      class="logo-dark w-28 sm:w-40 my-2 sm:my-3 hidden dark:block"
       alt="zap.cooking Logo With Text"
     />
   </button>

--- a/src/components/MediaUploader.svelte
+++ b/src/components/MediaUploader.svelte
@@ -38,16 +38,19 @@
       urlError = 'URL must start with http:// or https://.';
       return;
     }
+    // Normalize via URL so `example.com` vs `example.com/` (or different
+    // casing/encoding) collapse to the same entry for the dedupe check.
+    const normalizedUrl = parsed.toString();
     if (limit > 0 && $uploadedImages.length >= limit) {
       urlError = `Limit of ${limit} media reached.`;
       return;
     }
-    if ($uploadedImages.includes(value)) {
+    if ($uploadedImages.includes(normalizedUrl)) {
       urlError = 'That URL is already added.';
       return;
     }
 
-    uploadedImages.update((imgs) => [...imgs, value]);
+    uploadedImages.update((imgs) => [...imgs, normalizedUrl]);
     urlInput = '';
   }
 
@@ -349,6 +352,8 @@
     <button
       type="button"
       class="flex items-center gap-1 text-xs text-caption hover:opacity-80 transition-opacity cursor-pointer"
+      aria-expanded={urlSectionOpen}
+      aria-controls="media-url-panel"
       on:click={() => (urlSectionOpen = !urlSectionOpen)}
     >
       <CaretDownIcon
@@ -359,7 +364,7 @@
     </button>
 
     {#if urlSectionOpen}
-      <div class="flex flex-col gap-1.5 mt-2">
+      <div id="media-url-panel" class="flex flex-col gap-1.5 mt-2">
         <div class="flex flex-col sm:flex-row gap-2">
           <input
             type="url"

--- a/src/components/MediaUploader.svelte
+++ b/src/components/MediaUploader.svelte
@@ -8,6 +8,7 @@
   import ImageIcon from 'phosphor-svelte/lib/Image';
   import UploadIcon from 'phosphor-svelte/lib/UploadSimple';
   import ArrowsClockwiseIcon from 'phosphor-svelte/lib/ArrowsClockwise';
+  import CaretDownIcon from 'phosphor-svelte/lib/CaretDown';
 
   export let uploadedImages: Writable<string[]>;
   export let limit = 0; // 0 = unlimited
@@ -16,6 +17,46 @@
   let isDragging = false;
   let isUploading = false;
   let uploadProgress = '';
+
+  let urlInput = '';
+  let urlError = '';
+  let urlSectionOpen = false;
+
+  function addByUrl() {
+    urlError = '';
+    const value = urlInput.trim();
+    if (!value) return;
+
+    let parsed: URL;
+    try {
+      parsed = new URL(value);
+    } catch {
+      urlError = 'Enter a valid URL (including https://).';
+      return;
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      urlError = 'URL must start with http:// or https://.';
+      return;
+    }
+    if (limit > 0 && $uploadedImages.length >= limit) {
+      urlError = `Limit of ${limit} media reached.`;
+      return;
+    }
+    if ($uploadedImages.includes(value)) {
+      urlError = 'That URL is already added.';
+      return;
+    }
+
+    uploadedImages.update((imgs) => [...imgs, value]);
+    urlInput = '';
+  }
+
+  function handleUrlKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      addByUrl();
+    }
+  }
 
   // Check if URL is a video
   function isVideo(url: string): boolean {
@@ -302,5 +343,47 @@
       Add photos and videos to showcase your recipe
     </p>
   {/if}
+
+  <!-- Subtle: add media by URL -->
+  <div>
+    <button
+      type="button"
+      class="flex items-center gap-1 text-xs text-caption hover:opacity-80 transition-opacity cursor-pointer"
+      on:click={() => (urlSectionOpen = !urlSectionOpen)}
+    >
+      <CaretDownIcon
+        size={12}
+        class="transition-transform duration-200 {urlSectionOpen ? 'rotate-180' : ''}"
+      />
+      <span>Add images by URL</span>
+    </button>
+
+    {#if urlSectionOpen}
+      <div class="flex flex-col gap-1.5 mt-2">
+        <div class="flex flex-col sm:flex-row gap-2">
+          <input
+            type="url"
+            bind:value={urlInput}
+            on:keydown={handleUrlKeydown}
+            placeholder="https://example.com/photo.jpg"
+            class="flex-1 rounded-md px-2.5 py-1.5 text-xs border focus:outline-none focus:ring-1 focus:ring-primary/40"
+            style="background-color: var(--color-input-bg); color: var(--color-text-primary); border-color: var(--color-input-border)"
+          />
+          <button
+            type="button"
+            class="px-3 py-1.5 rounded-md text-xs font-medium border hover:bg-accent-gray disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer transition-colors"
+            style="color: var(--color-text-primary); border-color: var(--color-input-border)"
+            disabled={!urlInput.trim()}
+            on:click={addByUrl}
+          >
+            Add
+          </button>
+        </div>
+        {#if urlError}
+          <p class="text-xs text-red-500">{urlError}</p>
+        {/if}
+      </div>
+    {/if}
+  </div>
 </div>
 

--- a/src/components/StringComboBox.svelte
+++ b/src/components/StringComboBox.svelte
@@ -19,6 +19,7 @@
   // Drag state
   let draggedIndex: number | null = null;
   let dragOverIndex: number | null = null;
+  let dragOverPosition: 'before' | 'after' = 'before';
 
   function removeTag(index: number) {
     let nSelected = $selected;
@@ -86,25 +87,34 @@
       e.dataTransfer.dropEffect = 'move';
     }
     dragOverIndex = index;
+    // Determine whether the cursor is in the top or bottom half of the
+    // target. This lets users drop past the last item (cursor below midpoint
+    // of the final row = "after"), which was previously impossible.
+    const target = e.currentTarget as HTMLElement;
+    const rect = target.getBoundingClientRect();
+    dragOverPosition = e.clientY < rect.top + rect.height / 2 ? 'before' : 'after';
   }
 
   function handleDrop(e: DragEvent, index: number) {
     e.preventDefault();
 
-    if (draggedIndex === null || draggedIndex === index) {
+    if (draggedIndex === null) {
       resetDragState();
       return;
     }
 
-    let nSelected = [...$selected];
-    const draggedItem = nSelected[draggedIndex];
-
-    // Remove from old position
-    nSelected.splice(draggedIndex, 1);
-
-    // Insert at new position
-    const insertIndex = draggedIndex < index ? index - 1 : index;
-    nSelected.splice(insertIndex, 0, draggedItem);
+    // Convert drop-target + before/after into an absolute destination index,
+    // then account for the dragged item being removed from an earlier slot.
+    let destIndex = dragOverPosition === 'after' ? index + 1 : index;
+    const nSelected = [...$selected];
+    const [draggedItem] = nSelected.splice(draggedIndex, 1);
+    if (draggedIndex < destIndex) destIndex--;
+    if (destIndex === draggedIndex) {
+      // No-op reorder — restore and bail
+      resetDragState();
+      return;
+    }
+    nSelected.splice(destIndex, 0, draggedItem);
 
     selected.set(nSelected);
     resetDragState();
@@ -117,12 +127,13 @@
   function resetDragState() {
     draggedIndex = null;
     dragOverIndex = null;
+    dragOverPosition = 'before';
   }
 </script>
 
 <div class="mb-0">
   {#if $selected.length > 0}
-    <ul class="flex flex-col gap-2 mb-2">
+    <ul class="flex flex-col mb-2">
       {#each $selected as tag, index (tag + index)}
         <li
           draggable={editingIndex !== index}
@@ -131,12 +142,16 @@
           on:drop={(e) => handleDrop(e, index)}
           on:dragend={handleDragEnd}
           on:dragleave={() => { if (dragOverIndex === index) dragOverIndex = null; }}
-          class="flex items-center gap-2 input transition-all duration-150
-            {dragOverIndex === index && draggedIndex !== index ? 'border-primary border-2' : ''}
-            {draggedIndex === index ? 'opacity-50' : ''}
-            {editingIndex === index ? 'ring-2 ring-primary border-primary' : ''}"
+          class="py-1 first:pt-0 last:pb-0"
           transition:slide|global={{ duration: 300 }}
         >
+          <div
+            class="flex items-center gap-2 input transition-all duration-150
+              {dragOverIndex === index && draggedIndex !== index && dragOverPosition === 'before' ? 'drop-indicator-top' : ''}
+              {dragOverIndex === index && draggedIndex !== index && dragOverPosition === 'after' ? 'drop-indicator-bottom' : ''}
+              {draggedIndex === index ? 'opacity-50' : ''}
+              {editingIndex === index ? 'ring-2 ring-primary border-primary' : ''}"
+          >
           <!-- Grip handle -->
           <button
             type="button"
@@ -200,6 +215,7 @@
               <TrashIcon size={16} />
             </button>
           </div>
+          </div>
         </li>
       {/each}
     </ul>
@@ -210,3 +226,13 @@
   <input bind:value={inputNewThing} class="input grow" {placeholder} />
   <Button on:click={addTag} primary={false}>Add</Button>
 </form>
+
+<style>
+  /* Drop-position indicators — use box-shadow so they don't shift layout */
+  :global(.drop-indicator-top) {
+    box-shadow: inset 0 3px 0 0 var(--color-primary);
+  }
+  :global(.drop-indicator-bottom) {
+    box-shadow: inset 0 -3px 0 0 var(--color-primary);
+  }
+</style>

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -14,22 +14,26 @@ md.renderer.rules.link_open = function(tokens, idx, options, env, self) {
   return defaultRender(tokens, idx, options, env, self);
 };
 
-// DOMPurify's default config can drop target/rel on <a> in some browsers;
-// force both back on after sanitization so rendered markdown links always
-// open in a new tab (important for the recipe editor preview — clicking a
-// link in-place would otherwise destroy unsaved edits).
-if (typeof window !== 'undefined') {
-  DOMPurify.addHook('afterSanitizeAttributes', (node) => {
-    if (node.tagName === 'A') {
-      node.setAttribute('target', '_blank');
-      node.setAttribute('rel', 'noopener noreferrer');
-    }
-  });
-}
+// Dedicated DOMPurify instance for markdown so the afterSanitizeAttributes
+// hook doesn't leak into every other sanitize() call in the app (the longform
+// editor and a handful of other callers import DOMPurify directly). The hook
+// forces target=_blank + rel on every <a> — DOMPurify drops those attrs in
+// some configs, which caused the recipe-editor markdown preview to navigate
+// in-place and destroy unsaved edits.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const markdownPurifier =
+  typeof window !== 'undefined' ? DOMPurify(window as any) : null;
+markdownPurifier?.addHook('afterSanitizeAttributes', (node) => {
+  if (node.tagName === 'A') {
+    node.setAttribute('target', '_blank');
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+});
 
 export function parseMarkdown(markdown: string) {
   const parsedMarkdown = md.render(markdown);
-  return DOMPurify.sanitize(parsedMarkdown, { ADD_ATTR: ['target'] });
+  const purifier = markdownPurifier ?? DOMPurify;
+  return purifier.sanitize(parsedMarkdown, { ADD_ATTR: ['target'] });
 }
 
 interface MarkdownInformation {

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -14,9 +14,22 @@ md.renderer.rules.link_open = function(tokens, idx, options, env, self) {
   return defaultRender(tokens, idx, options, env, self);
 };
 
+// DOMPurify's default config can drop target/rel on <a> in some browsers;
+// force both back on after sanitization so rendered markdown links always
+// open in a new tab (important for the recipe editor preview — clicking a
+// link in-place would otherwise destroy unsaved edits).
+if (typeof window !== 'undefined') {
+  DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+    if (node.tagName === 'A') {
+      node.setAttribute('target', '_blank');
+      node.setAttribute('rel', 'noopener noreferrer');
+    }
+  });
+}
+
 export function parseMarkdown(markdown: string) {
   const parsedMarkdown = md.render(markdown);
-  return DOMPurify.sanitize(parsedMarkdown);
+  return DOMPurify.sanitize(parsedMarkdown, { ADD_ATTR: ['target'] });
 }
 
 interface MarkdownInformation {

--- a/src/routes/create/+page.svelte
+++ b/src/routes/create/+page.svelte
@@ -14,7 +14,7 @@
   import { addClientTagToEvent } from '$lib/nip89';
   import Button from '../../components/Button.svelte';
   import MarkdownEditor from '../../components/MarkdownEditor.svelte';
-  import { onMount, onDestroy } from 'svelte';
+  import { onMount, onDestroy, tick } from 'svelte';
   import { RECIPE_TAG_PREFIX_NEW } from '$lib/consts';
   import {
     saveDraft,
@@ -60,7 +60,13 @@
 
   let cancelListenerAttached = false;
 
-  onMount(() => {
+  // Auto-save state
+  let autoSaveTimer: ReturnType<typeof setTimeout> | null = null;
+  let initialLoadComplete = false;
+  let lastSavedSignature = '';
+  const AUTO_SAVE_DEBOUNCE_MS = 2000;
+
+  onMount(async () => {
     if ($userPublickey == '') goto('/login');
 
     // Initialize draft store
@@ -76,13 +82,71 @@
       window.addEventListener('create-cancel-requested', handleCancelRequest);
       cancelListenerAttached = true;
     }
+
+    // Wait for reactive statements to populate draftSignature, then arm auto-save
+    await tick();
+    lastSavedSignature = draftSignature;
+    initialLoadComplete = true;
   });
 
   onDestroy(() => {
     if (browser && cancelListenerAttached) {
       window.removeEventListener('create-cancel-requested', handleCancelRequest);
     }
+    if (autoSaveTimer) {
+      clearTimeout(autoSaveTimer);
+      autoSaveTimer = null;
+    }
   });
+
+  function scheduleAutoSave() {
+    if (autoSaveTimer) clearTimeout(autoSaveTimer);
+    autoSaveTimer = setTimeout(runAutoSave, AUTO_SAVE_DEBOUNCE_MS);
+  }
+
+  async function runAutoSave() {
+    autoSaveTimer = null;
+    // If a manual save is in flight, wait and retry
+    if (isSavingDraft) {
+      scheduleAutoSave();
+      return;
+    }
+    if (!hasDraftContent) return;
+    if (draftSignature === lastSavedSignature) return;
+
+    const signatureAtSave = draftSignature;
+    isSavingDraft = true;
+    try {
+      const draftData = {
+        title,
+        images: $images,
+        tags: $selectedTags,
+        summary,
+        chefsnotes,
+        preptime,
+        cooktime,
+        servings,
+        ingredients: $ingredientsArray,
+        directions: $directionsArray,
+        additionalMarkdown
+      };
+      const { draftId } = saveDraft(draftData, currentDraftId || undefined, false);
+      currentDraftId = draftId;
+      if (browser) {
+        const url = new URL(window.location.href);
+        url.searchParams.set('draft', currentDraftId);
+        window.history.replaceState({}, '', url.toString());
+      }
+      lastSavedSignature = signatureAtSave;
+      if (currentDraftSyncStatus === undefined) currentDraftSyncStatus = 'local';
+      draftSaveMessage = 'Draft auto-saved';
+      setTimeout(() => {
+        if (draftSaveMessage === 'Draft auto-saved') draftSaveMessage = '';
+      }, 1500);
+    } finally {
+      isSavingDraft = false;
+    }
+  }
 
   function loadDraftById(draftId: string) {
     const draft = getDraftWithSyncState(draftId);
@@ -209,6 +273,7 @@
       draftSaveMessage = 'Saved locally';
     }
 
+    lastSavedSignature = draftSignature;
     isSavingDraft = false;
     setTimeout(() => {
       draftSaveMessage = '';
@@ -339,6 +404,30 @@
     $ingredientsArray.length > 0 ||
     $directionsArray.length > 0 ||
     Boolean(additionalMarkdown.trim());
+
+  // Serialized form of all draft fields — drives change detection for auto-save
+  $: draftSignature = JSON.stringify([
+    title,
+    $images,
+    $selectedTags,
+    summary,
+    chefsnotes,
+    preptime,
+    cooktime,
+    servings,
+    $ingredientsArray,
+    $directionsArray,
+    additionalMarkdown
+  ]);
+
+  // Schedule an auto-save whenever the draft changes (post-load)
+  $: if (
+    initialLoadComplete &&
+    hasDraftContent &&
+    draftSignature !== lastSavedSignature
+  ) {
+    scheduleAutoSave();
+  }
 </script>
 
 <svelte:head>

--- a/src/routes/create/+page.svelte
+++ b/src/routes/create/+page.svelte
@@ -83,8 +83,14 @@
       cancelListenerAttached = true;
     }
 
-    // Wait for reactive statements to populate draftSignature, then arm auto-save
+    // Compute the baseline signature immediately (bypassing the debounced
+    // reactive) so the first edit after load is detected correctly.
     await tick();
+    if (draftSignatureTimer) {
+      clearTimeout(draftSignatureTimer);
+      draftSignatureTimer = null;
+    }
+    recomputeDraftSignature();
     lastSavedSignature = draftSignature;
     initialLoadComplete = true;
   });
@@ -96,6 +102,10 @@
     if (autoSaveTimer) {
       clearTimeout(autoSaveTimer);
       autoSaveTimer = null;
+    }
+    if (draftSignatureTimer) {
+      clearTimeout(draftSignatureTimer);
+      draftSignatureTimer = null;
     }
   });
 
@@ -111,7 +121,18 @@
       scheduleAutoSave();
       return;
     }
-    if (!hasDraftContent) return;
+    // Flush any pending debounced signature computation so we compare against
+    // the latest typed state, not the previous tick's.
+    if (draftSignatureTimer) {
+      clearTimeout(draftSignatureTimer);
+      draftSignatureTimer = null;
+      recomputeDraftSignature();
+    }
+    // Skip the very first save when the composer is empty and there's no
+    // existing draft — no point creating an empty draft entry. But once a
+    // draft exists, always persist subsequent changes (including clearing
+    // all fields) so the "I deleted everything" state is saved too.
+    if (!hasDraftContent && !currentDraftId) return;
     if (draftSignature === lastSavedSignature) return;
 
     const signatureAtSave = draftSignature;
@@ -400,25 +421,60 @@
     $directionsArray.length > 0 ||
     Boolean(additionalMarkdown.trim());
 
-  // Serialized form of all draft fields — drives change detection for auto-save
-  $: draftSignature = JSON.stringify([
-    title,
-    $images,
-    $selectedTags,
-    summary,
-    chefsnotes,
-    preptime,
-    cooktime,
-    servings,
-    $ingredientsArray,
-    $directionsArray,
-    additionalMarkdown
-  ]);
+  // Serialized form of all draft fields — drives change detection for
+  // auto-save. Declared explicitly (and the compute debounced via the
+  // reactive below) so TS knows the var exists before onMount reads it,
+  // and so we don't re-JSON.stringify the entire draft on every keystroke
+  // for recipes with long ingredient/direction lists.
+  let draftSignature = '';
+  let draftSignatureTimer: ReturnType<typeof setTimeout> | null = null;
 
-  // Schedule an auto-save whenever the draft changes (post-load)
+  function recomputeDraftSignature() {
+    draftSignature = JSON.stringify([
+      title,
+      $images,
+      $selectedTags,
+      summary,
+      chefsnotes,
+      preptime,
+      cooktime,
+      servings,
+      $ingredientsArray,
+      $directionsArray,
+      additionalMarkdown
+    ]);
+  }
+
+  $: {
+    // Touch every draft field so Svelte tracks it as a dep.
+    title;
+    $images;
+    $selectedTags;
+    summary;
+    chefsnotes;
+    preptime;
+    cooktime;
+    servings;
+    $ingredientsArray;
+    $directionsArray;
+    additionalMarkdown;
+    if (!browser) {
+      recomputeDraftSignature();
+    } else {
+      if (draftSignatureTimer) clearTimeout(draftSignatureTimer);
+      draftSignatureTimer = setTimeout(() => {
+        draftSignatureTimer = null;
+        recomputeDraftSignature();
+      }, 250);
+    }
+  }
+
+  // Schedule an auto-save whenever the draft changes (post-load). We also
+  // allow the save-through-empty case when a draft already exists so that
+  // clearing all fields on an existing draft is persisted.
   $: if (
     initialLoadComplete &&
-    hasDraftContent &&
+    (hasDraftContent || currentDraftId) &&
     draftSignature !== lastSavedSignature
   ) {
     scheduleAutoSave();

--- a/src/routes/create/+page.svelte
+++ b/src/routes/create/+page.svelte
@@ -104,9 +104,9 @@
     autoSaveTimer = setTimeout(runAutoSave, AUTO_SAVE_DEBOUNCE_MS);
   }
 
-  async function runAutoSave() {
+  function runAutoSave() {
     autoSaveTimer = null;
-    // If a manual save is in flight, wait and retry
+    // Defer to a manual save in flight; retry once it completes
     if (isSavingDraft) {
       scheduleAutoSave();
       return;
@@ -115,37 +115,32 @@
     if (draftSignature === lastSavedSignature) return;
 
     const signatureAtSave = draftSignature;
-    isSavingDraft = true;
-    try {
-      const draftData = {
-        title,
-        images: $images,
-        tags: $selectedTags,
-        summary,
-        chefsnotes,
-        preptime,
-        cooktime,
-        servings,
-        ingredients: $ingredientsArray,
-        directions: $directionsArray,
-        additionalMarkdown
-      };
-      const { draftId } = saveDraft(draftData, currentDraftId || undefined, false);
-      currentDraftId = draftId;
-      if (browser) {
-        const url = new URL(window.location.href);
-        url.searchParams.set('draft', currentDraftId);
-        window.history.replaceState({}, '', url.toString());
-      }
-      lastSavedSignature = signatureAtSave;
-      if (currentDraftSyncStatus === undefined) currentDraftSyncStatus = 'local';
-      draftSaveMessage = 'Draft auto-saved';
-      setTimeout(() => {
-        if (draftSaveMessage === 'Draft auto-saved') draftSaveMessage = '';
-      }, 1500);
-    } finally {
-      isSavingDraft = false;
+    const draftData = {
+      title,
+      images: $images,
+      tags: $selectedTags,
+      summary,
+      chefsnotes,
+      preptime,
+      cooktime,
+      servings,
+      ingredients: $ingredientsArray,
+      directions: $directionsArray,
+      additionalMarkdown
+    };
+    const { draftId } = saveDraft(draftData, currentDraftId || undefined, false);
+
+    // Only rewrite the URL when the draft id first gets assigned — avoids
+    // thrashing $page and causing the editor to jump while typing.
+    if (browser && currentDraftId !== draftId) {
+      const url = new URL(window.location.href);
+      url.searchParams.set('draft', draftId);
+      window.history.replaceState({}, '', url.toString());
     }
+    currentDraftId = draftId;
+    lastSavedSignature = signatureAtSave;
+    // No isSavingDraft toggle and no status message — keep auto-save silent
+    // so it doesn't mutate UI that's in the user's field of view.
   }
 
   function loadDraftById(draftId: string) {


### PR DESCRIPTION
## Summary

Six self-contained improvements to the recipe creation flow (plus one supporting app-shell fix):

- **Auto-save drafts** (`create/+page.svelte`) — debounced 2s local save on any field change, silent (no button toggle, no status flash, URL written only when a new draft is first assigned an id). Relay sync continues in background via `draftStore`'s existing debounced publisher.
- **Add images by URL** (`MediaUploader.svelte`) — small subtle toggle under the media grid; validates http/https and duplicates; first URL becomes cover. Available in all three editors (create, fork, gated) via the shared component.
- **Markdown preview links open in new tabs** (`parser.ts`) — DOMPurify was silently stripping `target`/`rel` from rendered markdown anchors, so clicking a link in the editor preview navigated in-place and nuked unsaved edits. An `afterSanitizeAttributes` hook reapplies `target="_blank"` + `rel="noopener noreferrer"` on every `<a>`.
- **Ingredient/direction drag-reorder fix** (`StringComboBox.svelte`) — dropping on the last item used to always place the dragged item *before* it, with no way to drop past the end. Detect top/bottom half of the target via cursor Y and insert accordingly. Also removed the 8px flex-gap dead zone between items — each `<li>` now has `py-1` padding so the hit area covers the gap.
- **Dark-mode logo flash** (`app.html`, `Header.svelte`, `DesktopSideNav.svelte`) — inline `<style>` in `app.html` keyed on `html.dark` hides the wrong-theme logo at first paint, before the Tailwind bundle loads. Marker classes `logo-light`/`logo-dark` added to the `<img>` pairs.

## Test plan

- [ ] `/create`: type in any field — no button flicker or layout jump. URL gains `?draft=<id>` after ~2s, but only once.
- [ ] `/create`: kill/reload the tab mid-edit; the draft reloads via `?draft=<id>`.
- [ ] `/create`: manual Save Draft still shows "Saving..." → "Saved & synced" feedback with cloud icon.
- [ ] `/create`: Media section → "Add images by URL" toggle → paste a URL → first becomes cover and publish button enables.
- [ ] `/create`: toggle to Preview in the markdown editor, click any link → opens in new tab, editor state retained.
- [ ] `/create`: drag the last ingredient up and then back down past the new last → it lands at the end. Drop indicator (top/bottom blue bar) matches the final position.
- [ ] First paint on a dark-mode device: correct (white) logo appears immediately; no light-mode flash.