### PR TITLE
fix(auth,encryption): drive NIP-46 via real NDK API surface

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.282",
+  "version": "4.2.283",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/authManager.ts
+++ b/src/lib/authManager.ts
@@ -75,6 +75,65 @@ export class AuthManager {
     }
   }
 
+  // Ask the remote signer for the user's actual pubkey via an explicit
+  // NIP-46 `get_public_key` RPC. NDKNip46Signer.user() is NOT an RPC —
+  // it synchronously returns the `remoteUser` built from the pubkey passed
+  // to its constructor (i.e. the signer service pubkey). Using user() to
+  // obtain the user's identity silently logs the session in as the signer
+  // service instead of the user, which was the root cause of wrong-npub
+  // sign-in against Amber/Primal and any other signer whose service and
+  // user pubkeys differ.
+  private async fetchNip46UserPubkey(
+    signerPubkey: string,
+    timeoutMs = 15000
+  ): Promise<string> {
+    const signer = this.nip46Signer;
+    if (!signer) throw new Error('NIP-46 signer not initialized');
+    type RpcSendRequest = (
+      remotePubkey: string,
+      method: string,
+      params: string[],
+      kind: number,
+      callback: (response: { result?: string; error?: string }) => void
+    ) => void;
+    const rpc = (signer as unknown as { rpc?: { sendRequest?: RpcSendRequest } }).rpc;
+    const sendRequest = rpc?.sendRequest;
+    if (!sendRequest) {
+      throw new Error('NIP-46 signer RPC channel not available');
+    }
+
+    return new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error('get_public_key timed out')),
+        timeoutMs
+      );
+      try {
+        sendRequest(
+          signerPubkey,
+          'get_public_key',
+          [],
+          24133,
+          (response: { result?: string; error?: string }) => {
+            clearTimeout(timer);
+            if (response?.error) {
+              reject(new Error(`get_public_key error: ${response.error}`));
+              return;
+            }
+            const pubkey = (response?.result || '').trim().toLowerCase();
+            if (!/^[0-9a-f]{64}$/.test(pubkey)) {
+              reject(new Error(`get_public_key invalid response: ${response?.result}`));
+              return;
+            }
+            resolve(pubkey);
+          }
+        );
+      } catch (e) {
+        clearTimeout(timer);
+        reject(e);
+      }
+    });
+  }
+
   // Initialize authentication from localStorage
   private async initializeFromStorage() {
     if (!browser) return;
@@ -383,10 +442,10 @@ export class AuthManager {
 
       console.log('[NIP-46] Connected! Getting user pubkey via get_public_key...');
 
-      // Per NIP-46: client MUST call get_public_key to learn user-pubkey
-      // The signer pubkey may differ from the actual user pubkey
-      const user = await this.nip46Signer.user();
-      const userPubkey = user.hexpubkey;
+      // Per NIP-46: client MUST call get_public_key to learn user-pubkey.
+      // See fetchNip46UserPubkey — NDK's user() is not an RPC.
+      const userPubkey = await this.fetchNip46UserPubkey(signerPubkey);
+      const user = this.ndk.getUser({ pubkey: userPubkey });
 
       console.log('[NIP-46] Signer pubkey:', signerPubkey);
       console.log('[NIP-46] User pubkey (from get_public_key):', userPubkey);
@@ -500,34 +559,31 @@ export class AuthManager {
         // Still proceed - might work anyway, or will fail on actual sign attempt
       }
 
-      // ALWAYS fetch the actual user pubkey from the signer to ensure it's correct
-      // The stored userPubkey might be incorrect (e.g., if it was stored as signer pubkey)
-      // Per NIP-46: client MUST call get_public_key to learn user-pubkey
-      let userPubkey = nip46Info.userPubkey; // Use as fallback
+      // Re-verify the user pubkey via a real get_public_key RPC so a stored
+      // value that was ever wrong (e.g. pre-fix sessions that recorded the
+      // signer pubkey) gets corrected on next login. If the RPC fails, fall
+      // back to the stored value — a previously-fetched correct pubkey is
+      // better than failing the reconnect.
+      let userPubkey = nip46Info.userPubkey;
       try {
         console.log('[NIP-46] Fetching actual user pubkey via get_public_key...');
-        const userFromSigner = await this.nip46Signer.user();
-        const actualUserPubkey = userFromSigner.hexpubkey;
+        const actualUserPubkey = await this.fetchNip46UserPubkey(nip46Info.signerPubkey);
         console.log('[NIP-46] Signer pubkey:', nip46Info.signerPubkey);
         console.log('[NIP-46] Stored user pubkey:', userPubkey);
         console.log('[NIP-46] Actual user pubkey (from get_public_key):', actualUserPubkey);
 
-        // Use the actual user pubkey from the signer
         userPubkey = actualUserPubkey;
 
-        // If stored userPubkey differs from actual, log a warning
         if (nip46Info.userPubkey && nip46Info.userPubkey !== actualUserPubkey) {
           console.warn(
-            '[NIP-46] Stored user pubkey differs from actual user pubkey! Updating stored value.'
+            '[NIP-46] Stored user pubkey differs from actual user pubkey — updating stored value'
           );
-          // Update the stored value
           nip46Info.userPubkey = actualUserPubkey;
           localStorage.setItem('nostrcooking_nip46', JSON.stringify(nip46Info));
           localStorage.setItem('nostrcooking_loggedInPublicKey', actualUserPubkey);
         }
       } catch (e) {
         console.warn('[NIP-46] Could not get user pubkey from signer, using stored value:', e);
-        // Fall back to stored value if we can't fetch it
       }
 
       const user = this.ndk.getUser({ pubkey: userPubkey });
@@ -915,29 +971,19 @@ export class AuthManager {
         );
       }
 
-      // Per NIP-46: client MUST call get_public_key to learn user-pubkey
-      // The signer pubkey may differ from the actual user pubkey
-      // ALWAYS try to get the user pubkey, even if session establishment timed out
-      // The signer might still be able to respond to get_public_key requests
-      let userPubkey = signerPubkey; // Fallback to signer pubkey
-      try {
-        console.log('[NIP-46] Calling get_public_key to get actual user pubkey...');
-        const user = await this.nip46Signer.user();
-        userPubkey = user.hexpubkey;
-        console.log('[NIP-46] Got user pubkey via get_public_key:', userPubkey);
-        console.log('[NIP-46] Signer pubkey:', signerPubkey);
-        if (signerPubkey !== userPubkey) {
-          console.log(
-            '[NIP-46] Note: signer pubkey differs from user pubkey (this is valid per spec)'
-          );
-        }
-      } catch (e) {
-        console.warn(
-          '[NIP-46] Could not get user pubkey via get_public_key, using signer pubkey as fallback:',
-          e
+      // Per NIP-46: client MUST call get_public_key to learn user-pubkey.
+      // Even if blockUntilReady timed out the RPC listener is still live,
+      // so get_public_key can still succeed. No silent fallback to signer
+      // pubkey — if we can't learn the user's identity we fail the auth
+      // rather than log the session in as the signer service.
+      console.log('[NIP-46] Calling get_public_key to get actual user pubkey...');
+      const userPubkey = await this.fetchNip46UserPubkey(signerPubkey);
+      console.log('[NIP-46] Got user pubkey via get_public_key:', userPubkey);
+      console.log('[NIP-46] Signer pubkey:', signerPubkey);
+      if (signerPubkey !== userPubkey) {
+        console.log(
+          '[NIP-46] Note: signer pubkey differs from user pubkey (this is valid per spec)'
         );
-        // Only use signer pubkey as fallback if we truly can't get the user pubkey
-        // This should be rare, as get_public_key should work even if blockUntilReady() timed out
       }
 
       const user = this.ndk.getUser({ pubkey: userPubkey });

--- a/src/lib/authManager.ts
+++ b/src/lib/authManager.ts
@@ -89,16 +89,21 @@ export class AuthManager {
   ): Promise<string> {
     const signer = this.nip46Signer;
     if (!signer) throw new Error('NIP-46 signer not initialized');
-    type RpcSendRequest = (
-      remotePubkey: string,
-      method: string,
-      params: string[],
-      kind: number,
-      callback: (response: { result?: string; error?: string }) => void
-    ) => void;
-    const rpc = (signer as unknown as { rpc?: { sendRequest?: RpcSendRequest } }).rpc;
-    const sendRequest = rpc?.sendRequest;
-    if (!sendRequest) {
+    // sendRequest is a method on NDKNostrRpc that depends on `this` (it
+    // reads this.signer etc. internally), so we must call it as a method —
+    // extracting the function and invoking it unbound throws a TypeError
+    // inside NDK.
+    type RpcChannel = {
+      sendRequest: (
+        remotePubkey: string,
+        method: string,
+        params: string[],
+        kind: number,
+        callback: (response: { result?: string; error?: string }) => void
+      ) => void;
+    };
+    const rpc = (signer as unknown as { rpc?: RpcChannel }).rpc;
+    if (!rpc || typeof rpc.sendRequest !== 'function') {
       throw new Error('NIP-46 signer RPC channel not available');
     }
 
@@ -108,7 +113,7 @@ export class AuthManager {
         timeoutMs
       );
       try {
-        sendRequest(
+        rpc.sendRequest(
           signerPubkey,
           'get_public_key',
           [],

--- a/src/lib/authManager.ts
+++ b/src/lib/authManager.ts
@@ -7,6 +7,7 @@ import {
 } from '@nostr-dev-kit/ndk';
 import { nip19, getPublicKey, generateSecretKey } from 'nostr-tools';
 import * as nip44 from 'nostr-tools/nip44';
+import { fetchNip46UserPubkey } from './nip46Rpc';
 
 export interface AuthState {
   isAuthenticated: boolean;
@@ -75,68 +76,11 @@ export class AuthManager {
     }
   }
 
-  // Ask the remote signer for the user's actual pubkey via an explicit
-  // NIP-46 `get_public_key` RPC. NDKNip46Signer.user() is NOT an RPC —
-  // it synchronously returns the `remoteUser` built from the pubkey passed
-  // to its constructor (i.e. the signer service pubkey). Using user() to
-  // obtain the user's identity silently logs the session in as the signer
-  // service instead of the user, which was the root cause of wrong-npub
-  // sign-in against Amber/Primal and any other signer whose service and
-  // user pubkeys differ.
-  private async fetchNip46UserPubkey(
-    signerPubkey: string,
-    timeoutMs = 15000
-  ): Promise<string> {
-    const signer = this.nip46Signer;
-    if (!signer) throw new Error('NIP-46 signer not initialized');
-    // sendRequest is a method on NDKNostrRpc that depends on `this` (it
-    // reads this.signer etc. internally), so we must call it as a method —
-    // extracting the function and invoking it unbound throws a TypeError
-    // inside NDK.
-    type RpcChannel = {
-      sendRequest: (
-        remotePubkey: string,
-        method: string,
-        params: string[],
-        kind: number,
-        callback: (response: { result?: string; error?: string }) => void
-      ) => void;
-    };
-    const rpc = (signer as unknown as { rpc?: RpcChannel }).rpc;
-    if (!rpc || typeof rpc.sendRequest !== 'function') {
-      throw new Error('NIP-46 signer RPC channel not available');
-    }
-
-    return new Promise<string>((resolve, reject) => {
-      const timer = setTimeout(
-        () => reject(new Error('get_public_key timed out')),
-        timeoutMs
-      );
-      try {
-        rpc.sendRequest(
-          signerPubkey,
-          'get_public_key',
-          [],
-          24133,
-          (response: { result?: string; error?: string }) => {
-            clearTimeout(timer);
-            if (response?.error) {
-              reject(new Error(`get_public_key error: ${response.error}`));
-              return;
-            }
-            const pubkey = (response?.result || '').trim().toLowerCase();
-            if (!/^[0-9a-f]{64}$/.test(pubkey)) {
-              reject(new Error(`get_public_key invalid response: ${response?.result}`));
-              return;
-            }
-            resolve(pubkey);
-          }
-        );
-      } catch (e) {
-        clearTimeout(timer);
-        reject(e);
-      }
-    });
+  // Resolve the real user pubkey via a NIP-46 get_public_key RPC.
+  // See src/lib/nip46Rpc.ts for why NDK's user() is not usable here.
+  private async fetchNip46UserPubkey(): Promise<string> {
+    if (!this.nip46Signer) throw new Error('NIP-46 signer not initialized');
+    return fetchNip46UserPubkey(this.nip46Signer);
   }
 
   // Initialize authentication from localStorage
@@ -449,7 +393,7 @@ export class AuthManager {
 
       // Per NIP-46: client MUST call get_public_key to learn user-pubkey.
       // See fetchNip46UserPubkey — NDK's user() is not an RPC.
-      const userPubkey = await this.fetchNip46UserPubkey(signerPubkey);
+      const userPubkey = await this.fetchNip46UserPubkey();
       const user = this.ndk.getUser({ pubkey: userPubkey });
 
       console.log('[NIP-46] Signer pubkey:', signerPubkey);
@@ -572,7 +516,7 @@ export class AuthManager {
       let userPubkey = nip46Info.userPubkey;
       try {
         console.log('[NIP-46] Fetching actual user pubkey via get_public_key...');
-        const actualUserPubkey = await this.fetchNip46UserPubkey(nip46Info.signerPubkey);
+        const actualUserPubkey = await this.fetchNip46UserPubkey();
         console.log('[NIP-46] Signer pubkey:', nip46Info.signerPubkey);
         console.log('[NIP-46] Stored user pubkey:', userPubkey);
         console.log('[NIP-46] Actual user pubkey (from get_public_key):', actualUserPubkey);
@@ -982,7 +926,7 @@ export class AuthManager {
       // pubkey — if we can't learn the user's identity we fail the auth
       // rather than log the session in as the signer service.
       console.log('[NIP-46] Calling get_public_key to get actual user pubkey...');
-      const userPubkey = await this.fetchNip46UserPubkey(signerPubkey);
+      const userPubkey = await this.fetchNip46UserPubkey();
       console.log('[NIP-46] Got user pubkey via get_public_key:', userPubkey);
       console.log('[NIP-46] Signer pubkey:', signerPubkey);
       if (signerPubkey !== userPubkey) {

--- a/src/lib/encryptionService.ts
+++ b/src/lib/encryptionService.ts
@@ -215,8 +215,8 @@ export async function getEncryptionMethod(): Promise<EncryptionMethod> {
       return 'nip44'; // Prefer NIP-44 for private key signers
     }
 
-    // NDK exposes encrypt/decrypt on its signer interface — prefer
-    // NIP-44 when the signer advertises nip04-only legacy support.
+    // NDK exposes encrypt/decrypt on its signer interface — use
+    // NIP-04 for signers that only advertise this legacy support.
     if (typeof signer.encrypt === 'function') {
       return 'nip04';
     }

--- a/src/lib/encryptionService.ts
+++ b/src/lib/encryptionService.ts
@@ -12,11 +12,12 @@
 
 import { get } from 'svelte/store';
 import { ndk } from '$lib/nostr';
-import { NDKUser } from '@nostr-dev-kit/ndk';
+import { NDKUser, type NDKNip46Signer } from '@nostr-dev-kit/ndk';
 import { browser } from '$app/environment';
 import * as nip44 from 'nostr-tools/nip44';
 import * as nip04 from 'nostr-tools/nip04';
 import { nip19 } from 'nostr-tools';
+import { nip44EncryptViaNip46, nip44DecryptViaNip46 } from '$lib/nip46Rpc';
 
 export type EncryptionMethod = 'nip44' | 'nip04' | null;
 
@@ -92,11 +93,13 @@ function isUserDenial(error: unknown): boolean {
   return /reject|denied|cancel|refused|declined|abort|dismissed/.test(msg);
 }
 
+// NDK exposes `encrypt(recipient, value)` / `decrypt(sender, value)` on
+// NDKNip46Signer, and these issue nip04_encrypt / nip04_decrypt RPCs
+// under the hood. NDK does NOT expose NIP-44 methods — those must be
+// driven through the raw RPC helper in $lib/nip46Rpc.
 type SignerWithEncryption = {
-  nip44Encrypt?: (recipient: NDKUser, plaintext: string) => Promise<string>;
-  nip04Encrypt?: (recipient: NDKUser, plaintext: string) => Promise<string>;
-  nip44Decrypt?: (sender: NDKUser, ciphertext: string) => Promise<string>;
-  nip04Decrypt?: (sender: NDKUser, ciphertext: string) => Promise<string>;
+  encrypt?: (recipient: NDKUser, plaintext: string) => Promise<string>;
+  decrypt?: (sender: NDKUser, ciphertext: string) => Promise<string>;
   constructor?: { name?: string };
 };
 
@@ -157,8 +160,9 @@ export function hasEncryptionSupport(): boolean {
       return true;
     }
 
-    // Direct encryption methods available on signer
-    if (typeof signer.nip44Encrypt === 'function' || typeof signer.nip04Encrypt === 'function') {
+    // Direct encryption method available on signer (NDK exposes
+    // encrypt() / decrypt() — nip04/44 prefixed variants do not exist).
+    if (typeof signer.encrypt === 'function') {
       return true;
     }
 
@@ -197,14 +201,24 @@ export async function getEncryptionMethod(): Promise<EncryptionMethod> {
 
   // If we have an NDK signer, it supports encryption via its interface
   if (signer) {
-    // NDK signers support both methods, prefer NIP-44
-    if (typeof signer.nip44Encrypt === 'function') return 'nip44';
-    if (typeof signer.nip04Encrypt === 'function') return 'nip04';
+    const signerName = signer.constructor?.name || '';
+
+    // NIP-46 signers: prefer NIP-44 (encrypt() in the service falls
+    // through to NIP-04 at runtime if the signer rejects nip44).
+    if (signerName.includes('Nip46Signer')) {
+      return 'nip44';
+    }
 
     // For private key signers, we can use nostr-tools directly
     // Use includes() to handle minified class names
-    if ((signer.constructor?.name || '').includes('PrivateKeySigner') && getPrivateKey()) {
+    if (signerName.includes('PrivateKeySigner') && getPrivateKey()) {
       return 'nip44'; // Prefer NIP-44 for private key signers
+    }
+
+    // NDK exposes encrypt/decrypt on its signer interface — prefer
+    // NIP-44 when the signer advertises nip04-only legacy support.
+    if (typeof signer.encrypt === 'function') {
+      return 'nip04';
     }
   }
 
@@ -310,31 +324,29 @@ export async function encrypt(
     );
   }
 
-  // For NIP-46 signers, use the signer's encryption methods
+  // For NIP-46 signers: NIP-44 goes through the raw RPC (NDK has no
+  // built-in for it); NIP-04 uses NDK's encrypt() which issues a
+  // nip04_encrypt RPC under the hood. Prefer NIP-44 and fall through
+  // to NIP-04 if the signer rejects NIP-44 (e.g. older signer that
+  // only grants nip04 permissions).
   if (signerName.includes('Nip46Signer') && signer) {
-
     const recipient = new NDKUser({ pubkey: recipientPubkey });
+    const nip46Signer = signer as unknown as NDKNip46Signer;
 
-    if (
-      typeof signer.nip44Encrypt === 'function' &&
-      (!preferredMethod || preferredMethod === 'nip44')
-    ) {
+    if (!preferredMethod || preferredMethod === 'nip44') {
       try {
-
-        const ciphertext = await signer.nip44Encrypt(recipient, plaintext);
+        const ciphertext = await nip44EncryptViaNip46(nip46Signer, recipientPubkey, plaintext);
         return { ciphertext, method: 'nip44' };
       } catch (e) {
-        console.warn('[Encryption] signer.nip44Encrypt failed:', e);
-        // Fall through to try nip04
+        console.warn('[Encryption] NIP-46 nip44_encrypt failed, falling back to nip04:', e);
       }
     }
-    if (typeof signer.nip04Encrypt === 'function') {
+    if (typeof signer.encrypt === 'function') {
       try {
-
-        const ciphertext = await signer.nip04Encrypt(recipient, plaintext);
+        const ciphertext = await signer.encrypt(recipient, plaintext);
         return { ciphertext, method: 'nip04' };
       } catch (e) {
-        console.error('[Encryption] signer.nip04Encrypt failed:', e);
+        console.error('[Encryption] NIP-46 nip04_encrypt failed:', e);
       }
     }
 
@@ -574,17 +586,21 @@ async function decryptViaSigner(
         if (result != null) return result;
       }
 
-      // Fallback to NDK signer (for NIP-46 remote signers, etc.)
+      // Fallback to NDK signer (NIP-46 remote signers). NIP-44 goes
+      // through the raw RPC; NIP-04 uses NDK's decrypt() which issues a
+      // nip04_decrypt RPC.
       const ndkInstance = get(ndk);
       const signer = ndkInstance.signer as SignerWithEncryption | null | undefined;
-      if (signer) {
+      const signerName = signer?.constructor?.name || '';
+      if (signer && signerName.includes('Nip46Signer')) {
         const sender = new NDKUser({ pubkey: senderPubkey });
+        const nip46Signer = signer as unknown as NDKNip46Signer;
 
-        if (tryMethod === 'nip44' && typeof signer.nip44Decrypt === 'function') {
-          const result = await signer.nip44Decrypt(sender, ciphertext);
+        if (tryMethod === 'nip44') {
+          const result = await nip44DecryptViaNip46(nip46Signer, senderPubkey, ciphertext);
           if (result != null) return result;
-        } else if (tryMethod === 'nip04' && typeof signer.nip04Decrypt === 'function') {
-          const result = await signer.nip04Decrypt(sender, ciphertext);
+        } else if (tryMethod === 'nip04' && typeof signer.decrypt === 'function') {
+          const result = await signer.decrypt(sender, ciphertext);
           if (result != null) return result;
         }
       }

--- a/src/lib/nip46Rpc.ts
+++ b/src/lib/nip46Rpc.ts
@@ -19,54 +19,65 @@ const NIP46_KIND = 24133;
 const DEFAULT_TIMEOUT_MS = 15000;
 
 type RpcChannel = {
-	sendRequest: (
-		remotePubkey: string,
-		method: string,
-		params: string[],
-		kind: number,
-		callback: (response: { result?: string; error?: string }) => void
-	) => void;
+  sendRequest: (
+    remotePubkey: string,
+    method: string,
+    params: string[],
+    kind: number,
+    callback: (response: { result?: string; error?: string }) => void
+  ) => void;
 };
 
 function getChannel(signer: NDKNip46Signer): { rpc: RpcChannel; remotePubkey: string } {
-	const view = signer as unknown as { rpc?: RpcChannel; remotePubkey?: string };
-	if (!view.rpc || typeof view.rpc.sendRequest !== 'function') {
-		throw new Error('NIP-46 signer RPC channel not available');
-	}
-	if (!view.remotePubkey) {
-		throw new Error('NIP-46 signer remote pubkey not resolved');
-	}
-	return { rpc: view.rpc, remotePubkey: view.remotePubkey };
+  const view = signer as unknown as { rpc?: RpcChannel; remotePubkey?: string };
+  if (!view.rpc || typeof view.rpc.sendRequest !== 'function') {
+    throw new Error('NIP-46 signer RPC channel not available');
+  }
+  if (!view.remotePubkey) {
+    throw new Error('NIP-46 signer remote pubkey not resolved');
+  }
+  return { rpc: view.rpc, remotePubkey: view.remotePubkey };
 }
 
 /**
  * Issue a NIP-46 JSON-RPC request through the signer's RPC channel and
  * resolve with the result string. Errors from the signer reject; an
  * absent response rejects after `timeoutMs`.
+ *
+ * An explicit empty-string `result` is a valid outcome for some methods
+ * (e.g. signers that ack without echoing data), so that is passed
+ * through. A missing or non-string `result` with no `error` is treated
+ * as a protocol failure and rejected rather than silently resolved to
+ * `''`, which would otherwise be indistinguishable from a successful
+ * encryption that happened to produce empty ciphertext.
  */
 export async function sendNip46Rpc(
-	signer: NDKNip46Signer,
-	method: string,
-	params: string[],
-	timeoutMs = DEFAULT_TIMEOUT_MS
+  signer: NDKNip46Signer,
+  method: string,
+  params: string[],
+  timeoutMs = DEFAULT_TIMEOUT_MS
 ): Promise<string> {
-	const { rpc, remotePubkey } = getChannel(signer);
-	return new Promise<string>((resolve, reject) => {
-		const timer = setTimeout(() => reject(new Error(`${method} timed out`)), timeoutMs);
-		try {
-			rpc.sendRequest(remotePubkey, method, params, NIP46_KIND, (response) => {
-				clearTimeout(timer);
-				if (response?.error) {
-					reject(new Error(`${method}: ${response.error}`));
-					return;
-				}
-				resolve(response?.result ?? '');
-			});
-		} catch (e) {
-			clearTimeout(timer);
-			reject(e);
-		}
-	});
+  const { rpc, remotePubkey } = getChannel(signer);
+  return new Promise<string>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${method} timed out`)), timeoutMs);
+    try {
+      rpc.sendRequest(remotePubkey, method, params, NIP46_KIND, (response) => {
+        clearTimeout(timer);
+        if (response?.error) {
+          reject(new Error(`${method}: ${response.error}`));
+          return;
+        }
+        if (typeof response?.result !== 'string') {
+          reject(new Error(`${method}: malformed response (missing result)`));
+          return;
+        }
+        resolve(response.result);
+      });
+    } catch (e) {
+      clearTimeout(timer);
+      reject(e);
+    }
+  });
 }
 
 /**
@@ -77,15 +88,15 @@ export async function sendNip46Rpc(
  * the signer service.
  */
 export async function fetchNip46UserPubkey(
-	signer: NDKNip46Signer,
-	timeoutMs = DEFAULT_TIMEOUT_MS
+  signer: NDKNip46Signer,
+  timeoutMs = DEFAULT_TIMEOUT_MS
 ): Promise<string> {
-	const result = await sendNip46Rpc(signer, 'get_public_key', [], timeoutMs);
-	const pubkey = result.trim().toLowerCase();
-	if (!/^[0-9a-f]{64}$/.test(pubkey)) {
-		throw new Error(`get_public_key invalid response: ${result}`);
-	}
-	return pubkey;
+  const result = await sendNip46Rpc(signer, 'get_public_key', [], timeoutMs);
+  const pubkey = result.trim().toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(pubkey)) {
+    throw new Error(`get_public_key invalid response: ${result}`);
+  }
+  return pubkey;
 }
 
 /**
@@ -94,22 +105,22 @@ export async function fetchNip46UserPubkey(
  * ciphertext string.
  */
 export async function nip44EncryptViaNip46(
-	signer: NDKNip46Signer,
-	recipientPubkey: string,
-	plaintext: string,
-	timeoutMs = DEFAULT_TIMEOUT_MS
+  signer: NDKNip46Signer,
+  recipientPubkey: string,
+  plaintext: string,
+  timeoutMs = DEFAULT_TIMEOUT_MS
 ): Promise<string> {
-	return sendNip46Rpc(signer, 'nip44_encrypt', [recipientPubkey, plaintext], timeoutMs);
+  return sendNip46Rpc(signer, 'nip44_encrypt', [recipientPubkey, plaintext], timeoutMs);
 }
 
 /**
  * NIP-44 decrypt via NIP-46. Mirror of nip44EncryptViaNip46.
  */
 export async function nip44DecryptViaNip46(
-	signer: NDKNip46Signer,
-	senderPubkey: string,
-	ciphertext: string,
-	timeoutMs = DEFAULT_TIMEOUT_MS
+  signer: NDKNip46Signer,
+  senderPubkey: string,
+  ciphertext: string,
+  timeoutMs = DEFAULT_TIMEOUT_MS
 ): Promise<string> {
-	return sendNip46Rpc(signer, 'nip44_decrypt', [senderPubkey, ciphertext], timeoutMs);
+  return sendNip46Rpc(signer, 'nip44_decrypt', [senderPubkey, ciphertext], timeoutMs);
 }

--- a/src/lib/nip46Rpc.ts
+++ b/src/lib/nip46Rpc.ts
@@ -1,0 +1,115 @@
+/**
+ * Low-level NIP-46 JSON-RPC helpers.
+ *
+ * NDK's NDKNip46Signer only exposes a subset of NIP-46 methods through
+ * idiomatic TypeScript methods (sign, encrypt/decrypt as NIP-04). For
+ * methods NDK doesn't wrap — get_public_key, nip44_encrypt,
+ * nip44_decrypt — and for cases where we need the real RPC response
+ * (rather than NDK's synchronous stand-ins), we drive the signer's
+ * already-connected RPC channel directly.
+ *
+ * The channel is attached to the signer as `signer.rpc` (an
+ * NDKNostrRpc instance). The `remotePubkey` field is the signer
+ * service pubkey, set in the NDK constructor.
+ */
+
+import type { NDKNip46Signer } from '@nostr-dev-kit/ndk';
+
+const NIP46_KIND = 24133;
+const DEFAULT_TIMEOUT_MS = 15000;
+
+type RpcChannel = {
+	sendRequest: (
+		remotePubkey: string,
+		method: string,
+		params: string[],
+		kind: number,
+		callback: (response: { result?: string; error?: string }) => void
+	) => void;
+};
+
+function getChannel(signer: NDKNip46Signer): { rpc: RpcChannel; remotePubkey: string } {
+	const view = signer as unknown as { rpc?: RpcChannel; remotePubkey?: string };
+	if (!view.rpc || typeof view.rpc.sendRequest !== 'function') {
+		throw new Error('NIP-46 signer RPC channel not available');
+	}
+	if (!view.remotePubkey) {
+		throw new Error('NIP-46 signer remote pubkey not resolved');
+	}
+	return { rpc: view.rpc, remotePubkey: view.remotePubkey };
+}
+
+/**
+ * Issue a NIP-46 JSON-RPC request through the signer's RPC channel and
+ * resolve with the result string. Errors from the signer reject; an
+ * absent response rejects after `timeoutMs`.
+ */
+export async function sendNip46Rpc(
+	signer: NDKNip46Signer,
+	method: string,
+	params: string[],
+	timeoutMs = DEFAULT_TIMEOUT_MS
+): Promise<string> {
+	const { rpc, remotePubkey } = getChannel(signer);
+	return new Promise<string>((resolve, reject) => {
+		const timer = setTimeout(() => reject(new Error(`${method} timed out`)), timeoutMs);
+		try {
+			rpc.sendRequest(remotePubkey, method, params, NIP46_KIND, (response) => {
+				clearTimeout(timer);
+				if (response?.error) {
+					reject(new Error(`${method}: ${response.error}`));
+					return;
+				}
+				resolve(response?.result ?? '');
+			});
+		} catch (e) {
+			clearTimeout(timer);
+			reject(e);
+		}
+	});
+}
+
+/**
+ * Resolve the user's actual pubkey by issuing a NIP-46 `get_public_key`
+ * RPC. NDK's `NDKNip46Signer.user()` is synchronous and returns the
+ * signer service pubkey from the constructor, not the user identity —
+ * calling it to obtain the user's pubkey silently logs sessions in as
+ * the signer service.
+ */
+export async function fetchNip46UserPubkey(
+	signer: NDKNip46Signer,
+	timeoutMs = DEFAULT_TIMEOUT_MS
+): Promise<string> {
+	const result = await sendNip46Rpc(signer, 'get_public_key', [], timeoutMs);
+	const pubkey = result.trim().toLowerCase();
+	if (!/^[0-9a-f]{64}$/.test(pubkey)) {
+		throw new Error(`get_public_key invalid response: ${result}`);
+	}
+	return pubkey;
+}
+
+/**
+ * NIP-44 encrypt via NIP-46. NDK exposes `encrypt` only for NIP-04, so
+ * NIP-44 must be driven through the raw RPC. Returns the signer's
+ * ciphertext string.
+ */
+export async function nip44EncryptViaNip46(
+	signer: NDKNip46Signer,
+	recipientPubkey: string,
+	plaintext: string,
+	timeoutMs = DEFAULT_TIMEOUT_MS
+): Promise<string> {
+	return sendNip46Rpc(signer, 'nip44_encrypt', [recipientPubkey, plaintext], timeoutMs);
+}
+
+/**
+ * NIP-44 decrypt via NIP-46. Mirror of nip44EncryptViaNip46.
+ */
+export async function nip44DecryptViaNip46(
+	signer: NDKNip46Signer,
+	senderPubkey: string,
+	ciphertext: string,
+	timeoutMs = DEFAULT_TIMEOUT_MS
+): Promise<string> {
+	return sendNip46Rpc(signer, 'nip44_decrypt', [senderPubkey, ciphertext], timeoutMs);
+}


### PR DESCRIPTION
> **Blocks #331.** The review cycle of #331 depends on this fix landing first. #331 carries forward the same broken API assumptions (it adds one more `user()` call site and touches none of the encryption paths) but does not fix the underlying wrong-npub bug or the DM/backup encryption failures. If #331 merges before this PR, every NIP-46 login shipped to prod continues to log users in as the signer service and DMs continue to fail. See chain-of-custody below — #331 is not the origin of the bug, but merging it ahead of this fix ships a known-wrong auth path.
>
> Related tracking:
>  - #322 — bunker login UX (the issue #331 implements)
>  - #333 — handshake timeout extension
>  - #334 — NIP-44 compat test matrix
>  - #335 — login box UX redesign
>  - #336 — compat matrix doc skeleton

## Summary

Two production bugs, one root cause: `authManager.ts` and `encryptionService.ts` both call methods on `NDKNip46Signer` that don't exist.

### Bug 1 — Wrong npub after NIP-46 sign-in

Three paths in `authManager.ts` call `this.nip46Signer.user()` expecting it to trigger a NIP-46 `get_public_key` RPC. It doesn't — NDK's implementation is literally:

```ts
async user() {
  return this.remoteUser;
}
```

where `remoteUser` is a synchronous `NDKUser` built from the pubkey passed to the signer's constructor (the signer service pubkey). Every NIP-46 sign-in was silently logging the session in as the signer service, not the user. Events signed and published were attributed to the signer service pubkey.

### Bug 2 — "Your remote signer does not support encryption"

`encryptionService.ts` calls `signer.nip44Encrypt`, `signer.nip04Encrypt`, `signer.nip44Decrypt`, `signer.nip04Decrypt` — **none of which exist** on `NDKNip46Signer`. NDK exposes only `encrypt(recipient, value)` and `decrypt(sender, value)` which issue `nip04_encrypt` / `nip04_decrypt` RPCs under the hood. There is no NDK method for NIP-44 at all via NIP-46.

Every `typeof signer.nipXXEncrypt === 'function'` check returns false, so every NIP-46 user hits "Your remote signer does not support encryption" on DM send, wallet backup restore, and any other encryption path routed through the signer.

## Fix

New shared module `$lib/nip46Rpc.ts` that drives the signer's already-connected RPC channel directly (`signer.rpc.sendRequest`):

- `sendNip46Rpc` — generic JSON-RPC request with timeout
- `fetchNip46UserPubkey` — `get_public_key` with 64-char hex validation
- `nip44EncryptViaNip46` / `nip44DecryptViaNip46` — raw RPCs for NIP-44

`authManager.ts`:
- Replaces all three `nip46Signer.user()` call sites with `fetchNip46UserPubkey` from the shared module.
- `authenticateWithNIP46` and `completeNip46PairingWithSignerPubkey` now resolve the real user pubkey; the reconnect path still falls back to the stored value on RPC failure (acceptable: previously fetched correct pubkey).
- `completeNip46PairingWithSignerPubkey` has **no silent fallback** — if the RPC fails, auth throws rather than logging the session in as the signer service.

`encryptionService.ts`:
- `encrypt()` NIP-46 branch prefers `nip44_encrypt` via raw RPC, falls through to NDK's `encrypt()` (NIP-04) on NIP-44 signer rejection.
- `decrypt()` NIP-46 branch mirrors the same shape.
- `getEncryptionMethod()` recognizes NIP-46 signers and returns `'nip44'` as preferred.
- `hasEncryptionSupport`'s direct-method check now looks for the real method name (`encrypt`) rather than nip04/44-prefixed variants.
- `SignerWithEncryption` type updated to match NDK's real API.

## Chain of custody

- `efbb79a` (2025-12-27, spe1020): original NIP-46 bunker feature — introduced the first `user()` call with the incorrect assumption about NDK's API.
- `6f51e53` (2026-01-06, spe1020): commit message says *"Always fetch user pubkey via get_public_key"* and *"Verify and update user pubkey on reconnect to prevent wrong npub authentication"*. Author was actively trying to fix wrong-npub but kept using the broken API. Added call sites 2 and 3.
- `a029069` (#331, 2026-04-24, DSanich): added a fourth `user()` call site in the new timeout-fallback path with the same pattern. **Not the origin of the bug.** When #331 merges, a trivial rebase against this PR's shared helper is required.
- The encryption half (`signer.nipXXEncrypt`) pre-dates the auth bugs and has been broken for NIP-46 users since the feature shipped.

## Test plan

- [x] `bun run check` — no new type errors; pre-existing 4 errors / 127 warnings unchanged.
- [x] Local sign-in verified — displayed npub now matches the Amber account approved (previously showed signer service pubkey).
- [ ] Amber via nostrconnect QR → displayed npub matches; NIP-04 DM sends succeed; NIP-44 DM sends succeed.
- [ ] Amber via `bunker://` paste → same.
- [ ] Primal via nostrconnect QR → same.
- [ ] Primal via `bunker://` paste → same.
- [ ] Wallet backup restore with NIP-46 signer succeeds.
- [ ] Reload page after login → session restored, correct npub persists.
- [ ] Logout and re-pair → fresh pairing, correct npub and working DMs.

Results will be recorded in `docs/dev/NIP46_SIGNER_COMPAT.md` (PR #336) as they come in.