### PR TITLE
feat(signin): refresh /login modal UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.287",
+  "version": "4.2.288",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/app.html
+++ b/src/app.html
@@ -65,11 +65,11 @@
     </script>
 
     <link rel="icon" href="%sveltekit.assets%/favicon.svg" />
-    <!-- Digital font for timer display -->
+    <!-- Display fonts: Orbitron for timer; Fraunces for marketing/login headlines. -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&family=Fraunces:ital,opsz,wght@0,9..144,500;0,9..144,600;1,9..144,500;1,9..144,600&display=swap"
       rel="stylesheet"
     />
     <meta

--- a/src/components/LoginFormIOS.svelte
+++ b/src/components/LoginFormIOS.svelte
@@ -834,94 +834,97 @@
     </div>
   </div>
 
-  <div class="relative flex flex-col items-center min-h-screen px-4 pt-12 md:pt-20 pb-8">
-    <!-- Main Content Card -->
+  <div class="ios-signin-wrap">
     <section
-      class="glass-card rounded-2xl p-6 md:p-8 w-full mx-auto text-center"
-      style="max-width: 420px;"
-      aria-label="Authentication options"
+      class="signin-card"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="ios-signin-title"
     >
-      <!-- Logo and Title -->
-      <div class="mb-5">
-        <img
-          src={isDarkMode ? '/zap_cooking_logo_white.svg' : '/zap_cooking_logo_black.svg'}
-          class="h-10 md:h-12 mb-2 mx-auto"
-          alt="Zap Cooking"
-        />
-        <h1 class="text-xl md:text-2xl font-bold mb-1" style="color: var(--color-text-primary)">
-          Welcome to <span class="text-orange-500">Zap Cooking</span>
-        </h1>
-        <p class="text-sm text-caption">Share recipes and support creators with Bitcoin zaps</p>
+      <div class="signin-brand" aria-hidden="true">
+        <span class="signin-bolt" />
       </div>
 
-      <!-- Authentication Options -->
-      <div class="space-y-2.5 mb-3">
-        <!-- Create Profile - Primary CTA for iOS -->
-        <button
-          on:click={() => (generateModal = true)}
-          disabled={authState.isLoading}
-          aria-label="Create a new Zap Cooking profile"
-          class="w-full bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 text-white font-semibold h-[52px] md:h-12 px-6 rounded-xl transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm"
-        >
-          <div class="flex items-center justify-center gap-2">
-            <span class="text-lg">⚡</span>
-            <span class="text-[15px]">Create Profile</span>
-          </div>
-        </button>
+      <h1 id="ios-signin-title" class="signin-title">
+        Welcome <em>back.</em>
+      </h1>
+      <p class="signin-subtitle">Pull up a chair. Your keys unlock the kitchen.</p>
 
-        <!-- Import Existing Key - Secondary -->
-        <button
-          on:click={() => (nsecModal = true)}
-          disabled={authState.isLoading}
-          aria-label="Sign in with your Nostr private key"
-          class="w-full bg-input hover:opacity-90 font-medium h-11 px-6 rounded-xl transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed border"
-          style="color: var(--color-text-primary); border-color: var(--color-input-border)"
-        >
-          <span class="text-sm">🔑 Import Private Key</span>
-        </button>
-        <button
-          on:click={openBunkerModal}
-          disabled={authState.isLoading}
-          aria-label="Sign in with bunker URI"
-          class="w-full text-caption hover:opacity-80 hover:underline transition-colors disabled:opacity-50 text-sm py-1"
-        >
-          🔐 Paste bunker URI
-        </button>
-      </div>
+      <!-- Primary CTA on iOS: create new account
+           (NIP-07 + QR pairing intentionally omitted on iOS — App Store
+            policy on cross-app handoff for unlisted signers.) -->
+      <button
+        type="button"
+        on:click={() => (generateModal = true)}
+        disabled={authState.isLoading}
+        aria-label="Create a new Zap Cooking profile"
+        class="signin-cta-primary"
+      >
+        <span class="signin-cta-label">
+          {authState.isLoading ? 'Connecting…' : 'Create a new account'}
+        </span>
+      </button>
 
-      <!-- Error Display -->
       {#if authState.error}
-        <div
-          class="bg-input border rounded-lg p-2.5 mb-3"
-          style="border-color: var(--color-danger, #ef4444)"
-        >
-          <p class="text-xs" style="color: var(--color-danger, #ef4444)">{authState.error}</p>
+        <div class="signin-error" role="alert">
+          {authState.error}
         </div>
       {/if}
 
-      <!-- Value Propositions -->
-      <section
-        class="grid grid-cols-2 gap-x-3 gap-y-1.5 text-[11px] text-caption pt-3 border-t"
-        style="border-color: var(--color-input-border)"
-        aria-label="Zap Cooking features"
-      >
-        <div class="flex items-center gap-1">
-          <span class="text-orange-400 text-xs">⚡</span>
-          <span>Instant Bitcoin Tips</span>
+      <div class="signin-divider" aria-hidden="true">
+        <span>or</span>
+      </div>
+
+      <details class="signin-disclosure">
+        <summary>
+          <span>More sign-in methods</span>
+          <svg
+            class="signin-chevron"
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+            aria-hidden="true"
+          >
+            <path
+              d="M4 6l4 4 4-4"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </summary>
+        <div class="signin-disclosure-list">
+          <button
+            type="button"
+            on:click={openBunkerModal}
+            disabled={authState.isLoading}
+            class="signin-method"
+          >
+            <span class="signin-method-title">Paste bunker URI</span>
+            <span class="signin-method-meta">NIP-46</span>
+          </button>
+          <button
+            type="button"
+            on:click={() => (nsecModal = true)}
+            disabled={authState.isLoading}
+            class="signin-method"
+          >
+            <span class="signin-method-title">Import private key</span>
+            <span class="signin-method-meta signin-method-meta-warn">advanced</span>
+          </button>
         </div>
-        <div class="flex items-center gap-1">
-          <span class="text-blue-400 text-xs">🔒</span>
-          <span>Decentralized & Private</span>
-        </div>
-        <div class="flex items-center gap-1">
-          <span class="text-purple-400 text-xs">🌍</span>
-          <span>Global Recipe Community</span>
-        </div>
-        <div class="flex items-center gap-1">
-          <span class="text-green-400 text-xs">📱</span>
-          <span>Cross-Platform Access</span>
-        </div>
-      </section>
+      </details>
+
+      <footer class="signin-footer">
+        <span class="signin-footer-tag">Your keys, your kitchen.</span>
+        <span class="signin-footer-links">
+          <a href="/terms">Terms</a>
+          <span aria-hidden="true">·</span>
+          <a href="/privacy">Privacy</a>
+        </span>
+      </footer>
     </section>
   </div>
 </main>
@@ -950,6 +953,246 @@
     50% {
       opacity: 0.8;
       transform: scale(1.05);
+    }
+  }
+
+  /* ───── New sign-in card (iOS parity) ───── */
+  /* Mirrors the desktop styles in src/routes/login/+page.svelte. Kept
+     duplicated rather than promoted to app.css because the visual is
+     scoped to the login surface. If we end up with a third entry point
+     we'll factor these into a shared component. */
+
+  .ios-signin-wrap {
+    position: relative;
+    z-index: 1;
+    min-height: 100vh;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 1.5rem 1rem;
+    padding-top: max(2.5rem, env(safe-area-inset-top));
+    padding-bottom: max(1.5rem, env(safe-area-inset-bottom));
+  }
+
+  .signin-card {
+    width: 100%;
+    max-width: 440px;
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-input-border);
+    border-radius: 24px;
+    padding: 2.25rem 1.75rem 1.5rem;
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 0.04) inset,
+      0 24px 64px rgba(0, 0, 0, 0.18),
+      0 4px 12px rgba(236, 71, 0, 0.06);
+    text-align: center;
+    animation: signinRise 320ms cubic-bezier(0.2, 0.8, 0.25, 1) both;
+  }
+
+  @keyframes signinRise {
+    from { opacity: 0; transform: translateY(8px) scale(0.985); }
+    to { opacity: 1; transform: translateY(0) scale(1); }
+  }
+
+  .signin-brand {
+    width: 56px;
+    height: 56px;
+    margin: 0 auto 1.25rem;
+    border-radius: 50%;
+    background: radial-gradient(
+      circle at 50% 45%,
+      #ffd28a 0%, #ff9542 32%, #ec4700 70%, #7c1d00 100%
+    );
+    box-shadow:
+      0 0 0 1px rgba(255, 213, 138, 0.35) inset,
+      0 0 24px rgba(236, 71, 0, 0.45);
+    display: grid;
+    place-items: center;
+    animation: signinPulse 3.2s ease-in-out infinite;
+  }
+
+  @keyframes signinPulse {
+    0%, 100% { box-shadow: 0 0 0 1px rgba(255, 213, 138, 0.35) inset, 0 0 24px rgba(236, 71, 0, 0.45); }
+    50% { box-shadow: 0 0 0 1px rgba(255, 213, 138, 0.5) inset, 0 0 36px rgba(236, 71, 0, 0.65); }
+  }
+
+  .signin-bolt {
+    width: 18px;
+    height: 30px;
+    background: #fff8ec;
+    clip-path: polygon(58% 0, 18% 56%, 46% 56%, 32% 100%, 82% 42%, 54% 42%, 70% 0);
+    filter: drop-shadow(0 0 4px rgba(255, 240, 200, 0.85));
+    animation: signinFlicker 4.8s ease-in-out infinite;
+  }
+
+  @keyframes signinFlicker {
+    0%, 92%, 100% { opacity: 1; }
+    93% { opacity: 0.55; }
+    94% { opacity: 1; }
+    96% { opacity: 0.7; }
+    97% { opacity: 1; }
+  }
+
+  .signin-title {
+    font-family: 'Fraunces', Georgia, 'Times New Roman', serif;
+    font-weight: 600;
+    font-size: 1.875rem;
+    line-height: 1.15;
+    letter-spacing: -0.01em;
+    color: var(--color-text-primary);
+    margin: 0 0 0.5rem;
+  }
+
+  .signin-title em {
+    font-style: italic;
+    font-weight: 500;
+    background: linear-gradient(135deg, #ff9542 0%, #ec4700 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+
+  .signin-subtitle {
+    font-size: 0.9375rem;
+    color: var(--color-text-secondary);
+    margin: 0 0 1.75rem;
+    line-height: 1.5;
+  }
+
+  .signin-cta-primary {
+    width: 100%;
+    height: 52px;
+    border-radius: 14px;
+    border: none;
+    background: linear-gradient(135deg, #ff9542 0%, #ec4700 100%);
+    color: #fff8ec;
+    font-weight: 600;
+    font-size: 0.9375rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.625rem;
+    padding: 0 1.25rem;
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 0.18) inset,
+      0 8px 24px rgba(236, 71, 0, 0.32),
+      0 2px 6px rgba(124, 29, 0, 0.18);
+    transition: transform 120ms ease, box-shadow 200ms ease, opacity 200ms ease;
+  }
+  .signin-cta-primary:hover:not(:disabled) { transform: translateY(-1px); }
+  .signin-cta-primary:disabled { opacity: 0.55; cursor: not-allowed; }
+  .signin-cta-primary:focus-visible { outline: 2px solid #ffd28a; outline-offset: 2px; }
+
+  .signin-error {
+    margin-top: 1rem;
+    padding: 0.625rem 0.75rem;
+    border-radius: 10px;
+    background: rgba(239, 68, 68, 0.08);
+    border: 1px solid var(--color-danger, #ef4444);
+    font-size: 0.8125rem;
+    color: var(--color-danger, #ef4444);
+    line-height: 1.5;
+  }
+
+  .signin-divider {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 1.5rem 0 1rem;
+    color: var(--color-text-secondary);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+  }
+  .signin-divider::before, .signin-divider::after {
+    content: ''; flex: 1; height: 1px; background: var(--color-input-border);
+  }
+
+  .signin-disclosure {
+    border-radius: 14px;
+    border: 1px solid var(--color-input-border);
+    background: var(--color-bg-primary);
+  }
+  .signin-disclosure summary {
+    list-style: none;
+    cursor: pointer;
+    padding: 0.875rem 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    color: var(--color-text-primary);
+    font-size: 0.9375rem;
+    font-weight: 500;
+    user-select: none;
+  }
+  .signin-disclosure summary::-webkit-details-marker { display: none; }
+  .signin-disclosure summary:focus-visible {
+    outline: 2px solid #ec4700;
+    outline-offset: -2px;
+    border-radius: 14px;
+  }
+  .signin-chevron { transition: transform 200ms ease; color: var(--color-text-secondary); }
+  .signin-disclosure[open] .signin-chevron { transform: rotate(180deg); }
+  .signin-disclosure-list {
+    display: flex;
+    flex-direction: column;
+    border-top: 1px solid var(--color-input-border);
+  }
+  .signin-method {
+    background: transparent; border: none;
+    padding: 0.875rem 1rem;
+    display: flex; align-items: center; justify-content: space-between;
+    color: var(--color-text-primary); font-size: 0.9375rem;
+    cursor: pointer; text-align: left;
+    border-bottom: 1px solid var(--color-input-border);
+    transition: background 150ms ease;
+  }
+  .signin-method:last-child { border-bottom: none; }
+  .signin-method:hover:not(:disabled) { background: rgba(236, 71, 0, 0.04); }
+  .signin-method:focus-visible { outline: 2px solid #ec4700; outline-offset: -2px; }
+  .signin-method:disabled { opacity: 0.55; cursor: not-allowed; }
+  .signin-method-title { font-weight: 500; }
+  .signin-method-meta {
+    font-size: 0.6875rem; font-weight: 600; letter-spacing: 0.04em;
+    color: var(--color-text-secondary);
+    padding: 0.125rem 0.5rem; border-radius: 999px;
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-input-border);
+  }
+  .signin-method-meta-warn {
+    color: #c2410c;
+    border-color: rgba(236, 71, 0, 0.35);
+    background: rgba(236, 71, 0, 0.08);
+  }
+
+  .signin-footer {
+    margin-top: 1.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--color-input-border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+  }
+  .signin-footer-tag { font-style: italic; }
+  .signin-footer-links { display: inline-flex; align-items: center; gap: 0.4rem; }
+  .signin-footer a { color: var(--color-primary, #ec4700); text-decoration: none; }
+  .signin-footer a:hover { text-decoration: underline; }
+
+  @media (max-width: 480px) {
+    .signin-card { padding: 1.75rem 1.25rem 1.25rem; border-radius: 20px; }
+    .signin-title { font-size: 1.625rem; }
+    .signin-subtitle { font-size: 0.875rem; margin-bottom: 1.5rem; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .signin-card, .signin-brand, .signin-bolt,
+    .signin-cta-primary, .signin-chevron {
+      animation: none !important;
+      transition: none !important;
     }
   }
 </style>

--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -16,7 +16,7 @@
 <script lang="ts">
   import { blur, scale } from 'svelte/transition';
   import CloseIcon from 'phosphor-svelte/lib/XCircle';
-  import { onMount, onDestroy } from 'svelte';
+  import { onMount, onDestroy, tick } from 'svelte';
 
   export let open = false;
   export let cleanup: (() => void) | null = null;
@@ -26,21 +26,76 @@
 
   // Portal target - render at document body level
   let portalTarget: HTMLElement;
+  let dialogEl: HTMLDialogElement | null = null;
+  let previousActiveElement: HTMLElement | null = null;
+  let lastOpen = false;
 
   onMount(() => {
     portalTarget = document.body;
   });
 
-  // Close on Escape key
-  function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape' && open) close();
+  // Find focusable descendants of the dialog. Hidden, disabled, or
+  // aria-hidden elements are excluded. Order matches DOM order.
+  function getFocusable(): HTMLElement[] {
+    if (!dialogEl) return [];
+    const selector =
+      'a[href], area[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+    return Array.from(dialogEl.querySelectorAll<HTMLElement>(selector)).filter((el) => {
+      if (el.hasAttribute('aria-hidden')) return false;
+      // offsetParent is null for display:none subtrees; visibility:hidden also reports null parent.
+      return el.offsetParent !== null || el === document.activeElement;
+    });
   }
 
-  $: if (typeof window !== 'undefined') {
+  function handleKeydown(e: KeyboardEvent) {
+    if (!open) return;
+    if (e.key === 'Escape') {
+      close();
+      return;
+    }
+    if (e.key === 'Tab') {
+      const focusable = getFocusable();
+      if (focusable.length === 0) {
+        // Nothing focusable inside — keep focus on the dialog itself.
+        e.preventDefault();
+        dialogEl?.focus();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && (active === first || !dialogEl?.contains(active))) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && (active === last || !dialogEl?.contains(active))) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+
+  // Open/close lifecycle: manage focus capture+restore + keydown listener.
+  $: if (typeof window !== 'undefined' && open !== lastOpen) {
+    lastOpen = open;
     if (open) {
+      previousActiveElement = (document.activeElement as HTMLElement) || null;
       window.addEventListener('keydown', handleKeydown);
+      // Defer initial focus so the dialog has mounted and transitions started.
+      tick().then(() => {
+        const focusable = getFocusable();
+        if (focusable.length > 0) {
+          focusable[0].focus();
+        } else {
+          dialogEl?.focus();
+        }
+      });
     } else {
       window.removeEventListener('keydown', handleKeydown);
+      // Return focus to whatever opened the modal.
+      if (previousActiveElement && typeof previousActiveElement.focus === 'function') {
+        previousActiveElement.focus();
+      }
+      previousActiveElement = null;
     }
   }
 
@@ -68,6 +123,8 @@
       class="fixed top-0 left-0 z-50 w-full h-full backdrop-brightness-50 backdrop-blur"
     >
       <dialog
+        bind:this={dialogEl}
+        tabindex="-1"
         transition:scale={{ duration: 250 }}
         aria-labelledby="title"
         aria-modal="true"

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1003,165 +1003,148 @@
     </div>
   </div>
 
-  <!-- Main Login Page (centered card, highest layer) -->
-  <main
-    class="login-viewport-center"
-    aria-label="Zap Cooking login page"
-  >
+  <!-- Main Login Card -->
+  <main class="login-viewport-center" aria-label="Sign in to Zap Cooking">
     <section
-      class="glass-card absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-3xl p-6 md:p-8 w-[calc(100%-2rem)] md:w-[calc(100vw-4em)] max-w-xl max-h-[85vh] md:max-h-[90vh] overflow-y-auto text-center"
-      aria-label="Authentication options"
+      class="signin-card"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="signin-title"
     >
-        <!-- Logo and Title -->
-        <div class="mb-5">
-          <img
-            src={isDarkMode ? '/zap_cooking_logo_white.svg' : '/zap_cooking_logo_black.svg'}
-            class="h-10 md:h-12 mb-2 mx-auto"
-            alt="Zap Cooking"
-          />
-          <h1 class="text-xl md:text-2xl font-bold mb-1" style="color: var(--color-text-primary)">
-            Welcome to <span class="text-orange-500">Zap Cooking</span>
-          </h1>
-          <p class="text-sm text-caption">Share recipes and support creators with Bitcoin zaps</p>
+      <!-- Brand mark -->
+      <div class="signin-brand" aria-hidden="true">
+        <span class="signin-bolt" />
+      </div>
+
+      <!-- Hero -->
+      <h1 id="signin-title" class="signin-title">
+        Welcome <em>back.</em>
+      </h1>
+      <p class="signin-subtitle">Pull up a chair. Your keys unlock the kitchen.</p>
+
+      <!-- Primary CTA: NIP-07 -->
+      <button
+        type="button"
+        on:click={loginWithNIP07}
+        on:mouseenter={() => (isHovered = true)}
+        on:mouseleave={() => (isHovered = false)}
+        disabled={authState.isLoading}
+        aria-label="Sign in to Zap Cooking using your Nostr browser extension"
+        class="signin-cta-primary"
+      >
+        <span class="signin-cta-label">
+          {authState.isLoading ? 'Connecting…' : 'Sign in with extension'}
+        </span>
+        <span class="signin-badge" aria-hidden="true">NIP-07</span>
+      </button>
+
+      <!-- Extension helper / missing-signer notice -->
+      {#if !showMissingSignerNotice && authManager?.isNIP07Available() === false}
+        <p class="signin-helper">
+          Works with
+          <a href="https://getalby.com" target="_blank" rel="noopener noreferrer">Alby</a>,
+          <a href="https://github.com/fiatjaf/nos2x" target="_blank" rel="noopener noreferrer"
+            >nos2x</a
+          >, and similar extensions.
+        </p>
+      {/if}
+      {#if showMissingSignerNotice}
+        <div class="signin-notice" role="alert">
+          No browser signer detected. Install
+          <a href="https://getalby.com" target="_blank" rel="noopener noreferrer">Alby</a>
+          or
+          <a href="https://github.com/fiatjaf/nos2x" target="_blank" rel="noopener noreferrer"
+            >nos2x</a
+          >, or pair an external signer like Amber below.
         </div>
+      {/if}
 
-        <!-- Authentication Options -->
-        <div class="space-y-2.5 mb-3">
-          <!-- NIP-07 Extension Login - Primary CTA -->
-          <div>
-            <button
-              on:click={loginWithNIP07}
-              on:mouseenter={() => (isHovered = true)}
-              on:mouseleave={() => (isHovered = false)}
-              disabled={authState.isLoading}
-              aria-label="Sign in to Zap Cooking using your Nostr browser extension"
-              class="w-full bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 text-white font-semibold h-[52px] md:h-12 px-6 rounded-xl transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm"
-            >
-              <div class="flex items-center justify-center gap-2">
-                <span class="text-lg">⚡</span>
-                <span class="text-[15px]">
-                  {authState.isLoading ? 'Connecting...' : 'Sign in with Browser Signer'}
-                </span>
-              </div>
-            </button>
-            <!-- Extension helper - show neutral info initially, warning only after click -->
-            {#if !showMissingSignerNotice && authManager?.isNIP07Available() === false}
-              <p class="text-[11px] text-caption mt-1.5 leading-relaxed">
-                Works with <a
-                  href="https://getalby.com"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="underline hover:opacity-80">Alby</a
-                >
-                or
-                <a
-                  href="https://github.com/fiatjaf/nos2x"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="underline hover:opacity-80">nos2x</a
-                >.
-              </p>
-            {/if}
-            <!-- Missing signer notice - shown only after user clicks and no extension detected -->
-            {#if showMissingSignerNotice}
-              <div
-                class="bg-input border rounded-lg p-2.5 mt-1.5"
-                style="border-color: var(--color-input-border)"
-              >
-                <p class="text-[11px] text-caption leading-relaxed">
-                  No browser signer detected. Install <a
-                    href="https://getalby.com"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="underline hover:opacity-80">Alby</a
-                  >
-                  or
-                  <a
-                    href="https://github.com/fiatjaf/nos2x"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="underline hover:opacity-80">nos2x</a
-                  >, or use an external signer like Amber.
-                </p>
-              </div>
-            {/if}
-          </div>
+      <!-- Secondary CTA: create new account -->
+      <button
+        type="button"
+        on:click={() => (generateModal = true)}
+        disabled={authState.isLoading}
+        aria-label="Create a new Zap Cooking profile"
+        class="signin-cta-secondary"
+      >
+        <span class="signin-plus" aria-hidden="true">+</span>
+        <span>Create a new account</span>
+      </button>
 
-          <!-- Generate New Account - Secondary CTA -->
-          <button
-            on:click={() => (generateModal = true)}
-            disabled={authState.isLoading}
-            aria-label="Create a new Zap Cooking profile"
-            class="w-full bg-input hover:opacity-90 font-medium h-11 px-6 rounded-xl transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed border"
-            style="color: var(--color-text-primary); border-color: var(--color-input-border)"
+      <!-- Error -->
+      {#if authState.error}
+        <div class="signin-error" role="alert">
+          {authState.error}
+        </div>
+      {/if}
+
+      <!-- Divider -->
+      <div class="signin-divider" aria-hidden="true">
+        <span>or</span>
+      </div>
+
+      <!-- Disclosure: more sign-in methods -->
+      <details class="signin-disclosure">
+        <summary>
+          <span>More sign-in methods</span>
+          <svg
+            class="signin-chevron"
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+            aria-hidden="true"
           >
-            <span class="text-sm">🔑 Create Profile</span>
+            <path
+              d="M4 6l4 4 4-4"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </summary>
+        <div class="signin-disclosure-list">
+          <button
+            type="button"
+            on:click={startUniversalPairing}
+            disabled={authState.isLoading}
+            class="signin-method"
+          >
+            <span class="signin-method-title">Scan QR / pair phone</span>
+            <span class="signin-method-meta">NIP-46</span>
+          </button>
+          <button
+            type="button"
+            on:click={openBunkerModal}
+            disabled={authState.isLoading}
+            class="signin-method"
+          >
+            <span class="signin-method-title">Paste bunker URI</span>
+            <span class="signin-method-meta">NIP-46</span>
+          </button>
+          <button
+            type="button"
+            on:click={() => (nsecModal = true)}
+            disabled={authState.isLoading}
+            class="signin-method"
+          >
+            <span class="signin-method-title">Import private key</span>
+            <span class="signin-method-meta signin-method-meta-warn">advanced</span>
           </button>
         </div>
+      </details>
 
-        <!-- Error Display -->
-        {#if authState.error}
-          <div
-            class="bg-input border rounded-lg p-2.5 mb-3"
-            style="border-color: var(--color-danger, #ef4444)"
-          >
-            <p class="text-xs" style="color: var(--color-danger, #ef4444)">{authState.error}</p>
-          </div>
-        {/if}
-
-        <!-- Advanced options -->
-        <div class="py-3 space-y-2">
-          <div class="flex items-center justify-center gap-3 text-[11px]">
-            <button
-              on:click={startUniversalPairing}
-              disabled={authState.isLoading}
-              class="text-caption hover:opacity-80 hover:underline transition-colors disabled:opacity-50"
-            >
-              📷 Scan QR / Universal pairing
-            </button>
-            <span class="text-caption">|</span>
-            <button
-              on:click={openBunkerModal}
-              disabled={authState.isLoading}
-              class="text-caption hover:opacity-80 hover:underline transition-colors disabled:opacity-50"
-            >
-              🔐 Paste bunker URI
-            </button>
-            <span class="text-caption">|</span>
-            <button
-              on:click={() => (nsecModal = true)}
-              disabled={authState.isLoading}
-              class="text-caption hover:opacity-80 hover:underline transition-colors disabled:opacity-50"
-            >
-              Import key
-            </button>
-          </div>
-        </div>
-
-        <!-- Value Propositions - Quieter styling -->
-        <section
-          class="grid grid-cols-2 gap-x-3 gap-y-1.5 text-[11px] text-caption pt-3 border-t"
-          style="border-color: var(--color-input-border)"
-          aria-label="Zap Cooking features"
-        >
-          <div class="flex items-center gap-1">
-            <span class="text-orange-400 text-xs">⚡</span>
-            <span>Instant Bitcoin Tips</span>
-          </div>
-          <div class="flex items-center gap-1">
-            <span class="text-blue-400 text-xs">🔒</span>
-            <span>Decentralized & Private</span>
-          </div>
-          <div class="flex items-center gap-1">
-            <span class="text-purple-400 text-xs">🌍</span>
-            <span>Global Recipe Community</span>
-          </div>
-          <div class="flex items-center gap-1">
-            <span class="text-green-400 text-xs">📱</span>
-            <span>Cross-Platform Access</span>
-          </div>
-        </section>
-      </section>
+      <!-- Footer strip -->
+      <footer class="signin-footer">
+        <span class="signin-footer-tag">Your keys, your kitchen.</span>
+        <span class="signin-footer-links">
+          <a href="/terms">Terms</a>
+          <span aria-hidden="true">·</span>
+          <a href="/privacy">Privacy</a>
+        </span>
+      </footer>
+    </section>
   </main>
 {/if}
 
@@ -1218,5 +1201,419 @@
     inset: 0;
     z-index: 31;
     overflow-y: auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem 1rem;
+    padding-top: max(1.5rem, env(safe-area-inset-top));
+    padding-bottom: max(1.5rem, env(safe-area-inset-bottom));
+  }
+
+  /* ───── New sign-in card ───── */
+
+  .signin-card {
+    width: 100%;
+    max-width: 440px;
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-input-border);
+    border-radius: 24px;
+    padding: 2.25rem 1.75rem 1.5rem;
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 0.04) inset,
+      0 24px 64px rgba(0, 0, 0, 0.18),
+      0 4px 12px rgba(236, 71, 0, 0.06);
+    text-align: center;
+    animation: signinRise 320ms cubic-bezier(0.2, 0.8, 0.25, 1) both;
+  }
+
+  @keyframes signinRise {
+    from {
+      opacity: 0;
+      transform: translateY(8px) scale(0.985);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+
+  /* ───── Brand mark ───── */
+
+  .signin-brand {
+    width: 56px;
+    height: 56px;
+    margin: 0 auto 1.25rem;
+    border-radius: 50%;
+    background: radial-gradient(
+      circle at 50% 45%,
+      #ffd28a 0%,
+      #ff9542 32%,
+      #ec4700 70%,
+      #7c1d00 100%
+    );
+    box-shadow:
+      0 0 0 1px rgba(255, 213, 138, 0.35) inset,
+      0 0 24px rgba(236, 71, 0, 0.45);
+    position: relative;
+    display: grid;
+    place-items: center;
+    animation: signinPulse 3.2s ease-in-out infinite;
+  }
+
+  @keyframes signinPulse {
+    0%, 100% { box-shadow: 0 0 0 1px rgba(255, 213, 138, 0.35) inset, 0 0 24px rgba(236, 71, 0, 0.45); }
+    50% { box-shadow: 0 0 0 1px rgba(255, 213, 138, 0.5) inset, 0 0 36px rgba(236, 71, 0, 0.65); }
+  }
+
+  /* Lightning bolt — drawn with clip-path so it inherits the gradient backdrop. */
+  .signin-bolt {
+    width: 18px;
+    height: 30px;
+    background: #fff8ec;
+    clip-path: polygon(58% 0, 18% 56%, 46% 56%, 32% 100%, 82% 42%, 54% 42%, 70% 0);
+    filter: drop-shadow(0 0 4px rgba(255, 240, 200, 0.85));
+    animation: signinFlicker 4.8s ease-in-out infinite;
+  }
+
+  @keyframes signinFlicker {
+    0%, 92%, 100% { opacity: 1; }
+    93% { opacity: 0.55; }
+    94% { opacity: 1; }
+    96% { opacity: 0.7; }
+    97% { opacity: 1; }
+  }
+
+  /* ───── Hero copy ───── */
+
+  .signin-title {
+    font-family: 'Fraunces', Georgia, 'Times New Roman', serif;
+    font-weight: 600;
+    font-size: 1.875rem;
+    line-height: 1.15;
+    letter-spacing: -0.01em;
+    color: var(--color-text-primary);
+    margin: 0 0 0.5rem;
+  }
+
+  .signin-title em {
+    font-style: italic;
+    font-weight: 500;
+    background: linear-gradient(135deg, #ff9542 0%, #ec4700 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+
+  .signin-subtitle {
+    font-size: 0.9375rem;
+    color: var(--color-text-secondary);
+    margin: 0 0 1.75rem;
+    line-height: 1.5;
+  }
+
+  /* ───── Primary CTA ───── */
+
+  .signin-cta-primary {
+    width: 100%;
+    height: 52px;
+    border-radius: 14px;
+    border: none;
+    background: linear-gradient(135deg, #ff9542 0%, #ec4700 100%);
+    color: #fff8ec;
+    font-weight: 600;
+    font-size: 0.9375rem;
+    letter-spacing: 0.005em;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.625rem;
+    padding: 0 1.25rem;
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 0.18) inset,
+      0 8px 24px rgba(236, 71, 0, 0.32),
+      0 2px 6px rgba(124, 29, 0, 0.18);
+    transition: transform 120ms ease, box-shadow 200ms ease, opacity 200ms ease;
+  }
+
+  .signin-cta-primary:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 0.22) inset,
+      0 12px 28px rgba(236, 71, 0, 0.4),
+      0 2px 8px rgba(124, 29, 0, 0.2);
+  }
+
+  .signin-cta-primary:active:not(:disabled) {
+    transform: translateY(0);
+  }
+
+  .signin-cta-primary:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+
+  .signin-cta-primary:focus-visible {
+    outline: 2px solid #ffd28a;
+    outline-offset: 2px;
+  }
+
+  .signin-badge {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    padding: 0.125rem 0.5rem;
+    border-radius: 999px;
+    background: rgba(255, 248, 236, 0.18);
+    color: #fff8ec;
+    border: 1px solid rgba(255, 248, 236, 0.35);
+  }
+
+  /* ───── Secondary CTA ───── */
+
+  .signin-cta-secondary {
+    width: 100%;
+    height: 48px;
+    margin-top: 0.75rem;
+    border-radius: 14px;
+    border: 1px solid var(--color-input-border);
+    background: var(--color-bg-primary);
+    color: var(--color-text-primary);
+    font-weight: 500;
+    font-size: 0.9375rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.625rem;
+    padding: 0 1.25rem;
+    transition: transform 120ms ease, border-color 200ms ease, opacity 200ms ease;
+  }
+
+  .signin-cta-secondary:hover:not(:disabled) {
+    transform: translateY(-1px);
+    border-color: #ec4700;
+  }
+
+  .signin-cta-secondary:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+
+  .signin-cta-secondary:focus-visible {
+    outline: 2px solid #ec4700;
+    outline-offset: 2px;
+  }
+
+  .signin-plus {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #ff9542 0%, #ec4700 100%);
+    color: #fff8ec;
+    font-weight: 600;
+    font-size: 0.875rem;
+    line-height: 1;
+    display: grid;
+    place-items: center;
+    box-shadow: 0 0 12px rgba(236, 71, 0, 0.3);
+  }
+
+  /* ───── Helper / notice / error ───── */
+
+  .signin-helper {
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+    margin: 0.625rem 0 0;
+    line-height: 1.5;
+  }
+
+  .signin-helper a,
+  .signin-notice a,
+  .signin-footer a {
+    color: var(--color-primary, #ec4700);
+    text-decoration: none;
+  }
+
+  .signin-helper a:hover,
+  .signin-notice a:hover,
+  .signin-footer a:hover {
+    text-decoration: underline;
+  }
+
+  .signin-notice {
+    margin-top: 0.625rem;
+    padding: 0.625rem 0.75rem;
+    border-radius: 10px;
+    background: var(--color-bg-primary);
+    border: 1px solid var(--color-input-border);
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+    text-align: left;
+  }
+
+  .signin-error {
+    margin-top: 1rem;
+    padding: 0.625rem 0.75rem;
+    border-radius: 10px;
+    background: rgba(239, 68, 68, 0.08);
+    border: 1px solid var(--color-danger, #ef4444);
+    font-size: 0.8125rem;
+    color: var(--color-danger, #ef4444);
+    line-height: 1.5;
+  }
+
+  /* ───── Divider ───── */
+
+  .signin-divider {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 1.5rem 0 1rem;
+    color: var(--color-text-secondary);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+  }
+
+  .signin-divider::before,
+  .signin-divider::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: var(--color-input-border);
+  }
+
+  /* ───── Disclosure ───── */
+
+  .signin-disclosure {
+    border-radius: 14px;
+    border: 1px solid var(--color-input-border);
+    background: var(--color-bg-primary);
+  }
+
+  .signin-disclosure summary {
+    list-style: none;
+    cursor: pointer;
+    padding: 0.875rem 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    color: var(--color-text-primary);
+    font-size: 0.9375rem;
+    font-weight: 500;
+    user-select: none;
+  }
+
+  .signin-disclosure summary::-webkit-details-marker { display: none; }
+  .signin-disclosure summary:focus-visible {
+    outline: 2px solid #ec4700;
+    outline-offset: -2px;
+    border-radius: 14px;
+  }
+
+  .signin-chevron {
+    transition: transform 200ms ease;
+    color: var(--color-text-secondary);
+  }
+
+  .signin-disclosure[open] .signin-chevron {
+    transform: rotate(180deg);
+  }
+
+  .signin-disclosure-list {
+    display: flex;
+    flex-direction: column;
+    border-top: 1px solid var(--color-input-border);
+  }
+
+  .signin-method {
+    background: transparent;
+    border: none;
+    padding: 0.875rem 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    color: var(--color-text-primary);
+    font-size: 0.9375rem;
+    cursor: pointer;
+    text-align: left;
+    border-bottom: 1px solid var(--color-input-border);
+    transition: background 150ms ease;
+  }
+
+  .signin-method:last-child { border-bottom: none; }
+  .signin-method:hover:not(:disabled) { background: rgba(236, 71, 0, 0.04); }
+  .signin-method:focus-visible {
+    outline: 2px solid #ec4700;
+    outline-offset: -2px;
+  }
+  .signin-method:disabled { opacity: 0.55; cursor: not-allowed; }
+
+  .signin-method-title { font-weight: 500; }
+
+  .signin-method-meta {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: var(--color-text-secondary);
+    padding: 0.125rem 0.5rem;
+    border-radius: 999px;
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-input-border);
+  }
+
+  .signin-method-meta-warn {
+    color: #c2410c;
+    border-color: rgba(236, 71, 0, 0.35);
+    background: rgba(236, 71, 0, 0.08);
+  }
+
+  /* ───── Footer ───── */
+
+  .signin-footer {
+    margin-top: 1.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--color-input-border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+  }
+
+  .signin-footer-tag {
+    font-style: italic;
+  }
+
+  .signin-footer-links {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  /* ───── Mobile tuning ───── */
+
+  @media (max-width: 480px) {
+    .signin-card {
+      padding: 1.75rem 1.25rem 1.25rem;
+      border-radius: 20px;
+    }
+    .signin-title { font-size: 1.625rem; }
+    .signin-subtitle { font-size: 0.875rem; margin-bottom: 1.5rem; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .signin-card,
+    .signin-brand,
+    .signin-bolt,
+    .signin-cta-primary,
+    .signin-cta-secondary,
+    .signin-chevron {
+      animation: none !important;
+      transition: none !important;
+    }
   }
 </style>


### PR DESCRIPTION
**Draft.** UI-only refresh of `/login`. All five existing sign-in handlers wired unchanged.

Pairs with `investigate/signin-modal-refresh` (INVESTIGATION.md on that branch).

## What this PR does

- Replaces the equal-weight CTA stack on `/login` with a hierarchy: brand mark + flame-bolt motif, **primary** "Sign in with extension", **secondary** "Create a new account", divider, **disclosure** "More sign-in methods" containing QR/universal pairing, paste bunker URI, and import private key. Footer strip with brand tag + Terms/Privacy.
- Refreshes `LoginFormIOS.svelte` with parity styling. NIP-07 and QR pairing intentionally omitted on iOS — matches existing platform policy in `src/lib/platform.ts` (App Store cross-app handoff restriction).
- Adds focus trap to the `<Modal>` primitive: focus capture on open, initial focus on first focusable, Tab/Shift-Tab cycle inside the dialog, focus restore on close. ~30 LOC inline; no new dependency.
- Adds Fraunces display serif via the existing Google Fonts preconnect in `app.html`.

## What this PR does NOT touch

- All five sign-in handlers (`loginWithNIP07`, `useGeneratedKeys`, `startUniversalPairing`, `loginWithBunker`, `loginWithPrivateKey`) are wired by reference; no signature, no body, no flow changes.
- The Modal primitive's existing aria-modal / aria-labelledby / ESC close / click-outside close / body scroll lock all preserved.
- The four sub-modals (nsec, bunker, generate keys, NIP-46 universal) keep their existing markup and multi-step guards (e.g., `disabled={!backupDownloaded}` on the Create Profile Next button).
- No analytics added. (None existed; investigation confirmed.)
- No new dependencies.
- No changes to post-signin flow, membership, profile setup, or NIP-05.

## Defaults I had to assume (please confirm or correct)

The brief and investigation flagged several open questions that didn't get answered before "implement"; I picked sensible defaults and documented them so they're easy to revise:

| # | Question | Default I went with |
|---|---|---|
| 1 | The mockup at `docs/design/signin-modal-v2.html` doesn't exist in the repo | Built from the inline brief. Used existing `--color-primary: #ec4700` + a flame ramp `#ffd28a → #ff9542 → #ec4700 → #7c1d00` for brand mark and primary CTA. |
| 2 | "Four sign-in methods" — typo for five? | Treated as five. Hierarchy maps cleanly. |
| 3 | iOS — refresh in same PR or collapse with web? | Refreshed both files for parity, kept separate. Collapsing is a follow-up. |
| 4 | Multi-step Create Profile flow — redesign inner steps too? | **No.** Only the entry-point card was touched. Inner steps unchanged. |
| 5 | Brand asset for the lightning bolt | Built inline with `clip-path` over the radial gradient — no SVG asset needed. |
| 6 | Disclosure inline or its own sub-modal? | **Inline** within the main card per brief reading. |
| 7 | NIP-46 universal pairing listener on ESC/backdrop close? | **Continues running.** Only an explicit Cancel aborts. Existing behavior unchanged. |

Ready to swap any of these — they're isolated edits.

## Acceptance criteria

- [ ] All five existing sign-in methods complete a successful sign-in (manual smoke per method)
- [ ] `npm run check` clean — **verified locally: 0 errors, 127 pre-existing warnings**
- [ ] Renders correctly at 320px / 375px / 768px / 1024px / 1440px
- [ ] Renders correctly inside iOS Capacitor build (safe-area handled via `env(safe-area-inset-*)`)
- [ ] Renders correctly inside Android Capacitor build
- [ ] Keyboard nav: Tab cycles all interactives in DOM order, focus rings visible, ESC closes sub-modals, focus trap holds inside sub-modals
- [ ] Screen reader: dialog announced (aria-modal, aria-labelledby), close labels, disclosure expanded/collapsed announced
- [ ] No console errors on open/close cycle
- [ ] Lighthouse a11y score on `/login` ≥ existing baseline

## Notable side notes from investigation

- **No analytics events fire from the current login.** "Preserve every existing event" simplifies to "no events to preserve" — flagging because the brief expected at least some.
- **`/login` is a SvelteKit route, not a global modal overlay.** Brief uses "modal" loosely for the visual treatment. Header "Sign in" buttons remain `href="/login"`.
- **`LoginFormIOS.svelte` and `+page.svelte` are still two files.** Collapsing into one component that gates by platform helpers (`supportsNIP46QRPairing` / `supportsNIP46BunkerPaste`) is the cleaner end state but bigger scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)