### PR TITLE
fix(publishQueue): 15s timeout on event.sign() to unstick silent signer hangs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.276",
+  "version": "4.2.277",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/publishQueue.ts
+++ b/src/lib/publishQueue.ts
@@ -27,6 +27,12 @@ const INITIAL_RETRY_DELAY = 2000; // 2 seconds
 const MAX_RETRY_DELAY = 30000; // 30 seconds
 const PUBLISH_TIMEOUT = 10000; // 10 seconds per relay
 const STALE_ITEM_AGE = 30 * 60 * 1000; // 30 minutes - auto-cleanup stale items
+// Safety cap on `event.sign()`. Some NIP-07 signers (notably Alby when a per-
+// origin permission has been denied) silently drop sign requests — the Promise
+// from window.nostr.signEvent never resolves or rejects, wedging any await
+// chain that waits on it. 15s is wide enough for a hardware-signer approval
+// tap or a NIP-46 bunker round-trip, tight enough to unstick the UI fast.
+const SIGN_TIMEOUT = 15000;
 
 /**
  * Represents a pending publish operation
@@ -427,7 +433,23 @@ class PublishQueueManager {
     // Sign the event if not already signed
     if (!event.sig) {
       console.log('[PublishQueue] Signing event...');
-      await event.sign();
+      const signTimeoutPromise = new Promise<never>((_, reject) => {
+        setTimeout(() => {
+          reject(
+            new Error(
+              `Signer did not respond within ${SIGN_TIMEOUT}ms. If you use Alby, check per-site permissions for this origin — Alby can silently drop sign requests for denied origins.`
+            )
+          );
+        }, SIGN_TIMEOUT);
+      });
+      try {
+        await Promise.race([event.sign(), signTimeoutPromise]);
+        console.log('[PublishQueue] Signed, proceeding to publish');
+      } catch (signError) {
+        const msg = signError instanceof Error ? signError.message : String(signError);
+        console.error('[PublishQueue] Signing failed:', msg);
+        throw signError;
+      }
     }
 
     console.log(`[PublishQueue] Publishing event (kind ${event.kind}) with mode: ${relayMode}`);


### PR DESCRIPTION
## The bug
Clicking vote on a `/polls` poll left the button stuck on "Voting..." indefinitely. The vote checkbox appeared on the selected option, but results never displayed and the button never re-enabled. The mobile app works fine — this was specific to the web signer permission state.

## Root cause
NIP-07 signers can silently drop sign requests. Seth confirmed this is Alby with a per-origin permission denied — `window.nostr.signEvent` returns a Promise that resolves neither success nor error, leaving \`await event.sign()\` blocked forever.

Walking through the logs:
- \`[PublishQueue] Ensuring NDK connection...\` ✓
- \`[PublishQueue] Signing event...\` ✓
- \`[PublishQueue] Publishing event (kind N) with mode: all\` ✗ **never**
- \`[PublishQueue] ✅ Published\` / \`❌ Publish failed\` ✗ **never**
- \`[PublishQueue] Initial publish failed:\` ✗ **never**

The only await between the "Signing event..." log and the next expected log is \`event.sign()\`. That's the wedge. Downstream: \`attemptPublish\` never returns → \`publishWithRetry\` never returns → \`PollDisplay.submitVote\`'s \`await\` never resolves → the finally block that sets \`voting = false\` never runs → button stuck.

## Fix
Race \`event.sign()\` against a 15s timeout. If the signer doesn't respond in that window, reject with a descriptive error that names Alby's per-origin-permission behavior directly. The error propagates up through \`attemptPublish\` → \`publishWithRetry\`'s existing catch, which queues the item for retry and returns to the caller. The caller's \`await\` resolves, \`voting = false\` fires in the \`PollDisplay\` finally, and the UI unsticks.

Also adds two log lines around the sign call so future repros of this class of bug are instantly diagnosable:
- \`[PublishQueue] Signed, proceeding to publish\` — confirms sign returned successfully.
- \`[PublishQueue] Signing failed: <msg>\` — surfaces the sign error without requiring the caller to log it.

**15s is wide enough** for hardware-signer user-approval taps and NIP-46 bunker round-trips, **tight enough** to unstick a wedged UI fast.

## Scope
This is a defensive UX fix, not a root-cause fix. The underlying problem — that Alby silently denies origins with no callback — is upstream of this codebase. The right action for an affected user is to open Alby and grant permission for the site origin. This PR ensures the client never wedges its UI waiting on a signer that will never respond, regardless of which signer is involved.

Not touched: the optimistic "set \`voted = true\` on queued-but-not-yet-published" behavior in \`PollDisplay.submitVote\`. That's a separate UX question about whether queued-publish should show as voted immediately.

## Verification
- [x] \`pnpm exec eslint src/lib/publishQueue.ts\` — 6 pre-existing \`any\` errors in the file, unchanged.
- [x] \`pnpm check\` — 4 pre-existing errors in other files, unchanged.
- [ ] **Seth on CF Pages preview**:
  - Deny Alby permission for the site origin, click vote on a poll. Expected: within ~15s the button transitions from "Voting..." back to "Vote", and the console shows \`[PublishQueue] Signing failed: Signer did not respond within 15000ms. If you use Alby...\`.
  - Grant Alby permission, click vote. Expected: normal vote flow — button unsticks immediately on successful publish, results display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)