### PR TITLE
fix(recent): skeleton stuck on client-side nav from other tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.275",
+  "version": "4.2.276",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.274",
+  "version": "4.2.275",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/routes/recent/+page.svelte
+++ b/src/routes/recent/+page.svelte
@@ -14,6 +14,11 @@
   // Pull-to-refresh refs
   let pullToRefreshEl: PullToRefresh;
   let subscription: NDKSubscription | null = null;
+  // Tracked so a new loadRecipes() (e.g. pull-to-refresh) or onDestroy can
+  // cancel a pending safety timeout. Without this, a stale timeout from the
+  // previous load fires during the next load while `loaded` is still false
+  // after the reset and forces `loaded=true` prematurely.
+  let loadTimeout: ReturnType<typeof setTimeout> | null = null;
 
   type TabType = 'recent';
   let activeTab: TabType = 'recent';
@@ -30,6 +35,13 @@
 
   async function loadRecipes(skipCache = false) {
     const perfStart = performance.now();
+
+    // Cancel any pending safety timeout from a prior load so it can't fire
+    // during this load's `loaded=false` reset window and flip the flag early.
+    if (loadTimeout) {
+      clearTimeout(loadTimeout);
+      loadTimeout = null;
+    }
 
     // Capture relay generation at start to detect stale data from relay switches
     const startGeneration = getCurrentRelayGeneration();
@@ -141,7 +153,10 @@
       // reached us. Prevents a stuck skeleton when SvelteKit nav lands on
       // /recent and NDK's cache replay emits before handlers can attach,
       // or when EOSE is otherwise delayed. Mirrors /polls' timeout pattern.
-      setTimeout(() => {
+      // Tracked in `loadTimeout` so a subsequent loadRecipes() call or
+      // onDestroy can cancel it.
+      loadTimeout = setTimeout(() => {
+        loadTimeout = null;
         if (!loaded) {
           console.warn(`[Recent] Load timeout after 10s with ${fetchedEvents.length} events, forcing loaded=true`);
           loaded = true;
@@ -174,6 +189,12 @@
     if (subscription) {
       subscription.stop();
       subscription = null;
+    }
+    // Cancel a pending safety timeout so it can't fire on a destroyed
+    // component and log a spurious warn.
+    if (loadTimeout) {
+      clearTimeout(loadTimeout);
+      loadTimeout = null;
     }
   });
 </script>

--- a/src/routes/recent/+page.svelte
+++ b/src/routes/recent/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ndk, userPublickey, getCurrentRelayGeneration } from '$lib/nostr';
+  import { ndk, userPublickey, getCurrentRelayGeneration, ensureNdkConnected } from '$lib/nostr';
   import type { NDKEvent, NDKFilter, NDKSubscription } from '@nostr-dev-kit/ndk';
   import { onMount, onDestroy } from 'svelte';
   import Feed from '../../components/Feed.svelte';
@@ -30,11 +30,20 @@
 
   async function loadRecipes(skipCache = false) {
     const perfStart = performance.now();
-    
+
     // Capture relay generation at start to detect stale data from relay switches
     const startGeneration = getCurrentRelayGeneration();
-    
+
     try {
+      // Wait for NDK to connect before subscribing. Mirrors /polls' pattern.
+      // On SvelteKit client-side nav from another tab, NDK may already be
+      // connected — this is a near no-op in that case.
+      try {
+        await ensureNdkConnected();
+      } catch {
+        console.warn('[Recent] NDK connection timed out, trying anyway');
+      }
+
       if (!$ndk) {
         console.warn('NDK not available, skipping subscription');
         loaded = true;
@@ -92,9 +101,13 @@
         if (validateMarkdownTemplate(event.content) !== null) {
           fetchedEvents.push(event);
           events = [...fetchedEvents];
-          
-          // Show content early after first batch (progressive loading)
-          if (fetchedEvents.length >= 12 && !loaded) {
+
+          // Progressive paint on FIRST valid event (was: >= 12). The old
+          // threshold left the page stuck on skeleton if fewer than 12
+          // recipes arrived before EOSE, or if EOSE fired during NDK's
+          // cache-replay window and was lost to the race with handler
+          // attach on SvelteKit client-side nav.
+          if (!loaded) {
             loaded = true;
             console.log(`🚀 First paint: ${fetchedEvents.length} recipes in ${(performance.now() - perfStart).toFixed(0)}ms`);
           }
@@ -107,10 +120,10 @@
           console.log('🚫 Relay changed during fetch, discarding results');
           return;
         }
-        
+
         loaded = true;
         console.log(`📡 Network load complete: ${fetchedEvents.length} recipes in ${(performance.now() - perfStart).toFixed(0)}ms`);
-        
+
         // Cache the fetched events for next time
         if (fetchedEvents.length > 0) {
           try {
@@ -123,6 +136,17 @@
           }
         }
       });
+
+      // Safety timeout: flip loaded after 10s if neither an event nor EOSE
+      // reached us. Prevents a stuck skeleton when SvelteKit nav lands on
+      // /recent and NDK's cache replay emits before handlers can attach,
+      // or when EOSE is otherwise delayed. Mirrors /polls' timeout pattern.
+      setTimeout(() => {
+        if (!loaded) {
+          console.warn(`[Recent] Load timeout after 10s with ${fetchedEvents.length} events, forcing loaded=true`);
+          loaded = true;
+        }
+      }, 10000);
 
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
## The bug
Clicking into `/recent` from any other tab (`/polls`, `/marketplace`, etc.) leaves the page showing skeleton placeholders indefinitely. Only Cmd+R reload recovers — and does so in 1-2 seconds, confirming the relays have the data. Navigating back via the browser back button has the same symptom.

## Root cause
Three cooperating factors in `loadRecipes()` in `src/routes/recent/+page.svelte`:

1. **No wait for NDK connection.** SvelteKit-nav can land on `/recent` while the NDK pool is mid-reconnect. `/polls` already does `await ensureNdkConnected()` for this reason.
2. **Progressive paint gated at >= 12 valid recipes.** If the first batch returned fewer than 12 and EOSE was lost or delayed, `loaded` never flipped.
3. **No safety timeout.** On repeat subscribes for the same filter, NDK 2.x's `startWithCache` path can fire EOSE synchronously during `subscribe()` — before `.on('eose', ...)` is attached on the following line. The handler misses it, and with no timeout there's no recovery. `/polls` has a 15s safety timeout for this.

Seth's diagnostic: Cmd+R reload (fresh NDK instance, empty dexie cache) works in 1-2s. SvelteKit nav (reused NDK instance with dexie cache populated by other tabs) hangs. That's the fingerprint of a cache-replay-vs-handler-attach race, and/or a progressive-paint threshold that didn't get met.

## Fix
Adopt the `/polls` pattern on all three points:

- `await ensureNdkConnected()` at the top of `loadRecipes()`, wrapped in try/catch so a connection timeout doesn't abort the function.
- Flip `loaded = true` on the **first** valid event instead of the 12th. Earlier paint also improves perceived perf on cold loads.
- **10s safety `setTimeout`** that forces `loaded = true` if neither an event nor EOSE ever arrived. Logs a warn so the cause is visible if it fires.

No changes to the NDK subscription lifecycle, cache layer, or relay-generation gating. The subscribe-then-attach pattern is unchanged — we're just making the component resilient to timing it can't directly control.

## Verification
- [x] \`pnpm exec eslint src/routes/recent/+page.svelte\` — clean.
- [x] \`pnpm check\` — 4 errors (baseline preserved; all in pre-existing files).
- [ ] **Seth on CF Pages preview**:
  - Navigate \`/polls → /recent\` — page loads without Cmd+R.
  - Navigate \`/marketplace → /recent\` — same.
  - Browser back from a recipe detail page to \`/recent\` — same.
  - Cmd+R on \`/recent\` still loads fast (no regression on the already-working path).
  - If the 10s safety timeout fires, console shows \`[Recent] Load timeout after 10s…\` — that's a fingerprint we'd want to see if there are still edge cases.

## Out of scope
- Hardening the underlying NDK cache-replay race (would require patching NDK subscription options or rewriting to `fetchEvents`). The three component-level changes here are sufficient to eliminate the user-visible symptom.
- Similar patterns elsewhere — \`/reads\`, \`/premium\`, \`[nip19]\` also use \`ndk.subscribe\` + \`feedCacheService\`. If they exhibit the same bug, the same three-change fix applies. Not touching them in this PR to keep scope tight to the reported symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)