### PR TITLE
Free AI URL import hero on landing page (anon-accessible)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.249",
+  "version": "4.2.250",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.257",
+  "version": "4.2.258",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -18,6 +18,8 @@ declare global {
           NOTIFICATION_PRIVATE_KEY?: string;
           CRON_SECRET?: string;
           MEMBERSHIP_ENABLED?: string;
+          /** OpenAI API key — used by /api/extract-recipe and /api/nourish. */
+          OPENAI_API_KEY?: string;
           MEMBERSHIP_LIGHTNING_ADDRESS?: string;
           STRIKE_API_KEY?: string;
           STRIKE_API_BASE_URL?: string;

--- a/src/components/LandingImportHero.svelte
+++ b/src/components/LandingImportHero.svelte
@@ -2,12 +2,17 @@
   /**
    * Free AI recipe-import hero for the public landing page.
    *
-   * Renders in one of three modes based on auth + membership tier:
+   * Renders in one of three modes based on auth + membership tier. All
+   * visible modes show the same headline + subtext + input row; the
+   * difference is padding density and the feature-card treatment:
    *
-   *   1. Logged-out          → full hero (headline + subtext + input)
-   *   2. Logged-in non-Pro   → compact pill (just input, discoverable
-   *                            for free and Cook+ users)
-   *   3. Logged-in Pro/Founder → hidden (they have the nav sparkle)
+   *   1. Logged-out           → full feature card (orange-tinted
+   *                             background + border via color-mix on
+   *                             --color-primary)
+   *   2. Logged-in non-Pro    → compact variant (tighter padding, no
+   *                             feature wash)
+   *   3. Logged-in Pro/Founder → hidden (they already have the nav
+   *                             sparkle entry point)
    *
    * The submit path POSTs to `/api/extract-recipe/public`, stashes the
    * parsed recipe in sessionStorage under `ANON_IMPORT_HANDOFF_KEY`, and
@@ -120,17 +125,25 @@
         return;
       }
 
+      let handoffStashed = false;
       if (browser) {
         try {
           sessionStorage.setItem(
             ANON_IMPORT_HANDOFF_KEY,
             JSON.stringify({ recipe: data.recipe, sourceUrl: urlInput.trim(), at: Date.now() })
           );
+          handoffStashed = true;
         } catch {
-          // If sessionStorage is disabled (private mode with strict settings),
-          // fall back to a querystring flag and let /souschef show a generic
-          // "please re-paste" state.
+          // sessionStorage disabled or quota exceeded. We can't hand the
+          // parsed recipe over to /souschef, so surface an inline error
+          // here instead of sending the user somewhere without their
+          // result. Users in this state are rare (strict private mode).
         }
+      }
+      if (!handoffStashed) {
+        error =
+          'We couldn\u2019t save the import for the next step. Try again, or open this site in a normal (non-private) browser window.';
+        return;
       }
 
       recordHit(RATE_LIMIT_OPTS);

--- a/src/components/LandingImportHero.svelte
+++ b/src/components/LandingImportHero.svelte
@@ -1,0 +1,408 @@
+<script lang="ts">
+  /**
+   * Free AI recipe-import hero for the public landing page.
+   *
+   * Renders in one of three modes based on auth + membership tier:
+   *
+   *   1. Logged-out          → full hero (headline + subtext + input)
+   *   2. Logged-in non-Pro   → compact pill (just input, discoverable
+   *                            for free and Cook+ users)
+   *   3. Logged-in Pro/Founder → hidden (they have the nav sparkle)
+   *
+   * The submit path POSTs to `/api/extract-recipe/public`, stashes the
+   * parsed recipe in sessionStorage under `ANON_IMPORT_HANDOFF_KEY`, and
+   * navigates to `/souschef` where the anon-preview branch reads the
+   * handoff and shows the editor in view-only mode until sign-in.
+   *
+   * Rate limit: 3 imports/hour/browser via `$lib/rateLimit.ts`
+   * (localStorage, first-line UX guard). The real cost-cap is the
+   * per-IP limiter on the server endpoint.
+   */
+
+  import { goto } from '$app/navigation';
+  import { browser } from '$app/environment';
+  import { userPublickey } from '$lib/nostr';
+  import {
+    membershipStatusMap,
+    queueMembershipLookup,
+    type MembershipStatus
+  } from '$lib/stores/membershipStatus';
+  import { checkRateLimit, recordHit } from '$lib/rateLimit';
+  import { ANON_IMPORT_HANDOFF_KEY } from '$lib/anonImport';
+  import SparkleIcon from 'phosphor-svelte/lib/Sparkle';
+  import ArrowsClockwiseIcon from 'phosphor-svelte/lib/ArrowsClockwise';
+
+  const RATE_LIMIT_OPTS = {
+    bucket: 'anon-url-import',
+    limit: 3,
+    windowMs: 60 * 60 * 1000
+  } as const;
+
+  let urlInput = '';
+  let error = '';
+  let isSubmitting = false;
+
+  // Membership tier lookup — same pattern as explore/+page.svelte.
+  let membershipMap: Record<string, MembershipStatus> = {};
+  const unsubMembership = membershipStatusMap.subscribe((v) => {
+    membershipMap = v;
+  });
+  $: if ($userPublickey) queueMembershipLookup($userPublickey);
+  $: normalizedPk = String($userPublickey || '').trim().toLowerCase();
+  $: tierStatus = normalizedPk ? membershipMap[normalizedPk] : undefined;
+  $: isPremiumTier =
+    !!tierStatus?.active && (tierStatus.tier === 'pro_kitchen' || tierStatus.tier === 'founders');
+  $: isLoggedIn = $userPublickey !== '';
+  $: mode = isPremiumTier ? 'hidden' : isLoggedIn ? 'compact' : 'full';
+
+  import { onDestroy } from 'svelte';
+  onDestroy(() => unsubMembership());
+
+  function validateUrl(raw: string): string {
+    const trimmed = raw.trim();
+    if (!trimmed) return 'Paste a recipe URL first.';
+    let parsed: URL;
+    try {
+      parsed = new URL(trimmed);
+    } catch {
+      return 'That doesn\u2019t look like a valid URL.';
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return 'Only http(s) URLs are supported.';
+    }
+    if (trimmed.length > 2048) {
+      return 'That URL is too long.';
+    }
+    return '';
+  }
+
+  function formatRetryTime(retryAt: number): string {
+    const mins = Math.max(1, Math.ceil((retryAt - Date.now()) / 60_000));
+    return `Try again in about ${mins} min.`;
+  }
+
+  async function handleSubmit() {
+    if (isSubmitting) return;
+    error = '';
+
+    const validationError = validateUrl(urlInput);
+    if (validationError) {
+      error = validationError;
+      return;
+    }
+
+    const limit = checkRateLimit(RATE_LIMIT_OPTS);
+    if (!limit.allowed) {
+      error = `Free imports are capped at 3/hour. ${formatRetryTime(limit.retryAt)}`;
+      return;
+    }
+
+    // TODO(analytics): emit `anon_import_attempt` with { urlHost }.
+
+    isSubmitting = true;
+    try {
+      const res = await fetch('/api/extract-recipe/public', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: urlInput.trim() })
+      });
+
+      if (res.status === 429) {
+        const body = await res.json().catch(() => ({}));
+        const retryMins = body?.retryAfter ? Math.max(1, Math.ceil(body.retryAfter / 60)) : 60;
+        error = `We\u2019re a bit busy right now — try again in about ${retryMins} min.`;
+        return;
+      }
+
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || !data?.success) {
+        error = (data && typeof data.error === 'string' && data.error) || 'Import failed. Try a different URL.';
+        return;
+      }
+
+      if (browser) {
+        try {
+          sessionStorage.setItem(
+            ANON_IMPORT_HANDOFF_KEY,
+            JSON.stringify({ recipe: data.recipe, sourceUrl: urlInput.trim(), at: Date.now() })
+          );
+        } catch {
+          // If sessionStorage is disabled (private mode with strict settings),
+          // fall back to a querystring flag and let /souschef show a generic
+          // "please re-paste" state.
+        }
+      }
+
+      recordHit(RATE_LIMIT_OPTS);
+      // TODO(analytics): emit `anon_import_success` with { urlHost }.
+
+      urlInput = '';
+      await goto('/souschef?from=anon-import');
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Network error. Try again.';
+    } finally {
+      isSubmitting = false;
+    }
+  }
+
+  function handleKey(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      void handleSubmit();
+    }
+  }
+</script>
+
+{#if mode !== 'hidden'}
+  <section
+    class="hero-card"
+    class:hero-full={mode === 'full'}
+    class:hero-compact={mode === 'compact'}
+    data-section="import-hero"
+  >
+    <div class="hero-copy">
+      <h2 class="hero-title">
+        <SparkleIcon size={18} weight="fill" class="hero-sparkle" />
+        Import any recipe with AI
+      </h2>
+      <p class="hero-sub">Paste a link from any site</p>
+    </div>
+
+    <form class="hero-form" on:submit|preventDefault={handleSubmit}>
+      <div class="input-wrap">
+        <span class="input-prefix">zap.cooking/</span>
+        <input
+          type="url"
+          inputmode="url"
+          autocomplete="off"
+          autocapitalize="none"
+          spellcheck="false"
+          placeholder="Paste a recipe URL…"
+          bind:value={urlInput}
+          on:keydown={handleKey}
+          disabled={isSubmitting}
+          aria-label="Recipe URL"
+        />
+      </div>
+      <button
+        type="submit"
+        class="submit-btn"
+        disabled={isSubmitting || !urlInput.trim()}
+        aria-label="Import recipe"
+      >
+        {#if isSubmitting}
+          <ArrowsClockwiseIcon size={16} class="spin" />
+          <span>Importing…</span>
+        {:else}
+          <SparkleIcon size={16} weight="fill" />
+          <span>Import</span>
+        {/if}
+      </button>
+    </form>
+
+    {#if error}
+      <p class="hero-error" role="alert">{error}</p>
+    {/if}
+  </section>
+{/if}
+
+<style>
+  /* Sizing baseline — input and button share the same single-line
+     height so the row reads like one clean control. */
+  .hero-card {
+    --hero-control-h: 44px;
+
+    position: relative;
+    border: 1px solid var(--color-input-border);
+    border-radius: 0.85rem;
+    background: var(--color-bg-secondary);
+    padding: 0.85rem 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+
+  /* Full mode — anon visitors. Reads as a distinct feature card via
+     an orange-tinted border + background wash. Everything uses
+     --color-primary via color-mix so it tracks the light/dark theme. */
+  .hero-full {
+    padding: 1rem 1rem 0.95rem;
+    border-color: color-mix(in srgb, var(--color-primary) 35%, var(--color-input-border));
+    background:
+      linear-gradient(
+        135deg,
+        color-mix(in srgb, var(--color-primary) 10%, transparent) 0%,
+        color-mix(in srgb, var(--color-primary) 4%, transparent) 60%,
+        transparent 100%
+      ),
+      var(--color-bg-secondary);
+  }
+
+  /* Compact mode — logged-in non-premium users. Same feature copy,
+     just denser. */
+  .hero-compact {
+    padding: 0.75rem 0.9rem;
+  }
+
+  .hero-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+
+  .hero-title {
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-size: 0.95rem;
+    font-weight: 700;
+    line-height: 1.25;
+    color: var(--color-text-primary);
+  }
+
+  :global(.hero-sparkle) {
+    color: var(--color-primary);
+    flex-shrink: 0;
+  }
+
+  .hero-sub {
+    margin: 0;
+    font-size: 0.78rem;
+    line-height: 1.3;
+    color: var(--color-text-secondary);
+  }
+
+  .hero-form {
+    display: flex;
+    gap: 0.4rem;
+    align-items: center;
+  }
+
+  .input-wrap {
+    flex: 1 1 auto;
+    min-width: 0;
+    height: var(--hero-control-h);
+    display: flex;
+    align-items: center;
+    gap: 0.2rem;
+    padding: 0 0.7rem;
+    background: var(--color-input-bg);
+    border: 1px solid var(--color-input-border);
+    border-radius: 0.5rem;
+    transition: border-color 120ms ease;
+  }
+
+  .input-wrap:focus-within {
+    border-color: var(--color-primary);
+  }
+
+  .input-prefix {
+    color: var(--color-text-secondary);
+    font-size: 0.8rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    white-space: nowrap;
+    user-select: none;
+    flex-shrink: 0;
+  }
+
+  /* Explicit height + margin overrides defeat any ambient global
+     `input` rules that might otherwise inflate the control. */
+  .input-wrap input {
+    flex: 1 1 auto;
+    min-width: 0;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    margin: 0;
+    border: none;
+    background: transparent;
+    outline: none;
+    color: var(--color-text-primary);
+    font-size: 0.88rem;
+    font-family: inherit;
+    padding: 0;
+    line-height: 1.2;
+    box-sizing: border-box;
+  }
+
+  .input-wrap input::placeholder {
+    color: var(--color-text-secondary);
+    opacity: 0.7;
+  }
+
+  /* Button uses --color-primary flat rather than a hardcoded 2-stop
+     gradient so it's visibly calmer than the floating FAB in the
+     bottom nav. Shadow is tiny — it's a utility button, not a hero. */
+  .submit-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    height: var(--hero-control-h);
+    padding: 0 0.9rem;
+    border: none;
+    border-radius: 0.5rem;
+    background: var(--color-primary);
+    color: white;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 1px 2px color-mix(in srgb, var(--color-primary) 20%, transparent);
+    transition: filter 120ms ease, opacity 120ms ease;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .submit-btn:hover:not(:disabled) {
+    filter: brightness(1.05);
+  }
+
+  .submit-btn:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+    box-shadow: none;
+  }
+
+  .hero-error {
+    margin: 0;
+    font-size: 0.78rem;
+    color: #ef4444;
+  }
+
+  :global(.spin) {
+    animation: spin 0.8s linear infinite;
+  }
+
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  /* Phones that still have room to keep the row horizontal. Shorten
+     the subtext and the button label so they don't push the input
+     below the input's own sensible min width. */
+  @media (max-width: 520px) {
+    .hero-full {
+      padding: 0.85rem 0.9rem;
+    }
+    .input-prefix {
+      /* Prefix is nice-to-have context, not load-bearing. Drop it on
+         tight phones so the placeholder gets the visible real estate. */
+      display: none;
+    }
+  }
+
+  /* Only stack at truly narrow widths (<360px — small legacy phones).
+     At 400–433px the row still fits horizontally. */
+  @media (max-width: 359px) {
+    .hero-form {
+      flex-direction: column;
+      align-items: stretch;
+    }
+    .submit-btn {
+      width: 100%;
+    }
+  }
+</style>

--- a/src/lib/anonImport.ts
+++ b/src/lib/anonImport.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared constants + types for the anon URL-import handoff between the
+ * landing hero (`LandingImportHero.svelte`) and the Sous Chef editor
+ * (`/souschef`). The hero POSTs to `/api/extract-recipe/public`,
+ * stashes the parsed recipe in sessionStorage under this key, and
+ * navigates to `/souschef`. The editor reads and clears the handoff on
+ * mount, entering view-only preview mode until sign-in.
+ *
+ * Handoff is short-lived (single session, single page transition) and
+ * stored in sessionStorage rather than localStorage so it doesn't leak
+ * across tabs or persist after the browser closes.
+ */
+
+/**
+ * Mirror of the server-side `NormalizedRecipe` shape. We duplicate the
+ * type here rather than importing from `parseRecipe.server.ts` so
+ * SvelteKit's server-only module isolation isn't broken by type-only
+ * imports at build time.
+ */
+export interface NormalizedRecipe {
+  title: string;
+  summary: string;
+  chefsnotes: string;
+  preptime: string;
+  cooktime: string;
+  servings: string;
+  ingredients: string[];
+  directions: string[];
+  tags: string[];
+  imageUrls: string[];
+}
+
+export const ANON_IMPORT_HANDOFF_KEY = 'zapcooking:anon-import-handoff';
+
+export interface AnonImportHandoff {
+  recipe: NormalizedRecipe;
+  sourceUrl: string;
+  at: number;
+}
+
+/** Older handoffs are treated as stale and ignored. */
+export const ANON_IMPORT_MAX_AGE_MS = 10 * 60 * 1000;

--- a/src/lib/ipRateLimit.server.ts
+++ b/src/lib/ipRateLimit.server.ts
@@ -1,0 +1,154 @@
+/**
+ * Simple per-IP rate limiting for anon/public endpoints.
+ *
+ * Backed by a Cloudflare KV namespace. The helper is intentionally thin:
+ * one caller, one (scope, ipHash) counter per bucket, read-then-write
+ * without atomicity — acceptable at the low rates these endpoints see.
+ *
+ * Privacy: callers pass a raw IP; the helper salts and hashes it with a
+ * daily-rotated salt stored under the same KV namespace, mirroring the
+ * pattern in `$lib/nourish/flagRateLimit.server.ts`. IPs are never
+ * stored in plaintext.
+ *
+ * Usage:
+ *   const kv = platform?.env?.NOURISH_FLAGS; // or any KV binding
+ *   const res = await checkPerIpRateLimit(kv, {
+ *     ip,
+ *     scope: 'extract-url',
+ *     perHour: 8
+ *   });
+ *   if (res.limited) return json(res.body, { status: 429 });
+ */
+
+type IpRateLimitKV = {
+  get(key: string, type?: 'text' | 'json'): Promise<string | unknown | null>;
+  put(
+    key: string,
+    value: string,
+    options?: { expirationTtl?: number }
+  ): Promise<void>;
+};
+
+const SALT_RETENTION_DAYS = 3;
+const SALT_KEY_PREFIX = 'config:ip-salt-v2';
+
+function utcDay(d = new Date()): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function utcHour(d = new Date()): string {
+  return d.toISOString().slice(0, 13);
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function getTodaySalt(kv: IpRateLimitKV): Promise<string> {
+  const day = utcDay();
+  const key = `${SALT_KEY_PREFIX}:${day}`;
+  const existing = (await kv.get(key)) as string | null;
+  if (existing) return existing;
+
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  const salt = Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+
+  await kv.put(key, salt, {
+    expirationTtl: SALT_RETENTION_DAYS * 24 * 60 * 60
+  });
+  return salt;
+}
+
+export interface IpRateLimitParams {
+  ip: string;
+  scope: string;
+  perHour: number;
+  /** Optional per-day cap. When omitted, only the hourly tier is enforced. */
+  perDay?: number;
+}
+
+export type IpRateLimitResult =
+  | { limited: false; ipHash: string }
+  | {
+      limited: true;
+      ipHash: string;
+      body: { error: 'rate_limited'; retryAfter: number; scope: 'per-hour' | 'per-day' };
+    };
+
+/**
+ * Atomically-ish check and increment the rate-limit buckets for `ip`.
+ *
+ * Returns `limited: false` (with the IP hash for downstream logging) if
+ * the request is allowed, or `limited: true` with a 429 body describing
+ * which tier tripped. Fails open on unexpected KV errors — the cost of
+ * dropping a legitimate anon request is higher than the cost of an
+ * occasional extra OpenAI call during KV degradation.
+ */
+export async function checkPerIpRateLimit(
+  kv: IpRateLimitKV | undefined,
+  params: IpRateLimitParams
+): Promise<IpRateLimitResult> {
+  if (!kv) {
+    // No KV bound (e.g. local dev without bindings). Allow — the caller
+    // still has client-side rate limiting as a first line.
+    return { limited: false, ipHash: 'no-kv' };
+  }
+
+  const { ip, scope, perHour, perDay } = params;
+
+  try {
+    const salt = await getTodaySalt(kv);
+    const ipHash = await sha256Hex(`${ip}:${salt}`);
+
+    const hourKey = `rl:${scope}:hr:${ipHash}:${utcHour()}`;
+    const dayKey = perDay ? `rl:${scope}:day:${ipHash}:${utcDay()}` : null;
+
+    const hourCount = Number((await kv.get(hourKey)) as string | null) || 0;
+    if (hourCount >= perHour) {
+      return {
+        limited: true,
+        ipHash,
+        body: { error: 'rate_limited', retryAfter: 60 * 60, scope: 'per-hour' }
+      };
+    }
+
+    if (dayKey && perDay) {
+      const dayCount = Number((await kv.get(dayKey)) as string | null) || 0;
+      if (dayCount >= perDay) {
+        return {
+          limited: true,
+          ipHash,
+          body: { error: 'rate_limited', retryAfter: 24 * 60 * 60, scope: 'per-day' }
+        };
+      }
+    }
+
+    // Increment both buckets. Not transactional, but at this traffic
+    // level the race window is irrelevant — worst case a few extra
+    // requests squeak past the cap at minute boundaries.
+    await Promise.all([
+      kv.put(hourKey, String(hourCount + 1), { expirationTtl: 2 * 60 * 60 }),
+      dayKey
+        ? kv
+            .get(dayKey)
+            .then((raw) =>
+              kv.put(dayKey, String((Number(raw as string | null) || 0) + 1), {
+                expirationTtl: 26 * 60 * 60
+              })
+            )
+        : Promise.resolve()
+    ]);
+
+    return { limited: false, ipHash };
+  } catch (err) {
+    console.warn('[ipRateLimit] KV error — failing open:', err);
+    return { limited: false, ipHash: 'kv-error' };
+  }
+}

--- a/src/lib/parseRecipe.server.ts
+++ b/src/lib/parseRecipe.server.ts
@@ -1,0 +1,395 @@
+/**
+ * Shared recipe-extraction pipeline — used by both
+ *   - POST /api/extract-recipe         (authenticated, image/text/url)
+ *   - POST /api/extract-recipe/public  (anon, url only)
+ *
+ * Extracts a normalized recipe from an image (base64), a URL, or raw
+ * pasted text by round-tripping through OpenAI (gpt-4o-mini). Callers
+ * supply the input via a discriminated `ParseInput` and receive a
+ * discriminated `ParseResult`.
+ *
+ * SSRF hardening lives in `fetchUrlContent` and is non-negotiable for
+ * the public endpoint: the URL fetcher rejects non-http(s) schemes,
+ * IP-literal hostnames in the private/loopback/link-local ranges, and
+ * enforces a 5 MB response cap. Caller-side URL validation (type
+ * checks, length limits) is a secondary defense — this function is the
+ * last line before an outbound fetch.
+ */
+
+const EXTRACTION_PROMPT = `You are a recipe extraction assistant. Extract recipe information from the provided content and return it in a structured JSON format.
+
+Extract the following fields:
+- title: The name of the recipe
+- summary: A brief 1-2 sentence description of the dish
+- chefsnotes: Any additional notes, tips, or background about the recipe (can be empty)
+- preptime: Preparation time (e.g., "20 min", "1 hour")
+- cooktime: Cooking time (e.g., "30 min", "1 hour 15 min")
+- servings: Number of servings (e.g., "4", "6-8")
+- ingredients: Array of ingredients with quantities (e.g., ["2 cups flour", "1 tsp salt"])
+- directions: Array of step-by-step instructions
+- tags: Array of relevant tags for categorization (e.g., ["Italian", "Pasta", "Quick", "Vegetarian"])
+- imageUrls: Array of image URLs found in the content that show the recipe/dish (extract full URLs, prioritize the main recipe photo)
+
+Return ONLY valid JSON with this exact structure:
+{
+  "title": "string",
+  "summary": "string",
+  "chefsnotes": "string",
+  "preptime": "string",
+  "cooktime": "string",
+  "servings": "string",
+  "ingredients": ["string"],
+  "directions": ["string"],
+  "tags": ["string"],
+  "imageUrls": ["string"]
+}
+
+If any field cannot be determined, use an empty string or empty array as appropriate.
+Do not include any text outside the JSON object.`;
+
+export interface NormalizedRecipe {
+  title: string;
+  summary: string;
+  chefsnotes: string;
+  preptime: string;
+  cooktime: string;
+  servings: string;
+  ingredients: string[];
+  directions: string[];
+  tags: string[];
+  imageUrls: string[];
+}
+
+export type ParseInput =
+  | { type: 'image'; imageData: string }
+  | { type: 'url'; url: string }
+  | { type: 'text'; textData: string };
+
+export type ParseResult =
+  | { ok: true; recipe: NormalizedRecipe }
+  | { ok: false; status: number; error: string };
+
+export const MAX_FETCH_BYTES = 5 * 1024 * 1024; // 5 MB
+export const MAX_PROMPT_CONTENT_CHARS = 15000;
+export const MAX_TEXT_INPUT_CHARS = 10000;
+
+// ─── SSRF guard ──────────────────────────────────────────────────────
+//
+// Cloudflare Workers don't expose DNS resolution, so we can't guard
+// against DNS-rebinding attacks. Within that limit we do what we can:
+// only http(s), and if the URL hostname is an IP literal, reject known
+// private/loopback/link-local ranges plus the AWS instance-metadata IP
+// the user called out (169.254.169.254).
+
+function parsePublicUrl(raw: string): { ok: true; url: URL } | { ok: false; reason: string } {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return { ok: false, reason: 'Invalid URL' };
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return { ok: false, reason: 'Only http(s) URLs are supported' };
+  }
+  const host = url.hostname.toLowerCase();
+  if (host === 'localhost' || host.endsWith('.localhost') || host.endsWith('.local') || host.endsWith('.internal')) {
+    return { ok: false, reason: 'Internal hostnames are not allowed' };
+  }
+  if (isPrivateIpLiteral(host)) {
+    return { ok: false, reason: 'Private/loopback addresses are not allowed' };
+  }
+  return { ok: true, url };
+}
+
+function isPrivateIpLiteral(host: string): boolean {
+  // Strip IPv6 brackets if present (URL.hostname yields them unbracketed
+  // on WHATWG, but be defensive).
+  const h = host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
+
+  // IPv6 loopback / link-local / unique-local.
+  if (h === '::1' || h === '::') return true;
+  if (h.startsWith('fe80:') || h.startsWith('fe80::')) return true;
+  if (/^f[cd][0-9a-f]{2}:/.test(h)) return true;
+
+  // IPv4-literal check.
+  const v4 = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!v4) return false;
+  const [a, b] = [Number(v4[1]), Number(v4[2])];
+  if (a === 10) return true;
+  if (a === 127) return true;
+  if (a === 169 && b === 254) return true; // link-local, incl. 169.254.169.254
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 0) return true; // 0.0.0.0/8
+  return false;
+}
+
+function extractImageUrls(html: string, baseUrl: string): string[] {
+  const imageUrls: string[] = [];
+
+  let urlBase: URL;
+  try {
+    urlBase = new URL(baseUrl);
+  } catch {
+    return imageUrls;
+  }
+
+  const imgRegex = /<img[^>]+src=["']([^"']+)["'][^>]*>/gi;
+  let match;
+  while ((match = imgRegex.exec(html)) !== null) {
+    let src = match[1];
+    if (src.includes('1x1') || src.includes('pixel') || src.includes('spacer') || src.includes('icon')) continue;
+
+    try {
+      if (src.startsWith('//')) {
+        src = urlBase.protocol + src;
+      } else if (src.startsWith('/')) {
+        src = urlBase.origin + src;
+      } else if (!src.startsWith('http')) {
+        src = new URL(src, baseUrl).href;
+      }
+
+      if (src.match(/\.(jpg|jpeg|png|webp|gif)/i) || src.includes('image')) {
+        imageUrls.push(src);
+      }
+    } catch {
+      // skip invalid
+    }
+  }
+
+  const ogImageMatch = html.match(/<meta[^>]+property=["']og:image["'][^>]+content=["']([^"']+)["']/i);
+  if (ogImageMatch && ogImageMatch[1]) {
+    const ogImage = ogImageMatch[1];
+    if (!imageUrls.includes(ogImage)) imageUrls.unshift(ogImage);
+  }
+
+  const schemaImageMatch = html.match(/"image"\s*:\s*"([^"]+)"/);
+  if (schemaImageMatch && schemaImageMatch[1]) {
+    const schemaImage = schemaImageMatch[1];
+    if (!imageUrls.includes(schemaImage)) imageUrls.unshift(schemaImage);
+  }
+
+  return [...new Set(imageUrls)].slice(0, 5);
+}
+
+async function fetchUrlContent(
+  rawUrl: string
+): Promise<{ text: string; imageUrls: string[]; finalUrl: string }> {
+  const parsed = parsePublicUrl(rawUrl);
+  if (!parsed.ok) throw new Error(parsed.reason);
+
+  const response = await fetch(parsed.url.toString(), {
+    headers: { 'User-Agent': 'Mozilla/5.0 (compatible; ZapCooking/1.0; +https://zap.cooking)' },
+    redirect: 'follow'
+  });
+
+  if (!response.ok) throw new Error(`Failed to fetch URL: ${response.status}`);
+
+  // Enforce size cap up front when the server advertises Content-Length.
+  const contentLength = response.headers.get('content-length');
+  if (contentLength) {
+    const declared = Number(contentLength);
+    if (Number.isFinite(declared) && declared > MAX_FETCH_BYTES) {
+      throw new Error('URL response exceeds 5 MB cap');
+    }
+  }
+
+  const contentType = response.headers.get('content-type') || '';
+
+  // Stream the body so an unbounded or chunked response can't exhaust
+  // Worker memory. Abort as soon as we cross the cap.
+  if (!response.body) {
+    return { text: '', imageUrls: [], finalUrl: response.url || parsed.url.toString() };
+  }
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    let finished = false;
+    while (!finished) {
+      const { done, value } = await reader.read();
+      if (done) {
+        finished = true;
+        break;
+      }
+      if (value) {
+        total += value.byteLength;
+        if (total > MAX_FETCH_BYTES) {
+          try {
+            await reader.cancel();
+          } catch {
+            // Cancel can throw if the stream is already closed — no-op.
+          }
+          throw new Error('URL response exceeds 5 MB cap');
+        }
+        chunks.push(value);
+      }
+    }
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // releaseLock throws if the reader is already released — no-op.
+    }
+  }
+
+  // Concatenate and decode once the body is fully buffered under the cap.
+  const full = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    full.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  const bodyText = new TextDecoder('utf-8').decode(full);
+
+  if (contentType.includes('text/html')) {
+    const imageUrls = extractImageUrls(bodyText, parsed.url.toString());
+    const textContent = bodyText
+      .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+      .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .substring(0, MAX_PROMPT_CONTENT_CHARS);
+    return { text: textContent, imageUrls, finalUrl: response.url || parsed.url.toString() };
+  }
+
+  return { text: bodyText, imageUrls: [], finalUrl: response.url || parsed.url.toString() };
+}
+
+function normalizeRecipe(raw: Record<string, unknown>): NormalizedRecipe {
+  const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+  const strArr = (v: unknown): string[] =>
+    Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : [];
+  return {
+    title: str(raw.title),
+    summary: str(raw.summary),
+    chefsnotes: str(raw.chefsnotes) || str(raw.chefsNotes) || str(raw.notes),
+    preptime: str(raw.preptime) || str(raw.prepTime) || str(raw.prep_time),
+    cooktime: str(raw.cooktime) || str(raw.cookTime) || str(raw.cook_time),
+    servings: str(raw.servings),
+    ingredients: strArr(raw.ingredients),
+    directions: Array.isArray(raw.directions)
+      ? strArr(raw.directions)
+      : strArr(raw.instructions),
+    tags: strArr(raw.tags),
+    imageUrls: Array.isArray(raw.imageUrls) ? strArr(raw.imageUrls) : strArr(raw.images)
+  };
+}
+
+type ChatMessage =
+  | { role: 'system' | 'user' | 'assistant'; content: string }
+  | {
+      role: 'user';
+      content: Array<
+        | { type: 'text'; text: string }
+        | { type: 'image_url'; image_url: { url: string } }
+      >;
+    };
+
+async function callOpenAI(
+  openAiKey: string,
+  messages: ChatMessage[]
+): Promise<{ ok: true; content: string } | { ok: false; status: number; error: string }> {
+  const openaiResponse = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${openAiKey}`
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini',
+      messages,
+      max_tokens: 4096,
+      temperature: 0.3
+    })
+  });
+
+  if (!openaiResponse.ok) {
+    const errorData = await openaiResponse.json().catch(() => ({}));
+    console.error('[parseRecipe] OpenAI API error:', errorData);
+    return { ok: false, status: 500, error: 'Failed to extract recipe. Please try again.' };
+  }
+
+  const data = await openaiResponse.json();
+  const content = data.choices?.[0]?.message?.content;
+  if (!content) {
+    return { ok: false, status: 500, error: 'No response from AI. Please try again.' };
+  }
+  return { ok: true, content };
+}
+
+/**
+ * Run the full extraction pipeline for a single input. Returns a
+ * discriminated result; the HTTP handler maps `status` to the response
+ * code directly.
+ */
+export async function parseRecipe(openAiKey: string, input: ParseInput): Promise<ParseResult> {
+  const messages: ChatMessage[] = [{ role: 'system', content: EXTRACTION_PROMPT }];
+
+  if (input.type === 'image') {
+    if (!input.imageData) {
+      return { ok: false, status: 400, error: 'Image data is required for image extraction' };
+    }
+    messages.push({
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Extract the recipe information from this image:' },
+        {
+          type: 'image_url',
+          image_url: {
+            url: input.imageData.startsWith('data:')
+              ? input.imageData
+              : `data:image/jpeg;base64,${input.imageData}`
+          }
+        }
+      ]
+    });
+  } else if (input.type === 'text') {
+    const text = (input.textData || '').trim();
+    if (text.length === 0) {
+      return { ok: false, status: 400, error: 'Recipe text is required' };
+    }
+    if (text.length > MAX_TEXT_INPUT_CHARS) {
+      return { ok: false, status: 400, error: 'Recipe text is too long (max 10,000 characters)' };
+    }
+    messages.push({ role: 'user', content: `Extract the recipe information from this text:\n\n${text}` });
+  } else {
+    if (!input.url) {
+      return { ok: false, status: 400, error: 'URL is required for URL extraction' };
+    }
+    let urlContent: { text: string; imageUrls: string[]; finalUrl: string };
+    try {
+      urlContent = await fetchUrlContent(input.url);
+    } catch (err) {
+      return {
+        ok: false,
+        status: 400,
+        error: `Failed to fetch URL content: ${err instanceof Error ? err.message : 'Unknown error'}`
+      };
+    }
+    const imageUrlsInfo =
+      urlContent.imageUrls.length > 0 ? `\n\nFound image URLs:\n${urlContent.imageUrls.join('\n')}` : '';
+    messages.push({
+      role: 'user',
+      content: `Extract the recipe information from this webpage content:\n\nURL: ${urlContent.finalUrl}\n\nContent:\n${urlContent.text}${imageUrlsInfo}`
+    });
+  }
+
+  const openaiResult = await callOpenAI(openAiKey, messages);
+  if (!openaiResult.ok) return openaiResult;
+
+  let recipe: NormalizedRecipe;
+  try {
+    const cleanContent = openaiResult.content
+      .replace(/```json\n?/g, '')
+      .replace(/```\n?/g, '')
+      .trim();
+    recipe = normalizeRecipe(JSON.parse(cleanContent));
+  } catch {
+    console.error('[parseRecipe] Failed to parse AI response:', openaiResult.content);
+    return { ok: false, status: 500, error: 'Failed to parse recipe data. Please try again.' };
+  }
+
+  return { ok: true, recipe };
+}

--- a/src/lib/parseRecipe.server.ts
+++ b/src/lib/parseRecipe.server.ts
@@ -104,14 +104,34 @@ function parsePublicUrl(raw: string): { ok: true; url: URL } | { ok: false; reas
 function isPrivateIpLiteral(host: string): boolean {
   // Strip IPv6 brackets if present (URL.hostname yields them unbracketed
   // on WHATWG, but be defensive).
-  const h = host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
+  const h = (host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host).toLowerCase();
 
-  // IPv6 loopback / link-local / unique-local.
-  if (h === '::1' || h === '::') return true;
+  // IPv6 loopback / unspecified / link-local / unique-local.
+  if (h === '::1' || h === '::' || h === '0:0:0:0:0:0:0:1' || h === '0:0:0:0:0:0:0:0') return true;
   if (h.startsWith('fe80:') || h.startsWith('fe80::')) return true;
   if (/^f[cd][0-9a-f]{2}:/.test(h)) return true;
 
-  // IPv4-literal check.
+  // IPv4-mapped and IPv4-compatible IPv6: ::ffff:127.0.0.1, ::ffff:0:127.0.0.1,
+  // ::127.0.0.1, 0:0:0:0:0:ffff:... etc. If we can find a trailing
+  // dotted-quad in what's otherwise an IPv6 literal, test the IPv4
+  // portion against the private-range check. This catches most
+  // embedded-IPv4 bypass attempts without trying to parse the full
+  // IPv6 grammar (which is hostile at best on Workers).
+  if (h.includes(':') && /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(h)) {
+    const dottedMatch = h.match(/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+    if (dottedMatch && isPrivateIpv4(dottedMatch[1])) return true;
+    // Any IPv6 literal with an embedded IPv4 portion is unusual and
+    // only really used for tunneling/compat — reject even if the v4
+    // portion is public, since the v6 prefix (::ffff:, ::) is a
+    // known bypass vector. Be conservative.
+    return true;
+  }
+
+  // Plain IPv4-literal check.
+  return isPrivateIpv4(h);
+}
+
+function isPrivateIpv4(h: string): boolean {
   const v4 = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
   if (!v4) return false;
   const [a, b] = [Number(v4[1]), Number(v4[2])];
@@ -172,18 +192,55 @@ function extractImageUrls(html: string, baseUrl: string): string[] {
   return [...new Set(imageUrls)].slice(0, 5);
 }
 
+const MAX_REDIRECTS = 5;
+
 async function fetchUrlContent(
   rawUrl: string
 ): Promise<{ text: string; imageUrls: string[]; finalUrl: string }> {
-  const parsed = parsePublicUrl(rawUrl);
-  if (!parsed.ok) throw new Error(parsed.reason);
+  // Manual redirect loop — `redirect: 'follow'` would let a public URL
+  // bounce into a private IP / metadata host without re-validation.
+  // Each hop runs back through parsePublicUrl so the SSRF guard
+  // applies to the final host the fetch lands on, not just the one
+  // the caller typed in.
+  let currentUrl = rawUrl;
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    const parsed = parsePublicUrl(currentUrl);
+    if (!parsed.ok) throw new Error(parsed.reason);
 
-  const response = await fetch(parsed.url.toString(), {
-    headers: { 'User-Agent': 'Mozilla/5.0 (compatible; ZapCooking/1.0; +https://zap.cooking)' },
-    redirect: 'follow'
-  });
+    const fetchTarget = parsed.url.toString();
+    const response = await fetch(fetchTarget, {
+      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; ZapCooking/1.0; +https://zap.cooking)' },
+      redirect: 'manual'
+    });
 
-  if (!response.ok) throw new Error(`Failed to fetch URL: ${response.status}`);
+    // 3xx with a Location header → revalidate and loop. Workers
+    // `redirect: 'manual'` yields the redirect response with status
+    // in the 300s and the Location header intact.
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location');
+      if (!location) throw new Error(`Redirect without Location header (${response.status})`);
+      // Resolve relative Location against the current URL before
+      // re-running the guard; otherwise `/admin` would be rejected
+      // as a scheme-less URL when it's legitimately same-origin.
+      try {
+        currentUrl = new URL(location, fetchTarget).toString();
+      } catch {
+        throw new Error('Invalid redirect Location');
+      }
+      continue;
+    }
+
+    if (!response.ok) throw new Error(`Failed to fetch URL: ${response.status}`);
+
+    return await readResponseBody(response, fetchTarget);
+  }
+  throw new Error('Too many redirects');
+}
+
+async function readResponseBody(
+  response: Response,
+  sourceUrl: string
+): Promise<{ text: string; imageUrls: string[]; finalUrl: string }> {
 
   // Enforce size cap up front when the server advertises Content-Length.
   const contentLength = response.headers.get('content-length');
@@ -199,7 +256,7 @@ async function fetchUrlContent(
   // Stream the body so an unbounded or chunked response can't exhaust
   // Worker memory. Abort as soon as we cross the cap.
   if (!response.body) {
-    return { text: '', imageUrls: [], finalUrl: response.url || parsed.url.toString() };
+    return { text: '', imageUrls: [], finalUrl: response.url || sourceUrl };
   }
   const reader = response.body.getReader();
   const chunks: Uint8Array[] = [];
@@ -243,7 +300,7 @@ async function fetchUrlContent(
   const bodyText = new TextDecoder('utf-8').decode(full);
 
   if (contentType.includes('text/html')) {
-    const imageUrls = extractImageUrls(bodyText, parsed.url.toString());
+    const imageUrls = extractImageUrls(bodyText, sourceUrl);
     const textContent = bodyText
       .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
       .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
@@ -251,10 +308,10 @@ async function fetchUrlContent(
       .replace(/\s+/g, ' ')
       .trim()
       .substring(0, MAX_PROMPT_CONTENT_CHARS);
-    return { text: textContent, imageUrls, finalUrl: response.url || parsed.url.toString() };
+    return { text: textContent, imageUrls, finalUrl: response.url || sourceUrl };
   }
 
-  return { text: bodyText, imageUrls: [], finalUrl: response.url || parsed.url.toString() };
+  return { text: bodyText, imageUrls: [], finalUrl: response.url || sourceUrl };
 }
 
 function normalizeRecipe(raw: Record<string, unknown>): NormalizedRecipe {

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -29,7 +29,11 @@ export interface RateLimitOptions {
 
 export interface RateLimitCheck {
   allowed: boolean;
-  /** Remaining hits in the current window after this check. */
+  /**
+   * Remaining hits currently available in the window. `checkRateLimit`
+   * is non-destructive, so this is the capacity *before* the caller
+   * records the next hit — a subsequent `recordHit` will consume one.
+   */
   remaining: number;
   /** Epoch-ms at which the bucket next frees up a slot. 0 if allowed. */
   retryAt: number;

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -1,0 +1,102 @@
+/**
+ * Client-side per-bucket rate limiter backed by localStorage.
+ *
+ * First-line UX guard for anon-accessible actions (e.g. the landing-page
+ * AI import hero). Trivially bypassable — a user can clear site data or
+ * open incognito to reset — so the server-side per-IP cap in
+ * `$lib/ipRateLimit.server.ts` is the real enforcement. This helper
+ * exists to give honest callers a clear "try again later" signal
+ * without round-tripping to the server, and to slow casual abuse.
+ *
+ * Stored shape per bucket:
+ *   rate-limit:<bucket> → JSON { hits: number[], version: 1 }
+ * where `hits` is a list of epoch-ms timestamps trimmed to the window.
+ */
+
+import { browser } from '$app/environment';
+
+const STORAGE_PREFIX = 'rate-limit:';
+const STORAGE_VERSION = 1;
+
+export interface RateLimitOptions {
+  /** Logical bucket name (e.g. `anon-url-import`). */
+  bucket: string;
+  /** Max hits allowed within the rolling window. */
+  limit: number;
+  /** Window length in milliseconds. */
+  windowMs: number;
+}
+
+export interface RateLimitCheck {
+  allowed: boolean;
+  /** Remaining hits in the current window after this check. */
+  remaining: number;
+  /** Epoch-ms at which the bucket next frees up a slot. 0 if allowed. */
+  retryAt: number;
+}
+
+interface StoredBucket {
+  version: number;
+  hits: number[];
+}
+
+function loadBucket(key: string): StoredBucket {
+  if (!browser) return { version: STORAGE_VERSION, hits: [] };
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return { version: STORAGE_VERSION, hits: [] };
+    const parsed = JSON.parse(raw) as StoredBucket;
+    if (!parsed || parsed.version !== STORAGE_VERSION || !Array.isArray(parsed.hits)) {
+      return { version: STORAGE_VERSION, hits: [] };
+    }
+    return parsed;
+  } catch {
+    return { version: STORAGE_VERSION, hits: [] };
+  }
+}
+
+function saveBucket(key: string, bucket: StoredBucket): void {
+  if (!browser) return;
+  try {
+    localStorage.setItem(key, JSON.stringify(bucket));
+  } catch {
+    // Quota or access errors — silently drop. Rate-limit is best-effort.
+  }
+}
+
+/**
+ * Non-destructive check: returns whether the next hit would be allowed,
+ * without recording it. Pair with `recordHit` after a successful action.
+ */
+export function checkRateLimit(opts: RateLimitOptions): RateLimitCheck {
+  const now = Date.now();
+  const key = STORAGE_PREFIX + opts.bucket;
+  const bucket = loadBucket(key);
+  const cutoff = now - opts.windowMs;
+  const windowHits = bucket.hits.filter((t) => t > cutoff);
+  const remaining = Math.max(0, opts.limit - windowHits.length);
+  if (windowHits.length < opts.limit) {
+    return { allowed: true, remaining, retryAt: 0 };
+  }
+  // Bucket full — retry when the oldest in-window hit ages out.
+  const oldest = Math.min(...windowHits);
+  return {
+    allowed: false,
+    remaining: 0,
+    retryAt: oldest + opts.windowMs
+  };
+}
+
+/**
+ * Record a hit against the bucket. Call AFTER the action succeeds so
+ * users aren't penalized for network errors or server-side rejections.
+ */
+export function recordHit(opts: RateLimitOptions): void {
+  const now = Date.now();
+  const key = STORAGE_PREFIX + opts.bucket;
+  const bucket = loadBucket(key);
+  const cutoff = now - opts.windowMs;
+  bucket.hits = bucket.hits.filter((t) => t > cutoff);
+  bucket.hits.push(now);
+  saveBucket(key, bucket);
+}

--- a/src/routes/api/extract-recipe/+server.ts
+++ b/src/routes/api/extract-recipe/+server.ts
@@ -1,365 +1,120 @@
 /**
- * Extract Recipe API
- * 
- * Uses OpenAI GPT-4o-mini to extract recipe information from images or URLs.
- * 
- * POST /api/extract-recipe
- * 
- * Body:
- * {
- *   type: 'image' | 'url',
- *   imageData?: string,  // Base64 encoded image data (for type: 'image')
- *   url?: string         // URL to extract recipe from (for type: 'url')
- * }
- * 
- * Returns:
- * {
- *   success: boolean,
- *   recipe?: {
- *     title: string,
- *     summary: string,
- *     chefsnotes: string,
- *     preptime: string,
- *     cooktime: string,
- *     servings: string,
- *     ingredients: string[],
- *     directions: string[],
- *     tags: string[],
- *     imageUrl?: string
- *   },
- *   error?: string
- * }
+ * POST /api/extract-recipe — authenticated recipe import.
+ *
+ * Accepts image (vision), text, or URL input and returns a normalized
+ * recipe via `parseRecipe`. Gating rules changed in the free-URL-import
+ * rollout:
+ *
+ *   - type: 'url'          — free for everyone (anon + members). The
+ *                            anon-hero entry point lives at the sibling
+ *                            `/api/extract-recipe/public` endpoint, which
+ *                            is stricter (URL only, per-IP cap, no
+ *                            pubkey field). This endpoint also accepts
+ *                            URL for logged-in callers as a convenience
+ *                            so the souschef page doesn't need a split.
+ *   - type: 'image'|'text' — requires active membership (any tier).
+ *                            `pubkey` is required and checked via
+ *                            `hasActiveMembership`.
+ *
+ * The "pubkey optional" part: for URL imports `pubkey` is no longer
+ * required in the request body. The field is still accepted so existing
+ * callers (souschef page) don't need a simultaneous change, but its
+ * presence is no longer load-bearing for URL.
+ *
+ * Response shape is unchanged from prior versions.
  */
 
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
-
-// Recipe extraction prompt for OpenAI
-const EXTRACTION_PROMPT = `You are a recipe extraction assistant. Extract recipe information from the provided content and return it in a structured JSON format.
-
-Extract the following fields:
-- title: The name of the recipe
-- summary: A brief 1-2 sentence description of the dish
-- chefsnotes: Any additional notes, tips, or background about the recipe (can be empty)
-- preptime: Preparation time (e.g., "20 min", "1 hour")
-- cooktime: Cooking time (e.g., "30 min", "1 hour 15 min")
-- servings: Number of servings (e.g., "4", "6-8")
-- ingredients: Array of ingredients with quantities (e.g., ["2 cups flour", "1 tsp salt"])
-- directions: Array of step-by-step instructions
-- tags: Array of relevant tags for categorization (e.g., ["Italian", "Pasta", "Quick", "Vegetarian"])
-- imageUrls: Array of image URLs found in the content that show the recipe/dish (extract full URLs, prioritize the main recipe photo)
-
-Return ONLY valid JSON with this exact structure:
-{
-  "title": "string",
-  "summary": "string",
-  "chefsnotes": "string",
-  "preptime": "string",
-  "cooktime": "string",
-  "servings": "string",
-  "ingredients": ["string"],
-  "directions": ["string"],
-  "tags": ["string"],
-  "imageUrls": ["string"]
-}
-
-If any field cannot be determined, use an empty string or empty array as appropriate.
-Do not include any text outside the JSON object.`;
-
-// Extract image URLs from HTML
-function extractImageUrls(html: string, baseUrl: string): string[] {
-  const imageUrls: string[] = [];
-  
-  // Parse base URL for resolving relative URLs
-  let urlBase: URL;
-  try {
-    urlBase = new URL(baseUrl);
-  } catch {
-    return imageUrls;
-  }
-  
-  // Match img src attributes
-  const imgRegex = /<img[^>]+src=["']([^"']+)["'][^>]*>/gi;
-  let match;
-  while ((match = imgRegex.exec(html)) !== null) {
-    let src = match[1];
-    // Skip tiny images, icons, tracking pixels
-    if (src.includes('1x1') || src.includes('pixel') || src.includes('spacer') || src.includes('icon')) continue;
-    
-    // Resolve relative URLs
-    try {
-      if (src.startsWith('//')) {
-        src = urlBase.protocol + src;
-      } else if (src.startsWith('/')) {
-        src = urlBase.origin + src;
-      } else if (!src.startsWith('http')) {
-        src = new URL(src, baseUrl).href;
-      }
-      
-      // Only include valid image URLs
-      if (src.match(/\.(jpg|jpeg|png|webp|gif)/i) || src.includes('image')) {
-        imageUrls.push(src);
-      }
-    } catch {
-      // Skip invalid URLs
-    }
-  }
-  
-  // Also check for og:image meta tag (often the main recipe image)
-  const ogImageMatch = html.match(/<meta[^>]+property=["']og:image["'][^>]+content=["']([^"']+)["']/i);
-  if (ogImageMatch && ogImageMatch[1]) {
-    const ogImage = ogImageMatch[1];
-    if (!imageUrls.includes(ogImage)) {
-      imageUrls.unshift(ogImage); // Add to front as it's usually the main image
-    }
-  }
-  
-  // Check for schema.org recipe image
-  const schemaImageMatch = html.match(/"image"\s*:\s*"([^"]+)"/);
-  if (schemaImageMatch && schemaImageMatch[1]) {
-    const schemaImage = schemaImageMatch[1];
-    if (!imageUrls.includes(schemaImage)) {
-      imageUrls.unshift(schemaImage);
-    }
-  }
-  
-  // Deduplicate and limit
-  return [...new Set(imageUrls)].slice(0, 5);
-}
-
-// Fetch URL content for extraction
-async function fetchUrlContent(url: string): Promise<{ text: string; imageUrls: string[] }> {
-  const response = await fetch(url, {
-    headers: {
-      'User-Agent': 'Mozilla/5.0 (compatible; ZapCooking/1.0; +https://zap.cooking)'
-    }
-  });
-  
-  if (!response.ok) {
-    throw new Error(`Failed to fetch URL: ${response.status}`);
-  }
-  
-  const contentType = response.headers.get('content-type') || '';
-  
-  if (contentType.includes('text/html')) {
-    const html = await response.text();
-    
-    // Extract image URLs before stripping HTML
-    const imageUrls = extractImageUrls(html, url);
-    
-    // Extract text content from HTML (basic extraction)
-    const textContent = html
-      .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
-      .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
-      .replace(/<[^>]+>/g, ' ')
-      .replace(/\s+/g, ' ')
-      .trim()
-      .substring(0, 15000); // Limit content length
-    return { text: textContent, imageUrls };
-  }
-  
-  return { text: await response.text(), imageUrls: [] };
-}
+import { parseRecipe, type ParseInput } from '$lib/parseRecipe.server';
 
 export const POST: RequestHandler = async ({ request, platform }) => {
   try {
-    // Check for OpenAI API key
-    const OPENAI_API_KEY = (platform?.env as any)?.OPENAI_API_KEY || env.OPENAI_API_KEY;
+    const OPENAI_API_KEY = platform?.env?.OPENAI_API_KEY || env.OPENAI_API_KEY;
     if (!OPENAI_API_KEY) {
-      return json(
-        { success: false, error: 'OpenAI API key not configured' },
-        { status: 500 }
-      );
+      return json({ success: false, error: 'OpenAI API key not configured' }, { status: 500 });
     }
-    
-    // Check membership (premium feature)
-    const MEMBERSHIP_ENABLED = platform?.env?.MEMBERSHIP_ENABLED || env.MEMBERSHIP_ENABLED;
-    
-    const body = await request.json();
-    const { type, imageData, url, pubkey } = body;
-    
-    // Validate request
-    if (!type || (type !== 'image' && type !== 'url' && type !== 'text')) {
+
+    let body: Record<string, unknown>;
+    try {
+      body = (await request.json()) as Record<string, unknown>;
+    } catch {
+      return json({ success: false, error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    const { type, imageData, url, pubkey, textData } = body ?? {};
+
+    if (type !== 'image' && type !== 'url' && type !== 'text') {
       return json(
         { success: false, error: 'Invalid type. Must be "image", "url", or "text"' },
         { status: 400 }
       );
     }
 
-    if (type === 'image' && !imageData) {
-      return json(
-        { success: false, error: 'Image data is required for image extraction' },
-        { status: 400 }
-      );
-    }
-
-    if (type === 'url' && !url) {
-      return json(
-        { success: false, error: 'URL is required for URL extraction' },
-        { status: 400 }
-      );
-    }
-
-    if (type === 'text' && (typeof body.textData !== 'string' || body.textData.trim().length === 0)) {
-      return json(
-        { success: false, error: 'Recipe text is required' },
-        { status: 400 }
-      );
-    }
-
-    if (type === 'text' && typeof body.textData === 'string' && body.textData.length > 10000) {
-      return json(
-        { success: false, error: 'Recipe text is too long (max 10,000 characters)' },
-        { status: 400 }
-      );
-    }
-    
-    // Check membership status if enabled
-    if (MEMBERSHIP_ENABLED?.toLowerCase() === 'true' && pubkey) {
-      const API_SECRET = platform?.env?.RELAY_API_SECRET || env.RELAY_API_SECRET;
-      if (API_SECRET) {
-        try {
-          const { hasActiveMembership } = await import('$lib/membershipApi.server');
-          const isActive = await hasActiveMembership(pubkey, API_SECRET);
-          if (!isActive) {
-            return json(
-              { success: false, error: 'Premium membership required for AI recipe extraction' },
-              { status: 403 }
-            );
+    // Gate — image/text remain premium, URL is free for everyone.
+    if (type === 'image' || type === 'text') {
+      const MEMBERSHIP_ENABLED =
+        platform?.env?.MEMBERSHIP_ENABLED || env.MEMBERSHIP_ENABLED;
+      if (MEMBERSHIP_ENABLED?.toLowerCase() === 'true') {
+        if (typeof pubkey !== 'string' || pubkey.trim().length === 0) {
+          return json(
+            { success: false, error: 'Premium membership required for AI recipe extraction' },
+            { status: 403 }
+          );
+        }
+        const API_SECRET = platform?.env?.RELAY_API_SECRET || env.RELAY_API_SECRET;
+        if (API_SECRET) {
+          try {
+            const { hasActiveMembership } = await import('$lib/membershipApi.server');
+            const isActive = await hasActiveMembership(pubkey, API_SECRET);
+            if (!isActive) {
+              return json(
+                { success: false, error: 'Premium membership required for AI recipe extraction' },
+                { status: 403 }
+              );
+            }
+          } catch (err) {
+            console.error('[Extract Recipe] Error checking membership:', err);
+            // Fail open on membership-API outage — better than stranding
+            // legitimate paid members.
           }
-        } catch (err) {
-          console.error('[Extract Recipe] Error checking membership:', err);
-          // Continue anyway if membership check fails
         }
       }
     }
-    
-    // Build OpenAI request
-    let messages: any[] = [
-      { role: 'system', content: EXTRACTION_PROMPT }
-    ];
-    
+
+    let input: ParseInput;
     if (type === 'image') {
-      // For image extraction, use vision capability
-      messages.push({
-        role: 'user',
-        content: [
-          {
-            type: 'text',
-            text: 'Extract the recipe information from this image:'
-          },
-          {
-            type: 'image_url',
-            image_url: {
-              url: imageData.startsWith('data:') ? imageData : `data:image/jpeg;base64,${imageData}`
-            }
-          }
-        ]
-      });
-    } else if (type === 'text') {
-      // For text extraction, send the pasted text directly
-      messages.push({
-        role: 'user',
-        content: `Extract the recipe information from this text:\n\n${body.textData}`
-      });
-    } else {
-      // For URL extraction, fetch the content first
-      let urlContent: { text: string; imageUrls: string[] };
-      try {
-        urlContent = await fetchUrlContent(url);
-      } catch (err) {
+      if (typeof imageData !== 'string' || imageData.length === 0) {
         return json(
-          { success: false, error: `Failed to fetch URL content: ${err instanceof Error ? err.message : 'Unknown error'}` },
+          { success: false, error: 'Image data is required for image extraction' },
           { status: 400 }
         );
       }
-      
-      // Include image URLs in the prompt so AI can prioritize/select the best ones
-      const imageUrlsInfo = urlContent.imageUrls.length > 0 
-        ? `\n\nFound image URLs:\n${urlContent.imageUrls.join('\n')}`
-        : '';
-      
-      messages.push({
-        role: 'user',
-        content: `Extract the recipe information from this webpage content:\n\nURL: ${url}\n\nContent:\n${urlContent.text}${imageUrlsInfo}`
-      });
+      input = { type: 'image', imageData };
+    } else if (type === 'url') {
+      if (typeof url !== 'string' || url.trim().length === 0) {
+        return json(
+          { success: false, error: 'URL is required for URL extraction' },
+          { status: 400 }
+        );
+      }
+      input = { type: 'url', url };
+    } else {
+      if (typeof textData !== 'string' || textData.trim().length === 0) {
+        return json({ success: false, error: 'Recipe text is required' }, { status: 400 });
+      }
+      input = { type: 'text', textData };
     }
-    
-    // Call OpenAI API
-    const openaiResponse = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${OPENAI_API_KEY}`
-      },
-      body: JSON.stringify({
-        model: 'gpt-4o-mini',
-        messages,
-        max_tokens: 4096,
-        temperature: 0.3
-      })
-    });
-    
-    if (!openaiResponse.ok) {
-      const errorData = await openaiResponse.json().catch(() => ({}));
-      console.error('[Extract Recipe] OpenAI API error:', errorData);
-      return json(
-        { success: false, error: 'Failed to extract recipe. Please try again.' },
-        { status: 500 }
-      );
+
+    const result = await parseRecipe(OPENAI_API_KEY, input);
+    if (!result.ok) {
+      return json({ success: false, error: result.error }, { status: result.status });
     }
-    
-    const openaiData = await openaiResponse.json();
-    const content = openaiData.choices?.[0]?.message?.content;
-    
-    if (!content) {
-      return json(
-        { success: false, error: 'No response from AI. Please try again.' },
-        { status: 500 }
-      );
-    }
-    
-    // Parse the JSON response
-    let recipe;
-    try {
-      // Clean up potential markdown code blocks
-      const cleanContent = content
-        .replace(/```json\n?/g, '')
-        .replace(/```\n?/g, '')
-        .trim();
-      recipe = JSON.parse(cleanContent);
-    } catch (err) {
-      console.error('[Extract Recipe] Failed to parse AI response:', content);
-      return json(
-        { success: false, error: 'Failed to parse recipe data. Please try again.' },
-        { status: 500 }
-      );
-    }
-    
-    // Validate and normalize the response
-    const normalizedRecipe = {
-      title: recipe.title || '',
-      summary: recipe.summary || '',
-      chefsnotes: recipe.chefsnotes || recipe.chefsNotes || recipe.notes || '',
-      preptime: recipe.preptime || recipe.prepTime || recipe.prep_time || '',
-      cooktime: recipe.cooktime || recipe.cookTime || recipe.cook_time || '',
-      servings: recipe.servings || '',
-      ingredients: Array.isArray(recipe.ingredients) ? recipe.ingredients : [],
-      directions: Array.isArray(recipe.directions) ? recipe.directions : (Array.isArray(recipe.instructions) ? recipe.instructions : []),
-      tags: Array.isArray(recipe.tags) ? recipe.tags : [],
-      imageUrls: Array.isArray(recipe.imageUrls) ? recipe.imageUrls : (Array.isArray(recipe.images) ? recipe.images : [])
-    };
-    
-    return json({
-      success: true,
-      recipe: normalizedRecipe
-    });
-    
-  } catch (error: any) {
-    console.error('[Extract Recipe] Error:', error);
-    return json(
-      { success: false, error: error.message || 'An unexpected error occurred' },
-      { status: 500 }
-    );
+
+    return json({ success: true, recipe: result.recipe });
+  } catch (err) {
+    console.error('[Extract Recipe] Error:', err);
+    const message = err instanceof Error ? err.message : 'An unexpected error occurred';
+    return json({ success: false, error: message }, { status: 500 });
   }
 };

--- a/src/routes/api/extract-recipe/+server.ts
+++ b/src/routes/api/extract-recipe/+server.ts
@@ -12,6 +12,9 @@
  *                            pubkey field). This endpoint also accepts
  *                            URL for logged-in callers as a convenience
  *                            so the souschef page doesn't need a split.
+ *                            The same per-IP rate limit applies so this
+ *                            endpoint can't be used as a quieter bypass
+ *                            of /public's cap.
  *   - type: 'image'|'text' — requires active membership (any tier).
  *                            `pubkey` is required and checked via
  *                            `hasActiveMembership`.
@@ -27,8 +30,16 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { parseRecipe, type ParseInput } from '$lib/parseRecipe.server';
+import { checkPerIpRateLimit } from '$lib/ipRateLimit.server';
 
-export const POST: RequestHandler = async ({ request, platform }) => {
+// URL imports on this endpoint share the same per-IP cap as the public
+// sibling so a caller can't route around /public/'s rate limit by
+// hitting this route without a pubkey. Image/text don't need a cap
+// here — they're already gated to active members above.
+const URL_PER_HOUR = 8;
+const URL_PER_DAY = 30;
+
+export const POST: RequestHandler = async ({ request, getClientAddress, platform }) => {
   try {
     const OPENAI_API_KEY = platform?.env?.OPENAI_API_KEY || env.OPENAI_API_KEY;
     if (!OPENAI_API_KEY) {
@@ -98,6 +109,26 @@ export const POST: RequestHandler = async ({ request, platform }) => {
           { status: 400 }
         );
       }
+
+      // Per-IP cap — prevents this endpoint from being used as a
+      // quieter bypass of /api/extract-recipe/public's rate limit.
+      let ip = '127.0.0.1';
+      try {
+        ip = getClientAddress();
+      } catch {
+        // Local dev / missing CF headers.
+      }
+      const kv = platform?.env?.NOURISH_FLAGS;
+      const rl = await checkPerIpRateLimit(kv, {
+        ip,
+        scope: 'extract-url',
+        perHour: URL_PER_HOUR,
+        perDay: URL_PER_DAY
+      });
+      if (rl.limited) {
+        return json(rl.body, { status: 429 });
+      }
+
       input = { type: 'url', url };
     } else {
       if (typeof textData !== 'string' || textData.trim().length === 0) {

--- a/src/routes/api/extract-recipe/public/+server.ts
+++ b/src/routes/api/extract-recipe/public/+server.ts
@@ -1,0 +1,104 @@
+/**
+ * POST /api/extract-recipe/public — anon-allowed URL-only recipe import.
+ *
+ * Powers the free AI-import hero on the landing page. Accepts a single
+ * URL, runs it through the shared `parseRecipe` pipeline, and returns a
+ * normalized recipe. No membership check, no pubkey required — the
+ * server gate that `/api/extract-recipe` enforces for image/text is
+ * deliberately absent here. See the sibling endpoint's docstring for
+ * the full gating story.
+ *
+ * Defenses:
+ *   - URL-only: rejects any non-`url` type so the public surface can't
+ *     be abused for vision/text extraction.
+ *   - SSRF/size cap: enforced inside `parseRecipe` (http(s) only, private
+ *     IP ranges blocked, 5 MB response cap).
+ *   - Per-IP rate limit: 8/hour, 30/day via `NOURISH_FLAGS` KV with the
+ *     `extract-url` scope. Trivially bypassable IP rotation is accepted
+ *     — this is a cost-cap, not an abuse shield.
+ *
+ * Request body:
+ *   { url: string }
+ *
+ * Response:
+ *   200 { success: true, recipe: NormalizedRecipe }
+ *   400 { success: false, error: string }
+ *   429 { error: 'rate_limited', retryAfter, scope }
+ *   500 { success: false, error: string }
+ */
+
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import { parseRecipe } from '$lib/parseRecipe.server';
+import { checkPerIpRateLimit } from '$lib/ipRateLimit.server';
+
+const PER_HOUR = 8;
+const PER_DAY = 30;
+
+export const POST: RequestHandler = async ({ request, getClientAddress, platform }) => {
+  try {
+    const OPENAI_API_KEY = platform?.env?.OPENAI_API_KEY || env.OPENAI_API_KEY;
+    if (!OPENAI_API_KEY) {
+      return json({ success: false, error: 'OpenAI API key not configured' }, { status: 500 });
+    }
+
+    let body: Record<string, unknown>;
+    try {
+      body = (await request.json()) as Record<string, unknown>;
+    } catch {
+      return json({ success: false, error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    const { url } = body ?? {};
+    if (typeof url !== 'string' || url.trim().length === 0) {
+      return json({ success: false, error: 'URL is required' }, { status: 400 });
+    }
+    if (url.length > 2048) {
+      return json({ success: false, error: 'URL is too long' }, { status: 400 });
+    }
+
+    // Per-IP cap. Falls open if KV is unbound (local dev without
+    // bindings) — client-side rate limit still applies there.
+    let ip = '127.0.0.1';
+    try {
+      ip = getClientAddress();
+    } catch {
+      // Local dev / missing CF headers. Use loopback sentinel.
+    }
+    const kv = platform?.env?.NOURISH_FLAGS;
+    const rl = await checkPerIpRateLimit(kv, {
+      ip,
+      scope: 'extract-url',
+      perHour: PER_HOUR,
+      perDay: PER_DAY
+    });
+    if (rl.limited) {
+      return json(rl.body, { status: 429 });
+    }
+
+    const result = await parseRecipe(OPENAI_API_KEY, { type: 'url', url });
+    if (!result.ok) {
+      return json({ success: false, error: result.error }, { status: result.status });
+    }
+
+    // TODO(analytics): emit `anon_import_success` with { ipHash: rl.ipHash, urlHost }.
+    console.log('[extract-recipe.public] ok', {
+      ipHash: rl.ipHash.slice(0, 8),
+      urlHost: safeHost(url)
+    });
+
+    return json({ success: true, recipe: result.recipe });
+  } catch (err) {
+    console.error('[extract-recipe.public] error:', err);
+    const message = err instanceof Error ? err.message : 'An unexpected error occurred';
+    return json({ success: false, error: message }, { status: 500 });
+  }
+};
+
+function safeHost(raw: string): string {
+  try {
+    return new URL(raw).hostname;
+  } catch {
+    return 'unknown';
+  }
+}

--- a/src/routes/explore/+page.svelte
+++ b/src/routes/explore/+page.svelte
@@ -17,6 +17,7 @@
   import SponsorBanner from '../../components/SponsorBanner.svelte';
   import PullToRefresh from '../../components/PullToRefresh.svelte';
   import LongformFoodFeed from '../../components/LongformFoodFeed.svelte';
+  import LandingImportHero from '../../components/LandingImportHero.svelte';
   import type { NDKEvent } from '@nostr-dev-kit/ndk';
   import { nip19 } from 'nostr-tools';
   import { init, markOnce } from '$lib/perf/explorePerf';
@@ -388,6 +389,10 @@
           </div>
         {/if}
       </section>
+
+      <!-- Free AI recipe import — full card for anon visitors, compact pill
+           for logged-in non-premium users, hidden for Pro Kitchen / Founders. -->
+      <LandingImportHero />
 
       <!-- Popular Cooks -->
       <section class="flex flex-col gap-4">

--- a/src/routes/souschef/+page.svelte
+++ b/src/routes/souschef/+page.svelte
@@ -12,6 +12,11 @@
   import { createMarkdown, validateMarkdownTemplate } from '$lib/parser';
   import { addClientTagToEvent } from '$lib/nip89';
   import { nip19 } from 'nostr-tools';
+  import {
+    ANON_IMPORT_HANDOFF_KEY,
+    ANON_IMPORT_MAX_AGE_MS,
+    type AnonImportHandoff
+  } from '$lib/anonImport';
   import Button from '../../components/Button.svelte';
   import Tabs from '../../components/Tabs.svelte';
   import TagsComboBox from '../../components/TagsComboBox.svelte';
@@ -38,15 +43,28 @@
   // State management
   let isLoading = true;
   let errorMessage = '';
+
+  // Anon preview — set when an unauthenticated user arrives via the
+  // landing hero with a parsed recipe stashed in sessionStorage.
+  // Collapses the extraction UI and renders the editor read-only with
+  // a sign-in CTA. Transitions to normal mode automatically if the user
+  // signs in while on this page (see reactive block below).
+  let isAnonPreview = false;
+  let anonPreviewSourceUrl = '';
   
   // Input mode
   type InputMode = 'image' | 'url' | 'text';
-  let inputMode: InputMode = 'text';
-  const tabs = [
+  let inputMode: InputMode = 'url';
+  const ALL_TABS = [
     { id: 'image', label: 'Upload Image' },
     { id: 'url', label: 'Paste URL' },
     { id: 'text', label: 'Paste Text' }
   ];
+  // URL import is free for everyone; image/text stay behind the member
+  // gate. Non-members see a URL-only tab set so the premium surfaces
+  // aren't advertised to them inline.
+  $: tabs = hasMembership ? ALL_TABS : ALL_TABS.filter((t) => t.id === 'url');
+  $: if (!hasMembership && inputMode !== 'url') inputMode = 'url';
 
   // Text input state
   let textInput = '';
@@ -85,9 +103,82 @@
   let additionalMarkdown = '';
   
   onMount(() => {
+    // Handoff from the landing-page import hero. Present for both
+    // anon visitors (full hero) AND logged-in non-premium users
+    // (compact pill). If present and fresh, hydrate the editor and
+    // skip the extraction UI — the recipe is already parsed. Only
+    // enter "view-only preview" mode for actual anon visitors; a
+    // logged-in user continuing from the pill should see full
+    // publish/save-draft controls.
+    if (browser) {
+      try {
+        const raw = sessionStorage.getItem(ANON_IMPORT_HANDOFF_KEY);
+        if (raw) {
+          const parsed = JSON.parse(raw) as AnonImportHandoff | null;
+          if (
+            parsed &&
+            parsed.recipe &&
+            typeof parsed.at === 'number' &&
+            Date.now() - parsed.at <= ANON_IMPORT_MAX_AGE_MS
+          ) {
+            hydrateFromHandoff(parsed, !$userPublickey);
+          }
+          // Always clear — a stale or malformed handoff shouldn't
+          // linger and re-hydrate on a later visit.
+          sessionStorage.removeItem(ANON_IMPORT_HANDOFF_KEY);
+        }
+      } catch {
+        // sessionStorage disabled or JSON malformed — fall through to
+        // the normal extraction UI.
+      }
+    }
     isLoading = false;
     return () => unsubMembership();
   });
+
+  function hydrateFromHandoff(handoff: AnonImportHandoff, viewOnly: boolean) {
+    const recipe = handoff.recipe;
+    title = recipe.title || '';
+    summary = recipe.summary || '';
+    chefsnotes = recipe.chefsnotes || '';
+    preptime = recipe.preptime || '';
+    cooktime = recipe.cooktime || '';
+    servings = recipe.servings || '';
+    ingredientsArray.set(recipe.ingredients || []);
+    directionsArray.set(recipe.directions || []);
+
+    // Tag matching mirrors the authenticated extractRecipe path so the
+    // handoff looks identical to a fresh member extraction.
+    const matchedTags: recipeTagSimple[] = [];
+    for (const tagName of recipe.tags || []) {
+      const normalizedTag = tagName.toLowerCase().trim();
+      const existing = recipeTags.find((t) => t.title.toLowerCase() === normalizedTag);
+      matchedTags.push(existing ?? { title: tagName });
+    }
+    selectedTags.set(matchedTags);
+
+    // Anon can't rehost to nostr.build (NIP-98 sign required) — use the
+    // raw external URLs as-is. If the user signs in and publishes, the
+    // URLs are emitted on the kind:30023 event directly; this matches
+    // the existing member-side fallback when rehosting fails.
+    if (Array.isArray(recipe.imageUrls) && recipe.imageUrls.length > 0) {
+      images.set([recipe.imageUrls[0]]);
+    }
+
+    anonPreviewSourceUrl = handoff.sourceUrl || '';
+    isAnonPreview = viewOnly;
+    extractionSuccess = true;
+  }
+
+  // If the user signs in while on this page (e.g. after clicking
+  // "Sign in to publish"), drop the anon-preview flag so the normal
+  // publish/save-draft controls unlock. The hydrated form fields stay
+  // populated — they just become editable.
+  $: if (isAnonPreview && $userPublickey) {
+    isAnonPreview = false;
+    // TODO(analytics): emit `post_import_signup` with
+    // { sourceUrl: anonPreviewSourceUrl }.
+  }
   
   // Handle tab change
   function handleTabChange(event: CustomEvent<string>) {
@@ -518,33 +609,33 @@
     <p class="text-caption">
       A little extra help in the kitchen.
     </p>
-    <p class="text-caption text-sm">Pro Kitchen feature.</p>
+    <p class="text-caption text-sm">
+      URL imports are free. Image and text imports are a Pro Kitchen feature.
+    </p>
   </div>
-  
+
   {#if isLoading}
     <!-- Loading state -->
     <div class="flex flex-col items-center justify-center py-16 gap-4">
       <ArrowsClockwiseIcon size={48} class="animate-spin text-primary" />
       <p class="text-caption">Checking membership status...</p>
     </div>
-  {:else if $userPublickey && !hasMembership}
-    <!-- No membership -->
-    <div class="flex flex-col items-center justify-center py-16 gap-6">
-      <div class="w-20 h-20 rounded-full bg-primary/10 flex items-center justify-center">
-        <SparkleIcon size={40} class="text-primary" weight="fill" />
-      </div>
-      <div class="text-center max-w-md">
-        <h2 class="mb-2">Pro Kitchen Feature</h2>
-        <p class="text-caption mb-6">
-          Sous Chef is available exclusively for Pro Kitchen members. 
-          Upgrade your membership to unlock your AI recipe assistant.
-        </p>
-        <Button on:click={() => goto('/membership')}>
-          View Membership Options
-        </Button>
-      </div>
-    </div>
   {:else}
+    {#if $userPublickey && !hasMembership && !isAnonPreview && !extractionSuccess}
+      <!-- Non-member upgrade nudge — inline banner rather than a blocking
+           gate. URL import is free for all; this banner surfaces the
+           image/text benefit without hiding the whole feature. -->
+      <div class="flex items-start gap-3 p-4 rounded-xl" style="background-color: rgba(249, 115, 22, 0.08); border: 1px solid rgba(249, 115, 22, 0.25);">
+        <SparkleIcon size={22} class="text-primary flex-shrink-0 mt-0.5" weight="fill" />
+        <div class="flex-1">
+          <p class="text-sm">
+            <span class="font-semibold" style="color: var(--color-primary);">URL imports are on us.</span>
+            Unlock image + text imports and more with
+            <button type="button" class="underline" on:click={() => goto('/membership')}>Pro Kitchen</button>.
+          </p>
+        </div>
+      </div>
+    {/if}
     <!-- Has membership - show extraction UI -->
     
     {#if !extractionSuccess}
@@ -671,29 +762,45 @@
     {:else}
       <!-- Extraction Success - Show Editor -->
       <div class="flex flex-col gap-6">
-        <!-- Success Banner -->
-        <div class="flex items-center gap-3 p-4 rounded-xl bg-green-500/10 border border-green-500/20">
-          <CheckCircleIcon size={24} class="text-green-500" weight="fill" />
-          <div class="flex-1">
-            <p class="font-semibold text-green-600 dark:text-green-400">Recipe Extracted Successfully!</p>
-            <p class="text-sm text-caption">
-              Review and edit the details below, then choose an action.
-              {#if $images.length > 0}
-                <span class="inline-flex items-center gap-1 ml-1">
-                  <ImageIcon size={14} class="text-green-500" />
-                  <span class="text-green-600 dark:text-green-400">Image ready!</span>
-                </span>
-              {/if}
-            </p>
+        {#if isAnonPreview}
+          <!-- Anon-preview banner (via landing hero handoff) -->
+          <div class="flex items-start gap-3 p-4 rounded-xl" style="background-color: rgba(249, 115, 22, 0.08); border: 1px solid rgba(249, 115, 22, 0.25);">
+            <SparkleIcon size={24} class="text-primary flex-shrink-0 mt-0.5" weight="fill" />
+            <div class="flex-1">
+              <p class="font-semibold" style="color: var(--color-primary);">Recipe imported — sign in to save or publish</p>
+              <p class="text-sm text-caption mt-1">
+                {#if anonPreviewSourceUrl}
+                  Parsed from <span class="font-mono text-xs break-all">{anonPreviewSourceUrl}</span>.
+                {/if}
+                You can review the details below. Signing in unlocks editing, draft saving, and publishing to your feed.
+              </p>
+            </div>
           </div>
-        </div>
+        {:else}
+          <!-- Success Banner -->
+          <div class="flex items-center gap-3 p-4 rounded-xl bg-green-500/10 border border-green-500/20">
+            <CheckCircleIcon size={24} class="text-green-500" weight="fill" />
+            <div class="flex-1">
+              <p class="font-semibold text-green-600 dark:text-green-400">Recipe Extracted Successfully!</p>
+              <p class="text-sm text-caption">
+                Review and edit the details below, then choose an action.
+                {#if $images.length > 0}
+                  <span class="inline-flex items-center gap-1 ml-1">
+                    <ImageIcon size={14} class="text-green-500" />
+                    <span class="text-green-600 dark:text-green-400">Image ready!</span>
+                  </span>
+                {/if}
+              </p>
+            </div>
+          </div>
+        {/if}
         
         <!-- Recipe Form -->
         <div class="flex flex-col gap-6">
           <!-- Title -->
           <div class="flex flex-col gap-2">
             <h3>Title*</h3>
-            <input placeholder="Recipe title" bind:value={title} class="input" />
+            <input placeholder="Recipe title" bind:value={title} class="input" disabled={isAnonPreview} />
           </div>
           
           <!-- Tags -->
@@ -711,6 +818,7 @@
               bind:value={summary}
               rows="3"
               class="input"
+              disabled={isAnonPreview}
             />
           </div>
           
@@ -730,15 +838,15 @@
             <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
               <div class="flex flex-col gap-2">
                 <span class="text-sm font-medium">Prep Time</span>
-                <input placeholder="20 min" bind:value={preptime} class="input" />
+                <input placeholder="20 min" bind:value={preptime} class="input" disabled={isAnonPreview} />
               </div>
               <div class="flex flex-col gap-2">
                 <span class="text-sm font-medium">Cook Time</span>
-                <input placeholder="1 hour" bind:value={cooktime} class="input" />
+                <input placeholder="1 hour" bind:value={cooktime} class="input" disabled={isAnonPreview} />
               </div>
               <div class="flex flex-col gap-2">
                 <span class="text-sm font-medium">Servings</span>
-                <input placeholder="4" bind:value={servings} class="input" />
+                <input placeholder="4" bind:value={servings} class="input" disabled={isAnonPreview} />
               </div>
             </div>
           </div>
@@ -778,6 +886,24 @@
             </div>
           {/if}
 
+          {#if isAnonPreview}
+            <!-- Sign-in CTA replaces publish/save-draft for anon preview.
+                 redirect=/souschef keeps the handoff-populated form in
+                 place (sessionStorage was already cleared on mount, but
+                 the in-memory fields persist across login). -->
+            <button
+              type="button"
+              on:click={() => goto('/login?redirect=/souschef')}
+              class="w-full flex items-center justify-center gap-2 px-6 py-3 rounded-full font-semibold transition-all"
+              style="background: linear-gradient(135deg, #f97316 0%, #fb923c 100%); color: white; box-shadow: 0 2px 8px rgba(249, 115, 22, 0.3);"
+            >
+              <SparkleIcon size={18} weight="fill" />
+              Sign in to publish
+            </button>
+            <p class="text-xs text-caption text-center">
+              No account? You can create one in a few seconds — no email required.
+            </p>
+          {:else}
           <!-- Primary: Publish Recipe -->
           <button
             type="button"
@@ -818,6 +944,7 @@
           >
             Cancel
           </button>
+          {/if}
         </div>
       </div>
     {/if}

--- a/src/routes/souschef/+page.svelte
+++ b/src/routes/souschef/+page.svelte
@@ -62,7 +62,10 @@
   ];
   // URL import is free for everyone; image/text stay behind the member
   // gate. Non-members see a URL-only tab set so the premium surfaces
-  // aren't advertised to them inline.
+  // aren't advertised to them inline. Initialize optimistically to the
+  // URL-only set — the reactive statement below widens to ALL_TABS
+  // once `hasMembership` resolves.
+  let tabs: { id: string; label: string }[] = ALL_TABS.filter((t) => t.id === 'url');
   $: tabs = hasMembership ? ALL_TABS : ALL_TABS.filter((t) => t.id === 'url');
   $: if (!hasMembership && inputMode !== 'url') inputMode = 'url';
 


### PR DESCRIPTION
## Summary

- Opens the existing premium Sous Chef URL-import flow to everyone via a new hero card on the `/explore` landing page. Image/text import remain behind the membership gate.
- New anon-accessible `POST /api/extract-recipe/public` endpoint with SSRF hardening, 5 MB response cap, and per-IP rate limit (8/hour, 30/day). Parsing logic extracted to a shared `parseRecipe.server.ts` util used by both the authenticated and public endpoints.
- `/souschef` gains an anon-preview mode: an sessionStorage handoff from the hero populates the editor read-only with a "Sign in to publish" CTA. Signing in on the page reactively unlocks the full controls without a remount.

## Gate policy change

URL import is now **free everywhere** (hero + `/souschef` tab set + `/api/extract-recipe` URL type). Image + text import stay behind the existing `hasActiveMembership` gate. Rationale: a logged-in free user shouldn't have to log out (or use the compact pill) to URL-import. Three distinct surfaces, one consistent rule.

The old blocking "Pro Kitchen Feature" gate on `/souschef` for non-members is replaced with an inline upgrade nudge — non-members now see a URL-only tab set and can import directly from that page.

## New files

- `src/components/LandingImportHero.svelte` — three modes based on auth + tier:
  - Full card (anon)
  - Compact pill (logged-in non-premium)
  - Hidden (Pro Kitchen / Founders — they have the nav sparkle)
  - Submit button uses flat `--color-primary` + a 1px color-mix shadow so it doesn't visually fight the bottom-nav FAB.
- `src/routes/api/extract-recipe/public/+server.ts` — URL-only anon endpoint. Returns the same `NormalizedRecipe` shape as the authenticated sibling. Reuses `NOURISH_FLAGS` KV with a disjoint `rl:extract-url:*` prefix so no new `wrangler.jsonc` binding is required.
- `src/lib/parseRecipe.server.ts` — shared extraction pipeline. SSRF guard rejects non-http(s) schemes and IP literals in `10/8`, `127/8`, `169.254/16` (AWS metadata), `172.16-31/12`, `192.168/16`, `0/8`, `::1`, `fc00::/7`, `fe80::/10`, plus `localhost` / `*.local` / `*.internal` hostnames. Streaming response reader enforces a 5 MB cap even when `Content-Length` is absent.
- `src/lib/ipRateLimit.server.ts` — generalized per-IP limiter with daily-salted IP hashing (mirrors `flagRateLimit.server.ts`). Fails open on KV error.
- `src/lib/rateLimit.ts` — client-side localStorage limiter (3/hour for `anon-url-import` bucket). First-line UX guard; server-side IP cap is the real enforcement.
- `src/lib/anonImport.ts` — shared handoff key + typed shape + 10-minute staleness cap.

## Modified

- `src/routes/api/extract-recipe/+server.ts` — delegates to `parseRecipe.server.ts`. `pubkey` now optional; URL type skips the gate; image/text keep it. Dropped `err: any` and the inline fetch/OpenAI/normalization code.
- `src/routes/souschef/+page.svelte` — `onMount` reads the sessionStorage handoff; populates the form; enters view-only mode for actual anon users (disabled inputs + "Sign in to publish" CTA). Logged-in non-premium users using the compact pill skip view-only and get the full editor. Reactive block flips out of view-only when the user signs in mid-page.
- `src/routes/explore/+page.svelte` — `<LandingImportHero />` inserted between "Fresh from the Kitchen" and "Popular Cooks".
- `src/app.d.ts` — added `OPENAI_API_KEY?: string` to `App.Platform.env` so endpoints can read it without `as any`.

## Flagged for reviewer attention

- **Server gate is tier-agnostic, label on `/souschef` used to say "Pro Kitchen feature."** The server's `hasActiveMembership` check lets any active tier through (Cook+, Pro Kitchen, Founders). The new header text reads "URL imports are free. Image and text imports are a Pro Kitchen feature" — accurate with the new gating, but if product wants to tighten image/text to Pro Kitchen specifically, that's a follow-up in `membershipApi.server.ts`.
- **No analytics utility in the repo**, so three `TODO(analytics)` markers sit at the conversion-funnel call sites with the exact event names: `anon_import_attempt` (hero submit), `anon_import_success` (handoff stashed), `post_import_signup` (reactive block in souschef when an anon-preview user signs in). Wire once an analytics client lands.
- **KV binding reuse**: per-IP rate limiter uses `NOURISH_FLAGS` with `rl:extract-url:*` and `config:ip-salt-v2:*` key prefixes. Disjoint from Nourish's keys. Alternative was a new binding in `wrangler.jsonc`; happy to split if you'd prefer.

## Test plan

- [ ] **Anon (logged-out) on `/explore`**: full hero card renders between "Fresh from the Kitchen" and "Popular Cooks" with orange-tinted border/wash.
- [ ] Paste a real recipe URL → lands on `/souschef` with editor in read-only mode, sessionStorage cleared after consumption, "Sign in to publish" CTA visible.
- [ ] Click "Sign in to publish" → login flow → return to `/souschef` → `isAnonPreview` flips, normal publish + save-draft buttons appear, form fields editable, same data intact.
- [ ] **Logged-in free user** on `/explore`: compact pill variant (no headline/subtext). Submit routes through the same public endpoint + handoff; arrives at `/souschef` with full editor directly (no view-only because they're logged in).
- [ ] **Logged-in Pro Kitchen / Founders**: hero hidden entirely on `/explore`.
- [ ] **`/souschef` direct access, non-member**: inline upgrade banner shows; tab set is URL-only; URL extraction works end-to-end.
- [ ] **`/souschef` direct access, member**: all three tabs (image / url / text) available and functional; unchanged from prior behavior.
- [ ] **Mobile viewport (~433px)**: hero renders as a single row (input + Import button side-by-side), ~single recipe-tile height, no layout break.
- [ ] **Mobile viewport (<360px)**: hero stacks (input full-width, button full-width below).
- [ ] **SSRF**: try `http://127.0.0.1/`, `http://169.254.169.254/`, `ftp://...`, `file:///` in the hero — each surfaces an inline 4xx error with a clear message.
- [ ] **Rate limit**: 4th URL import within an hour from the same browser → inline "Try again in about N min" from the localStorage guard.
- [ ] **5 MB cap**: serve a large response (or one with an inflated `Content-Length`) and confirm the endpoint rejects with a clear error.
- [ ] `pnpm check` — baseline 4 errors / 127 warnings preserved (same as `main`).
- [ ] `pnpm exec eslint` on touched files — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)