### PR TITLE
perf(reactions): key ReactionPills each by group.emoji

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.286",
+  "version": "4.2.287",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/Reactions/ReactionPills.svelte
+++ b/src/components/Reactions/ReactionPills.svelte
@@ -110,7 +110,7 @@
 
 {#if $store.reactions.groups.length > 0}
   <div class="flex flex-wrap gap-1 mb-2">
-    {#each visibleGroups as group}
+    {#each visibleGroups as group (group.emoji)}
       <button
         type="button"
         class="flex items-center gap-1 h-6 px-1.5 rounded-full border text-sm transition-colors cursor-pointer {group.userReacted


### PR DESCRIPTION
## Summary
**R4 from `docs/perf/2026-04-review.md`.** Adds an explicit each-block key to `ReactionPills`. One-line change, no behavior change, intentionally tiny scope.

`visibleGroups` (`ReactionPills.svelte:93`) is computed as `$store.reactions.groups.slice(0, maxVisible)` — `slice` returns a fresh array reference every reactive tick, so without an explicit key Svelte falls back to identity-based keying and remounts every pill button when the count updates. The buttons are visually identical between updates; the remount is pure render churn.

Keying on `group.emoji` keeps each button instance across count changes.

## Why this PR is just R4

The original plan was R1 + R2 + R4 in one PR. Closer reading of the actual code changed that:

- **R1 (feed-tab remount → prop)** is bigger than the report estimated. `FoodstrFeedOptimized` declares `lastFilterMode` at `:487` but never reads it — there's **no reactive watcher on `filterMode`** anywhere in the 5000-line component. The `{#key feedKey}` remount is the only change-detection mechanism. Replacing it properly means extracting `setupFeed()`/`teardownFeed()` helpers from `onMount`/`onDestroy` and wiring a `$:` watcher. That's a real refactor on a critical UX surface; deserves its own PR with focused review and shouldn't be bundled with anything else. **Tracking separately.**
- **R2 (wire `batchFetchEngagement`)** turned out to already be wired. The function is called at `FoodstrFeedOptimized.svelte:4717` (preload, 20-event batches with `lastBatchedIds` dedup) and `:4753` (visibility-driven, 100ms-debounced). My report's "imported but never called" claim was a partial-grep miss — apologies for the noise. Pushing batching further needs Stage 1 measurement (also tracked in the report) to know what's actually fanning out.

So this PR ships only the literally-one-keyword change. Risk surface against PRs #321/#323's count-correctness work is zero — counts, ordering, optimistic-update flow, and the dedup architecture in `engagementCache.ts` are untouched.

## Test plan
- [ ] Open a recipe with multiple emoji reactions; click one of your own pills (un-react, then re-react).
  - **Pass:** the pill stays in place; count animates without the button visually flickering.
  - **Fail (current behavior pre-PR):** brief flash where buttons reflow as Svelte remounts them.
- [ ] Add a new emoji that wasn't in the visible set yet.
  - **Pass:** the new pill appears at the end without disturbing existing ones.
- [ ] `pnpm svelte-check` reports 0 errors (already verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)