### PR TITLE
Recipe display: flat directions, tickable ingredient & direction checkboxes

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -16,6 +16,12 @@
       })();
     </script>
 
+    <!-- Logo visibility rule inlined so it applies before the Tailwind bundle loads (prevents light-logo flash in dark mode) -->
+    <style>
+      html.dark .logo-light { display: none !important; }
+      html:not(.dark) .logo-dark { display: none !important; }
+    </style>
+
     <!-- Override fetch BEFORE anything else loads to intercept __data.json requests in static builds -->
     <script>
       (function () {

--- a/src/components/DesktopSideNav.svelte
+++ b/src/components/DesktopSideNav.svelte
@@ -170,12 +170,12 @@
     >
       <img
         src={SVGNostrCookingWithText}
-        class="w-40 dark:hidden"
+        class="logo-light w-40 dark:hidden"
         alt="Zap Cooking"
       />
       <img
         src="/zap_cooking_logo_white.svg"
-        class="w-40 hidden dark:block"
+        class="logo-dark w-40 hidden dark:block"
         alt="Zap Cooking"
       />
     </button>

--- a/src/components/ErrorBoundary.svelte
+++ b/src/components/ErrorBoundary.svelte
@@ -81,7 +81,7 @@
     // in particular fires spurious error events during share / backgrounding
     // / service-worker transitions that are not fatal to the app. Log the
     // real error details for debugging — the error UI is reserved for
-    // explicit programmatic dispatches via the CustomEvent path above.
+    // explicit programmatic dispatches via `zc:fatal-error` below.
     const handleUnhandledError = (event: ErrorEvent) => {
       console.warn(
         '[ErrorBoundary] Window error (suppressed):',
@@ -95,12 +95,17 @@
       console.warn('[ErrorBoundary] Unhandled rejection (suppressed):', msg);
     };
 
+    // Explicit opt-in: child components that hit a truly fatal error can
+    // `window.dispatchEvent(new CustomEvent('zc:fatal-error', { detail: { error, errorInfo } }))`
+    // to surface the boundary's fallback UI.
     window.addEventListener('error', handleUnhandledError);
     window.addEventListener('unhandledrejection', handleUnhandledRejection);
+    window.addEventListener('zc:fatal-error', handleError as EventListener);
 
     return () => {
       window.removeEventListener('error', handleUnhandledError);
       window.removeEventListener('unhandledrejection', handleUnhandledRejection);
+      window.removeEventListener('zc:fatal-error', handleError as EventListener);
     };
   });
 </script>

--- a/src/components/ErrorBoundary.svelte
+++ b/src/components/ErrorBoundary.svelte
@@ -15,7 +15,10 @@
 
   const dispatch = createEventDispatcher();
 
-  // Error handling function
+  // Error handling function — only invoked for programmatically dispatched
+  // CustomEvents (e.g. from child components that rethrow). Native window
+  // `error` events are handled separately in onMount and are treated as
+  // non-fatal (logged only), matching how unhandled rejections are handled.
   function handleError(event: Event) {
     const customEvent = event as CustomEvent;
     error = customEvent.detail?.error || new Error('Unknown error');
@@ -74,24 +77,20 @@
   }
 
   onMount(() => {
-    // Listen for unhandled errors
+    // Don't replace the entire page for random window errors. iOS Safari
+    // in particular fires spurious error events during share / backgrounding
+    // / service-worker transitions that are not fatal to the app. Log the
+    // real error details for debugging — the error UI is reserved for
+    // explicit programmatic dispatches via the CustomEvent path above.
     const handleUnhandledError = (event: ErrorEvent) => {
-      if (!error) { // Only handle if we don't already have an error
-        error = new Error(event.message);
-        errorInfo = {
-          filename: event.filename,
-          lineno: event.lineno,
-          colno: event.colno
-        };
-      }
+      console.warn(
+        '[ErrorBoundary] Window error (suppressed):',
+        event.message,
+        event.error ?? { filename: event.filename, lineno: event.lineno, colno: event.colno }
+      );
     };
 
     const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
-      // Don't replace the entire page for background/network promise rejections.
-      // These are typically relay timeouts, fetch failures, or WebSocket errors
-      // that should be handled gracefully by the calling code, not by showing
-      // an error screen.  Only log them — the real fix is adding .catch() to
-      // the source promises.
       const msg = event.reason?.message || String(event.reason || '');
       console.warn('[ErrorBoundary] Unhandled rejection (suppressed):', msg);
     };
@@ -105,8 +104,6 @@
     };
   });
 </script>
-
-<svelte:window on:error={handleError} />
 
 {#if error}
   <div class="error-boundary">

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -119,12 +119,12 @@
   >
     <img
       src={SVGNostrCookingWithText}
-      class="w-28 sm:w-40 my-2 sm:my-3 dark:hidden"
+      class="logo-light w-28 sm:w-40 my-2 sm:my-3 dark:hidden"
       alt="zap.cooking Logo With Text"
     />
     <img
       src="/zap_cooking_logo_white.svg"
-      class="w-28 sm:w-40 my-2 sm:my-3 hidden dark:block"
+      class="logo-dark w-28 sm:w-40 my-2 sm:my-3 hidden dark:block"
       alt="zap.cooking Logo With Text"
     />
   </button>

--- a/src/components/MediaUploader.svelte
+++ b/src/components/MediaUploader.svelte
@@ -38,16 +38,19 @@
       urlError = 'URL must start with http:// or https://.';
       return;
     }
+    // Normalize via URL so `example.com` vs `example.com/` (or different
+    // casing/encoding) collapse to the same entry for the dedupe check.
+    const normalizedUrl = parsed.toString();
     if (limit > 0 && $uploadedImages.length >= limit) {
       urlError = `Limit of ${limit} media reached.`;
       return;
     }
-    if ($uploadedImages.includes(value)) {
+    if ($uploadedImages.includes(normalizedUrl)) {
       urlError = 'That URL is already added.';
       return;
     }
 
-    uploadedImages.update((imgs) => [...imgs, value]);
+    uploadedImages.update((imgs) => [...imgs, normalizedUrl]);
     urlInput = '';
   }
 
@@ -349,6 +352,8 @@
     <button
       type="button"
       class="flex items-center gap-1 text-xs text-caption hover:opacity-80 transition-opacity cursor-pointer"
+      aria-expanded={urlSectionOpen}
+      aria-controls="media-url-panel"
       on:click={() => (urlSectionOpen = !urlSectionOpen)}
     >
       <CaretDownIcon
@@ -359,7 +364,7 @@
     </button>
 
     {#if urlSectionOpen}
-      <div class="flex flex-col gap-1.5 mt-2">
+      <div id="media-url-panel" class="flex flex-col gap-1.5 mt-2">
         <div class="flex flex-col sm:flex-row gap-2">
           <input
             type="url"

--- a/src/components/MediaUploader.svelte
+++ b/src/components/MediaUploader.svelte
@@ -8,6 +8,7 @@
   import ImageIcon from 'phosphor-svelte/lib/Image';
   import UploadIcon from 'phosphor-svelte/lib/UploadSimple';
   import ArrowsClockwiseIcon from 'phosphor-svelte/lib/ArrowsClockwise';
+  import CaretDownIcon from 'phosphor-svelte/lib/CaretDown';
 
   export let uploadedImages: Writable<string[]>;
   export let limit = 0; // 0 = unlimited
@@ -16,6 +17,46 @@
   let isDragging = false;
   let isUploading = false;
   let uploadProgress = '';
+
+  let urlInput = '';
+  let urlError = '';
+  let urlSectionOpen = false;
+
+  function addByUrl() {
+    urlError = '';
+    const value = urlInput.trim();
+    if (!value) return;
+
+    let parsed: URL;
+    try {
+      parsed = new URL(value);
+    } catch {
+      urlError = 'Enter a valid URL (including https://).';
+      return;
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      urlError = 'URL must start with http:// or https://.';
+      return;
+    }
+    if (limit > 0 && $uploadedImages.length >= limit) {
+      urlError = `Limit of ${limit} media reached.`;
+      return;
+    }
+    if ($uploadedImages.includes(value)) {
+      urlError = 'That URL is already added.';
+      return;
+    }
+
+    uploadedImages.update((imgs) => [...imgs, value]);
+    urlInput = '';
+  }
+
+  function handleUrlKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      addByUrl();
+    }
+  }
 
   // Check if URL is a video
   function isVideo(url: string): boolean {
@@ -302,5 +343,47 @@
       Add photos and videos to showcase your recipe
     </p>
   {/if}
+
+  <!-- Subtle: add media by URL -->
+  <div>
+    <button
+      type="button"
+      class="flex items-center gap-1 text-xs text-caption hover:opacity-80 transition-opacity cursor-pointer"
+      on:click={() => (urlSectionOpen = !urlSectionOpen)}
+    >
+      <CaretDownIcon
+        size={12}
+        class="transition-transform duration-200 {urlSectionOpen ? 'rotate-180' : ''}"
+      />
+      <span>Add images by URL</span>
+    </button>
+
+    {#if urlSectionOpen}
+      <div class="flex flex-col gap-1.5 mt-2">
+        <div class="flex flex-col sm:flex-row gap-2">
+          <input
+            type="url"
+            bind:value={urlInput}
+            on:keydown={handleUrlKeydown}
+            placeholder="https://example.com/photo.jpg"
+            class="flex-1 rounded-md px-2.5 py-1.5 text-xs border focus:outline-none focus:ring-1 focus:ring-primary/40"
+            style="background-color: var(--color-input-bg); color: var(--color-text-primary); border-color: var(--color-input-border)"
+          />
+          <button
+            type="button"
+            class="px-3 py-1.5 rounded-md text-xs font-medium border hover:bg-accent-gray disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer transition-colors"
+            style="color: var(--color-text-primary); border-color: var(--color-input-border)"
+            disabled={!urlInput.trim()}
+            on:click={addByUrl}
+          >
+            Add
+          </button>
+        </div>
+        {#if urlError}
+          <p class="text-xs text-red-500">{urlError}</p>
+        {/if}
+      </div>
+    {/if}
+  </div>
 </div>
 

--- a/src/components/MentionDropdown.svelte
+++ b/src/components/MentionDropdown.svelte
@@ -1,3 +1,19 @@
+<script context="module" lang="ts">
+	// Portal action — mounts the node directly to document.body so the
+	// dropdown's position:fixed is viewport-relative (otherwise a
+	// transform on the containing modal would scope it to the modal box).
+	function portal(node: HTMLElement) {
+		document.body.appendChild(node);
+		return {
+			destroy() {
+				if (node.parentNode === document.body) {
+					document.body.removeChild(node);
+				}
+			}
+		};
+	}
+</script>
+
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 	import CustomAvatar from './CustomAvatar.svelte';
@@ -32,7 +48,11 @@
 </script>
 
 {#if show}
-	<div class="mention-dropdown" style="border-color: var(--color-input-border); top: {fixedTop}px; left: {fixedLeft}px;">
+	<div
+		use:portal
+		class="mention-dropdown"
+		style="border-color: var(--color-input-border); top: {fixedTop}px; left: {fixedLeft}px;"
+	>
 		{#if suggestions.length > 0}
 			<div class="mention-dropdown-content">
 				{#each suggestions as suggestion, index}

--- a/src/components/PostComposer.svelte
+++ b/src/components/PostComposer.svelte
@@ -461,10 +461,7 @@
                   aria-multiline="true"
                   data-placeholder="What are you eating, cooking, or loving?"
                   on:keydown={handleKeydown}
-                  on:input={() => {
-                    content = mentionCtrl.handleInput();
-                    lastRenderedContent = content;
-                  }}
+                  on:input={() => mentionCtrl.handleInput()}
                   on:beforeinput={(e) => mentionCtrl.handleBeforeInput(e)}
                   on:paste={(e) => mentionCtrl.handlePaste(e)}
                 ></div>

--- a/src/components/Recipe/DirectionsPhases.svelte
+++ b/src/components/Recipe/DirectionsPhases.svelte
@@ -1,22 +1,115 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
+  import { browser } from '$app/environment';
   import type { DirectionPhase } from '$lib/parser';
 
   export let phases: DirectionPhase[];
+  export let recipeId: string = '';
 
   // Directions are no longer grouped into phases — render every step as a
   // single flat numbered list. Prop shape kept for call-site compatibility.
   $: steps = phases.flatMap((p) => p.steps);
+
+  // Check state persisted per-recipe in localStorage, same pattern as
+  // Ingredients. Keyed by step number (stable across the flattened list).
+  const STORAGE_PREFIX = 'recipe_directions_checked:';
+  let checked: Set<number> = new Set();
+
+  $: storageKey = `${STORAGE_PREFIX}${recipeId}`;
+
+  onMount(() => {
+    if (!browser || !recipeId) return;
+    try {
+      const stored = localStorage.getItem(storageKey);
+      if (stored) {
+        const nums = JSON.parse(stored) as number[];
+        checked = new Set(nums);
+      }
+    } catch {
+      // ignore
+    }
+  });
+
+  function toggle(n: number) {
+    const next = new Set(checked);
+    if (next.has(n)) next.delete(n);
+    else next.add(n);
+    checked = next;
+    if (browser && recipeId) {
+      try {
+        localStorage.setItem(storageKey, JSON.stringify([...next]));
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  function clearAll() {
+    checked = new Set();
+    if (browser && recipeId) {
+      try {
+        localStorage.removeItem(storageKey);
+      } catch {
+        // ignore
+      }
+    }
+  }
 </script>
 
 {#if steps.length > 0}
   <div class="directions-phases">
-    <h2 class="text-2xl font-bold mb-4">Directions</h2>
-    <div id="directions" class="rounded-lg border border-input-border p-4" style="background-color: var(--color-bg-secondary);">
-      <ol class="space-y-3 list-none">
-        {#each steps as step}
-          <li class="flex gap-3">
-            <span class="font-semibold text-primary flex-shrink-0">{step.number}.</span>
-            <span class="flex-1">{step.text}</span>
+    <div class="flex items-baseline justify-between mb-4">
+      <h2 class="text-2xl font-bold">Directions</h2>
+      {#if checked.size > 0}
+        <button
+          type="button"
+          class="text-sm text-caption hover:text-primary transition-colors px-2 py-1 rounded cursor-pointer print:hidden"
+          on:click={clearAll}
+          aria-label="Clear checked steps"
+        >
+          Clear
+        </button>
+      {/if}
+    </div>
+    <div
+      id="directions"
+      class="rounded-lg border border-input-border p-4"
+      style="background-color: var(--color-bg-secondary);"
+    >
+      <ol class="flex flex-col gap-1 list-none">
+        {#each steps as step (step.number)}
+          <li>
+            <button
+              type="button"
+              class="flex items-start gap-3 w-full text-left py-1.5 rounded group cursor-pointer hover:bg-accent-gray/50 transition-colors"
+              on:click={() => toggle(step.number)}
+              aria-pressed={checked.has(step.number)}
+            >
+              <span
+                class="flex-shrink-0 w-5 h-5 mt-0.5 rounded border-2 flex items-center justify-center transition-colors"
+                style={checked.has(step.number)
+                  ? 'background: var(--color-primary); border-color: var(--color-primary); color: white;'
+                  : 'border-color: var(--color-input-border);'}
+                aria-hidden="true"
+              >
+                {#if checked.has(step.number)}
+                  <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+                    <path
+                      d="M2 6l3 3 5-6"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                {/if}
+              </span>
+              <span
+                class="font-semibold text-primary flex-shrink-0"
+                class:struck={checked.has(step.number)}>{step.number}.</span
+              >
+              <span class="flex-1" class:struck={checked.has(step.number)}>{step.text}</span>
+            </button>
           </li>
         {/each}
       </ol>
@@ -27,5 +120,16 @@
 <style>
   .directions-phases {
     margin-top: 1.5rem;
+  }
+
+  .struck {
+    text-decoration: line-through;
+    color: var(--color-caption);
+  }
+
+  @media print {
+    .directions-phases button {
+      cursor: default;
+    }
   }
 </style>

--- a/src/components/Recipe/DirectionsPhases.svelte
+++ b/src/components/Recipe/DirectionsPhases.svelte
@@ -1,198 +1,31 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import { browser } from '$app/environment';
   import type { DirectionPhase } from '$lib/parser';
-  import ChevronDownIcon from 'phosphor-svelte/lib/CaretDown';
-  import ChevronUpIcon from 'phosphor-svelte/lib/CaretUp';
 
   export let phases: DirectionPhase[];
 
-  // Track expanded state for each phase using object for better Svelte reactivity
-  let expandedPhases: Record<string, boolean> = {};
-  let initialized = false;
-
-  // Initialize first phase as expanded when phases become available
-  $: if (phases.length > 0 && !initialized) {
-    initialized = true;
-    if (browser) {
-      const hash = window.location.hash;
-      if (hash && hash.startsWith('#directions-')) {
-        const phaseId = hash.replace('#directions-', '');
-        if (phases.some(p => p.id === phaseId)) {
-          expandedPhases = { [phaseId]: true };
-        } else {
-          expandedPhases = { [phases[0].id]: true };
-        }
-      } else {
-        expandedPhases = { [phases[0].id]: true };
-      }
-    } else {
-      // SSR: expand first phase by default
-      expandedPhases = { [phases[0].id]: true };
-    }
-  }
-
-  // Handle hash changes after mount
-  onMount(() => {
-    const handleHashChange = () => {
-      const hash = window.location.hash;
-      if (hash && hash.startsWith('#directions-')) {
-        const phaseId = hash.replace('#directions-', '');
-        if (phases.some(p => p.id === phaseId)) {
-          expandedPhases = { ...expandedPhases, [phaseId]: true };
-          setTimeout(() => {
-            const element = document.getElementById(`directions-${phaseId}`);
-            if (element) {
-              element.scrollIntoView({ behavior: 'smooth', block: 'start' });
-            }
-          }, 100);
-        }
-      }
-    };
-
-    window.addEventListener('hashchange', handleHashChange);
-    return () => window.removeEventListener('hashchange', handleHashChange);
-  });
-
-  function togglePhase(phaseId: string) {
-    expandedPhases = {
-      ...expandedPhases,
-      [phaseId]: !expandedPhases[phaseId]
-    };
-  }
-
-  function expandAll() {
-    const newState: Record<string, boolean> = {};
-    phases.forEach(p => { newState[p.id] = true; });
-    expandedPhases = newState;
-  }
-
-  function collapseAll() {
-    expandedPhases = {};
-  }
-
-  function updateHash(phaseId: string) {
-    if (browser) {
-      window.history.replaceState(null, '', `#directions-${phaseId}`);
-    }
-  }
+  // Directions are no longer grouped into phases — render every step as a
+  // single flat numbered list. Prop shape kept for call-site compatibility.
+  $: steps = phases.flatMap((p) => p.steps);
 </script>
 
-<div class="directions-phases">
-  <div class="flex justify-between items-center mb-4">
-    <h2 class="text-2xl font-bold">Directions</h2>
-    <div class="flex gap-2">
-      <button
-        type="button"
-        on:click={expandAll}
-        class="text-sm text-caption hover:text-primary transition-colors px-2 py-1 rounded cursor-pointer"
-        aria-label="Expand all phases"
-      >
-        Expand all
-      </button>
-      <span class="text-caption">|</span>
-      <button
-        type="button"
-        on:click={collapseAll}
-        class="text-sm text-caption hover:text-primary transition-colors px-2 py-1 rounded cursor-pointer"
-        aria-label="Collapse all phases"
-      >
-        Collapse all
-      </button>
+{#if steps.length > 0}
+  <div class="directions-phases">
+    <h2 class="text-2xl font-bold mb-4">Directions</h2>
+    <div id="directions" class="rounded-lg border border-input-border p-4" style="background-color: var(--color-bg-secondary);">
+      <ol class="space-y-3 list-none">
+        {#each steps as step}
+          <li class="flex gap-3">
+            <span class="font-semibold text-primary flex-shrink-0">{step.number}.</span>
+            <span class="flex-1">{step.text}</span>
+          </li>
+        {/each}
+      </ol>
     </div>
   </div>
-
-  <div class="flex flex-col gap-3">
-    {#each phases as phase (phase.id)}
-      <div
-        id="directions-{phase.id}"
-        class="phase-container border border-input-border rounded-lg overflow-hidden transition-all"
-      >
-        <div>
-          <button
-            type="button"
-            class="phase-header w-full flex justify-between items-center p-4 hover:bg-input-bg transition-colors text-left"
-            on:click={() => {
-              togglePhase(phase.id);
-              updateHash(phase.id);
-            }}
-            aria-expanded={expandedPhases[phase.id] || false}
-            aria-controls="phase-content-{phase.id}"
-          >
-            <div class="flex flex-col gap-1 flex-1">
-              <h3 class="font-semibold text-lg">{phase.title}</h3>
-              <span class="text-sm text-caption">
-                {phase.steps.length} {phase.steps.length === 1 ? 'step' : 'steps'}
-              </span>
-            </div>
-            <div class="flex-shrink-0 ml-4">
-              {#if expandedPhases[phase.id]}
-                <ChevronUpIcon size={20} class="text-caption" />
-              {:else}
-                <ChevronDownIcon size={20} class="text-caption" />
-              {/if}
-            </div>
-          </button>
-
-          {#if !expandedPhases[phase.id] && phase.steps.length > 0}
-            <!-- Preview: show first 1-2 steps when collapsed -->
-            <div class="px-4 pb-4 text-caption opacity-50 space-y-1.5 text-sm">
-              {#each phase.steps.slice(0, Math.min(2, phase.steps.length)) as step}
-                <div class="flex gap-2">
-                  <span class="font-medium opacity-70">{step.number}.</span>
-                  <span>{step.text}</span>
-                </div>
-              {/each}
-              {#if phase.steps.length > 2}
-                <div class="text-xs italic opacity-60 mt-1">... and {phase.steps.length - 2} more {phase.steps.length - 2 === 1 ? 'step' : 'steps'}</div>
-              {/if}
-            </div>
-          {/if}
-        </div>
-
-        <div
-          id="phase-content-{phase.id}"
-          class="phase-content overflow-hidden transition-all duration-300"
-          style="max-height: {expandedPhases[phase.id] ? '10000px' : '0px'}; opacity: {expandedPhases[phase.id] ? '1' : '0'};"
-        >
-          <div class="p-4 pt-0">
-            <!-- Full steps when expanded -->
-            <ol class="space-y-3 list-none">
-              {#each phase.steps as step}
-                <li class="flex gap-3">
-                  <span class="font-semibold text-primary flex-shrink-0">{step.number}.</span>
-                  <span class="flex-1">{step.text}</span>
-                </li>
-              {/each}
-            </ol>
-          </div>
-        </div>
-      </div>
-    {/each}
-  </div>
-</div>
+{/if}
 
 <style>
   .directions-phases {
     margin-top: 1.5rem;
   }
-
-  .phase-container {
-    background-color: var(--color-bg-secondary);
-  }
-
-  .phase-header {
-    cursor: pointer;
-    outline: none;
-  }
-
-  .phase-header:focus-visible {
-    outline: 2px solid var(--color-primary);
-    outline-offset: -2px;
-  }
-
-  .phase-content {
-    will-change: max-height, opacity;
-  }
 </style>
-

--- a/src/components/Recipe/Ingredients.svelte
+++ b/src/components/Recipe/Ingredients.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { browser } from '$app/environment';
+
+  export let items: string[] = [];
+  export let recipeId: string;
+
+  // Check state persisted per-recipe in localStorage keyed by event id.
+  // Keyed by index; edits that change ingredient ordering invalidate
+  // existing checks — acceptable for this cooking-UX use case.
+  const STORAGE_PREFIX = 'recipe_ingredients_checked:';
+  let checked: Set<number> = new Set();
+
+  $: storageKey = `${STORAGE_PREFIX}${recipeId}`;
+
+  onMount(() => {
+    if (!browser || !recipeId) return;
+    try {
+      const stored = localStorage.getItem(storageKey);
+      if (stored) {
+        const indices = JSON.parse(stored) as number[];
+        checked = new Set(indices);
+      }
+    } catch {
+      // ignore corrupt entries
+    }
+  });
+
+  function toggle(index: number) {
+    const next = new Set(checked);
+    if (next.has(index)) next.delete(index);
+    else next.add(index);
+    checked = next;
+    if (browser && recipeId) {
+      try {
+        localStorage.setItem(storageKey, JSON.stringify([...next]));
+      } catch {
+        // quota exceeded / disabled — state still works in-memory
+      }
+    }
+  }
+
+  function clearAll() {
+    checked = new Set();
+    if (browser && recipeId) {
+      try {
+        localStorage.removeItem(storageKey);
+      } catch {
+        // ignore
+      }
+    }
+  }
+</script>
+
+{#if items.length > 0}
+  <div id="ingredients-section" class="ingredients-section">
+    <div class="flex items-baseline justify-between mb-4">
+      <h2 class="text-2xl font-bold">Ingredients</h2>
+      {#if checked.size > 0}
+        <button
+          type="button"
+          class="text-sm text-caption hover:text-primary transition-colors px-2 py-1 rounded cursor-pointer print:hidden"
+          on:click={clearAll}
+          aria-label="Clear checked ingredients"
+        >
+          Clear
+        </button>
+      {/if}
+    </div>
+    <ul class="flex flex-col gap-0.5 list-none">
+      {#each items as item, i (i)}
+        <li>
+          <button
+            type="button"
+            class="flex items-start gap-3 w-full text-left py-1.5 rounded group cursor-pointer hover:bg-accent-gray/50 transition-colors"
+            on:click={() => toggle(i)}
+            aria-pressed={checked.has(i)}
+          >
+            <span
+              class="flex-shrink-0 w-5 h-5 mt-0.5 rounded border-2 flex items-center justify-center transition-colors"
+              class:is-checked={checked.has(i)}
+              style={checked.has(i)
+                ? 'background: var(--color-primary); border-color: var(--color-primary); color: white;'
+                : 'border-color: var(--color-input-border);'}
+              aria-hidden="true"
+            >
+              {#if checked.has(i)}
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+                  <path
+                    d="M2 6l3 3 5-6"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              {/if}
+            </span>
+            <span class="flex-1" class:struck={checked.has(i)}>{item}</span>
+          </button>
+        </li>
+      {/each}
+    </ul>
+  </div>
+{/if}
+
+<style>
+  .ingredients-section {
+    margin-top: 1.5rem;
+  }
+
+  .struck {
+    text-decoration: line-through;
+    color: var(--color-caption);
+  }
+
+  @media print {
+    .ingredients-section button {
+      cursor: default;
+    }
+  }
+</style>

--- a/src/components/Recipe/Recipe.svelte
+++ b/src/components/Recipe/Recipe.svelte
@@ -50,6 +50,7 @@
   import { resolveProfileByPubkey } from '$lib/profileResolver';
   import { buildCanonicalRecipeShareUrl } from '$lib/utils/share';
   import DirectionsPhases from './DirectionsPhases.svelte';
+  import Ingredients from './Ingredients.svelte';
   import AddToListModal from '../grocery/AddToListModal.svelte';
   import PrintRecipeModal from './PrintRecipeModal.svelte';
   import GatedRecipePayment from '../GatedRecipePayment.svelte';
@@ -609,12 +610,32 @@
     // Match "## Details" followed by content until next "##" heading or end
     const detailsSectionRegex = /## Details\s*\n[\s\S]*?(?=\n## |$)/i;
     if (detailsSectionRegex.test(beforeDirections)) {
-      markdownBeforeDirections = beforeDirections.replace(detailsSectionRegex, '').trim();
+      beforeDirections = beforeDirections.replace(detailsSectionRegex, '').trim();
+    }
+
+    // Extract the Ingredients list so it can render as a checkbox component
+    // outside the prose markdown. Strip the section from the prose-rendered
+    // chunk so we don't get a duplicate bullet list.
+    const ingredientsSectionRegex = /## Ingredients\s*\n([\s\S]*?)(?=\n## |$)/i;
+    const ingredientsMatch = beforeDirections.match(ingredientsSectionRegex);
+    if (ingredientsMatch) {
+      const items: string[] = [];
+      const lines = ingredientsMatch[1].split('\n');
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed.startsWith('- ')) items.push(trimmed.substring(2).trim());
+        else if (trimmed.startsWith('* ')) items.push(trimmed.substring(2).trim());
+        else if (trimmed && !trimmed.startsWith('#')) items.push(trimmed);
+      }
+      ingredientItems = items;
+      markdownBeforeDirections = beforeDirections.replace(ingredientsSectionRegex, '').trim();
     } else {
+      ingredientItems = [];
       markdownBeforeDirections = beforeDirections;
     }
   }
 
+  let ingredientItems: string[] = [];
   let markdownBeforeDirections = '';
   let markdownAfterDirections = '';
 
@@ -968,16 +989,9 @@
           }
         }}
         scrollToIngredients={() => {
-          // Try to find Ingredients section and scroll to it
           setTimeout(() => {
-            const headings = document.querySelectorAll('article .prose h2');
-            for (const heading of headings) {
-              const text = heading.textContent?.trim().toLowerCase();
-              if (text === 'ingredients') {
-                heading.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                break;
-              }
-            }
+            const el = document.getElementById('ingredients-section');
+            if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
           }, 100);
         }}
       />
@@ -1048,9 +1062,15 @@
         </div>
       {/if}
 
-      <!-- Collapsible Directions -->
+      <!-- Ingredients with checkboxes — persisted per recipe so checks
+           survive reloads while cooking -->
+      {#if ingredientItems.length > 0}
+        <Ingredients items={ingredientItems} recipeId={event.id} />
+      {/if}
+
+      <!-- Directions with checkboxes -->
       {#if directionsPhases.length > 0}
-        <DirectionsPhases phases={directionsPhases} />
+        <DirectionsPhases phases={directionsPhases} recipeId={event.id} />
       {/if}
 
       <!-- Content after Directions -->

--- a/src/components/StringComboBox.svelte
+++ b/src/components/StringComboBox.svelte
@@ -19,6 +19,7 @@
   // Drag state
   let draggedIndex: number | null = null;
   let dragOverIndex: number | null = null;
+  let dragOverPosition: 'before' | 'after' = 'before';
 
   function removeTag(index: number) {
     let nSelected = $selected;
@@ -86,25 +87,34 @@
       e.dataTransfer.dropEffect = 'move';
     }
     dragOverIndex = index;
+    // Determine whether the cursor is in the top or bottom half of the
+    // target. This lets users drop past the last item (cursor below midpoint
+    // of the final row = "after"), which was previously impossible.
+    const target = e.currentTarget as HTMLElement;
+    const rect = target.getBoundingClientRect();
+    dragOverPosition = e.clientY < rect.top + rect.height / 2 ? 'before' : 'after';
   }
 
   function handleDrop(e: DragEvent, index: number) {
     e.preventDefault();
 
-    if (draggedIndex === null || draggedIndex === index) {
+    if (draggedIndex === null) {
       resetDragState();
       return;
     }
 
-    let nSelected = [...$selected];
-    const draggedItem = nSelected[draggedIndex];
-
-    // Remove from old position
-    nSelected.splice(draggedIndex, 1);
-
-    // Insert at new position
-    const insertIndex = draggedIndex < index ? index - 1 : index;
-    nSelected.splice(insertIndex, 0, draggedItem);
+    // Convert drop-target + before/after into an absolute destination index,
+    // then account for the dragged item being removed from an earlier slot.
+    let destIndex = dragOverPosition === 'after' ? index + 1 : index;
+    const nSelected = [...$selected];
+    const [draggedItem] = nSelected.splice(draggedIndex, 1);
+    if (draggedIndex < destIndex) destIndex--;
+    if (destIndex === draggedIndex) {
+      // No-op reorder — restore and bail
+      resetDragState();
+      return;
+    }
+    nSelected.splice(destIndex, 0, draggedItem);
 
     selected.set(nSelected);
     resetDragState();
@@ -117,12 +127,13 @@
   function resetDragState() {
     draggedIndex = null;
     dragOverIndex = null;
+    dragOverPosition = 'before';
   }
 </script>
 
 <div class="mb-0">
   {#if $selected.length > 0}
-    <ul class="flex flex-col gap-2 mb-2">
+    <ul class="flex flex-col mb-2">
       {#each $selected as tag, index (tag + index)}
         <li
           draggable={editingIndex !== index}
@@ -131,12 +142,16 @@
           on:drop={(e) => handleDrop(e, index)}
           on:dragend={handleDragEnd}
           on:dragleave={() => { if (dragOverIndex === index) dragOverIndex = null; }}
-          class="flex items-center gap-2 input transition-all duration-150
-            {dragOverIndex === index && draggedIndex !== index ? 'border-primary border-2' : ''}
-            {draggedIndex === index ? 'opacity-50' : ''}
-            {editingIndex === index ? 'ring-2 ring-primary border-primary' : ''}"
+          class="py-1 first:pt-0 last:pb-0"
           transition:slide|global={{ duration: 300 }}
         >
+          <div
+            class="flex items-center gap-2 input transition-all duration-150
+              {dragOverIndex === index && draggedIndex !== index && dragOverPosition === 'before' ? 'drop-indicator-top' : ''}
+              {dragOverIndex === index && draggedIndex !== index && dragOverPosition === 'after' ? 'drop-indicator-bottom' : ''}
+              {draggedIndex === index ? 'opacity-50' : ''}
+              {editingIndex === index ? 'ring-2 ring-primary border-primary' : ''}"
+          >
           <!-- Grip handle -->
           <button
             type="button"
@@ -200,6 +215,7 @@
               <TrashIcon size={16} />
             </button>
           </div>
+          </div>
         </li>
       {/each}
     </ul>
@@ -210,3 +226,13 @@
   <input bind:value={inputNewThing} class="input grow" {placeholder} />
   <Button on:click={addTag} primary={false}>Add</Button>
 </form>
+
+<style>
+  /* Drop-position indicators — use box-shadow so they don't shift layout */
+  :global(.drop-indicator-top) {
+    box-shadow: inset 0 3px 0 0 var(--color-primary);
+  }
+  :global(.drop-indicator-bottom) {
+    box-shadow: inset 0 -3px 0 0 var(--color-primary);
+  }
+</style>

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -290,19 +290,16 @@ ${additionalMarkdown}
   return template;
 }
 
-// Phase definitions for grouping directions
+// Phase shape preserved for component/print-modal compatibility. We no longer
+// auto-group directions into phases — the keyword heuristic frequently
+// mis-classified steps (e.g. assigning "Bake for 65 minutes" to Finishing),
+// which confused readers more than it helped. `extractAndGroupDirections` now
+// always returns a single "Directions" phase containing every step.
 export interface DirectionPhase {
   id: string;
   title: string;
   steps: Array<{ number: number; text: string }>;
 }
-
-const PHASE_KEYWORDS: Record<string, string[]> = {
-  preparation: ['crust', 'dough', 'pastry', 'base', 'bottom', 'prepare', 'ready', 'separate bowl'],
-  mixing: ['mix', 'combine', 'blend', 'beat', 'whisk', 'fold', 'stir', 'cream', 'batter', 'mixture', 'filling', 'cheesecake', 'cream cheese', 'layer', 'add', 'ingredients'],
-  baking: ['preheat', 'bake', 'oven', 'temperature', 'degrees', 'minutes', 'scoop', 'cookie sheet', 'baking sheet', 'cook', 'roast', 'grill'],
-  finishing: ['cool', 'chill', 'refrigerate', 'set', 'rest', 'garnish', 'serve', 'raspberr', 'mint', 'sprinkle', 'decorate', 'top', 'walnuts', 'nuts', 'ganache', 'chocolate', 'melt', 'chocolate chips']
-};
 
 /**
  * Flexible parser for directions that handles various formats
@@ -385,69 +382,33 @@ function extractDirectionsFlexible(markdown: string): Array<{ number: number; te
 }
 
 /**
- * Extracts directions from markdown and groups them into phases
+ * Extracts directions from markdown. Returns a single "Directions" phase so
+ * downstream renderers/print code don't have to change shape.
  */
 export function extractAndGroupDirections(markdown: string): {
   directions: DirectionPhase[];
   markdownWithoutDirections: string;
 } {
   const steps = extractDirectionsFlexible(markdown);
-  
-  if (steps.length === 0) {
-    // Return empty phases and original markdown if directions can't be parsed
-    return { directions: [], markdownWithoutDirections: markdown };
-  }
-
-  // Group steps into phases
-  // Note: Phases are generic enough to work for various recipe types
-  // Steps are automatically grouped based on keyword matching
-  const phases: DirectionPhase[] = [
-    { id: 'preparation', title: 'Preparation', steps: [] },
-    { id: 'mixing', title: 'Mixing & Combining', steps: [] },
-    { id: 'baking', title: 'Baking & Cooking', steps: [] },
-    { id: 'finishing', title: 'Finishing & Serving', steps: [] }
-  ];
-
-  let currentPhaseIndex = 0;
-
-  for (const step of steps) {
-    const stepLower = step.text.toLowerCase();
-    
-    // Use keyword matching to assign steps to phases (only move forward)
-    let phaseFound = false;
-    for (let i = currentPhaseIndex; i < phases.length; i++) {
-      const keywords = PHASE_KEYWORDS[phases[i].id];
-      if (keywords && keywords.some(keyword => stepLower.includes(keyword))) {
-        currentPhaseIndex = i;
-        phaseFound = true;
-        break;
-      }
-    }
-
-    // Assign step to current phase (or keep in current phase if no keywords matched)
-    phases[currentPhaseIndex].steps.push(step);
-  }
-
-  // Filter out empty phases
-  const nonEmptyPhases = phases.filter(phase => phase.steps.length > 0);
 
   // Remove Directions section from markdown (case-insensitive, handles various formats)
   let markdownWithoutDirections = markdown;
-  
-  // Try to remove ## Directions section
   const directionsSectionRegex = /## Directions\s*\n[\s\S]*?(?=\n## |$)/i;
   if (directionsSectionRegex.test(markdownWithoutDirections)) {
     markdownWithoutDirections = markdownWithoutDirections.replace(directionsSectionRegex, '').trim();
   } else {
-    // Try without ##
     const altDirectionsRegex = /(?:^|\n)Directions\s*\n[\s\S]*?(?=\n(?:## |[A-Z][a-z]+:)|$)/i;
     if (altDirectionsRegex.test(markdownWithoutDirections)) {
       markdownWithoutDirections = markdownWithoutDirections.replace(altDirectionsRegex, '').trim();
     }
   }
 
+  if (steps.length === 0) {
+    return { directions: [], markdownWithoutDirections };
+  }
+
   return {
-    directions: nonEmptyPhases,
+    directions: [{ id: 'directions', title: 'Directions', steps }],
     markdownWithoutDirections
   };
 }

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -14,22 +14,26 @@ md.renderer.rules.link_open = function(tokens, idx, options, env, self) {
   return defaultRender(tokens, idx, options, env, self);
 };
 
-// DOMPurify's default config can drop target/rel on <a> in some browsers;
-// force both back on after sanitization so rendered markdown links always
-// open in a new tab (important for the recipe editor preview — clicking a
-// link in-place would otherwise destroy unsaved edits).
-if (typeof window !== 'undefined') {
-  DOMPurify.addHook('afterSanitizeAttributes', (node) => {
-    if (node.tagName === 'A') {
-      node.setAttribute('target', '_blank');
-      node.setAttribute('rel', 'noopener noreferrer');
-    }
-  });
-}
+// Dedicated DOMPurify instance for markdown so the afterSanitizeAttributes
+// hook doesn't leak into every other sanitize() call in the app (the longform
+// editor and a handful of other callers import DOMPurify directly). The hook
+// forces target=_blank + rel on every <a> — DOMPurify drops those attrs in
+// some configs, which caused the recipe-editor markdown preview to navigate
+// in-place and destroy unsaved edits.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const markdownPurifier =
+  typeof window !== 'undefined' ? DOMPurify(window as any) : null;
+markdownPurifier?.addHook('afterSanitizeAttributes', (node) => {
+  if (node.tagName === 'A') {
+    node.setAttribute('target', '_blank');
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+});
 
 export function parseMarkdown(markdown: string) {
   const parsedMarkdown = md.render(markdown);
-  return DOMPurify.sanitize(parsedMarkdown, { ADD_ATTR: ['target'] });
+  const purifier = markdownPurifier ?? DOMPurify;
+  return purifier.sanitize(parsedMarkdown, { ADD_ATTR: ['target'] });
 }
 
 interface MarkdownInformation {

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -14,9 +14,22 @@ md.renderer.rules.link_open = function(tokens, idx, options, env, self) {
   return defaultRender(tokens, idx, options, env, self);
 };
 
+// DOMPurify's default config can drop target/rel on <a> in some browsers;
+// force both back on after sanitization so rendered markdown links always
+// open in a new tab (important for the recipe editor preview — clicking a
+// link in-place would otherwise destroy unsaved edits).
+if (typeof window !== 'undefined') {
+  DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+    if (node.tagName === 'A') {
+      node.setAttribute('target', '_blank');
+      node.setAttribute('rel', 'noopener noreferrer');
+    }
+  });
+}
+
 export function parseMarkdown(markdown: string) {
   const parsedMarkdown = md.render(markdown);
-  return DOMPurify.sanitize(parsedMarkdown);
+  return DOMPurify.sanitize(parsedMarkdown, { ADD_ATTR: ['target'] });
 }
 
 interface MarkdownInformation {

--- a/src/routes/create/+page.svelte
+++ b/src/routes/create/+page.svelte
@@ -14,7 +14,7 @@
   import { addClientTagToEvent } from '$lib/nip89';
   import Button from '../../components/Button.svelte';
   import MarkdownEditor from '../../components/MarkdownEditor.svelte';
-  import { onMount, onDestroy } from 'svelte';
+  import { onMount, onDestroy, tick } from 'svelte';
   import { RECIPE_TAG_PREFIX_NEW } from '$lib/consts';
   import {
     saveDraft,
@@ -60,7 +60,13 @@
 
   let cancelListenerAttached = false;
 
-  onMount(() => {
+  // Auto-save state
+  let autoSaveTimer: ReturnType<typeof setTimeout> | null = null;
+  let initialLoadComplete = false;
+  let lastSavedSignature = '';
+  const AUTO_SAVE_DEBOUNCE_MS = 2000;
+
+  onMount(async () => {
     if ($userPublickey == '') goto('/login');
 
     // Initialize draft store
@@ -76,13 +82,71 @@
       window.addEventListener('create-cancel-requested', handleCancelRequest);
       cancelListenerAttached = true;
     }
+
+    // Wait for reactive statements to populate draftSignature, then arm auto-save
+    await tick();
+    lastSavedSignature = draftSignature;
+    initialLoadComplete = true;
   });
 
   onDestroy(() => {
     if (browser && cancelListenerAttached) {
       window.removeEventListener('create-cancel-requested', handleCancelRequest);
     }
+    if (autoSaveTimer) {
+      clearTimeout(autoSaveTimer);
+      autoSaveTimer = null;
+    }
   });
+
+  function scheduleAutoSave() {
+    if (autoSaveTimer) clearTimeout(autoSaveTimer);
+    autoSaveTimer = setTimeout(runAutoSave, AUTO_SAVE_DEBOUNCE_MS);
+  }
+
+  async function runAutoSave() {
+    autoSaveTimer = null;
+    // If a manual save is in flight, wait and retry
+    if (isSavingDraft) {
+      scheduleAutoSave();
+      return;
+    }
+    if (!hasDraftContent) return;
+    if (draftSignature === lastSavedSignature) return;
+
+    const signatureAtSave = draftSignature;
+    isSavingDraft = true;
+    try {
+      const draftData = {
+        title,
+        images: $images,
+        tags: $selectedTags,
+        summary,
+        chefsnotes,
+        preptime,
+        cooktime,
+        servings,
+        ingredients: $ingredientsArray,
+        directions: $directionsArray,
+        additionalMarkdown
+      };
+      const { draftId } = saveDraft(draftData, currentDraftId || undefined, false);
+      currentDraftId = draftId;
+      if (browser) {
+        const url = new URL(window.location.href);
+        url.searchParams.set('draft', currentDraftId);
+        window.history.replaceState({}, '', url.toString());
+      }
+      lastSavedSignature = signatureAtSave;
+      if (currentDraftSyncStatus === undefined) currentDraftSyncStatus = 'local';
+      draftSaveMessage = 'Draft auto-saved';
+      setTimeout(() => {
+        if (draftSaveMessage === 'Draft auto-saved') draftSaveMessage = '';
+      }, 1500);
+    } finally {
+      isSavingDraft = false;
+    }
+  }
 
   function loadDraftById(draftId: string) {
     const draft = getDraftWithSyncState(draftId);
@@ -209,6 +273,7 @@
       draftSaveMessage = 'Saved locally';
     }
 
+    lastSavedSignature = draftSignature;
     isSavingDraft = false;
     setTimeout(() => {
       draftSaveMessage = '';
@@ -339,6 +404,30 @@
     $ingredientsArray.length > 0 ||
     $directionsArray.length > 0 ||
     Boolean(additionalMarkdown.trim());
+
+  // Serialized form of all draft fields — drives change detection for auto-save
+  $: draftSignature = JSON.stringify([
+    title,
+    $images,
+    $selectedTags,
+    summary,
+    chefsnotes,
+    preptime,
+    cooktime,
+    servings,
+    $ingredientsArray,
+    $directionsArray,
+    additionalMarkdown
+  ]);
+
+  // Schedule an auto-save whenever the draft changes (post-load)
+  $: if (
+    initialLoadComplete &&
+    hasDraftContent &&
+    draftSignature !== lastSavedSignature
+  ) {
+    scheduleAutoSave();
+  }
 </script>
 
 <svelte:head>

--- a/src/routes/create/+page.svelte
+++ b/src/routes/create/+page.svelte
@@ -83,8 +83,14 @@
       cancelListenerAttached = true;
     }
 
-    // Wait for reactive statements to populate draftSignature, then arm auto-save
+    // Compute the baseline signature immediately (bypassing the debounced
+    // reactive) so the first edit after load is detected correctly.
     await tick();
+    if (draftSignatureTimer) {
+      clearTimeout(draftSignatureTimer);
+      draftSignatureTimer = null;
+    }
+    recomputeDraftSignature();
     lastSavedSignature = draftSignature;
     initialLoadComplete = true;
   });
@@ -96,6 +102,10 @@
     if (autoSaveTimer) {
       clearTimeout(autoSaveTimer);
       autoSaveTimer = null;
+    }
+    if (draftSignatureTimer) {
+      clearTimeout(draftSignatureTimer);
+      draftSignatureTimer = null;
     }
   });
 
@@ -111,7 +121,18 @@
       scheduleAutoSave();
       return;
     }
-    if (!hasDraftContent) return;
+    // Flush any pending debounced signature computation so we compare against
+    // the latest typed state, not the previous tick's.
+    if (draftSignatureTimer) {
+      clearTimeout(draftSignatureTimer);
+      draftSignatureTimer = null;
+      recomputeDraftSignature();
+    }
+    // Skip the very first save when the composer is empty and there's no
+    // existing draft — no point creating an empty draft entry. But once a
+    // draft exists, always persist subsequent changes (including clearing
+    // all fields) so the "I deleted everything" state is saved too.
+    if (!hasDraftContent && !currentDraftId) return;
     if (draftSignature === lastSavedSignature) return;
 
     const signatureAtSave = draftSignature;
@@ -400,25 +421,60 @@
     $directionsArray.length > 0 ||
     Boolean(additionalMarkdown.trim());
 
-  // Serialized form of all draft fields — drives change detection for auto-save
-  $: draftSignature = JSON.stringify([
-    title,
-    $images,
-    $selectedTags,
-    summary,
-    chefsnotes,
-    preptime,
-    cooktime,
-    servings,
-    $ingredientsArray,
-    $directionsArray,
-    additionalMarkdown
-  ]);
+  // Serialized form of all draft fields — drives change detection for
+  // auto-save. Declared explicitly (and the compute debounced via the
+  // reactive below) so TS knows the var exists before onMount reads it,
+  // and so we don't re-JSON.stringify the entire draft on every keystroke
+  // for recipes with long ingredient/direction lists.
+  let draftSignature = '';
+  let draftSignatureTimer: ReturnType<typeof setTimeout> | null = null;
 
-  // Schedule an auto-save whenever the draft changes (post-load)
+  function recomputeDraftSignature() {
+    draftSignature = JSON.stringify([
+      title,
+      $images,
+      $selectedTags,
+      summary,
+      chefsnotes,
+      preptime,
+      cooktime,
+      servings,
+      $ingredientsArray,
+      $directionsArray,
+      additionalMarkdown
+    ]);
+  }
+
+  $: {
+    // Touch every draft field so Svelte tracks it as a dep.
+    title;
+    $images;
+    $selectedTags;
+    summary;
+    chefsnotes;
+    preptime;
+    cooktime;
+    servings;
+    $ingredientsArray;
+    $directionsArray;
+    additionalMarkdown;
+    if (!browser) {
+      recomputeDraftSignature();
+    } else {
+      if (draftSignatureTimer) clearTimeout(draftSignatureTimer);
+      draftSignatureTimer = setTimeout(() => {
+        draftSignatureTimer = null;
+        recomputeDraftSignature();
+      }, 250);
+    }
+  }
+
+  // Schedule an auto-save whenever the draft changes (post-load). We also
+  // allow the save-through-empty case when a draft already exists so that
+  // clearing all fields on an existing draft is persisted.
   $: if (
     initialLoadComplete &&
-    hasDraftContent &&
+    (hasDraftContent || currentDraftId) &&
     draftSignature !== lastSavedSignature
   ) {
     scheduleAutoSave();

--- a/src/routes/create/+page.svelte
+++ b/src/routes/create/+page.svelte
@@ -104,9 +104,9 @@
     autoSaveTimer = setTimeout(runAutoSave, AUTO_SAVE_DEBOUNCE_MS);
   }
 
-  async function runAutoSave() {
+  function runAutoSave() {
     autoSaveTimer = null;
-    // If a manual save is in flight, wait and retry
+    // Defer to a manual save in flight; retry once it completes
     if (isSavingDraft) {
       scheduleAutoSave();
       return;
@@ -115,37 +115,32 @@
     if (draftSignature === lastSavedSignature) return;
 
     const signatureAtSave = draftSignature;
-    isSavingDraft = true;
-    try {
-      const draftData = {
-        title,
-        images: $images,
-        tags: $selectedTags,
-        summary,
-        chefsnotes,
-        preptime,
-        cooktime,
-        servings,
-        ingredients: $ingredientsArray,
-        directions: $directionsArray,
-        additionalMarkdown
-      };
-      const { draftId } = saveDraft(draftData, currentDraftId || undefined, false);
-      currentDraftId = draftId;
-      if (browser) {
-        const url = new URL(window.location.href);
-        url.searchParams.set('draft', currentDraftId);
-        window.history.replaceState({}, '', url.toString());
-      }
-      lastSavedSignature = signatureAtSave;
-      if (currentDraftSyncStatus === undefined) currentDraftSyncStatus = 'local';
-      draftSaveMessage = 'Draft auto-saved';
-      setTimeout(() => {
-        if (draftSaveMessage === 'Draft auto-saved') draftSaveMessage = '';
-      }, 1500);
-    } finally {
-      isSavingDraft = false;
+    const draftData = {
+      title,
+      images: $images,
+      tags: $selectedTags,
+      summary,
+      chefsnotes,
+      preptime,
+      cooktime,
+      servings,
+      ingredients: $ingredientsArray,
+      directions: $directionsArray,
+      additionalMarkdown
+    };
+    const { draftId } = saveDraft(draftData, currentDraftId || undefined, false);
+
+    // Only rewrite the URL when the draft id first gets assigned — avoids
+    // thrashing $page and causing the editor to jump while typing.
+    if (browser && currentDraftId !== draftId) {
+      const url = new URL(window.location.href);
+      url.searchParams.set('draft', draftId);
+      window.history.replaceState({}, '', url.toString());
     }
+    currentDraftId = draftId;
+    lastSavedSignature = signatureAtSave;
+    // No isSavingDraft toggle and no status message — keep auto-save silent
+    // so it doesn't mutate UI that's in the user's field of view.
   }
 
   function loadDraftById(draftId: string) {


### PR DESCRIPTION
## Summary

Three related recipe-display improvements on top of #306 → #305 → #304.

### 1. Remove auto-grouping of directions into phases

The keyword heuristic was mis-classifying steps — e.g. a banana-bread recipe landed `Heat oven to 350°` under "Baking & Cooking" and every remaining step (including `Bake for 65 minutes`) under "Finishing & Serving", which read as nonsense.

Drop `PHASE_KEYWORDS` and the phase-assignment loop. `extractAndGroupDirections` now always returns a single `{ id: 'directions', title: 'Directions', steps }` phase; the collapsibles, expand/collapse controls, and hash-scroll per phase are gone with the phase concept. Existing callers (Recipe, PrintRecipeModal) work unchanged because both already handle the single-phase case.

### 2. Tickable ingredient checkboxes (closes #223)

Replace the bullet-list ingredients with a checkbox list so cooks can tick off items as they shop or cook. Checks persist per-recipe in `localStorage` keyed by the Nostr event id (`recipe_ingredients_checked:<id>`) so state survives reloads and navigation. A "Clear" affordance appears once anything is checked.

Implementation: extract the `## Ingredients` section out of the prose "before directions" chunk the same way `## Details` already is, parse its items, and render them via a new `Ingredients.svelte` component between the prose and DirectionsPhases. Updated `scrollToIngredients` to target the new section's DOM id. `PrintRecipeModal` pulls ingredients from `event.content` independently, so printing is unaffected.

### 3. Tickable direction checkboxes

Mirror the ingredients pattern for directions. Checks persist at `recipe_directions_checked:<id>`; checked steps get strikethrough + muted color but retain their step number for easy resumption. Step text is left verbatim — no scaling, no transformation.

## Notes

- Stacked on #306 → #305 → #304. Once those merge, this PR's diff collapses to 3 commits touching `parser.ts`, `Recipe.svelte`, `DirectionsPhases.svelte`, and the new `Ingredients.svelte`.
- Recipe scaling (the "double the recipe" math) is **intentionally out of scope** for this PR and will follow in a separate branch/PR (#308).

## Test plan

- [ ] Open a recipe — directions render as a flat numbered list (no phase headings or collapsibles).
- [ ] Ingredients render as checkable items; tapping toggles the check + strikethrough; "Clear" resets.
- [ ] Reload the page — ingredient and direction checks persist.
- [ ] Open a different recipe — checks are recipe-specific, not shared.
- [ ] Overview card's "jump to ingredients" button still scrolls correctly.
- [ ] Print Recipe Modal still shows ingredients and directions.
- [ ] No regressions for recipes that have no `## Ingredients` section (they simply don't render the checkbox block).