### PR TITLE
feat(nourish): stability — remaining drift fixes (scan drop, refresh pantry-first, flag promptVersion)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.241",
+  "version": "4.2.242",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.238",
+  "version": "4.2.239",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.240",
+  "version": "4.2.241",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.239",
+  "version": "4.2.240",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/nourish/NourishDimensionBar.svelte
+++ b/src/components/nourish/NourishDimensionBar.svelte
@@ -33,8 +33,13 @@
    */
   export let flagDimension: NourishDimension | null = null;
 
-  /** Nourish model/prompt version snapshot — required when flagTarget is set. */
-  export let nourishVer: string = '';
+  /**
+   * The promptVersion that produced this score — required when
+   * flagTarget is set. Passed through to NourishFlagButton so the
+   * flag event records the score's actual version, not the current
+   * NOURISH_PROMPT_VERSION constant at render time.
+   */
+  export let promptVersion: string = '';
 
   let expanded = false;
 
@@ -42,7 +47,7 @@
     if (reason) expanded = !expanded;
   }
 
-  $: canFlag = !!flagTarget && !!flagDimension && !!nourishVer;
+  $: canFlag = !!flagTarget && !!flagDimension && !!promptVersion;
 </script>
 
 <button
@@ -75,7 +80,7 @@
           target={flagTarget}
           dimension={flagDimension}
           {score}
-          {nourishVer}
+          {promptVersion}
           iconSize={12}
           dimensionLabel={label.toLowerCase()}
         />

--- a/src/components/nourish/NourishFlagButton.svelte
+++ b/src/components/nourish/NourishFlagButton.svelte
@@ -36,8 +36,15 @@
   /** Score at flag time (0..10). Stored in the flag record for admin triage. */
   export let score: number;
 
-  /** Nourish model/prompt version (from $lib/nourish/types). */
-  export let nourishVer: string;
+  /**
+   * The promptVersion that produced the score being flagged. Pulled
+   * from the ResolvedEntry that rendered the score, NOT from the
+   * global NOURISH_PROMPT_VERSION constant — so flags against a cached
+   * v1 score record v1 even after the constant bumps to v2. The
+   * on-wire flag tag name (`nourish-ver`) stays unchanged; only the
+   * prop renamed for clarity.
+   */
+  export let promptVersion: string;
 
   /** Icon size in px. Default 14 (matches NourishDimensionBar size scale). */
   export let iconSize = 14;
@@ -113,7 +120,10 @@
       dimension,
       direction: selectedDirection,
       score,
-      nourishVer,
+      // submitFlag's internal contract still uses `nourishVer` (it's
+      // the field name on the on-wire flag event tag and the admin
+      // aggregator reads it). Map the prop through unchanged.
+      nourishVer: promptVersion,
       reason: reason.trim() || undefined
     });
 

--- a/src/components/nourish/NourishModal.svelte
+++ b/src/components/nourish/NourishModal.svelte
@@ -7,11 +7,15 @@
 	import LockIcon from 'phosphor-svelte/lib/Lock';
 	import ArrowClockwiseIcon from 'phosphor-svelte/lib/ArrowClockwise';
 	import { parseMarkdownForEditing } from '$lib/parser';
-	import { setNourishScores, type NourishCacheKey } from '$lib/nourish/cache';
+	import {
+		setNourishScores,
+		clearNourishCache,
+		type NourishCacheKey
+	} from '$lib/nourish/cache';
 	import { generateSuggestions, mergeImprovements } from '$lib/nourish/suggestions';
 	import { ingredientStore } from '$lib/nourish/ingredientStore';
-	import { computeContentHash } from '$lib/nourish/nourishRelay';
-	import { resolveScore, type ResolveResult } from '$lib/nourish/scoreResolver';
+	import { computeContentHash, queryNourishEvent } from '$lib/nourish/nourishRelay';
+	import { resolveScore, purgeMemory, type ResolveResult } from '$lib/nourish/scoreResolver';
 	import type { NourishScores } from '$lib/nourish/types';
 	import { NOURISH_PROMPT_VERSION } from '$lib/nourish/types';
 	import type { FlagTarget } from '$lib/nourish/flagSubmit';
@@ -240,7 +244,63 @@
 
 	function retry() { scores = null; analyzeRecipe(); }
 
-	function reanalyze() { scores = null; stale = false; analyzeRecipe(); }
+	// Refresh the stale banner's score without unconditionally burning
+	// an LLM call. Flow:
+	//   1. Purge local cache under the current key (L2 + L3)
+	//   2. Query pantry directly — skipping resolveScore avoids a
+	//      speculative write-through of whatever pantry returns, since
+	//      we only want to cache a score whose contentHash matches the
+	//      recipe as it exists NOW.
+	//   3. If pantry has a fresh-hash version (e.g. another client
+	//      already rescored), use it + write through.
+	//   4. Otherwise fall through to analyzeRecipe — this path was
+	//      always the old behavior; it's the expensive fallback.
+	// Closes drift source #5 (refresh button unconditionally computes).
+	async function reanalyze() {
+		scores = null;
+		stale = false;
+
+		const { recipePubkey, recipeDTag } = getRecipeCoordinates();
+		const key: NourishCacheKey = {
+			recipePubkey,
+			recipeDTag,
+			promptVersion: NOURISH_PROMPT_VERSION
+		};
+
+		purgeMemory(key);
+		clearNourishCache(key);
+
+		checking = true;
+		try {
+			const currentHash = await computeContentHash(event.content || '');
+			const pantry = await queryNourishEvent($ndk, recipePubkey, recipeDTag);
+			if (pantry.status === 'hit' && pantry.result.contentHash === currentHash) {
+				// Pantry already has the fresh-hash version — use it, no
+				// LLM call. Write-through so subsequent mounts skip the
+				// pantry query.
+				scores = pantry.result.scores;
+				analyzedAt = pantry.result.createdAt;
+				buildImprovements(pantry.result.scores, pantry.result.improvements);
+				setNourishScores(
+					{ ...key, promptVersion: pantry.result.promptVersion },
+					pantry.result.scores,
+					{
+						contentHash: pantry.result.contentHash,
+						createdAt: pantry.result.createdAt,
+						improvements: pantry.result.improvements,
+						ingredientSignals: pantry.result.ingredientSignals
+					}
+				);
+				return;
+			}
+		} finally {
+			checking = false;
+		}
+
+		// Pantry miss, timeout, or pantry's version still carries the
+		// old (stale) content hash → compute fresh.
+		await analyzeRecipe();
+	}
 
 	// Retry-UI handlers. handleRetry re-runs the resolver (next pantry
 	// query); handleAnalyze commits to an explicit compute. The "Score

--- a/src/components/nourish/NourishModal.svelte
+++ b/src/components/nourish/NourishModal.svelte
@@ -47,6 +47,12 @@
 	let stale = false;
 	let analyzedAt = 0;
 	let error = '';
+	// PromptVersion that produced the currently-rendered score. Passed
+	// to NourishResult → NourishDimensionBar → NourishFlagButton so flag
+	// events carry the score's actual version, not the global constant
+	// at render time (closes 1c gap #3 from Phase 1 Stability). Defaults
+	// to the current constant; overwritten on hit + API-success paths.
+	let resolvedPromptVersion: string = NOURISH_PROMPT_VERSION;
 	// Pantry-timeout state — set when resolveScore returns
 	// { status: 'timeout' } (drift #1 fix: no more silent compute on
 	// pantry failure). Retry UI consumes attemptCount to decide when
@@ -90,6 +96,7 @@
 		pantryTimeout = false;
 		attemptCount = 0;
 		fetched = false;
+		resolvedPromptVersion = NOURISH_PROMPT_VERSION;
 	}
 
 	function getRecipeCoordinates() {
@@ -131,6 +138,7 @@
 			improvements = [];
 			buildImprovements(result.entry.scores, result.entry.improvements);
 			analyzedAt = result.entry.createdAt;
+			resolvedPromptVersion = result.entry.promptVersion;
 
 			// Preserve the original ingredient-store semantics: save only on
 			// a pantry hit (first-time surfacing of this event in a session).
@@ -212,6 +220,7 @@
 
 			scores = data.scores;
 			analyzedAt = data.createdAt ?? Math.floor(Date.now() / 1000);
+			resolvedPromptVersion = data.promptVersion ?? NOURISH_PROMPT_VERSION;
 			const writeKey = toCacheKey(recipePubkey, recipeDTag);
 			if (writeKey) {
 				setNourishScores(
@@ -280,6 +289,7 @@
 				// pantry query.
 				scores = pantry.result.scores;
 				analyzedAt = pantry.result.createdAt;
+				resolvedPromptVersion = pantry.result.promptVersion;
 				buildImprovements(pantry.result.scores, pantry.result.improvements);
 				setNourishScores(
 					{ ...key, promptVersion: pantry.result.promptVersion },
@@ -363,7 +373,7 @@
 			{scores}
 			{improvements}
 			{flagTarget}
-			nourishVer={NOURISH_PROMPT_VERSION}
+			promptVersion={resolvedPromptVersion}
 			compact
 		/>
 

--- a/src/components/nourish/NourishResult.svelte
+++ b/src/components/nourish/NourishResult.svelte
@@ -25,8 +25,12 @@
    */
   export let flagTarget: FlagTarget | null = null;
 
-  /** Nourish model/prompt version for the flag snapshot. */
-  export let nourishVer: string = '';
+  /**
+   * PromptVersion for the flag snapshot — the version that produced
+   * the scores being rendered, so flag events carry the right
+   * version when the constant has since bumped.
+   */
+  export let promptVersion: string = '';
 
   /**
    * Derive strength tags from scores — only highlight genuinely strong dimensions.
@@ -94,7 +98,7 @@
         reason={scores.realFood.reason}
         {flagTarget}
         flagDimension={flagTarget ? 'realFood' : null}
-        {nourishVer}
+        {promptVersion}
       />
       <NourishDimensionBar
         icon="🌱"
@@ -103,7 +107,7 @@
         reason={scores.gut.reason}
         {flagTarget}
         flagDimension={flagTarget ? 'gut' : null}
-        {nourishVer}
+        {promptVersion}
       />
       <NourishDimensionBar
         icon="💪"
@@ -112,7 +116,7 @@
         reason={scores.protein.reason}
         {flagTarget}
         flagDimension={flagTarget ? 'protein' : null}
-        {nourishVer}
+        {promptVersion}
       />
     </div>
   </div>

--- a/src/lib/nourish/cache.ts
+++ b/src/lib/nourish/cache.ts
@@ -53,6 +53,20 @@ export function getNourishCache(key: NourishCacheKey): CacheEntry | null {
 	}
 }
 
+/**
+ * Remove a single Nourish cache entry. Used by the stale-refresh flow
+ * to invalidate L3 state before re-querying pantry + optionally
+ * computing fresh, so we don't carry a known-stale blob forward.
+ */
+export function clearNourishCache(key: NourishCacheKey): void {
+	if (!browser) return;
+	try {
+		localStorage.removeItem(cacheKey(key));
+	} catch {
+		// localStorage unavailable — ignore
+	}
+}
+
 export function setNourishScores(
 	key: NourishCacheKey,
 	scores: NourishScores,

--- a/src/lib/nourish/cache.ts
+++ b/src/lib/nourish/cache.ts
@@ -1,5 +1,5 @@
 import { browser } from '$app/environment';
-import { NOURISH_CACHE_VERSION, type NourishScores, type ScanResponse } from './types';
+import { NOURISH_CACHE_VERSION, type NourishScores } from './types';
 
 const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
@@ -82,54 +82,7 @@ export function setNourishScores(
 	}
 }
 
-// ─── Scan result cache (keyed by content hash) ──────────────
-
-interface ScanCacheEntry {
-	data: ScanResponse;
-	timestamp: number;
-	cacheVersion: string;
-}
-
-/** Derive a cache key from text with extra entropy to reduce collisions. */
-function hashText(text: string): string {
-	const lengthPart = text.length.toString(36);
-	const prefixPart = text.slice(0, 32).replace(/[^a-zA-Z0-9]/g, '_');
-	let hash = 0;
-	for (let i = 0; i < text.length; i++) {
-		hash = ((hash << 5) - hash + text.charCodeAt(i)) | 0;
-	}
-	return `nourish_scan_${lengthPart}_${prefixPart}_${Math.abs(hash).toString(36)}`;
-}
-
-export function getScanResult(text: string): ScanResponse | null {
-	if (!browser) return null;
-
-	try {
-		const raw = localStorage.getItem(hashText(text));
-		if (!raw) return null;
-
-		const entry: ScanCacheEntry = JSON.parse(raw);
-
-		if (entry.cacheVersion !== NOURISH_CACHE_VERSION) return null;
-		if (Date.now() - entry.timestamp > CACHE_TTL_MS) return null;
-
-		return entry.data;
-	} catch {
-		return null;
-	}
-}
-
-export function setScanResult(text: string, data: ScanResponse): void {
-	if (!browser) return;
-
-	try {
-		const entry: ScanCacheEntry = {
-			data,
-			timestamp: Date.now(),
-			cacheVersion: NOURISH_CACHE_VERSION
-		};
-		localStorage.setItem(hashText(text), JSON.stringify(entry));
-	} catch {
-		// localStorage full — silently ignore
-	}
-}
+// Scan result caching was removed in PR 3 commit 6. Scans are per-user
+// and often personal; cross-user caching via a weak text hash was a
+// privacy + staleness risk. See src/lib/nourish/scanCacheCleanup.ts
+// for the one-shot cleanup of legacy `nourish_scan_*` entries.

--- a/src/lib/nourish/index.ts
+++ b/src/lib/nourish/index.ts
@@ -12,7 +12,7 @@ export {
 	type IngredientRecord
 } from './types';
 
-export { getNourishCache, setNourishScores, getScanResult, setScanResult } from './cache';
+export { getNourishCache, setNourishScores } from './cache';
 export type { NourishCacheKey } from './cache';
 
 export { generateSuggestions, mergeImprovements } from './suggestions';

--- a/src/lib/nourish/index.ts
+++ b/src/lib/nourish/index.ts
@@ -12,7 +12,7 @@ export {
 	type IngredientRecord
 } from './types';
 
-export { getNourishCache, setNourishScores } from './cache';
+export { getNourishCache, setNourishScores, clearNourishCache } from './cache';
 export type { NourishCacheKey } from './cache';
 
 export { generateSuggestions, mergeImprovements } from './suggestions';

--- a/src/lib/nourish/scanCacheCleanup.ts
+++ b/src/lib/nourish/scanCacheCleanup.ts
@@ -1,0 +1,56 @@
+/**
+ * One-shot cleanup for legacy Nourish scan cache entries.
+ *
+ * PR 3 commit 6 dropped scan caching (privacy + staleness). Existing
+ * browsers may still have `nourish_scan_*` localStorage entries from
+ * the old caching implementation. This runs once per browser (gated
+ * by a sentinel flag), via requestIdleCallback so it doesn't block
+ * initial render. If localStorage is unavailable or the sentinel
+ * write fails, the next page load retries.
+ */
+
+import { browser } from '$app/environment';
+
+const SENTINEL_KEY = 'nourish_scan_cleanup_done_v1';
+const LEGACY_KEY_PREFIX = 'nourish_scan_';
+
+type IdleScheduler = (cb: () => void) => void;
+
+function getScheduler(): IdleScheduler {
+  if (browser && typeof (window as any).requestIdleCallback === 'function') {
+    return (cb) => (window as any).requestIdleCallback(cb);
+  }
+  // Fallback for browsers without requestIdleCallback (Safari pre-16).
+  // setTimeout with a minimal delay still gets us off the critical
+  // rendering path for initial paint.
+  return (cb) => setTimeout(cb, 1);
+}
+
+export function cleanupLegacyScanCache(): void {
+  if (!browser) return;
+
+  try {
+    if (localStorage.getItem(SENTINEL_KEY) === '1') return;
+  } catch {
+    return; // localStorage unavailable — nothing to clean
+  }
+
+  const schedule = getScheduler();
+  schedule(() => {
+    try {
+      const toDelete: string[] = [];
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key && key.startsWith(LEGACY_KEY_PREFIX)) {
+          toDelete.push(key);
+        }
+      }
+      for (const key of toDelete) {
+        localStorage.removeItem(key);
+      }
+      localStorage.setItem(SENTINEL_KEY, '1');
+    } catch {
+      // Quota exhausted or permission denied — try again next boot.
+    }
+  });
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -314,10 +314,16 @@
   // One-shot pass to clear legacy nourish_scan_* localStorage entries
   // left behind when scan caching was removed in PR 3 commit 6. Runs
   // via requestIdleCallback so it doesn't block initial paint; sentinel
-  // flag ensures single-run per browser.
+  // flag ensures single-run per browser. Wrapped so a dynamic-import
+  // failure (chunk not yet cached, network blip) can't surface as an
+  // unhandled rejection during app boot.
   onMount(async () => {
-    const { cleanupLegacyScanCache } = await import('$lib/nourish/scanCacheCleanup');
-    cleanupLegacyScanCache();
+    try {
+      const { cleanupLegacyScanCache } = await import('$lib/nourish/scanCacheCleanup');
+      cleanupLegacyScanCache();
+    } catch (err) {
+      console.warn('[nourish.scan-cleanup.import-failed]', err);
+    }
   });
 
   // Show wallet welcome after leaving login/onboarding (e.g. after suggested follows completes)

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -311,6 +311,15 @@
     }
   });
 
+  // One-shot pass to clear legacy nourish_scan_* localStorage entries
+  // left behind when scan caching was removed in PR 3 commit 6. Runs
+  // via requestIdleCallback so it doesn't block initial paint; sentinel
+  // flag ensures single-run per browser.
+  onMount(async () => {
+    const { cleanupLegacyScanCache } = await import('$lib/nourish/scanCacheCleanup');
+    cleanupLegacyScanCache();
+  });
+
   // Show wallet welcome after leaving login/onboarding (e.g. after suggested follows completes)
   $: {
     const onboardingFlow = $page.url.pathname.startsWith('/login') || $page.url.pathname.startsWith('/onboarding');

--- a/src/routes/nourish/+page.svelte
+++ b/src/routes/nourish/+page.svelte
@@ -172,7 +172,7 @@
       ingredientSignals={scanResult.ingredient_signals || []}
       onReset={resetScan}
       {flagTarget}
-      nourishVer={NOURISH_PROMPT_VERSION}
+      promptVersion={scanResult.promptVersion ?? NOURISH_PROMPT_VERSION}
     />
 
   {:else}

--- a/src/routes/nourish/+page.svelte
+++ b/src/routes/nourish/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { userPublickey } from '$lib/nostr';
   import { membershipStatusMap, queueMembershipLookup, type MembershipStatus } from '$lib/stores/membershipStatus';
-  import { getScanResult, setScanResult } from '$lib/nourish/cache';
   import { generateSuggestions, mergeImprovements } from '$lib/nourish/suggestions';
   import { ingredientStore } from '$lib/nourish/ingredientStore';
   import type { ScanResponse } from '$lib/nourish/types';
@@ -71,16 +70,10 @@
       return;
     }
 
-    // Check scan cache (text-only, not images)
-    if (text && !imageData) {
-      const cached = getScanResult(text);
-      if (cached?.scores) {
-        scanResult = cached;
-        buildImprovements(cached);
-        return;
-      }
-    }
-
+    // Scan results are no longer cached locally (PR 3 commit 6).
+    // Scans are per-user and often personal; cross-user caching via a
+    // weak text hash was a privacy + staleness risk. Every scan now
+    // fires a fresh compute.
     scanning = true;
     scanError = '';
 
@@ -109,11 +102,6 @@
 
       scanResult = data;
       buildImprovements(data);
-
-      // Cache text-based results (not image-based — different images same text)
-      if (text && !imageData) {
-        setScanResult(text, data);
-      }
 
       // Save ingredient signals to build dataset over time
       if (data.ingredient_signals?.length) {


### PR DESCRIPTION
**Draft.** PR 3 of 4 in the Nourish Stability feature. Three atomic commits close the remaining long-tail drift sources that don't require a new auth model.

Prerequisite: #311 (foundation) + #312 (dedup / conflict resolution / retry UI) — both merged.

## Scope change — commit 5 deferred to PR 3.5

Originally this PR included commit 5 (opportunistic pantry republish, drift #4). **Copilot review surfaced a pantry-spoofing vector** in the blob-trust design: the endpoint is reachable via direct HTTP bypassing the client-side trust chain, and my Phase 1b analysis conflated "no existing client path writes arbitrary JSON to localStorage" (true) with "the endpoint can therefore trust submitted blobs" (false — any client can POST whatever they want).

Commit 5 has been reverted from this branch. Drift #4 will ship in **PR 3.5** with a proper Phase 1 investigation of auth token shape, lifecycle, expiry, server-side secret management, and rotation. Tracking issue: [link added once filed].

Drift #4 is MODERATE severity and pantry's NIP-33 replaceable-event semantics bound any fabrication damage — acceptable for one more PR cycle while we design auth correctly.

## Commit plan (revised)

| # | Commit | SHA | Drift source |
|---|---|---|---|
| 6 | Drop scan caching (privacy + staleness) | `c63cbf4` | **#7 LOW** |
| 7 | Refresh button checks pantry before recomputing | `f3f4879` | **#5 LOW** |
| 8 | Flag captures promptVersion from scored event | `c9bafa3` | 1c gap #3 |
| — | Guard scan-cleanup dynamic import from unhandled rejection | `b212d4e` | Copilot review #5 |

## After this PR merges

Drift source status:

| # | Severity | Closed in |
|---|---|---|
| #1 Pantry timeout → silent compute | BLOCKER | PR 2 commit 4 (retry UI) |
| #2 No Promise-level dedup | BLOCKER | PR 2 commit 2 (L1 cache) |
| #3 Multiple cache keys | MODERATE | PR 2 commit 3 (conflict resolution) |
| #4 Silent pantry publish failure | MODERATE | **PR 3.5 (deferred)** |
| #5 Refresh unconditionally recomputes | LOW | **PR 3 commit 7** |
| #6 Seed endpoint no invalidation | LOW | self-heals via #3 (documented) |
| #7 Scan cache collisions | LOW | **PR 3 commit 6** |

PR 4 will activate the Flag signal (#303) via the admin rescore loop.

## Commit-by-commit

### Commit 6 — drop scan caching

Scan results on `/nourish` are now compute-on-demand only. Previously cached at `nourish_scan_${weakHash(text)}` with 7d TTL. Dropped because scan text is personal (privacy) and the weak rolling hash amplified collisions on similar-but-distinct text (staleness).

One-shot async cleanup on first app load deletes existing `nourish_scan_*` localStorage entries via `requestIdleCallback` (fallback to `setTimeout(cb, 1)` for Safari pre-16). Sentinel key (`nourish_scan_cleanup_done_v1`) gates subsequent runs.

### Commit 7 — refresh button pantry-first

The stale-banner Refresh no longer unconditionally fires an LLM call. New flow:

1. Purge L2 (via `purgeMemory` from PR 2) + L3 (via new `clearNourishCache` export)
2. Compute current content hash
3. Query pantry **directly via `queryNourishEvent`** (not `resolveScore`, to avoid speculative write-through of a stale-hash score)
4. If pantry has a hit whose `contentHash === currentHash` → use it + write through
5. Else → `analyzeRecipe()` (the expensive fallback, unchanged)

User-visible: feels identical — loading spinner, score updates, stale badge clears. When another client already rescored and pantry has the fresh-hash version, refresh is zero-LLM-cost.

### Commit 8 — flag captures promptVersion

Component-chain rename: `nourishVer` → `promptVersion` through `NourishFlagButton`, `NourishDimensionBar`, `NourishResult`. Modal threads `resolvedPromptVersion` (set from `ResolvedEntry.promptVersion` on hit, from `data.promptVersion` on API compute) instead of the global constant at render time.

On-wire tag name `nourish-ver` in `flagSubmit.ts:232` stays unchanged for backward compat with existing flag events + admin aggregator.

### Cleanup fix (`b212d4e`)

Wraps the scan-cleanup dynamic import in try/catch so a chunk-load failure can't surface as an unhandled rejection during app boot (Copilot review comment #5).

## Verification plan

### Commit 6 — scan cache drop
- [ ] Pre-populate localStorage with `nourish_scan_test_fake_key = "{}"` before loading the app → after idle callback fires, confirm the key is gone and `nourish_scan_cleanup_done_v1 === '1'`
- [ ] Submit a scan on `/nourish` → scoring works end-to-end
- [ ] Submit the same scan twice → second fires a fresh LLM call (no cache hit, expected)

### Commit 7 — refresh pantry-first
- [ ] Edit a recipe's content → open modal → stale banner appears → click Refresh → if pantry already has a fresh-hash rescore, network shows ONE `queryNourishEvent` pantry query and NO `/api/nourish` POST. If pantry is also stale, `/api/nourish` fires as before.

### Commit 8 — flag promptVersion
- [ ] On a recipe with a Nourish score (ideally one scored under v1), click a dimension flag button → submit → inspect the flag event on pantry → tag `['nourish-ver', <score's actual v1>]`, not the current constant
- [ ] `/admin/nourish-flags` still loads flags without regression

### Regression sweep
- [ ] Full Nourish modal flow (pantry-hit, compute, stale refresh, flag submit) on a fresh browser
- [ ] Scan page (`/nourish`) with text, with image, with both

## Check / build status

- `pnpm run check`: 4 pre-existing errors / 127 warnings (baseline preserved across all commits)
- `pnpm run build`: passes

## Why the force-push

Branch was rebased onto `main` to drop the original commit 5 (`224a411`) cleanly. Commits 6, 7, 8 replay as `c63cbf4`, `f3f4879`, `c9bafa3` with identical content — SHAs changed because their base changed.