### PR TITLE
fix(zaps): use canonical bolt11 extractor in getZapTotals

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.276",
+  "version": "4.2.277",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/zapManager.ts
+++ b/src/lib/zapManager.ts
@@ -5,6 +5,7 @@ import { resolveProfileByPubkey } from './profileResolver';
 import { AuthManager, getAuthManager } from './authManager';
 import { generateSecretKey } from 'nostr-tools';
 import { ensureClientTag } from './nip89';
+import { extractZapAmountSats } from './zapAmount';
 
 export interface ZapRequest {
   eventId?: string;
@@ -501,16 +502,14 @@ export class ZapManager {
       
       await new Promise<void>((resolve) => {
         subscription.on('event', (receipt: any) => {
-          console.log('Processing receipt:', receipt.id, 'tags:', receipt.tags);
-          const bolt11Tags = receipt.tags.filter((tag: any) => tag[0] === 'bolt11');
-          if (bolt11Tags.length > 0) {
-            // Parse bolt11 invoice to get amount (simplified - in production you'd want proper bolt11 parsing)
-            const bolt11 = bolt11Tags[0][1];
-            // This is a simplified amount extraction - you might want to use a proper bolt11 decoder
-            const amountMatch = bolt11.match(/lnbc(\d+)/);
-            if (amountMatch) {
-              total += parseInt(amountMatch[1]);
-            }
+          // Bolt11 multipliers (m/u/n/p) and the msats→sats conversion are
+          // handled by the canonical extractor in zapAmount.ts; the previous
+          // regex `/lnbc(\d+)/` dropped the multiplier and treated raw
+          // pre-multiplier digits as sats, so any invoice with a `u` / `n` /
+          // `p` suffix displayed with a 10³–10¹² error.
+          const { sats } = extractZapAmountSats(receipt);
+          if (sats > 0) {
+            total += sats;
             count++;
           }
         });


### PR DESCRIPTION
## Summary

`ZapManager.getZapTotals` was the last caller still using the legacy `/lnbc(\d+)/` regex, which:
- dropped bolt11 multipliers (`m`/`u`/`n`/`p`), and
- treated the pre-multiplier digit group as sats without converting msats→sats.

Any invoice with a `u`/`n`/`p` suffix rendered with a 10³–10¹² error in the totals surfaced by \`ZapDisplay\`.

Route the receipt through \`extractZapAmountSats\` — the canonical extractor already used by \`ZapDisplay\`, \`CommentCard\`, \`TopZappers\`, \`NoteEmbed\`, etc. It decodes the invoice via \`@gandlaf21/bolt11-decode\`, honors all multipliers, and falls back to the zap-request \`amount\` tag only when bolt11 is undecodable.

## Scope

- One file touched (\`src/lib/zapManager.ts\`); behavior-only, no API change.
- No new tests needed: \`src/lib/zapAmount.test.ts\` already covers all six branches (spec-compliant, misformatted amount tag, no amount tag, malformed bolt11 fallback, nothing extractable, msats-as-sats regression). All pass.

## Test plan

- [x] \`npx tsx src/lib/zapAmount.test.ts\` — all 6 tests pass.
- [x] \`bun run check\` — no new type errors in touched files.
- [ ] On a deployed preview, open a recipe page and confirm total zaps rendered by \`ZapDisplay\` matches what the underlying receipts actually paid.