### PR TITLE
feat(nourish): stability — admin rescore loop (endpoint, UI, Updated pill, upgrade candidates)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.244",
+  "version": "4.2.245",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.243",
+  "version": "4.2.244",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.247",
+  "version": "4.2.248",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.242",
+  "version": "4.2.243",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.246",
+  "version": "4.2.247",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.245",
+  "version": "4.2.246",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.248",
+  "version": "4.2.249",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/nourish/NourishModal.svelte
+++ b/src/components/nourish/NourishModal.svelte
@@ -53,6 +53,16 @@
 	// at render time (closes 1c gap #3 from Phase 1 Stability). Defaults
 	// to the current constant; overwritten on hit + API-success paths.
 	let resolvedPromptVersion: string = NOURISH_PROMPT_VERSION;
+	// updatedAt from the resolved score, if present. Populated on hit
+	// paths from pantry events published with an `updated_at` tag (admin
+	// rescore endpoint, PR 4 commit 9b). Undefined on first-time scores —
+	// pill intentionally hidden for those.
+	//
+	// Render-time check only: isRecentlyUpdated evaluates when the modal
+	// mounts and doesn't reactively hide the pill at the 24h boundary if
+	// the modal is still open. Acceptable — nobody stares at a modal for
+	// 24h; next mount re-evaluates.
+	let resolvedUpdatedAt: number | undefined = undefined;
 	// Pantry-timeout state — set when resolveScore returns
 	// { status: 'timeout' } (drift #1 fix: no more silent compute on
 	// pantry failure). Retry UI consumes attemptCount to decide when
@@ -97,6 +107,7 @@
 		attemptCount = 0;
 		fetched = false;
 		resolvedPromptVersion = NOURISH_PROMPT_VERSION;
+		resolvedUpdatedAt = undefined;
 	}
 
 	function getRecipeCoordinates() {
@@ -139,6 +150,7 @@
 			buildImprovements(result.entry.scores, result.entry.improvements);
 			analyzedAt = result.entry.createdAt;
 			resolvedPromptVersion = result.entry.promptVersion;
+			resolvedUpdatedAt = result.entry.updatedAt;
 
 			// Preserve the original ingredient-store semantics: save only on
 			// a pantry hit (first-time surfacing of this event in a session).
@@ -290,6 +302,7 @@
 				scores = pantry.result.scores;
 				analyzedAt = pantry.result.createdAt;
 				resolvedPromptVersion = pantry.result.promptVersion;
+				resolvedUpdatedAt = pantry.result.updatedAt;
 				buildImprovements(pantry.result.scores, pantry.result.improvements);
 				setNourishScores(
 					{ ...key, promptVersion: pantry.result.promptVersion },
@@ -297,6 +310,7 @@
 					{
 						contentHash: pantry.result.contentHash,
 						createdAt: pantry.result.createdAt,
+						updatedAt: pantry.result.updatedAt,
 						improvements: pantry.result.improvements,
 						ingredientSignals: pantry.result.ingredientSignals
 					}
@@ -367,6 +381,13 @@
 					</button>
 				{/if}
 			</div>
+		{/if}
+
+		{#if resolvedUpdatedAt && Date.now() / 1000 - resolvedUpdatedAt < 86400}
+			<!-- "Updated" pill — shown for 24h after an admin rescore so returning
+			     users notice the score changed. Render-time check (see the
+			     resolvedUpdatedAt state comment for intentional non-reactivity). -->
+			<span class="updated-pill" title="Recently updated by moderator">Updated</span>
 		{/if}
 
 		<NourishResult
@@ -445,6 +466,14 @@
 		border: none;
 	}
 	.stale-refresh:hover { background: rgba(234, 179, 8, 0.2); }
+
+	/* ── Updated pill (24h post-admin-rescore) ── */
+	.updated-pill {
+		@apply inline-flex items-center gap-1 self-start px-2 py-0.5 rounded-full text-xs font-medium mb-2;
+		color: #22c55e;
+		background: rgba(34, 197, 94, 0.1);
+		border: 1px solid rgba(34, 197, 94, 0.2);
+	}
 
 	/* ── Loading / Error ── */
 	.error-state { @apply flex flex-col items-center text-center gap-3 py-4; }

--- a/src/lib/nip98.server.ts
+++ b/src/lib/nip98.server.ts
@@ -1,0 +1,131 @@
+/**
+ * NIP-98 HTTP Auth — server-side verifier.
+ *
+ * Paired with `signNip98AuthHeader` in src/lib/nip98.ts. Decodes the
+ * `Authorization: Nostr <base64>` header, verifies the signed
+ * kind-27235 event, and checks that the event binds to this specific
+ * request (URL, method, recent timestamp, and — when a body is
+ * present — its exact bytes via a `payload` tag hash).
+ *
+ * Returns a discriminated result with one of a fixed set of failure
+ * reasons so callers can `console.warn` them for greppable logs while
+ * uniformly returning `403 { error: 'forbidden' }` to clients (no
+ * information leak about which check failed).
+ */
+
+import { verifyEvent, type Event as NostrEvent } from 'nostr-tools';
+import { normalizeUrl, sha256Hex } from './nip98';
+
+export type Nip98FailureReason =
+  | 'missing-header'
+  | 'malformed-header'
+  | 'invalid-signature'
+  | 'wrong-kind'
+  | 'stale-timestamp'
+  | 'url-mismatch'
+  | 'method-mismatch'
+  | 'payload-mismatch'
+  | 'missing-payload-tag'
+  | 'pubkey-mismatch';
+
+export type Nip98Verification =
+  | { ok: true; pubkey: string }
+  | { ok: false; reason: Nip98FailureReason };
+
+const DEFAULT_MAX_SKEW_SECONDS = 60;
+
+/**
+ * Verify a NIP-98 Authorization header against the current request.
+ *
+ * Caller reads the request body ONCE (via `request.arrayBuffer()` or
+ * equivalent) and passes the bytes in `bodyBytes` — avoids the
+ * `request.clone().arrayBuffer()` pattern which has subtle
+ * body-consumption semantics on Cloudflare Workers. Callers that
+ * parse the body themselves after this verifier returns should reuse
+ * the same bytes rather than touching `request.json()`.
+ *
+ * A `bodyBytes` value of undefined means "no body to verify" (GET-
+ * style). For POST/PUT/PATCH with a JSON body, always pass the bytes
+ * — a missing `payload` tag is a verification failure (prevents a
+ * caller from signing a header for an empty body and replaying it
+ * against a request with a real body).
+ */
+export async function verifyNip98(
+  request: Request,
+  opts: {
+    expectedPubkey: string;
+    bodyBytes?: Uint8Array;
+    maxSkewSeconds?: number;
+  }
+): Promise<Nip98Verification> {
+  const header = request.headers.get('Authorization');
+  if (!header) return { ok: false, reason: 'missing-header' };
+  if (!header.startsWith('Nostr ')) {
+    return { ok: false, reason: 'malformed-header' };
+  }
+  const encoded = header.slice('Nostr '.length).trim();
+
+  let event: NostrEvent;
+  try {
+    const decoded = atob(encoded);
+    event = JSON.parse(decoded);
+  } catch {
+    return { ok: false, reason: 'malformed-header' };
+  }
+
+  if (event.kind !== 27235) return { ok: false, reason: 'wrong-kind' };
+
+  // Signature verification uses @noble/secp256k1 + @noble/hashes under
+  // the hood — pure JS, works on Cloudflare Workers. Same crypto
+  // substrate as publishNourishEvent's finalizeEvent.
+  let valid = false;
+  try {
+    valid = verifyEvent(event);
+  } catch {
+    valid = false;
+  }
+  if (!valid) return { ok: false, reason: 'invalid-signature' };
+
+  // Timestamp skew — ±60s default.
+  const now = Math.floor(Date.now() / 1000);
+  const maxSkew = opts.maxSkewSeconds ?? DEFAULT_MAX_SKEW_SECONDS;
+  if (Math.abs(now - (event.created_at || 0)) > maxSkew) {
+    return { ok: false, reason: 'stale-timestamp' };
+  }
+
+  // URL match — both sides use normalizeUrl from the shared module
+  // so any discrepancy is a real mismatch, not a normalization bug.
+  const uTag = event.tags.find((t) => t[0] === 'u')?.[1];
+  if (!uTag) return { ok: false, reason: 'url-mismatch' };
+  if (normalizeUrl(uTag) !== normalizeUrl(request.url)) {
+    return { ok: false, reason: 'url-mismatch' };
+  }
+
+  // Method match.
+  const methodTag = event.tags.find((t) => t[0] === 'method')?.[1];
+  if (!methodTag || methodTag.toUpperCase() !== request.method.toUpperCase()) {
+    return { ok: false, reason: 'method-mismatch' };
+  }
+
+  // Payload binding — required when the caller passes bodyBytes.
+  // Missing tag is a distinct failure reason from mismatch so admin
+  // logs can tell "attacker stripped the tag" from "attacker swapped
+  // the body."
+  if (opts.bodyBytes !== undefined) {
+    const payloadTag = event.tags.find((t) => t[0] === 'payload')?.[1];
+    if (!payloadTag) return { ok: false, reason: 'missing-payload-tag' };
+    const expected = await sha256Hex(opts.bodyBytes);
+    if (payloadTag.toLowerCase() !== expected.toLowerCase()) {
+      return { ok: false, reason: 'payload-mismatch' };
+    }
+  }
+
+  // Identity gate — only the expected pubkey is authorized for this
+  // endpoint. Signature was valid (the caller proved they hold some
+  // key), but only ADMIN_PUBKEY is allowed to rescore.
+  if (event.pubkey !== opts.expectedPubkey) {
+    return { ok: false, reason: 'pubkey-mismatch' };
+  }
+
+  return { ok: true, pubkey: event.pubkey };
+}

--- a/src/lib/nip98.ts
+++ b/src/lib/nip98.ts
@@ -1,0 +1,93 @@
+/**
+ * NIP-98 HTTP Auth — client-side helpers + shared primitives.
+ *
+ * Callers sign a short-lived kind-27235 event bound to a specific
+ * URL, method, and (optionally) request-body hash, then send the
+ * base64-encoded event in the `Authorization: Nostr <…>` header.
+ * See src/lib/nip98.server.ts for the matching verifier.
+ *
+ * Pattern mirrors the existing client usage (nostr.build uploads in
+ * mediaUpload.ts, nip29.ts, etc.) and factors out URL normalization
+ * + payload hashing so client and server agree on the exact strings
+ * being signed.
+ */
+
+import type NDK from '@nostr-dev-kit/ndk';
+import { NDKEvent } from '@nostr-dev-kit/ndk';
+
+/**
+ * Canonicalize a URL for NIP-98 `u` tag matching. Uses origin +
+ * pathname, drops query string and fragment, strips trailing slash
+ * on non-root paths. Client and server call this same helper so both
+ * sides agree on the exact string — mismatches here produce
+ * `url-mismatch` failures that would be painful to debug otherwise.
+ */
+export function normalizeUrl(url: string): string {
+  const u = new URL(url);
+  let pathname = u.pathname;
+  if (pathname.length > 1 && pathname.endsWith('/')) {
+    pathname = pathname.slice(0, -1);
+  }
+  return `${u.origin}${pathname}`;
+}
+
+/** Lowercase-hex SHA-256 of raw bytes — NIP-98 `payload` tag format. */
+export async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const hashBuffer = await crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/**
+ * Build + sign a NIP-98 Authorization header value for a single
+ * request. Returns the full header string (including the "Nostr "
+ * prefix) so callers can drop it directly into `headers.Authorization`.
+ *
+ * When `bodyString` is provided, the event includes a `payload` tag
+ * with the hex SHA-256 of its UTF-8 bytes — the server verifier
+ * compares this against the actual received body, preventing
+ * body-swap replay while reusing the same auth header.
+ *
+ * Callers should pass the exact string they'll send as the fetch
+ * body (rather than an object the helper stringifies internally) so
+ * there's a single source of truth for what the signature covers.
+ *
+ * Throws if the NDK instance has no signer set.
+ */
+export async function signNip98AuthHeader(
+  ndk: NDK,
+  opts: { method: string; url: string; bodyString?: string }
+): Promise<string> {
+  if (!ndk.signer) {
+    throw new Error('NIP-98 signing requires an NDK signer (not logged in?)');
+  }
+
+  const template = new NDKEvent(ndk);
+  template.kind = 27235;
+  template.created_at = Math.floor(Date.now() / 1000);
+  template.content = '';
+  const tags: string[][] = [
+    ['u', normalizeUrl(opts.url)],
+    ['method', opts.method.toUpperCase()]
+  ];
+  if (opts.bodyString !== undefined) {
+    const hex = await sha256Hex(new TextEncoder().encode(opts.bodyString));
+    tags.push(['payload', hex]);
+  }
+  template.tags = tags;
+
+  await template.sign();
+
+  const authEvent = {
+    id: template.id,
+    pubkey: template.pubkey,
+    created_at: template.created_at,
+    kind: template.kind,
+    tags: template.tags,
+    content: template.content,
+    sig: template.sig
+  };
+
+  return `Nostr ${btoa(JSON.stringify(authEvent))}`;
+}

--- a/src/lib/nourish/cache.ts
+++ b/src/lib/nourish/cache.ts
@@ -21,6 +21,15 @@ interface CacheEntry {
 	contentHash?: string;
 	promptVersion?: string;
 	createdAt?: number;
+	/**
+	 * Unix seconds of the last admin rescore, if any. Populated from
+	 * the pantry event's `updated_at` tag when we cache a rescored
+	 * score. Drives the 24h "Updated" pill on the client. Pre-PR-4
+	 * entries lack this field and won't show the pill — by design:
+	 * they weren't rescored. No bulk migration; entries age out
+	 * naturally.
+	 */
+	updatedAt?: number;
 	improvements?: string[];
 	ingredientSignals?: import('./types').IngredientSignal[];
 }
@@ -73,6 +82,7 @@ export function setNourishScores(
 	extra?: {
 		contentHash?: string;
 		createdAt?: number;
+		updatedAt?: number;
 		improvements?: string[];
 		ingredientSignals?: import('./types').IngredientSignal[];
 	}
@@ -87,6 +97,7 @@ export function setNourishScores(
 			contentHash: extra?.contentHash,
 			promptVersion: key.promptVersion,
 			createdAt: extra?.createdAt,
+			updatedAt: extra?.updatedAt,
 			improvements: extra?.improvements,
 			ingredientSignals: extra?.ingredientSignals
 		};

--- a/src/lib/nourish/nourishDiscovery.ts
+++ b/src/lib/nourish/nourishDiscovery.ts
@@ -203,13 +203,19 @@ export interface OutOfVersionCandidate {
   contentHash: string;
 }
 
+const CANDIDATES_FETCH_LIMIT = 500;
+
 /**
  * Fetch pantry Nourish events whose promptVersion doesn't match the
  * current server constant. Admin view joins these with flag counts
  * client-side and surfaces them in the "Upgrade candidates" tab.
  *
- * Returns the full list (no pagination) — admin surface, volume is
- * bounded by the number of scored recipes.
+ * Bounded by a {@link CANDIDATES_FETCH_LIMIT}-event relay cap — emits
+ * a `[nourish.candidates.truncated]` warn when the cap is hit so the
+ * admin can decide whether paging is worth adding. Deduplicates by
+ * `(recipePubkey, recipeDTag)` keeping the newest `createdAt`, so
+ * historical copies of the same addressable event returned by the
+ * relay don't double-count in the UI.
  */
 export async function fetchOutOfVersionCandidates(
   ndk: NDK,
@@ -218,7 +224,7 @@ export async function fetchOutOfVersionCandidates(
   const filter = {
     kinds: [30078 as number],
     authors: [NOURISH_SERVICE_PUBKEY],
-    limit: 500
+    limit: CANDIDATES_FETCH_LIMIT
   };
 
   const relaySet = NDKRelaySet.fromRelayUrls([PANTRY_RELAY], ndk, true);
@@ -236,7 +242,18 @@ export async function fetchOutOfVersionCandidates(
     nourishEvents = await Promise.race([broadFetch, broadTimeout]);
   }
 
-  const candidates: OutOfVersionCandidate[] = [];
+  if (nourishEvents.size >= CANDIDATES_FETCH_LIMIT) {
+    console.warn('[nourish.candidates.truncated]', {
+      fetched: nourishEvents.size,
+      limit: CANDIDATES_FETCH_LIMIT
+    });
+  }
+
+  // Kind 30078 is addressable/replaceable by d-tag, but relays can
+  // still return multiple historical versions for the same coordinate.
+  // Dedup by (recipePubkey, recipeDTag) keeping the newest createdAt
+  // so the Upgrade candidates tab shows one row per target.
+  const byCoord = new Map<string, OutOfVersionCandidate>();
   for (const event of nourishEvents) {
     const parsed = parseNourishEvent(event);
     if (!parsed) continue;
@@ -251,7 +268,10 @@ export async function fetchOutOfVersionCandidates(
     const recipeDTag = rest.join(':');
     if (!recipePubkey || !recipeDTag) continue;
 
-    candidates.push({
+    const existing = byCoord.get(aTagFull);
+    if (existing && existing.createdAt >= parsed.createdAt) continue;
+
+    byCoord.set(aTagFull, {
       recipePubkey,
       recipeDTag,
       aTag: aTagFull,
@@ -263,5 +283,5 @@ export async function fetchOutOfVersionCandidates(
     });
   }
 
-  return candidates;
+  return Array.from(byCoord.values());
 }

--- a/src/lib/nourish/nourishDiscovery.ts
+++ b/src/lib/nourish/nourishDiscovery.ts
@@ -10,6 +10,7 @@ import type NDK from '@nostr-dev-kit/ndk';
 import type { NDKEvent } from '@nostr-dev-kit/ndk';
 import { NDKRelaySet } from '@nostr-dev-kit/ndk';
 import { NOURISH_SERVICE_PUBKEY } from './types';
+import type { NourishScores } from './types';
 import { parseNourishEvent, type NourishRelayResult } from './nourishRelay';
 
 const PANTRY_RELAY = 'wss://pantry.zap.cooking';
@@ -180,4 +181,87 @@ export async function fetchNourishRankedRecipes(
   }
 
   return results;
+}
+
+// ─── Admin: model-upgrade candidates ────────────────────────
+
+/**
+ * Candidate for admin-triggered rescore because its stored
+ * promptVersion doesn't match the server's current
+ * NOURISH_PROMPT_VERSION (or it's a legacy `'unknown'` event per
+ * PR 311's untagged-event handling).
+ */
+export interface OutOfVersionCandidate {
+  recipePubkey: string;
+  recipeDTag: string;
+  /** `30023:${recipePubkey}:${recipeDTag}` — joinable against flag aggregator's `target` (minus the `a:` prefix). */
+  aTag: string;
+  eventId: string;
+  promptVersion: string;
+  createdAt: number;
+  scores: NourishScores;
+  contentHash: string;
+}
+
+/**
+ * Fetch pantry Nourish events whose promptVersion doesn't match the
+ * current server constant. Admin view joins these with flag counts
+ * client-side and surfaces them in the "Upgrade candidates" tab.
+ *
+ * Returns the full list (no pagination) — admin surface, volume is
+ * bounded by the number of scored recipes.
+ */
+export async function fetchOutOfVersionCandidates(
+  ndk: NDK,
+  currentPromptVersion: string
+): Promise<OutOfVersionCandidate[]> {
+  const filter = {
+    kinds: [30078 as number],
+    authors: [NOURISH_SERVICE_PUBKEY],
+    limit: 500
+  };
+
+  const relaySet = NDKRelaySet.fromRelayUrls([PANTRY_RELAY], ndk, true);
+  const fetchPromise = ndk.fetchEvents(filter, undefined, relaySet);
+  const timeoutPromise = new Promise<Set<NDKEvent>>((resolve) =>
+    setTimeout(() => resolve(new Set()), FETCH_TIMEOUT_MS)
+  );
+  let nourishEvents = await Promise.race([fetchPromise, timeoutPromise]);
+
+  if (nourishEvents.size === 0) {
+    const broadFetch = ndk.fetchEvents(filter);
+    const broadTimeout = new Promise<Set<NDKEvent>>((resolve) =>
+      setTimeout(() => resolve(new Set()), FETCH_TIMEOUT_MS)
+    );
+    nourishEvents = await Promise.race([broadFetch, broadTimeout]);
+  }
+
+  const candidates: OutOfVersionCandidate[] = [];
+  for (const event of nourishEvents) {
+    const parsed = parseNourishEvent(event);
+    if (!parsed) continue;
+    if (parsed.promptVersion === currentPromptVersion) continue;
+
+    // Recipe coordinates come from the `a` tag (kind:pubkey:dTag).
+    const aTagFull = event.tags.find((t) => t[0] === 'a')?.[1];
+    if (!aTagFull) continue;
+    const parts = aTagFull.split(':');
+    if (parts.length < 3) continue;
+    const [, recipePubkey, ...rest] = parts;
+    const recipeDTag = rest.join(':');
+    if (!recipePubkey || !recipeDTag) continue;
+
+    candidates.push({
+      recipePubkey,
+      recipeDTag,
+      aTag: aTagFull,
+      eventId: parsed.eventId,
+      promptVersion: parsed.promptVersion,
+      createdAt: parsed.createdAt,
+      scores: parsed.scores,
+      contentHash: parsed.contentHash
+    });
+  }
+
+  return candidates;
 }

--- a/src/lib/nourish/nourishPublisher.server.ts
+++ b/src/lib/nourish/nourishPublisher.server.ts
@@ -82,6 +82,11 @@ function publishToRelay(relayUrl: string, event: any): Promise<boolean> {
 
 /**
  * Publish a Nourish analysis event to relays.
+ *
+ * Set `updatedAt` on rescores (admin-triggered) so the client can
+ * distinguish fresh compute from re-scoring and render an "Updated"
+ * badge for 24h. Normal first-time compute omits it — no tag is
+ * emitted, so those events don't trigger the badge.
  */
 export async function publishNourishEvent(opts: {
   privateKey: string;
@@ -91,31 +96,42 @@ export async function publishNourishEvent(opts: {
   scores: NourishScores;
   improvements: string[];
   ingredientSignals: IngredientSignal[];
+  /**
+   * Unix seconds. When set, emit an `updated_at` tag (and content-JSON
+   * mirror) marking this event as a rescore rather than a first-time
+   * score. Undefined → no tag emitted.
+   */
+  updatedAt?: number;
 }): Promise<boolean> {
-  const { privateKey, recipePubkey, recipeDTag, contentHash, scores, improvements, ingredientSignals } = opts;
+  const { privateKey, recipePubkey, recipeDTag, contentHash, scores, improvements, ingredientSignals, updatedAt } = opts;
 
   try {
     const privKeyBytes = resolvePrivateKey(privateKey);
     const dTag = buildNourishDTag(recipePubkey, recipeDTag);
     const createdAt = Math.floor(Date.now() / 1000);
 
+    const tags: string[][] = [
+      ['d', dTag],
+      ['client', 'zap.cooking'],
+      ['a', `30023:${recipePubkey}:${recipeDTag}`],
+      ['p', recipePubkey],
+      ['nourish_version', NOURISH_CACHE_VERSION],
+      ['content_hash', contentHash],
+      ['prompt_version', NOURISH_PROMPT_VERSION],
+      ['nourish_overall', String(scores.overall.score)],
+      ['nourish_gut', String(scores.gut.score)],
+      ['nourish_protein', String(scores.protein.score)],
+      ['nourish_realfood', String(scores.realFood.score)]
+    ];
+    if (updatedAt !== undefined) {
+      tags.push(['updated_at', String(updatedAt)]);
+    }
+
     // Build and sign event using nostr-tools (works on CF Workers)
     const event = finalizeEvent({
       kind: 30078,
       created_at: createdAt,
-      tags: [
-        ['d', dTag],
-        ['client', 'zap.cooking'],
-        ['a', `30023:${recipePubkey}:${recipeDTag}`],
-        ['p', recipePubkey],
-        ['nourish_version', NOURISH_CACHE_VERSION],
-        ['content_hash', contentHash],
-        ['prompt_version', NOURISH_PROMPT_VERSION],
-        ['nourish_overall', String(scores.overall.score)],
-        ['nourish_gut', String(scores.gut.score)],
-        ['nourish_protein', String(scores.protein.score)],
-        ['nourish_realfood', String(scores.realFood.score)]
-      ],
+      tags,
       content: JSON.stringify({
         gut: scores.gut,
         protein: scores.protein,
@@ -130,7 +146,8 @@ export async function publishNourishEvent(opts: {
         // downstream consumers read either location).
         promptVersion: NOURISH_PROMPT_VERSION,
         contentHash,
-        createdAt
+        createdAt,
+        ...(updatedAt !== undefined ? { updatedAt } : {})
       })
     }, privKeyBytes);
 

--- a/src/lib/nourish/nourishRelay.ts
+++ b/src/lib/nourish/nourishRelay.ts
@@ -184,6 +184,16 @@ export function parseNourishEvent(event: NDKEvent): NourishRelayResult | null {
     const promptVersion = event.tags.find((t) => t[0] === 'prompt_version')?.[1] || 'unknown';
     const nourishVersion = event.tags.find((t) => t[0] === 'nourish_version')?.[1] || NOURISH_CACHE_VERSION;
 
+    // updated_at tag is present only on admin rescores. Accept the tag
+    // or the mirrored content field; undefined on first-time scores.
+    const updatedAtTag = event.tags.find((t) => t[0] === 'updated_at')?.[1];
+    const updatedAtParsed = updatedAtTag ? Number(updatedAtTag) : NaN;
+    const updatedAt = Number.isFinite(updatedAtParsed)
+      ? updatedAtParsed
+      : typeof content.updatedAt === 'number'
+        ? content.updatedAt
+        : undefined;
+
     return {
       scores,
       improvements,
@@ -192,6 +202,7 @@ export function parseNourishEvent(event: NDKEvent): NourishRelayResult | null {
       promptVersion,
       nourishVersion,
       createdAt: event.created_at || 0,
+      updatedAt,
       eventId: event.id
     };
   } catch {

--- a/src/lib/nourish/scoreResolver.ts
+++ b/src/lib/nourish/scoreResolver.ts
@@ -36,6 +36,12 @@ export interface ResolvedEntry {
   scores: NourishScores;
   contentHash?: string;
   createdAt: number;
+  /**
+   * Unix seconds of the last admin rescore. Undefined on first-time
+   * scored events (which don't emit the `updated_at` tag). Drives
+   * the 24h "Updated" pill.
+   */
+  updatedAt?: number;
   improvements?: string[];
   ingredientSignals?: IngredientSignal[];
   promptVersion: string;
@@ -234,6 +240,7 @@ function writeThrough(requestedKey: NourishCacheKey, winner: Candidate): void {
     setNourishScores(writeKey, winner.entry.scores, {
       contentHash: winner.entry.contentHash,
       createdAt: winner.entry.createdAt,
+      updatedAt: winner.entry.updatedAt,
       improvements: winner.entry.improvements,
       ingredientSignals: winner.entry.ingredientSignals
     });
@@ -251,6 +258,7 @@ function l3EntryToResolved(
     // that lack a persisted createdAt. Matches the fallback the modal
     // already uses for its "analyzed at" label.
     createdAt: l3.createdAt ?? Math.floor(l3.timestamp / 1000),
+    updatedAt: l3.updatedAt,
     improvements: l3.improvements,
     ingredientSignals: l3.ingredientSignals,
     promptVersion
@@ -282,6 +290,7 @@ async function doResolve(ndk: NDK, key: NourishCacheKey): Promise<ResolveResult>
         scores: l4.result.scores,
         contentHash: l4.result.contentHash,
         createdAt: l4.result.createdAt,
+        updatedAt: l4.result.updatedAt,
         improvements: l4.result.improvements,
         ingredientSignals: l4.result.ingredientSignals,
         promptVersion: l4.result.promptVersion

--- a/src/lib/nourish/scoringEngine.server.ts
+++ b/src/lib/nourish/scoringEngine.server.ts
@@ -1,0 +1,243 @@
+/**
+ * Nourish Scoring Engine (server-side)
+ *
+ * Shared LLM scoring pipeline used by both the user-facing compute
+ * endpoint (`/api/nourish`) and the admin rescore endpoint
+ * (`/api/admin/nourish/rescore`). Extracted in PR 4 commit 9a so both
+ * endpoints drive through one implementation — preventing drift
+ * between them as either evolves.
+ *
+ * This module handles ONLY the deterministic-shape parts of scoring:
+ * prompt construction, OpenAI invocation, response parsing,
+ * validation, and final NourishScores assembly. It does NOT handle
+ * auth (caller's concern), request-body validation (caller's
+ * concern), or pantry publishing (caller's concern).
+ *
+ * Behavior is identical to the pre-extraction logic in
+ * `/api/nourish/+server.ts`. Non-shape outputs (LLM-derived scores)
+ * are non-deterministic; only the shape/validation is preserved.
+ */
+
+import { NOURISH_CACHE_VERSION, computeOverallScore } from './types';
+import type { IngredientSignal, NourishScores } from './types';
+
+// ─── Prompt template ────────────────────────────────────────
+
+const NOURISH_PROMPT = `You are a recipe analysis assistant for a cooking platform. Analyze the recipe below and return three food quality scores.
+
+SCORING RULES:
+- All scores are integers from 0 to 10.
+- Base your analysis ONLY on the ingredient list provided.
+- Be consistent: similar ingredient profiles should produce similar scores.
+- These are rough estimates. Err toward the middle of the range unless the recipe clearly skews high or low.
+
+GUT SCORE (0-10): How well does this recipe support digestive health?
+- Fermented foods (yogurt, kimchi, sauerkraut, miso, kefir, sourdough): +2-3 points
+- Prebiotic-rich ingredients (garlic, onions, leeks, asparagus, bananas, oats): +1-2 points
+- High-fiber plants (legumes, whole grains, vegetables, fruits): +1-2 points
+- Plant diversity (5+ different plants): +1 point
+- Ultra-processed ingredients (artificial sweeteners, emulsifiers, processed oils): -1-2 points
+- Low plant content or highly refined base: 0-2 score
+
+PROTEIN SCORE (0-10): How useful is this recipe as a protein source?
+- Contains high-protein main ingredient (meat, fish, eggs, tofu, tempeh, legumes): +3-4 points
+- Protein-rich supporting ingredients (cheese, nuts, seeds, Greek yogurt): +1-2 points
+- Protein appears as the main focus of the dish: +2 points
+- Recipe is primarily carbohydrate/fat-focused with incidental protein: 2-4 score
+- No meaningful protein source: 0-2 score
+
+REAL FOOD SCORE (0-10): How close are ingredients to their whole, unprocessed form?
+- All recognizable whole foods (fresh produce, raw meat/fish, whole grains): 8-10
+- Some minimally processed items (canned beans, pasta, bread, cheese): 5-7
+- Contains refined ingredients (white sugar, white flour, vegetable oil): -1-2 points
+- Contains ultra-processed items (processed cheese, instant mixes, artificial flavors): -2-3 points
+- Mostly packaged/convenience ingredients: 0-3 score
+
+LABELS:
+- 0-2: "Low"
+- 3-4: "Fair"
+- 5-6: "Moderate"
+- 7-8: "Strong"
+- 9-10: "Excellent"
+
+Recipe Title: {{title}}
+Servings: {{servings}}
+Tags: {{tags}}
+
+Ingredients:
+{{ingredients}}
+
+Return ONLY valid JSON with this exact structure:
+{
+  "gut": { "score": <number>, "label": "<string>", "reason": "<one sentence>" },
+  "protein": { "score": <number>, "label": "<string>", "reason": "<one sentence>" },
+  "realFood": { "score": <number>, "label": "<string>", "reason": "<one sentence>" },
+  "summary": "<1-2 sentences>",
+  "ingredients": [
+    { "name": "<ingredient>", "signals": ["<tag>"], "contribution": "<gut|protein|realFood|neutral>" }
+  ],
+  "improvements": ["<short actionable suggestion>"]
+}
+
+Do not include any text outside the JSON object.`;
+
+// ─── Validators (module-private) ────────────────────────────
+
+function clampScore(value: unknown): number {
+	const num = typeof value === 'number' ? value : parseInt(String(value), 10);
+	if (isNaN(num)) return 0;
+	return Math.max(0, Math.min(10, Math.round(num)));
+}
+
+function validateLabel(label: unknown): string {
+	const valid = ['Low', 'Fair', 'Moderate', 'Strong', 'Excellent'];
+	if (typeof label === 'string' && valid.includes(label)) return label;
+	return 'Moderate';
+}
+
+function validateImprovements(raw: unknown): string[] {
+	if (!Array.isArray(raw)) return [];
+	return raw
+		.filter((s: unknown): s is string => typeof s === 'string')
+		.slice(0, 5);
+}
+
+function validateIngredientSignals(raw: unknown): IngredientSignal[] {
+	if (!Array.isArray(raw)) return [];
+	return raw
+		.filter((i: any) => i && typeof i.name === 'string')
+		.map((i: any) => ({
+			name: String(i.name).toLowerCase().trim(),
+			signals: Array.isArray(i.signals)
+				? i.signals.filter((s: unknown): s is string => typeof s === 'string')
+				: [],
+			contribution: ['gut', 'protein', 'realFood', 'neutral'].includes(i.contribution)
+				? i.contribution
+				: 'neutral'
+		}));
+}
+
+// ─── Public API ─────────────────────────────────────────────
+
+export interface ScoringPipelineInput {
+	title: string;
+	ingredients: string[];
+	tags: string[];
+	servings: string;
+}
+
+export type ScoringPipelineResult =
+	| {
+			ok: true;
+			scores: NourishScores;
+			improvements: string[];
+			ingredientSignals: IngredientSignal[];
+	  }
+	| { ok: false; status: number; error: string };
+
+/**
+ * Run the LLM scoring pipeline end-to-end.
+ *
+ * Behavior mirrors the pre-extraction inline logic from
+ * /api/nourish/+server.ts:
+ *   1. Construct prompt from input
+ *   2. POST to OpenAI chat completions (gpt-4o-mini, 1500 tokens, temp 0.3)
+ *   3. Parse JSON with markdown-fence stripping
+ *   4. Clamp + validate per-dimension scores and labels
+ *   5. Compute overall score via the shared weighting
+ *   6. Parse improvements + ingredient signals
+ *
+ * Caller is responsible for: auth/membership gating, request body
+ * validation (title/ingredients non-empty), OPENAI_API_KEY
+ * provisioning, and pantry publishing.
+ */
+export async function runScoringPipeline(
+	openAiKey: string,
+	input: ScoringPipelineInput
+): Promise<ScoringPipelineResult> {
+	const { title, ingredients, tags, servings } = input;
+
+	const prompt = NOURISH_PROMPT.replace('{{title}}', title || 'Untitled')
+		.replace('{{servings}}', servings || 'Not specified')
+		.replace('{{tags}}', Array.isArray(tags) && tags.length > 0 ? tags.join(', ') : 'None')
+		.replace(
+			'{{ingredients}}',
+			ingredients.map((i: string) => `- ${i}`).join('\n')
+		);
+
+	const openaiResponse = await fetch('https://api.openai.com/v1/chat/completions', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${openAiKey}`
+		},
+		body: JSON.stringify({
+			model: 'gpt-4o-mini',
+			messages: [{ role: 'system', content: prompt }],
+			max_tokens: 1500,
+			temperature: 0.3
+		})
+	});
+
+	if (!openaiResponse.ok) {
+		const errorData = await openaiResponse.json().catch(() => ({}));
+		console.error('[Nourish] OpenAI API error:', errorData);
+		return { ok: false, status: 500, error: 'Failed to analyze recipe. Please try again.' };
+	}
+
+	const openaiData = await openaiResponse.json();
+	const content = openaiData.choices?.[0]?.message?.content;
+
+	if (!content) {
+		return { ok: false, status: 500, error: 'No response from AI. Please try again.' };
+	}
+
+	let parsed;
+	try {
+		const cleanContent = content
+			.replace(/```json\n?/g, '')
+			.replace(/```\n?/g, '')
+			.trim();
+		parsed = JSON.parse(cleanContent);
+	} catch (err) {
+		console.error('[Nourish] Failed to parse AI response:', content);
+		return { ok: false, status: 500, error: 'Failed to parse analysis. Please try again.' };
+	}
+
+	const gutScore = clampScore(parsed.gut?.score);
+	const proteinScore = clampScore(parsed.protein?.score);
+	const realFoodScore = clampScore(parsed.realFood?.score);
+	const overall = computeOverallScore(gutScore, proteinScore, realFoodScore);
+
+	const scores: NourishScores = {
+		gut: {
+			score: gutScore,
+			label: validateLabel(parsed.gut?.label),
+			reason: String(parsed.gut?.reason || '')
+		},
+		protein: {
+			score: proteinScore,
+			label: validateLabel(parsed.protein?.label),
+			reason: String(parsed.protein?.reason || '')
+		},
+		realFood: {
+			score: realFoodScore,
+			label: validateLabel(parsed.realFood?.label),
+			reason: String(parsed.realFood?.reason || '')
+		},
+		overall: {
+			score: overall.score,
+			label: overall.label,
+			reason: `Weighted: Real Food 45%, Gut 35%, Protein 20%`
+		},
+		summary: String(parsed.summary || ''),
+		cacheVersion: NOURISH_CACHE_VERSION
+	};
+
+	return {
+		ok: true,
+		scores,
+		improvements: validateImprovements(parsed.improvements),
+		ingredientSignals: validateIngredientSignals(parsed.ingredients)
+	};
+}

--- a/src/lib/nourish/types.ts
+++ b/src/lib/nourish/types.ts
@@ -20,6 +20,13 @@ export interface NourishRelayResult {
   promptVersion: string;
   nourishVersion: string;
   createdAt: number;
+  /**
+   * Unix seconds of the last admin rescore. Present only on events
+   * published by the admin rescore endpoint; first-time-scored events
+   * omit the `updated_at` tag and this field is undefined. Drives the
+   * 24h "Updated" pill in the client UI.
+   */
+  updatedAt?: number;
   eventId: string;
 }
 
@@ -89,6 +96,16 @@ export interface NourishResponse {
 	promptVersion?: string;
 	contentHash?: string;
 	createdAt?: number;
+	/**
+	 * Set by the admin rescore endpoint when the server publishes with
+	 * an `updated_at` tag. Undefined on normal compute responses.
+	 */
+	updatedAt?: number;
+	/**
+	 * Set by the admin rescore endpoint to report pantry publish outcome.
+	 * Undefined on normal compute responses.
+	 */
+	published?: boolean;
 }
 
 // ─── Scan Anything ───────────────────────────────────────────

--- a/src/routes/admin/nourish-flags/+page.svelte
+++ b/src/routes/admin/nourish-flags/+page.svelte
@@ -25,6 +25,11 @@
     SCAN_I_TAG_PREFIX
   } from '$lib/nourish/flagSubmit';
   import { NDKRelaySet, type NDKEvent } from '@nostr-dev-kit/ndk';
+  import Modal from '../../../components/Modal.svelte';
+  import { computeContentHash, queryNourishEvent } from '$lib/nourish/nourishRelay';
+  import { parseMarkdownForEditing } from '$lib/parser';
+  import type { NourishScores } from '$lib/nourish/types';
+  import { NOURISH_PROMPT_VERSION } from '$lib/nourish/types';
 
   interface AnonFlag {
     target: string;
@@ -152,6 +157,7 @@
   interface Group {
     target: string;
     dimension: string;
+    nourishVer: string;
     tooHighSigned: number;
     tooHighAnon: number;
     tooLowSigned: number;
@@ -167,8 +173,12 @@
     }>;
   }
 
-  function keyOf(target: string, dimension: string): string {
-    return `${target}|${dimension}`;
+  // Grouping tuple partitions by (target, dimension, nourishVer) so
+  // flags against a v1 score don't collapse with flags against a v2
+  // score on the same target — the admin can see whether a prior
+  // rescore cleared the v1 cluster.
+  function keyOf(target: string, dimension: string, nourishVer: string): string {
+    return `${target}|${dimension}|${nourishVer || 'unknown'}`;
   }
 
   function groupFlags(
@@ -181,6 +191,7 @@
     const push = (
       target: string,
       dimension: string,
+      nourishVer: string,
       direction: string,
       source: Source,
       author: string,
@@ -189,13 +200,14 @@
     ) => {
       const matchesTab = isRecipesTab ? target.startsWith('a:') : target.startsWith('scan:');
       if (!matchesTab) return;
-      const k = keyOf(target, dimension);
+      const k = keyOf(target, dimension, nourishVer);
       const ts = Date.parse(createdAt) || 0;
       let g = map.get(k);
       if (!g) {
         g = {
           target,
           dimension,
+          nourishVer: nourishVer || 'unknown',
           tooHighSigned: 0,
           tooHighAnon: 0,
           tooLowSigned: 0,
@@ -224,6 +236,7 @@
       push(
         f.target,
         f.dimension,
+        f.nourishVer,
         f.direction,
         'signed',
         // Truncated hex pubkey — labelling as "pubkey" honestly rather than
@@ -237,6 +250,7 @@
       push(
         f.target,
         f.dimension,
+        f.nourishVer,
         f.direction,
         'anon',
         `anon-${f.ipHash.slice(0, 4)}`,
@@ -261,6 +275,223 @@
 
   function toggleExpand(key: string) {
     expandedKey = expandedKey === key ? null : key;
+  }
+
+  // ── Rescore state ──────────────────────────────────────────────────
+  //
+  // Per-row state tracks whether a rescore is in flight or has completed.
+  // Keyed by the full group key (target|dimension|nourishVer). The
+  // confirmation modal is a single instance driven by `pendingRescore`.
+  // Previous score is captured client-side via queryNourishEvent BEFORE
+  // the POST fires (per Phase 1 late-surface refinement) so the admin
+  // can see old→new even after pantry has been overwritten.
+
+  interface ScoreSnapshot {
+    scores: NourishScores;
+    createdAt: number;
+    promptVersion: string;
+  }
+
+  type RescoreState =
+    | { status: 'idle' }
+    | { status: 'submitting' }
+    | { status: 'success'; previous: ScoreSnapshot | null; next: ScoreSnapshot }
+    | { status: 'error'; message: string };
+
+  // Svelte 4 reactivity: reassign the object to trigger updates rather
+  // than mutating the Map in place.
+  let rescoreStates: Record<string, RescoreState> = {};
+
+  let pendingRescore:
+    | {
+        key: string;
+        group: Group;
+        recipePubkey: string;
+        recipeDTag: string;
+        content: { title: string; ingredients: string[]; tags: string[]; servings: string };
+        contentHash: string;
+        previous: ScoreSnapshot | null;
+      }
+    | null = null;
+  let preparingRescore = false;
+  let prepareError = '';
+
+  function getRescoreState(key: string): RescoreState {
+    return rescoreStates[key] ?? { status: 'idle' };
+  }
+
+  function setRescoreState(key: string, state: RescoreState) {
+    rescoreStates = { ...rescoreStates, [key]: state };
+  }
+
+  /**
+   * Parse the target string back into (recipePubkey, recipeDTag).
+   * Targets in the recipes tab are `a:30023:pubkey:dTag`. Returns null
+   * for non-recipe targets or malformed a-tags.
+   */
+  function parseRecipeTarget(target: string): { recipePubkey: string; recipeDTag: string } | null {
+    if (!target.startsWith('a:')) return null;
+    const parts = target.slice(2).split(':');
+    if (parts.length < 3) return null;
+    // a-tag = kind:pubkey:dTag. We ignore kind (always 30023 here).
+    const [, recipePubkey, ...rest] = parts;
+    const recipeDTag = rest.join(':');
+    if (!recipePubkey || !recipeDTag) return null;
+    return { recipePubkey, recipeDTag };
+  }
+
+  /**
+   * Fetch the kind-30023 recipe event from relays so we can extract
+   * the content for the rescore pipeline. Returns null if the event
+   * can't be located — rescore can't proceed without content.
+   */
+  async function fetchRecipeEvent(recipePubkey: string, recipeDTag: string): Promise<NDKEvent | null> {
+    if (!$ndk) return null;
+    try {
+      const ev = await Promise.race([
+        $ndk.fetchEvent({
+          kinds: [30023 as number],
+          authors: [recipePubkey],
+          '#d': [recipeDTag]
+        } as never),
+        new Promise<null>((resolve) => setTimeout(() => resolve(null), 6000))
+      ]);
+      return ev ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  async function handleRescoreClick(g: Group) {
+    if (!$ndk) return;
+    const parsed = parseRecipeTarget(g.target);
+    if (!parsed) {
+      prepareError = 'Unable to parse recipe coordinates.';
+      return;
+    }
+    const { recipePubkey, recipeDTag } = parsed;
+
+    preparingRescore = true;
+    prepareError = '';
+    try {
+      // Capture previous score from pantry BEFORE POSTing. After rescore,
+      // pantry will have replaced the event; this snapshot is the
+      // admin's only before/after record.
+      const [recipeEv, pantryRes] = await Promise.all([
+        fetchRecipeEvent(recipePubkey, recipeDTag),
+        queryNourishEvent($ndk, recipePubkey, recipeDTag)
+      ]);
+
+      if (!recipeEv) {
+        prepareError = 'Could not fetch the recipe event from relays.';
+        return;
+      }
+
+      const title =
+        recipeEv.tags.find((t) => t[0] === 'title')?.[1] ||
+        recipeEv.tags.find((t) => t[0] === 'd')?.[1] ||
+        '';
+      const tags = recipeEv.tags.filter((t) => t[0] === 't' && t[1]).map((t) => t[1]);
+      const parsedMd = parseMarkdownForEditing(recipeEv.content || '');
+      const servings = parsedMd.information?.servings || '';
+      const ingredients = parsedMd.ingredients;
+
+      if (!ingredients || ingredients.length === 0) {
+        prepareError = 'Recipe has no ingredients to score.';
+        return;
+      }
+
+      const contentHash = await computeContentHash(recipeEv.content || '');
+
+      const previous: ScoreSnapshot | null =
+        pantryRes.status === 'hit'
+          ? {
+              scores: pantryRes.result.scores,
+              createdAt: pantryRes.result.createdAt,
+              promptVersion: pantryRes.result.promptVersion
+            }
+          : null;
+
+      pendingRescore = {
+        key: keyOf(g.target, g.dimension, g.nourishVer),
+        group: g,
+        recipePubkey,
+        recipeDTag,
+        content: { title, ingredients, tags, servings },
+        contentHash,
+        previous
+      };
+    } finally {
+      preparingRescore = false;
+    }
+  }
+
+  function cancelRescore() {
+    pendingRescore = null;
+    prepareError = '';
+  }
+
+  async function confirmRescore() {
+    if (!pendingRescore || !$userPublickey) return;
+    const { key, recipePubkey, recipeDTag, content, contentHash, previous } = pendingRescore;
+
+    setRescoreState(key, { status: 'submitting' });
+    // Keep the pending context around so we still know which row is
+    // confirming; close the modal so the row shows submitting state.
+    pendingRescore = null;
+
+    try {
+      const res = await fetch('/api/admin/nourish/rescore', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-admin-pubkey': $userPublickey
+        },
+        body: JSON.stringify({
+          recipePubkey,
+          recipeDTag,
+          title: content.title,
+          ingredients: content.ingredients,
+          tags: content.tags,
+          servings: content.servings,
+          contentHash
+        })
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setRescoreState(key, {
+          status: 'error',
+          message: typeof body?.error === 'string' ? body.error : `HTTP ${res.status}`
+        });
+        return;
+      }
+      const data = await res.json();
+      if (!data?.success || data?.published !== true) {
+        setRescoreState(key, {
+          status: 'error',
+          message: typeof data?.error === 'string' ? data.error : 'Rescore failed'
+        });
+        return;
+      }
+      setRescoreState(key, {
+        status: 'success',
+        previous,
+        next: {
+          scores: data.scores,
+          createdAt: data.createdAt,
+          promptVersion: data.promptVersion
+        }
+      });
+    } catch (err) {
+      setRescoreState(key, {
+        status: 'error',
+        message: err instanceof Error ? err.message : String(err)
+      });
+    }
+  }
+
+  function retryRescore(key: string) {
+    setRescoreState(key, { status: 'idle' });
   }
 </script>
 
@@ -301,8 +532,9 @@
       <p class="status">No flags in this bucket yet.</p>
     {:else}
       <div class="list">
-        {#each groups as g (keyOf(g.target, g.dimension))}
-          {@const k = keyOf(g.target, g.dimension)}
+        {#each groups as g (keyOf(g.target, g.dimension, g.nourishVer))}
+          {@const k = keyOf(g.target, g.dimension, g.nourishVer)}
+          {@const rescoreState = getRescoreState(k)}
           <div class="row" class:expanded={expandedKey === k}>
             <button
               type="button"
@@ -311,6 +543,7 @@
             >
               <span class="target">{g.target}</span>
               <span class="dim">{g.dimension}</span>
+              <span class="ver">v{g.nourishVer}</span>
               <span class="counts">
                 <span class="count high">↑ {g.tooHighSigned + g.tooHighAnon}</span>
                 <span class="count low">↓ {g.tooLowSigned + g.tooLowAnon}</span>
@@ -337,6 +570,62 @@
                     {/each}
                   </ul>
                 {/if}
+
+                {#if activeTab === 'recipes'}
+                  <div class="rescore-block">
+                    {#if rescoreState.status === 'idle'}
+                      <button
+                        type="button"
+                        class="btn-rescore"
+                        disabled={preparingRescore}
+                        on:click={() => handleRescoreClick(g)}
+                      >
+                        {preparingRescore ? 'Preparing…' : 'Rescore'}
+                      </button>
+                      {#if prepareError}
+                        <p class="rescore-error">{prepareError}</p>
+                      {/if}
+                    {:else if rescoreState.status === 'submitting'}
+                      <p class="rescore-submitting">Rescoring…</p>
+                    {:else if rescoreState.status === 'success'}
+                      <div class="rescore-success">
+                        <p class="rescore-label">Rescored</p>
+                        <div class="rescore-diff">
+                          <div class="rescore-col">
+                            <span class="rescore-heading">Before</span>
+                            {#if rescoreState.previous}
+                              <span class="rescore-score">
+                                {rescoreState.previous.scores.overall.score} ({rescoreState.previous.scores.overall.label})
+                              </span>
+                              <span class="rescore-meta">v{rescoreState.previous.promptVersion}</span>
+                            {:else}
+                              <span class="rescore-meta">No prior score</span>
+                            {/if}
+                          </div>
+                          <span class="rescore-arrow">→</span>
+                          <div class="rescore-col">
+                            <span class="rescore-heading">After</span>
+                            <span class="rescore-score">
+                              {rescoreState.next.scores.overall.score} ({rescoreState.next.scores.overall.label})
+                            </span>
+                            <span class="rescore-meta">v{rescoreState.next.promptVersion}</span>
+                          </div>
+                        </div>
+                      </div>
+                    {:else if rescoreState.status === 'error'}
+                      <div class="rescore-error-block">
+                        <p class="rescore-error">Rescore failed: {rescoreState.message}</p>
+                        <button
+                          type="button"
+                          class="btn-rescore-retry"
+                          on:click={() => retryRescore(k)}
+                        >
+                          Retry
+                        </button>
+                      </div>
+                    {/if}
+                  </div>
+                {/if}
               </div>
             {/if}
           </div>
@@ -345,6 +634,23 @@
     {/if}
   {/if}
 </div>
+
+<!-- Confirmation modal — shared instance driven by pendingRescore. -->
+<Modal open={pendingRescore !== null} compact cleanup={cancelRescore}>
+  <span slot="title">Rescore this recipe?</span>
+  <div class="confirm-body">
+    <p>This will compute a new Nourish score and replace the current one. Cannot be undone.</p>
+    {#if pendingRescore?.previous}
+      <p class="confirm-meta">
+        Current: {pendingRescore.previous.scores.overall.score} ({pendingRescore.previous.scores.overall.label}) · v{pendingRescore.previous.promptVersion}
+      </p>
+    {/if}
+    <div class="confirm-actions">
+      <button type="button" class="btn-cancel" on:click={cancelRescore}>Cancel</button>
+      <button type="button" class="btn-confirm" on:click={confirmRescore}>Rescore</button>
+    </div>
+  </div>
+</Modal>
 
 <style>
   .page {
@@ -408,7 +714,7 @@
 
   .row-header {
     display: grid;
-    grid-template-columns: 1fr auto auto auto;
+    grid-template-columns: 1fr auto auto auto auto;
     align-items: center;
     gap: 1rem;
     padding: 0.75rem 1rem;
@@ -419,6 +725,151 @@
     text-align: left;
     cursor: pointer;
     font-family: inherit;
+  }
+
+  .ver {
+    font-size: 0.6875rem;
+    font-family: ui-monospace, monospace;
+    color: var(--color-text-secondary);
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.25rem;
+    background: var(--color-bg-tertiary, rgba(255, 255, 255, 0.04));
+  }
+
+  .rescore-block {
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--color-input-border);
+  }
+
+  .btn-rescore,
+  .btn-rescore-retry {
+    padding: 0.375rem 0.75rem;
+    border-radius: 0.4rem;
+    background: var(--color-primary);
+    color: white;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    border: none;
+    cursor: pointer;
+  }
+
+  .btn-rescore:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .btn-rescore-retry {
+    background: var(--color-bg-tertiary);
+    color: var(--color-text-primary);
+    border: 1px solid var(--color-input-border);
+  }
+
+  .rescore-submitting {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
+  }
+
+  .rescore-error-block {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .rescore-error {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: #ef4444;
+  }
+
+  .rescore-success {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .rescore-label {
+    margin: 0;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-secondary);
+  }
+
+  .rescore-diff {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .rescore-col {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+  }
+
+  .rescore-heading {
+    font-size: 0.6875rem;
+    color: var(--color-text-secondary);
+  }
+
+  .rescore-score {
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: var(--color-text-primary);
+  }
+
+  .rescore-meta {
+    font-size: 0.6875rem;
+    font-family: ui-monospace, monospace;
+    color: var(--color-text-secondary);
+  }
+
+  .rescore-arrow {
+    font-size: 1.25rem;
+    color: var(--color-text-secondary);
+  }
+
+  .confirm-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .confirm-meta {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
+  }
+
+  .confirm-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+
+  .btn-cancel,
+  .btn-confirm {
+    padding: 0.4rem 0.9rem;
+    border-radius: 0.4rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    border: none;
+  }
+
+  .btn-cancel {
+    background: var(--color-bg-tertiary);
+    color: var(--color-text-primary);
+    border: 1px solid var(--color-input-border);
+  }
+
+  .btn-confirm {
+    background: var(--color-primary);
+    color: white;
   }
 
   .row-header:hover {

--- a/src/routes/admin/nourish-flags/+page.svelte
+++ b/src/routes/admin/nourish-flags/+page.svelte
@@ -30,6 +30,10 @@
   import { parseMarkdownForEditing } from '$lib/parser';
   import type { NourishScores } from '$lib/nourish/types';
   import { NOURISH_PROMPT_VERSION } from '$lib/nourish/types';
+  import {
+    fetchOutOfVersionCandidates,
+    type OutOfVersionCandidate
+  } from '$lib/nourish/nourishDiscovery';
 
   interface AnonFlag {
     target: string;
@@ -54,12 +58,13 @@
   }
 
   type Source = 'signed' | 'anon';
-  type TabKind = 'recipes' | 'scans';
+  type TabKind = 'recipes' | 'scans' | 'candidates';
 
   let loading = true;
   let loadError = '';
   let anonFlags: AnonFlag[] = [];
   let signedFlags: SignedFlag[] = [];
+  let candidates: OutOfVersionCandidate[] = [];
   let activeTab: TabKind = 'recipes';
   let expandedKey: string | null = null;
 
@@ -133,11 +138,16 @@
     };
   }
 
+  async function loadCandidates() {
+    if (!$ndk) return;
+    candidates = await fetchOutOfVersionCandidates($ndk, NOURISH_PROMPT_VERSION);
+  }
+
   async function loadAll() {
     loading = true;
     loadError = '';
     try {
-      await Promise.all([loadAnon(), loadSigned()]);
+      await Promise.all([loadAnon(), loadSigned(), loadCandidates()]);
     } catch (err) {
       loadError = err instanceof Error ? err.message : String(err);
     } finally {
@@ -264,6 +274,26 @@
 
   $: groups = groupFlags(signedFlags, anonFlags, activeTab);
 
+  // Total flag count per target (across all dimensions / directions /
+  // sources) — used to prioritize candidates in the upgrade-candidates
+  // tab. Keyed on the bare a-tag so it can be joined directly against
+  // OutOfVersionCandidate.aTag.
+  $: flagCountsByTarget = (() => {
+    const counts = new Map<string, number>();
+    const bump = (target: string) => {
+      if (!target.startsWith('a:')) return;
+      const aTag = target.slice(2);
+      counts.set(aTag, (counts.get(aTag) ?? 0) + 1);
+    };
+    for (const f of signedFlags) bump(f.target);
+    for (const f of anonFlags) bump(f.target);
+    return counts;
+  })();
+
+  $: sortedCandidates = [...candidates]
+    .map((c) => ({ candidate: c, flagCount: flagCountsByTarget.get(c.aTag) ?? 0 }))
+    .sort((a, b) => b.flagCount - a.flagCount || b.candidate.createdAt - a.candidate.createdAt);
+
   function formatAgo(iso: number): string {
     if (!iso) return '—';
     const diff = Date.now() - iso;
@@ -305,7 +335,6 @@
   let pendingRescore:
     | {
         key: string;
-        group: Group;
         recipePubkey: string;
         recipeDTag: string;
         content: { title: string; ingredients: string[]; tags: string[]; servings: string };
@@ -362,15 +391,12 @@
     }
   }
 
-  async function handleRescoreClick(g: Group) {
+  async function prepareRescore(
+    key: string,
+    recipePubkey: string,
+    recipeDTag: string
+  ) {
     if (!$ndk) return;
-    const parsed = parseRecipeTarget(g.target);
-    if (!parsed) {
-      prepareError = 'Unable to parse recipe coordinates.';
-      return;
-    }
-    const { recipePubkey, recipeDTag } = parsed;
-
     preparingRescore = true;
     prepareError = '';
     try {
@@ -413,8 +439,7 @@
           : null;
 
       pendingRescore = {
-        key: keyOf(g.target, g.dimension, g.nourishVer),
-        group: g,
+        key,
         recipePubkey,
         recipeDTag,
         content: { title, ingredients, tags, servings },
@@ -424,6 +449,30 @@
     } finally {
       preparingRescore = false;
     }
+  }
+
+  async function handleRescoreClick(g: Group) {
+    const parsed = parseRecipeTarget(g.target);
+    if (!parsed) {
+      prepareError = 'Unable to parse recipe coordinates.';
+      return;
+    }
+    await prepareRescore(
+      keyOf(g.target, g.dimension, g.nourishVer),
+      parsed.recipePubkey,
+      parsed.recipeDTag
+    );
+  }
+
+  async function handleCandidateRescoreClick(c: OutOfVersionCandidate) {
+    // Candidate key uses the pantry d-tag + current version so it
+    // doesn't collide with flag row keys. Candidates don't have a
+    // dimension — rescore applies to the whole target.
+    await prepareRescore(
+      `candidate:${c.aTag}`,
+      c.recipePubkey,
+      c.recipeDTag
+    );
   }
 
   function cancelRescore() {
@@ -526,9 +575,97 @@
       >
         Scans
       </button>
+      <button
+        class="tab"
+        class:active={activeTab === 'candidates'}
+        on:click={() => (activeTab = 'candidates')}
+      >
+        Upgrade candidates
+        {#if sortedCandidates.length > 0}
+          <span class="tab-badge">{sortedCandidates.length}</span>
+        {/if}
+      </button>
     </div>
 
-    {#if groups.length === 0}
+    {#if activeTab === 'candidates'}
+      {#if sortedCandidates.length === 0}
+        <p class="status">
+          No candidates. All scored recipes match the current model version (v{NOURISH_PROMPT_VERSION}).
+        </p>
+      {:else}
+        <div class="list">
+          {#each sortedCandidates as { candidate, flagCount } (candidate.eventId)}
+            {@const k = `candidate:${candidate.aTag}`}
+            {@const rescoreState = getRescoreState(k)}
+            <div class="row">
+              <div class="row-header row-header-candidate">
+                <span class="target">a:{candidate.aTag}</span>
+                <span class="ver">
+                  v{candidate.promptVersion} → v{NOURISH_PROMPT_VERSION}
+                </span>
+                <span class="candidate-flags">Flags: {flagCount}</span>
+                <span class="candidate-score">
+                  Overall {candidate.scores.overall.score}
+                </span>
+              </div>
+              <div class="row-detail">
+                {#if rescoreState.status === 'idle'}
+                  <button
+                    type="button"
+                    class="btn-rescore"
+                    disabled={preparingRescore}
+                    on:click={() => handleCandidateRescoreClick(candidate)}
+                  >
+                    {preparingRescore ? 'Preparing…' : 'Rescore to current version'}
+                  </button>
+                  {#if prepareError}
+                    <p class="rescore-error">{prepareError}</p>
+                  {/if}
+                {:else if rescoreState.status === 'submitting'}
+                  <p class="rescore-submitting">Rescoring…</p>
+                {:else if rescoreState.status === 'success'}
+                  <div class="rescore-success">
+                    <p class="rescore-label">Rescored</p>
+                    <div class="rescore-diff">
+                      <div class="rescore-col">
+                        <span class="rescore-heading">Before</span>
+                        {#if rescoreState.previous}
+                          <span class="rescore-score">
+                            {rescoreState.previous.scores.overall.score} ({rescoreState.previous.scores.overall.label})
+                          </span>
+                          <span class="rescore-meta">v{rescoreState.previous.promptVersion}</span>
+                        {:else}
+                          <span class="rescore-meta">No prior score</span>
+                        {/if}
+                      </div>
+                      <span class="rescore-arrow">→</span>
+                      <div class="rescore-col">
+                        <span class="rescore-heading">After</span>
+                        <span class="rescore-score">
+                          {rescoreState.next.scores.overall.score} ({rescoreState.next.scores.overall.label})
+                        </span>
+                        <span class="rescore-meta">v{rescoreState.next.promptVersion}</span>
+                      </div>
+                    </div>
+                  </div>
+                {:else if rescoreState.status === 'error'}
+                  <div class="rescore-error-block">
+                    <p class="rescore-error">Rescore failed: {rescoreState.message}</p>
+                    <button
+                      type="button"
+                      class="btn-rescore-retry"
+                      on:click={() => retryRescore(k)}
+                    >
+                      Retry
+                    </button>
+                  </div>
+                {/if}
+              </div>
+            </div>
+          {/each}
+        </div>
+      {/if}
+    {:else if groups.length === 0}
       <p class="status">No flags in this bucket yet.</p>
     {:else}
       <div class="list">
@@ -734,6 +871,35 @@
     padding: 0.125rem 0.375rem;
     border-radius: 0.25rem;
     background: var(--color-bg-tertiary, rgba(255, 255, 255, 0.04));
+  }
+
+  .tab-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.25rem;
+    padding: 0 0.375rem;
+    margin-left: 0.375rem;
+    border-radius: 9999px;
+    background: var(--color-primary);
+    color: white;
+    font-size: 0.6875rem;
+    font-weight: 600;
+  }
+
+  .row-header-candidate {
+    /* Non-button header for candidate rows — no toggle-expand needed. */
+    display: grid;
+    grid-template-columns: 1fr auto auto auto;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.75rem 1rem;
+  }
+
+  .candidate-flags,
+  .candidate-score {
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
   }
 
   .rescore-block {

--- a/src/routes/admin/nourish-flags/+page.svelte
+++ b/src/routes/admin/nourish-flags/+page.svelte
@@ -34,6 +34,7 @@
     fetchOutOfVersionCandidates,
     type OutOfVersionCandidate
   } from '$lib/nourish/nourishDiscovery';
+  import { signNip98AuthHeader } from '$lib/nip98';
 
   interface AnonFlag {
     target: string;
@@ -503,21 +504,41 @@
     pendingRescore = null;
 
     try {
-      const res = await fetch('/api/admin/nourish/rescore', {
+      // Serialize once so the exact bytes we sign are the exact bytes
+      // we send — the server's NIP-98 verifier hashes the received
+      // body and compares to the `payload` tag in the signed event.
+      const bodyString = JSON.stringify({
+        recipePubkey,
+        recipeDTag,
+        title: content.title,
+        ingredients: content.ingredients,
+        tags: content.tags,
+        servings: content.servings,
+        contentHash
+      });
+      const url = new URL('/api/admin/nourish/rescore', window.location.origin).toString();
+      let authorization: string;
+      try {
+        authorization = await signNip98AuthHeader($ndk, {
+          method: 'POST',
+          url,
+          bodyString
+        });
+      } catch (err) {
+        setRescoreState(key, {
+          status: 'error',
+          message:
+            err instanceof Error ? err.message : 'Could not sign admin auth'
+        });
+        return;
+      }
+      const res = await fetch(url, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'x-admin-pubkey': $userPublickey
+          Authorization: authorization
         },
-        body: JSON.stringify({
-          recipePubkey,
-          recipeDTag,
-          title: content.title,
-          ingredients: content.ingredients,
-          tags: content.tags,
-          servings: content.servings,
-          contentHash
-        })
+        body: bodyString
       });
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));

--- a/src/routes/admin/nourish-flags/+page.svelte
+++ b/src/routes/admin/nourish-flags/+page.svelte
@@ -324,12 +324,16 @@
 
   type RescoreState =
     | { status: 'idle' }
+    | { status: 'preparing' }
+    | { status: 'prepare-error'; message: string }
     | { status: 'submitting' }
     | { status: 'success'; previous: ScoreSnapshot | null; next: ScoreSnapshot }
     | { status: 'error'; message: string };
 
   // Svelte 4 reactivity: reassign the object to trigger updates rather
-  // than mutating the Map in place.
+  // than mutating the Map in place. All prepare/submit state is keyed
+  // per row so one row's failure can't disable or leak error text into
+  // another row's button.
   let rescoreStates: Record<string, RescoreState> = {};
 
   let pendingRescore:
@@ -342,8 +346,6 @@
         previous: ScoreSnapshot | null;
       }
     | null = null;
-  let preparingRescore = false;
-  let prepareError = '';
 
   function getRescoreState(key: string): RescoreState {
     return rescoreStates[key] ?? { status: 'idle' };
@@ -397,8 +399,7 @@
     recipeDTag: string
   ) {
     if (!$ndk) return;
-    preparingRescore = true;
-    prepareError = '';
+    setRescoreState(key, { status: 'preparing' });
     try {
       // Capture previous score from pantry BEFORE POSTing. After rescore,
       // pantry will have replaced the event; this snapshot is the
@@ -409,7 +410,10 @@
       ]);
 
       if (!recipeEv) {
-        prepareError = 'Could not fetch the recipe event from relays.';
+        setRescoreState(key, {
+          status: 'prepare-error',
+          message: 'Could not fetch the recipe event from relays.'
+        });
         return;
       }
 
@@ -423,7 +427,10 @@
       const ingredients = parsedMd.ingredients;
 
       if (!ingredients || ingredients.length === 0) {
-        prepareError = 'Recipe has no ingredients to score.';
+        setRescoreState(key, {
+          status: 'prepare-error',
+          message: 'Recipe has no ingredients to score.'
+        });
         return;
       }
 
@@ -446,22 +453,29 @@
         contentHash,
         previous
       };
-    } finally {
-      preparingRescore = false;
+      // Preparation done; return to idle so the confirmation modal
+      // (driven by pendingRescore) can take over. confirmRescore will
+      // transition to submitting.
+      setRescoreState(key, { status: 'idle' });
+    } catch (err) {
+      setRescoreState(key, {
+        status: 'prepare-error',
+        message: err instanceof Error ? err.message : String(err)
+      });
     }
   }
 
   async function handleRescoreClick(g: Group) {
+    const key = keyOf(g.target, g.dimension, g.nourishVer);
     const parsed = parseRecipeTarget(g.target);
     if (!parsed) {
-      prepareError = 'Unable to parse recipe coordinates.';
+      setRescoreState(key, {
+        status: 'prepare-error',
+        message: 'Unable to parse recipe coordinates.'
+      });
       return;
     }
-    await prepareRescore(
-      keyOf(g.target, g.dimension, g.nourishVer),
-      parsed.recipePubkey,
-      parsed.recipeDTag
-    );
+    await prepareRescore(key, parsed.recipePubkey, parsed.recipeDTag);
   }
 
   async function handleCandidateRescoreClick(c: OutOfVersionCandidate) {
@@ -477,7 +491,6 @@
 
   function cancelRescore() {
     pendingRescore = null;
-    prepareError = '';
   }
 
   async function confirmRescore() {
@@ -613,14 +626,23 @@
                   <button
                     type="button"
                     class="btn-rescore"
-                    disabled={preparingRescore}
                     on:click={() => handleCandidateRescoreClick(candidate)}
                   >
-                    {preparingRescore ? 'Preparing…' : 'Rescore to current version'}
+                    Rescore to current version
                   </button>
-                  {#if prepareError}
-                    <p class="rescore-error">{prepareError}</p>
-                  {/if}
+                {:else if rescoreState.status === 'preparing'}
+                  <p class="rescore-submitting">Preparing…</p>
+                {:else if rescoreState.status === 'prepare-error'}
+                  <div class="rescore-error-block">
+                    <p class="rescore-error">{rescoreState.message}</p>
+                    <button
+                      type="button"
+                      class="btn-rescore-retry"
+                      on:click={() => retryRescore(k)}
+                    >
+                      Retry
+                    </button>
+                  </div>
                 {:else if rescoreState.status === 'submitting'}
                   <p class="rescore-submitting">Rescoring…</p>
                 {:else if rescoreState.status === 'success'}
@@ -714,14 +736,23 @@
                       <button
                         type="button"
                         class="btn-rescore"
-                        disabled={preparingRescore}
                         on:click={() => handleRescoreClick(g)}
                       >
-                        {preparingRescore ? 'Preparing…' : 'Rescore'}
+                        Rescore
                       </button>
-                      {#if prepareError}
-                        <p class="rescore-error">{prepareError}</p>
-                      {/if}
+                    {:else if rescoreState.status === 'preparing'}
+                      <p class="rescore-submitting">Preparing…</p>
+                    {:else if rescoreState.status === 'prepare-error'}
+                      <div class="rescore-error-block">
+                        <p class="rescore-error">{rescoreState.message}</p>
+                        <button
+                          type="button"
+                          class="btn-rescore-retry"
+                          on:click={() => retryRescore(k)}
+                        >
+                          Retry
+                        </button>
+                      </div>
                     {:else if rescoreState.status === 'submitting'}
                       <p class="rescore-submitting">Rescoring…</p>
                     {:else if rescoreState.status === 'success'}

--- a/src/routes/api/admin/nourish/rescore/+server.ts
+++ b/src/routes/api/admin/nourish/rescore/+server.ts
@@ -163,6 +163,17 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 			return json({ success: false, error: 'Publish failed' }, { status: 500 });
 		}
 
+		// Publish attempt returned false (no relay accepted the event) —
+		// treat as a server-side failure so the admin UI can surface a
+		// clear error instead of showing a misleading "Rescore failed"
+		// on a success response.
+		if (!published) {
+			return json(
+				{ success: false, error: 'Publish failed: no relay accepted the event' },
+				{ status: 500 }
+			);
+		}
+
 		return json({
 			success: true,
 			scores,

--- a/src/routes/api/admin/nourish/rescore/+server.ts
+++ b/src/routes/api/admin/nourish/rescore/+server.ts
@@ -1,0 +1,184 @@
+/**
+ * POST /api/admin/nourish/rescore — admin-triggered Nourish rescore.
+ *
+ * Runs the shared scoring pipeline (identical to /api/nourish) then
+ * publishes a fresh kind-30078 pantry event under
+ * NOURISH_SERVICE_PUBKEY with an `updated_at` tag — the tag drives
+ * the client-side "Updated" badge visible for 24h after rescore.
+ *
+ * Auth: `x-admin-pubkey` header must match ADMIN_PUBKEY from
+ * $lib/adminAuth. Same pattern as /api/admin/nourish-flags. A future
+ * FOLLOWUPS item formalizes this with NIP-98 HTTP-Auth; until that
+ * lands, all admin endpoints share the weak-but-consistent check so
+ * the migration can cover them together.
+ *
+ * Request body:
+ *   {
+ *     recipePubkey: string,    // hex-64
+ *     recipeDTag: string,      // non-empty, ≤200 chars
+ *     title: string,
+ *     ingredients: string[],   // non-empty
+ *     tags: string[],
+ *     servings: string,
+ *     contentHash: string,     // hex-64 — admin UI computes client-side
+ *     reason?: string          // optional admin note, logged but not persisted
+ *   }
+ *
+ * Success response:
+ *   {
+ *     success: true,
+ *     scores: NourishScores,
+ *     improvements: string[],
+ *     ingredient_signals: IngredientSignal[],
+ *     promptVersion: string,
+ *     contentHash: string,
+ *     createdAt: number,
+ *     updatedAt: number,
+ *     published: boolean
+ *   }
+ *
+ * Error response:
+ *   { error: 'forbidden' }           // 403 — missing/invalid admin header
+ *   { success: false, error: string } // 400/500 — validation or server error
+ *
+ * The admin UI captures the previous score client-side via
+ * queryNourishEvent before POSTing, so the response does NOT include
+ * previousScore — the caller holds that state.
+ */
+
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import { NOURISH_PROMPT_VERSION } from '$lib/nourish/types';
+import { runScoringPipeline } from '$lib/nourish/scoringEngine.server';
+import { ADMIN_PUBKEY } from '$lib/adminAuth';
+
+const HEX_64_RE = /^[a-fA-F0-9]{64}$/;
+
+export const POST: RequestHandler = async ({ request, platform }) => {
+	// Admin auth — same verbatim pattern as /api/admin/nourish-flags so
+	// the eventual NIP-98 migration covers both endpoints in one pass.
+	const adminPubkey = request.headers.get('x-admin-pubkey');
+	if (!adminPubkey || adminPubkey !== ADMIN_PUBKEY) {
+		return json({ error: 'forbidden' }, { status: 403 });
+	}
+
+	try {
+		const OPENAI_API_KEY = (platform?.env as any)?.OPENAI_API_KEY || env.OPENAI_API_KEY;
+		if (!OPENAI_API_KEY) {
+			return json({ success: false, error: 'OpenAI API key not configured' }, { status: 500 });
+		}
+
+		const body = await request.json();
+		const {
+			recipePubkey,
+			recipeDTag,
+			title,
+			ingredients,
+			tags,
+			servings,
+			contentHash,
+			reason
+		} = body ?? {};
+
+		// Request validation. Admin endpoint requires the publish
+		// coordinates upfront (unlike /api/nourish where they're optional
+		// and gate only the publish side — here rescore without publish
+		// would be pointless).
+		const validRecipePubkey = typeof recipePubkey === 'string' && HEX_64_RE.test(recipePubkey.trim());
+		const validRecipeDTag =
+			typeof recipeDTag === 'string' &&
+			recipeDTag.trim().length > 0 &&
+			recipeDTag.trim().length <= 200;
+		const validContentHash = typeof contentHash === 'string' && HEX_64_RE.test(contentHash.trim());
+		if (!validRecipePubkey || !validRecipeDTag || !validContentHash) {
+			return json(
+				{ success: false, error: 'Invalid rescore coordinates' },
+				{ status: 400 }
+			);
+		}
+
+		if (!Array.isArray(ingredients) || ingredients.length === 0) {
+			return json(
+				{ success: false, error: 'Ingredients list is required' },
+				{ status: 400 }
+			);
+		}
+
+		// Optional audit-trail context; logged, not persisted. Keeps the
+		// happy-path admin action greppable in Workers logs.
+		if (typeof reason === 'string' && reason.length > 0) {
+			console.log(
+				`[Nourish Rescore] admin=${adminPubkey} target=${recipeDTag.trim()} reason=${reason.slice(0, 200)}`
+			);
+		} else {
+			console.log(`[Nourish Rescore] admin=${adminPubkey} target=${recipeDTag.trim()}`);
+		}
+
+		// Run the shared scoring pipeline — same implementation as the
+		// user compute endpoint.
+		const pipelineResult = await runScoringPipeline(OPENAI_API_KEY, {
+			title: typeof title === 'string' ? title : '',
+			ingredients,
+			tags: Array.isArray(tags) ? tags : [],
+			servings: typeof servings === 'string' ? servings : ''
+		});
+		if (!pipelineResult.ok) {
+			return json(
+				{ success: false, error: pipelineResult.error },
+				{ status: pipelineResult.status }
+			);
+		}
+		const { scores, improvements, ingredientSignals } = pipelineResult;
+
+		// Publish the new pantry event with the `updated_at` tag that
+		// drives the 24h "Updated" badge on the client.
+		const NOTIFICATION_PRIVATE_KEY =
+			(platform?.env as any)?.NOTIFICATION_PRIVATE_KEY || env.NOTIFICATION_PRIVATE_KEY;
+		if (!NOTIFICATION_PRIVATE_KEY) {
+			return json(
+				{ success: false, error: 'Publisher not configured' },
+				{ status: 500 }
+			);
+		}
+
+		const updatedAt = Math.floor(Date.now() / 1000);
+		let published = false;
+		try {
+			const { publishNourishEvent } = await import('$lib/nourish/nourishPublisher.server');
+			published = await publishNourishEvent({
+				privateKey: NOTIFICATION_PRIVATE_KEY,
+				recipePubkey: recipePubkey.trim(),
+				recipeDTag: recipeDTag.trim(),
+				contentHash: contentHash.trim(),
+				scores,
+				improvements,
+				ingredientSignals,
+				updatedAt
+			});
+			console.log(
+				`[Nourish Rescore] publish ${published ? 'succeeded' : 'failed'} for ${recipeDTag.trim()}`
+			);
+		} catch (err) {
+			console.error('[Nourish Rescore] publish error:', err);
+			return json({ success: false, error: 'Publish failed' }, { status: 500 });
+		}
+
+		return json({
+			success: true,
+			scores,
+			improvements,
+			ingredient_signals: ingredientSignals,
+			promptVersion: NOURISH_PROMPT_VERSION,
+			contentHash: contentHash.trim(),
+			createdAt: updatedAt,
+			updatedAt,
+			published
+		});
+	} catch (error: any) {
+		console.error('[Nourish Rescore] Error:', error);
+		return json(
+			{ success: false, error: error.message || 'An unexpected error occurred' },
+			{ status: 500 }
+		);
+	}
+};

--- a/src/routes/api/admin/nourish/rescore/+server.ts
+++ b/src/routes/api/admin/nourish/rescore/+server.ts
@@ -6,11 +6,18 @@
  * NOURISH_SERVICE_PUBKEY with an `updated_at` tag — the tag drives
  * the client-side "Updated" badge visible for 24h after rescore.
  *
- * Auth: `x-admin-pubkey` header must match ADMIN_PUBKEY from
- * $lib/adminAuth. Same pattern as /api/admin/nourish-flags. A future
- * FOLLOWUPS item formalizes this with NIP-98 HTTP-Auth; until that
- * lands, all admin endpoints share the weak-but-consistent check so
- * the migration can cover them together.
+ * Auth: NIP-98 HTTP Auth. Caller sends `Authorization: Nostr <base64>`
+ * containing a signed kind-27235 event bound to this URL, POST
+ * method, and the exact request body (via `payload` tag hash).
+ * Server verifies signature, timestamp skew (±60s), URL/method match,
+ * body hash, and that the signing pubkey === ADMIN_PUBKEY. See
+ * src/lib/nip98.server.ts for verifier details.
+ *
+ * The companion read endpoint /api/admin/nourish-flags still uses
+ * the older `x-admin-pubkey` header pattern pending a follow-up
+ * migration — read endpoints leak info at worst, whereas this write
+ * endpoint spends LLM credit and signs pantry events under the
+ * service pubkey, so the auth models diverge for now.
  *
  * Request body:
  *   {
@@ -38,7 +45,7 @@
  *   }
  *
  * Error response:
- *   { error: 'forbidden' }           // 403 — missing/invalid admin header
+ *   { error: 'forbidden' }            // 403 — auth failed (reason logged only)
  *   { success: false, error: string } // 400/500 — validation or server error
  *
  * The admin UI captures the previous score client-side via
@@ -51,14 +58,24 @@ import { env } from '$env/dynamic/private';
 import { NOURISH_PROMPT_VERSION } from '$lib/nourish/types';
 import { runScoringPipeline } from '$lib/nourish/scoringEngine.server';
 import { ADMIN_PUBKEY } from '$lib/adminAuth';
+import { verifyNip98 } from '$lib/nip98.server';
 
 const HEX_64_RE = /^[a-fA-F0-9]{64}$/;
 
 export const POST: RequestHandler = async ({ request, platform }) => {
-	// Admin auth — same verbatim pattern as /api/admin/nourish-flags so
-	// the eventual NIP-98 migration covers both endpoints in one pass.
-	const adminPubkey = request.headers.get('x-admin-pubkey');
-	if (!adminPubkey || adminPubkey !== ADMIN_PUBKEY) {
+	// Read the body ONCE — we need the raw bytes for NIP-98 payload
+	// verification AND the JSON parse below. Reading via arrayBuffer
+	// then decoding avoids the request.clone() pattern (whose body-
+	// consumption semantics on Cloudflare Workers are worth not
+	// depending on when a single read works fine).
+	const bodyBytes = new Uint8Array(await request.arrayBuffer());
+
+	const auth = await verifyNip98(request, {
+		expectedPubkey: ADMIN_PUBKEY,
+		bodyBytes
+	});
+	if (!auth.ok) {
+		console.warn('[nourish.rescore.auth-failed]', { reason: auth.reason });
 		return json({ error: 'forbidden' }, { status: 403 });
 	}
 
@@ -68,7 +85,12 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 			return json({ success: false, error: 'OpenAI API key not configured' }, { status: 500 });
 		}
 
-		const body = await request.json();
+		let body: any;
+		try {
+			body = JSON.parse(new TextDecoder().decode(bodyBytes));
+		} catch {
+			return json({ success: false, error: 'Invalid JSON body' }, { status: 400 });
+		}
 		const {
 			recipePubkey,
 			recipeDTag,
@@ -108,10 +130,10 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 		// happy-path admin action greppable in Workers logs.
 		if (typeof reason === 'string' && reason.length > 0) {
 			console.log(
-				`[Nourish Rescore] admin=${adminPubkey} target=${recipeDTag.trim()} reason=${reason.slice(0, 200)}`
+				`[Nourish Rescore] admin=${auth.pubkey} target=${recipeDTag.trim()} reason=${reason.slice(0, 200)}`
 			);
 		} else {
-			console.log(`[Nourish Rescore] admin=${adminPubkey} target=${recipeDTag.trim()}`);
+			console.log(`[Nourish Rescore] admin=${auth.pubkey} target=${recipeDTag.trim()}`);
 		}
 
 		// Run the shared scoring pipeline — same implementation as the

--- a/src/routes/api/nourish/+server.ts
+++ b/src/routes/api/nourish/+server.ts
@@ -39,78 +39,9 @@
 
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
-import { NOURISH_CACHE_VERSION, NOURISH_PROMPT_VERSION, computeOverallScore } from '$lib/nourish/types';
+import { NOURISH_PROMPT_VERSION } from '$lib/nourish/types';
+import { runScoringPipeline } from '$lib/nourish/scoringEngine.server';
 import { requireMembership } from './membershipCheck';
-
-const NOURISH_PROMPT = `You are a recipe analysis assistant for a cooking platform. Analyze the recipe below and return three food quality scores.
-
-SCORING RULES:
-- All scores are integers from 0 to 10.
-- Base your analysis ONLY on the ingredient list provided.
-- Be consistent: similar ingredient profiles should produce similar scores.
-- These are rough estimates. Err toward the middle of the range unless the recipe clearly skews high or low.
-
-GUT SCORE (0-10): How well does this recipe support digestive health?
-- Fermented foods (yogurt, kimchi, sauerkraut, miso, kefir, sourdough): +2-3 points
-- Prebiotic-rich ingredients (garlic, onions, leeks, asparagus, bananas, oats): +1-2 points
-- High-fiber plants (legumes, whole grains, vegetables, fruits): +1-2 points
-- Plant diversity (5+ different plants): +1 point
-- Ultra-processed ingredients (artificial sweeteners, emulsifiers, processed oils): -1-2 points
-- Low plant content or highly refined base: 0-2 score
-
-PROTEIN SCORE (0-10): How useful is this recipe as a protein source?
-- Contains high-protein main ingredient (meat, fish, eggs, tofu, tempeh, legumes): +3-4 points
-- Protein-rich supporting ingredients (cheese, nuts, seeds, Greek yogurt): +1-2 points
-- Protein appears as the main focus of the dish: +2 points
-- Recipe is primarily carbohydrate/fat-focused with incidental protein: 2-4 score
-- No meaningful protein source: 0-2 score
-
-REAL FOOD SCORE (0-10): How close are ingredients to their whole, unprocessed form?
-- All recognizable whole foods (fresh produce, raw meat/fish, whole grains): 8-10
-- Some minimally processed items (canned beans, pasta, bread, cheese): 5-7
-- Contains refined ingredients (white sugar, white flour, vegetable oil): -1-2 points
-- Contains ultra-processed items (processed cheese, instant mixes, artificial flavors): -2-3 points
-- Mostly packaged/convenience ingredients: 0-3 score
-
-LABELS:
-- 0-2: "Low"
-- 3-4: "Fair"
-- 5-6: "Moderate"
-- 7-8: "Strong"
-- 9-10: "Excellent"
-
-Recipe Title: {{title}}
-Servings: {{servings}}
-Tags: {{tags}}
-
-Ingredients:
-{{ingredients}}
-
-Return ONLY valid JSON with this exact structure:
-{
-  "gut": { "score": <number>, "label": "<string>", "reason": "<one sentence>" },
-  "protein": { "score": <number>, "label": "<string>", "reason": "<one sentence>" },
-  "realFood": { "score": <number>, "label": "<string>", "reason": "<one sentence>" },
-  "summary": "<1-2 sentences>",
-  "ingredients": [
-    { "name": "<ingredient>", "signals": ["<tag>"], "contribution": "<gut|protein|realFood|neutral>" }
-  ],
-  "improvements": ["<short actionable suggestion>"]
-}
-
-Do not include any text outside the JSON object.`;
-
-function clampScore(value: unknown): number {
-	const num = typeof value === 'number' ? value : parseInt(String(value), 10);
-	if (isNaN(num)) return 0;
-	return Math.max(0, Math.min(10, Math.round(num)));
-}
-
-function validateLabel(label: unknown): string {
-	const valid = ['Low', 'Fair', 'Moderate', 'Strong', 'Excellent'];
-	if (typeof label === 'string' && valid.includes(label)) return label;
-	return 'Moderate';
-}
 
 export const POST: RequestHandler = async ({ request, platform }) => {
 	try {
@@ -141,116 +72,21 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 		const membershipError = await requireMembership(pubkey, platform);
 		if (membershipError) return membershipError;
 
-		// Build prompt with recipe data
-		const prompt = NOURISH_PROMPT.replace('{{title}}', title || 'Untitled')
-			.replace('{{servings}}', servings || 'Not specified')
-			.replace('{{tags}}', Array.isArray(tags) && tags.length > 0 ? tags.join(', ') : 'None')
-			.replace(
-				'{{ingredients}}',
-				ingredients.map((i: string) => `- ${i}`).join('\n')
-			);
-
-		// Call OpenAI API
-		const openaiResponse = await fetch('https://api.openai.com/v1/chat/completions', {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json',
-				Authorization: `Bearer ${OPENAI_API_KEY}`
-			},
-			body: JSON.stringify({
-				model: 'gpt-4o-mini',
-				messages: [
-					{ role: 'system', content: prompt }
-				],
-				max_tokens: 1500,
-				temperature: 0.3
-			})
+		// Run the shared scoring pipeline (prompt → OpenAI → parse → validate)
+		const pipelineResult = await runScoringPipeline(OPENAI_API_KEY, {
+			title,
+			ingredients,
+			tags,
+			servings
 		});
-
-		if (!openaiResponse.ok) {
-			const errorData = await openaiResponse.json().catch(() => ({}));
-			console.error('[Nourish] OpenAI API error:', errorData);
+		if (!pipelineResult.ok) {
 			return json(
-				{ success: false, error: 'Failed to analyze recipe. Please try again.' },
-				{ status: 500 }
+				{ success: false, error: pipelineResult.error },
+				{ status: pipelineResult.status }
 			);
 		}
-
-		const openaiData = await openaiResponse.json();
-		const content = openaiData.choices?.[0]?.message?.content;
-
-		if (!content) {
-			return json(
-				{ success: false, error: 'No response from AI. Please try again.' },
-				{ status: 500 }
-			);
-		}
-
-		// Parse JSON response
-		let parsed;
-		try {
-			const cleanContent = content
-				.replace(/```json\n?/g, '')
-				.replace(/```\n?/g, '')
-				.trim();
-			parsed = JSON.parse(cleanContent);
-		} catch (err) {
-			console.error('[Nourish] Failed to parse AI response:', content);
-			return json(
-				{ success: false, error: 'Failed to parse analysis. Please try again.' },
-				{ status: 500 }
-			);
-		}
-
-		// Normalize and validate scores
-		const gutScore = clampScore(parsed.gut?.score);
-		const proteinScore = clampScore(parsed.protein?.score);
-		const realFoodScore = clampScore(parsed.realFood?.score);
-		const overall = computeOverallScore(gutScore, proteinScore, realFoodScore);
-
-		const scores = {
-			gut: {
-				score: gutScore,
-				label: validateLabel(parsed.gut?.label),
-				reason: String(parsed.gut?.reason || '')
-			},
-			protein: {
-				score: proteinScore,
-				label: validateLabel(parsed.protein?.label),
-				reason: String(parsed.protein?.reason || '')
-			},
-			realFood: {
-				score: realFoodScore,
-				label: validateLabel(parsed.realFood?.label),
-				reason: String(parsed.realFood?.reason || '')
-			},
-			overall: {
-				score: overall.score,
-				label: overall.label,
-				reason: `Weighted: Real Food 45%, Gut 35%, Protein 20%`
-			},
-			summary: String(parsed.summary || ''),
-			cacheVersion: NOURISH_CACHE_VERSION
-		};
-
-		// Parse optional new fields gracefully (backward compatible)
-		const improvements = Array.isArray(parsed.improvements)
-			? parsed.improvements.filter((s: unknown) => typeof s === 'string').slice(0, 5)
-			: [];
-
-		const ingredient_signals = Array.isArray(parsed.ingredients)
-			? parsed.ingredients
-					.filter((i: any) => i && typeof i.name === 'string')
-					.map((i: any) => ({
-						name: String(i.name).toLowerCase().trim(),
-						signals: Array.isArray(i.signals)
-							? i.signals.filter((s: unknown) => typeof s === 'string')
-							: [],
-						contribution: ['gut', 'protein', 'realFood', 'neutral'].includes(i.contribution)
-							? i.contribution
-							: 'neutral'
-					}))
-			: [];
+		const { scores, improvements, ingredientSignals } = pipelineResult;
+		const ingredient_signals = ingredientSignals;
 
 		// Publish Nourish event to relay (awaited — not fire-and-forget).
 		// On CF Workers, background WebSocket tasks die after response. We await


### PR DESCRIPTION
**Draft.** PR 4 of 4 — completes the Nourish Stability feature end-to-end. Five atomic commits close the Flag → Rescore actionability gap from #303 and finalize the Stability work started by #311, #312, #313.

Prerequisite: #313 merged (all prior Stability PRs landed on main).

## Commit plan

| # | Commit | SHA | Scope |
|---|---|---|---|
| 9a | Extract runScoringPipeline from /api/nourish | `3e9d9fc` | Pure refactor; shared helper foundation |
| 9b | POST /api/admin/nourish/rescore + updatedAt override | `f635d6d` | Admin-gated endpoint + publisher param |
| 10 | /admin/nourish-flags version-aware grouping + Rescore button | `a6e949d` | Version grouping, confirmation modal, previousScore capture, success expansion |
| 11 | "Updated" pill (24h) in NourishModal | `2cbec10` | updatedAt threaded through types/cache/resolver/relay/modal |
| 12 | "Upgrade candidates" tab in /admin/nourish-flags | `9173235` | fetchOutOfVersionCandidates helper + new tab |

## End-of-Stability drift-source status

| # | Severity | Closed in |
|---|---|---|
| #1 Pantry timeout → silent compute | BLOCKER | PR 2 commit 4 |
| #2 No Promise-level dedup | BLOCKER | PR 2 commit 2 |
| #3 Multiple cache keys | MODERATE | PR 2 commit 3 |
| #4 Silent pantry publish failure | MODERATE | deferred to issue #314 (PR 3.5) |
| #5 Refresh unconditionally recomputes | LOW | PR 3 commit 7 |
| #6 Seed endpoint no invalidation | LOW | self-heals via #3 |
| #7 Scan cache collisions | LOW | PR 3 commit 6 |

After this PR, the Flag → Rescore loop is live. Admin triages flags → triggers rescore → new score propagates → users see the Updated pill for 24h. Flag data is finally actionable.

## Key design decisions (captured in commit messages)

### Commit 9a — extraction rigor
Pure refactor. Response-shape audit documented in the commit message: every response path (4 validation errors, 3 pipeline errors, outer catch, success) returns identical field names/order/types. Non-deterministic LLM scores naturally differ; **shape must be byte-for-byte identical** and is.

### Commit 9b — verbatim admin auth
```ts
const adminPubkey = request.headers.get('x-admin-pubkey');
if (!adminPubkey || adminPubkey !== ADMIN_PUBKEY) {
  return json({ error: 'forbidden' }, { status: 403 });
}
```
Exact pattern from `/api/admin/nourish-flags/+server.ts:44-47` so the eventual NIP-98 migration (#303 follow-up #9) covers both admin endpoints in one pass. Membership gate bypassed by design — admin is the gate, and rescore has no LLM cost distinction from compute (both fire one LLM call).

`publishNourishEvent` gains `updatedAt?: number`. Conditional emission: tag written only when explicitly set. First-time compute path (unchanged) passes nothing → no tag → no Updated pill. Seed endpoint (CRON_SECRET admin backfill) also passes nothing, so backfills correctly don't trigger the pill.

### Commit 10 — client-side previousScore capture
Per Phase 1 late-surface refinement. Admin UI captures previous score via `queryNourishEvent` BEFORE POSTing the rescore. After POST, server returns the new score; UI composes old→new in component state. Drops the server-side NDK dependency that would otherwise have complicated Cloudflare Workers deployment.

Confirmation modal copy (exact approved wording): "Rescore this recipe? This will compute a new Nourish score and replace the current one. Cannot be undone."

### Commit 11 — non-migration documented
Existing localStorage entries don't carry `updatedAt` and continue to render without the pill until naturally evicted and re-cached via a rescored event. **No bulk migration required** — the pill is opt-in by construction (tag must be present), and old entries correctly represent pre-rescore scores.

Render-time check is intentional: if a modal is open when the 24h boundary crosses, the pill doesn't reactively disappear until next modal mount. Acceptable UX; no one stares at a modal for 24h.

### Commit 12 — client-side flag-count join
No new server endpoint. `fetchOutOfVersionCandidates` pulls the pantry events via the existing NDK infrastructure; flag counts come from the already-loaded flags arrays; they join reactively in a derived Map. Empty state copy: "No candidates. All scored recipes match the current model version (v1)."

## Verification plan

### Phase 4 end-to-end Stability loop

1. **Non-admin**: flag a recipe's dimension as "too low" → flag event publishes
2. **Admin**: open `/admin/nourish-flags` → see flagged dimension grouped by `(target, dimension, promptVersion)`
3. **Admin**: click Rescore → confirm modal with exact copy → confirm → row expands with Before (4.2, v1) → After (6.8, v1)
4. **Non-admin**: refresh recipe → see new score + "Updated" pill
5. Wait 24h (or test via localStorage mtime manipulation) → pill gone on next modal mount

### Model-upgrade candidates flow

1. **Preferred path**: query pantry for any legacy `promptVersion: 'unknown'` events. If present, the Upgrade candidates tab populates naturally without env tweaking.
2. **Fallback**: if no `'unknown'` events exist, bump `NOURISH_PROMPT_VERSION` in a preview env to make existing v1 scores "out of version"
3. Open `/admin/nourish-flags` → third tab "Upgrade candidates" with badge count
4. Click Rescore on a candidate → same flow as flags tab → after success, candidate drops from the list on next refresh

### Regression sweep

- [ ] `/api/nourish` compute path: shape-identical response (field names, order, types)
- [ ] `/api/admin/nourish/rescore` returns 403 without admin header; 200 with valid body
- [ ] NourishModal still displays scores correctly, stale banner unchanged
- [ ] Flag submit + admin view still work (no regression from PR 303/313)

### Check / build

- `pnpm run check`: **4 pre-existing errors / 127 warnings (baseline preserved across all 5 commits)**
- `pnpm run build`: passes

## What this PR does NOT do

Scope discipline — these belong to follow-up features:

1. Does **not** auto-rescore based on flag thresholds. Admin-triggered only.
2. Does **not** bulk rescore on `NOURISH_PROMPT_VERSION` bump.
3. Does **not** surface model-version status on public pages.
4. Does **not** change the scoring model.
5. Does **not** fix drift #4 (issue #314 — authenticated republish, PR 3.5).
6. Does **not** expand `NourishScores` with new dimensions — that's the post-Stability expansion feature.

## After merge

- Nourish Stability is complete end-to-end
- Trust infrastructure supports the expansion feature (new dimensions + Audience expansion can now start)
- Issue #314 (authenticated republish for drift #4) remains open as the single loose thread from the feature