### PR TITLE
feat(nourish): stability — dedup, conflict resolution, pantry retry UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.237",
+  "version": "4.2.238",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.235",
+  "version": "4.2.236",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.236",
+  "version": "4.2.237",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.234",
+  "version": "4.2.235",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.233",
+  "version": "4.2.234",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/Recipe/Recipe.svelte
+++ b/src/components/Recipe/Recipe.svelte
@@ -60,8 +60,7 @@
   import LeafIcon from 'phosphor-svelte/lib/Leaf';
   import NourishModal from '../nourish/NourishModal.svelte';
   import NourishPill from '../nourish/NourishPill.svelte';
-  import { fetchNourishEvent } from '$lib/nourish/nourishRelay';
-  import { getNourishCache } from '$lib/nourish/cache';
+  import { resolveScore } from '$lib/nourish/scoreResolver';
   import { NOURISH_PROMPT_VERSION } from '$lib/nourish/types';
   import { membershipStatusMap, queueMembershipLookup, type MembershipStatus } from '$lib/stores/membershipStatus';
 
@@ -123,24 +122,17 @@
     const recipePubkey = event.author?.hexpubkey || event.pubkey;
     const recipeDTag = event.tags.find((t: string[]) => t[0] === 'd')?.[1] || '';
 
-    // Check localStorage first (instant)
-    if (recipePubkey && recipeDTag) {
-      const cached = getNourishCache({
+    // Resolver walks L2 → L3 → L4 and returns a miss for invalid keys.
+    // Write-through on pantry hit is handled inside the resolver, so
+    // subsequent mounts of the same recipe skip the pantry query.
+    if ($ndk) {
+      resolveScore($ndk, {
         recipePubkey,
         recipeDTag,
         promptVersion: NOURISH_PROMPT_VERSION
-      });
-      if (cached) {
-        applyNourishScores(cached.scores);
-        return;
-      }
-    }
-    // Check relay in background
-    if (recipePubkey && recipeDTag && $ndk) {
-      fetchNourishEvent($ndk, recipePubkey, recipeDTag).then((result) => {
-        // Ignore stale result if event changed while fetching
+      }).then((result) => {
         if (event.id !== targetEventId) return;
-        if (result) applyNourishScores(result.scores);
+        if (result.status === 'hit') applyNourishScores(result.entry.scores);
       }).catch(() => {});
     }
   }

--- a/src/components/Recipe/Recipe.svelte
+++ b/src/components/Recipe/Recipe.svelte
@@ -122,9 +122,12 @@
     const recipePubkey = event.author?.hexpubkey || event.pubkey;
     const recipeDTag = event.tags.find((t: string[]) => t[0] === 'd')?.[1] || '';
 
-    // Resolver walks L2 → L3 → L4 and returns a miss for invalid keys.
-    // Write-through on pantry hit is handled inside the resolver, so
-    // subsequent mounts of the same recipe skip the pantry query.
+    // Resolver walks L2 → L3 → L4 gathering every candidate and picks
+    // the max-createdAt winner (write-through across layers handled
+    // internally). Invalid keys return a miss + emit a warn. Every
+    // call still awaits the pantry query in order to reconcile local
+    // state against the authoritative source — L2/L3 hits don't
+    // short-circuit the pantry read in commit 3's algorithm.
     if ($ndk) {
       resolveScore($ndk, {
         recipePubkey,

--- a/src/components/nourish/NourishLoadingState.svelte
+++ b/src/components/nourish/NourishLoadingState.svelte
@@ -30,6 +30,7 @@
   // window. Gating it on membership prevents non-members from bypassing
   // the paywall via the retry flow — the underlying analyzeRecipe path
   // already enforces this, but hiding the button is the cleaner UX.
+  let canEscape = false;
   $: canEscape = attemptCount >= 3 && hasMembership;
 
   const dispatch = createEventDispatcher<{

--- a/src/components/nourish/NourishLoadingState.svelte
+++ b/src/components/nourish/NourishLoadingState.svelte
@@ -1,0 +1,163 @@
+<script lang="ts">
+  /**
+   * NourishLoadingState — shared skeleton / retry / miss / offline UI
+   * for Nourish score surfaces. Ships in PR 2 commit 4 to close drift
+   * source #1 (silent compute on pantry timeout).
+   *
+   * States:
+   *   pending  — pantry query in flight; skeleton shimmer, no buttons
+   *   timeout  — pantry didn't respond; [Try again], plus [Score now]
+   *              escape hatch when attemptCount >= 3 (member only)
+   *   miss     — pantry confirmed no event; [Analyze] for members,
+   *              silent for non-members (matches existing UX)
+   *   offline  — navigator.onLine is false; no retry, no escape
+   *
+   * Variants:
+   *   full     — modal context, vertical stack with message + buttons
+   *   compact  — designed for future pill-context use (PR 3+). Not
+   *              wired in PR 2; present so subsequent PRs don't need
+   *              to introduce a second component.
+   */
+  import { createEventDispatcher } from 'svelte';
+  import Skeleton from '../Skeleton.svelte';
+
+  export let variant: 'full' | 'compact' = 'full';
+  export let state: 'pending' | 'timeout' | 'miss' | 'offline';
+  export let attemptCount = 0;
+  export let hasMembership = false;
+
+  // Escape hatch appears after three timeouts in the current 60s
+  // window. Gating it on membership prevents non-members from bypassing
+  // the paywall via the retry flow — the underlying analyzeRecipe path
+  // already enforces this, but hiding the button is the cleaner UX.
+  $: canEscape = attemptCount >= 3 && hasMembership;
+
+  const dispatch = createEventDispatcher<{
+    retry: void;
+    'score-now': void;
+    analyze: void;
+  }>();
+</script>
+
+{#if variant === 'full'}
+  <div class="nourish-loading nourish-loading--full">
+    {#if state === 'pending'}
+      <div class="skeleton-stack">
+        <Skeleton height="24px" width="100%" />
+        <Skeleton height="16px" width="70%" />
+        <Skeleton height="16px" width="85%" />
+      </div>
+    {:else if state === 'timeout'}
+      <div class="skeleton-stack">
+        <Skeleton height="24px" width="100%" animate={false} />
+      </div>
+      <p class="msg">Couldn't reach the Nourish index.</p>
+      <div class="actions">
+        <button type="button" class="btn-primary" on:click={() => dispatch('retry')}>
+          Try again
+        </button>
+        {#if canEscape}
+          <button type="button" class="btn-secondary" on:click={() => dispatch('score-now')}>
+            Score now
+          </button>
+        {/if}
+      </div>
+    {:else if state === 'miss'}
+      <p class="msg">No Nourish score yet for this recipe.</p>
+      {#if hasMembership}
+        <div class="actions">
+          <button type="button" class="btn-primary" on:click={() => dispatch('analyze')}>
+            Analyze
+          </button>
+        </div>
+      {/if}
+    {:else if state === 'offline'}
+      <p class="msg">You're offline. Nourish scores will load when you reconnect.</p>
+    {/if}
+  </div>
+{:else}
+  <!-- Compact variant for future pill-context use (PR 3+). -->
+  <span class="nourish-loading nourish-loading--compact">
+    {#if state === 'pending'}
+      <Skeleton height="14px" width="36px" />
+    {:else if state === 'timeout'}
+      <button
+        type="button"
+        class="compact-retry"
+        aria-label="Retry loading Nourish score"
+        on:click={() => dispatch('retry')}
+      >
+        ↻
+      </button>
+    {/if}
+  </span>
+{/if}
+
+<style>
+  .nourish-loading--full {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1rem 0;
+  }
+
+  .skeleton-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .msg {
+    color: var(--color-caption);
+    font-size: 0.875rem;
+    margin: 0;
+  }
+
+  .actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .btn-primary,
+  .btn-secondary {
+    padding: 0.4rem 0.9rem;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: opacity 0.15s ease;
+  }
+
+  .btn-primary {
+    background: var(--color-primary);
+    color: white;
+  }
+
+  .btn-secondary {
+    background: var(--color-input-bg);
+    color: var(--color-text-primary);
+    border: 1px solid var(--color-input-border);
+  }
+
+  .btn-primary:hover,
+  .btn-secondary:hover {
+    opacity: 0.85;
+  }
+
+  .nourish-loading--compact {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .compact-retry {
+    background: transparent;
+    border: 1px solid var(--color-input-border);
+    border-radius: 9999px;
+    width: 22px;
+    height: 22px;
+    font-size: 12px;
+    color: var(--color-caption);
+    cursor: pointer;
+  }
+</style>

--- a/src/components/nourish/NourishModal.svelte
+++ b/src/components/nourish/NourishModal.svelte
@@ -5,8 +5,6 @@
 	import Button from '../Button.svelte';
 	import LeafIcon from 'phosphor-svelte/lib/Leaf';
 	import LockIcon from 'phosphor-svelte/lib/Lock';
-	import SpinnerIcon from 'phosphor-svelte/lib/SpinnerGap';
-	// CaretDownIcon no longer needed — NourishResult handles expand
 	import ArrowClockwiseIcon from 'phosphor-svelte/lib/ArrowClockwise';
 	import { parseMarkdownForEditing } from '$lib/parser';
 	import { setNourishScores, type NourishCacheKey } from '$lib/nourish/cache';
@@ -17,7 +15,9 @@
 	import type { NourishScores } from '$lib/nourish/types';
 	import { NOURISH_PROMPT_VERSION } from '$lib/nourish/types';
 	import type { FlagTarget } from '$lib/nourish/flagSubmit';
+	import { onMount, onDestroy } from 'svelte';
 	import NourishResult from './NourishResult.svelte';
+	import NourishLoadingState from './NourishLoadingState.svelte';
 
 	export let open = false;
 	export let event: NDKEvent;
@@ -43,9 +43,50 @@
 	let stale = false;
 	let analyzedAt = 0;
 	let error = '';
+	// Pantry-timeout state — set when resolveScore returns
+	// { status: 'timeout' } (drift #1 fix: no more silent compute on
+	// pantry failure). Retry UI consumes attemptCount to decide when
+	// to surface the "Score now" escape hatch.
+	let pantryTimeout = false;
+	let attemptCount = 0;
+	let isOffline = false;
+
+	// Latch to prevent the reactive open-guard from re-firing fetchScores
+	// when the `checking` flag flips false → false on a miss. Without
+	// this, miss/timeout states would loop because the guard's deps
+	// re-evaluate on every `checking` transition. Cleared on modal close
+	// and on explicit handleRetry so retries still fire.
+	let fetched = false;
+
+	// Online/offline listeners — low-cost navigator.onLine check per
+	// the Phase 2 refinement. Accepts occasional false "offline"
+	// states; retry button dismisses it anyway.
+	function handleOnline() { isOffline = false; }
+	function handleOffline() { isOffline = true; }
+	onMount(() => {
+		if (typeof navigator === 'undefined') return;
+		isOffline = !navigator.onLine;
+		window.addEventListener('online', handleOnline);
+		window.addEventListener('offline', handleOffline);
+	});
+	onDestroy(() => {
+		if (typeof window === 'undefined') return;
+		window.removeEventListener('online', handleOnline);
+		window.removeEventListener('offline', handleOffline);
+	});
+
 	// Open modal: anyone can VIEW existing scores, only members can GENERATE new ones
-	$: if (open && !scores && !loading && !checking) { fetchScores(); }
-	$: if (!open) { error = ''; stale = false; }
+	$: if (open && !scores && !loading && !checking && !pantryTimeout && !fetched) {
+		fetched = true;
+		fetchScores();
+	}
+	$: if (!open) {
+		error = '';
+		stale = false;
+		pantryTimeout = false;
+		attemptCount = 0;
+		fetched = false;
+	}
 
 	function getRecipeCoordinates() {
 		const recipePubkey = event.author?.hexpubkey || event.pubkey;
@@ -73,6 +114,7 @@
 
 		checking = true;
 		error = '';
+		pantryTimeout = false;
 		let result: ResolveResult = { status: 'miss' };
 		try {
 			result = await resolveScore($ndk, key);
@@ -114,12 +156,20 @@
 			return;
 		}
 
-		// Miss — no score anywhere. Membership-gated compute is the only
-		// way forward today. Commit 4 replaces the silent fall-through on
-		// pantry timeout with an explicit retry UI; for now this branch
-		// preserves current behavior.
-		if (!hasMembership) return;
-		await analyzeRecipe();
+		if (result.status === 'timeout') {
+			// Drift #1 fix: pantry is unreachable and we have no local
+			// score. Surface a retry UI instead of silently computing a
+			// fresh score via /api/nourish — compute now requires an
+			// explicit user click.
+			pantryTimeout = true;
+			attemptCount = result.attemptCount;
+			return;
+		}
+
+		// Miss — pantry confirmed no event. Members see an [Analyze]
+		// button via NourishLoadingState; non-members see the lock-state
+		// membership upsell. Compute fires only on explicit click — no
+		// more silent fall-through.
 	}
 
 	async function analyzeRecipe() {
@@ -192,6 +242,37 @@
 
 	function reanalyze() { scores = null; stale = false; analyzeRecipe(); }
 
+	// Retry-UI handlers. handleRetry re-runs the resolver (next pantry
+	// query); handleAnalyze commits to an explicit compute. The "Score
+	// now" escape hatch also routes through handleAnalyze — member
+	// gating is enforced both by NourishLoadingState hiding the button
+	// for non-members AND by the existing paywall path below.
+	function handleRetry() {
+		// Clear the flags and let the reactive guard re-fire fetchScores.
+		// Calling fetchScores directly here would double-fire because
+		// the guard re-evaluates when pantryTimeout flips to false.
+		pantryTimeout = false;
+		fetched = false;
+	}
+	function handleAnalyze() {
+		pantryTimeout = false;
+		if (!hasMembership) return;
+		analyzeRecipe();
+	}
+
+	// Derived state for the shared NourishLoadingState component. Order
+	// of precedence: offline > pending (network in flight) > timeout >
+	// miss (no data, show [Analyze] for members). Explicit type so the
+	// ternary chain doesn't widen to `string` for the child prop.
+	let loadingState: 'pending' | 'timeout' | 'miss' | 'offline' = 'pending';
+	$: loadingState = isOffline
+		? 'offline'
+		: checking || loading
+			? 'pending'
+			: pantryTimeout
+				? 'timeout'
+				: 'miss';
+
 	function formatAnalyzedAt(ts: number): string {
 		if (!ts) return '';
 		const diff = Math.floor(Date.now() / 1000) - ts;
@@ -204,36 +285,7 @@
 
 <Modal bind:open compact noHeader>
 	<h2 id="title" class="sr-only">Nourish analysis</h2>
-	{#if !hasMembership && !scores && !checking}
-		<!-- Lock state — only shown if no existing scores exist -->
-		<div class="lock-state">
-			<div class="lock-icon-wrap">
-				<LockIcon size={24} weight="fill" class="text-orange-500" />
-			</div>
-			<h3 class="lock-title">Unlock Nourish</h3>
-			<p class="lock-desc">See how this recipe scores for gut health, protein, and real food quality.</p>
-			<a href="/membership" class="w-full"><Button primary>View Membership</Button></a>
-		</div>
-
-	{:else if checking}
-		<div class="loading-state">
-			<SpinnerIcon size={28} class="animate-spin text-green-500" />
-			<p class="loading-text">Checking for analysis...</p>
-		</div>
-
-	{:else if loading}
-		<div class="loading-state">
-			<SpinnerIcon size={28} class="animate-spin text-green-500" />
-			<p class="loading-text">Analyzing recipe...</p>
-		</div>
-
-	{:else if error}
-		<div class="error-state">
-			<p class="error-text">{error}</p>
-			<Button primary={false} on:click={retry}>Try Again</Button>
-		</div>
-
-	{:else if scores}
+	{#if scores}
 		<!-- ── Stale banner ── -->
 		{#if stale}
 			<div class="stale-banner">
@@ -263,6 +315,37 @@
 				<a href="/nourish" class="footer-link">Explore Nourish</a>
 			</p>
 		</div>
+
+	{:else if !hasMembership}
+		<!-- Lock state — non-members see the membership upsell regardless
+		     of pantry reachability. They can't compute, so the retry UI
+		     and "not yet scored" miss state wouldn't be actionable. -->
+		<div class="lock-state">
+			<div class="lock-icon-wrap">
+				<LockIcon size={24} weight="fill" class="text-orange-500" />
+			</div>
+			<h3 class="lock-title">Unlock Nourish</h3>
+			<p class="lock-desc">See how this recipe scores for gut health, protein, and real food quality.</p>
+			<a href="/membership" class="w-full"><Button primary>View Membership</Button></a>
+		</div>
+
+	{:else if error}
+		<div class="error-state">
+			<p class="error-text">{error}</p>
+			<Button primary={false} on:click={retry}>Try Again</Button>
+		</div>
+
+	{:else}
+		<!-- Shared loading/retry/miss/offline UI. loadingState is derived
+		     above; the component dispatches retry/score-now/analyze. -->
+		<NourishLoadingState
+			state={loadingState}
+			{attemptCount}
+			{hasMembership}
+			on:retry={handleRetry}
+			on:score-now={handleAnalyze}
+			on:analyze={handleAnalyze}
+		/>
 	{/if}
 </Modal>
 
@@ -294,8 +377,6 @@
 	.stale-refresh:hover { background: rgba(234, 179, 8, 0.2); }
 
 	/* ── Loading / Error ── */
-	.loading-state { @apply flex flex-col items-center gap-3 py-8; }
-	.loading-text { @apply text-sm; color: var(--color-text-secondary); }
 	.error-state { @apply flex flex-col items-center text-center gap-3 py-4; }
 	.error-text { @apply text-sm; color: var(--color-text-secondary); }
 

--- a/src/components/nourish/NourishModal.svelte
+++ b/src/components/nourish/NourishModal.svelte
@@ -13,7 +13,7 @@
 	import { generateSuggestions, mergeImprovements } from '$lib/nourish/suggestions';
 	import { ingredientStore } from '$lib/nourish/ingredientStore';
 	import { computeContentHash } from '$lib/nourish/nourishRelay';
-	import { resolveScore } from '$lib/nourish/scoreResolver';
+	import { resolveScore, type ResolveResult } from '$lib/nourish/scoreResolver';
 	import type { NourishScores } from '$lib/nourish/types';
 	import { NOURISH_PROMPT_VERSION } from '$lib/nourish/types';
 	import type { FlagTarget } from '$lib/nourish/flagSubmit';
@@ -73,7 +73,7 @@
 
 		checking = true;
 		error = '';
-		let result;
+		let result: ResolveResult = { status: 'miss' };
 		try {
 			result = await resolveScore($ndk, key);
 		} finally {

--- a/src/components/nourish/NourishModal.svelte
+++ b/src/components/nourish/NourishModal.svelte
@@ -9,10 +9,11 @@
 	// CaretDownIcon no longer needed — NourishResult handles expand
 	import ArrowClockwiseIcon from 'phosphor-svelte/lib/ArrowClockwise';
 	import { parseMarkdownForEditing } from '$lib/parser';
-	import { getNourishCache, setNourishScores } from '$lib/nourish/cache';
+	import { setNourishScores, type NourishCacheKey } from '$lib/nourish/cache';
 	import { generateSuggestions, mergeImprovements } from '$lib/nourish/suggestions';
 	import { ingredientStore } from '$lib/nourish/ingredientStore';
-	import { fetchNourishEvent, isNourishStale, computeContentHash } from '$lib/nourish/nourishRelay';
+	import { computeContentHash } from '$lib/nourish/nourishRelay';
+	import { resolveScore } from '$lib/nourish/scoreResolver';
 	import type { NourishScores } from '$lib/nourish/types';
 	import { NOURISH_PROMPT_VERSION } from '$lib/nourish/types';
 	import type { FlagTarget } from '$lib/nourish/flagSubmit';
@@ -52,11 +53,10 @@
 		return { recipePubkey, recipeDTag };
 	}
 
-	// Cache key, or null when the event lacks the coordinates we need to
-	// build a unique key. Empty recipeDTag would collapse keys across
-	// recipes from the same author, so we skip the cache entirely rather
-	// than collide. Hex-validity check on recipePubkey matches the
-	// server-side guard in /api/nourish.
+	// The resolver (scoreResolver.ts) owns the hex-64 + non-empty-d-tag
+	// guard on read paths. analyzeRecipe's post-API write still needs a
+	// local guard so a malformed recipe event doesn't write a colliding
+	// localStorage key.
 	const HEX_64_RE = /^[a-fA-F0-9]{64}$/;
 	function toCacheKey(recipePubkey: string, recipeDTag: string) {
 		if (!recipeDTag || !HEX_64_RE.test(recipePubkey)) return null;
@@ -65,88 +65,60 @@
 
 	async function fetchScores() {
 		const { recipePubkey, recipeDTag } = getRecipeCoordinates();
-		const cacheKey = toCacheKey(recipePubkey, recipeDTag);
+		const key: NourishCacheKey = {
+			recipePubkey,
+			recipeDTag,
+			promptVersion: NOURISH_PROMPT_VERSION
+		};
 
-		// 1. Check localStorage cache (instant)
-		const cached = cacheKey ? getNourishCache(cacheKey) : null;
-		if (cached) {
-			scores = cached.scores;
-			improvements = [];
-			buildImprovements(cached.scores, cached.improvements);
-			// Check staleness against current content if we have a hash
-			if (cached.contentHash) {
-				computeContentHash(event.content || '').then((currentHash) => {
-					if (currentHash !== cached.contentHash) {
-						stale = true;
-					}
-				}).catch(() => {});
-			}
-			// Prefer the score's createdAt (when analysis actually ran) over
-			// the cache's timestamp (when localStorage last wrote). They
-			// diverge across reloads, and createdAt is the one users see in
-			// the "analyzed at" label.
-			analyzedAt = cached.createdAt ?? (cached.timestamp ? Math.floor(cached.timestamp / 1000) : 0);
-			return;
-		}
-
-		// 2. Check pantry relay for existing analysis (fast, ~200ms)
 		checking = true;
 		error = '';
+		let result;
 		try {
-			if (recipePubkey && recipeDTag && $ndk) {
-				const relayResult = await fetchNourishEvent($ndk, recipePubkey, recipeDTag);
-				if (relayResult) {
-					scores = relayResult.scores;
-					buildImprovements(relayResult.scores, relayResult.improvements);
-					analyzedAt = relayResult.createdAt;
-
-					// Cache locally for next time, keyed under the relay event's
-					// own prompt version so a v1 hit doesn't collide with v2.
-					// Guarded by toCacheKey — if coordinates are incomplete we
-					// skip the write rather than produce a colliding key.
-					const writeKey = toCacheKey(recipePubkey, recipeDTag);
-					if (writeKey) {
-						setNourishScores(
-							{ ...writeKey, promptVersion: relayResult.promptVersion },
-							relayResult.scores,
-							{
-								contentHash: relayResult.contentHash,
-								createdAt: relayResult.createdAt,
-								improvements: relayResult.improvements
-							}
-						);
-					}
-
-					// Populate ingredient store from relay data (build dataset over time)
-					if (relayResult.ingredientSignals.length > 0) {
-						ingredientStore
-							.saveIngredients(
-								relayResult.ingredientSignals,
-								'recipe',
-								event.id,
-								relayResult.promptVersion
-							)
-							.catch(() => {});
-					}
-
-					// Check staleness
-					const isStale = await isNourishStale(relayResult, event.content || '');
-					stale = isStale;
-
-					checking = false;
-					return;
-				}
-			}
-		} catch {
-			// Relay query failed — fall through to API
+			result = await resolveScore($ndk, key);
+		} finally {
+			checking = false;
 		}
-		checking = false;
 
-		// 3. No existing analysis — call API (requires membership)
-		if (!hasMembership) {
-			// No cached score and no membership — show lock state
+		if (result.status === 'hit') {
+			scores = result.entry.scores;
+			improvements = [];
+			buildImprovements(result.entry.scores, result.entry.improvements);
+			analyzedAt = result.entry.createdAt;
+
+			// Preserve the original ingredient-store semantics: save only on
+			// a pantry hit (first-time surfacing of this event in a session).
+			// L2/memory and L3/localStorage hits were written from a prior
+			// pantry hit that already saved the signals.
+			if (result.source === 'pantry' && result.entry.ingredientSignals?.length) {
+				ingredientStore
+					.saveIngredients(
+						result.entry.ingredientSignals,
+						'recipe',
+						event.id,
+						result.entry.promptVersion
+					)
+					.catch(() => {});
+			}
+
+			// Preserve the original blocking-vs-nonblocking staleness pattern:
+			// pantry hit awaits the content-hash comparison (so stale renders
+			// before the modal settles); L2/L3 hits fire-and-forget (so the
+			// score displays immediately and the stale badge lights up after).
+			if (result.entry.contentHash) {
+				const pending = computeContentHash(event.content || '').then((currentHash) => {
+					if (currentHash !== result.entry.contentHash) stale = true;
+				}).catch(() => {});
+				if (result.source === 'pantry') await pending;
+			}
 			return;
 		}
+
+		// Miss — no score anywhere. Membership-gated compute is the only
+		// way forward today. Commit 4 replaces the silent fall-through on
+		// pantry timeout with an explicit retry UI; for now this branch
+		// preserves current behavior.
+		if (!hasMembership) return;
 		await analyzeRecipe();
 	}
 

--- a/src/lib/nourish/nourishRelay.ts
+++ b/src/lib/nourish/nourishRelay.ts
@@ -82,6 +82,7 @@ export async function queryNourishEvent(
 ): Promise<{ status: 'hit'; result: NourishRelayResult } | { status: 'miss' }> {
   const dTag = buildNourishDTag(recipePubkey, recipeDTag);
 
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   try {
     const filter = {
       kinds: [30078 as number],
@@ -92,9 +93,9 @@ export async function queryNourishEvent(
     const relaySet = NDKRelaySet.fromRelayUrls([PANTRY_RELAY], ndk, true);
 
     const eventPromise = ndk.fetchEvent(filter, undefined, relaySet);
-    const timeoutPromise = new Promise<null>((resolve) =>
-      setTimeout(() => resolve(null), timeoutMs)
-    );
+    const timeoutPromise = new Promise<null>((resolve) => {
+      timeoutHandle = setTimeout(() => resolve(null), timeoutMs);
+    });
 
     const event = await Promise.race([eventPromise, timeoutPromise]);
     if (!event) return { status: 'miss' };
@@ -105,6 +106,10 @@ export async function queryNourishEvent(
     return { status: 'hit', result: parsed };
   } catch {
     return { status: 'miss' };
+  } finally {
+    // Clear the pending timer on the winning branch so long-lived
+    // sessions don't accumulate dead setTimeout handles.
+    if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
   }
 }
 

--- a/src/lib/nourish/nourishRelay.ts
+++ b/src/lib/nourish/nourishRelay.ts
@@ -19,7 +19,9 @@ import {
 } from './types';
 
 const PANTRY_RELAY = 'wss://pantry.zap.cooking';
-const QUERY_TIMEOUT_MS = 4000;
+// Default pantry query timeout. Commit 2 holds this at 4s to preserve
+// current behavior; commit 4 drops it to 2s when the retry UI lands.
+const DEFAULT_QUERY_TIMEOUT_MS = 4000;
 
 // ─── Content hashing ────────────────────────────────────────
 
@@ -47,12 +49,37 @@ export function buildNourishDTag(recipePubkey: string, recipeDTag: string): stri
 /**
  * Fetch an existing Nourish analysis event from the pantry relay.
  * Returns null if no analysis exists for this recipe.
+ *
+ * Retained for existing callers outside the resolver path (e.g.
+ * nourishDiscovery). The resolver uses queryNourishEvent below,
+ * which returns a discriminated hit/miss result. Migration of the
+ * discovery caller to queryNourishEvent is a follow-up; once that
+ * lands, this wrapper can be deleted.
  */
 export async function fetchNourishEvent(
   ndk: NDK,
   recipePubkey: string,
   recipeDTag: string
 ): Promise<NourishRelayResult | null> {
+  const res = await queryNourishEvent(ndk, recipePubkey, recipeDTag);
+  return res.status === 'hit' ? res.result : null;
+}
+
+/**
+ * Query the pantry relay with a discriminated result.
+ *
+ * Commit 2 folds timeout into `miss` to preserve current behavior;
+ * commit 4 splits `timeout` out as a third status so the retry UI
+ * can distinguish "pantry didn't respond" from "pantry confirmed no
+ * event." Default timeoutMs stays at 4s in commit 2 for pure-refactor
+ * no-op semantics; commit 4 drops the default to 2s.
+ */
+export async function queryNourishEvent(
+  ndk: NDK,
+  recipePubkey: string,
+  recipeDTag: string,
+  timeoutMs: number = DEFAULT_QUERY_TIMEOUT_MS
+): Promise<{ status: 'hit'; result: NourishRelayResult } | { status: 'miss' }> {
   const dTag = buildNourishDTag(recipePubkey, recipeDTag);
 
   try {
@@ -62,21 +89,22 @@ export async function fetchNourishEvent(
       '#d': [dTag]
     };
 
-    // Query the pantry relay specifically (where Nourish events are published)
     const relaySet = NDKRelaySet.fromRelayUrls([PANTRY_RELAY], ndk, true);
 
-    // Race against timeout
     const eventPromise = ndk.fetchEvent(filter, undefined, relaySet);
     const timeoutPromise = new Promise<null>((resolve) =>
-      setTimeout(() => resolve(null), QUERY_TIMEOUT_MS)
+      setTimeout(() => resolve(null), timeoutMs)
     );
 
     const event = await Promise.race([eventPromise, timeoutPromise]);
-    if (!event) return null;
+    if (!event) return { status: 'miss' };
 
-    return parseNourishEvent(event);
+    const parsed = parseNourishEvent(event);
+    if (!parsed) return { status: 'miss' };
+
+    return { status: 'hit', result: parsed };
   } catch {
-    return null;
+    return { status: 'miss' };
   }
 }
 

--- a/src/lib/nourish/nourishRelay.ts
+++ b/src/lib/nourish/nourishRelay.ts
@@ -19,9 +19,17 @@ import {
 } from './types';
 
 const PANTRY_RELAY = 'wss://pantry.zap.cooking';
-// Default pantry query timeout. Commit 2 holds this at 4s to preserve
-// current behavior; commit 4 drops it to 2s when the retry UI lands.
-const DEFAULT_QUERY_TIMEOUT_MS = 4000;
+// Pantry query timeout. Calibrated to 2s — healthy pantry median sits
+// at ~800ms, so 2s catches p95 with headroom. Revisit if production
+// observability shows timeout rate >5% sustained.
+const DEFAULT_QUERY_TIMEOUT_MS = 2000;
+
+// Sentinel used to disambiguate pantry timeout from an explicit no-event
+// response. Without it, Promise.race([eventPromise, timeoutPromise])
+// collapses both "relay returned null" and "timer fired" into the same
+// null value, and the resolver needs to tell them apart for the retry
+// UI (drift #1 fix).
+const TIMEOUT_SENTINEL = Symbol('nourish-pantry-timeout');
 
 // ─── Content hashing ────────────────────────────────────────
 
@@ -68,18 +76,25 @@ export async function fetchNourishEvent(
 /**
  * Query the pantry relay with a discriminated result.
  *
- * Commit 2 folds timeout into `miss` to preserve current behavior;
- * commit 4 splits `timeout` out as a third status so the retry UI
- * can distinguish "pantry didn't respond" from "pantry confirmed no
- * event." Default timeoutMs stays at 4s in commit 2 for pure-refactor
- * no-op semantics; commit 4 drops the default to 2s.
+ * Three-way status:
+ *   - hit:     an event was returned and parsed
+ *   - miss:    pantry confirmed no event (or parse failed)
+ *   - timeout: timer fired before pantry responded
+ *
+ * The timeout/miss split is what lets the resolver show a retry UI
+ * when pantry is unreachable (drift #1 fix) instead of silently
+ * falling through to a fresh /api/nourish compute.
  */
 export async function queryNourishEvent(
   ndk: NDK,
   recipePubkey: string,
   recipeDTag: string,
   timeoutMs: number = DEFAULT_QUERY_TIMEOUT_MS
-): Promise<{ status: 'hit'; result: NourishRelayResult } | { status: 'miss' }> {
+): Promise<
+  | { status: 'hit'; result: NourishRelayResult }
+  | { status: 'miss' }
+  | { status: 'timeout' }
+> {
   const dTag = buildNourishDTag(recipePubkey, recipeDTag);
 
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
@@ -93,14 +108,15 @@ export async function queryNourishEvent(
     const relaySet = NDKRelaySet.fromRelayUrls([PANTRY_RELAY], ndk, true);
 
     const eventPromise = ndk.fetchEvent(filter, undefined, relaySet);
-    const timeoutPromise = new Promise<null>((resolve) => {
-      timeoutHandle = setTimeout(() => resolve(null), timeoutMs);
+    const timeoutPromise = new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
+      timeoutHandle = setTimeout(() => resolve(TIMEOUT_SENTINEL), timeoutMs);
     });
 
-    const event = await Promise.race([eventPromise, timeoutPromise]);
-    if (!event) return { status: 'miss' };
+    const winner = await Promise.race([eventPromise, timeoutPromise]);
+    if (winner === TIMEOUT_SENTINEL) return { status: 'timeout' };
+    if (!winner) return { status: 'miss' };
 
-    const parsed = parseNourishEvent(event);
+    const parsed = parseNourishEvent(winner);
     if (!parsed) return { status: 'miss' };
 
     return { status: 'hit', result: parsed };

--- a/src/lib/nourish/scoreResolver.ts
+++ b/src/lib/nourish/scoreResolver.ts
@@ -204,25 +204,33 @@ function pickWinner(candidates: Candidate[]): Candidate {
 // an older createdAt. Keyed under the winner's promptVersion (which
 // may differ from the requested key's when pantry has an event tagged
 // with a different version — strict version partitioning preserved).
-function writeThrough(
-  requestedKey: NourishCacheKey,
-  winner: Candidate,
-  existing: {
-    l2Hit: ResolvedEntry | undefined;
-    l3HitCreatedAt: number; // 0 when no L3 entry exists
-  }
-): void {
+//
+// Crucially, the existence check must be re-run under the WRITE key,
+// not the requested key. When winner.promptVersion !== requestedKey
+// .promptVersion, the requested-key L2/L3 lookups say nothing about
+// what's stored under writeKey — and blindly writing there could
+// overwrite a newer entry (e.g., localStorage has a fresh v1 entry,
+// pantry returns an older v1 event while the caller asked for v2:
+// the requested-key L3 hit is `undefined`, but the write-key L3 hit
+// is the newer v1 entry we must not clobber).
+function writeThrough(requestedKey: NourishCacheKey, winner: Candidate): void {
   const writeKey: NourishCacheKey = {
     recipePubkey: requestedKey.recipePubkey,
     recipeDTag: requestedKey.recipeDTag,
     promptVersion: winner.entry.promptVersion
   };
+  const writeMapKey = toMapKey(writeKey);
 
-  if (!existing.l2Hit || existing.l2Hit.createdAt < winner.entry.createdAt) {
-    memory.set(toMapKey(writeKey), winner.entry);
+  const existingL2 = memory.get(writeMapKey);
+  if (!existingL2 || existingL2.createdAt < winner.entry.createdAt) {
+    memory.set(writeMapKey, winner.entry);
   }
 
-  if (existing.l3HitCreatedAt < winner.entry.createdAt) {
+  const existingL3 = getNourishCache(writeKey);
+  const existingL3CreatedAt =
+    existingL3?.createdAt ??
+    (existingL3?.timestamp ? Math.floor(existingL3.timestamp / 1000) : 0);
+  if (existingL3CreatedAt < winner.entry.createdAt) {
     setNourishScores(writeKey, winner.entry.scores, {
       contentHash: winner.entry.contentHash,
       createdAt: winner.entry.createdAt,
@@ -298,10 +306,7 @@ async function doResolve(ndk: NDK, key: NourishCacheKey): Promise<ResolveResult>
 
   const winner = pickWinner(candidates);
 
-  writeThrough(key, winner, {
-    l2Hit,
-    l3HitCreatedAt: l3Hit?.createdAt ?? (l3Hit?.timestamp ? Math.floor(l3Hit.timestamp / 1000) : 0)
-  });
+  writeThrough(key, winner);
 
   // Winner isn't pantry AND pantry confirmed miss → our local cache
   // has a score pantry doesn't know about. Republish it so the next

--- a/src/lib/nourish/scoreResolver.ts
+++ b/src/lib/nourish/scoreResolver.ts
@@ -10,10 +10,15 @@
  *   L3 localStorage      — 7d TTL (via cache.ts)
  *   L4 pantry relay      — durable, authoritative source
  *
- * Commit 2 introduces L1 + L2 with "first non-null in L2 → L3 → L4"
- * semantics. Commit 3 upgrades this to a createdAt-based winner with
- * write-through reconciliation. Commit 4 splits pantry timeout out
- * from miss and introduces the retry UI state.
+ * Commit 2 introduced L1 + L2 with a simple "first non-null in L2 →
+ * L3 → L4" rule. Commit 3 (this commit) upgrades that to a full
+ * createdAt-based winner with write-through reconciliation across
+ * layers: gather all candidates, pick the max-createdAt one (tiebreak:
+ * pantry > local > memory), write-through to any layer that's missing
+ * or carrying an older entry, and call scheduleOpportunisticRepublish
+ * when the winner didn't come from pantry AND pantry confirmed a miss.
+ * Commit 4 will split pantry timeout out from miss and introduce the
+ * retry UI state.
  *
  * The resolver never computes a fresh score — that's the caller's
  * concern (/api/nourish + membership gating). A `miss` result means
@@ -75,16 +80,47 @@ export function purgeMemory(key: NourishCacheKey): void {
   memory.delete(mapKey);
 }
 
-// ─── Attempt counter (commit 3 activates) ───────────────────
+// ─── Attempt counter (fixed 60s window) ─────────────────────
+//
+// First pantry-timeout opens a 60s window anchored on that moment.
+// All timeouts within the window increment the count. A timeout that
+// arrives after the window closed opens a fresh window (count = 1).
+// A successful resolve invalidates the window so subsequent failures
+// start fresh counts.
+//
+// recordTimeout is dormant in commit 3 (queryNourishEvent still folds
+// timeout into miss, so doResolve never detects one). Commit 4 splits
+// the timeout status out and calls recordTimeout on each.
 
-/**
- * Number of consecutive pantry-timeout attempts for a key, within
- * the current 60s window. Commit 2 returns 0 always; commit 3 wires
- * the actual counter; commit 4's UI consumes it.
- */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function getAttemptCount(_key: NourishCacheKey): number {
-  return 0;
+interface AttemptWindow {
+  count: number;
+  windowStart: number;
+}
+
+const WINDOW_MS = 60_000;
+const attempts = new Map<string, AttemptWindow>();
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- commit 4 wires
+function recordTimeout(key: NourishCacheKey): number {
+  const k = toMapKey(key);
+  const now = Date.now();
+  const existing = attempts.get(k);
+  if (!existing || now - existing.windowStart >= WINDOW_MS) {
+    attempts.set(k, { count: 1, windowStart: now });
+    return 1;
+  }
+  existing.count += 1;
+  return existing.count;
+}
+
+function clearAttempts(key: NourishCacheKey): void {
+  attempts.delete(toMapKey(key));
+}
+
+export function getAttemptCount(key: NourishCacheKey): number {
+  const w = attempts.get(toMapKey(key));
+  if (!w || Date.now() - w.windowStart >= WINDOW_MS) return 0;
+  return w.count;
 }
 
 // ─── Opportunistic republish hook (PR 3 wires) ──────────────
@@ -134,62 +170,143 @@ export async function resolveScore(
 
 // ─── Internal resolution ────────────────────────────────────
 
-async function doResolve(ndk: NDK, key: NourishCacheKey): Promise<ResolveResult> {
-  // L2 — module memory
-  const l2Hit = memory.get(toMapKey(key));
-  if (l2Hit) {
-    return { status: 'hit', source: 'memory', entry: l2Hit };
+type CandidateSource = 'memory' | 'local' | 'pantry';
+
+interface Candidate {
+  source: CandidateSource;
+  entry: ResolvedEntry;
+}
+
+// Tiebreak ranks for equal createdAt. Pantry is authoritative, so
+// if a local and a pantry entry share the same createdAt we prefer
+// pantry. Memory at the bottom because it was populated from L3/L4
+// in the first place — pointing back at memory over its source is
+// never informative.
+const TIEBREAK_RANK: Record<CandidateSource, number> = {
+  pantry: 2,
+  local: 1,
+  memory: 0
+};
+
+function pickWinner(candidates: Candidate[]): Candidate {
+  return candidates.reduce((best, c) => {
+    if (c.entry.createdAt > best.entry.createdAt) return c;
+    if (
+      c.entry.createdAt === best.entry.createdAt &&
+      TIEBREAK_RANK[c.source] > TIEBREAK_RANK[best.source]
+    ) {
+      return c;
+    }
+    return best;
+  });
+}
+
+// Write-through: update any layer that's missing the winner or carries
+// an older createdAt. Keyed under the winner's promptVersion (which
+// may differ from the requested key's when pantry has an event tagged
+// with a different version — strict version partitioning preserved).
+function writeThrough(
+  requestedKey: NourishCacheKey,
+  winner: Candidate,
+  existing: {
+    l2Hit: ResolvedEntry | undefined;
+    l3HitCreatedAt: number; // 0 when no L3 entry exists
+  }
+): void {
+  const writeKey: NourishCacheKey = {
+    recipePubkey: requestedKey.recipePubkey,
+    recipeDTag: requestedKey.recipeDTag,
+    promptVersion: winner.entry.promptVersion
+  };
+
+  if (!existing.l2Hit || existing.l2Hit.createdAt < winner.entry.createdAt) {
+    memory.set(toMapKey(writeKey), winner.entry);
   }
 
-  // L3 — localStorage
+  if (existing.l3HitCreatedAt < winner.entry.createdAt) {
+    setNourishScores(writeKey, winner.entry.scores, {
+      contentHash: winner.entry.contentHash,
+      createdAt: winner.entry.createdAt,
+      improvements: winner.entry.improvements,
+      ingredientSignals: winner.entry.ingredientSignals
+    });
+  }
+}
+
+function l3EntryToResolved(
+  l3: NonNullable<ReturnType<typeof getNourishCache>>,
+  promptVersion: string
+): ResolvedEntry {
+  return {
+    scores: l3.scores,
+    contentHash: l3.contentHash,
+    // Fall back to the localStorage write timestamp for pre-1a entries
+    // that lack a persisted createdAt. Matches the fallback the modal
+    // already uses for its "analyzed at" label.
+    createdAt: l3.createdAt ?? Math.floor(l3.timestamp / 1000),
+    improvements: l3.improvements,
+    ingredientSignals: l3.ingredientSignals,
+    promptVersion
+  };
+}
+
+async function doResolve(ndk: NDK, key: NourishCacheKey): Promise<ResolveResult> {
+  // Gather candidates from every layer before deciding. Unlike commit
+  // 2's first-non-null short-circuit, we need all of them because a
+  // stale L2 or L3 must lose to a newer pantry event, and vice versa.
+  const candidates: Candidate[] = [];
+
+  const l2Hit = memory.get(toMapKey(key));
+  if (l2Hit) candidates.push({ source: 'memory', entry: l2Hit });
+
   const l3Hit = getNourishCache(key);
   if (l3Hit) {
-    const entry: ResolvedEntry = {
-      scores: l3Hit.scores,
-      contentHash: l3Hit.contentHash,
-      // Fall back to localStorage write timestamp for pre-1a entries
-      // that lack a persisted createdAt. Matches the fallback the
-      // modal already uses for its "analyzed at" label.
-      createdAt: l3Hit.createdAt ?? Math.floor(l3Hit.timestamp / 1000),
-      improvements: l3Hit.improvements,
-      ingredientSignals: l3Hit.ingredientSignals,
-      promptVersion: key.promptVersion
-    };
-    memory.set(toMapKey(key), entry);
-    return { status: 'hit', source: 'local', entry };
+    candidates.push({
+      source: 'local',
+      entry: l3EntryToResolved(l3Hit, key.promptVersion)
+    });
   }
 
-  // L4 — pantry relay (4s timeout in commit 2; 2s in commit 4)
   const l4 = await queryNourishEvent(ndk, key.recipePubkey, key.recipeDTag);
   if (l4.status === 'hit') {
-    const entry: ResolvedEntry = {
-      scores: l4.result.scores,
-      contentHash: l4.result.contentHash,
-      createdAt: l4.result.createdAt,
-      improvements: l4.result.improvements,
-      ingredientSignals: l4.result.ingredientSignals,
-      promptVersion: l4.result.promptVersion
-    };
-
-    // Write-through to L2 + L3 so the next mount of the same recipe
-    // skips the pantry query. Preserves the modal's existing pattern
-    // of writing under the event's promptVersion (not the caller's)
-    // — strict version partitioning lives here too.
-    const writeKey: NourishCacheKey = {
-      recipePubkey: key.recipePubkey,
-      recipeDTag: key.recipeDTag,
-      promptVersion: l4.result.promptVersion
-    };
-    memory.set(toMapKey(writeKey), entry);
-    setNourishScores(writeKey, entry.scores, {
-      contentHash: entry.contentHash,
-      createdAt: entry.createdAt,
-      improvements: entry.improvements,
-      ingredientSignals: entry.ingredientSignals
+    candidates.push({
+      source: 'pantry',
+      entry: {
+        scores: l4.result.scores,
+        contentHash: l4.result.contentHash,
+        createdAt: l4.result.createdAt,
+        improvements: l4.result.improvements,
+        ingredientSignals: l4.result.ingredientSignals,
+        promptVersion: l4.result.promptVersion
+      }
     });
-
-    return { status: 'hit', source: 'pantry', entry };
   }
 
-  return { status: 'miss' };
+  if (candidates.length === 0) {
+    // Commit 3 still folds timeout into miss via queryNourishEvent.
+    // Commit 4 splits them and emits [nourish.pantry.timeout] plus a
+    // { status: 'timeout' } return with recordTimeout(key) attached.
+    return { status: 'miss' };
+  }
+
+  const winner = pickWinner(candidates);
+
+  writeThrough(key, winner, {
+    l2Hit,
+    l3HitCreatedAt: l3Hit?.createdAt ?? (l3Hit?.timestamp ? Math.floor(l3Hit.timestamp / 1000) : 0)
+  });
+
+  // Winner isn't pantry AND pantry confirmed miss → our local cache
+  // has a score pantry doesn't know about. Republish it so the next
+  // cold client isn't forced to recompute. No-op stub in PR 2; PR 3
+  // wires the implementation.
+  if (winner.source !== 'pantry' && l4.status === 'miss') {
+    scheduleOpportunisticRepublish({ key, entry: winner.entry });
+  }
+
+  // Successful resolve invalidates the attempt window — subsequent
+  // failures start fresh counts rather than inheriting a stale streak.
+  clearAttempts(key);
+
+  return { status: 'hit', source: winner.source, entry: winner.entry };
 }

--- a/src/lib/nourish/scoreResolver.ts
+++ b/src/lib/nourish/scoreResolver.ts
@@ -1,0 +1,190 @@
+/**
+ * Nourish Score Resolver
+ *
+ * Owns the ephemeral cache layers (L1 in-flight Promise cache, L2
+ * module memory Map) and orchestrates the full lookup chain for a
+ * Nourish score:
+ *
+ *   L1 in-flight Promise — dedup concurrent calls for the same key
+ *   L2 module memory     — session-scoped, no TTL
+ *   L3 localStorage      — 7d TTL (via cache.ts)
+ *   L4 pantry relay      — durable, authoritative source
+ *
+ * Commit 2 introduces L1 + L2 with "first non-null in L2 → L3 → L4"
+ * semantics. Commit 3 upgrades this to a createdAt-based winner with
+ * write-through reconciliation. Commit 4 splits pantry timeout out
+ * from miss and introduces the retry UI state.
+ *
+ * The resolver never computes a fresh score — that's the caller's
+ * concern (/api/nourish + membership gating). A `miss` result means
+ * "no cached score anywhere for this key"; the caller decides
+ * whether to surface "not yet scored" UI or to trigger compute.
+ */
+
+import type NDK from '@nostr-dev-kit/ndk';
+import { getNourishCache, setNourishScores, type NourishCacheKey } from './cache';
+import { queryNourishEvent } from './nourishRelay';
+import type { NourishScores, IngredientSignal } from './types';
+
+// ─── Public types ────────────────────────────────────────────
+
+export interface ResolvedEntry {
+  scores: NourishScores;
+  contentHash?: string;
+  createdAt: number;
+  improvements?: string[];
+  ingredientSignals?: IngredientSignal[];
+  promptVersion: string;
+}
+
+export type ResolveResult =
+  | { status: 'hit'; source: 'memory' | 'local' | 'pantry'; entry: ResolvedEntry }
+  | { status: 'miss' };
+
+// ─── Key helpers ────────────────────────────────────────────
+
+const HEX_64_RE = /^[a-fA-F0-9]{64}$/;
+
+function isValidKey(key: NourishCacheKey): boolean {
+  return HEX_64_RE.test(key.recipePubkey) && !!key.recipeDTag && !!key.promptVersion;
+}
+
+function toMapKey(key: NourishCacheKey): string {
+  return `${key.recipePubkey}:${key.recipeDTag}:${key.promptVersion}`;
+}
+
+// ─── Layer 1: in-flight Promise cache ────────────────────────
+
+const inflight = new Map<string, Promise<ResolveResult>>();
+
+// ─── Layer 2: module memory Map ─────────────────────────────
+
+const memory = new Map<string, ResolvedEntry>();
+
+/**
+ * Drop an L2 memory entry. Used by admin-triggered rescore (PR 4)
+ * to force the next resolve to re-query lower layers. Exported now
+ * so PR 4 has a stable hook.
+ */
+export function purgeMemory(key: NourishCacheKey): void {
+  memory.delete(toMapKey(key));
+}
+
+// ─── Attempt counter (commit 3 activates) ───────────────────
+
+/**
+ * Number of consecutive pantry-timeout attempts for a key, within
+ * the current 60s window. Commit 2 returns 0 always; commit 3 wires
+ * the actual counter; commit 4's UI consumes it.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function getAttemptCount(_key: NourishCacheKey): number {
+  return 0;
+}
+
+// ─── Opportunistic republish hook (PR 3 wires) ──────────────
+
+/**
+ * Fire-and-forget republish of a winning score to the pantry relay
+ * when we detect a winner whose source is not pantry AND pantry
+ * confirmed a miss. Closes drift source #4 (silent publish failure).
+ *
+ * PR 2: no-op stub. PR 3 wires the implementation.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function scheduleOpportunisticRepublish(_winner: {
+  key: NourishCacheKey;
+  entry: ResolvedEntry;
+}): void {
+  // Intentionally empty.
+}
+
+// ─── Main entry ─────────────────────────────────────────────
+
+/**
+ * Resolve a Nourish score across all cache layers.
+ *
+ * Same-key concurrent calls dedup via the L1 in-flight Map.
+ * Invalid keys (non-hex-64 pubkey, empty d-tag, empty promptVersion)
+ * are warned + returned as a miss — lets callers skip the cache path
+ * gracefully while surfacing the bug in Workers logs.
+ */
+export async function resolveScore(
+  ndk: NDK,
+  key: NourishCacheKey
+): Promise<ResolveResult> {
+  if (!isValidKey(key)) {
+    console.warn('[nourish.resolver.invalid-key]', { key });
+    return { status: 'miss' };
+  }
+
+  const mapKey = toMapKey(key);
+  const existing = inflight.get(mapKey);
+  if (existing) return existing;
+
+  const p = doResolve(ndk, key).finally(() => inflight.delete(mapKey));
+  inflight.set(mapKey, p);
+  return p;
+}
+
+// ─── Internal resolution ────────────────────────────────────
+
+async function doResolve(ndk: NDK, key: NourishCacheKey): Promise<ResolveResult> {
+  // L2 — module memory
+  const l2Hit = memory.get(toMapKey(key));
+  if (l2Hit) {
+    return { status: 'hit', source: 'memory', entry: l2Hit };
+  }
+
+  // L3 — localStorage
+  const l3Hit = getNourishCache(key);
+  if (l3Hit) {
+    const entry: ResolvedEntry = {
+      scores: l3Hit.scores,
+      contentHash: l3Hit.contentHash,
+      // Fall back to localStorage write timestamp for pre-1a entries
+      // that lack a persisted createdAt. Matches the fallback the
+      // modal already uses for its "analyzed at" label.
+      createdAt: l3Hit.createdAt ?? Math.floor(l3Hit.timestamp / 1000),
+      improvements: l3Hit.improvements,
+      ingredientSignals: l3Hit.ingredientSignals,
+      promptVersion: key.promptVersion
+    };
+    memory.set(toMapKey(key), entry);
+    return { status: 'hit', source: 'local', entry };
+  }
+
+  // L4 — pantry relay (4s timeout in commit 2; 2s in commit 4)
+  const l4 = await queryNourishEvent(ndk, key.recipePubkey, key.recipeDTag);
+  if (l4.status === 'hit') {
+    const entry: ResolvedEntry = {
+      scores: l4.result.scores,
+      contentHash: l4.result.contentHash,
+      createdAt: l4.result.createdAt,
+      improvements: l4.result.improvements,
+      ingredientSignals: l4.result.ingredientSignals,
+      promptVersion: l4.result.promptVersion
+    };
+
+    // Write-through to L2 + L3 so the next mount of the same recipe
+    // skips the pantry query. Preserves the modal's existing pattern
+    // of writing under the event's promptVersion (not the caller's)
+    // — strict version partitioning lives here too.
+    const writeKey: NourishCacheKey = {
+      recipePubkey: key.recipePubkey,
+      recipeDTag: key.recipeDTag,
+      promptVersion: l4.result.promptVersion
+    };
+    memory.set(toMapKey(writeKey), entry);
+    setNourishScores(writeKey, entry.scores, {
+      contentHash: entry.contentHash,
+      createdAt: entry.createdAt,
+      improvements: entry.improvements,
+      ingredientSignals: entry.ingredientSignals
+    });
+
+    return { status: 'hit', source: 'pantry', entry };
+  }
+
+  return { status: 'miss' };
+}

--- a/src/lib/nourish/scoreResolver.ts
+++ b/src/lib/nourish/scoreResolver.ts
@@ -62,12 +62,17 @@ const inflight = new Map<string, Promise<ResolveResult>>();
 const memory = new Map<string, ResolvedEntry>();
 
 /**
- * Drop an L2 memory entry. Used by admin-triggered rescore (PR 4)
- * to force the next resolve to re-query lower layers. Exported now
- * so PR 4 has a stable hook.
+ * Drop ephemeral cache entries for a key. Used by admin-triggered
+ * rescore (PR 4) to force the next resolve to re-query lower layers.
+ *
+ * Clears both the L1 in-flight Promise and the L2 memory entry. If
+ * only L2 were cleared, an in-flight resolve from just before the
+ * purge could repopulate memory with the stale result on resolution.
  */
 export function purgeMemory(key: NourishCacheKey): void {
-  memory.delete(toMapKey(key));
+  const mapKey = toMapKey(key);
+  inflight.delete(mapKey);
+  memory.delete(mapKey);
 }
 
 // ─── Attempt counter (commit 3 activates) ───────────────────

--- a/src/lib/nourish/scoreResolver.ts
+++ b/src/lib/nourish/scoreResolver.ts
@@ -10,15 +10,14 @@
  *   L3 localStorage      — 7d TTL (via cache.ts)
  *   L4 pantry relay      — durable, authoritative source
  *
- * Commit 2 introduced L1 + L2 with a simple "first non-null in L2 →
- * L3 → L4" rule. Commit 3 (this commit) upgrades that to a full
- * createdAt-based winner with write-through reconciliation across
- * layers: gather all candidates, pick the max-createdAt one (tiebreak:
- * pantry > local > memory), write-through to any layer that's missing
- * or carrying an older entry, and call scheduleOpportunisticRepublish
- * when the winner didn't come from pantry AND pantry confirmed a miss.
- * Commit 4 will split pantry timeout out from miss and introduce the
- * retry UI state.
+ * Resolution algorithm: gather all layer candidates, pick the
+ * max-createdAt one (tiebreak: pantry > local > memory), write-through
+ * to any layer that's missing or carrying an older entry, and call
+ * scheduleOpportunisticRepublish when the winner didn't come from
+ * pantry AND pantry confirmed a miss. Pantry timeout with no other
+ * candidates returns { status: 'timeout', attemptCount } so the
+ * retry UI can surface the blocked state explicitly (drift #1 fix)
+ * instead of silently falling through to compute.
  *
  * The resolver never computes a fresh score — that's the caller's
  * concern (/api/nourish + membership gating). A `miss` result means
@@ -44,7 +43,8 @@ export interface ResolvedEntry {
 
 export type ResolveResult =
   | { status: 'hit'; source: 'memory' | 'local' | 'pantry'; entry: ResolvedEntry }
-  | { status: 'miss' };
+  | { status: 'miss' }
+  | { status: 'timeout'; attemptCount: number };
 
 // ─── Key helpers ────────────────────────────────────────────
 
@@ -100,7 +100,6 @@ interface AttemptWindow {
 const WINDOW_MS = 60_000;
 const attempts = new Map<string, AttemptWindow>();
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- commit 4 wires
 function recordTimeout(key: NourishCacheKey): number {
   const k = toMapKey(key);
   const now = Date.now();
@@ -282,10 +281,18 @@ async function doResolve(ndk: NDK, key: NourishCacheKey): Promise<ResolveResult>
     });
   }
 
+  // Emit pantry-timeout warn regardless of other candidates so the
+  // Workers log captures p95 data for calibration. recordTimeout is
+  // only called when the user is blocked (no other candidates) — the
+  // counter drives the "Score now" escape hatch, not observability.
+  if (l4.status === 'timeout') {
+    console.warn('[nourish.pantry.timeout]', { key: toMapKey(key) });
+  }
+
   if (candidates.length === 0) {
-    // Commit 3 still folds timeout into miss via queryNourishEvent.
-    // Commit 4 splits them and emits [nourish.pantry.timeout] plus a
-    // { status: 'timeout' } return with recordTimeout(key) attached.
+    if (l4.status === 'timeout') {
+      return { status: 'timeout', attemptCount: recordTimeout(key) };
+    }
     return { status: 'miss' };
   }
 


### PR DESCRIPTION
**Draft — all three commits landed. Ready for preview verification.** PR 2 of 4 in the Nourish Stability feature (follow-up to #311 foundation).

## Commit plan

| # | Commit | Status | Drift source |
|---|---|---|---|
| 2 | L1 Promise cache + L2 memory Map — dedup concurrent lookups | ✅ `0fff88b` + `0fdf183` | #2 BLOCKER |
| 3 | `createdAt`-based conflict resolution + write-through | ✅ `b14c498` | #3 MODERATE |
| 4 | Pantry timeout retry UI + 2s calibrated timeout | ✅ `272f6a6` | #1 BLOCKER |

## Summary

### Commit 2 — dedup foundation
- `scoreResolver.ts` owning L1 in-flight Promise cache + L2 module memory Map. `resolveScore(ndk, key)` dedups same-tab concurrent lookups; rejected promises purge immediately and don't poison retries.
- `queryNourishEvent` added to `nourishRelay.ts`, discriminated `{hit|miss}` return. Old `fetchNourishEvent` retained as wrapper for `nourishDiscovery`.
- `NourishModal` + `Recipe.svelte` route through `resolveScore` instead of direct `getNourishCache` + `fetchNourishEvent`.
- Closes a latent cache-miss gap in `Recipe.svelte#loadNourishPreview` where pantry hits never wrote through to localStorage.
- Invalid keys emit `[nourish.resolver.invalid-key]` warn.
- Review fixes on `0fdf183`: `purgeMemory` clears L1 + L2, `queryNourishEvent` `clearTimeout`s in `finally`, explicit `ResolveResult` type annotation.

### Commit 3 — conflict resolution
- Full createdAt-based winner + write-through across layers. Tiebreak: `pantry > local > memory`.
- Winner writes under its own `promptVersion` (preserves PR 311's strict version partitioning).
- Fixed 60s attempt window wired; `clearAttempts` on successful resolve. Successful resolve invalidates the window — subsequent failures start fresh counts.
- Opportunistic republish hook fires from `winner.source !== 'pantry' && l4.status === 'miss'` branch. Still a no-op stub; PR 3 wires the implementation.

### Commit 4 — retry UI + 2s timeout (BLOCKER fix)
- `queryNourishEvent` distinguishes `{hit | miss | timeout}` via `TIMEOUT_SENTINEL`. Default timeout `4000ms → 2000ms`.
- `ResolveResult` adds `{status: 'timeout', attemptCount}` variant. Every pantry timeout emits `[nourish.pantry.timeout]` warn (Workers-log p95 tracking); `recordTimeout` called only when user is blocked (no other candidates).
- New `src/components/nourish/NourishLoadingState.svelte` — shared skeleton/retry/miss/offline UI. Full variant used in `NourishModal` now; compact variant designed for future pill-context use.
- `NourishModal` swaps old spinner blocks for `NourishLoadingState` driven by derived `loadingState`. Silent pantry-miss → `analyzeRecipe` fall-through **removed**.
- Members see explicit `[Analyze]` button on miss; non-members keep the existing membership-upsell lock state.
- `[Score now]` escape hatch appears for members after 3 timeouts in the fixed 60s window. Routes through `analyzeRecipe` (enforces membership).
- Offline detection via `navigator.onLine` + `online`/`offline` listeners. Low-cost imprecision accepted; retry button dismisses any false state.
- Added a `fetched` latch on the reactive open-guard to prevent re-fire loops when `checking` transitions false → false on a miss.

## User-visible behavior changes (intentional)

1. Pantry timeout → retry UI (was: silent compute via `/api/nourish`)
2. Miss for members → explicit `[Analyze]` button (was: auto-compute)
3. Score-now escape hatch appears after 3 timeouts in 60s (new capability)
4. Pantry query timeout reduced 4s → 2s

## Dedup scope (reminder)

L1 is module-scoped = **same-tab only**. Cross-tab coordination (via `storage` event / `BroadcastChannel`) is out of scope for PR 2 (filed as follow-up per Phase 1 §1h.2). The real dedup win is pill + modal mounting concurrently on the same recipe — previously two pantry queries, now one.

## Preview-deploy verification (merge gate)

All five scenarios must pass visually on the Cloudflare Pages preview before merging:

- [ ] **1. Pantry fast**: open a scored recipe → skeleton briefly → score renders, no retry UI, one pantry `REQ` in Network tab
- [ ] **2. Pantry slow** (DevTools Slow 3G): clear localStorage, open recipe → skeleton → retry UI appears → click retry → resolves to score
- [ ] **3. Pantry unreachable** (block `wss://pantry.zap.cooking`): skeleton → retry UI → 3 attempts → `[Score now]` button appears → click → explicit compute
- [ ] **4. Browser offline** (DevTools Network → Offline): offline copy appears promptly, no hang; on reconnect, state re-derives to miss or timeout
- [ ] **5. Recovery** (pantry recovers mid-retry): 2 timeouts → retry → pantry responds → score renders, retry UI dismisses, attempt counter clears (verify by closing + reopening the modal — no `[Score now]` button on fresh open)

Also verify:
- [ ] Member miss path: open an unscored recipe as a member → `[Analyze]` button appears, clicking fires one `/api/nourish` call
- [ ] Non-member still sees the lock-state membership upsell (not the `[Analyze]` button)
- [ ] Existing-score stale-badge behavior unchanged
- [ ] `console.warn('[nourish.pantry.timeout]')` fires in DevTools on each pantry timeout (Workers-log observability)

## Check / build

- `pnpm run check`: 4 pre-existing errors / 127 warnings (baseline preserved)
- `pnpm run build`: passes