### PR TITLE
feat(engagement): refresh stale counts when tab returns from background

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.276",
+  "version": "4.2.277",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.277",
+  "version": "4.2.278",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/engagementCache.ts
+++ b/src/lib/engagementCache.ts
@@ -1126,6 +1126,28 @@ export async function batchFetchEngagement(
   }
 }
 
+// Refresh engagement data for the N most-recently-touched active events.
+// Intended for tab-return: the user is looking at what they were last looking
+// at, so those are the counts most likely to surprise them by being stale.
+// batchFetchEngagement applies its own 5-minute TTL, so calling this on every
+// tab-return is cheap when nothing has actually gone stale.
+export async function refreshActiveEngagement(
+  ndk: NDK,
+  userPublickey: string,
+  maxEvents = 20
+): Promise<void> {
+  if (!ndk) return;
+  const mostRecent = Array.from(persistentSubscriptions.entries())
+    .sort((a, b) => b[1].lastActivity - a[1].lastActivity)
+    .slice(0, maxEvents)
+    .map(([eventId]) => eventId);
+
+  if (mostRecent.length === 0) return;
+
+  console.debug('[Engagement] refreshing', mostRecent.length, 'events on tab visible');
+  await batchFetchEngagement(ndk, mostRecent, userPublickey);
+}
+
 // Clear all caches (for logout, etc)
 export function clearAllEngagementCaches(): void {
   // Stop persistent subscriptions

--- a/src/lib/tabVisibility.ts
+++ b/src/lib/tabVisibility.ts
@@ -1,0 +1,36 @@
+import { readable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+// Minimum hide duration before we treat a tab-return as worth refreshing.
+// Filters out quick app-switches / accidental toggles where data can't have
+// gone meaningfully stale.
+const MIN_HIDDEN_MS = 1000;
+
+/**
+ * Increments each time the tab becomes visible after being hidden for at
+ * least MIN_HIDDEN_MS. Value 0 is the initial state and never represents a
+ * real transition — consumers should trigger only when the value is > 0.
+ */
+export const tabVisibleAfterHide = readable(0, (set) => {
+	if (!browser) return () => {};
+
+	let hiddenSince = 0;
+	let count = 0;
+
+	const handler = () => {
+		if (document.hidden) {
+			hiddenSince = Date.now();
+			return;
+		}
+		if (hiddenSince && Date.now() - hiddenSince >= MIN_HIDDEN_MS) {
+			hiddenSince = 0;
+			count += 1;
+			set(count);
+			return;
+		}
+		hiddenSince = 0;
+	};
+
+	document.addEventListener('visibilitychange', handler);
+	return () => document.removeEventListener('visibilitychange', handler);
+});

--- a/src/lib/tabVisibility.ts
+++ b/src/lib/tabVisibility.ts
@@ -12,25 +12,25 @@ const MIN_HIDDEN_MS = 1000;
  * real transition — consumers should trigger only when the value is > 0.
  */
 export const tabVisibleAfterHide = readable(0, (set) => {
-	if (!browser) return () => {};
+  if (!browser) return () => {};
 
-	let hiddenSince = 0;
-	let count = 0;
+  let hiddenSince = 0;
+  let count = 0;
 
-	const handler = () => {
-		if (document.hidden) {
-			hiddenSince = Date.now();
-			return;
-		}
-		if (hiddenSince && Date.now() - hiddenSince >= MIN_HIDDEN_MS) {
-			hiddenSince = 0;
-			count += 1;
-			set(count);
-			return;
-		}
-		hiddenSince = 0;
-	};
+  const handler = () => {
+    if (document.hidden) {
+      hiddenSince = Date.now();
+      return;
+    }
+    if (hiddenSince && Date.now() - hiddenSince >= MIN_HIDDEN_MS) {
+      hiddenSince = 0;
+      count += 1;
+      set(count);
+      return;
+    }
+    hiddenSince = 0;
+  };
 
-	document.addEventListener('visibilitychange', handler);
-	return () => document.removeEventListener('visibilitychange', handler);
+  document.addEventListener('visibilitychange', handler);
+  return () => document.removeEventListener('visibilitychange', handler);
 });

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -45,6 +45,9 @@
   import { feedInitialLoadDone } from '$lib/startupState';
   // Prewarm outbox relay list cache early (on login, regardless of page)
   import { prewarmOutboxCache } from '$lib/followOutbox';
+  // Refresh engagement counts when the tab returns from background
+  import { tabVisibleAfterHide } from '$lib/tabVisibility';
+  import { refreshActiveEngagement } from '$lib/engagementCache';
 
   // Accept props from SvelteKit to prevent warnings
   export let data: LayoutData = {} as LayoutData;
@@ -342,6 +345,15 @@
 
   $: if (walletWelcomeOpen && hasWallet) {
     markWalletWelcomeSeen();
+  }
+
+  // When the tab returns from background (hidden ≥1s), refresh the
+  // most-recently-touched engagement counts. batchFetchEngagement has its
+  // own 5-min TTL so a near-zero-gap return is cheap.
+  $: if ($tabVisibleAfterHide > 0 && $userPublickey && $ndk) {
+    refreshActiveEngagement($ndk, $userPublickey).catch((err) =>
+      console.warn('[tab-visible] engagement refresh failed:', err)
+    );
   }
 </script>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -350,10 +350,18 @@
   // When the tab returns from background (hidden ≥1s), refresh the
   // most-recently-touched engagement counts. batchFetchEngagement has its
   // own 5-min TTL so a near-zero-gap return is cheap.
-  $: if ($tabVisibleAfterHide > 0 && $userPublickey && $ndk) {
-    refreshActiveEngagement($ndk, $userPublickey).catch((err) =>
-      console.warn('[tab-visible] engagement refresh failed:', err)
-    );
+  //
+  // Edge-trigger on the counter increment — without this latch, an
+  // unrelated change to userPublickey/ndk (login, reconnect) while the
+  // counter is already > 0 would re-fire the refresh.
+  let lastSeenTabVisible = 0;
+  $: if ($tabVisibleAfterHide > lastSeenTabVisible) {
+    lastSeenTabVisible = $tabVisibleAfterHide;
+    if ($userPublickey && $ndk) {
+      refreshActiveEngagement($ndk, $userPublickey).catch((err) =>
+        console.warn('[tab-visible] engagement refresh failed:', err)
+      );
+    }
   }
 </script>
 


### PR DESCRIPTION
## Summary

When a user returns to a tab that was backgrounded for a while, engagement counts (zaps, reactions, comments, reposts) can be out of date — nothing in the app was invalidating them on tab return, so users had to refresh the page to see up-to-date numbers.

This PR adds:

1. **\`src/lib/tabVisibility.ts\`** (new, ~25 lines) — a Svelte readable store that increments on \`visibilitychange → visible\`, but only after the tab was hidden for ≥1 s (filters out quick app-switches where data can't have gone meaningfully stale).

2. **\`refreshActiveEngagement\`** on \`engagementCache.ts\` — picks the 20 most-recently-touched active events (what the user was just looking at, ranked by \`lastActivity\` on \`persistentSubscriptions\`) and routes them through the existing \`batchFetchEngagement\` path.

3. **Wiring in \`+layout.svelte\`** — a single \`\$:\` reactive block ties the two together when authenticated.

## Why this is cheap

\`batchFetchEngagement\` already applies a 5-minute TTL internally — if counts aren't stale, it's a near no-op. Quick tab flickers (<1 s) don't fire at all because of the debounce.

## Why no coupling

\`engagementCache\` does not import \`tabVisibility\`. The layout is the only file that wires them. Either module can be used independently.

## Scope

- 3 files changed (1 new, 2 touched).
- No new runtime dependencies.
- Behavior-only feature; no API change to existing exports.

## Test plan

- [x] \`bun run check\` — no new type errors in touched files (pre-existing warnings/errors unchanged).
- [ ] Open a recipe or feed page, confirm zap/reaction counts are present. Switch to another tab for ≥1 s. Return. Observe the counts re-fetched for the events currently on screen (visible in network/console as \`[Engagement] refreshing N events on tab visible\`).
- [ ] Flick to another tab for <1 s and back — no refresh logged (debounce).
- [ ] Logged-out session — no refresh attempted (guarded by \`\$userPublickey\`).