### PR TITLE
docs(perf): 2026-04 speed & functionality review

### DIFF
--- a/docs/perf/2026-04-review.md
+++ b/docs/perf/2026-04-review.md
@@ -1,0 +1,538 @@
+# zap.cooking Speed & Functionality Review — 2026-04
+
+**Status:** investigation only. No production code changes proposed in this pass.
+**Scope:** toggle crispness on Community feed and recipe pages; relay strategy
+across the codebase; reaction button architecture (without regressing the
+count-correctness work in PRs #321 / #323).
+**Working branch:** `docs/perf-2026-04-review` off `origin/main`. The
+prompt referenced a `perf/feed-measurement` baseline that does not exist
+on `origin` — closest matches are `perf/following-feed-optimization` and
+`perf/nip29-group-loading-speed`. See **Open Questions** below.
+
+---
+
+## 1. Executive summary
+
+- **The biggest single perceived-latency win sits behind one Svelte
+  pattern.** `routes/community/+page.svelte:120` increments a `feedKey`
+  on tab change and the feed at `:379` is wrapped in `{#key feedKey}`.
+  Switching tabs **destroys and remounts the entire `FoodstrFeedOptimized`
+  component**, including its caches, subscriptions, and scroll position.
+  Tabs paint instantly (state is local) but the body re-initializes from
+  scratch every switch. Pass `filterMode` as a prop and let the feed
+  branch internally instead.
+- **Reaction publishes are already optimistic.** `ReactionTrigger.svelte:69`
+  calls `trackOptimisticReaction()` and bumps the store at `:72–90`
+  *before* `await publishReaction()`. Click-to-paint is sub-frame on the
+  pill itself. The dedup architecture from PRs #321/#323 (per-event
+  Maps with init-if-absent semantics) is intact and should not be
+  modified.
+- **`batchFetchEngagement` is imported but never called from the feed.**
+  `FoodstrFeedOptimized.svelte:91` imports it; grep across the file
+  shows zero call sites. Per-card `fetchEngagement` calls fan out from
+  five children (likes, comments, zaps, repost, pills) for every card
+  on screen. Wiring batch in is a high-impact, low-risk change with
+  zero impact on dedup correctness.
+- **NIP-65 is fully implemented for read but ignored on write.**
+  `relayListCache.ts` parses kind:10002 with read/write markers and
+  caches with SWR semantics, and `followOutbox.ts` uses it for feed
+  reads. `publishQueue.ts` ignores it entirely — publishes go to one
+  of four hardcoded modes (`default`, `garden`, `pantry`,
+  `garden+pantry`). Reactions, comments, and zaps therefore never
+  reach the recipient's published inbox.
+- **`members.zap.cooking` is referenced but unused.** `nostr.ts:140-176`
+  defines a `members` mode and `relays/relaySets.ts:42` lists it, but
+  no read or write call site targets it. Either the integration was
+  removed and the dead config was left behind, or it's planned and not
+  wired up. Worth resolving before more relay work.
+- **Comment toggle on feed cells uses a fragile DOM-event bridge.**
+  `NoteTotalComments.svelte:23-32` does
+  `document.querySelector('[data-event-id=...]').closest('.inline-comments')`
+  and dispatches a `CustomEvent('toggleComments')` that
+  `CommentThread.svelte:66` listens for. Any DOM-structure change
+  silently breaks the button — no console error, no fallback. The
+  subscription is also lazy: first toggle has a 500ms+ warm-start.
+- **`ReactionPills` `{#each}` is implicit-keyed.**
+  `ReactionPills.svelte:113` iterates `visibleGroups` (a sliced derived
+  array, new ref every tick) without an explicit `(group.emoji)` key.
+  Pills remount on count changes. Render churn, not correctness.
+- **Timeouts are scattered.** Six different timeout constants live across
+  six files (6s/8s/10s/15s/30s). One central `NETWORK_TIMEOUT_CONFIG`
+  with named profiles would cut down on drift and make slow-relay
+  tuning a one-line change.
+- **No `AbortController` use anywhere in the relay path.** All timeouts
+  are `setTimeout` / `Promise.race`. This forecloses cancelling
+  in-flight fetches when the user navigates away — relevant if we
+  later want to abandon a slow recipe-detail open.
+- **No reaction undo (NIP-09 deletion) is implemented.** Reactions are
+  one-way. Not a perf issue per se, but if undo is added later it has
+  to filter referenced kind:7 events at read time in `processReaction`
+  — flagging now so it doesn't get bolted on without spec compliance.
+
+---
+
+## 2. Toggle crispness
+
+### 2.1 Toggle inventory
+
+| # | Toggle | File:line | State owner | Click→paint sync? | Notable symptom |
+|---|---|---|---|---|---|
+| 1 | Feed tab (Global / Following / Replies / Groups / Garden) | `routes/community/+page.svelte:44`, setter `:116-126` | local `let activeTab` + `feedKey` increment | Y for tab itself; **N for feed body** | `{#key feedKey}` at `:379` forces full feed remount |
+| 2 | Reaction picker open/close | `Reactions/ReactionTrigger.svelte:24` | local `showPicker` | Y | none |
+| 3 | Reaction pill (recipe) | `Reactions/ReactionPills.svelte:12` | engagement store | Y (optimistic) | `{#each}` at `:113` lacks explicit key |
+| 4 | Reaction button (alt API) | `Reactions/ReactionButton.svelte:20` | local + engagement store | Y (optimistic) | 2s NIP-45 COUNT timeout can produce a second re-render when EOSE arrives later |
+| 5 | Inline comment toggle (feed variant) | `comments/CommentThread.svelte:51`, bridge `NoteTotalComments.svelte:23-32` | local `showComments` via DOM `CustomEvent` | Y for fold; **N for first paint** | lazy sub at `:81`, fragile selector |
+| 6 | Repost menu / repost action | `NoteRepost.svelte:21` | local `showMenu` + engagement store | Y (optimistic for action) | none |
+| 7 | Zap one-tap / long-press modal | `NoteTotalZaps.svelte:19-24` | local + engagement store | Y after gesture detection | fixed 500ms long-press window |
+| 8 | Mesh theme / filter / layer / cuisine | `mesh/MeshControlPanel.svelte:21-44` | global stores | Y | mesh re-render is a separate concern |
+| 9 | Cooking tools tabs (Timer ↔ Converter) | `CookingToolsWidget.svelte:614-625` | store | Y | none |
+| 10 | Generic `<Tabs>` | `components/Tabs.svelte:5` | prop-driven | Y | depends on parent |
+| 11 | Nourish flag direction | `nourish/NourishFlagButton.svelte:175-183` | local | Y | none |
+| 12 | Nourish input tabs | `nourish/NourishInputTabs.svelte:72` | local/prop | Y | none |
+
+### 2.2 Where the felt latency actually comes from
+
+Three paths, ranked by impact:
+
+**A. Feed tab remount (`routes/community/+page.svelte:120` + `:379`).**
+The active-class flip on the tab itself paints instantly because
+`activeTab` is a plain Svelte `let`. The body lag comes from the
+`{#key feedKey}` wrapper around `<FoodstrFeedOptimized>`: every tab
+click increments `feedKey`, which Svelte interprets as "destroy and
+remount." Result: every internal cache the feed has built — engagement
+stores, subscriptions, render windowing state — gets thrown away. On a
+cold tab switch this dominates perceived latency.
+
+The cleaner pattern is to pass `filterMode={activeTab}` as a prop and
+let the feed branch internally. The dedup work in PRs #321/#323 is
+already keyed by event id (singletons in `engagementCache.ts:25-39`),
+so the engagement layer survives a prop swap fine.
+
+**B. Comment toggle first-paint stall
+(`comments/CommentThread.svelte:81`).** The reactive block
+`$: if ($ndk && !sub && showComments)` opens the comment subscription
+*on toggle*, not on parent mount. First click pays the full
+subscription warm-start latency before any comments paint. Second
+click is fast because `sub` is already set.
+
+Two options: (a) pre-warm the subscription on parent render with a
+small visibility-gated batch (similar to the engagement batching
+opportunity in §4); (b) render a cheap skeleton while the subscription
+is warming. (a) costs more bandwidth, (b) is a UI tweak. Want to
+measure before deciding.
+
+**C. The DOM-event bridge that drives the comment toggle
+(`NoteTotalComments.svelte:23-32`).** Independent of (B), the toggle
+itself uses
+```js
+document.querySelector(`[data-event-id="${event.id}"]`).closest('.inline-comments').dispatchEvent(new CustomEvent('toggleComments'))
+```
+This is a brittle two-step DOM walk; if either selector misses, the
+button silently does nothing. Replace with a Svelte event or a
+component prop binding. Independent of any perf concern, this is a
+correctness papercut.
+
+### 2.3 Render-churn watchpoints
+
+- **`ReactionPills.svelte:113`** — `{#each visibleGroups as group}`
+  with no key. `visibleGroups` is `$: $store.reactions.groups.slice(0,
+  maxVisible)` (`:93`); `slice` returns a new array ref every reactive
+  tick, even if contents are identical. Pills remount on every count
+  update. Add `(group.emoji)`.
+- **`{#if activeTab === 'members'}` at `:338`** swaps a Groups UI block
+  for the feed block on tab change. With (A) above already addressed,
+  this is fine; without it, this is a second source of layout shift on
+  the same click.
+
+### 2.4 Existing instrumentation
+
+- `src/lib/perf/explorePerf.ts` — `init() / mark() / markOnce() / reset()`
+  with console output `[perf:explore] ${label} +${elapsed}ms`. Wired
+  only to the Explore route. **Not** used on Community feed or any
+  toggle.
+- `src/lib/performanceMonitor.ts` — profile-cache hit/miss counters,
+  feed-load timings, subscription leak tracker. Throttled to 5s in
+  dev. Not wired to toggles either.
+- Neither covers click-to-paint; that's the gap if we want to quantify
+  toggle latency before optimizing.
+
+---
+
+## 3. Relay strategy
+
+### 3.1 Default and pool wiring
+
+- Canonical default list: **6 relays** in `lib/consts.ts:1-8` —
+  `relay.damus.io`, `garden.zap.cooking`, `nos.lol`, `purplepag.es`,
+  `relay.primal.net`, `nostr.wine`.
+- NDK init in `lib/nostr.ts:140-176` exposes four modes: `default`,
+  `garden`, `members`, `discovery`. All four enable NDK's outbox model
+  with a hardcoded fallback set
+  `DEFAULT_OUTBOX_RELAY_URLS = ['wss://purplepag.es', 'wss://nos.lol']`
+  (`:16`).
+- `autoConnectUserRelays: false` (`:196`) — NDK does **not**
+  auto-discover the user's published relay list at boot; we resolve it
+  manually through `relayListCache.ts`.
+- `getCurrentRelays()` (`:207-221`) reads from `localStorage`, falling
+  back to `standardRelays`. Read vs. write split is explicit via the
+  outbox URLs.
+
+### 3.2 Owned infrastructure
+
+| Relay | Role | Used at | Notes |
+|---|---|---|---|
+| `wss://garden.zap.cooking` | Pyramid relay (writes for general events; **excluded** from longform reads) | `lib/nostr.ts:604`, `lib/relays/relaySets.ts:22,33`, `lib/publishQueue.ts:439-445` | Dedicated `GardenRelayMonitor` in `nostr.ts:632-923` (NIP-42, 60s heartbeat, exponential backoff). `lib/articleOutbox.ts:45` explicitly **excludes** garden from kind:30023 reads ("issues with longform"). |
+| `wss://pantry.zap.cooking` | NIP-29 group chat + Nourish events | `lib/nip29.ts:19-61`, `lib/relays/relaySets.ts:42`, `lib/publishQueue.ts:446-452` | Hardcoded as a one-relay `NDKRelaySet`. NIP-42 auto-sign at `nip29.ts:96-100,127-156`. Fully isolated; no cross-leak. |
+| `wss://members.zap.cooking` | khatru relay | Referenced in `relays/relaySets.ts:42`, mentioned in `tiers.ts:12,17` | **No active call site found.** The `members` mode in `nostr.ts` exists but no read/write path targets it. **UNKNOWN** whether this is dead config or planned-but-unwired. |
+
+The garden-excluded-from-longform asymmetry is the only confirmed
+content-type leakage guard. `publishQueue.ts:462-502` has an `all`
+mode that can include garden for any kind, including kind:30023, if
+the pool happens to contain it — that's the leakage risk in the other
+direction.
+
+### 3.3 NIP-65 (kind:10002)
+
+`lib/relayListCache.ts` is a complete implementation:
+
+- Parses read/write markers per spec (`:397-441`), matching NIP-65's
+  optional third-element `read` / `write` marker.
+- 6h SWR TTL, 7d hard expire, IndexedDB persistence, memory cache,
+  batch prefetch (`:54-74`).
+- Discovery relay set `purplepag.es / relay.damus.io / nos.lol /
+  relay.primal.net` for fetching other users' kind:10002.
+- Public API `getOutboxRelays()`, `getInboxRelays()`, `getOutboxRelaysMany()`
+  at `:918-956`.
+
+**Read uses it:** `lib/followOutbox.ts:140-200` calls
+`relayListCache.getMany()` for author write-relay lookup before feed
+queries. `lib/queryBatcher.ts` batches by relay list.
+
+**Write doesn't use it:** `lib/publishQueue.ts` ignores the cache;
+publishes route through one of the four hardcoded modes. NIP-65's
+mandate that publishes also go to **read relays of each tagged user**
+is not honored. Practical effect: replies, mentions, reactions, and
+zaps don't reach the recipient's chosen inbox unless that inbox
+happens to overlap with our default pool.
+
+### 3.4 Read flow per content type
+
+| Kind | Flow | Relay set | File:line |
+|---|---|---|---|
+| 0 (profile) | NDK outbox model + author-specific writes via cache | hardcoded outbox + cached NIP-65 outbox | `lib/nostr.ts:16,196`, `lib/followOutbox.ts:140-200` |
+| 30023 (recipe/article) | Primal-first, then 7 article relays, fallback 2 | `ARTICLE_RELAYS` (excludes garden) | `lib/articleOutbox.ts:85-93` |
+| 7 (reaction) | Default pool | `getCurrentRelays()` | `lib/engagementCache.ts:143,468-500` |
+| 1 / 1111 (note / NIP-22 longform comment) | Default pool via shared sub manager | `getCurrentRelays()` | `lib/feedSubscriptionManager.ts:71-112` |
+| 9735 (zap) | Default pool ± custom relays | `getCurrentRelays()` | `lib/zapPollCache.ts` |
+| 9 / 39000 / 39002 (NIP-29) | Pantry only (single-relay set) | `[PANTRY_RELAY]` | `lib/nip29.ts:19,60-61` |
+
+Two consistency gaps stand out: (a) reactions, comments, and zaps don't
+target the **author's** outbox or the **target's** inbox, and (b)
+profiles partially do (via `followOutbox`) but profile **publishes**
+don't (`publishQueue` ignores the cache).
+
+### 3.5 Subscription lifecycle
+
+- Reuse: yes. `feedSubscriptionManager.ts:71-112` derives `subId` from
+  the filter and reuses if present (`:101-112`); multiple components
+  register callbacks on one underlying sub.
+- Closure: `closeOnEose: true` for ephemeral fetches
+  (`feedSubscriptionManager:115`, `zapPollCache`); `closeOnEose: false`
+  for engagement (`engagementCache.ts:143`) and articles
+  (`articleOutbox.ts:240`).
+- Manual stop: relay-switch callbacks at `lib/nostr.ts:53-72` walk
+  registered subs and stop them. No `AbortController` anywhere.
+- NDK groupable behavior handles same-filter dedup at the protocol
+  layer; we don't have an explicit dedup shim above it.
+
+### 3.6 EOSE / "done loading"
+
+- Feed: first-relay EOSE triggers `onEose` callback
+  (`feedSubscriptionManager.ts:129`). `closeOnEose: true` → done.
+- Engagement: `closeOnEose: false` plus a 30s soft idle timeout
+  (`engagementCache.ts:142-143`) — first EOSE OR timeout, whichever
+  fires.
+- Articles: parallel Primal (6s) + relay (15s) fetches; render on
+  partial data via `onEvent` callback (`articleOutbox.ts:125`).
+- NIP-29: explicit per-operation timeouts (auth 8s, data 15s).
+
+There's no first-quorum `K-of-N` rendering policy; everything either
+renders on first EOSE or streams continuously and is gated by an idle
+timeout. **UNKNOWN** whether any place currently waits for *all*
+relays — grep didn't find one, but worth confirming if we want a
+formal redundancy target.
+
+### 3.7 Timeout map
+
+| Component | Timeout | Per |
+|---|---|---|
+| `publishQueue.ts` | 10s relay + 5s wrapper = 15s | per query |
+| `articleOutbox.ts` | 6s Primal, 15s relays | per source |
+| `engagementCache.ts` | 30s idle | per sub |
+| `zapPollCache.ts` | 10s | per query |
+| `nip29.ts` | 8s auth, 15s data | per operation |
+| `relayListCache.ts` | 8s | per batch |
+
+Six numbers across six files. None abortable.
+
+### 3.8 Redundancy map
+
+| Set | Count | Members |
+|---|---|---|
+| Default | 6 | damus, garden, nos.lol, purplepag.es, primal.net, nostr.wine |
+| Articles | 7 | default minus garden plus nostr.band, antiprimal.net |
+| Discovery | 4 | purplepag.es, damus, nos.lol, primal.net |
+| Garden | 2 | garden, nos.lol |
+| Pantry | 1 | pantry only |
+| `MAX_RELAYS_PER_AUTHOR` | 3 | per `lib/relaySelector.ts:47` |
+| `MAX_AUTHORS_PER_SUB` | 500 | per `feedSubscriptionManager.ts:45` |
+
+### 3.9 Consistency-risk table
+
+| Content | Read | Write | Honors NIP-65 (read) | Honors NIP-65 (write) | Risk |
+|---|---|---|---|---|---|
+| Profile (0) | outbox pool + cached NIP-65 outbox | hardcoded outbox URLs | partial | **no** | Medium |
+| Recipe (30023) | Primal + 7 article relays | hardcoded modes (garden excluded) | n/a | **no** | Low |
+| Reaction (7) | default pool | hardcoded modes | **no** | **no** | Medium |
+| Note / Comment (1, 1111) | default pool | hardcoded modes | **no** | **no** | High — replies/mentions can miss recipient inbox |
+| Zap (9735) | default pool | hardcoded modes | **no** | **no** | Medium |
+| NIP-29 (9, 39000, 39002) | pantry only | pantry only | n/a | n/a | Low (isolated) |
+
+---
+
+## 4. Reaction architecture
+
+### 4.1 Lifecycle (ASCII)
+
+```
+USER CLICK
+  │
+  ▼
+ReactionTrigger.handleReaction()           [Reactions/ReactionTrigger.svelte:49]
+  │
+  ▼
+trackOptimisticReaction(eventId, emoji)    [engagementCache.ts:744]
+  │  ── adds (eventId,emoji) to optimisticReactions sentinel before ack
+  ▼
+store.update(reactions.count++)            [Reactions/ReactionTrigger.svelte:72-90]
+  │  ── pill paints instantly (sub-frame)
+  ▼
+await publishReaction(...)                 [publishReaction.ts:33]
+  │  ├─ ensureNip46SignerReady              [:45-48]
+  │  ├─ build NDKEvent kind:7               [:50-59]
+  │  ├─ await event.sign()                  [:62]
+  │  └─ Promise.race([publish, timeout])    [:64-69]
+  │
+  ▼
+markEventAsProcessed(event.id)             [Reactions/ReactionTrigger.svelte:104]
+  │
+  ▼ (async, via sub echo)
+engagementCache sub.on('event', ...)       [engagementCache.ts:468-500]
+  │  ├─ if processed.has(event.id) return       [:469]   ← dedup A
+  │  └─ processReaction()                       [:558-623]
+  │     ├─ if optimisticReactions.has(...)      [:576-584] ← dedup B (skips +1)
+  │     └─ else update store                    [:598-622]
+  ▼
+final on-screen count = optimistic +1, never echoed twice
+```
+
+### 4.2 Count source of truth
+
+`engagementCache.ts:25-39` keys writable stores by event id (singleton
+per id). All five rendering children — `NoteTotalLikes`, `ReactionPills`,
+`NoteTotalComments`, `NoteTotalZaps`, `NoteRepost` — share the same
+underlying store for a given event because `getEngagementStore(eventId)`
+returns the same ref.
+
+Counts are scalar (`reactions.count`) plus a per-emoji array
+(`reactions.groups[]`). Both update atomically inside `processReaction`
+(`:598-622`).
+
+The dedup architecture from PRs #321/#323:
+
+- `processedEventIds: Map<eventId, Set<eventId>>` (`:67`)
+- `processedReactionPairs: Map<eventId, Set<'pubkey:emoji'>>` (`:69`)
+- Init-if-absent at `:348-354` (the #323 fix). **Do not move that to
+  reset-on-entry.**
+- Cleared only by `cleanupEngagement(eventId)` (`:832-839`) when a note
+  leaves the viewport.
+
+### 4.3 NIP-25 compliance (cross-checked against the spec)
+
+`publishReaction.ts:50-59` builds the kind:7 event:
+
+- `content` → emoji string (e.g. `'❤️'`, `'🔥'`). **Spec OK** — NIP-25
+  permits any emoji or NIP-30 shortcode; legacy `+`/`-` are normalized
+  on the **read** side at `engagementCache.ts:563-571`.
+- For notes (`targetType='note'`): tags `['e', id, '', 'reply']` plus
+  `['p', author]`. Spec wants `['e', id, hint, author]` — we pass an
+  empty relay hint and put `'reply'` in the author slot. **Minor spec
+  drift:** the relay hint should be a wss URL, and the third position
+  is *not* `'reply'`; that's NIP-10 marker semantics applied to the
+  wrong position. Read clients will still find the target by id, but
+  outbound relay routing loses a hint.
+- For recipes (`targetType='recipe'`): tags include `['a',
+  '<kind>:<pubkey>:<d-tag>']` plus `['p', author]`. **Spec OK** —
+  matches NIP-25's "Reactions to a website" guidance for replaceable
+  events.
+- `k` tag with the target kind: **omitted**. NIP-25 says this MAY be
+  included; not a defect.
+
+Self-reaction filter: not implemented. `engagementCache.ts:576,601`
+attribute the event to the user via `userReacted` but still count it.
+This is a product decision, not a bug.
+
+Undo / NIP-09: **not implemented at all** for reactions. Grep across
+the codebase finds kind:5 only for recipe deletion
+(`Recipe.svelte:422-441`). `CommentCard.toggleLike()` (`:225-266`),
+`ReactionTrigger`, and `ReactionPills` are all one-way. If undo is
+added later, `processReaction` (`:558-623`) needs to learn to filter
+out kind:7 events that the user has subsequently kind:5'd.
+
+### 4.4 Cross-relay dedup
+
+The same kind:7 from two relays hits one subscription handler. Dedup A
+at `engagementCache.ts:469` short-circuits on `event.id` already in
+`processed`. Dedup B at `:576-584` skips counting on
+`(eventId, emoji)` pair already in the optimistic sentinel. Belt and
+suspenders; both are necessary for the fixes from PR #323 to hold
+under concurrent re-entry.
+
+### 4.5 UI block points
+
+`Reactions/ReactionTrigger.svelte:49-115` flow:
+
+| Op | Blocking | When |
+|---|---|---|
+| `trackOptimisticReaction()` | no | sync, ~µs |
+| `store.update()` | no | sync, Svelte mutation |
+| `await publishReaction()` | yes | sign + publish round-trip |
+| `ensureNip46SignerReady()` | yes | NIP-46 handshake (can be seconds on first publish) |
+| `await event.sign()` | yes | crypto |
+| `Promise.race([publish, 30s])` | yes | one relay ack or timeout |
+
+The optimistic update happens **before** the first `await`, so the
+button paints immediately. The only user-visible wait is on undo /
+revert, which only fires if publish fails — and even then the rollback
+is a single store mutation.
+
+`CommentCard.toggleLike()` (`:225-266`) follows the same shape: sign
+→ optimistic mutate → publish, with rollback on failure.
+
+### 4.6 Memoization watchpoints
+
+- `ReactionPills.svelte:113` — `{#each visibleGroups as group}` with
+  no explicit key. `visibleGroups` at `:93` is
+  `$store.reactions.groups.slice(0, maxVisible)` — new array ref every
+  reactive tick. Add `(group.emoji)`.
+- `FoodstrFeedOptimized.svelte:91` — `batchFetchEngagement` is
+  imported but never invoked in the file. Five children fan out per
+  card and call `fetchEngagement(event.id)` individually. The shared
+  store layer dedup-protects correctness; the cost is N concurrent
+  per-card subscriptions instead of one batched one.
+
+### 4.7 Notable findings outside the count path
+
+- `Reactions/ReactionButton.svelte` exists but isn't referenced. Either
+  dead code from an earlier refactor or a deliberate fallback that's
+  no longer wired. Worth confirming before any reaction changes ship.
+- The 30s freshness gate at `engagementCache.ts:246-250` skips re-fetch
+  if data is <30s old. For a fast-scroll user revisiting a card within
+  that window, the freshness gate is a feature, not a bug. For a
+  long-idle user it's a bottleneck on first interaction. A
+  viewport-re-entry signal would be more targeted than a flat TTL.
+
+---
+
+## 5. Prioritized recommendations
+
+Ordering: **impact** × **inverse risk** × **inverse effort**. Effort is
+dev-days, rough order of magnitude.
+
+| # | Recommendation | Impact | Risk | Effort | Notes |
+|---|---|---|---|---|---|
+| **R1** | Replace `{#key feedKey}` remount in community/+page.svelte with prop-based filterMode | **H** | L | 0.5–1d | Biggest single perceived-latency win on the feed. Engagement layer is event-id keyed, survives prop swap. |
+| **R2** | Wire `batchFetchEngagement` from FoodstrFeedOptimized | **H** | L | 0.5d | Already imported, never called. Per-card sub fan-out → batch. Dedup unaffected. |
+| **R3** | Replace comment-toggle DOM bridge with Svelte event/prop | M | L | 0.5d | `NoteTotalComments.svelte:23-32`. Correctness papercut + small perf win. |
+| **R4** | Add explicit key to `ReactionPills` `{#each}` | L | L | <0.25d | `ReactionPills.svelte:113`. Pure render churn fix. |
+| **R5** | Centralize relay timeouts into `NETWORK_TIMEOUT_CONFIG` | M | L | 0.5–1d | Six timeouts across six files; consolidating makes slow-relay tuning a one-line change. |
+| **R6** | Fix NIP-25 `e`-tag shape in `publishReaction.ts:50-59` | M | L | <0.25d | `['e', id, '', 'reply']` → `['e', id, <relay hint>, <author>]` per spec. Read paths already tolerant; outbound routing improves. |
+| **R7** | Decide `members.zap.cooking` — wire it or remove it | M | L | 0.5–2d | Depends on which way you go. Currently dead config that confuses reasoning about relay strategy. |
+| **R8** | Pre-warm comment subscriptions on visibility | M | M | 1–2d | Eliminates first-toggle stall but trades for bandwidth. Measure first. |
+| **R9** | Honor NIP-65 in `publishQueue.ts` for tagged-user inbox routing | **H** | M | 2–3d | Replies/mentions reach intended recipients. Cache layer already exists. Bigger surface area; do after R1+R2 ship. |
+| **R10** | Migrate engagement freshness gate from flat TTL to viewport re-entry | M | M | 1–2d | Replace 30s wall-clock check at `engagementCache.ts:246-250` with an IntersectionObserver-driven signal. |
+| **R11** | Add `AbortController` to long-running fetches (recipe detail, mesh, garden) | M | M | 2d | Lets us cancel on navigation. Required before any "first-quorum K-of-N" rendering. |
+| **R12** | Click-to-paint instrumentation on top toggles | M | L | 1d | Without it, "this feels faster" is unfalsifiable. Use the `performanceMonitor.ts` skeleton as the host. |
+| **R13** | Remove or restore `Reactions/ReactionButton.svelte` | L | L | <0.25d | Dead code or undocumented fallback. Decide and clean. |
+
+---
+
+## 6. Proposed implementation order
+
+The feed-speed initiative has five stages; here's how this slots in.
+
+**Stage 1 — measurement.** R12 + a baseline run on Community feed
+tab-switch, comment-toggle, reaction-click. Land on
+`perf/feed-measurement` (which we'll create off this branch since it
+doesn't exist on origin) as `TEMP-INSTRUMENT` commits per the prompt's
+working rules. *Stop and capture numbers before touching anything.*
+
+**Stage 2 — biggest perceived-latency wins, no behavior change.**
+R1 (feed remount), R2 (batch engagement), R4 (pill key). All three are
+small, low-risk, and the dedup layer guarantees correctness. Re-run
+the Stage 1 instrumentation; expect tab-switch latency to drop from
+"full feed reset" to "filter swap" and per-card subscription count to
+collapse.
+
+**Stage 3 — correctness papercuts touched up alongside.**
+R3 (DOM bridge), R6 (NIP-25 e-tag), R13 (dead code). All <0.5d each.
+Land in one PR with R5 (timeout consolidation) so the relay-touching
+work in Stage 4 has a clean surface.
+
+**Stage 4 — relay strategy.**
+R7 (members decision) → R5 lands (already done in Stage 3) → R9
+(NIP-65 publish honoring) → R8 (comment pre-warm) in that order. R7
+first because it changes our "what relays exist" mental model. R9 is
+the largest semantic change — replies, mentions, and reactions start
+reaching the right inbox. R8 changes load characteristics; tune
+last.
+
+**Stage 5 — render quality.**
+R10 (viewport-aware freshness), R11 (AbortController), and any
+follow-ups Stage 1's data surfaces.
+
+If we have to ship just one PR before the next sprint review, **R1 +
+R2 + R4 in a single change** is the correct call: they're the
+biggest felt wins, share zero risk surface with the count work, and
+together cost ~1 dev-day.
+
+---
+
+## 7. Open questions / spec ambiguities
+
+1. **Missing baseline branch.** The prompt assumes
+   `perf/feed-measurement` exists. It doesn't on origin. Either it was
+   never pushed, was renamed (`perf/following-feed-optimization` is the
+   closest match), or lives on a personal fork. Need confirmation
+   before Stage 1 starts.
+2. **Self-reaction filter — product decision needed.** Code currently
+   counts user's own reactions (`engagementCache.ts:576,601`). NIP-25
+   says nothing about it. Confirm this is intentional.
+3. **`members.zap.cooking` status.** Dead, planned, or wired in a path
+   I missed? Need a yes/no before relay consolidation.
+4. **First-quorum render policy.** Do we want a formal "render after K
+   of N relays respond, or after T ms"? Today every place either waits
+   for first EOSE or streams forever with an idle timer. If yes, this
+   is a Stage 5 change and `AbortController` (R11) is a prereq.
+5. **NIP-25 `k` tag.** Spec says MAY include the target kind in the
+   reaction event. Worth adding (no cost) for downstream clients that
+   filter by it?
+6. **Reaction undo.** Not implemented today. Is undo desired? If yes,
+   `processReaction` needs kind:5 awareness; flag now so the data
+   model accounts for it.
+7. **`Reactions/ReactionButton.svelte` purpose.** Unreferenced. Stale
+   refactor leftover or fallback for a flag that's currently off?
+8. **NIP-46 round-trip cost on first reaction.** `ensureNip46SignerReady`
+   can dominate the first-publish latency for remote-signer users.
+   Should that be measured separately in Stage 1, or is the optimistic
+   UI sufficient cover?

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.284",
+  "version": "4.2.285",
   "private": true,
   "scripts": {
     "dev": "vite dev",


### PR DESCRIPTION
## Summary
Investigation-only report covering toggle crispness on the Community feed and recipe pages, the relay strategy across the codebase, and the reaction button architecture (without regressing the count-correctness work in #321/#323). No production code changes — `docs/perf/2026-04-review.md` is the only file added.

## Top findings (full detail in the report)

- **Feed tab remount** — `routes/community/+page.svelte:120` increments `feedKey` and `:379` wraps the feed in `{#key feedKey}`. Every tab click destroys and remounts `FoodstrFeedOptimized` plus all its caches and subscriptions. Switching to a prop-driven `filterMode` is the biggest single perceived-latency win.
- **`batchFetchEngagement` imported but never called** in `FoodstrFeedOptimized.svelte:91`. Five per-card children fan out individual `fetchEngagement` calls; the engagement-cache singleton dedup-protects correctness but the subscription count multiplies needlessly.
- **NIP-65 fully implemented for read, ignored on write.** `relayListCache.ts` parses kind:10002 with read/write markers and SWR caching; `publishQueue.ts` routes through four hardcoded modes and never consults the cache. Replies, mentions, reactions, and zaps don't reach the recipient's published inbox.
- **`members.zap.cooking` is dead config.** Referenced in `tiers.ts` and `relays/relaySets.ts:42`; the `members` mode in `nostr.ts:140-176` exists; no active read or write call site targets it.
- **Comment toggle uses a fragile DOM bridge.** `NoteTotalComments.svelte:23-32` does `document.querySelector('[data-event-id=...]').closest('.inline-comments').dispatchEvent(new CustomEvent('toggleComments'))`. Silent failure on any DOM-structure change. Subscription is also lazy at `CommentThread.svelte:81` → 500ms+ first-paint stall.
- **`ReactionPills` `{#each}` is unkeyed.** `:113` iterates `visibleGroups` (sliced derived array, new ref every tick) without `(group.emoji)`. Pills remount on every count update.
- **Minor NIP-25 e-tag drift** at `publishReaction.ts:50-59`. `['e', id, '', 'reply']` puts the NIP-10 marker in what NIP-25 reserves for the author hint.
- **No reaction undo path.** Kind:5 deletions only exist for recipes; reactions are one-way. Flagging now so it isn't bolted on without spec compliance later.
- **Six different timeout constants across six files**, none abortable. No `AbortController` in the relay path.

## What's in the report

1. Executive summary (10 bullets)
2. Section per scope area (toggles, relays, reactions) with file:line citations
3. **R1–R13 prioritized recommendations** tagged with impact (H/M/L), risk (H/M/L), and effort
4. **Proposed 5-stage implementation order** — Stage 1 measurement, Stage 2 the biggest felt-latency wins (R1+R2+R4), Stage 3 papercuts, Stage 4 relay strategy, Stage 5 render quality
5. **Open Questions** — including: the `perf/feed-measurement` branch the original prompt referenced doesn't exist on `origin` (closest match: `perf/following-feed-optimization`)

## Implementation footprint if we land just one follow-up PR

R1 (feed remount) + R2 (batch engagement) + R4 (pill key) in one change. ~1 dev-day, biggest felt wins, zero risk surface against the PR #321/#323 count-correctness work.

## Test plan
- [ ] Markdown renders correctly on GitHub
- [ ] Reviewers agree on the implementation order in §6 before any follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)