### PR TITLE
fix: dedup reactions and recipe comment counts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.264",
+  "version": "4.2.266",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.260",
+  "version": "4.2.261",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.263",
+  "version": "4.2.264",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.261",
+  "version": "4.2.262",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.262",
+  "version": "4.2.263",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/Reactions/ReactionButton.svelte
+++ b/src/components/Reactions/ReactionButton.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte';
+  import { onMount, onDestroy, beforeUpdate } from 'svelte';
   import { ndk, userPublickey } from '$lib/nostr';
   import type { NDKEvent, NDKSubscription } from '@nostr-dev-kit/ndk';
   import type { TargetType, AggregatedReactions } from '$lib/types/reactions';
@@ -165,19 +165,42 @@
     handleReaction(emoji);
   }
 
+  // Lifecycle: load once on mount, re-subscribe only when the `event`
+  // prop's id actually changes after mount. The prior implementation
+  // had both `onMount(loadReactions)` AND a reactive
+  // `$: if (event?.id) loadReactions()` — the latter fired on any
+  // reactive dependency tick, creating a second subscription on
+  // first mount (plus more on subsequent ticks) without stopping
+  // the previous one. onDestroy only stopped the latest `subscription`
+  // reference, so earlier subs leaked.
+  //
+  // `mounted` guard prevents `beforeUpdate` from firing a redundant
+  // load on the pre-mount tick (it runs before onMount on initial
+  // render). `lastEventId` tracks the id we currently hold a sub
+  // against so we only react to real id changes, not to any other
+  // reactive update this component consumes.
+  let mounted = false;
+  let lastEventId: string | null = null;
+
   onMount(() => {
-    loadReactions();
+    mounted = true;
+    lastEventId = event?.id ?? null;
+    if (lastEventId) loadReactions();
   });
 
-  onDestroy(() => {
-    if (subscription) {
-      subscription.stop();
+  beforeUpdate(() => {
+    if (!mounted) return;
+    const newId = event?.id ?? null;
+    if (newId && newId !== lastEventId) {
+      subscription?.stop();
+      lastEventId = newId;
+      loadReactions();
     }
   });
 
-  $: if (event?.id) {
-    loadReactions();
-  }
+  onDestroy(() => {
+    subscription?.stop();
+  });
 </script>
 
 <div class="flex items-center gap-1">

--- a/src/components/Reactions/ReactionButton.svelte
+++ b/src/components/Reactions/ReactionButton.svelte
@@ -29,6 +29,16 @@
   let processedIds = new Set<string>();
   let buttonEl: HTMLButtonElement;
 
+  // Monotonically-increasing token used by loadReactions to cancel work
+  // started against a stale event.id. Each call captures the current
+  // value, and mutations / subscriptions after any await check against
+  // `currentLoadToken` — if the token has advanced, a newer call owns
+  // this component's state and the older call bails. Without this, an
+  // in-flight fetchCount could resolve after the event prop changed,
+  // overwrite `subscription` with a subscription to the stale id, and
+  // leak the newer call's subscription.
+  let currentLoadToken = 0;
+
   function getFilter() {
     if (targetType === 'recipe') {
       const dTag = event.tags.find((t) => t[0] === 'd')?.[1];
@@ -52,6 +62,12 @@
   async function loadReactions() {
     if (!event?.id) return;
 
+    // Claim the latest load slot. Every mutation / subscription below
+    // guards against `myToken !== currentLoadToken` — if a later
+    // `loadReactions()` overtakes us mid-await, we drop our partial
+    // work and the newer call owns the component's state.
+    const myToken = ++currentLoadToken;
+
     loading = true;
     reactionEvents = [];
     processedIds.clear();
@@ -64,7 +80,10 @@
         { kinds: filter.kinds, ...('#a' in filter ? { '#a': filter['#a'] } : { '#e': filter['#e'] }) },
         { timeout: 2000 }
       );
-      
+
+      // Post-await check: abort if a newer loadReactions has started.
+      if (myToken !== currentLoadToken) return;
+
       if (countResult && countResult.count > 0) {
         // Show fast count immediately (just total, no breakdown)
         reactions = {
@@ -78,12 +97,27 @@
       // Fast count failed, subscription will provide data
     }
 
+    // Second gate before any subscription work — the catch above may
+    // have swallowed the await, so re-check here too.
+    if (myToken !== currentLoadToken) return;
+
     // FULL PATH: Subscribe for detailed breakdown + user reactions
     try {
       const filter = getFilter();
-      subscription = $ndk.subscribe(filter);
+      const newSub = $ndk.subscribe(filter);
+
+      // NDK subscribe is synchronous but the filter build above may
+      // have raced too; final check before we hand ownership over.
+      // If we lost the race, stop the just-created sub immediately so
+      // it doesn't leak.
+      if (myToken !== currentLoadToken) {
+        newSub.stop();
+        return;
+      }
+      subscription = newSub;
 
       subscription.on('event', (e: NDKEvent) => {
+        if (myToken !== currentLoadToken) return;
         if (!e.id || processedIds.has(e.id)) return;
         processedIds.add(e.id);
         reactionEvents = [...reactionEvents, e];
@@ -92,6 +126,7 @@
       });
 
       subscription.on('eose', () => {
+        if (myToken !== currentLoadToken) return;
         loading = false;
       });
     } catch (error) {

--- a/src/components/Reactions/ReactionTrigger.svelte
+++ b/src/components/Reactions/ReactionTrigger.svelte
@@ -4,7 +4,13 @@
   import type { NDKEvent } from '@nostr-dev-kit/ndk';
   import type { TargetType } from '$lib/types/reactions';
   import { publishReaction, canPublishReaction } from '$lib/reactions/publishReaction';
-  import { getEngagementStore, fetchEngagement } from '$lib/engagementCache';
+  import {
+    getEngagementStore,
+    fetchEngagement,
+    markEventAsProcessed,
+    trackOptimisticReaction,
+    clearOptimisticReaction
+  } from '$lib/engagementCache';
   import EmojiReactionPicker from './EmojiReactionPicker.svelte';
   import FullEmojiPicker from './FullEmojiPicker.svelte';
   import HeartIcon from 'phosphor-svelte/lib/Heart';
@@ -52,6 +58,16 @@
     const wasReacted = $store.reactions.userReactions.has(emoji);
 
     if (!wasReacted) {
+      // Register the pending reaction with engagementCache BEFORE the
+      // optimistic store update, and before any await. When the relay
+      // echoes the just-published event back through the shared
+      // subscription, processReaction will find this entry via
+      // `optimisticReactions.has(...)` and skip its own `count++`,
+      // leaving only the optimistic +1 that happens below. Without this
+      // pre-registration the echo double-counts. Matches the pattern
+      // already used by ReactionPills.svelte.
+      trackOptimisticReaction(event.id, emoji, $userPublickey);
+
       // Optimistic update
       store.update((s) => {
         const updated = { ...s };
@@ -80,8 +96,17 @@
         targetType
       });
 
-      if (!result?.id) {
-        // Revert on failure
+      if (result?.id) {
+        // Secondary protection — also mark by event id so the subscription's
+        // `processed.has(event.id)` short-circuit fires first, covering the
+        // case where content normalization drift (e.g. `+` vs `❤️` mapping)
+        // would make the optimistic-emoji key miss.
+        markEventAsProcessed(event.id, result.id);
+      } else {
+        // Publish failed — clear the optimistic tracking so a retry can
+        // re-register cleanly, and roll back the optimistic store update.
+        clearOptimisticReaction(event.id, emoji, $userPublickey);
+
         store.update((s) => {
           const updated = { ...s };
           updated.reactions.userReactions.delete(emoji);

--- a/src/components/Recipe/TotalComments.svelte
+++ b/src/components/Recipe/TotalComments.svelte
@@ -44,8 +44,17 @@
     const filter = createCommentFilter(event);
     subscription = $ndk.subscribe(filter, { closeOnEose: true });
 
+    // Dedup by event id. The NDK subscription pool fans the same event
+    // in from every connected relay that holds it; without this Set
+    // we'd `eventCount++` once per arrival, inflating the recipe
+    // comment count to roughly `N_comments * N_relays`. The shared
+    // createCommentSubscription in $lib/comments/subscription.ts uses
+    // the same pattern — this component is the outlier.
+    const processedIds = new Set<string>();
     let eventCount = 0;
-    subscription.on('event', () => {
+    subscription.on('event', (ev: NDKEvent) => {
+      if (!ev.id || processedIds.has(ev.id)) return;
+      processedIds.add(ev.id);
       eventCount++;
       // Only update if:
       // - We didn't get a fast count, OR

--- a/src/components/comments/CommentCard.svelte
+++ b/src/components/comments/CommentCard.svelte
@@ -225,21 +225,43 @@
   async function toggleLike() {
     if (liked || !$userPublickey) return;
 
+    const reactionEvent = new NDKEvent($ndk);
+    reactionEvent.kind = 7;
+    reactionEvent.content = '+';
+    reactionEvent.tags = [
+      ['e', event.id, '', 'reply'],
+      ['p', event.pubkey]
+    ];
+    addClientTagToEvent(reactionEvent);
+
+    // Sign first so we have the event id, then register it in the
+    // component's `processedLikes` Set BEFORE the publish await. The
+    // subscription echo of our own reaction can arrive synchronously
+    // once the relay receives it; without the pre-registration, the
+    // echo passes the `processedLikes.has(e.id)` guard on line 206,
+    // runs its own `likeCount++` on line 209, and the post-publish
+    // `likeCount++` below brings the total to +2.
     try {
-      const reactionEvent = new NDKEvent($ndk);
-      reactionEvent.kind = 7;
-      reactionEvent.content = '+';
-      reactionEvent.tags = [
-        ['e', event.id, '', 'reply'],
-        ['p', event.pubkey]
-      ];
-      addClientTagToEvent(reactionEvent);
-      await reactionEvent.publish();
-      liked = true;
-      likeCount++;
+      await reactionEvent.sign();
     } catch {
-      // Failed to like — swallow. Reactions never surface errors to the user
-      // in this app; only comment-post errors do (via ReplyComposer's toast).
+      return;
+    }
+    if (!reactionEvent.id) return;
+    processedLikes.add(reactionEvent.id);
+
+    // Optimistic UI — bump before publish resolves so the click
+    // feels instant. Revert in the catch if publish fails.
+    likeCount++;
+    liked = true;
+
+    try {
+      await reactionEvent.publish();
+    } catch {
+      // Rollback both the optimistic count AND the dedup sentinel so a
+      // retry can register cleanly under the same event id.
+      processedLikes.delete(reactionEvent.id);
+      likeCount--;
+      liked = false;
     }
   }
 


### PR DESCRIPTION
## Summary

Three reaction-count bugs + one recipe-comment-count bug, each in a shared component so a single fix covers both feed and recipe contexts. Published kind-7 / kind-1111 event bytes are **unchanged** — these are all read-side dedup fixes. Other clients already render the correct counts from our events.

**Not in this PR:** feed comment-count doubling. Phase 1's code-read said the feed path dedupes correctly via `engagementCache.processedEventIds`, but empirical observation contradicts that. A separate branch (`fix/feed-comment-count-dedup`) carries temporary fingerprint-5 instrumentation to let us capture the actual behaviour; the fix will ship as a follow-up PR once the fingerprint lands.

## What each commit does

### `2237aaf` — `fix(ReactionTrigger)`: register optimistic dedup before publish

**Bug:** Main like button (heart icon on both feed and recipe pages) incremented the local count by +2 on click. Other clients saw +1.

**Root cause:** `ReactionTrigger.handleReaction()` did the optimistic `store.update(count++)` then `await publishReaction(...)`, but never called `trackOptimisticReaction(...)` or `markEventAsProcessed(...)` on `engagementCache`. The relay echo of the user's own reaction came back through the shared persistent subscription, entered `processReaction`, found no `optimisticReactions` entry (never registered), passed the `processedReactionPairs` first-time gate, and ran `data.reactions.count++` a second time.

**Fix:** Matches the pattern already used by `ReactionPills.svelte`:
1. `trackOptimisticReaction(event.id, emoji, userPublickey)` synchronously, before any `await`.
2. Optimistic `store.update(count++)` (unchanged).
3. `await publishReaction(...)`.
4. On success with signed id: `markEventAsProcessed(event.id, result.id)` as secondary protection against emoji-normalization drift.
5. On failure: `clearOptimisticReaction(...)` + revert the optimistic store update.

**Scope:** `ReactionTrigger` is rendered by both `NoteTotalLikes` (feed) and `Recipe/TotalLikes` (recipe) — single change, both contexts fixed.

### `5498cb2` — `fix(CommentCard)`: add processedLikes before publish

**Bug:** Per-comment like button (inside any `CommentThread`) incremented `likeCount` by +2 on click. Classic Fingerprint A.

**Root cause:** `toggleLike()` published then incremented without registering the event id in `processedLikes` beforehand. The subscription's `on('event')` handler on line 205-211 saw the echo first, passed `processedLikes.has(e.id)` (false — never added), and ran its own `likeCount++`; then the post-publish `likeCount++` ran on top.

**Fix:** Sign first to obtain `.id`, `processedLikes.add(reactionEvent.id)` synchronously before publish, optimistic `likeCount++` and `liked = true`, then publish. Catch reverts all three (including `processedLikes.delete(id)` so retries re-register cleanly).

**Scope:** `CommentCard` renders in both recipe and feed `CommentThread` variants — single change, both contexts fixed.

### `de51ddd` — `fix(ReactionButton)`: consolidate subscription lifecycle to onMount

**Bug:** `ReactionButton.svelte` had both `onMount(loadReactions)` and a reactive `$: if (event?.id) loadReactions()` firing on first mount, leaking a subscription per mount.

**Root cause:** Reactive `$:` blocks fire whenever *any* reactive dependency ticks, not only on the watched identifier change. Each fire created a new `$ndk.subscribe(...)`, reassigned the `subscription` variable, and left the previous one open. `onDestroy` only stopped the latest reference.

**Fix:** Remove the reactive `$:`. Keep `onMount` as the single mount-time subscribe; use `beforeUpdate` + `mounted` guard + `lastEventId` tracking to re-subscribe *only* when the `event.id` prop actually changes post-mount.

**Defensive scope:** Note in the commit — `ReactionButton.svelte` is currently unreferenced (zero `<ReactionButton` usages in the tree). The fix costs nothing and keeps the file correct if anyone rewires it; if the intention is to delete the file outright, this patch doesn't block that decision.

### `8c64d90` — `fix(Recipe/TotalComments)`: dedup by event id to stop multi-relay inflation

**Bug:** Recipe comment count inflated to 2–5× the true value on page load. Other clients showed the correct count.

**Root cause:** `TotalComments.svelte` ran a standalone subscription (separate from `createCommentSubscription`) and counted with `eventCount++` per `on('event')` callback. No dedup. NDK's subscription pool delivers the same event once per relay that holds it, so one real kind-1111 NIP-22 comment with 5 relays reporting it landed `eventCount = 5`. The handler didn't even destructure `event` from the callback — literally could not dedupe as written.

**Fix:** Instance-local `processedIds = new Set<string>()` inside the `onMount` closure (tied to subscription lifetime, not module-scoped). Guard with `.has(ev.id)` before `eventCount++`. Mirrors the pattern already in `$lib/comments/subscription.ts`; `TotalComments` was the outlier.

**Scope:** Only kind-30023 recipe pages render `TotalComments`. Feed-note comment counts flow through `NoteTotalComments` → `engagementCache` which handles dedup differently (and has a separate doubling bug — see below).

## Verification

For each fix, ran `pnpm exec eslint` on the touched file immediately after editing. All errors surfaced in each file (mostly pre-existing `any` types in helper functions) were present on `main` already — zero new errors introduced by this PR.

`pnpm check` → 4 errors (baseline preserved; same pre-existing failures in `kitchens.ts`, `nourishDiscovery.ts`, `FoodstrFeedOptimized.svelte`).

**Event shape unchanged:** for each fix, the code constructing `reactionEvent.tags` / `reactionEvent.content` is identical to `main`. Confirmed via `git diff main -- <file>` inspection during each commit.

## Test plan

Per-bug, in order:

### ReactionTrigger (`2237aaf`)

- [ ] Open a kind-1 feed note → click the heart/react → pick an emoji → count increments by exactly 1.
- [ ] Reload → count stays at the new value.
- [ ] Repeat on a kind-30023 recipe (same component via `Recipe/TotalLikes`) → same single-increment.
- [ ] Cross-client: open the same note in Primal or Nostrudel → reaction count matches.
- [ ] Rollback: force `publishReaction` to fail (e.g. offline) → UI reverts the count, `userReactions.delete(emoji)` runs, retry works cleanly.

### CommentCard (`5498cb2`)

- [ ] Click the heart on any comment inside a thread → like count +1, not +2.
- [ ] Reload → still +1.
- [ ] Rollback: force `reactionEvent.publish()` to fail → `likeCount--`, `liked = false`, next click re-registers and works.

### ReactionButton (`de51ddd`)

- [ ] Not live in the app — no behavioural test. Verify via `pnpm exec eslint src/components/Reactions/ReactionButton.svelte` (pre-existing `fastCountLoaded` unused-var is the only error; no new ones).

### Recipe/TotalComments (`8c64d90`)

- [ ] Post a comment on a recipe → reload the recipe page → count goes to N+1, not N+k where k = number of relays holding the comment.
- [ ] Cross-client check against Primal.
- [ ] Repeat on a recipe that already had several comments from other users → count stays accurate.

### Cross-bug

- [ ] `pnpm run check` and `pnpm run build` both pass.
- [ ] Click like 10× in a row on a single post → count increments by exactly 10, not 20.

## Known follow-up (out of scope for this PR)

- **Feed comment-count doubling** — real user-visible bug; Phase 1's code-read flagged the feed path as clean but empirical repro shows it's not. Temporary fingerprint-5 instrumentation lives on `fix/feed-comment-count-dedup` (commit `0a35d70`). Once the console logs are captured and the fingerprint matched (F5-A through F5-E — see that commit's message), a targeted fix lands as a follow-up PR, and the instrumentation commit gets reverted as the last step of that PR.
- **`ReactionButton.svelte` dead code** — either delete outright or wait until a future feature rewires it; either decision is safe after this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)