### PR TITLE
feat(nourish): expansion — 4 new dimensions + Audience concept (background mode)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.252",
+  "version": "4.2.253",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.253",
+  "version": "4.2.254",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.249",
+  "version": "4.2.250",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.255",
+  "version": "4.2.256",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.251",
+  "version": "4.2.252",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.250",
+  "version": "4.2.251",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.254",
+  "version": "4.2.255",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.256",
+  "version": "4.2.257",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/nourish/cache.ts
+++ b/src/lib/nourish/cache.ts
@@ -1,5 +1,5 @@
 import { browser } from '$app/environment';
-import { NOURISH_CACHE_VERSION, type NourishScores } from './types';
+import { NOURISH_CACHE_VERSION, type NourishScores, type AudienceScores } from './types';
 
 const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
@@ -30,6 +30,14 @@ interface CacheEntry {
 	 * naturally.
 	 */
 	updatedAt?: number;
+	/**
+	 * Audience scores from v2-scored events. Undefined on v1 entries
+	 * and on entries where the LLM omitted the kidFriendly field.
+	 * Background mode: no UI consumer renders this today; the field
+	 * is persisted so future UI can retrieve it without a fresh LLM
+	 * call.
+	 */
+	audienceScores?: AudienceScores;
 	improvements?: string[];
 	ingredientSignals?: import('./types').IngredientSignal[];
 }
@@ -83,6 +91,7 @@ export function setNourishScores(
 		contentHash?: string;
 		createdAt?: number;
 		updatedAt?: number;
+		audienceScores?: AudienceScores;
 		improvements?: string[];
 		ingredientSignals?: import('./types').IngredientSignal[];
 	}
@@ -98,6 +107,7 @@ export function setNourishScores(
 			promptVersion: key.promptVersion,
 			createdAt: extra?.createdAt,
 			updatedAt: extra?.updatedAt,
+			audienceScores: extra?.audienceScores,
 			improvements: extra?.improvements,
 			ingredientSignals: extra?.ingredientSignals
 		};

--- a/src/lib/nourish/nourishPublisher.server.ts
+++ b/src/lib/nourish/nourishPublisher.server.ts
@@ -11,6 +11,7 @@ import {
   NOURISH_CACHE_VERSION,
   NOURISH_PROMPT_VERSION,
   type NourishScores,
+  type AudienceScores,
   type IngredientSignal
 } from './types';
 import { buildNourishDTag } from './nourishRelay';
@@ -97,13 +98,30 @@ export async function publishNourishEvent(opts: {
   improvements: string[];
   ingredientSignals: IngredientSignal[];
   /**
+   * Audience scores (v2 events). When present, emit `audience_*`
+   * tags and an `audience` key in the content JSON. Omitted on v1
+   * events — downstream parsers treat missing `audience` as "no
+   * data" distinct from "score 0."
+   */
+  audienceScores?: AudienceScores;
+  /**
    * Unix seconds. When set, emit an `updated_at` tag (and content-JSON
    * mirror) marking this event as a rescore rather than a first-time
    * score. Undefined → no tag emitted.
    */
   updatedAt?: number;
 }): Promise<boolean> {
-  const { privateKey, recipePubkey, recipeDTag, contentHash, scores, improvements, ingredientSignals, updatedAt } = opts;
+  const {
+    privateKey,
+    recipePubkey,
+    recipeDTag,
+    contentHash,
+    scores,
+    improvements,
+    ingredientSignals,
+    audienceScores,
+    updatedAt
+  } = opts;
 
   try {
     const privKeyBytes = resolvePrivateKey(privateKey);
@@ -121,8 +139,20 @@ export async function publishNourishEvent(opts: {
       ['nourish_overall', String(scores.overall.score)],
       ['nourish_gut', String(scores.gut.score)],
       ['nourish_protein', String(scores.protein.score)],
-      ['nourish_realfood', String(scores.realFood.score)]
+      ['nourish_realfood', String(scores.realFood.score)],
+      // v2 Nourish dimensions — emitted on all events going forward.
+      // v1 events in the wild won't have them; parser defaults to 0.
+      ['nourish_antiinflammatory', String(scores.antiInflammatory.score)],
+      ['nourish_bloodsugar', String(scores.bloodSugar.score)],
+      ['nourish_immunesupportive', String(scores.immuneSupportive.score)],
+      ['nourish_brainhealth', String(scores.brainHealth.score)]
     ];
+    // Audience tag prefix is distinct from nourish_* so future consumers
+    // can filter queries by namespace (e.g. only Nourish, only Audience,
+    // or both) without pulling one when they want the other.
+    if (audienceScores) {
+      tags.push(['audience_kidfriendly', String(audienceScores.kidFriendly.score)]);
+    }
     if (updatedAt !== undefined) {
       tags.push(['updated_at', String(updatedAt)]);
     }
@@ -136,11 +166,21 @@ export async function publishNourishEvent(opts: {
         gut: scores.gut,
         protein: scores.protein,
         realFood: scores.realFood,
+        // v2 Nourish dimensions — flat at root (preserves v1 parse path).
+        antiInflammatory: scores.antiInflammatory,
+        bloodSugar: scores.bloodSugar,
+        immuneSupportive: scores.immuneSupportive,
+        brainHealth: scores.brainHealth,
         overall: scores.overall,
         summary: scores.summary,
         improvements,
         ingredient_signals: ingredientSignals,
         cacheVersion: scores.cacheVersion,
+        // Audience — new root key, present only on v2 events. Keeping
+        // it at the root (rather than restructuring Nourish fields
+        // under a `nourish` key) preserves backward-compat for the
+        // relay parser's existing flat-shape assumptions.
+        ...(audienceScores ? { audience: audienceScores } : {}),
         // Mirror identity fields into content so the payload is self-
         // describing (tags already carry them; content duplication lets
         // downstream consumers read either location).

--- a/src/lib/nourish/nourishRelay.ts
+++ b/src/lib/nourish/nourishRelay.ts
@@ -14,6 +14,7 @@ import {
   NOURISH_CACHE_VERSION,
   computeOverallScore,
   type NourishScores,
+  type AudienceScores,
   type NourishRelayResult,
   type IngredientSignal
 } from './types';
@@ -136,11 +137,27 @@ export function parseNourishEvent(event: NDKEvent): NourishRelayResult | null {
   try {
     const content = JSON.parse(event.content);
 
-    // Extract scores — recompute overall with current weights for forward compatibility
+    // Extract scores — recompute overall with current weights for forward
+    // compatibility. v1 events lack the four new health dimensions; they
+    // default to 0, which contributes nothing to the weighted overall
+    // (consistent with legacy behavior since those weights didn't exist
+    // when the event was scored). v2 events populate them.
     const gutScore = content.gut?.score ?? 0;
     const proteinScore = content.protein?.score ?? 0;
     const realFoodScore = content.realFood?.score ?? 0;
-    const overall = computeOverallScore(gutScore, proteinScore, realFoodScore);
+    const antiInflammatoryScore = content.antiInflammatory?.score ?? 0;
+    const bloodSugarScore = content.bloodSugar?.score ?? 0;
+    const immuneSupportiveScore = content.immuneSupportive?.score ?? 0;
+    const brainHealthScore = content.brainHealth?.score ?? 0;
+    const overall = computeOverallScore({
+      gut: gutScore,
+      protein: proteinScore,
+      realFood: realFoodScore,
+      antiInflammatory: antiInflammatoryScore,
+      bloodSugar: bloodSugarScore,
+      immuneSupportive: immuneSupportiveScore,
+      brainHealth: brainHealthScore
+    });
 
     const scores: NourishScores = {
       gut: {
@@ -158,16 +175,55 @@ export function parseNourishEvent(event: NDKEvent): NourishRelayResult | null {
         label: content.realFood?.label || 'Moderate',
         reason: content.realFood?.reason || ''
       },
+      antiInflammatory: {
+        score: antiInflammatoryScore,
+        label: content.antiInflammatory?.label || 'Moderate',
+        reason: content.antiInflammatory?.reason || ''
+      },
+      bloodSugar: {
+        score: bloodSugarScore,
+        label: content.bloodSugar?.label || 'Moderate',
+        reason: content.bloodSugar?.reason || ''
+      },
+      immuneSupportive: {
+        score: immuneSupportiveScore,
+        label: content.immuneSupportive?.label || 'Moderate',
+        reason: content.immuneSupportive?.reason || ''
+      },
+      brainHealth: {
+        score: brainHealthScore,
+        label: content.brainHealth?.label || 'Moderate',
+        reason: content.brainHealth?.reason || ''
+      },
       overall: {
         score: overall.score,
         label: overall.label,
-        reason: content.overall?.reason || `Weighted: Real Food 45%, Gut 35%, Protein 20%`
+        reason:
+          content.overall?.reason ||
+          `Weighted: Real Food 35%, Gut 25%, Protein 15%, Anti-Inflammatory 10%, Blood Sugar 10%, Immune-Supportive 3%, Brain Health 2%`
       },
       summary: content.summary || '',
       // Accept both the new `cacheVersion` and the legacy `version` field
       // so pre-2.0 events in the wild still parse.
       cacheVersion: content.cacheVersion || content.version || NOURISH_CACHE_VERSION
     };
+
+    // Audience scores — v2 events carry an `audience` root key with
+    // kidFriendly. v1 events omit this; leave audienceScores undefined
+    // so consumers see "no audience data" distinctly from "score 0".
+    let audienceScores: AudienceScores | undefined = undefined;
+    if (content.audience && typeof content.audience === 'object') {
+      const kf = content.audience.kidFriendly;
+      if (kf && typeof kf.score === 'number') {
+        audienceScores = {
+          kidFriendly: {
+            score: kf.score,
+            label: typeof kf.label === 'string' ? kf.label : 'Moderate',
+            reason: typeof kf.reason === 'string' ? kf.reason : ''
+          }
+        };
+      }
+    }
 
     const improvements: string[] = Array.isArray(content.improvements)
       ? content.improvements.filter((s: unknown) => typeof s === 'string')
@@ -198,6 +254,7 @@ export function parseNourishEvent(event: NDKEvent): NourishRelayResult | null {
       scores,
       improvements,
       ingredientSignals,
+      audienceScores,
       contentHash,
       promptVersion,
       nourishVersion,

--- a/src/lib/nourish/nourishRelay.ts
+++ b/src/lib/nourish/nourishRelay.ts
@@ -137,11 +137,8 @@ export function parseNourishEvent(event: NDKEvent): NourishRelayResult | null {
   try {
     const content = JSON.parse(event.content);
 
-    // Extract scores — recompute overall with current weights for forward
-    // compatibility. v1 events lack the four new health dimensions; they
-    // default to 0, which contributes nothing to the weighted overall
-    // (consistent with legacy behavior since those weights didn't exist
-    // when the event was scored). v2 events populate them.
+    // Extract per-dimension scores. v1 events lack the four new health
+    // dimensions; they default to 0.
     const gutScore = content.gut?.score ?? 0;
     const proteinScore = content.protein?.score ?? 0;
     const realFoodScore = content.realFood?.score ?? 0;
@@ -149,15 +146,38 @@ export function parseNourishEvent(event: NDKEvent): NourishRelayResult | null {
     const bloodSugarScore = content.bloodSugar?.score ?? 0;
     const immuneSupportiveScore = content.immuneSupportive?.score ?? 0;
     const brainHealthScore = content.brainHealth?.score ?? 0;
-    const overall = computeOverallScore({
-      gut: gutScore,
-      protein: proteinScore,
-      realFood: realFoodScore,
-      antiInflammatory: antiInflammatoryScore,
-      bloodSugar: bloodSugarScore,
-      immuneSupportive: immuneSupportiveScore,
-      brainHealth: brainHealthScore
-    });
+
+    // Overall: trust the stored value when present. Recomputing with
+    // current weights against legacy v1 events depresses overall by
+    // ~25% because the four new dimensions are 0 under ~25% of the
+    // weight (10% + 10% + 3% + 2%). The stored overall was computed
+    // under whichever weights were current when the event was
+    // published; honoring it preserves the "background mode" contract
+    // that users see no visible change in their existing scores.
+    // Only fall back to recomputation for events that somehow lack a
+    // stored overall (pre-overall-field legacy, corrupted content).
+    let overall: { score: number; label: string };
+    const storedOverallScore = content.overall?.score;
+    if (typeof storedOverallScore === 'number' && Number.isFinite(storedOverallScore)) {
+      const rawScore = Math.round(Math.max(0, Math.min(10, storedOverallScore)));
+      overall = {
+        score: rawScore,
+        label:
+          typeof content.overall?.label === 'string'
+            ? content.overall.label
+            : 'Moderate'
+      };
+    } else {
+      overall = computeOverallScore({
+        gut: gutScore,
+        protein: proteinScore,
+        realFood: realFoodScore,
+        antiInflammatory: antiInflammatoryScore,
+        bloodSugar: bloodSugarScore,
+        immuneSupportive: immuneSupportiveScore,
+        brainHealth: brainHealthScore
+      });
+    }
 
     const scores: NourishScores = {
       gut: {

--- a/src/lib/nourish/scoreResolver.ts
+++ b/src/lib/nourish/scoreResolver.ts
@@ -255,7 +255,7 @@ function writeThrough(requestedKey: NourishCacheKey, winner: Candidate): void {
 
 function l3EntryToResolved(
   l3: NonNullable<ReturnType<typeof getNourishCache>>,
-  promptVersion: string
+  fallbackPromptVersion: string
 ): ResolvedEntry {
   return {
     scores: l3.scores,
@@ -268,9 +268,23 @@ function l3EntryToResolved(
     audienceScores: l3.audienceScores,
     improvements: l3.improvements,
     ingredientSignals: l3.ingredientSignals,
-    promptVersion
+    // Prefer the entry's stored promptVersion over the caller's hint.
+    // Matters on legacy-version fallback lookups: a v2-keyed caller
+    // finding a v1 entry via fallback must see promptVersion = '1' so
+    // downstream consumers (flag button, admin aggregation) record the
+    // correct version.
+    promptVersion: l3.promptVersion ?? fallbackPromptVersion
   };
 }
+
+// Previous prompt versions to fall back to on a cache miss under the
+// current version. Allows returning-user offline continuity during the
+// expansion rollout — a v1-cached entry still resolves under a v2
+// lookup until bulk rescore migrates the pantry event. After migration
+// + L3 write-through, the v2 key gets populated naturally and these
+// fallback reads become unused. Add new predecessors here as the
+// constant bumps.
+const LEGACY_PROMPT_VERSIONS = ['1', 'unknown'] as const;
 
 async function doResolve(ndk: NDK, key: NourishCacheKey): Promise<ResolveResult> {
   // Gather candidates from every layer before deciding. Unlike commit
@@ -287,6 +301,36 @@ async function doResolve(ndk: NDK, key: NourishCacheKey): Promise<ResolveResult>
       source: 'local',
       entry: l3EntryToResolved(l3Hit, key.promptVersion)
     });
+  }
+
+  // Legacy-version fallback: during the expansion rollout window,
+  // returning users have v1 entries under v1 keys from prior sessions.
+  // Without this fallback, every v2 lookup would miss L2/L3 and force
+  // a pantry round-trip (or break entirely when offline) until a bulk
+  // rescore migrates pantry events + a subsequent resolve writes v2
+  // entries. The fallback preserves the "no user-visible change"
+  // contract during the migration window. Skipped once we've already
+  // got hits under the requested version so fresh reads stay cheap.
+  if (!l2Hit && !l3Hit) {
+    for (const legacyVersion of LEGACY_PROMPT_VERSIONS) {
+      if (legacyVersion === key.promptVersion) continue;
+      const legacyKey: NourishCacheKey = {
+        recipePubkey: key.recipePubkey,
+        recipeDTag: key.recipeDTag,
+        promptVersion: legacyVersion
+      };
+      const legacyL2 = memory.get(toMapKey(legacyKey));
+      if (legacyL2) {
+        candidates.push({ source: 'memory', entry: legacyL2 });
+      }
+      const legacyL3 = getNourishCache(legacyKey);
+      if (legacyL3) {
+        candidates.push({
+          source: 'local',
+          entry: l3EntryToResolved(legacyL3, legacyVersion)
+        });
+      }
+    }
   }
 
   const l4 = await queryNourishEvent(ndk, key.recipePubkey, key.recipeDTag);

--- a/src/lib/nourish/scoreResolver.ts
+++ b/src/lib/nourish/scoreResolver.ts
@@ -28,7 +28,7 @@
 import type NDK from '@nostr-dev-kit/ndk';
 import { getNourishCache, setNourishScores, type NourishCacheKey } from './cache';
 import { queryNourishEvent } from './nourishRelay';
-import type { NourishScores, IngredientSignal } from './types';
+import type { AudienceScores, NourishScores, IngredientSignal } from './types';
 
 // ─── Public types ────────────────────────────────────────────
 
@@ -42,6 +42,11 @@ export interface ResolvedEntry {
    * the 24h "Updated" pill.
    */
   updatedAt?: number;
+  /**
+   * Audience scores from v2 events. Undefined on v1 entries (pre-
+   * expansion). Background mode — no UI consumer reads this yet.
+   */
+  audienceScores?: AudienceScores;
   improvements?: string[];
   ingredientSignals?: IngredientSignal[];
   promptVersion: string;
@@ -241,6 +246,7 @@ function writeThrough(requestedKey: NourishCacheKey, winner: Candidate): void {
       contentHash: winner.entry.contentHash,
       createdAt: winner.entry.createdAt,
       updatedAt: winner.entry.updatedAt,
+      audienceScores: winner.entry.audienceScores,
       improvements: winner.entry.improvements,
       ingredientSignals: winner.entry.ingredientSignals
     });
@@ -259,6 +265,7 @@ function l3EntryToResolved(
     // already uses for its "analyzed at" label.
     createdAt: l3.createdAt ?? Math.floor(l3.timestamp / 1000),
     updatedAt: l3.updatedAt,
+    audienceScores: l3.audienceScores,
     improvements: l3.improvements,
     ingredientSignals: l3.ingredientSignals,
     promptVersion
@@ -291,6 +298,7 @@ async function doResolve(ndk: NDK, key: NourishCacheKey): Promise<ResolveResult>
         contentHash: l4.result.contentHash,
         createdAt: l4.result.createdAt,
         updatedAt: l4.result.updatedAt,
+        audienceScores: l4.result.audienceScores,
         improvements: l4.result.improvements,
         ingredientSignals: l4.result.ingredientSignals,
         promptVersion: l4.result.promptVersion

--- a/src/lib/nourish/scoringEngine.server.ts
+++ b/src/lib/nourish/scoringEngine.server.ts
@@ -19,17 +19,19 @@
  */
 
 import { NOURISH_CACHE_VERSION, computeOverallScore } from './types';
-import type { IngredientSignal, NourishScores } from './types';
+import type { AudienceScores, IngredientSignal, NourishScores } from './types';
 
-// ─── Prompt template ────────────────────────────────────────
+// ─── Prompt template (v2) ───────────────────────────────────
 
-const NOURISH_PROMPT = `You are a recipe analysis assistant for a cooking platform. Analyze the recipe below and return three food quality scores.
+const NOURISH_PROMPT = `You are a recipe analysis assistant for a cooking platform. Analyze the recipe below and return eight food scores: seven Nourish health dimensions, and one Audience appeal dimension.
 
 SCORING RULES:
 - All scores are integers from 0 to 10.
 - Base your analysis ONLY on the ingredient list provided.
 - Be consistent: similar ingredient profiles should produce similar scores.
 - These are rough estimates. Err toward the middle of the range unless the recipe clearly skews high or low.
+
+════════ NOURISH DIMENSIONS (HEALTH) ════════
 
 GUT SCORE (0-10): How well does this recipe support digestive health?
 - Fermented foods (yogurt, kimchi, sauerkraut, miso, kefir, sourdough): +2-3 points
@@ -53,6 +55,56 @@ REAL FOOD SCORE (0-10): How close are ingredients to their whole, unprocessed fo
 - Contains ultra-processed items (processed cheese, instant mixes, artificial flavors): -2-3 points
 - Mostly packaged/convenience ingredients: 0-3 score
 
+ANTI-INFLAMMATORY SCORE (0-10): How well does this recipe support the body's anti-inflammatory response?
+- Omega-3 rich (fatty fish, walnuts, flaxseed, chia): +2-3
+- Turmeric, ginger, extra-virgin olive oil: +1-2
+- Leafy greens, dark berries: +1-2
+- Colorful vegetables (bell peppers, tomatoes, beets): +1
+- Refined vegetable oils (corn, soybean, safflower): -1-2
+- Processed meats (bacon, sausage, deli meat): -2
+- Added sugar, refined carbs: -1-2
+- Ultra-processed ingredients: -1-2
+
+BLOOD SUGAR SCORE (0-10): How well does this recipe support stable blood sugar?
+- Fiber + protein + healthy fat balance: +2-3
+- Whole grains (oats, quinoa, brown rice), legumes: +1-2
+- Added sugar (cane/honey/syrup/etc.): -1-2
+- Refined flour, white rice, fruit juice: -1-2
+- Ultra-processed snacks: -1-2
+
+IMMUNE-SUPPORTIVE SCORE (0-10): How well does this recipe provide immune-supportive nutrients?
+- Vitamin-C-rich (citrus, bell peppers, broccoli, kiwi): +1-2
+- Zinc sources (pumpkin seeds, oysters, legumes, red meat): +1
+- Alliums (garlic, onion, leek, shallot): +1
+- Ginger, turmeric, mushrooms: +1
+- Fermented foods (yogurt, kimchi, kefir, sauerkraut): +1-2
+- Bone broth: +1
+- Mostly refined/processed: 0-2 range
+
+BRAIN HEALTH SCORE (0-10): How well does this recipe support cognitive health?
+- Omega-3 fatty fish (salmon, sardines, mackerel): +2-3
+- Leafy greens, berries: +1-2
+- Walnuts, other nuts: +1-2
+- Turmeric, whole grains, olive oil: +1
+- Refined sugar, trans fats, ultra-processed: -1-2
+
+════════ AUDIENCE DIMENSION (APPEAL) ════════
+
+KID-FRIENDLY SCORE (0-10): How likely is a typical kid (ages 5-10) to eat this dish willingly?
+
+IMPORTANT: This is NOT a health score. Do not penalize healthy food for being healthy, and do not reward unhealthy food for being palatable. It's a palate-appeal score: flavor familiarity, texture approachability, visual presentation, and how picky-eater-compatible the dish is. A nutrient-dense stir-fry can score low on kid-friendly; a plain buttered pasta can score high. Both are legitimate signals and independent of health.
+
+- Familiar flavors (mild cheese, pasta, rice, mild chicken, butter): +2-3
+- Slightly sweet or savory-sweet profile: +1
+- Finger foods, nugget/patty shapes, pizza, tacos, dips: +1-2
+- Visual appeal (colorful, fun shapes, dippable components): +1
+- Hidden-veggie dishes (blended into sauces): +1
+- Strong/bitter flavors (olives, blue cheese, bitter greens, heavy spices): -1-2
+- Unfamiliar textures (raw fish, tripe, very chewy): -1-2
+- Visible large pieces of commonly-resisted vegetables: -1
+- Complex plated dishes requiring utensil skill: -1
+- Many separately-prepared components: 0-2 range
+
 LABELS:
 - 0-2: "Low"
 - 3-4: "Fair"
@@ -72,6 +124,11 @@ Return ONLY valid JSON with this exact structure:
   "gut": { "score": <number>, "label": "<string>", "reason": "<one sentence>" },
   "protein": { "score": <number>, "label": "<string>", "reason": "<one sentence>" },
   "realFood": { "score": <number>, "label": "<string>", "reason": "<one sentence>" },
+  "antiInflammatory": { "score": <number>, "label": "<string>", "reason": "<one sentence>" },
+  "bloodSugar": { "score": <number>, "label": "<string>", "reason": "<one sentence>" },
+  "immuneSupportive": { "score": <number>, "label": "<string>", "reason": "<one sentence>" },
+  "brainHealth": { "score": <number>, "label": "<string>", "reason": "<one sentence>" },
+  "kidFriendly": { "score": <number>, "label": "<string>", "reason": "<one sentence>" },
   "summary": "<1-2 sentences>",
   "ingredients": [
     { "name": "<ingredient>", "signals": ["<tag>"], "contribution": "<gut|protein|realFood|neutral>" }
@@ -132,6 +189,13 @@ export type ScoringPipelineResult =
 			scores: NourishScores;
 			improvements: string[];
 			ingredientSignals: IngredientSignal[];
+			/**
+			 * Audience scores from the v2 prompt (kidFriendly only for now).
+			 * Undefined if the LLM response didn't include the kidFriendly
+			 * field — shouldn't happen with the v2 prompt, but defensive
+			 * parsing keeps the pipeline resilient to truncated responses.
+			 */
+			audienceScores?: AudienceScores;
 	  }
 	| { ok: false; status: number; error: string };
 
@@ -174,7 +238,7 @@ export async function runScoringPipeline(
 		body: JSON.stringify({
 			model: 'gpt-4o-mini',
 			messages: [{ role: 'system', content: prompt }],
-			max_tokens: 1500,
+			max_tokens: 2000,
 			temperature: 0.3
 		})
 	});
@@ -270,10 +334,26 @@ export async function runScoringPipeline(
 		cacheVersion: NOURISH_CACHE_VERSION
 	};
 
+	// Audience — v2 prompt returns kidFriendly at the root. Defensive
+	// parse: if the model truncated output or omitted the field, leave
+	// audienceScores undefined rather than fabricating a score.
+	let audienceScores: AudienceScores | undefined = undefined;
+	const kfRaw = parsed.kidFriendly;
+	if (kfRaw && typeof kfRaw.score === 'number') {
+		audienceScores = {
+			kidFriendly: {
+				score: clampScore(kfRaw.score),
+				label: validateLabel(kfRaw.label),
+				reason: String(kfRaw.reason || '')
+			}
+		};
+	}
+
 	return {
 		ok: true,
 		scores,
 		improvements: validateImprovements(parsed.improvements),
-		ingredientSignals: validateIngredientSignals(parsed.ingredients)
+		ingredientSignals: validateIngredientSignals(parsed.ingredients),
+		audienceScores
 	};
 }

--- a/src/lib/nourish/scoringEngine.server.ts
+++ b/src/lib/nourish/scoringEngine.server.ts
@@ -271,10 +271,12 @@ export async function runScoringPipeline(
 	const gutScore = clampScore(parsed.gut?.score);
 	const proteinScore = clampScore(parsed.protein?.score);
 	const realFoodScore = clampScore(parsed.realFood?.score);
-	// v1 prompt doesn't score the four new dimensions — clampScore(undefined)
-	// returns 0 so they contribute nothing to the weighted overall until
-	// commit 2 ships the v2 prompt. Placeholder reason kept empty so a
-	// downstream "why this score" consumer can't mistake silence for signal.
+	// Defensive parse: the v2 prompt requests these dimensions, but if
+	// the model omits a field or truncates its JSON, clampScore(undefined)
+	// falls back to 0 so the missing dimension contributes nothing to
+	// the weighted overall rather than throwing. Placeholder reason kept
+	// empty so a downstream "why this score" consumer can't mistake
+	// silence for signal.
 	const antiInflammatoryScore = clampScore(parsed.antiInflammatory?.score);
 	const bloodSugarScore = clampScore(parsed.bloodSugar?.score);
 	const immuneSupportiveScore = clampScore(parsed.immuneSupportive?.score);

--- a/src/lib/nourish/scoringEngine.server.ts
+++ b/src/lib/nourish/scoringEngine.server.ts
@@ -207,7 +207,23 @@ export async function runScoringPipeline(
 	const gutScore = clampScore(parsed.gut?.score);
 	const proteinScore = clampScore(parsed.protein?.score);
 	const realFoodScore = clampScore(parsed.realFood?.score);
-	const overall = computeOverallScore(gutScore, proteinScore, realFoodScore);
+	// v1 prompt doesn't score the four new dimensions — clampScore(undefined)
+	// returns 0 so they contribute nothing to the weighted overall until
+	// commit 2 ships the v2 prompt. Placeholder reason kept empty so a
+	// downstream "why this score" consumer can't mistake silence for signal.
+	const antiInflammatoryScore = clampScore(parsed.antiInflammatory?.score);
+	const bloodSugarScore = clampScore(parsed.bloodSugar?.score);
+	const immuneSupportiveScore = clampScore(parsed.immuneSupportive?.score);
+	const brainHealthScore = clampScore(parsed.brainHealth?.score);
+	const overall = computeOverallScore({
+		gut: gutScore,
+		protein: proteinScore,
+		realFood: realFoodScore,
+		antiInflammatory: antiInflammatoryScore,
+		bloodSugar: bloodSugarScore,
+		immuneSupportive: immuneSupportiveScore,
+		brainHealth: brainHealthScore
+	});
 
 	const scores: NourishScores = {
 		gut: {
@@ -225,10 +241,30 @@ export async function runScoringPipeline(
 			label: validateLabel(parsed.realFood?.label),
 			reason: String(parsed.realFood?.reason || '')
 		},
+		antiInflammatory: {
+			score: antiInflammatoryScore,
+			label: validateLabel(parsed.antiInflammatory?.label),
+			reason: String(parsed.antiInflammatory?.reason || '')
+		},
+		bloodSugar: {
+			score: bloodSugarScore,
+			label: validateLabel(parsed.bloodSugar?.label),
+			reason: String(parsed.bloodSugar?.reason || '')
+		},
+		immuneSupportive: {
+			score: immuneSupportiveScore,
+			label: validateLabel(parsed.immuneSupportive?.label),
+			reason: String(parsed.immuneSupportive?.reason || '')
+		},
+		brainHealth: {
+			score: brainHealthScore,
+			label: validateLabel(parsed.brainHealth?.label),
+			reason: String(parsed.brainHealth?.reason || '')
+		},
 		overall: {
 			score: overall.score,
 			label: overall.label,
-			reason: `Weighted: Real Food 45%, Gut 35%, Protein 20%`
+			reason: `Weighted: Real Food 35%, Gut 25%, Protein 15%, Anti-Inflammatory 10%, Blood Sugar 10%, Immune-Supportive 3%, Brain Health 2%`
 		},
 		summary: String(parsed.summary || ''),
 		cacheVersion: NOURISH_CACHE_VERSION

--- a/src/lib/nourish/types.ts
+++ b/src/lib/nourish/types.ts
@@ -1,5 +1,5 @@
 export const NOURISH_CACHE_VERSION = '2.0';
-export const NOURISH_PROMPT_VERSION = '1';
+export const NOURISH_PROMPT_VERSION = '2';
 
 /**
  * Public key of the Zap Cooking service account that publishes Nourish analysis events.

--- a/src/lib/nourish/types.ts
+++ b/src/lib/nourish/types.ts
@@ -16,6 +16,13 @@ export interface NourishRelayResult {
   scores: NourishScores;
   improvements: string[];
   ingredientSignals: IngredientSignal[];
+  /**
+   * Audience scores — parallel dimension to Nourish, answering "will
+   * this person eat it?" separately from "is this food good for you?"
+   * Present on v2 events; undefined on v1 events (background mode —
+   * no UI renders this yet; PR 3 Phase 2 #1d decision).
+   */
+  audienceScores?: AudienceScores;
   contentHash: string;
   promptVersion: string;
   nourishVersion: string;
@@ -51,33 +58,68 @@ export interface NourishScores {
 	gut: ScoreDetail;
 	protein: ScoreDetail;
 	realFood: ScoreDetail;
+	antiInflammatory: ScoreDetail;
+	bloodSugar: ScoreDetail;
+	immuneSupportive: ScoreDetail;
+	brainHealth: ScoreDetail;
 	overall: ScoreDetail;
 	summary: string;
 	cacheVersion: string;
 }
 
+/**
+ * Audience scores — parallel dimension to Nourish. Answers "will
+ * this person eat it?" independently of "is this food good for you?"
+ * First entry is kidFriendly; future entries (elderlyFriendly,
+ * athleteFriendly, etc.) add as named fields for TypeScript narrowing.
+ *
+ * Background mode (PR 3): scored + stored but not rendered. Future
+ * UI will expose these separately from the Nourish weighted overall.
+ */
+export interface AudienceScores {
+	kidFriendly: ScoreDetail;
+}
+
 // ─── Overall score weights (transparent) ─────────────────────
-// Real Food is weighted highest because ingredient quality is the
-// foundation — it affects everything else. Gut health is next because
-// fiber, fermentation, and plant diversity are strong markers of a
-// nourishing meal. Protein is weighted lowest (but still meaningful)
-// because many healthy meals are naturally lower in protein.
+// Real Food is the foundation — ingredient quality affects everything
+// else. Gut health is next (fiber, fermentation, plant diversity are
+// strong markers of a nourishing meal). Protein is baseline. The four
+// new dimensions contribute smaller weights until proven:
+//   - antiInflammatory and bloodSugar each carry 10% — broad signals
+//   - immuneSupportive (3%) and brainHealth (2%) are narrower — they
+//     participate in the overall but don't dominate
 export const NOURISH_WEIGHTS = {
-	realFood: 0.45,
-	gut: 0.35,
-	protein: 0.20
+	realFood: 0.35,
+	gut: 0.25,
+	protein: 0.15,
+	antiInflammatory: 0.10,
+	bloodSugar: 0.10,
+	immuneSupportive: 0.03,
+	brainHealth: 0.02
 } as const;
 
-/** Compute the weighted overall Nourish score (0–10). */
-export function computeOverallScore(
-	gut: number,
-	protein: number,
-	realFood: number
-): { score: number; label: string } {
+/**
+ * Compute the weighted overall Nourish score (0–10) from per-dimension
+ * scores. Takes an object argument rather than positional args because
+ * 7 positional numbers is unreadable and order-fragile.
+ */
+export function computeOverallScore(scores: {
+	gut: number;
+	protein: number;
+	realFood: number;
+	antiInflammatory: number;
+	bloodSugar: number;
+	immuneSupportive: number;
+	brainHealth: number;
+}): { score: number; label: string } {
 	const raw =
-		realFood * NOURISH_WEIGHTS.realFood +
-		gut * NOURISH_WEIGHTS.gut +
-		protein * NOURISH_WEIGHTS.protein;
+		scores.realFood * NOURISH_WEIGHTS.realFood +
+		scores.gut * NOURISH_WEIGHTS.gut +
+		scores.protein * NOURISH_WEIGHTS.protein +
+		scores.antiInflammatory * NOURISH_WEIGHTS.antiInflammatory +
+		scores.bloodSugar * NOURISH_WEIGHTS.bloodSugar +
+		scores.immuneSupportive * NOURISH_WEIGHTS.immuneSupportive +
+		scores.brainHealth * NOURISH_WEIGHTS.brainHealth;
 	const score = Math.round(Math.max(0, Math.min(10, raw)));
 	const label =
 		score <= 2 ? 'Low' :
@@ -92,6 +134,12 @@ export interface NourishResponse {
 	scores?: NourishScores;
 	improvements?: string[];
 	ingredient_signals?: IngredientSignal[];
+	/**
+	 * Audience scores (kidFriendly + future audiences). Present on v2
+	 * responses; undefined on v1 legacy responses. Background mode —
+	 * no UI consumer renders this yet (PR 3).
+	 */
+	audience_scores?: AudienceScores;
 	error?: string;
 	promptVersion?: string;
 	contentHash?: string;
@@ -122,6 +170,11 @@ export interface ScanResponse {
 	quick_take?: string;
 	improvements?: string[];
 	ingredient_signals?: IngredientSignal[];
+	/**
+	 * Audience scores — same shape as NourishResponse's field.
+	 * Background mode; no UI consumer renders this yet.
+	 */
+	audience_scores?: AudienceScores;
 	error?: string;
 	promptVersion?: string;
 	createdAt?: number;

--- a/src/routes/admin/nourish-flags/+page.svelte
+++ b/src/routes/admin/nourish-flags/+page.svelte
@@ -576,6 +576,239 @@
   function retryRescore(key: string) {
     setRescoreState(key, { status: 'idle' });
   }
+
+  // ── Bulk rescore batch ─────────────────────────────────────────────
+  //
+  // Admin-triggered migration: iterate the Upgrade Candidates list in
+  // the browser with bounded concurrency (3 parallel), calling the
+  // same /api/admin/nourish/rescore endpoint the per-row button uses.
+  // Each POST is NIP-98 signed. Retries transient errors once with a
+  // 2s backoff; 403 aborts the whole batch (signer/auth issue —
+  // individual-recipe retries won't help). Other 4xx responses mark
+  // the individual recipe as failed and the batch continues.
+  //
+  // No server-side batch endpoint — CF Workers' 30s HTTP-request
+  // limit fights long-running server operations. Client-driven keeps
+  // each request well under that bound.
+
+  const BATCH_CONCURRENCY = 3;
+  const BATCH_RETRY_DELAY_MS = 2000;
+
+  type BatchState = 'idle' | 'confirming' | 'running' | 'aborting' | 'done';
+  let batchState: BatchState = 'idle';
+  let batchAbortRequested = false;
+  let batchSummary:
+    | { succeeded: number; failed: number; total: number; aborted: boolean }
+    | null = null;
+
+  $: batchProgress = (() => {
+    if (batchState !== 'running' && batchState !== 'aborting') return null;
+    let done = 0;
+    let succeeded = 0;
+    for (const { candidate } of sortedCandidates) {
+      const s = getRescoreState(`candidate:${candidate.aTag}`);
+      if (s.status === 'success') {
+        done++;
+        succeeded++;
+      } else if (s.status === 'error' || s.status === 'prepare-error') {
+        done++;
+      }
+    }
+    return {
+      done,
+      succeeded,
+      failed: done - succeeded,
+      total: sortedCandidates.length
+    };
+  })();
+
+  type BatchOutcome =
+    | { kind: 'success' }
+    | { kind: 'recipe-error'; message: string }
+    | { kind: 'retriable'; message: string; status: number }
+    | { kind: 'fatal'; message: string };
+
+  async function batchRescoreOne(
+    candidate: OutOfVersionCandidate
+  ): Promise<BatchOutcome> {
+    if (!$ndk || !$userPublickey) {
+      return { kind: 'fatal', message: 'Not signed in' };
+    }
+    const key = `candidate:${candidate.aTag}`;
+    setRescoreState(key, { status: 'preparing' });
+
+    const [recipeEv, pantryRes] = await Promise.all([
+      fetchRecipeEvent(candidate.recipePubkey, candidate.recipeDTag),
+      queryNourishEvent($ndk, candidate.recipePubkey, candidate.recipeDTag)
+    ]);
+    if (!recipeEv) {
+      const msg = 'Could not fetch the recipe event from relays.';
+      setRescoreState(key, { status: 'prepare-error', message: msg });
+      return { kind: 'recipe-error', message: msg };
+    }
+
+    const title =
+      recipeEv.tags.find((t) => t[0] === 'title')?.[1] ||
+      recipeEv.tags.find((t) => t[0] === 'd')?.[1] ||
+      '';
+    const tags = recipeEv.tags.filter((t) => t[0] === 't' && t[1]).map((t) => t[1]);
+    const parsedMd = parseMarkdownForEditing(recipeEv.content || '');
+    const servings = parsedMd.information?.servings || '';
+    const ingredients = parsedMd.ingredients;
+    if (!ingredients || ingredients.length === 0) {
+      const msg = 'Recipe has no ingredients to score.';
+      setRescoreState(key, { status: 'prepare-error', message: msg });
+      return { kind: 'recipe-error', message: msg };
+    }
+    const contentHash = await computeContentHash(recipeEv.content || '');
+    const previous: ScoreSnapshot | null =
+      pantryRes.status === 'hit'
+        ? {
+            scores: pantryRes.result.scores,
+            createdAt: pantryRes.result.createdAt,
+            promptVersion: pantryRes.result.promptVersion
+          }
+        : null;
+
+    setRescoreState(key, { status: 'submitting' });
+
+    const bodyString = JSON.stringify({
+      recipePubkey: candidate.recipePubkey,
+      recipeDTag: candidate.recipeDTag,
+      title,
+      ingredients,
+      tags,
+      servings,
+      contentHash
+    });
+    const url = new URL('/api/admin/nourish/rescore', window.location.origin).toString();
+    let authorization: string;
+    try {
+      authorization = await signNip98AuthHeader($ndk, {
+        method: 'POST',
+        url,
+        bodyString
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Could not sign admin auth';
+      setRescoreState(key, { status: 'error', message: msg });
+      // Sign failure is typically the signer being unavailable — likely
+      // to repeat for every candidate, so treat as fatal.
+      return { kind: 'fatal', message: msg };
+    }
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: authorization },
+      body: bodyString
+    });
+
+    if (res.status === 403) {
+      setRescoreState(key, { status: 'error', message: 'Forbidden' });
+      return { kind: 'fatal', message: 'Forbidden' };
+    }
+    if (res.status === 429 || (res.status >= 500 && res.status < 600)) {
+      const msg = `HTTP ${res.status}`;
+      // Don't finalize per-row state yet — caller will retry once.
+      return { kind: 'retriable', message: msg, status: res.status };
+    }
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      const msg = typeof body?.error === 'string' ? body.error : `HTTP ${res.status}`;
+      setRescoreState(key, { status: 'error', message: msg });
+      return { kind: 'recipe-error', message: msg };
+    }
+
+    const data = await res.json();
+    if (!data?.success || data?.published !== true) {
+      const msg = typeof data?.error === 'string' ? data.error : 'Rescore failed';
+      setRescoreState(key, { status: 'error', message: msg });
+      return { kind: 'recipe-error', message: msg };
+    }
+    setRescoreState(key, {
+      status: 'success',
+      previous,
+      next: {
+        scores: data.scores,
+        createdAt: data.createdAt,
+        promptVersion: data.promptVersion
+      }
+    });
+    return { kind: 'success' };
+  }
+
+  async function batchRescoreOneWithRetry(
+    candidate: OutOfVersionCandidate
+  ): Promise<BatchOutcome> {
+    let result = await batchRescoreOne(candidate);
+    if (result.kind === 'retriable') {
+      await new Promise((r) => setTimeout(r, BATCH_RETRY_DELAY_MS));
+      result = await batchRescoreOne(candidate);
+      // If still retriable after second attempt, mark as recipe-error
+      // so the batch continues rather than looping forever.
+      if (result.kind === 'retriable') {
+        const key = `candidate:${candidate.aTag}`;
+        setRescoreState(key, { status: 'error', message: result.message });
+        result = { kind: 'recipe-error', message: result.message };
+      }
+    }
+    return result;
+  }
+
+  function handleBatchRescoreClick() {
+    if (sortedCandidates.length === 0) return;
+    batchState = 'confirming';
+  }
+
+  function cancelBatchRescore() {
+    if (batchState === 'confirming') batchState = 'idle';
+  }
+
+  function abortBatchRescore() {
+    if (batchState === 'running') {
+      batchAbortRequested = true;
+      batchState = 'aborting';
+    }
+  }
+
+  async function confirmBatchRescore() {
+    batchState = 'running';
+    batchAbortRequested = false;
+    batchSummary = null;
+
+    const queue = sortedCandidates.map(({ candidate }) => candidate);
+    const total = queue.length;
+    let succeeded = 0;
+    let failed = 0;
+
+    const workers = Array.from({ length: BATCH_CONCURRENCY }, async () => {
+      while (queue.length > 0 && !batchAbortRequested) {
+        const c = queue.shift();
+        if (!c) return;
+        const result = await batchRescoreOneWithRetry(c);
+        if (result.kind === 'fatal') {
+          batchAbortRequested = true;
+          return;
+        }
+        if (result.kind === 'success') succeeded++;
+        else failed++;
+      }
+    });
+    await Promise.all(workers);
+
+    batchSummary = {
+      succeeded,
+      failed,
+      total,
+      aborted: batchAbortRequested
+    };
+    batchState = 'done';
+  }
+
+  function closeBatchSummary() {
+    batchState = 'idle';
+    batchSummary = null;
+  }
 </script>
 
 <svelte:head>
@@ -622,11 +855,79 @@
     </div>
 
     {#if activeTab === 'candidates'}
-      {#if sortedCandidates.length === 0}
+      {#if sortedCandidates.length === 0 && batchState === 'idle'}
         <p class="status">
           No candidates. All scored recipes match the current model version (v{NOURISH_PROMPT_VERSION}).
         </p>
       {:else}
+        <div class="batch-bar">
+          {#if batchState === 'idle' && sortedCandidates.length > 0}
+            <div class="batch-idle">
+              <p class="batch-idle-text">
+                Migrates {sortedCandidates.length} pre-v{NOURISH_PROMPT_VERSION} recipe{sortedCandidates.length === 1 ? '' : 's'}
+                to the current model version. Each rescore fires one LLM call.
+              </p>
+              <button type="button" class="btn-batch" on:click={handleBatchRescoreClick}>
+                Rescore all {sortedCandidates.length}
+              </button>
+            </div>
+          {:else if batchState === 'running' || batchState === 'aborting'}
+            <div class="batch-running">
+              <div class="batch-header">
+                <span class="batch-label">
+                  {batchState === 'aborting' ? 'Aborting…' : 'Rescoring…'}
+                </span>
+                {#if batchProgress}
+                  <span class="batch-counts">
+                    {batchProgress.done} / {batchProgress.total}
+                    · <span class="batch-ok">{batchProgress.succeeded} ok</span>
+                    · <span class="batch-fail">{batchProgress.failed} failed</span>
+                  </span>
+                {/if}
+                <button
+                  type="button"
+                  class="btn-batch-abort"
+                  disabled={batchState === 'aborting'}
+                  on:click={abortBatchRescore}
+                >
+                  {batchState === 'aborting' ? 'Aborting…' : 'Abort'}
+                </button>
+              </div>
+              {#if batchProgress}
+                <div class="batch-progress-track">
+                  <div
+                    class="batch-progress-fill"
+                    style="width: {batchProgress.total === 0
+                      ? 0
+                      : (batchProgress.done / batchProgress.total) * 100}%"
+                  ></div>
+                </div>
+              {/if}
+            </div>
+          {:else if batchState === 'done' && batchSummary}
+            <div class="batch-done">
+              <p class="batch-done-text">
+                Rescored {batchSummary.succeeded} of {batchSummary.total}.
+                {#if batchSummary.failed > 0}
+                  {batchSummary.failed} failed.
+                {/if}
+                {#if batchSummary.aborted}
+                  (Aborted.)
+                {/if}
+                {#if batchSummary.failed > 0 && batchSummary.succeeded === 0}
+                  <br />
+                  <span class="batch-hint">
+                    All attempts failed — usually a temporary upstream issue. Try again later.
+                  </span>
+                {/if}
+              </p>
+              <button type="button" class="btn-batch-close" on:click={closeBatchSummary}>
+                Close
+              </button>
+            </div>
+          {/if}
+        </div>
+
         <div class="list">
           {#each sortedCandidates as { candidate, flagCount } (candidate.eventId)}
             {@const k = `candidate:${candidate.aTag}`}
@@ -837,6 +1138,27 @@
     <div class="confirm-actions">
       <button type="button" class="btn-cancel" on:click={cancelRescore}>Cancel</button>
       <button type="button" class="btn-confirm" on:click={confirmRescore}>Rescore</button>
+    </div>
+  </div>
+</Modal>
+
+<!-- Batch rescore confirmation modal. -->
+<Modal open={batchState === 'confirming'} compact cleanup={cancelBatchRescore}>
+  <span slot="title">Rescore all {sortedCandidates.length} candidates?</span>
+  <div class="confirm-body">
+    <p>
+      This will compute a new Nourish score for each candidate and replace the current one.
+      Each rescore fires one LLM call; expect ~2-3 minutes for {sortedCandidates.length} recipe{sortedCandidates.length === 1 ? '' : 's'} at 3 in parallel.
+      Cannot be undone.
+    </p>
+    <p class="confirm-meta">
+      You can abort mid-batch. Already-rescored recipes will stay rescored; remaining candidates will reappear in this list on the next page load.
+    </p>
+    <div class="confirm-actions">
+      <button type="button" class="btn-cancel" on:click={cancelBatchRescore}>Cancel</button>
+      <button type="button" class="btn-confirm" on:click={confirmBatchRescore}>
+        Rescore all
+      </button>
     </div>
   </div>
 </Modal>
@@ -1088,6 +1410,135 @@
   .btn-confirm {
     background: var(--color-primary);
     color: white;
+  }
+
+  /* ── Bulk rescore batch UI ── */
+
+  .batch-bar {
+    margin-bottom: 1rem;
+    border: 1px solid var(--color-input-border);
+    border-radius: 0.6rem;
+    background: var(--color-bg-secondary);
+    padding: 0.9rem 1rem;
+  }
+
+  .batch-idle {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .batch-idle-text {
+    margin: 0;
+    flex: 1 1 auto;
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
+    min-width: 200px;
+  }
+
+  .btn-batch {
+    padding: 0.45rem 0.9rem;
+    border-radius: 0.5rem;
+    border: none;
+    background: var(--color-primary);
+    color: white;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .batch-running {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+
+  .batch-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .batch-label {
+    font-weight: 600;
+    font-size: 0.875rem;
+  }
+
+  .batch-counts {
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
+    flex: 1 1 auto;
+    min-width: 160px;
+  }
+
+  .batch-ok {
+    color: #22c55e;
+  }
+
+  .batch-fail {
+    color: #ef4444;
+  }
+
+  .btn-batch-abort {
+    padding: 0.3rem 0.75rem;
+    border-radius: 0.4rem;
+    background: var(--color-bg-tertiary);
+    color: var(--color-text-primary);
+    border: 1px solid var(--color-input-border);
+    font-size: 0.8125rem;
+    cursor: pointer;
+  }
+
+  .btn-batch-abort:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .batch-progress-track {
+    width: 100%;
+    height: 6px;
+    background: var(--color-bg-tertiary, rgba(255, 255, 255, 0.06));
+    border-radius: 3px;
+    overflow: hidden;
+  }
+
+  .batch-progress-fill {
+    height: 100%;
+    background: var(--color-primary);
+    transition: width 250ms ease-out;
+  }
+
+  .batch-done {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .batch-done-text {
+    margin: 0;
+    flex: 1 1 auto;
+    font-size: 0.8125rem;
+    color: var(--color-text-primary);
+    min-width: 200px;
+  }
+
+  .batch-hint {
+    color: var(--color-text-secondary);
+    font-style: italic;
+  }
+
+  .btn-batch-close {
+    padding: 0.3rem 0.75rem;
+    border-radius: 0.4rem;
+    background: var(--color-bg-tertiary);
+    color: var(--color-text-primary);
+    border: 1px solid var(--color-input-border);
+    font-size: 0.8125rem;
+    cursor: pointer;
   }
 
   .row-header:hover {

--- a/src/routes/api/admin/nourish/rescore/+server.ts
+++ b/src/routes/api/admin/nourish/rescore/+server.ts
@@ -150,7 +150,7 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 				{ status: pipelineResult.status }
 			);
 		}
-		const { scores, improvements, ingredientSignals } = pipelineResult;
+		const { scores, improvements, ingredientSignals, audienceScores } = pipelineResult;
 
 		// Publish the new pantry event with the `updated_at` tag that
 		// drives the 24h "Updated" badge on the client.
@@ -175,6 +175,7 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 				scores,
 				improvements,
 				ingredientSignals,
+				audienceScores,
 				updatedAt
 			});
 			console.log(
@@ -201,6 +202,7 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 			scores,
 			improvements,
 			ingredient_signals: ingredientSignals,
+			audience_scores: audienceScores,
 			promptVersion: NOURISH_PROMPT_VERSION,
 			contentHash: contentHash.trim(),
 			createdAt: updatedAt,

--- a/src/routes/api/nourish/+server.ts
+++ b/src/routes/api/nourish/+server.ts
@@ -85,7 +85,7 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 				{ status: pipelineResult.status }
 			);
 		}
-		const { scores, improvements, ingredientSignals } = pipelineResult;
+		const { scores, improvements, ingredientSignals, audienceScores } = pipelineResult;
 		const ingredient_signals = ingredientSignals;
 
 		// Publish Nourish event to relay (awaited — not fire-and-forget).
@@ -109,7 +109,8 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 						contentHash: contentHash.trim(),
 						scores,
 						improvements,
-						ingredientSignals: ingredient_signals
+						ingredientSignals: ingredient_signals,
+						audienceScores
 					});
 					console.log(`[Nourish] Publish ${published ? 'succeeded' : 'failed'} for ${recipeDTag}`);
 				} catch (err) {
@@ -123,6 +124,7 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 			scores,
 			improvements,
 			ingredient_signals,
+			audience_scores: audienceScores,
 			// Identity fields — let clients cache/reconcile by promptVersion
 			// + contentHash + createdAt instead of inferring from cacheVersion.
 			promptVersion: NOURISH_PROMPT_VERSION,

--- a/src/routes/api/nourish/scan/+server.ts
+++ b/src/routes/api/nourish/scan/+server.ts
@@ -286,11 +286,12 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 			);
 		}
 
-		// Normalize scores. Commit 2 will update SCAN_PROMPT to v2 (7
-		// Nourish dimensions + kidFriendly); for now the v1 prompt only
-		// produces gut/protein/realFood. clampScore(undefined) returns
-		// 0 so the four new dimensions contribute nothing to the
-		// weighted overall until the v2 prompt lands.
+		// Normalize scores defensively. SCAN_PROMPT already requests the
+		// full current schema (7 Nourish dimensions + kidFriendly), but
+		// model responses can still omit fields or return malformed
+		// values. clampScore(undefined) falls back to 0 so a missing
+		// dimension contributes nothing to the weighted overall rather
+		// than throwing.
 		const gutScore = clampScore(parsed.gut?.score);
 		const proteinScore = clampScore(parsed.protein?.score);
 		const realFoodScore = clampScore(parsed.realFood?.score);

--- a/src/routes/api/nourish/scan/+server.ts
+++ b/src/routes/api/nourish/scan/+server.ts
@@ -38,7 +38,7 @@ import { env } from '$env/dynamic/private';
 import { NOURISH_CACHE_VERSION, NOURISH_PROMPT_VERSION, computeOverallScore } from '$lib/nourish/types';
 import { requireMembership } from '../membershipCheck';
 
-const SCAN_PROMPT = `You are a food analysis assistant for a cooking platform. Analyze the following food description and return quality scores.
+const SCAN_PROMPT = `You are a food analysis assistant for a cooking platform. Analyze the following food description and return eight food scores: seven Nourish health dimensions, and one Audience appeal dimension.
 
 The input may be an ingredient list, a restaurant dish description, a partial recipe, or any food-related text. Do your best with whatever information is provided.
 
@@ -47,6 +47,8 @@ SCORING RULES:
 - Base your analysis ONLY on the information provided.
 - Be consistent: similar ingredient profiles should produce similar scores.
 - These are rough estimates. Err toward the middle of the range unless the input clearly skews high or low.
+
+════════ NOURISH DIMENSIONS (HEALTH) ════════
 
 GUT SCORE (0-10): How well does this food support digestive health?
 - Fermented foods (yogurt, kimchi, sauerkraut, miso, kefir, sourdough): +2-3 points
@@ -70,6 +72,56 @@ REAL FOOD SCORE (0-10): How close are the ingredients to their whole, unprocesse
 - Contains ultra-processed items (processed cheese, instant mixes, artificial flavors): -2-3 points
 - Mostly packaged/convenience ingredients: 0-3 score
 
+ANTI-INFLAMMATORY SCORE (0-10): How well does this food support the body's anti-inflammatory response?
+- Omega-3 rich (fatty fish, walnuts, flaxseed, chia): +2-3
+- Turmeric, ginger, extra-virgin olive oil: +1-2
+- Leafy greens, dark berries: +1-2
+- Colorful vegetables (bell peppers, tomatoes, beets): +1
+- Refined vegetable oils (corn, soybean, safflower): -1-2
+- Processed meats (bacon, sausage, deli meat): -2
+- Added sugar, refined carbs: -1-2
+- Ultra-processed ingredients: -1-2
+
+BLOOD SUGAR SCORE (0-10): How well does this food support stable blood sugar?
+- Fiber + protein + healthy fat balance: +2-3
+- Whole grains (oats, quinoa, brown rice), legumes: +1-2
+- Added sugar (cane/honey/syrup/etc.): -1-2
+- Refined flour, white rice, fruit juice: -1-2
+- Ultra-processed snacks: -1-2
+
+IMMUNE-SUPPORTIVE SCORE (0-10): How well does this food provide immune-supportive nutrients?
+- Vitamin-C-rich (citrus, bell peppers, broccoli, kiwi): +1-2
+- Zinc sources (pumpkin seeds, oysters, legumes, red meat): +1
+- Alliums (garlic, onion, leek, shallot): +1
+- Ginger, turmeric, mushrooms: +1
+- Fermented foods (yogurt, kimchi, kefir, sauerkraut): +1-2
+- Bone broth: +1
+- Mostly refined/processed: 0-2 range
+
+BRAIN HEALTH SCORE (0-10): How well does this food support cognitive health?
+- Omega-3 fatty fish (salmon, sardines, mackerel): +2-3
+- Leafy greens, berries: +1-2
+- Walnuts, other nuts: +1-2
+- Turmeric, whole grains, olive oil: +1
+- Refined sugar, trans fats, ultra-processed: -1-2
+
+════════ AUDIENCE DIMENSION (APPEAL) ════════
+
+KID-FRIENDLY SCORE (0-10): How likely is a typical kid (ages 5-10) to eat this food willingly?
+
+IMPORTANT: This is NOT a health score. Do not penalize healthy food for being healthy, and do not reward unhealthy food for being palatable. It's a palate-appeal score: flavor familiarity, texture approachability, visual presentation, and how picky-eater-compatible the food is. A nutrient-dense stir-fry can score low on kid-friendly; a plain buttered pasta can score high. Both are legitimate signals and independent of health.
+
+- Familiar flavors (mild cheese, pasta, rice, mild chicken, butter): +2-3
+- Slightly sweet or savory-sweet profile: +1
+- Finger foods, nugget/patty shapes, pizza, tacos, dips: +1-2
+- Visual appeal (colorful, fun shapes, dippable components): +1
+- Hidden-veggie dishes (blended into sauces): +1
+- Strong/bitter flavors (olives, blue cheese, bitter greens, heavy spices): -1-2
+- Unfamiliar textures (raw fish, tripe, very chewy): -1-2
+- Visible large pieces of commonly-resisted vegetables: -1
+- Complex plated dishes requiring utensil skill: -1
+- Many separately-prepared components: 0-2 range
+
 LABELS:
 - 0-2: "Low"
 - 3-4: "Fair"
@@ -85,6 +137,11 @@ Return ONLY valid JSON with this exact structure:
   "gut": { "score": <number>, "label": "<string>", "reason": "<one sentence>" },
   "protein": { "score": <number>, "label": "<string>", "reason": "<one sentence>" },
   "realFood": { "score": <number>, "label": "<string>", "reason": "<one sentence>" },
+  "antiInflammatory": { "score": <number>, "label": "<string>", "reason": "<one sentence>" },
+  "bloodSugar": { "score": <number>, "label": "<string>", "reason": "<one sentence>" },
+  "immuneSupportive": { "score": <number>, "label": "<string>", "reason": "<one sentence>" },
+  "brainHealth": { "score": <number>, "label": "<string>", "reason": "<one sentence>" },
+  "kidFriendly": { "score": <number>, "label": "<string>", "reason": "<one sentence>" },
   "summary": "<1-2 sentences>",
   "quick_take": "<one short sentence describing what this food leans toward>",
   "ingredients": [
@@ -193,7 +250,7 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 			body: JSON.stringify({
 				model: 'gpt-4o-mini',
 				messages,
-				max_tokens: 1500,
+				max_tokens: 2000,
 				temperature: 0.3
 			})
 		});
@@ -315,12 +372,27 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 					}))
 			: [];
 
+		// Audience scores — v2 prompt returns kidFriendly. Defensive
+		// parsing: undefined if the model omitted or truncated.
+		const kfRaw = parsed.kidFriendly;
+		const audience_scores =
+			kfRaw && typeof kfRaw.score === 'number'
+				? {
+						kidFriendly: {
+							score: clampScore(kfRaw.score),
+							label: validateLabel(kfRaw.label),
+							reason: String(kfRaw.reason || '')
+						}
+					}
+				: undefined;
+
 		return json({
 			success: true,
 			scores,
 			quick_take,
 			improvements,
 			ingredient_signals,
+			audience_scores,
 			// Identity fields — scans have no durable pantry cache, but
 			// response shape stays consistent with /api/nourish so clients
 			// can reconcile by promptVersion / createdAt.

--- a/src/routes/api/nourish/scan/+server.ts
+++ b/src/routes/api/nourish/scan/+server.ts
@@ -229,11 +229,27 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 			);
 		}
 
-		// Normalize scores
+		// Normalize scores. Commit 2 will update SCAN_PROMPT to v2 (7
+		// Nourish dimensions + kidFriendly); for now the v1 prompt only
+		// produces gut/protein/realFood. clampScore(undefined) returns
+		// 0 so the four new dimensions contribute nothing to the
+		// weighted overall until the v2 prompt lands.
 		const gutScore = clampScore(parsed.gut?.score);
 		const proteinScore = clampScore(parsed.protein?.score);
 		const realFoodScore = clampScore(parsed.realFood?.score);
-		const overall = computeOverallScore(gutScore, proteinScore, realFoodScore);
+		const antiInflammatoryScore = clampScore(parsed.antiInflammatory?.score);
+		const bloodSugarScore = clampScore(parsed.bloodSugar?.score);
+		const immuneSupportiveScore = clampScore(parsed.immuneSupportive?.score);
+		const brainHealthScore = clampScore(parsed.brainHealth?.score);
+		const overall = computeOverallScore({
+			gut: gutScore,
+			protein: proteinScore,
+			realFood: realFoodScore,
+			antiInflammatory: antiInflammatoryScore,
+			bloodSugar: bloodSugarScore,
+			immuneSupportive: immuneSupportiveScore,
+			brainHealth: brainHealthScore
+		});
 
 		const scores = {
 			gut: {
@@ -251,10 +267,30 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 				label: validateLabel(parsed.realFood?.label),
 				reason: String(parsed.realFood?.reason || '')
 			},
+			antiInflammatory: {
+				score: antiInflammatoryScore,
+				label: validateLabel(parsed.antiInflammatory?.label),
+				reason: String(parsed.antiInflammatory?.reason || '')
+			},
+			bloodSugar: {
+				score: bloodSugarScore,
+				label: validateLabel(parsed.bloodSugar?.label),
+				reason: String(parsed.bloodSugar?.reason || '')
+			},
+			immuneSupportive: {
+				score: immuneSupportiveScore,
+				label: validateLabel(parsed.immuneSupportive?.label),
+				reason: String(parsed.immuneSupportive?.reason || '')
+			},
+			brainHealth: {
+				score: brainHealthScore,
+				label: validateLabel(parsed.brainHealth?.label),
+				reason: String(parsed.brainHealth?.reason || '')
+			},
 			overall: {
 				score: overall.score,
 				label: overall.label,
-				reason: `Weighted: Real Food 45%, Gut 35%, Protein 20%`
+				reason: `Weighted: Real Food 35%, Gut 25%, Protein 15%, Anti-Inflammatory 10%, Blood Sugar 10%, Immune-Supportive 3%, Brain Health 2%`
 			},
 			summary: String(parsed.summary || ''),
 			cacheVersion: NOURISH_CACHE_VERSION


### PR DESCRIPTION
**Draft — requires live sanity-check on preview deploy before merge.** Expands the scoring model from 3 Nourish dimensions to 7 and introduces the Audience concept with kidFriendly as the first entry. Data flows through every surface; UI renders nothing new (background mode).

## Commit plan — 7 commits

| # | Commit | SHA | Scope |
|---|---|---|---|
| 1 | types + weighting (Alt A) | `f85a86c` | NourishScores +4 fields, AudienceScores, NOURISH_WEIGHTS, computeOverallScore object-arg |
| 2 | v2 scoring prompt + parser | `5a7272e` | Recipe + scan prompts; kidFriendly with "NOT a health score" framing; max_tokens 1500→2000 |
| 3 | publisher + new tags | `6088a11` | 4 new nourish_* tags + audience_kidfriendly + content JSON audience key |
| 4 | cache + resolver threading | `db75aa1` | CacheEntry.audienceScores, ResolvedEntry.audienceScores, writeThrough |
| 5 | API response shapes | `da25086` | /api/nourish + admin rescore return audience_scores |
| 6 | bump NOURISH_PROMPT_VERSION '1' → '2' | `4b342ad` | Single-line activation |
| 7 | "Rescore all" admin UI | `75287c3` | Client-driven batch loop, 3-concurrency, retry-once-2s-backoff, abort support |

## 🚨 Live sanity-check GATE before merge (Phase 2 refinement #1)

Commit 2 is the high-risk commit. Before merging this PR:

1. Deploy this branch to preview
2. Call `/api/nourish` against these five recipes and capture actual JSON responses:
   - **Mac and cheese** (elbow pasta, butter, cheddar, milk, flour, salt)
   - **Spicy kimchi stew** (kimchi, gochujang, pork belly, tofu, garlic, ginger, green onion, sesame oil, anchovy stock)
   - **Plain grilled chicken + veg** (chicken breast, olive oil, salt, pepper, bell peppers, broccoli, carrots)
   - **PB&J** (whole wheat bread, peanut butter, grape jelly)
   - **Sushi** (sushi rice, nori, raw salmon, avocado, cucumber, soy sauce, wasabi, pickled ginger)
3. Verify the six pass criteria from the commit 2 message:
   - [ ] Mac and cheese `kidFriendly >= 7` (highest-signal check — confirms "NOT a health score" framing)
   - [ ] Kimchi stew `kidFriendly <= 4`
   - [ ] Kimchi stew `immuneSupportive >= 7`
   - [ ] PB&J `kidFriendly >= 8`
   - [ ] Grilled chicken `realFood >= 9`
   - [ ] Sushi `brainHealth >= 7`
4. If any criterion fails, **do not merge**. Flag the failure; iterate the prompt on commit 2; re-verify.

The mac-and-cheese check is the most important — if the LLM treats kidFriendly as a health score and drops mac-and-cheese below 7, the "IMPORTANT: NOT a health score" paragraph in the prompt isn't landing and needs reinforcement.

## What "background mode" means

**Data flows through everywhere**:
- Pantry events (kind 30078) gain `nourish_antiinflammatory`/`nourish_bloodsugar`/`nourish_immunesupportive`/`nourish_brainhealth` + `audience_kidfriendly` tags, plus flat root-level Nourish fields and an `audience` key in content JSON
- localStorage cache entries persist 7 Nourish dimensions + audienceScores
- API responses (`/api/nourish`, `/api/nourish/scan`, `/api/admin/nourish/rescore`) return new fields
- Resolver threads everything through L2/L3/L4

**UI renders nothing new**:
- NourishModal/NourishPill/NourishResult/Recipe.svelte display only the original 3 Nourish dimensions + overall, exactly as today
- No "kid-friendly" display anywhere
- Flag picker stays on the 3 existing dimensions
- No search/sort changes

Users see identical interface. Future feature will design and build UI for the new dimensions with real data in hand.

## Architecture decisions (recap)

- **Weighting (Alt A)**: realFood 35, gut 25, protein 15, antiInflammatory 10, bloodSugar 10, immuneSupportive 3, brainHealth 2. All 7 contribute. Audience does NOT roll into overall.
- **Content JSON shape**: flat at root with `audience` as a new root key. No `{nourish: {}, audience: {}}` restructuring — preserves backward-compat with the v1 parser.
- **Tag namespace**: `audience_*` prefix distinct from `nourish_*` so future queries can filter.
- **IngredientSignal.contribution** stays on 3 dimensions — expanding to 7 would produce LLM-classification noise.
- **Bulk rescore**: client-driven browser loop, 3 parallel, reuses the existing per-row `/api/admin/nourish/rescore` endpoint. No new server endpoint — Cloudflare Workers 30s request limit fights long-running server operations.

## Rollout

**Phase A — code deploy.** Merge this PR. No UI change; new scores are v2, old scores stay v1 (versioned cache partitioning from PR 311 keeps both working).

**Phase B — bulk migration.** Admin opens `/admin/nourish-flags` → Upgrade Candidates → "Rescore all N". Browser iterates with 3 concurrency. 2-3 minutes for ~100 recipes. After: all recipes at v2; Candidates tab empty.

Flexible timing between A and B — minutes or days apart.

## Verification (post sanity-check)

### Background mode (zero user-visible change)
- [ ] Existing recipe modal: 3 dimensions + overall render as before, no new dimensions appear
- [ ] NourishPill on recipe cards: identical display
- [ ] `/nourish` scan page: identical display (new fields in response but not rendered)
- [ ] Flag picker: still 3 dimensions + overall
- [ ] v1-cached recipe renders correctly (old shape, no errors)

### Data plumbing (observable in data, not UI)
- [ ] Score a new recipe post-deploy → pantry event carries all 7 nourish_* tags + audience_kidfriendly
- [ ] localStorage entry has 7 dimensions + audienceScores
- [ ] `/api/nourish` response includes `audience_scores`
- [ ] Resolver returns `ResolvedEntry.audienceScores` populated from a v2 event

### Bulk rescore flow
- [ ] Admin clicks "Rescore all N" → confirmation modal → confirm → progress bar advances
- [ ] Abort button stops the queue; already-rescored stay rescored; remainder reappear next load
- [ ] All-failures done state shows the "temporary upstream issue" hint
- [ ] After completion, Candidates tab shows 0 v1 candidates

### Check + build
- `pnpm run check`: 4 pre-existing errors / 127 warnings (baseline preserved on every commit)
- `pnpm run build`: passes

## Out of scope

- UI rendering of new dimensions (follow-up feature)
- Flag picker entries for new dimensions
- Nourish-powered search / sort
- Explain modal
- Read endpoint (`/api/admin/nourish-flags`) NIP-98 migration (issue #316)