### PR TITLE
fix(nip46): use NIP-44-aware local signer so QR pairing actually completes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.284",
+  "version": "4.2.285",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.285",
+  "version": "4.2.286",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/authManager.ts
+++ b/src/lib/authManager.ts
@@ -9,7 +9,9 @@ import {
 } from '@nostr-dev-kit/ndk';
 import { nip19, getPublicKey, generateSecretKey } from 'nostr-tools';
 import * as nip44 from 'nostr-tools/nip44';
+import * as nip04 from 'nostr-tools/nip04';
 import { fetchNip46UserPubkey } from './nip46Rpc';
+import { Nip44LocalSigner } from './nip44LocalSigner';
 
 export interface AuthState {
   isAuthenticated: boolean;
@@ -346,8 +348,10 @@ export class AuthManager {
         .map((b) => b.toString(16).padStart(2, '0'))
         .join('');
 
-      // Create a local signer for the NIP-46 client
-      const localSigner = new NDKPrivateKeySigner(localPrivateKey);
+      // Create a local signer for the NIP-46 client. NIP-44-aware
+      // wrapper: NDK 2.10's NDKPrivateKeySigner is NIP-04-only and the
+      // RPC channel inherits its encrypt/decrypt — see Nip44LocalSigner.
+      const localSigner = new Nip44LocalSigner(localPrivateKey);
 
       // Add relays to NDK if not already present
       for (const relay of relays) {
@@ -473,17 +477,19 @@ export class AuthManager {
     try {
       console.log('[NIP-46] Reconnecting to bunker...');
 
-      // Use stored local private key if available
-      let localSigner: NDKPrivateKeySigner;
+      // Use stored local private key if available. NIP-44-aware wrapper —
+      // see Nip44LocalSigner for why NDKPrivateKeySigner alone hangs on
+      // spec-compliant signers.
+      let localSigner: Nip44LocalSigner;
       if (nip46Info.localPrivateKey) {
-        localSigner = new NDKPrivateKeySigner(nip46Info.localPrivateKey);
+        localSigner = new Nip44LocalSigner(nip46Info.localPrivateKey);
       } else {
         // Generate new ephemeral key (will need re-pairing)
         const localPrivateKeyBytes = generateSecretKey();
         const localPrivateKey = Array.from(localPrivateKeyBytes)
           .map((b) => b.toString(16).padStart(2, '0'))
           .join('');
-        localSigner = new NDKPrivateKeySigner(localPrivateKey);
+        localSigner = new Nip44LocalSigner(localPrivateKey);
       }
 
       // Add relays first
@@ -717,26 +723,33 @@ export class AuthManager {
     return { uri, relays };
   }
 
-  // Decrypt NIP-44 encrypted content
-  private decryptNip44(
+  // Decrypt a NIP-46 connect-response payload. Tries NIP-44 first
+  // (current spec) then falls back to NIP-04 — older signers (and
+  // some bunker servers that mirror the request format) still publish
+  // their connect-response in NIP-04. Async because `nostr-tools/nip04`
+  // exposes `decrypt` as a Promise.
+  private async decryptNip44(
     ciphertext: string,
     senderPubkey: string,
     recipientPrivateKey: string
-  ): string {
+  ): Promise<string> {
+    const privateKeyBytes = new Uint8Array(
+      recipientPrivateKey.match(/.{1,2}/g)!.map((byte) => parseInt(byte, 16))
+    );
+
     try {
-      // Convert hex private key to Uint8Array
-      const privateKeyBytes = new Uint8Array(
-        recipientPrivateKey.match(/.{1,2}/g)!.map((byte) => parseInt(byte, 16))
-      );
-
-      // Get conversation key
       const conversationKey = nip44.v2.utils.getConversationKey(privateKeyBytes, senderPubkey);
-
-      // Decrypt
       return nip44.v2.decrypt(ciphertext, conversationKey);
-    } catch (e) {
-      console.error('[NIP-46] Failed to decrypt NIP-44 content:', e);
-      throw new Error('Failed to decrypt response');
+    } catch (nip44Error) {
+      try {
+        return await nip04.decrypt(recipientPrivateKey, senderPubkey, ciphertext);
+      } catch {
+        console.error(
+          '[NIP-46] Failed to decrypt response with NIP-44 or NIP-04:',
+          nip44Error
+        );
+        throw new Error('Failed to decrypt response');
+      }
     }
   }
 
@@ -793,7 +806,7 @@ export class AuthManager {
       // spoofed pairing attempts at worst.
       let response: { id?: string; method?: string; result?: unknown; error?: string };
       try {
-        const decrypted = this.decryptNip44(
+        const decrypted = await this.decryptNip44(
           event.content,
           signerPubkey,
           pendingInfo.localPrivateKey
@@ -945,7 +958,8 @@ export class AuthManager {
     this.updateState({ isLoading: true, error: null });
 
     try {
-      const localSigner = new NDKPrivateKeySigner(pendingInfo.localPrivateKey);
+      // NIP-44-aware local signer — see Nip44LocalSigner.
+      const localSigner = new Nip44LocalSigner(pendingInfo.localPrivateKey);
 
       for (const relay of pendingInfo.relays) {
         try {

--- a/src/lib/nip44LocalSigner.ts
+++ b/src/lib/nip44LocalSigner.ts
@@ -1,0 +1,76 @@
+/**
+ * NIP-44-aware local signer for NIP-46 RPC channels.
+ *
+ * Background — why this wrapper exists:
+ *
+ * NIP-46 mandates that the JSON-RPC `content` carried by kind:24133
+ * events is NIP-44 encrypted. NDK 2.10.0's `NDKPrivateKeySigner` (the
+ * default local signer used by `NDKNip46Signer`) implements
+ * `encrypt`/`decrypt` with `nostr-tools/nip04` only. Every RPC NDK sends
+ * via `signer.rpc.sendRequest` is therefore NIP-04 on the wire, and
+ * every incoming response is fed back through the same NIP-04 decrypt
+ * inside `NDKNostrRpc.parseEvent`.
+ *
+ * Modern signers (Primal, current Amber, nsec.app) follow the spec and
+ * respond NIP-44, so NDK silently fails to decrypt their responses —
+ * `response-${id}` never emits, the `sendRequest` callback never fires,
+ * and our `blockUntilReady` / `fetchNip46UserPubkey` hang for their
+ * full timeout window. Symptom: QR pairing stalls on "Waiting for
+ * approval…" even though the signer reports a successful connection.
+ *
+ * This wrapper substitutes `nip44.v2` on the encrypt path and tries
+ * `nip44.v2` first / `nip04` fallback on the decrypt path. NIP-04
+ * fallback preserves compatibility with older signers that haven't
+ * migrated yet.
+ *
+ * Pass an instance of this class as the `localSigner` argument to
+ * `NDKNip46Signer` — never as a user-facing signer for events the
+ * client publishes (the user's own events are not NIP-46 RPCs).
+ */
+
+import { NDKPrivateKeySigner, type NDKUser } from '@nostr-dev-kit/ndk';
+import * as nip44 from 'nostr-tools/nip44';
+import * as nip04 from 'nostr-tools/nip04';
+
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.substr(i * 2, 2), 16);
+  }
+  return bytes;
+}
+
+export class Nip44LocalSigner extends NDKPrivateKeySigner {
+  async encrypt(recipient: NDKUser, value: string): Promise<string> {
+    const hex = this.privateKey;
+    if (!hex) {
+      throw new Error('Nip44LocalSigner: private key not available');
+    }
+    const conversationKey = nip44.v2.utils.getConversationKey(hexToBytes(hex), recipient.pubkey);
+    return nip44.v2.encrypt(value, conversationKey);
+  }
+
+  async decrypt(sender: NDKUser, value: string): Promise<string> {
+    const hex = this.privateKey;
+    if (!hex) {
+      throw new Error('Nip44LocalSigner: private key not available');
+    }
+
+    // Try NIP-44 first (current spec). Fall through to NIP-04 only if
+    // NIP-44 throws — older signers may still emit NIP-04 ciphertexts
+    // and we don't want to break compat by forcing the new format.
+    try {
+      const conversationKey = nip44.v2.utils.getConversationKey(hexToBytes(hex), sender.pubkey);
+      return nip44.v2.decrypt(value, conversationKey);
+    } catch (nip44Error) {
+      try {
+        return await nip04.decrypt(hex, sender.pubkey, value);
+      } catch (nip04Error) {
+        // Surface the original NIP-44 error — that's the spec-mandated
+        // path, and the fallback failure is rarely what the caller
+        // needs to debug.
+        throw nip44Error;
+      }
+    }
+  }
+}

--- a/src/lib/nip44LocalSigner.ts
+++ b/src/lib/nip44LocalSigner.ts
@@ -31,14 +31,7 @@
 import { NDKPrivateKeySigner, type NDKUser } from '@nostr-dev-kit/ndk';
 import * as nip44 from 'nostr-tools/nip44';
 import * as nip04 from 'nostr-tools/nip04';
-
-function hexToBytes(hex: string): Uint8Array {
-  const bytes = new Uint8Array(hex.length / 2);
-  for (let i = 0; i < bytes.length; i++) {
-    bytes[i] = parseInt(hex.substr(i * 2, 2), 16);
-  }
-  return bytes;
-}
+import { hexToBytes } from '@noble/hashes/utils.js';
 
 export class Nip44LocalSigner extends NDKPrivateKeySigner {
   async encrypt(recipient: NDKUser, value: string): Promise<string> {
@@ -65,7 +58,7 @@ export class Nip44LocalSigner extends NDKPrivateKeySigner {
     } catch (nip44Error) {
       try {
         return await nip04.decrypt(hex, sender.pubkey, value);
-      } catch (nip04Error) {
+      } catch {
         // Surface the original NIP-44 error — that's the spec-mandated
         // path, and the fallback failure is rarely what the caller
         // needs to debug.


### PR DESCRIPTION
## Summary
QR / universal NIP-46 pairing currently stalls on "Waiting for approval…" — even when the signer reports a successful connection on its end — and eventually times out. This PR fixes the underlying NIP-04/NIP-44 mismatch.

## Root cause
NIP-46's current spec mandates **NIP-44** for the kind:24133 RPC `content`. NDK 2.10's `NDKPrivateKeySigner.encrypt`/`decrypt` are **NIP-04 only**, and `NDKNip46Signer` drives its RPC channel through that local signer:

- `NDKNostrRpc.sendRequest` → `signer.encrypt(...)` (NIP-04 outgoing)
- `NDKNostrRpc.parseEvent` → `signer.decrypt(...)` (NIP-04 incoming)

Spec-compliant signers (Primal, current Amber, nsec.app) respond NIP-44. NDK's NIP-04 decrypt silently fails on those responses, the per-id `response-${id}` event never emits, and `blockUntilReady` / `fetchNip46UserPubkey` hang for their full timeout window. The catch in `startNip46ResponseListener` then logs and silently returns, leaving the modal stuck on "Waiting for approval…".

## Fix
**`src/lib/nip44LocalSigner.ts`** (new) — `Nip44LocalSigner` subclasses `NDKPrivateKeySigner` and overrides:
- `encrypt` → `nip44.v2.encrypt`
- `decrypt` → `nip44.v2.decrypt` first, NIP-04 fallback for older signers

**`src/lib/authManager.ts`** — three NIP-46 call-site swaps where the local signer is passed to `NDKNip46Signer`: `authenticateWithNIP46`, `reconnectNIP46`, `completeNip46PairingWithSignerPubkey`. Non-NIP-46 uses of `NDKPrivateKeySigner` (private-key login, anonymous post) are deliberately untouched — those publish events as the user, not as RPC payloads.

Also adds NIP-04 fallback to `startNip46ResponseListener`'s `decryptNip44` so older signers' connect-responses still parse. The listener's strict early-return validation (secret match, `'ack'` compat, single-listener lifecycle, all from #331's review pass) is unchanged — fallback is purely inside the decrypt helper. That helper becomes async because `nostr-tools/nip04.decrypt` is a Promise; the listener already awaits its result.

## What this does NOT touch
- `NIP46ConnectionInfo.secret` persistence and `pubkey#secret` reconstruction
- `supportsNIP46QRPairing` / `supportsNIP46BunkerPaste` platform split
- `nip46Rpc.ts` module surface — it auto-benefits because `signer.rpc.sendRequest` now produces NIP-44 with the wrapper in place
- `encryptionService.ts` post-pairing crypto routing (#337)

## Test plan
- [ ] Universal QR pairing with Primal mobile signer → modal advances past "Waiting for approval…" within seconds, npub displayed matches the Primal account
- [ ] Universal QR pairing with Amber → same
- [ ] Universal QR pairing with nsec.app → same
- [ ] Bunker URI paste (web + iOS) → still works
- [ ] NIP-46 reload → session restores, correct npub
- [ ] DM send via NIP-46 signer → encryption goes through (`encryptionService.ts` is unchanged but benefits from the same wire-format fix)

`svelte-check`: 0 errors / 127 warnings (warnings all pre-existing on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)