### PR TITLE
feat(recipe): scale ingredient quantities (½×, 1×, 2×, 3×)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.230",
+  "version": "4.2.231",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/Recipe/Ingredients.svelte
+++ b/src/components/Recipe/Ingredients.svelte
@@ -1,25 +1,42 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { browser } from '$app/environment';
+  import { scaleIngredientLine } from '$lib/ingredientScaling';
 
   export let items: string[] = [];
   export let recipeId: string;
 
-  // Check state persisted per-recipe in localStorage keyed by event id.
-  // Keyed by index; edits that change ingredient ordering invalidate
-  // existing checks — acceptable for this cooking-UX use case.
-  const STORAGE_PREFIX = 'recipe_ingredients_checked:';
-  let checked: Set<number> = new Set();
+  // Presets a home cook actually reaches for — half, original, double, triple.
+  const SCALE_PRESETS: Array<{ value: number; label: string }> = [
+    { value: 0.5, label: '½×' },
+    { value: 1, label: '1×' },
+    { value: 2, label: '2×' },
+    { value: 3, label: '3×' }
+  ];
 
-  $: storageKey = `${STORAGE_PREFIX}${recipeId}`;
+  // Check state & scale persisted per-recipe in localStorage.
+  const CHECKED_KEY = 'recipe_ingredients_checked:';
+  const SCALE_KEY = 'recipe_ingredients_scale:';
+
+  let checked: Set<number> = new Set();
+  let scale = 1;
+
+  $: checkedStorageKey = `${CHECKED_KEY}${recipeId}`;
+  $: scaleStorageKey = `${SCALE_KEY}${recipeId}`;
+  $: scaledItems = items.map((item) => scaleIngredientLine(item, scale));
 
   onMount(() => {
     if (!browser || !recipeId) return;
     try {
-      const stored = localStorage.getItem(storageKey);
-      if (stored) {
-        const indices = JSON.parse(stored) as number[];
+      const storedChecked = localStorage.getItem(checkedStorageKey);
+      if (storedChecked) {
+        const indices = JSON.parse(storedChecked) as number[];
         checked = new Set(indices);
+      }
+      const storedScale = localStorage.getItem(scaleStorageKey);
+      if (storedScale) {
+        const n = parseFloat(storedScale);
+        if (Number.isFinite(n) && n > 0) scale = n;
       }
     } catch {
       // ignore corrupt entries
@@ -33,9 +50,21 @@
     checked = next;
     if (browser && recipeId) {
       try {
-        localStorage.setItem(storageKey, JSON.stringify([...next]));
+        localStorage.setItem(checkedStorageKey, JSON.stringify([...next]));
       } catch {
-        // quota exceeded / disabled — state still works in-memory
+        // quota / disabled — state still works in-memory
+      }
+    }
+  }
+
+  function setScale(n: number) {
+    scale = n;
+    if (browser && recipeId) {
+      try {
+        if (n === 1) localStorage.removeItem(scaleStorageKey);
+        else localStorage.setItem(scaleStorageKey, String(n));
+      } catch {
+        // ignore
       }
     }
   }
@@ -44,7 +73,7 @@
     checked = new Set();
     if (browser && recipeId) {
       try {
-        localStorage.removeItem(storageKey);
+        localStorage.removeItem(checkedStorageKey);
       } catch {
         // ignore
       }
@@ -54,21 +83,49 @@
 
 {#if items.length > 0}
   <div id="ingredients-section" class="ingredients-section">
-    <div class="flex items-baseline justify-between mb-4">
+    <div class="flex flex-wrap items-baseline justify-between gap-2 mb-3">
       <h2 class="text-2xl font-bold">Ingredients</h2>
-      {#if checked.size > 0}
-        <button
-          type="button"
-          class="text-sm text-caption hover:text-primary transition-colors px-2 py-1 rounded cursor-pointer print:hidden"
-          on:click={clearAll}
-          aria-label="Clear checked ingredients"
+      <div class="flex items-center gap-2 print:hidden">
+        <div
+          class="flex items-center rounded-full border overflow-hidden"
+          style="border-color: var(--color-input-border);"
+          role="group"
+          aria-label="Scale ingredients"
         >
-          Clear
-        </button>
-      {/if}
+          {#each SCALE_PRESETS as preset}
+            <button
+              type="button"
+              class="px-2.5 py-1 text-xs font-medium transition-colors cursor-pointer"
+              class:is-active={scale === preset.value}
+              style={scale === preset.value
+                ? 'background: var(--color-primary); color: white;'
+                : 'color: var(--color-text-primary);'}
+              on:click={() => setScale(preset.value)}
+              aria-pressed={scale === preset.value}
+            >
+              {preset.label}
+            </button>
+          {/each}
+        </div>
+        {#if checked.size > 0}
+          <button
+            type="button"
+            class="text-sm text-caption hover:text-primary transition-colors px-2 py-1 rounded cursor-pointer"
+            on:click={clearAll}
+            aria-label="Clear checked ingredients"
+          >
+            Clear
+          </button>
+        {/if}
+      </div>
     </div>
+    {#if scale !== 1}
+      <p class="text-xs text-caption mb-3">
+        Scaled to {scale}× — directions and cook times are unchanged.
+      </p>
+    {/if}
     <ul class="flex flex-col gap-0.5 list-none">
-      {#each items as item, i (i)}
+      {#each scaledItems as item, i (i)}
         <li>
           <button
             type="button"
@@ -78,7 +135,6 @@
           >
             <span
               class="flex-shrink-0 w-5 h-5 mt-0.5 rounded border-2 flex items-center justify-center transition-colors"
-              class:is-checked={checked.has(i)}
               style={checked.has(i)
                 ? 'background: var(--color-primary); border-color: var(--color-primary); color: white;'
                 : 'border-color: var(--color-input-border);'}

--- a/src/lib/ingredientScaling.ts
+++ b/src/lib/ingredientScaling.ts
@@ -1,0 +1,149 @@
+/**
+ * Ingredient-quantity scaling.
+ *
+ * Parses the leading numeric quantity from an ingredient line (whole,
+ * decimal, fraction, mixed number, unicode fraction, or a range of the
+ * same) and re-emits the line with the quantity multiplied by `scale`.
+ * Lines without a parseable leading number are returned unchanged, so
+ * entries like "salt to taste" or "a pinch of cinnamon" pass through
+ * without damage.
+ */
+
+const UNICODE_FRACTIONS: Record<string, number> = {
+	'½': 0.5,
+	'⅓': 1 / 3,
+	'⅔': 2 / 3,
+	'¼': 0.25,
+	'¾': 0.75,
+	'⅕': 0.2,
+	'⅖': 0.4,
+	'⅗': 0.6,
+	'⅘': 0.8,
+	'⅙': 1 / 6,
+	'⅚': 5 / 6,
+	'⅛': 0.125,
+	'⅜': 0.375,
+	'⅝': 0.625,
+	'⅞': 0.875
+};
+
+const FRACTION_CHARS = Object.keys(UNICODE_FRACTIONS).join('');
+
+// Leading quantity pattern: mixed number, fraction, decimal, whole int,
+// or single unicode fraction. Ordered most-specific-first — JS alternation
+// doesn't try for longest match.
+const QTY_TOKEN = `(?:\\d+\\s+\\d+\\/\\d+|\\d+\\/\\d+|\\d+\\.\\d+|\\d+|[${FRACTION_CHARS}])`;
+
+// Whole-line pattern: leading quantity, optional range (" - quantity"),
+// and the remainder. The range separator accepts hyphen, en-dash, em-dash,
+// or "to" surrounded by spaces. The whitespace before the range lives
+// INSIDE the optional group so backtracking restores it to `rest` when
+// there is no range (otherwise "2 tbsp" would lose its space and render
+// as "2tbsp" after scaling).
+const QTY_RE = new RegExp(
+	`^\\s*(${QTY_TOKEN})(?:\\s*(?:-|–|—|\\s+to\\s+)\\s*(${QTY_TOKEN}))?(.*)$`
+);
+
+/** Parse a quantity string (one of the accepted forms) to a number. */
+function parseQuantity(raw: string): number | null {
+	const s = raw.trim();
+	if (!s) return null;
+
+	// Single unicode fraction
+	if (s.length === 1 && UNICODE_FRACTIONS[s] !== undefined) {
+		return UNICODE_FRACTIONS[s];
+	}
+
+	// Mixed number: "1 1/2"
+	const mixed = s.match(/^(\d+)\s+(\d+)\/(\d+)$/);
+	if (mixed) {
+		const denom = parseInt(mixed[3], 10);
+		if (denom === 0) return null;
+		return parseInt(mixed[1], 10) + parseInt(mixed[2], 10) / denom;
+	}
+
+	// Simple fraction: "1/2"
+	const frac = s.match(/^(\d+)\/(\d+)$/);
+	if (frac) {
+		const denom = parseInt(frac[2], 10);
+		if (denom === 0) return null;
+		return parseInt(frac[1], 10) / denom;
+	}
+
+	// Decimal or whole number
+	if (/^\d+(?:\.\d+)?$/.test(s)) {
+		const n = parseFloat(s);
+		return Number.isFinite(n) ? n : null;
+	}
+
+	return null;
+}
+
+// Common culinary fractions to match against — rendered as unicode when
+// a scaled value lands within tolerance.
+const NICE_FRACTIONS: Array<{ val: number; display: string }> = [
+	{ val: 0.125, display: '⅛' },
+	{ val: 0.25, display: '¼' },
+	{ val: 1 / 3, display: '⅓' },
+	{ val: 0.375, display: '⅜' },
+	{ val: 0.5, display: '½' },
+	{ val: 0.625, display: '⅝' },
+	{ val: 2 / 3, display: '⅔' },
+	{ val: 0.75, display: '¾' },
+	{ val: 0.875, display: '⅞' }
+];
+
+const FRACTION_TOLERANCE = 0.015;
+
+/** Format a scaled numeric quantity for display. */
+function formatQuantity(n: number): string {
+	if (!Number.isFinite(n)) return String(n);
+	if (Math.abs(n) < 0.005) return '0';
+
+	const whole = Math.floor(n);
+	const frac = n - whole;
+
+	// Exact whole (or near-whole after rounding error)
+	if (frac < FRACTION_TOLERANCE) {
+		return String(whole);
+	}
+	// Near-next-whole (e.g. 0.998 → 1)
+	if (1 - frac < FRACTION_TOLERANCE) {
+		return String(whole + 1);
+	}
+
+	for (const { val, display } of NICE_FRACTIONS) {
+		if (Math.abs(frac - val) < FRACTION_TOLERANCE) {
+			return whole === 0 ? display : `${whole} ${display}`;
+		}
+	}
+
+	// Fall back to a short decimal; strip trailing zeros.
+	return Number(n.toFixed(2)).toString();
+}
+
+/**
+ * Scale a single ingredient line. Returns the line unchanged when it has
+ * no parseable leading quantity (e.g. "salt to taste").
+ */
+export function scaleIngredientLine(line: string, scale: number): string {
+	if (scale === 1 || !Number.isFinite(scale) || scale <= 0) return line;
+	const m = line.match(QTY_RE);
+	if (!m) return line;
+
+	const first = parseQuantity(m[1]);
+	if (first === null) return line;
+
+	const second = m[2] ? parseQuantity(m[2]) : null;
+	const rest = m[3] ?? '';
+
+	const scaledFirst = formatQuantity(first * scale);
+	if (second !== null) {
+		const scaledSecond = formatQuantity(second * scale);
+		return `${scaledFirst}–${scaledSecond}${rest}`;
+	}
+	return `${scaledFirst}${rest}`;
+}
+
+// Exposed for tests
+export const __test = { parseQuantity, formatQuantity, QTY_RE };


### PR DESCRIPTION
## Summary

Add a scale selector to the recipe's Ingredients section so cooks can double, triple, or halve a recipe on the fly. Chosen scale persists per-recipe in `localStorage` (`recipe_ingredients_scale:<id>`) and only appears in the UI when ≠ 1×; when active a caption notes that directions and cook times are unchanged (they don't scale linearly with batch size).

## Parsing

The new `$lib/ingredientScaling.ts` utility handles the common ingredient-line shapes:

- whole / decimal / fraction / mixed number / unicode fraction — `2`, `0.5`, `1/2`, `1 1/2`, `½`
- optional range — `2-3 cloves`, `1/2 to 1 cup`

Non-parseable lines pass through **unchanged** so entries like _"salt to taste"_ or _"a pinch of cinnamon"_ are never mangled. Output reformats to nice unicode fractions (½, ⅓, ⅔, ¼, ¾, ⅛, ⅜, ⅝, ⅞) when the scaled value lands within tolerance, else a short decimal.

## Examples

| Original | 2× | 3× |
| --- | --- | --- |
| `2 cups flour` | `4 cups flour` | `6 cups flour` |
| `1/2 tsp salt` | `1 tsp salt` | `1 ½ tsp salt` |
| `1 1/2 cups milk` | `3 cups milk` | `4 ½ cups milk` |
| `1/3 cup sugar` | `⅔ cup sugar` | `1 cup sugar` |
| `2-3 cloves garlic` | `4–6 cloves garlic` | `6–9 cloves garlic` |
| `salt to taste` | unchanged | unchanged |

## Notes

- Stacked on #308 → #306 → #305 → #304. Once those merge, this PR's diff collapses to the new `ingredientScaling.ts` plus a small Ingredients.svelte header update.
- Parser lives in a pure utility so future surfaces (print modal, grocery list export) can reuse it.

## Test plan

- [x] Set scale to 2× / 3× / ½× → quantities update in place; unicode fractions render correctly.
- [x] Reload — chosen scale persists per recipe.
- [x] Switch recipes — scale is recipe-specific, not shared.
- [ ] Scale a recipe with a ranged ingredient (`2-3 cloves`) — both ends scale.
- [ ] Scale a recipe containing non-numeric entries (`salt to taste`, `pinch of cinnamon`) — those pass through unchanged.
- [ ] Printing still shows the original (unscaled) ingredient list (`PrintRecipeModal` reads from `event.content` directly).