### PR TITLE
fix(composer): mobile mention dropdown position + pill caret placement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.276",
+  "version": "4.2.277",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.277",
+  "version": "4.2.279",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/MentionDropdown.svelte
+++ b/src/components/MentionDropdown.svelte
@@ -1,7 +1,7 @@
 <script context="module" lang="ts">
-	// Portal action — mounts the node directly to document.body so the
-	// dropdown's position:fixed is viewport-relative (otherwise a
-	// transform on the containing modal would scope it to the modal box).
+	// Portal the node to document.body so the dropdown's positioning is
+	// document-relative (otherwise a transform on a containing modal
+	// would scope it to the modal box).
 	function portal(node: HTMLElement) {
 		document.body.appendChild(node);
 		return {
@@ -15,7 +15,7 @@
 </script>
 
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte';
+	import { createEventDispatcher, onMount, tick } from 'svelte';
 	import CustomAvatar from './CustomAvatar.svelte';
 	import type { MentionSuggestion } from '$lib/mentionComposer';
 
@@ -27,34 +27,107 @@
 
 	const dispatch = createEventDispatcher<{ select: MentionSuggestion }>();
 
-	// Capture caret viewport position when dropdown opens
 	let fixedTop = 0;
 	let fixedLeft = 0;
+	let fixedMaxHeight = 240;
+	let dropdownEl: HTMLDivElement;
 
-	$: if (show) {
+	const GAP = 4;
+	const MARGIN = 8;
+	const DEFAULT_WIDTH = 280;
+
+	function computePosition() {
+		if (!show || !dropdownEl) return;
 		const sel = window.getSelection();
-		if (sel && sel.rangeCount) {
-			const rect = sel.getRangeAt(0).getBoundingClientRect();
-			if (rect.height > 0) {
-				fixedTop = rect.bottom + 4;
-				fixedLeft = rect.left;
-			} else {
-				const parentRect = sel.anchorNode?.parentElement?.getBoundingClientRect();
-				fixedTop = (parentRect?.bottom ?? 0) + 4;
-				fixedLeft = parentRect?.left ?? 0;
-			}
+		if (!sel || !sel.rangeCount) return;
+
+		let caretRect: DOMRect | { top: number; bottom: number; left: number; height: number } =
+			sel.getRangeAt(0).getBoundingClientRect();
+		if (caretRect.height === 0) {
+			const parentRect = (
+				sel.anchorNode?.parentElement as HTMLElement | undefined
+			)?.getBoundingClientRect();
+			if (!parentRect) return;
+			caretRect = parentRect;
 		}
+
+		const vv = window.visualViewport;
+		const vpTop = vv?.offsetTop ?? 0;
+		const vpLeft = vv?.offsetLeft ?? 0;
+		const vpHeight = vv?.height ?? window.innerHeight;
+		const vpWidth = vv?.width ?? window.innerWidth;
+		const vpBottom = vpTop + vpHeight;
+		const vpRight = vpLeft + vpWidth;
+
+		const anchorBottom = caretRect.bottom;
+		const anchorLeft = caretRect.left;
+
+		const width = dropdownEl.offsetWidth || DEFAULT_WIDTH;
+
+		const spaceBelow = vpBottom - anchorBottom - GAP - MARGIN;
+		const layoutTop = anchorBottom + GAP;
+		const available = Math.max(120, spaceBelow);
+
+		let layoutLeft = anchorLeft;
+		if (layoutLeft + width > vpRight - MARGIN) {
+			layoutLeft = vpRight - width - MARGIN;
+		}
+		if (layoutLeft < vpLeft + MARGIN) {
+			layoutLeft = vpLeft + MARGIN;
+		}
+
+		// Document-relative coords. iOS Safari with the keyboard open
+		// scrolls the page (window.scrollY > 0) and treats position:fixed
+		// like position:absolute, so standardizing on absolute + scrollY
+		// offset gives consistent positioning on every platform. scrollY
+		// is 0 on desktop / Android / emulated mobile.
+		fixedTop = layoutTop + window.scrollY;
+		fixedLeft = layoutLeft + window.scrollX;
+		fixedMaxHeight = available;
 	}
+
+	async function schedulePosition() {
+		await tick();
+		computePosition();
+	}
+
+	// Recompute when dropdown opens or its size changes (new suggestions,
+	// searching indicator, etc.) — each of these can grow/shrink the
+	// dropdown and change whether "below" still fits.
+	$: if (show) {
+		void suggestions;
+		void searching;
+		void query;
+		schedulePosition();
+	}
+
+	onMount(() => {
+		const handler = () => {
+			if (show) computePosition();
+		};
+		window.addEventListener('resize', handler);
+		window.visualViewport?.addEventListener('resize', handler);
+		window.visualViewport?.addEventListener('scroll', handler);
+		return () => {
+			window.removeEventListener('resize', handler);
+			window.visualViewport?.removeEventListener('resize', handler);
+			window.visualViewport?.removeEventListener('scroll', handler);
+		};
+	});
 </script>
 
 {#if show}
 	<div
+		bind:this={dropdownEl}
 		use:portal
 		class="mention-dropdown"
-		style="border-color: var(--color-input-border); top: {fixedTop}px; left: {fixedLeft}px;"
+		style="border-color: var(--color-input-border); top: {fixedTop}px; left: {fixedLeft}px; max-height: {fixedMaxHeight}px;"
 	>
 		{#if suggestions.length > 0}
-			<div class="mention-dropdown-content">
+			<div
+				class="mention-dropdown-content"
+				style="max-height: {Math.max(80, fixedMaxHeight - 8)}px;"
+			>
 				{#each suggestions as suggestion, index}
 					<button
 						type="button"
@@ -84,7 +157,7 @@
 <style>
 	/* PR #143 fix #3: z-index 50 -> 1000 */
 	.mention-dropdown {
-		position: fixed;
+		position: absolute;
 		z-index: 1000;
 		width: 280px;
 		max-width: calc(100vw - 2rem);

--- a/src/lib/mentionComposer.ts
+++ b/src/lib/mentionComposer.ts
@@ -50,21 +50,38 @@ type TextChangeCallback = (text: string) => void;
 // Uses [^@] instead of [^\s@] to allow spaces in names (PR #143 fix #1).
 const MENTION_TRIGGER_REGEX = /@([^@]*)$/;
 
-// A text node is "ZWSP-only" when it contains only zero-width spaces. Those
-// nodes are inserted around mention pills as caret-landing spacers so the
-// selection has somewhere to sit on either side of the contenteditable=false
-// pill. They're invisible to the user and stripped on content extraction.
+// Zero-width space (U+200B). Inserted around mention pills as caret-landing
+// spacers so the selection has somewhere to sit on either side of the
+// contenteditable=false pill. Invisible to the user and stripped on content
+// extraction (htmlToPlainText). Use the named constant rather than the literal
+// character so it stays visible to reviewers and survives formatters.
+const ZWSP = '\u200B';
+const ZWSP_REGEX = /\u200B/g;
+
 function isZwspOnlyText(node: Node | null): node is Text {
 	if (!node || node.nodeType !== Node.TEXT_NODE) return false;
 	const value = (node as Text).nodeValue ?? '';
-	return value.length > 0 && value.replace(/​/g, '').length === 0;
+	return value.length > 0 && value.replace(ZWSP_REGEX, '').length === 0;
+}
+
+// When two pills are adjacent, the HTML parser can coalesce their facing
+// ZWSP spacers into a single text node holding multiple ZWSPs. Removing
+// the whole node would strip the neighbor pill's caret landing spot too,
+// so trim down to one ZWSP if more remain after this pill is gone.
+function trimOrRemoveZwspText(node: Text): void {
+	const value = node.nodeValue ?? '';
+	if (value.length > 1) {
+		node.nodeValue = ZWSP;
+		return;
+	}
+	node.remove();
 }
 
 function removePillWithZwsps(pill: HTMLElement): void {
 	const before = pill.previousSibling;
 	const after = pill.nextSibling;
-	if (isZwspOnlyText(before)) before.remove();
-	if (isZwspOnlyText(after)) after.remove();
+	if (isZwspOnlyText(before)) trimOrRemoveZwspText(before);
+	if (isZwspOnlyText(after)) trimOrRemoveZwspText(after);
 	pill.remove();
 }
 
@@ -173,7 +190,7 @@ export class MentionComposerController {
 					const textNode = startContainer as Text;
 					const value = textNode.nodeValue ?? '';
 					const afterCursor = value.slice(startOffset);
-					if (afterCursor.replace(/​/g, '').length === 0) {
+					if (afterCursor.replace(ZWSP_REGEX, '').length === 0) {
 						let next: Node | null = textNode.nextSibling;
 						if (isZwspOnlyText(next)) next = next.nextSibling;
 						if (
@@ -222,7 +239,7 @@ export class MentionComposerController {
 						const textNode = startContainer as Text;
 						const value = textNode.nodeValue ?? '';
 						const beforeCursor = value.slice(0, startOffset);
-						if (beforeCursor.replace(/​/g, '').length === 0) {
+						if (beforeCursor.replace(ZWSP_REGEX, '').length === 0) {
 							let prev: Node | null = textNode.previousSibling;
 							if (isZwspOnlyText(prev)) prev = prev.previousSibling;
 							if (
@@ -554,13 +571,13 @@ export class MentionComposerController {
 		// both sides of the contenteditable=false span. Without them, iOS
 		// Safari renders the caret at end-of-line (far right of the input)
 		// and users can't tap before the pill to type leading text.
-		const leadingZwsp = document.createTextNode('​');
+		const leadingZwsp = document.createTextNode(ZWSP);
 		newRange.insertNode(leadingZwsp);
 		newRange.setStartAfter(leadingZwsp);
 		newRange.insertNode(pill);
 		newRange.setStartAfter(pill);
 
-		const trailingZwsp = document.createTextNode('​');
+		const trailingZwsp = document.createTextNode(ZWSP);
 		newRange.insertNode(trailingZwsp);
 		newRange.setStartAfter(trailingZwsp);
 
@@ -587,7 +604,7 @@ export class MentionComposerController {
 		const range = selection.getRangeAt(0);
 		const marker = document.createElement('span');
 		marker.dataset.mentionCaret = 'true';
-		marker.textContent = '\u200B';
+		marker.textContent = ZWSP;
 		range.insertNode(marker);
 
 		const composerEl = this.composerEl;
@@ -633,9 +650,9 @@ export class MentionComposerController {
 				const displayName = getDisplayNameForMention(mention, cache);
 				// ZWSP spacers give the caret a landing spot on either side of
 				// the contenteditable=false pill (see insertMentionNode).
-				fragment.appendChild(document.createTextNode('​'));
+				fragment.appendChild(document.createTextNode(ZWSP));
 				fragment.appendChild(createMentionPill(mention, displayName));
-				fragment.appendChild(document.createTextNode('​'));
+				fragment.appendChild(document.createTextNode(ZWSP));
 
 				lastIndex = match.index + rawMention.length;
 			}

--- a/src/lib/mentionComposer.ts
+++ b/src/lib/mentionComposer.ts
@@ -50,6 +50,24 @@ type TextChangeCallback = (text: string) => void;
 // Uses [^@] instead of [^\s@] to allow spaces in names (PR #143 fix #1).
 const MENTION_TRIGGER_REGEX = /@([^@]*)$/;
 
+// A text node is "ZWSP-only" when it contains only zero-width spaces. Those
+// nodes are inserted around mention pills as caret-landing spacers so the
+// selection has somewhere to sit on either side of the contenteditable=false
+// pill. They're invisible to the user and stripped on content extraction.
+function isZwspOnlyText(node: Node | null): node is Text {
+	if (!node || node.nodeType !== Node.TEXT_NODE) return false;
+	const value = (node as Text).nodeValue ?? '';
+	return value.length > 0 && value.replace(/​/g, '').length === 0;
+}
+
+function removePillWithZwsps(pill: HTMLElement): void {
+	const before = pill.previousSibling;
+	const after = pill.nextSibling;
+	if (isZwspOnlyText(before)) before.remove();
+	if (isZwspOnlyText(after)) after.remove();
+	pill.remove();
+}
+
 export class MentionComposerController {
 	private composerEl: HTMLDivElement | null = null;
 	private searchTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -146,20 +164,28 @@ export class MentionComposerController {
 		if (selection && selection.rangeCount) {
 			const range = selection.getRangeAt(0);
 
-			// Delete key — remove mention pill ahead of cursor
+			// Delete key — remove mention pill ahead of cursor. Treats
+			// ZWSP-only text nodes (the pill's caret-landing spacers) as
+			// transparent so one press removes the pill + its ZWSPs.
 			if (event.key === 'Delete' && range.collapsed) {
 				const { startContainer, startOffset } = range;
 				if (startContainer.nodeType === Node.TEXT_NODE) {
 					const textNode = startContainer as Text;
-					if (startOffset === textNode.length) {
-						const nextSibling = startContainer.nextSibling;
+					const value = textNode.nodeValue ?? '';
+					const afterCursor = value.slice(startOffset);
+					if (afterCursor.replace(/​/g, '').length === 0) {
+						let next: Node | null = textNode.nextSibling;
+						if (isZwspOnlyText(next)) next = next.nextSibling;
 						if (
-							nextSibling &&
-							nextSibling.nodeType === Node.ELEMENT_NODE &&
-							(nextSibling as HTMLElement).dataset.mention
+							next &&
+							next.nodeType === Node.ELEMENT_NODE &&
+							(next as HTMLElement).dataset.mention
 						) {
 							event.preventDefault();
-							nextSibling.remove();
+							if (afterCursor.length > 0) {
+								textNode.nodeValue = value.slice(0, startOffset);
+							}
+							removePillWithZwsps(next as HTMLElement);
 							this.updateContentFromComposer();
 							return true;
 						}
@@ -184,7 +210,7 @@ export class MentionComposerController {
 
 					if (mentionElement) {
 						event.preventDefault();
-						mentionElement.remove();
+						removePillWithZwsps(mentionElement);
 						this.updateContentFromComposer();
 						return true;
 					}
@@ -192,17 +218,31 @@ export class MentionComposerController {
 
 				if (range.collapsed) {
 					const { startContainer, startOffset } = range;
-					if (startContainer.nodeType === Node.TEXT_NODE && startOffset === 0) {
-						const prevSibling = startContainer.previousSibling;
-						if (
-							prevSibling &&
-							prevSibling.nodeType === Node.ELEMENT_NODE &&
-							(prevSibling as HTMLElement).dataset.mention
-						) {
-							event.preventDefault();
-							prevSibling.remove();
-							this.updateContentFromComposer();
-							return true;
+					if (startContainer.nodeType === Node.TEXT_NODE) {
+						const textNode = startContainer as Text;
+						const value = textNode.nodeValue ?? '';
+						const beforeCursor = value.slice(0, startOffset);
+						if (beforeCursor.replace(/​/g, '').length === 0) {
+							let prev: Node | null = textNode.previousSibling;
+							if (isZwspOnlyText(prev)) prev = prev.previousSibling;
+							if (
+								prev &&
+								prev.nodeType === Node.ELEMENT_NODE &&
+								(prev as HTMLElement).dataset.mention
+							) {
+								event.preventDefault();
+								if (beforeCursor.length > 0) {
+									textNode.nodeValue = value.slice(startOffset);
+									const newRange = document.createRange();
+									newRange.setStart(textNode, 0);
+									newRange.collapse(true);
+									selection.removeAllRanges();
+									selection.addRange(newRange);
+								}
+								removePillWithZwsps(prev as HTMLElement);
+								this.updateContentFromComposer();
+								return true;
+							}
 						}
 					}
 				}
@@ -509,14 +549,25 @@ export class MentionComposerController {
 		const newRange = document.createRange();
 		newRange.setStart(range.startContainer, range.startOffset);
 		newRange.collapse(true);
+
+		// Zero-width spaces around the pill give the caret a landing spot on
+		// both sides of the contenteditable=false span. Without them, iOS
+		// Safari renders the caret at end-of-line (far right of the input)
+		// and users can't tap before the pill to type leading text.
+		const leadingZwsp = document.createTextNode('​');
+		newRange.insertNode(leadingZwsp);
+		newRange.setStartAfter(leadingZwsp);
 		newRange.insertNode(pill);
+		newRange.setStartAfter(pill);
+
+		const trailingZwsp = document.createTextNode('​');
+		newRange.insertNode(trailingZwsp);
+		newRange.setStartAfter(trailingZwsp);
 
 		if (addTrailingSpace) {
 			const spacer = document.createTextNode(' ');
-			pill.after(spacer);
+			newRange.insertNode(spacer);
 			newRange.setStartAfter(spacer);
-		} else {
-			newRange.setStartAfter(pill);
 		}
 
 		newRange.collapse(true);
@@ -580,7 +631,11 @@ export class MentionComposerController {
 					? `nostr:${rawMention.slice(1)}`
 					: rawMention;
 				const displayName = getDisplayNameForMention(mention, cache);
+				// ZWSP spacers give the caret a landing spot on either side of
+				// the contenteditable=false pill (see insertMentionNode).
+				fragment.appendChild(document.createTextNode('​'));
 				fragment.appendChild(createMentionPill(mention, displayName));
+				fragment.appendChild(document.createTextNode('​'));
 
 				lastIndex = match.index + rawMention.length;
 			}

--- a/src/lib/mentionUtils.ts
+++ b/src/lib/mentionUtils.ts
@@ -70,7 +70,11 @@ export function renderTextWithMentions(
 		const rawMention = match[0];
 		const mention = rawMention.startsWith('@') ? `nostr:${rawMention.slice(1)}` : rawMention;
 		const displayName = getDisplayNameForMention(mention, profileCache);
-		html += `<span class="mention-pill" contenteditable="false" data-mention="${mention}">@${escapeHtml(displayName)}</span>`;
+		// Wrap each pill in zero-width space text nodes so the caret has a
+		// landing spot before and after the contenteditable=false element.
+		// Fixes iOS Safari caret jumping to end-of-line and makes it
+		// possible to tap/place the cursor before a pill.
+		html += `&#8203;<span class="mention-pill" contenteditable="false" data-mention="${mention}">@${escapeHtml(displayName)}</span>&#8203;`;
 
 		lastIndex = match.index + rawMention.length;
 	}


### PR DESCRIPTION
Two mobile bugs in the kind-1 / reply composers:

1. The @-mention autocomplete dropdown landed above the caret on iOS Safari when the keyboard was open. With the keyboard up, iOS auto-scrolls the page (window.scrollY becomes non-zero) and then treats position:fixed like position:absolute — our top:X ended up rendering at viewport_y = X − scrollY. Switch MentionDropdown to position:absolute and add window.scrollY/scrollX to its top/left, so we explicitly opt into document-relative coordinates that work the same on every platform (scrollY is 0 on desktop / Android / emulated mobile so it's a no-op there). Also listens on visualViewport resize/scroll so the dropdown tracks keyboard open/close, and caps max-height to the space below the caret so the list scrolls internally when room is tight.

2. A pill inserted as the first/only content had no adjacent text node, so iOS Safari rendered the caret at end-of-line (far right of the input) and users couldn't place the cursor before the pill to add leading text. Wrap every pill — both at insert time and when rendering content via renderTextWithMentions / convertRawMentionsToPills — with zero-width space text nodes so the caret has a landing spot on either side. Backspace/Delete treat ZWSP-only text nodes as transparent and remove the pill plus its spacers in one press; htmlToPlainText already strips ZWSPs so extracted content is unchanged.