### PR TITLE
feat(composer): single media button for photo + video uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.229",
+  "version": "4.2.230",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.228",
+  "version": "4.2.229",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/PostComposer.svelte
+++ b/src/components/PostComposer.svelte
@@ -22,6 +22,7 @@
   import { MentionComposerController, type MentionState } from '$lib/mentionComposer';
   import { uploadImage, uploadVideo } from '$lib/mediaUpload';
   import { detectHaiku } from '$lib/haiku';
+  import { clickOutside } from '$lib/clickOutside';
 
   // Clear stuck posts from the publish queue
   async function clearPendingQueue() {
@@ -57,6 +58,17 @@
   let uploadingVideo = false;
   let imageInputEl: HTMLInputElement;
   let videoInputEl: HTMLInputElement;
+  let showMediaMenu = false;
+
+  function openImagePicker() {
+    showMediaMenu = false;
+    imageInputEl?.click();
+  }
+
+  function openVideoPicker() {
+    showMediaMenu = false;
+    videoInputEl?.click();
+  }
   let quotedNote: { nevent: string; event: NDKEventType } | null = null;
   let showGifPicker = false;
   let showPollCreator = false;
@@ -650,14 +662,46 @@
             style="border-top: 1px solid var(--color-input-border)"
           >
           <div class="flex items-center gap-3">
-            <label
-              class="cursor-pointer p-1.5 rounded-full hover:bg-accent-gray transition-colors"
-              class:opacity-50={posting || uploadingImage || uploadingVideo}
-              class:cursor-not-allowed={posting || uploadingImage || uploadingVideo}
-              aria-disabled={posting || uploadingImage}
-              title="Upload image"
+            <div
+              class="media-menu"
+              use:clickOutside
+              on:click_outside={() => (showMediaMenu = false)}
             >
-              <ImageIcon size={18} class="text-caption" />
+              <button
+                type="button"
+                class="cursor-pointer p-1.5 rounded-full hover:bg-accent-gray transition-colors"
+                class:opacity-50={posting || uploadingImage || uploadingVideo}
+                class:cursor-not-allowed={posting || uploadingImage || uploadingVideo}
+                disabled={posting || uploadingImage || uploadingVideo}
+                aria-haspopup="menu"
+                aria-expanded={showMediaMenu}
+                title="Upload photo or video"
+                on:click={() => (showMediaMenu = !showMediaMenu)}
+              >
+                <ImageIcon size={18} class="text-caption" />
+              </button>
+              {#if showMediaMenu}
+                <div class="media-menu-panel" role="menu">
+                  <button
+                    type="button"
+                    class="media-menu-item"
+                    role="menuitem"
+                    on:click={openImagePicker}
+                  >
+                    <ImageIcon size={16} />
+                    <span>Photo</span>
+                  </button>
+                  <button
+                    type="button"
+                    class="media-menu-item"
+                    role="menuitem"
+                    on:click={openVideoPicker}
+                  >
+                    <VideoIcon size={16} />
+                    <span>Video</span>
+                  </button>
+                </div>
+              {/if}
               <input
                 bind:this={imageInputEl}
                 type="file"
@@ -666,16 +710,6 @@
                 on:change={handleImageUpload}
                 disabled={posting || uploadingImage}
               />
-            </label>
-
-            <label
-              class="cursor-pointer p-1.5 rounded-full hover:bg-accent-gray transition-colors"
-              class:opacity-50={posting || uploadingVideo}
-              class:cursor-not-allowed={posting || uploadingVideo}
-              aria-disabled={posting || uploadingVideo}
-              title="Upload video"
-            >
-              <VideoIcon size={18} class="text-caption" />
               <input
                 bind:this={videoInputEl}
                 type="file"
@@ -684,7 +718,7 @@
                 on:change={handleVideoUpload}
                 disabled={posting || uploadingVideo}
               />
-            </label>
+            </div>
 
             <button
               on:click={() => (showGifPicker = true)}
@@ -918,5 +952,43 @@
   .quoted-note-content :global(*) {
     overflow-wrap: anywhere;
     word-break: break-word;
+  }
+
+  .media-menu {
+    position: relative;
+    display: inline-flex;
+  }
+
+  .media-menu-panel {
+    position: absolute;
+    bottom: calc(100% + 0.375rem);
+    left: 0;
+    z-index: 45;
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-input-border);
+    border-radius: 0.6rem;
+    min-width: 140px;
+    padding: 0.3rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.2);
+  }
+
+  .media-menu-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 0.6rem;
+    border-radius: 0.4rem;
+    color: var(--color-text-primary);
+    font-size: 0.8125rem;
+    font-weight: 500;
+    text-align: left;
+    transition: background 0.15s ease;
+  }
+
+  .media-menu-item:hover {
+    background: var(--color-accent-gray);
   }
 </style>

--- a/src/components/PostComposer.svelte
+++ b/src/components/PostComposer.svelte
@@ -69,6 +69,11 @@
     showMediaMenu = false;
     videoInputEl?.click();
   }
+
+  // Close the media menu if posting / upload starts while it's open.
+  $: if (showMediaMenu && (posting || uploadingImage || uploadingVideo)) {
+    showMediaMenu = false;
+  }
   let quotedNote: { nevent: string; event: NDKEventType } | null = null;
   let showGifPicker = false;
   let showPollCreator = false;
@@ -675,6 +680,7 @@
                 disabled={posting || uploadingImage || uploadingVideo}
                 aria-haspopup="menu"
                 aria-expanded={showMediaMenu}
+                aria-label="Upload photo or video"
                 title="Upload photo or video"
                 on:click={() => (showMediaMenu = !showMediaMenu)}
               >
@@ -708,7 +714,7 @@
                 accept="image/*"
                 class="sr-only"
                 on:change={handleImageUpload}
-                disabled={posting || uploadingImage}
+                disabled={posting || uploadingImage || uploadingVideo}
               />
               <input
                 bind:this={videoInputEl}
@@ -716,7 +722,7 @@
                 accept="video/*"
                 class="sr-only"
                 on:change={handleVideoUpload}
-                disabled={posting || uploadingVideo}
+                disabled={posting || uploadingImage || uploadingVideo}
               />
             </div>
 

--- a/src/components/comments/ReplyComposer.svelte
+++ b/src/components/comments/ReplyComposer.svelte
@@ -95,6 +95,11 @@
 		videoInputEl?.click();
 	}
 
+	// Close the media menu if posting / upload starts while it's open.
+	$: if (showMediaMenu && (posting || uploadingImage || uploadingVideo)) {
+		showMediaMenu = false;
+	}
+
 	let mentionState: MentionState = {
 		mentionQuery: '',
 		showMentionSuggestions: false,

--- a/src/components/comments/ReplyComposer.svelte
+++ b/src/components/comments/ReplyComposer.svelte
@@ -23,6 +23,7 @@
 	import { createEventDispatcher, onDestroy } from 'svelte';
 	import MentionDropdown from '../MentionDropdown.svelte';
 	import { MentionComposerController, type MentionState } from '$lib/mentionComposer';
+	import { clickOutside } from '$lib/clickOutside';
 	import GifIcon from 'phosphor-svelte/lib/Gif';
 	import ImageIcon from 'phosphor-svelte/lib/Image';
 	import VideoIcon from 'phosphor-svelte/lib/Video';
@@ -82,6 +83,17 @@
 	let uploadError = '';
 	let imageInputEl: HTMLInputElement;
 	let videoInputEl: HTMLInputElement;
+	let showMediaMenu = false;
+
+	function openImagePicker() {
+		showMediaMenu = false;
+		imageInputEl?.click();
+	}
+
+	function openVideoPicker() {
+		showMediaMenu = false;
+		videoInputEl?.click();
+	}
 
 	let mentionState: MentionState = {
 		mentionQuery: '',
@@ -346,13 +358,46 @@
 	{/if}
 
 	<div class="reply-composer-actions">
-		<label
-			class="btn-media"
-			class:opacity-50={uploadingImage || uploadingVideo || posting}
-			title="Upload image"
-			aria-label="Upload image"
+		<div
+			class="media-menu"
+			use:clickOutside
+			on:click_outside={() => (showMediaMenu = false)}
 		>
-			<ImageIcon size={compact ? 16 : 18} />
+			<button
+				type="button"
+				class="btn-media"
+				class:opacity-50={uploadingImage || uploadingVideo || posting}
+				title="Upload photo or video"
+				aria-label="Upload photo or video"
+				aria-haspopup="menu"
+				aria-expanded={showMediaMenu}
+				disabled={posting || uploadingImage || uploadingVideo}
+				on:click={() => (showMediaMenu = !showMediaMenu)}
+			>
+				<ImageIcon size={compact ? 16 : 18} />
+			</button>
+			{#if showMediaMenu}
+				<div class="media-menu-panel" role="menu">
+					<button
+						type="button"
+						class="media-menu-item"
+						role="menuitem"
+						on:click={openImagePicker}
+					>
+						<ImageIcon size={16} />
+						<span>Photo</span>
+					</button>
+					<button
+						type="button"
+						class="media-menu-item"
+						role="menuitem"
+						on:click={openVideoPicker}
+					>
+						<VideoIcon size={16} />
+						<span>Video</span>
+					</button>
+				</div>
+			{/if}
 			<input
 				bind:this={imageInputEl}
 				type="file"
@@ -361,14 +406,6 @@
 				on:change={handleImageUpload}
 				disabled={posting || uploadingImage || uploadingVideo}
 			/>
-		</label>
-		<label
-			class="btn-media"
-			class:opacity-50={uploadingImage || uploadingVideo || posting}
-			title="Upload video"
-			aria-label="Upload video"
-		>
-			<VideoIcon size={compact ? 16 : 18} />
 			<input
 				bind:this={videoInputEl}
 				type="file"
@@ -377,7 +414,7 @@
 				on:change={handleVideoUpload}
 				disabled={posting || uploadingImage || uploadingVideo}
 			/>
-		</label>
+		</div>
 		<button
 			type="button"
 			on:click={() => (showGifPicker = true)}
@@ -543,8 +580,47 @@
 		opacity: 0.7;
 	}
 
-	.btn-gif:disabled {
+	.btn-gif:disabled,
+	.btn-media:disabled {
 		opacity: 0.4;
 		cursor: not-allowed;
+	}
+
+	.media-menu {
+		position: relative;
+		display: inline-flex;
+	}
+
+	.media-menu-panel {
+		position: absolute;
+		bottom: calc(100% + 0.375rem);
+		left: 0;
+		z-index: 45;
+		background: var(--color-bg-secondary);
+		border: 1px solid var(--color-input-border);
+		border-radius: 0.6rem;
+		min-width: 140px;
+		padding: 0.3rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.15rem;
+		box-shadow: 0 8px 20px rgba(15, 23, 42, 0.2);
+	}
+
+	.media-menu-item {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.4rem 0.6rem;
+		border-radius: 0.4rem;
+		color: var(--color-text-primary);
+		font-size: 0.8125rem;
+		font-weight: 500;
+		text-align: left;
+		transition: background 0.15s ease;
+	}
+
+	.media-menu-item:hover {
+		background: var(--color-accent-gray);
 	}
 </style>


### PR DESCRIPTION
## Summary
- Replaces the separate image and video buttons in **ReplyComposer** (comments) and **PostComposer** (posts) with a single media button that opens a small popover menu offering "Photo" or "Video".
- Menu closes on outside-click via the existing `clickOutside` directive. Hidden `<input type="file">` elements are triggered programmatically, so all upload logic (`uploadImage` / `uploadVideo`, error state, previews, removal) is unchanged.
- GIF and Poll buttons are untouched.

## Test plan
- [ ] Comment composer (top-level and inline reply): click media button → see Photo/Video menu → choose Photo → upload image → preview renders → post succeeds
- [ ] Comment composer: same flow with Video
- [ ] Main post composer: both Photo and Video flows succeed
- [ ] Menu closes when clicking outside, when selecting an item, or while an upload is in flight
- [ ] Disabled states during upload and while posting still apply to the new trigger button
- [ ] Compact reply-composer variant renders the menu at the right size