### PR TITLE
feat(nourish): stability foundation — versioning schema + cache key partitioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.232",
+  "version": "4.2.233",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.231",
+  "version": "4.2.232",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.230",
+  "version": "4.2.231",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/Recipe/Recipe.svelte
+++ b/src/components/Recipe/Recipe.svelte
@@ -61,6 +61,7 @@
   import NourishPill from '../nourish/NourishPill.svelte';
   import { fetchNourishEvent } from '$lib/nourish/nourishRelay';
   import { getNourishCache } from '$lib/nourish/cache';
+  import { NOURISH_PROMPT_VERSION } from '$lib/nourish/types';
   import { membershipStatusMap, queueMembershipLookup, type MembershipStatus } from '$lib/stores/membershipStatus';
 
   export let event: NDKEvent;
@@ -118,16 +119,22 @@
     }
 
     const targetEventId = event.id;
-
-    // Check localStorage first (instant)
-    const cached = getNourishCache(targetEventId);
-    if (cached) {
-      applyNourishScores(cached.scores);
-      return;
-    }
-    // Check relay in background
     const recipePubkey = event.author?.hexpubkey || event.pubkey;
     const recipeDTag = event.tags.find((t: string[]) => t[0] === 'd')?.[1] || '';
+
+    // Check localStorage first (instant)
+    if (recipePubkey && recipeDTag) {
+      const cached = getNourishCache({
+        recipePubkey,
+        recipeDTag,
+        promptVersion: NOURISH_PROMPT_VERSION
+      });
+      if (cached) {
+        applyNourishScores(cached.scores);
+        return;
+      }
+    }
+    // Check relay in background
     if (recipePubkey && recipeDTag && $ndk) {
       fetchNourishEvent($ndk, recipePubkey, recipeDTag).then((result) => {
         // Ignore stale result if event changed while fetching

--- a/src/components/nourish/NourishModal.svelte
+++ b/src/components/nourish/NourishModal.svelte
@@ -52,12 +52,23 @@
 		return { recipePubkey, recipeDTag };
 	}
 
+	// Cache key, or null when the event lacks the coordinates we need to
+	// build a unique key. Empty recipeDTag would collapse keys across
+	// recipes from the same author, so we skip the cache entirely rather
+	// than collide. Hex-validity check on recipePubkey matches the
+	// server-side guard in /api/nourish.
+	const HEX_64_RE = /^[a-fA-F0-9]{64}$/;
+	function toCacheKey(recipePubkey: string, recipeDTag: string) {
+		if (!recipeDTag || !HEX_64_RE.test(recipePubkey)) return null;
+		return { recipePubkey, recipeDTag, promptVersion: NOURISH_PROMPT_VERSION };
+	}
+
 	async function fetchScores() {
 		const { recipePubkey, recipeDTag } = getRecipeCoordinates();
-		const cacheKey = { recipePubkey, recipeDTag, promptVersion: NOURISH_PROMPT_VERSION };
+		const cacheKey = toCacheKey(recipePubkey, recipeDTag);
 
 		// 1. Check localStorage cache (instant)
-		const cached = getNourishCache(cacheKey);
+		const cached = cacheKey ? getNourishCache(cacheKey) : null;
 		if (cached) {
 			scores = cached.scores;
 			improvements = [];
@@ -70,7 +81,11 @@
 					}
 				}).catch(() => {});
 			}
-			analyzedAt = cached.timestamp ? Math.floor(cached.timestamp / 1000) : 0;
+			// Prefer the score's createdAt (when analysis actually ran) over
+			// the cache's timestamp (when localStorage last wrote). They
+			// diverge across reloads, and createdAt is the one users see in
+			// the "analyzed at" label.
+			analyzedAt = cached.createdAt ?? (cached.timestamp ? Math.floor(cached.timestamp / 1000) : 0);
 			return;
 		}
 
@@ -87,15 +102,20 @@
 
 					// Cache locally for next time, keyed under the relay event's
 					// own prompt version so a v1 hit doesn't collide with v2.
-					setNourishScores(
-						{ recipePubkey, recipeDTag, promptVersion: relayResult.promptVersion },
-						relayResult.scores,
-						{
-							contentHash: relayResult.contentHash,
-							createdAt: relayResult.createdAt,
-							improvements: relayResult.improvements
-						}
-					);
+					// Guarded by toCacheKey — if coordinates are incomplete we
+					// skip the write rather than produce a colliding key.
+					const writeKey = toCacheKey(recipePubkey, recipeDTag);
+					if (writeKey) {
+						setNourishScores(
+							{ ...writeKey, promptVersion: relayResult.promptVersion },
+							relayResult.scores,
+							{
+								contentHash: relayResult.contentHash,
+								createdAt: relayResult.createdAt,
+								improvements: relayResult.improvements
+							}
+						);
+					}
 
 					// Populate ingredient store from relay data (build dataset over time)
 					if (relayResult.ingredientSignals.length > 0) {
@@ -166,20 +186,19 @@
 
 			scores = data.scores;
 			analyzedAt = data.createdAt ?? Math.floor(Date.now() / 1000);
-			setNourishScores(
-				{
-					recipePubkey,
-					recipeDTag,
-					promptVersion: data.promptVersion ?? NOURISH_PROMPT_VERSION
-				},
-				data.scores,
-				{
-					contentHash,
-					createdAt: data.createdAt,
-					improvements: data.improvements,
-					ingredientSignals: data.ingredient_signals
-				}
-			);
+			const writeKey = toCacheKey(recipePubkey, recipeDTag);
+			if (writeKey) {
+				setNourishScores(
+					{ ...writeKey, promptVersion: data.promptVersion ?? NOURISH_PROMPT_VERSION },
+					data.scores,
+					{
+						contentHash,
+						createdAt: data.createdAt,
+						improvements: data.improvements,
+						ingredientSignals: data.ingredient_signals
+					}
+				);
+			}
 			buildImprovements(data.scores, data.improvements);
 
 			if (data.ingredient_signals?.length > 0) {

--- a/src/components/nourish/NourishModal.svelte
+++ b/src/components/nourish/NourishModal.svelte
@@ -86,12 +86,21 @@
 					// Cache locally for next time
 					setNourishScores(event.id, relayResult.scores, {
 						contentHash: relayResult.contentHash,
+						promptVersion: relayResult.promptVersion,
+						createdAt: relayResult.createdAt,
 						improvements: relayResult.improvements
 					});
 
 					// Populate ingredient store from relay data (build dataset over time)
 					if (relayResult.ingredientSignals.length > 0) {
-						ingredientStore.saveIngredients(relayResult.ingredientSignals, 'recipe', event.id).catch(() => {});
+						ingredientStore
+							.saveIngredients(
+								relayResult.ingredientSignals,
+								'recipe',
+								event.id,
+								relayResult.promptVersion
+							)
+							.catch(() => {});
 					}
 
 					// Check staleness
@@ -150,16 +159,20 @@
 			if (!data.success) { error = data.error || 'Failed to analyze recipe.'; return; }
 
 			scores = data.scores;
-			analyzedAt = Math.floor(Date.now() / 1000);
+			analyzedAt = data.createdAt ?? Math.floor(Date.now() / 1000);
 			setNourishScores(event.id, data.scores, {
 				contentHash,
+				promptVersion: data.promptVersion,
+				createdAt: data.createdAt,
 				improvements: data.improvements,
 				ingredientSignals: data.ingredient_signals
 			});
 			buildImprovements(data.scores, data.improvements);
 
 			if (data.ingredient_signals?.length > 0) {
-				ingredientStore.saveIngredients(data.ingredient_signals, 'recipe', event.id).catch(() => {});
+				ingredientStore
+					.saveIngredients(data.ingredient_signals, 'recipe', event.id, data.promptVersion)
+					.catch(() => {});
 			}
 		} catch (err) {
 			console.error('[Nourish] Fetch error:', err);

--- a/src/components/nourish/NourishModal.svelte
+++ b/src/components/nourish/NourishModal.svelte
@@ -53,8 +53,11 @@
 	}
 
 	async function fetchScores() {
+		const { recipePubkey, recipeDTag } = getRecipeCoordinates();
+		const cacheKey = { recipePubkey, recipeDTag, promptVersion: NOURISH_PROMPT_VERSION };
+
 		// 1. Check localStorage cache (instant)
-		const cached = getNourishCache(event.id);
+		const cached = getNourishCache(cacheKey);
 		if (cached) {
 			scores = cached.scores;
 			improvements = [];
@@ -75,7 +78,6 @@
 		checking = true;
 		error = '';
 		try {
-			const { recipePubkey, recipeDTag } = getRecipeCoordinates();
 			if (recipePubkey && recipeDTag && $ndk) {
 				const relayResult = await fetchNourishEvent($ndk, recipePubkey, recipeDTag);
 				if (relayResult) {
@@ -83,13 +85,17 @@
 					buildImprovements(relayResult.scores, relayResult.improvements);
 					analyzedAt = relayResult.createdAt;
 
-					// Cache locally for next time
-					setNourishScores(event.id, relayResult.scores, {
-						contentHash: relayResult.contentHash,
-						promptVersion: relayResult.promptVersion,
-						createdAt: relayResult.createdAt,
-						improvements: relayResult.improvements
-					});
+					// Cache locally for next time, keyed under the relay event's
+					// own prompt version so a v1 hit doesn't collide with v2.
+					setNourishScores(
+						{ recipePubkey, recipeDTag, promptVersion: relayResult.promptVersion },
+						relayResult.scores,
+						{
+							contentHash: relayResult.contentHash,
+							createdAt: relayResult.createdAt,
+							improvements: relayResult.improvements
+						}
+					);
 
 					// Populate ingredient store from relay data (build dataset over time)
 					if (relayResult.ingredientSignals.length > 0) {
@@ -160,13 +166,20 @@
 
 			scores = data.scores;
 			analyzedAt = data.createdAt ?? Math.floor(Date.now() / 1000);
-			setNourishScores(event.id, data.scores, {
-				contentHash,
-				promptVersion: data.promptVersion,
-				createdAt: data.createdAt,
-				improvements: data.improvements,
-				ingredientSignals: data.ingredient_signals
-			});
+			setNourishScores(
+				{
+					recipePubkey,
+					recipeDTag,
+					promptVersion: data.promptVersion ?? NOURISH_PROMPT_VERSION
+				},
+				data.scores,
+				{
+					contentHash,
+					createdAt: data.createdAt,
+					improvements: data.improvements,
+					ingredientSignals: data.ingredient_signals
+				}
+			);
 			buildImprovements(data.scores, data.improvements);
 
 			if (data.ingredient_signals?.length > 0) {

--- a/src/lib/nourish/cache.ts
+++ b/src/lib/nourish/cache.ts
@@ -10,6 +10,8 @@ interface CacheEntry {
 	timestamp: number;
 	version: string;
 	contentHash?: string;
+	promptVersion?: string;
+	createdAt?: number;
 	improvements?: string[];
 	ingredientSignals?: import('./types').IngredientSignal[];
 }
@@ -44,7 +46,13 @@ export function getNourishScores(eventId: string): NourishScores | null {
 export function setNourishScores(
 	eventId: string,
 	scores: NourishScores,
-	extra?: { contentHash?: string; improvements?: string[]; ingredientSignals?: import('./types').IngredientSignal[] }
+	extra?: {
+		contentHash?: string;
+		promptVersion?: string;
+		createdAt?: number;
+		improvements?: string[];
+		ingredientSignals?: import('./types').IngredientSignal[];
+	}
 ): void {
 	if (!browser) return;
 
@@ -54,6 +62,8 @@ export function setNourishScores(
 			timestamp: Date.now(),
 			version: NOURISH_CACHE_VERSION,
 			contentHash: extra?.contentHash,
+			promptVersion: extra?.promptVersion,
+			createdAt: extra?.createdAt,
 			improvements: extra?.improvements,
 			ingredientSignals: extra?.ingredientSignals
 		};

--- a/src/lib/nourish/cache.ts
+++ b/src/lib/nourish/cache.ts
@@ -3,12 +3,21 @@ import { NOURISH_CACHE_VERSION, type NourishScores, type ScanResponse } from './
 
 const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
-// ─── Recipe score cache (keyed by eventId) ───────────────────
+// Cache-schema major version, used as a key prefix so future schema
+// breaks can invalidate all prior entries independent of the minor
+// version-mismatch check below. Bump by changing NOURISH_CACHE_VERSION
+// in types.ts to a new major.
+const SCHEMA_MAJOR = NOURISH_CACHE_VERSION.split('.')[0];
+
+// ─── Recipe score cache ──────────────────────────────────────
+// Keyed by (recipePubkey, recipeDTag, promptVersion) so that a v1
+// score and a v2 score for the same recipe are distinct entries —
+// cache hit guarantees version match without a post-read check.
 
 interface CacheEntry {
 	scores: NourishScores;
 	timestamp: number;
-	version: string;
+	cacheVersion: string;
 	contentHash?: string;
 	promptVersion?: string;
 	createdAt?: number;
@@ -16,20 +25,26 @@ interface CacheEntry {
 	ingredientSignals?: import('./types').IngredientSignal[];
 }
 
-function cacheKey(eventId: string): string {
-	return `nourish_${eventId}`;
+export interface NourishCacheKey {
+	recipePubkey: string;
+	recipeDTag: string;
+	promptVersion: string;
 }
 
-export function getNourishCache(eventId: string): CacheEntry | null {
+function cacheKey({ recipePubkey, recipeDTag, promptVersion }: NourishCacheKey): string {
+	return `nourish_v${SCHEMA_MAJOR}_${recipePubkey}:${recipeDTag}:${promptVersion}`;
+}
+
+export function getNourishCache(key: NourishCacheKey): CacheEntry | null {
 	if (!browser) return null;
 
 	try {
-		const raw = localStorage.getItem(cacheKey(eventId));
+		const raw = localStorage.getItem(cacheKey(key));
 		if (!raw) return null;
 
 		const entry: CacheEntry = JSON.parse(raw);
 
-		if (entry.version !== NOURISH_CACHE_VERSION) return null;
+		if (entry.cacheVersion !== NOURISH_CACHE_VERSION) return null;
 		if (Date.now() - entry.timestamp > CACHE_TTL_MS) return null;
 
 		return entry;
@@ -38,17 +53,11 @@ export function getNourishCache(eventId: string): CacheEntry | null {
 	}
 }
 
-/** @deprecated Use getNourishCache for full entry with contentHash */
-export function getNourishScores(eventId: string): NourishScores | null {
-	return getNourishCache(eventId)?.scores ?? null;
-}
-
 export function setNourishScores(
-	eventId: string,
+	key: NourishCacheKey,
 	scores: NourishScores,
 	extra?: {
 		contentHash?: string;
-		promptVersion?: string;
 		createdAt?: number;
 		improvements?: string[];
 		ingredientSignals?: import('./types').IngredientSignal[];
@@ -60,14 +69,14 @@ export function setNourishScores(
 		const entry: CacheEntry = {
 			scores,
 			timestamp: Date.now(),
-			version: NOURISH_CACHE_VERSION,
+			cacheVersion: NOURISH_CACHE_VERSION,
 			contentHash: extra?.contentHash,
-			promptVersion: extra?.promptVersion,
+			promptVersion: key.promptVersion,
 			createdAt: extra?.createdAt,
 			improvements: extra?.improvements,
 			ingredientSignals: extra?.ingredientSignals
 		};
-		localStorage.setItem(cacheKey(eventId), JSON.stringify(entry));
+		localStorage.setItem(cacheKey(key), JSON.stringify(entry));
 	} catch {
 		// localStorage full or unavailable — silently ignore
 	}
@@ -78,7 +87,7 @@ export function setNourishScores(
 interface ScanCacheEntry {
 	data: ScanResponse;
 	timestamp: number;
-	version: string;
+	cacheVersion: string;
 }
 
 /** Derive a cache key from text with extra entropy to reduce collisions. */
@@ -101,7 +110,7 @@ export function getScanResult(text: string): ScanResponse | null {
 
 		const entry: ScanCacheEntry = JSON.parse(raw);
 
-		if (entry.version !== NOURISH_CACHE_VERSION) return null;
+		if (entry.cacheVersion !== NOURISH_CACHE_VERSION) return null;
 		if (Date.now() - entry.timestamp > CACHE_TTL_MS) return null;
 
 		return entry.data;
@@ -117,7 +126,7 @@ export function setScanResult(text: string, data: ScanResponse): void {
 		const entry: ScanCacheEntry = {
 			data,
 			timestamp: Date.now(),
-			version: NOURISH_CACHE_VERSION
+			cacheVersion: NOURISH_CACHE_VERSION
 		};
 		localStorage.setItem(hashText(text), JSON.stringify(entry));
 	} catch {

--- a/src/lib/nourish/index.ts
+++ b/src/lib/nourish/index.ts
@@ -12,7 +12,8 @@ export {
 	type IngredientRecord
 } from './types';
 
-export { getNourishScores, setNourishScores, getScanResult, setScanResult } from './cache';
+export { getNourishCache, setNourishScores, getScanResult, setScanResult } from './cache';
+export type { NourishCacheKey } from './cache';
 
 export { generateSuggestions, mergeImprovements } from './suggestions';
 

--- a/src/lib/nourish/ingredientStore.ts
+++ b/src/lib/nourish/ingredientStore.ts
@@ -60,7 +60,8 @@ class IngredientStoreManager {
 	async saveIngredients(
 		signals: IngredientSignal[],
 		source: 'recipe' | 'scan',
-		sourceId?: string
+		sourceId?: string,
+		promptVersion?: string
 	): Promise<void> {
 		if (!browser || signals.length === 0) return;
 		await this.dbReady;
@@ -79,7 +80,8 @@ class IngredientStoreManager {
 					contribution: signal.contribution,
 					source,
 					sourceId,
-					createdAt: now
+					createdAt: now,
+					promptVersion
 				};
 				store.put(record);
 			}

--- a/src/lib/nourish/nourishPublisher.server.ts
+++ b/src/lib/nourish/nourishPublisher.server.ts
@@ -97,11 +97,12 @@ export async function publishNourishEvent(opts: {
   try {
     const privKeyBytes = resolvePrivateKey(privateKey);
     const dTag = buildNourishDTag(recipePubkey, recipeDTag);
+    const createdAt = Math.floor(Date.now() / 1000);
 
     // Build and sign event using nostr-tools (works on CF Workers)
     const event = finalizeEvent({
       kind: 30078,
-      created_at: Math.floor(Date.now() / 1000),
+      created_at: createdAt,
       tags: [
         ['d', dTag],
         ['client', 'zap.cooking'],
@@ -123,7 +124,13 @@ export async function publishNourishEvent(opts: {
         summary: scores.summary,
         improvements,
         ingredient_signals: ingredientSignals,
-        version: scores.version
+        version: scores.version,
+        // Mirror identity fields into content so the payload is self-
+        // describing (tags already carry them; content duplication lets
+        // downstream consumers read either location).
+        promptVersion: NOURISH_PROMPT_VERSION,
+        contentHash,
+        createdAt
       })
     }, privKeyBytes);
 

--- a/src/lib/nourish/nourishPublisher.server.ts
+++ b/src/lib/nourish/nourishPublisher.server.ts
@@ -124,7 +124,7 @@ export async function publishNourishEvent(opts: {
         summary: scores.summary,
         improvements,
         ingredient_signals: ingredientSignals,
-        version: scores.version,
+        cacheVersion: scores.cacheVersion,
         // Mirror identity fields into content so the payload is self-
         // describing (tags already carry them; content duplication lets
         // downstream consumers read either location).

--- a/src/lib/nourish/nourishRelay.ts
+++ b/src/lib/nourish/nourishRelay.ts
@@ -126,9 +126,11 @@ export function parseNourishEvent(event: NDKEvent): NourishRelayResult | null {
       ? content.ingredient_signals.filter((i: any) => i && typeof i.name === 'string')
       : [];
 
-    // Extract metadata from tags
+    // Extract metadata from tags. Untagged legacy events surface as
+    // 'unknown' so the admin rescore-candidates view can triage them,
+    // rather than being silently mislabelled as v1.
     const contentHash = event.tags.find((t) => t[0] === 'content_hash')?.[1] || '';
-    const promptVersion = event.tags.find((t) => t[0] === 'prompt_version')?.[1] || '1';
+    const promptVersion = event.tags.find((t) => t[0] === 'prompt_version')?.[1] || 'unknown';
     const nourishVersion = event.tags.find((t) => t[0] === 'nourish_version')?.[1] || NOURISH_CACHE_VERSION;
 
     return {

--- a/src/lib/nourish/nourishRelay.ts
+++ b/src/lib/nourish/nourishRelay.ts
@@ -115,7 +115,9 @@ export function parseNourishEvent(event: NDKEvent): NourishRelayResult | null {
         reason: content.overall?.reason || `Weighted: Real Food 45%, Gut 35%, Protein 20%`
       },
       summary: content.summary || '',
-      version: content.version || NOURISH_CACHE_VERSION
+      // Accept both the new `cacheVersion` and the legacy `version` field
+      // so pre-2.0 events in the wild still parse.
+      cacheVersion: content.cacheVersion || content.version || NOURISH_CACHE_VERSION
     };
 
     const improvements: string[] = Array.isArray(content.improvements)

--- a/src/lib/nourish/types.ts
+++ b/src/lib/nourish/types.ts
@@ -86,6 +86,9 @@ export interface NourishResponse {
 	improvements?: string[];
 	ingredient_signals?: IngredientSignal[];
 	error?: string;
+	promptVersion?: string;
+	contentHash?: string;
+	createdAt?: number;
 }
 
 // ─── Scan Anything ───────────────────────────────────────────
@@ -103,6 +106,8 @@ export interface ScanResponse {
 	improvements?: string[];
 	ingredient_signals?: IngredientSignal[];
 	error?: string;
+	promptVersion?: string;
+	createdAt?: number;
 }
 
 // ─── Ingredient signals ──────────────────────────────────────
@@ -121,4 +126,5 @@ export interface IngredientRecord {
 	source: 'recipe' | 'scan';
 	sourceId?: string;
 	createdAt: number;
+	promptVersion?: string;
 }

--- a/src/lib/nourish/types.ts
+++ b/src/lib/nourish/types.ts
@@ -1,4 +1,4 @@
-export const NOURISH_CACHE_VERSION = '1.1';
+export const NOURISH_CACHE_VERSION = '2.0';
 export const NOURISH_PROMPT_VERSION = '1';
 
 /**
@@ -46,7 +46,7 @@ export interface NourishScores {
 	realFood: ScoreDetail;
 	overall: ScoreDetail;
 	summary: string;
-	version: string;
+	cacheVersion: string;
 }
 
 // ─── Overall score weights (transparent) ─────────────────────

--- a/src/routes/api/nourish/+server.ts
+++ b/src/routes/api/nourish/+server.ts
@@ -26,7 +26,7 @@
 
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
-import { NOURISH_CACHE_VERSION, computeOverallScore } from '$lib/nourish/types';
+import { NOURISH_CACHE_VERSION, NOURISH_PROMPT_VERSION, computeOverallScore } from '$lib/nourish/types';
 import { requireMembership } from './membershipCheck';
 
 const NOURISH_PROMPT = `You are a recipe analysis assistant for a cooking platform. Analyze the recipe below and return three food quality scores.
@@ -269,7 +269,17 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 			}
 		}
 
-		return json({ success: true, scores, improvements, ingredient_signals });
+		return json({
+			success: true,
+			scores,
+			improvements,
+			ingredient_signals,
+			// Identity fields — let clients cache/reconcile by promptVersion
+			// + contentHash + createdAt instead of inferring from cacheVersion.
+			promptVersion: NOURISH_PROMPT_VERSION,
+			contentHash: validContentHash ? contentHash.trim() : undefined,
+			createdAt: Math.floor(Date.now() / 1000)
+		});
 	} catch (error: any) {
 		console.error('[Nourish] Error:', error);
 		return json(

--- a/src/routes/api/nourish/+server.ts
+++ b/src/routes/api/nourish/+server.ts
@@ -217,7 +217,7 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 				reason: `Weighted: Real Food 45%, Gut 35%, Protein 20%`
 			},
 			summary: String(parsed.summary || ''),
-			version: NOURISH_CACHE_VERSION
+			cacheVersion: NOURISH_CACHE_VERSION
 		};
 
 		// Parse optional new fields gracefully (backward compatible)

--- a/src/routes/api/nourish/+server.ts
+++ b/src/routes/api/nourish/+server.ts
@@ -13,14 +13,27 @@
  *   title: string,
  *   ingredients: string[],
  *   tags: string[],
- *   servings: string
+ *   servings: string,
+ *   recipePubkey?: string,     // hex — required for pantry publish
+ *   recipeDTag?: string,       // required for pantry publish
+ *   contentHash?: string       // SHA-256 hex — required for pantry publish
  * }
  *
- * Returns:
+ * Success response:
  * {
- *   success: boolean,
- *   scores?: NourishScores,
- *   error?: string
+ *   success: true,
+ *   scores: NourishScores,              // includes cacheVersion
+ *   improvements: string[],             // up to 5
+ *   ingredient_signals: IngredientSignal[],
+ *   promptVersion: string,              // model/prompt identity
+ *   contentHash?: string,               // echoed when valid
+ *   createdAt: number                   // unix seconds
+ * }
+ *
+ * Error response:
+ * {
+ *   success: false,
+ *   error: string
  * }
  */
 

--- a/src/routes/api/nourish/scan/+server.ts
+++ b/src/routes/api/nourish/scan/+server.ts
@@ -240,7 +240,7 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 				reason: `Weighted: Real Food 45%, Gut 35%, Protein 20%`
 			},
 			summary: String(parsed.summary || ''),
-			version: NOURISH_CACHE_VERSION
+			cacheVersion: NOURISH_CACHE_VERSION
 		};
 
 		// Parse optional fields gracefully

--- a/src/routes/api/nourish/scan/+server.ts
+++ b/src/routes/api/nourish/scan/+server.ts
@@ -18,7 +18,7 @@
 
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
-import { NOURISH_CACHE_VERSION, computeOverallScore } from '$lib/nourish/types';
+import { NOURISH_CACHE_VERSION, NOURISH_PROMPT_VERSION, computeOverallScore } from '$lib/nourish/types';
 import { requireMembership } from '../membershipCheck';
 
 const SCAN_PROMPT = `You are a food analysis assistant for a cooking platform. Analyze the following food description and return quality scores.
@@ -267,7 +267,12 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 			scores,
 			quick_take,
 			improvements,
-			ingredient_signals
+			ingredient_signals,
+			// Identity fields — scans have no durable pantry cache, but
+			// response shape stays consistent with /api/nourish so clients
+			// can reconcile by promptVersion / createdAt.
+			promptVersion: NOURISH_PROMPT_VERSION,
+			createdAt: Math.floor(Date.now() / 1000)
 		});
 	} catch (error: any) {
 		console.error('[Nourish Scan] Error:', error);

--- a/src/routes/api/nourish/scan/+server.ts
+++ b/src/routes/api/nourish/scan/+server.ts
@@ -14,6 +14,23 @@
  *   title?: string;       // Optional label
  *   imageData?: string;   // Optional base64-encoded image for vision analysis (max ~20MB)
  * }
+ *
+ * Success response:
+ * {
+ *   success: true,
+ *   scores: NourishScores,              // includes cacheVersion
+ *   quick_take: string,                 // one-line narrative
+ *   improvements: string[],             // up to 5
+ *   ingredient_signals: IngredientSignal[],
+ *   promptVersion: string,              // model/prompt identity
+ *   createdAt: number                   // unix seconds
+ * }
+ *
+ * Error response:
+ * {
+ *   success: false,
+ *   error: string
+ * }
  */
 
 import { json, type RequestHandler } from '@sveltejs/kit';

--- a/src/routes/nourish/+page.svelte
+++ b/src/routes/nourish/+page.svelte
@@ -117,7 +117,9 @@
 
       // Save ingredient signals to build dataset over time
       if (data.ingredient_signals?.length) {
-        ingredientStore.saveIngredients(data.ingredient_signals, 'scan').catch(() => {});
+        ingredientStore
+          .saveIngredients(data.ingredient_signals, 'scan', undefined, data.promptVersion)
+          .catch(() => {});
       }
     } catch {
       scanError = "Couldn't analyze this one. Try again or rephrase.";


### PR DESCRIPTION
First of **four PRs** implementing the Nourish Stability feature (the follow-up to the Flag mechanism in #303). This one lays the versioning foundation; behavior changes land in PRs 2–4.

## Summary

Two atomic commits land here:

### Commit 1a — additive schema
Introduces `promptVersion`, `contentHash`, and `createdAt` as first-class fields on every Nourish surface (localStorage cache entries, pantry relay event content JSON, `/api/nourish` + `/api/nourish/scan` response bodies, IndexedDB ingredient records). Writes populate them; reads tolerate their absence. No key changes, no cache-version bump, no renames — safe to revert.

Also replaces the hard-coded `'1'` fallback in `nourishRelay.ts` for events missing a `prompt_version` tag with `'unknown'`. Untagged legacy events surface in the forthcoming admin "rescore candidates" view instead of being silently mislabelled as v1.

### Commit 1b — cache-version bump + key partitioning + rename
The destructive counterpart. Completes the foundation commits #2+ build on.

- Bumps `NOURISH_CACHE_VERSION` from `1.1` → `2.0`.
- Renames `NourishScores.version` → `NourishScores.cacheVersion`. The old name conflated two orthogonal concerns (cache schema vs score identity); after the rename the field is unambiguously schema, and score identity lives on the new `promptVersion`.
- Normalizes the cache key from `nourish_${eventId}` to `nourish_v${major}_${recipePubkey}:${recipeDTag}:${promptVersion}`. A v1 score and a v2 score for the same recipe are now distinct cache entries — cache hit = guaranteed version match, no post-read check needed. This addresses drift source #3 (multiple cache keys) from the Phase 1 enumeration.
- `getNourishCache` / `setNourishScores` now take a `NourishCacheKey` object (recipePubkey + recipeDTag + promptVersion) instead of an `eventId`.
- Deletes the deprecated `getNourishScores` shim — no remaining callers.
- Relay parser accepts both `content.cacheVersion` (new) and `content.version` (pre-2.0) so events in the wild still parse.

## Expected one-time cache eject behavior

⚠️ **First page load after deploy will show a pantry fetch for each Nourish score as the old cache is ejected.** This is expected and one-time; subsequent loads hit the new-format cache normally. The version-mismatch check already in `cache.ts` handles the ejection cleanly — no cleanup script needed.

## What's coming next (for context)

Three more PRs will land as part of Stability:

- **PR 2**: dedup (Layer-1 Promise cache), conflict resolution (`createdAt`-based write-through), pantry retry UI (replaces silent-compute fallback). Closes drift sources #1 (**BLOCKER**) and #2 (**BLOCKER**).
- **PR 3**: remaining drift fixes — opportunistic pantry republish (#4), drop scan caching (#7), refresh-button checks pantry first (#5), flag captures `promptVersion` from scored event (1c gap #3).
- **PR 4**: admin rescore loop — endpoint, version-aware grouping in `/admin/nourish-flags`, "Updated" badge, "model-upgrade candidates" view. Activates the Flag signal from #303.

## Test plan

- [ ] Deploy to preview; open a Nourish score; confirm one-time pantry refetch, then localStorage cache hit on reload
- [ ] Open a never-before-scored recipe; confirm normal compute + cache + pantry publish flow
- [ ] Legacy pantry events (any kind 30078 without `prompt_version` tag) parse without error and return `promptVersion: 'unknown'`
- [ ] `pnpm run check` — 4 pre-existing errors, unchanged
- [ ] `pnpm run build` — passes