### PR TITLE
perf(feed): drop {#key feedKey} remount in favor of existing watcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.286",
+  "version": "4.2.287",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/routes/community/+page.svelte
+++ b/src/routes/community/+page.svelte
@@ -47,9 +47,6 @@
   let hasActiveMembership = false;
   let checkingMembership = false;
 
-  // Key to force component recreation
-  let feedKey = 0;
-
   // Groups state (for Pantry tab)
   let selectedGroupId: string | null = null;
   let createGroupOpen = false;
@@ -117,7 +114,6 @@
     if (tab === activeTab) return;
 
     activeTab = tab;
-    feedKey++; // This forces component recreation with new filterMode
 
     // Update URL for bookmarking/sharing
     const url = new URL($page.url);
@@ -376,9 +372,7 @@
         <CreateGroupModal bind:open={createGroupOpen} on:created={handleGroupCreated} />
       {/if}
     {:else}
-      {#key feedKey}
-        <FoodstrFeedOptimized bind:this={feedComponent} filterMode={activeTab} />
-      {/key}
+      <FoodstrFeedOptimized bind:this={feedComponent} filterMode={activeTab} />
     {/if}
   </div>
 </PullToRefresh>

--- a/src/routes/kitchen/+page.svelte
+++ b/src/routes/kitchen/+page.svelte
@@ -22,12 +22,10 @@
   // Tab state
   type FilterMode = 'global' | 'following' | 'replies';
   let activeTab: FilterMode = 'global';
-  let feedKey = 0;
 
   function setTab(tab: FilterMode) {
     if (tab === activeTab) return;
     activeTab = tab;
-    feedKey++;
   }
 
 </script>
@@ -138,9 +136,7 @@
     </div>
   {/if}
 
-  {#key feedKey}
-    <FoodstrFeedOptimized bind:this={feedComponent} filterMode={activeTab} />
-  {/key}
+  <FoodstrFeedOptimized bind:this={feedComponent} filterMode={activeTab} />
 </div>
 </PullToRefresh>
 


### PR DESCRIPTION
**Draft.** Filed as draft because the change is small but lives in front of `FoodstrFeedOptimized`, which is the most-touched UI surface in the app — wants a careful manual smoke before promoting.

Closes #343 (R1 from `docs/perf/2026-04-review.md`).

## What changed
3 files, +3/-13. The entire diff is removing redundant glue:

- `routes/community/+page.svelte` — drop `let feedKey = 0`, drop `feedKey++` in `setTab`, drop `{#key feedKey}…{/key}` around `<FoodstrFeedOptimized>`.
- `routes/kitchen/+page.svelte` — same pattern, same removal.

No new code added.

## Why this works (and why I revised my prior diagnosis)

When I filed #343 I claimed `FoodstrFeedOptimized` had no reactive `filterMode` watcher — that the only change-detection mechanism was the `{#key feedKey}` remount. **Closer reading proved that wrong.** A complete watcher already exists at `FoodstrFeedOptimized.svelte:4371-4508`:

- Reads `lastFilterMode` at `:4373` (so it's not unused — I missed `:4381`'s assignment).
- Branches on transition type:
  - **garden/members entry** — hard reset: `stopSubscriptions()`, clear visible/rendered notes, `loadFoodstrFeed(false)`.
  - **leaving garden/members** — cache-first via `loadFromInstantCache`, background `fetchFreshAndMerge()`.
  - **between global/following/replies** — same cache-first warm path.
- Guards re-entry with `filterModeChangeInProgress`. Rapid clicks don't pile up.

The `{#key feedKey}` wrapper actively *prevents* this watcher from running. Every tab click destroys the component and creates a new one, and the new instance's `onMount` sets `lastFilterMode = filterMode` before any prop change can fire — so the optimized cache-first warm path never runs. We've been paying the destroy/rebuild cost AND ignoring the optimization that already lives in the file.

Drop the wrapper → the watcher takes over → tab switches keep the feed instance alive, the engagement stores it's already populated, and the cache-first warm path actually gets used.

## Risk surface

- **PR #321 / #323 dedup architecture is untouched.** Engagement stores are singletons keyed by event id (`engagementCache.ts:25-39`) — they survive any `FoodstrFeedOptimized` lifecycle independent of this PR. The `processedEventIds` and `processedReactionPairs` Maps in the same file aren't tied to feed mount either. Reaction count correctness from those PRs is preserved.
- **The `{#if activeTab === 'members'} … {:else} feed {/if}` block in community/+page.svelte is unchanged.** Members tab still mounts/unmounts the feed via that conditional. Only the redundant key-driven remount inside the `{:else}` branch is removed.
- **No subscription leaks.** `stopSubscriptions()` is already called by the watcher at `:4390 / :4411 / :4455`. Same teardown that previously happened in `onDestroy` now happens in the watcher.

## Why draft

I want a manual smoke pass before this gets promoted, since the file it's gating is so heavily used. The diff itself is reviewable in 30 seconds — the test plan is the gating step.

## Test plan
- [ ] **Happy path:** open `/community`, switch through Global → Following → Replies → Garden → Global. Each transition should:
  - paint the active tab indicator instantly
  - swap content without a full skeleton flash
  - preserve scroll position when returning to a tab (or document if scroll resets — that's expected with the cache-first reload, just confirm it's not jumpy)
- [ ] **Engagement stays correct.** On a tab with reactions visible, switch away and back. Reaction counts on the visible cards match what they were before the switch (PR #321/#323 regression check).
- [ ] **Members tab transitions still work.** Going FROM Members to any feed tab and FROM any feed tab to Members — the Groups UI mounts/unmounts via the existing `{#if/else}`. Should be unaffected.
- [ ] **Pull-to-refresh works in each mode.**
- [ ] **`/kitchen` page** — same checks, narrower set: Global / Following / Replies.
- [ ] **Cold load via direct URL** — `/community?tab=garden` and `/community?tab=following` both load correctly on first paint.
- [ ] **`pnpm svelte-check`** — 0 errors. Already verified locally.
- [ ] **Subscription leak check (DevTools):** open DevTools, switch tabs 10x, confirm WebSocket subscription count stays bounded. The watcher's `stopSubscriptions()` should match what `onDestroy` was doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)