### PR TITLE
feat(signin): refresh /login per revised brief — wordmark + 3-tile grid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.289",
+  "version": "4.2.290",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.287",
+  "version": "4.2.288",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.288",
+  "version": "4.2.289",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/app.html
+++ b/src/app.html
@@ -65,11 +65,11 @@
     </script>
 
     <link rel="icon" href="%sveltekit.assets%/favicon.svg" />
-    <!-- Digital font for timer display -->
+    <!-- Orbitron for the timer display; Albert Sans for the sign-in modal. -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&family=Albert+Sans:wght@300;400;500;600;700&display=swap"
       rel="stylesheet"
     />
     <meta

--- a/src/components/LoginFormIOS.svelte
+++ b/src/components/LoginFormIOS.svelte
@@ -914,7 +914,7 @@
       </div>
 
       <footer class="signin-footer">
-        <span class="signin-footer-tag">Your identity · Your data</span>
+        <span class="signin-footer-tag">Your identity · Your data · Your money</span>
         <span class="signin-footer-links">
           <a href="/terms">Terms</a>
           <span aria-hidden="true">·</span>

--- a/src/components/LoginFormIOS.svelte
+++ b/src/components/LoginFormIOS.svelte
@@ -18,16 +18,6 @@
   import { nip19 } from 'nostr-tools';
   import { createAuthManager, type AuthState } from '$lib/authManager';
   import { onMount, onDestroy } from 'svelte';
-  import { theme } from '$lib/themeStore';
-
-  // Dark mode detection for logo
-  $: resolvedTheme =
-    $theme === 'system'
-      ? browser && window.matchMedia('(prefers-color-scheme: dark)').matches
-        ? 'dark'
-        : 'light'
-      : $theme;
-  $: isDarkMode = resolvedTheme === 'dark';
 
   let authManager: any = null;
   let authState: AuthState = {
@@ -836,12 +826,7 @@
 
   <div class="ios-signin-wrap">
     <div class="signin-scrim" aria-hidden="true"></div>
-    <section
-      class="signin-card"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="ios-signin-title"
-    >
+    <section class="signin-card" aria-labelledby="ios-signin-title">
       <p class="signin-eyebrow">Welcome to</p>
       <h1 id="ios-signin-title" class="signin-wordmark">
         <img src="/zap_cooking_logo_white.svg" alt="Zap Cooking" />
@@ -968,12 +953,22 @@
     padding: 1.5rem 1rem;
     padding-top: max(2.5rem, env(safe-area-inset-top));
     padding-bottom: max(1.5rem, env(safe-area-inset-bottom));
+
+    --signin-ink: #0b0e14;
+    --signin-surface: #13171f;
+    --signin-elevated: #1b202b;
+    --signin-line: #262c3a;
+    --signin-flame: #f7931a;
+    --signin-ember: #ff5f1f;
+    --signin-cream: #f5ebdd;
+    --signin-wheat: #c5b8a3;
+    --signin-mute: #7e8597;
   }
 
   .signin-scrim {
     position: absolute;
     inset: 0;
-    background: rgba(11, 14, 20, 0.85);
+    background: color-mix(in srgb, var(--signin-ink) 85%, transparent);
     backdrop-filter: blur(14px);
     -webkit-backdrop-filter: blur(14px);
     z-index: -1;
@@ -983,8 +978,8 @@
     position: relative;
     width: 100%;
     max-width: 440px;
-    background: #13171f;
-    border: 1px solid #262c3a;
+    background: var(--signin-surface);
+    border: 1px solid var(--signin-line);
     border-radius: 24px;
     padding: 2.25rem 1.75rem 1.5rem;
     box-shadow:
@@ -992,7 +987,7 @@
       0 24px 64px rgba(0, 0, 0, 0.55),
       0 4px 12px rgba(247, 147, 26, 0.06);
     text-align: center;
-    color: #f5ebdd;
+    color: var(--signin-cream);
     font-family: 'Albert Sans', 'Inter', system-ui, -apple-system, sans-serif;
     animation: signinRise 320ms cubic-bezier(0.2, 0.8, 0.25, 1) both;
   }
@@ -1007,7 +1002,7 @@
     font-weight: 500;
     letter-spacing: 0.18em;
     text-transform: uppercase;
-    color: #7e8597;
+    color: var(--signin-mute);
     margin: 0 0 0.5rem;
   }
 
@@ -1023,7 +1018,7 @@
   .signin-tagline {
     font-size: 0.9375rem;
     font-weight: 400;
-    color: #c5b8a3;
+    color: var(--signin-wheat);
     margin: 0 0 1.75rem;
     line-height: 1.5;
   }
@@ -1033,7 +1028,7 @@
     height: 52px;
     border-radius: 14px;
     border: none;
-    background: linear-gradient(135deg, #f7931a 0%, #ff5f1f 100%);
+    background: linear-gradient(135deg, var(--signin-flame) 0%, var(--signin-ember) 100%);
     color: #fff8ec;
     font-family: inherit;
     font-weight: 600;
@@ -1046,13 +1041,13 @@
     padding: 0 1.25rem;
     box-shadow:
       0 1px 0 rgba(255, 255, 255, 0.18) inset,
-      0 8px 24px rgba(247, 147, 26, 0.36),
-      0 2px 6px rgba(255, 95, 31, 0.22);
+      0 8px 24px color-mix(in srgb, var(--signin-flame) 36%, transparent),
+      0 2px 6px color-mix(in srgb, var(--signin-ember) 22%, transparent);
     transition: transform 120ms ease, box-shadow 200ms ease, opacity 200ms ease;
   }
   .signin-cta-primary:hover:not(:disabled) { transform: translateY(-1px); }
   .signin-cta-primary:disabled { opacity: 0.55; cursor: not-allowed; }
-  .signin-cta-primary:focus-visible { outline: 2px solid #f5ebdd; outline-offset: 3px; }
+  .signin-cta-primary:focus-visible { outline: 2px solid var(--signin-cream); outline-offset: 3px; }
 
   .signin-icon { color: currentColor; flex-shrink: 0; }
 
@@ -1072,14 +1067,14 @@
     align-items: center;
     gap: 0.75rem;
     margin: 1.5rem 0 1rem;
-    color: #7e8597;
+    color: var(--signin-mute);
     font-size: 0.6875rem;
     font-weight: 500;
     text-transform: uppercase;
     letter-spacing: 0.16em;
   }
   .signin-divider::before, .signin-divider::after {
-    content: ''; flex: 1; height: 1px; background: #262c3a;
+    content: ''; flex: 1; height: 1px; background: var(--signin-line);
   }
 
   .signin-tiles {
@@ -1092,11 +1087,11 @@
   }
 
   .signin-tile {
-    background: #1b202b;
-    border: 1px solid #262c3a;
+    background: var(--signin-elevated);
+    border: 1px solid var(--signin-line);
     border-radius: 14px;
     padding: 0.875rem 0.5rem 0.75rem;
-    color: #f5ebdd;
+    color: var(--signin-cream);
     font-family: inherit;
     cursor: pointer;
     display: flex;
@@ -1108,39 +1103,39 @@
   }
   .signin-tile:hover:not(:disabled) {
     transform: translateY(-1px);
-    border-color: rgba(247, 147, 26, 0.5);
+    border-color: color-mix(in srgb, var(--signin-flame) 50%, transparent);
     background: #20262f;
   }
-  .signin-tile:focus-visible { outline: 2px solid #f7931a; outline-offset: 2px; }
+  .signin-tile:focus-visible { outline: 2px solid var(--signin-flame); outline-offset: 2px; }
   .signin-tile:disabled { opacity: 0.55; cursor: not-allowed; }
-  .signin-tile-icon { color: #f7931a; margin-bottom: 0.125rem; }
+  .signin-tile-icon { color: var(--signin-flame); margin-bottom: 0.125rem; }
   .signin-tile-title {
     font-size: 0.8125rem;
     font-weight: 600;
-    color: #f5ebdd;
+    color: var(--signin-cream);
     line-height: 1.2;
   }
   .signin-tile-sub {
     font-size: 0.6875rem;
     font-weight: 400;
-    color: #7e8597;
+    color: var(--signin-mute);
     line-height: 1.2;
   }
 
   .signin-footer {
     margin-top: 1.5rem;
     padding-top: 1rem;
-    border-top: 1px solid #262c3a;
+    border-top: 1px solid var(--signin-line);
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 0.75rem;
     font-size: 0.75rem;
-    color: #7e8597;
+    color: var(--signin-mute);
   }
   .signin-footer-tag { font-weight: 500; letter-spacing: 0.02em; }
   .signin-footer-links { display: inline-flex; align-items: center; gap: 0.4rem; }
-  .signin-footer a { color: #f7931a; text-decoration: none; }
+  .signin-footer a { color: var(--signin-flame); text-decoration: none; }
   .signin-footer a:hover { text-decoration: underline; }
 
   @media (max-width: 480px) {

--- a/src/components/LoginFormIOS.svelte
+++ b/src/components/LoginFormIOS.svelte
@@ -834,94 +834,93 @@
     </div>
   </div>
 
-  <div class="relative flex flex-col items-center min-h-screen px-4 pt-12 md:pt-20 pb-8">
-    <!-- Main Content Card -->
+  <div class="ios-signin-wrap">
+    <div class="signin-scrim" aria-hidden="true"></div>
     <section
-      class="glass-card rounded-2xl p-6 md:p-8 w-full mx-auto text-center"
-      style="max-width: 420px;"
-      aria-label="Authentication options"
+      class="signin-card"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="ios-signin-title"
     >
-      <!-- Logo and Title -->
-      <div class="mb-5">
-        <img
-          src={isDarkMode ? '/zap_cooking_logo_white.svg' : '/zap_cooking_logo_black.svg'}
-          class="h-10 md:h-12 mb-2 mx-auto"
-          alt="Zap Cooking"
-        />
-        <h1 class="text-xl md:text-2xl font-bold mb-1" style="color: var(--color-text-primary)">
-          Welcome to <span class="text-orange-500">Zap Cooking</span>
-        </h1>
-        <p class="text-sm text-caption">Share recipes and support creators with Bitcoin zaps</p>
-      </div>
+      <p class="signin-eyebrow">Welcome to</p>
+      <h1 id="ios-signin-title" class="signin-wordmark">
+        <img src="/zap_cooking_logo_white.svg" alt="Zap Cooking" />
+      </h1>
+      <p class="signin-tagline">Share recipes and get paid by your community.</p>
 
-      <!-- Authentication Options -->
-      <div class="space-y-2.5 mb-3">
-        <!-- Create Profile - Primary CTA for iOS -->
-        <button
-          on:click={() => (generateModal = true)}
-          disabled={authState.isLoading}
-          aria-label="Create a new Zap Cooking profile"
-          class="w-full bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 text-white font-semibold h-[52px] md:h-12 px-6 rounded-xl transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm"
-        >
-          <div class="flex items-center justify-center gap-2">
-            <span class="text-lg">⚡</span>
-            <span class="text-[15px]">Create Profile</span>
-          </div>
-        </button>
+      <!-- Primary CTA on iOS: Create Profile.
+           NIP-07 + QR pairing intentionally omitted on iOS — App Store
+           policy on cross-app handoff for unlisted signers. The existing
+           supportsNIP46QRPairing() helper at $lib/platform.ts returns
+           false here. -->
+      <button
+        type="button"
+        on:click={() => (generateModal = true)}
+        disabled={authState.isLoading}
+        aria-label="Create a new Zap Cooking profile"
+        class="signin-cta-primary"
+      >
+        <svg class="signin-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path d="M13 2L4 14h7l-1 8 9-12h-7l1-8z" fill="currentColor" />
+        </svg>
+        <span>{authState.isLoading ? 'Connecting…' : 'Create Profile'}</span>
+      </button>
 
-        <!-- Import Existing Key - Secondary -->
-        <button
-          on:click={() => (nsecModal = true)}
-          disabled={authState.isLoading}
-          aria-label="Sign in with your Nostr private key"
-          class="w-full bg-input hover:opacity-90 font-medium h-11 px-6 rounded-xl transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed border"
-          style="color: var(--color-text-primary); border-color: var(--color-input-border)"
-        >
-          <span class="text-sm">🔑 Import Private Key</span>
-        </button>
-        <button
-          on:click={openBunkerModal}
-          disabled={authState.isLoading}
-          aria-label="Sign in with bunker URI"
-          class="w-full text-caption hover:opacity-80 hover:underline transition-colors disabled:opacity-50 text-sm py-1"
-        >
-          🔐 Paste bunker URI
-        </button>
-      </div>
-
-      <!-- Error Display -->
       {#if authState.error}
-        <div
-          class="bg-input border rounded-lg p-2.5 mb-3"
-          style="border-color: var(--color-danger, #ef4444)"
-        >
-          <p class="text-xs" style="color: var(--color-danger, #ef4444)">{authState.error}</p>
+        <div class="signin-error" role="alert">
+          {authState.error}
         </div>
       {/if}
 
-      <!-- Value Propositions -->
-      <section
-        class="grid grid-cols-2 gap-x-3 gap-y-1.5 text-[11px] text-caption pt-3 border-t"
-        style="border-color: var(--color-input-border)"
-        aria-label="Zap Cooking features"
-      >
-        <div class="flex items-center gap-1">
-          <span class="text-orange-400 text-xs">⚡</span>
-          <span>Instant Bitcoin Tips</span>
-        </div>
-        <div class="flex items-center gap-1">
-          <span class="text-blue-400 text-xs">🔒</span>
-          <span>Decentralized & Private</span>
-        </div>
-        <div class="flex items-center gap-1">
-          <span class="text-purple-400 text-xs">🌍</span>
-          <span>Global Recipe Community</span>
-        </div>
-        <div class="flex items-center gap-1">
-          <span class="text-green-400 text-xs">📱</span>
-          <span>Cross-Platform Access</span>
-        </div>
-      </section>
+      <div class="signin-divider" aria-hidden="true">
+        <span>or</span>
+      </div>
+
+      <!-- Tile row on iOS: 2 tiles only (Bunker URI, Import key).
+           QR / pair phone is dropped per platform policy, not shown
+           disabled — disabled-but-untappable is worse UX than a
+           smaller grid. -->
+      <div class="signin-tiles signin-tiles-two" role="group" aria-label="Other sign-in methods">
+        <button
+          type="button"
+          on:click={openBunkerModal}
+          disabled={authState.isLoading}
+          aria-label="Sign in with a bunker URI from a remote signer"
+          class="signin-tile"
+        >
+          <svg class="signin-tile-icon" width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <rect x="4" y="10" width="16" height="11" rx="2" stroke="currentColor" stroke-width="1.6" />
+            <path d="M8 10V7a4 4 0 018 0v3" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+            <circle cx="12" cy="15" r="1.5" fill="currentColor" />
+          </svg>
+          <span class="signin-tile-title">Bunker URI</span>
+          <span class="signin-tile-sub">Remote signer</span>
+        </button>
+
+        <button
+          type="button"
+          on:click={() => (nsecModal = true)}
+          disabled={authState.isLoading}
+          aria-label="Sign in by importing a private key"
+          class="signin-tile"
+        >
+          <svg class="signin-tile-icon" width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <circle cx="8.5" cy="14.5" r="3.5" stroke="currentColor" stroke-width="1.6" />
+            <path d="M11 12l9-9m-3 0h3v3m-5 2l2 2" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+          <span class="signin-tile-title">Import key</span>
+          <span class="signin-tile-sub">Paste nsec</span>
+        </button>
+      </div>
+
+      <footer class="signin-footer">
+        <span class="signin-footer-tag">Your identity · Your data</span>
+        <span class="signin-footer-links">
+          <a href="/terms">Terms</a>
+          <span aria-hidden="true">·</span>
+          <a href="/privacy">Privacy</a>
+        </span>
+      </footer>
     </section>
   </div>
 </main>
@@ -950,6 +949,215 @@
     50% {
       opacity: 0.8;
       transform: scale(1.05);
+    }
+  }
+
+  /* ───── iOS sign-in card (parity with desktop) ─────
+     Mirrors the dark-surface styles in src/routes/login/+page.svelte.
+     Kept duplicated rather than promoted to app.css because the
+     visual is scoped to the login surface and the iOS layout has
+     small differences (full-page wrap, two-tile grid). */
+
+  .ios-signin-wrap {
+    position: relative;
+    z-index: 1;
+    min-height: 100vh;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 1.5rem 1rem;
+    padding-top: max(2.5rem, env(safe-area-inset-top));
+    padding-bottom: max(1.5rem, env(safe-area-inset-bottom));
+  }
+
+  .signin-scrim {
+    position: absolute;
+    inset: 0;
+    background: rgba(11, 14, 20, 0.85);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+    z-index: -1;
+  }
+
+  .signin-card {
+    position: relative;
+    width: 100%;
+    max-width: 440px;
+    background: #13171f;
+    border: 1px solid #262c3a;
+    border-radius: 24px;
+    padding: 2.25rem 1.75rem 1.5rem;
+    box-shadow:
+      0 1px 0 rgba(245, 235, 221, 0.04) inset,
+      0 24px 64px rgba(0, 0, 0, 0.55),
+      0 4px 12px rgba(247, 147, 26, 0.06);
+    text-align: center;
+    color: #f5ebdd;
+    font-family: 'Albert Sans', 'Inter', system-ui, -apple-system, sans-serif;
+    animation: signinRise 320ms cubic-bezier(0.2, 0.8, 0.25, 1) both;
+  }
+
+  @keyframes signinRise {
+    from { opacity: 0; transform: translateY(8px) scale(0.985); }
+    to { opacity: 1; transform: translateY(0) scale(1); }
+  }
+
+  .signin-eyebrow {
+    font-size: 0.75rem;
+    font-weight: 500;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: #7e8597;
+    margin: 0 0 0.5rem;
+  }
+
+  .signin-wordmark { margin: 0 auto 0.875rem; line-height: 0; }
+  .signin-wordmark img {
+    width: 240px;
+    max-width: 100%;
+    height: auto;
+    display: block;
+    margin: 0 auto;
+  }
+
+  .signin-tagline {
+    font-size: 0.9375rem;
+    font-weight: 400;
+    color: #c5b8a3;
+    margin: 0 0 1.75rem;
+    line-height: 1.5;
+  }
+
+  .signin-cta-primary {
+    width: 100%;
+    height: 52px;
+    border-radius: 14px;
+    border: none;
+    background: linear-gradient(135deg, #f7931a 0%, #ff5f1f 100%);
+    color: #fff8ec;
+    font-family: inherit;
+    font-weight: 600;
+    font-size: 0.9375rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.625rem;
+    padding: 0 1.25rem;
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 0.18) inset,
+      0 8px 24px rgba(247, 147, 26, 0.36),
+      0 2px 6px rgba(255, 95, 31, 0.22);
+    transition: transform 120ms ease, box-shadow 200ms ease, opacity 200ms ease;
+  }
+  .signin-cta-primary:hover:not(:disabled) { transform: translateY(-1px); }
+  .signin-cta-primary:disabled { opacity: 0.55; cursor: not-allowed; }
+  .signin-cta-primary:focus-visible { outline: 2px solid #f5ebdd; outline-offset: 3px; }
+
+  .signin-icon { color: currentColor; flex-shrink: 0; }
+
+  .signin-error {
+    margin-top: 1rem;
+    padding: 0.625rem 0.75rem;
+    border-radius: 10px;
+    background: rgba(239, 68, 68, 0.1);
+    border: 1px solid rgba(239, 68, 68, 0.6);
+    font-size: 0.8125rem;
+    color: #fca5a5;
+    line-height: 1.5;
+  }
+
+  .signin-divider {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 1.5rem 0 1rem;
+    color: #7e8597;
+    font-size: 0.6875rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+  }
+  .signin-divider::before, .signin-divider::after {
+    content: ''; flex: 1; height: 1px; background: #262c3a;
+  }
+
+  .signin-tiles {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.625rem;
+  }
+  .signin-tiles-two {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .signin-tile {
+    background: #1b202b;
+    border: 1px solid #262c3a;
+    border-radius: 14px;
+    padding: 0.875rem 0.5rem 0.75rem;
+    color: #f5ebdd;
+    font-family: inherit;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.375rem;
+    text-align: center;
+    transition: transform 120ms ease, border-color 200ms ease, background 200ms ease;
+  }
+  .signin-tile:hover:not(:disabled) {
+    transform: translateY(-1px);
+    border-color: rgba(247, 147, 26, 0.5);
+    background: #20262f;
+  }
+  .signin-tile:focus-visible { outline: 2px solid #f7931a; outline-offset: 2px; }
+  .signin-tile:disabled { opacity: 0.55; cursor: not-allowed; }
+  .signin-tile-icon { color: #f7931a; margin-bottom: 0.125rem; }
+  .signin-tile-title {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: #f5ebdd;
+    line-height: 1.2;
+  }
+  .signin-tile-sub {
+    font-size: 0.6875rem;
+    font-weight: 400;
+    color: #7e8597;
+    line-height: 1.2;
+  }
+
+  .signin-footer {
+    margin-top: 1.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid #262c3a;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    font-size: 0.75rem;
+    color: #7e8597;
+  }
+  .signin-footer-tag { font-weight: 500; letter-spacing: 0.02em; }
+  .signin-footer-links { display: inline-flex; align-items: center; gap: 0.4rem; }
+  .signin-footer a { color: #f7931a; text-decoration: none; }
+  .signin-footer a:hover { text-decoration: underline; }
+
+  @media (max-width: 480px) {
+    .signin-card { padding: 1.75rem 1.25rem 1.25rem; border-radius: 20px; }
+    .signin-wordmark img { width: 200px; }
+    .signin-tagline { font-size: 0.875rem; margin-bottom: 1.5rem; }
+    .signin-tile { padding: 0.75rem 0.375rem 0.625rem; }
+    .signin-tile-title { font-size: 0.75rem; }
+    .signin-tile-sub { font-size: 0.625rem; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .signin-card,
+    .signin-cta-primary,
+    .signin-tile {
+      animation: none !important;
+      transition: none !important;
     }
   }
 </style>

--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -24,26 +24,36 @@
   export let allowOverflow = false;
   export let compact = false;
 
-  // Portal target - render at document body level
-  let portalTarget: HTMLElement;
+  // Portal target - render at document body level. Initialized
+  // synchronously when document is available so the dialog can mount
+  // on the same tick the parent flips `open` to true; otherwise the
+  // initial-focus pass below would race the dialog's bind:this.
+  let portalTarget: HTMLElement | null =
+    typeof document !== 'undefined' ? document.body : null;
   let dialogEl: HTMLDialogElement | null = null;
   let previousActiveElement: HTMLElement | null = null;
   let lastOpen = false;
+  let pendingInitialFocus = false;
 
   onMount(() => {
-    portalTarget = document.body;
+    // Re-set in case the component was script-initialized before
+    // document was ready (e.g., SSR rehydrate). No-op when already set.
+    if (!portalTarget && typeof document !== 'undefined') {
+      portalTarget = document.body;
+    }
   });
 
-  // Find focusable descendants of the dialog. Hidden, disabled, or
-  // aria-hidden elements are excluded. Order matches DOM order.
+  // Find focusable descendants of the dialog. Disabled and explicitly
+  // aria-hidden="true" elements are excluded; visibility is checked via
+  // getClientRects() so we don't drop position:fixed children
+  // (offsetParent is null for those). Order matches DOM order.
   function getFocusable(): HTMLElement[] {
     if (!dialogEl) return [];
     const selector =
       'a[href], area[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
     return Array.from(dialogEl.querySelectorAll<HTMLElement>(selector)).filter((el) => {
-      if (el.hasAttribute('aria-hidden')) return false;
-      // offsetParent is null for display:none subtrees; visibility:hidden also reports null.
-      return el.offsetParent !== null || el === document.activeElement;
+      if (el.getAttribute('aria-hidden') === 'true') return false;
+      return el.getClientRects().length > 0 || el === document.activeElement;
     });
   }
 
@@ -75,28 +85,41 @@
   }
 
   // Open/close lifecycle: manage focus capture+restore + keydown listener.
+  // Actual initial focus runs in the second reactive block below, gated
+  // on dialogEl being bound — bind:this fires after the {#if} renders
+  // the dialog, which can trail this block by a tick on first open.
   $: if (typeof window !== 'undefined' && open !== lastOpen) {
     lastOpen = open;
     if (open) {
       previousActiveElement = (document.activeElement as HTMLElement) || null;
       window.addEventListener('keydown', handleKeydown);
-      // Defer initial focus so the dialog has mounted and transitions started.
-      tick().then(() => {
-        const focusable = getFocusable();
-        if (focusable.length > 0) {
-          focusable[0].focus();
-        } else {
-          dialogEl?.focus();
-        }
-      });
+      pendingInitialFocus = true;
     } else {
       window.removeEventListener('keydown', handleKeydown);
+      pendingInitialFocus = false;
       // Return focus to whatever opened the modal.
       if (previousActiveElement && typeof previousActiveElement.focus === 'function') {
         previousActiveElement.focus();
       }
       previousActiveElement = null;
     }
+  }
+
+  // Run the initial focus pass once the dialog is actually in the DOM.
+  // This handles the case where `open` is already true on mount AND
+  // the case where `open` flips true after the dialog has long been
+  // bound — the pendingInitialFocus flag carries the intent across
+  // the gap.
+  $: if (pendingInitialFocus && dialogEl) {
+    pendingInitialFocus = false;
+    tick().then(() => {
+      const focusable = getFocusable();
+      if (focusable.length > 0) {
+        focusable[0].focus();
+      } else {
+        dialogEl?.focus();
+      }
+    });
   }
 
   onDestroy(() => {

--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -16,7 +16,7 @@
 <script lang="ts">
   import { blur, scale } from 'svelte/transition';
   import CloseIcon from 'phosphor-svelte/lib/XCircle';
-  import { onMount, onDestroy } from 'svelte';
+  import { onMount, onDestroy, tick } from 'svelte';
 
   export let open = false;
   export let cleanup: (() => void) | null = null;
@@ -26,21 +26,76 @@
 
   // Portal target - render at document body level
   let portalTarget: HTMLElement;
+  let dialogEl: HTMLDialogElement | null = null;
+  let previousActiveElement: HTMLElement | null = null;
+  let lastOpen = false;
 
   onMount(() => {
     portalTarget = document.body;
   });
 
-  // Close on Escape key
-  function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape' && open) close();
+  // Find focusable descendants of the dialog. Hidden, disabled, or
+  // aria-hidden elements are excluded. Order matches DOM order.
+  function getFocusable(): HTMLElement[] {
+    if (!dialogEl) return [];
+    const selector =
+      'a[href], area[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+    return Array.from(dialogEl.querySelectorAll<HTMLElement>(selector)).filter((el) => {
+      if (el.hasAttribute('aria-hidden')) return false;
+      // offsetParent is null for display:none subtrees; visibility:hidden also reports null.
+      return el.offsetParent !== null || el === document.activeElement;
+    });
   }
 
-  $: if (typeof window !== 'undefined') {
+  function handleKeydown(e: KeyboardEvent) {
+    if (!open) return;
+    if (e.key === 'Escape') {
+      close();
+      return;
+    }
+    if (e.key === 'Tab') {
+      const focusable = getFocusable();
+      if (focusable.length === 0) {
+        // Nothing focusable inside — keep focus on the dialog itself.
+        e.preventDefault();
+        dialogEl?.focus();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && (active === first || !dialogEl?.contains(active))) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && (active === last || !dialogEl?.contains(active))) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+
+  // Open/close lifecycle: manage focus capture+restore + keydown listener.
+  $: if (typeof window !== 'undefined' && open !== lastOpen) {
+    lastOpen = open;
     if (open) {
+      previousActiveElement = (document.activeElement as HTMLElement) || null;
       window.addEventListener('keydown', handleKeydown);
+      // Defer initial focus so the dialog has mounted and transitions started.
+      tick().then(() => {
+        const focusable = getFocusable();
+        if (focusable.length > 0) {
+          focusable[0].focus();
+        } else {
+          dialogEl?.focus();
+        }
+      });
     } else {
       window.removeEventListener('keydown', handleKeydown);
+      // Return focus to whatever opened the modal.
+      if (previousActiveElement && typeof previousActiveElement.focus === 'function') {
+        previousActiveElement.focus();
+      }
+      previousActiveElement = null;
     }
   }
 
@@ -68,6 +123,8 @@
       class="fixed top-0 left-0 z-50 w-full h-full backdrop-brightness-50 backdrop-blur"
     >
       <dialog
+        bind:this={dialogEl}
+        tabindex="-1"
         transition:scale={{ duration: 250 }}
         aria-labelledby="title"
         aria-modal="true"

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -13,19 +13,9 @@
   import { createAuthManager, type AuthState } from '$lib/authManager';
   import { onMount, onDestroy } from 'svelte';
   import { DEFAULT_PROFILE_IMAGE } from '$lib/consts';
-  import { theme } from '$lib/themeStore';
   import { platformIsIOS } from '$lib/platform';
   import LoginFormIOS from '../../components/LoginFormIOS.svelte';
   import SuggestedFollowsModal from '../../components/SuggestedFollowsModal.svelte';
-
-  // Dark mode detection for logo
-  $: resolvedTheme =
-    $theme === 'system'
-      ? browser && window.matchMedia('(prefers-color-scheme: dark)').matches
-        ? 'dark'
-        : 'light'
-      : $theme;
-  $: isDarkMode = resolvedTheme === 'dark';
 
   let authManager: any = null;
   let authState: AuthState = {
@@ -79,9 +69,6 @@
   // Suggested follows state
   let showSuggestedFollows = false;
   let newAccountPubkey = '';
-
-  // Animation states
-  let isHovered = false;
 
   // UX state for extension detection warning
   let showMissingSignerNotice = false;
@@ -1009,12 +996,7 @@
          (z-30) doesn't bleed through. Tuned to 0.85 per spec. -->
     <div class="signin-scrim" aria-hidden="true"></div>
 
-    <section
-      class="signin-card"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="signin-title"
-    >
+    <section class="signin-card" aria-labelledby="signin-title">
       <p class="signin-eyebrow">Welcome to</p>
       <h1 id="signin-title" class="signin-wordmark">
         <img src="/zap_cooking_logo_white.svg" alt="Zap Cooking" />
@@ -1025,8 +1007,6 @@
       <button
         type="button"
         on:click={loginWithNIP07}
-        on:mouseenter={() => (isHovered = true)}
-        on:mouseleave={() => (isHovered = false)}
         disabled={authState.isLoading}
         aria-label="Sign in to Zap Cooking using your Nostr browser extension"
         class="signin-cta-primary"
@@ -1219,10 +1199,7 @@
      leak into the rest of the app. If we promote any of these to global
      tokens later, do it in src/app.css alongside the existing
      --color-* set rather than splitting the system. */
-  :global(.signin-card),
-  :global(.signin-scrim),
-  .signin-tiles,
-  .signin-footer {
+  .login-viewport-center {
     --signin-ink: #0b0e14;
     --signin-surface: #13171f;
     --signin-elevated: #1b202b;
@@ -1239,7 +1216,7 @@
   .signin-scrim {
     position: absolute;
     inset: 0;
-    background: rgba(11, 14, 20, 0.85);
+    background: color-mix(in srgb, var(--signin-ink) 85%, transparent);
     backdrop-filter: blur(14px);
     -webkit-backdrop-filter: blur(14px);
     z-index: -1;
@@ -1251,8 +1228,8 @@
     position: relative;
     width: 100%;
     max-width: 440px;
-    background: #13171f;
-    border: 1px solid #262c3a;
+    background: var(--signin-surface);
+    border: 1px solid var(--signin-line);
     border-radius: 24px;
     padding: 2.25rem 1.75rem 1.5rem;
     box-shadow:
@@ -1260,7 +1237,7 @@
       0 24px 64px rgba(0, 0, 0, 0.55),
       0 4px 12px rgba(247, 147, 26, 0.06);
     text-align: center;
-    color: #f5ebdd;
+    color: var(--signin-cream);
     font-family: 'Albert Sans', 'Inter', system-ui, -apple-system, sans-serif;
     animation: signinRise 320ms cubic-bezier(0.2, 0.8, 0.25, 1) both;
   }
@@ -1283,7 +1260,7 @@
     font-weight: 500;
     letter-spacing: 0.18em;
     text-transform: uppercase;
-    color: #7e8597;
+    color: var(--signin-mute);
     margin: 0 0 0.5rem;
   }
 
@@ -1303,7 +1280,7 @@
   .signin-tagline {
     font-size: 0.9375rem;
     font-weight: 400;
-    color: #c5b8a3;
+    color: var(--signin-wheat);
     margin: 0 0 1.75rem;
     line-height: 1.5;
   }
@@ -1315,7 +1292,7 @@
     height: 52px;
     border-radius: 14px;
     border: none;
-    background: linear-gradient(135deg, #f7931a 0%, #ff5f1f 100%);
+    background: linear-gradient(135deg, var(--signin-flame) 0%, var(--signin-ember) 100%);
     color: #fff8ec;
     font-family: inherit;
     font-weight: 600;
@@ -1328,8 +1305,8 @@
     padding: 0 1.25rem;
     box-shadow:
       0 1px 0 rgba(255, 255, 255, 0.18) inset,
-      0 8px 24px rgba(247, 147, 26, 0.36),
-      0 2px 6px rgba(255, 95, 31, 0.22);
+      0 8px 24px color-mix(in srgb, var(--signin-flame) 36%, transparent),
+      0 2px 6px color-mix(in srgb, var(--signin-ember) 22%, transparent);
     transition: transform 120ms ease, box-shadow 200ms ease, opacity 200ms ease;
   }
 
@@ -1337,8 +1314,8 @@
     transform: translateY(-1px);
     box-shadow:
       0 1px 0 rgba(255, 255, 255, 0.22) inset,
-      0 12px 30px rgba(247, 147, 26, 0.46),
-      0 2px 8px rgba(255, 95, 31, 0.28);
+      0 12px 30px color-mix(in srgb, var(--signin-flame) 46%, transparent),
+      0 2px 8px color-mix(in srgb, var(--signin-ember) 28%, transparent);
   }
 
   .signin-cta-primary:active:not(:disabled) {
@@ -1351,7 +1328,7 @@
   }
 
   .signin-cta-primary:focus-visible {
-    outline: 2px solid #f5ebdd;
+    outline: 2px solid var(--signin-cream);
     outline-offset: 3px;
   }
 
@@ -1362,9 +1339,9 @@
     height: 48px;
     margin-top: 0.75rem;
     border-radius: 14px;
-    border: 1px solid #262c3a;
-    background: #1b202b;
-    color: #f5ebdd;
+    border: 1px solid var(--signin-line);
+    background: var(--signin-elevated);
+    color: var(--signin-cream);
     font-family: inherit;
     font-weight: 500;
     font-size: 0.9375rem;
@@ -1379,7 +1356,7 @@
 
   .signin-cta-secondary:hover:not(:disabled) {
     transform: translateY(-1px);
-    border-color: rgba(247, 147, 26, 0.55);
+    border-color: color-mix(in srgb, var(--signin-flame) 55%, transparent);
     background: #20262f;
   }
 
@@ -1389,7 +1366,7 @@
   }
 
   .signin-cta-secondary:focus-visible {
-    outline: 2px solid #f7931a;
+    outline: 2px solid var(--signin-flame);
     outline-offset: 2px;
   }
 
@@ -1402,7 +1379,7 @@
 
   .signin-helper {
     font-size: 0.75rem;
-    color: #7e8597;
+    color: var(--signin-mute);
     margin: 0.625rem 0 0;
     line-height: 1.5;
   }
@@ -1410,7 +1387,7 @@
   .signin-helper a,
   .signin-notice a,
   .signin-footer a {
-    color: #f7931a;
+    color: var(--signin-flame);
     text-decoration: none;
   }
 
@@ -1424,10 +1401,10 @@
     margin-top: 0.625rem;
     padding: 0.625rem 0.75rem;
     border-radius: 10px;
-    background: #1b202b;
-    border: 1px solid #262c3a;
+    background: var(--signin-elevated);
+    border: 1px solid var(--signin-line);
     font-size: 0.8125rem;
-    color: #c5b8a3;
+    color: var(--signin-wheat);
     line-height: 1.5;
     text-align: left;
   }
@@ -1450,7 +1427,7 @@
     align-items: center;
     gap: 0.75rem;
     margin: 1.5rem 0 1rem;
-    color: #7e8597;
+    color: var(--signin-mute);
     font-size: 0.6875rem;
     font-weight: 500;
     text-transform: uppercase;
@@ -1462,7 +1439,7 @@
     content: '';
     flex: 1;
     height: 1px;
-    background: #262c3a;
+    background: var(--signin-line);
   }
 
   /* ───── Tiles ───── */
@@ -1474,11 +1451,11 @@
   }
 
   .signin-tile {
-    background: #1b202b;
-    border: 1px solid #262c3a;
+    background: var(--signin-elevated);
+    border: 1px solid var(--signin-line);
     border-radius: 14px;
     padding: 0.875rem 0.5rem 0.75rem;
-    color: #f5ebdd;
+    color: var(--signin-cream);
     font-family: inherit;
     cursor: pointer;
     display: flex;
@@ -1491,12 +1468,12 @@
 
   .signin-tile:hover:not(:disabled) {
     transform: translateY(-1px);
-    border-color: rgba(247, 147, 26, 0.5);
+    border-color: color-mix(in srgb, var(--signin-flame) 50%, transparent);
     background: #20262f;
   }
 
   .signin-tile:focus-visible {
-    outline: 2px solid #f7931a;
+    outline: 2px solid var(--signin-flame);
     outline-offset: 2px;
   }
 
@@ -1506,21 +1483,21 @@
   }
 
   .signin-tile-icon {
-    color: #f7931a;
+    color: var(--signin-flame);
     margin-bottom: 0.125rem;
   }
 
   .signin-tile-title {
     font-size: 0.8125rem;
     font-weight: 600;
-    color: #f5ebdd;
+    color: var(--signin-cream);
     line-height: 1.2;
   }
 
   .signin-tile-sub {
     font-size: 0.6875rem;
     font-weight: 400;
-    color: #7e8597;
+    color: var(--signin-mute);
     line-height: 1.2;
   }
 
@@ -1529,13 +1506,13 @@
   .signin-footer {
     margin-top: 1.5rem;
     padding-top: 1rem;
-    border-top: 1px solid #262c3a;
+    border-top: 1px solid var(--signin-line);
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 0.75rem;
     font-size: 0.75rem;
-    color: #7e8597;
+    color: var(--signin-mute);
   }
 
   .signin-footer-tag {

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1003,165 +1003,154 @@
     </div>
   </div>
 
-  <!-- Main Login Page (centered card, highest layer) -->
-  <main
-    class="login-viewport-center"
-    aria-label="Zap Cooking login page"
-  >
+  <!-- Sign-in card -->
+  <main class="login-viewport-center" aria-label="Sign in to Zap Cooking">
+    <!-- Scrim sits behind the card so the animated emoji background
+         (z-30) doesn't bleed through. Tuned to 0.85 per spec. -->
+    <div class="signin-scrim" aria-hidden="true"></div>
+
     <section
-      class="glass-card absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-3xl p-6 md:p-8 w-[calc(100%-2rem)] md:w-[calc(100vw-4em)] max-w-xl max-h-[85vh] md:max-h-[90vh] overflow-y-auto text-center"
-      aria-label="Authentication options"
+      class="signin-card"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="signin-title"
     >
-        <!-- Logo and Title -->
-        <div class="mb-5">
-          <img
-            src={isDarkMode ? '/zap_cooking_logo_white.svg' : '/zap_cooking_logo_black.svg'}
-            class="h-10 md:h-12 mb-2 mx-auto"
-            alt="Zap Cooking"
+      <p class="signin-eyebrow">Welcome to</p>
+      <h1 id="signin-title" class="signin-wordmark">
+        <img src="/zap_cooking_logo_white.svg" alt="Zap Cooking" />
+      </h1>
+      <p class="signin-tagline">Share recipes and get paid by your community.</p>
+
+      <!-- Primary CTA: NIP-07 -->
+      <button
+        type="button"
+        on:click={loginWithNIP07}
+        on:mouseenter={() => (isHovered = true)}
+        on:mouseleave={() => (isHovered = false)}
+        disabled={authState.isLoading}
+        aria-label="Sign in to Zap Cooking using your Nostr browser extension"
+        class="signin-cta-primary"
+      >
+        <svg class="signin-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path d="M13 2L4 14h7l-1 8 9-12h-7l1-8z" fill="currentColor" />
+        </svg>
+        <span>{authState.isLoading ? 'Connecting…' : 'Sign in with Browser Signer'}</span>
+      </button>
+
+      <!-- Extension helper / missing-signer notice -->
+      {#if !showMissingSignerNotice && authManager?.isNIP07Available() === false}
+        <p class="signin-helper">
+          Works with
+          <a href="https://getalby.com" target="_blank" rel="noopener noreferrer">Alby</a>,
+          <a href="https://github.com/fiatjaf/nos2x" target="_blank" rel="noopener noreferrer"
+            >nos2x</a
+          >, and similar.
+        </p>
+      {/if}
+      {#if showMissingSignerNotice}
+        <div class="signin-notice" role="alert">
+          No browser signer detected. Install
+          <a href="https://getalby.com" target="_blank" rel="noopener noreferrer">Alby</a>
+          or
+          <a href="https://github.com/fiatjaf/nos2x" target="_blank" rel="noopener noreferrer"
+            >nos2x</a
+          >, or pair an external signer below.
+        </div>
+      {/if}
+
+      <!-- Secondary CTA: Create Profile -->
+      <button
+        type="button"
+        on:click={() => (generateModal = true)}
+        disabled={authState.isLoading}
+        aria-label="Create a new Zap Cooking profile"
+        class="signin-cta-secondary"
+      >
+        <svg class="signin-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path
+            d="M21 14l-4-4m0 0l-3 3m3-3l-7 7-4-4 7-7m1-1l4 4-1 1M3 17v4h4l11-11"
+            stroke="currentColor"
+            stroke-width="1.75"
+            stroke-linecap="round"
+            stroke-linejoin="round"
           />
-          <h1 class="text-xl md:text-2xl font-bold mb-1" style="color: var(--color-text-primary)">
-            Welcome to <span class="text-orange-500">Zap Cooking</span>
-          </h1>
-          <p class="text-sm text-caption">Share recipes and support creators with Bitcoin zaps</p>
+        </svg>
+        <span>Create Profile</span>
+      </button>
+
+      <!-- Error -->
+      {#if authState.error}
+        <div class="signin-error" role="alert">
+          {authState.error}
         </div>
+      {/if}
 
-        <!-- Authentication Options -->
-        <div class="space-y-2.5 mb-3">
-          <!-- NIP-07 Extension Login - Primary CTA -->
-          <div>
-            <button
-              on:click={loginWithNIP07}
-              on:mouseenter={() => (isHovered = true)}
-              on:mouseleave={() => (isHovered = false)}
-              disabled={authState.isLoading}
-              aria-label="Sign in to Zap Cooking using your Nostr browser extension"
-              class="w-full bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 text-white font-semibold h-[52px] md:h-12 px-6 rounded-xl transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm"
-            >
-              <div class="flex items-center justify-center gap-2">
-                <span class="text-lg">⚡</span>
-                <span class="text-[15px]">
-                  {authState.isLoading ? 'Connecting...' : 'Sign in with Browser Signer'}
-                </span>
-              </div>
-            </button>
-            <!-- Extension helper - show neutral info initially, warning only after click -->
-            {#if !showMissingSignerNotice && authManager?.isNIP07Available() === false}
-              <p class="text-[11px] text-caption mt-1.5 leading-relaxed">
-                Works with <a
-                  href="https://getalby.com"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="underline hover:opacity-80">Alby</a
-                >
-                or
-                <a
-                  href="https://github.com/fiatjaf/nos2x"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="underline hover:opacity-80">nos2x</a
-                >.
-              </p>
-            {/if}
-            <!-- Missing signer notice - shown only after user clicks and no extension detected -->
-            {#if showMissingSignerNotice}
-              <div
-                class="bg-input border rounded-lg p-2.5 mt-1.5"
-                style="border-color: var(--color-input-border)"
-              >
-                <p class="text-[11px] text-caption leading-relaxed">
-                  No browser signer detected. Install <a
-                    href="https://getalby.com"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="underline hover:opacity-80">Alby</a
-                  >
-                  or
-                  <a
-                    href="https://github.com/fiatjaf/nos2x"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="underline hover:opacity-80">nos2x</a
-                  >, or use an external signer like Amber.
-                </p>
-              </div>
-            {/if}
-          </div>
+      <!-- Divider -->
+      <div class="signin-divider" aria-hidden="true">
+        <span>or</span>
+      </div>
 
-          <!-- Generate New Account - Secondary CTA -->
-          <button
-            on:click={() => (generateModal = true)}
-            disabled={authState.isLoading}
-            aria-label="Create a new Zap Cooking profile"
-            class="w-full bg-input hover:opacity-90 font-medium h-11 px-6 rounded-xl transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed border"
-            style="color: var(--color-text-primary); border-color: var(--color-input-border)"
-          >
-            <span class="text-sm">🔑 Create Profile</span>
-          </button>
-        </div>
-
-        <!-- Error Display -->
-        {#if authState.error}
-          <div
-            class="bg-input border rounded-lg p-2.5 mb-3"
-            style="border-color: var(--color-danger, #ef4444)"
-          >
-            <p class="text-xs" style="color: var(--color-danger, #ef4444)">{authState.error}</p>
-          </div>
-        {/if}
-
-        <!-- Advanced options -->
-        <div class="py-3 space-y-2">
-          <div class="flex items-center justify-center gap-3 text-[11px]">
-            <button
-              on:click={startUniversalPairing}
-              disabled={authState.isLoading}
-              class="text-caption hover:opacity-80 hover:underline transition-colors disabled:opacity-50"
-            >
-              📷 Scan QR / Universal pairing
-            </button>
-            <span class="text-caption">|</span>
-            <button
-              on:click={openBunkerModal}
-              disabled={authState.isLoading}
-              class="text-caption hover:opacity-80 hover:underline transition-colors disabled:opacity-50"
-            >
-              🔐 Paste bunker URI
-            </button>
-            <span class="text-caption">|</span>
-            <button
-              on:click={() => (nsecModal = true)}
-              disabled={authState.isLoading}
-              class="text-caption hover:opacity-80 hover:underline transition-colors disabled:opacity-50"
-            >
-              Import key
-            </button>
-          </div>
-        </div>
-
-        <!-- Value Propositions - Quieter styling -->
-        <section
-          class="grid grid-cols-2 gap-x-3 gap-y-1.5 text-[11px] text-caption pt-3 border-t"
-          style="border-color: var(--color-input-border)"
-          aria-label="Zap Cooking features"
+      <!-- Tile row: 3 methods always visible -->
+      <div class="signin-tiles" role="group" aria-label="Other sign-in methods">
+        <button
+          type="button"
+          on:click={startUniversalPairing}
+          disabled={authState.isLoading}
+          aria-label="Sign in by scanning a QR code with your phone signer"
+          class="signin-tile"
         >
-          <div class="flex items-center gap-1">
-            <span class="text-orange-400 text-xs">⚡</span>
-            <span>Instant Bitcoin Tips</span>
-          </div>
-          <div class="flex items-center gap-1">
-            <span class="text-blue-400 text-xs">🔒</span>
-            <span>Decentralized & Private</span>
-          </div>
-          <div class="flex items-center gap-1">
-            <span class="text-purple-400 text-xs">🌍</span>
-            <span>Global Recipe Community</span>
-          </div>
-          <div class="flex items-center gap-1">
-            <span class="text-green-400 text-xs">📱</span>
-            <span>Cross-Platform Access</span>
-          </div>
-        </section>
-      </section>
+          <svg class="signin-tile-icon" width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <rect x="3" y="3" width="7" height="7" rx="1" stroke="currentColor" stroke-width="1.6" />
+            <rect x="14" y="3" width="7" height="7" rx="1" stroke="currentColor" stroke-width="1.6" />
+            <rect x="3" y="14" width="7" height="7" rx="1" stroke="currentColor" stroke-width="1.6" />
+            <path d="M14 14h3v3M20 14v3M14 17v4h3M17 20h4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+          </svg>
+          <span class="signin-tile-title">Scan QR</span>
+          <span class="signin-tile-sub">Pair phone</span>
+        </button>
+
+        <button
+          type="button"
+          on:click={openBunkerModal}
+          disabled={authState.isLoading}
+          aria-label="Sign in with a bunker URI from a remote signer"
+          class="signin-tile"
+        >
+          <svg class="signin-tile-icon" width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <rect x="4" y="10" width="16" height="11" rx="2" stroke="currentColor" stroke-width="1.6" />
+            <path d="M8 10V7a4 4 0 018 0v3" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+            <circle cx="12" cy="15" r="1.5" fill="currentColor" />
+          </svg>
+          <span class="signin-tile-title">Bunker URI</span>
+          <span class="signin-tile-sub">Remote signer</span>
+        </button>
+
+        <button
+          type="button"
+          on:click={() => (nsecModal = true)}
+          disabled={authState.isLoading}
+          aria-label="Sign in by importing a private key"
+          class="signin-tile"
+        >
+          <svg class="signin-tile-icon" width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <circle cx="8.5" cy="14.5" r="3.5" stroke="currentColor" stroke-width="1.6" />
+            <path d="M11 12l9-9m-3 0h3v3m-5 2l2 2" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+          <span class="signin-tile-title">Import key</span>
+          <span class="signin-tile-sub">Paste nsec</span>
+        </button>
+      </div>
+
+      <!-- Footer strip -->
+      <footer class="signin-footer">
+        <span class="signin-footer-tag">Your identity · Your data</span>
+        <span class="signin-footer-links">
+          <a href="/terms">Terms</a>
+          <span aria-hidden="true">·</span>
+          <a href="/privacy">Privacy</a>
+        </span>
+      </footer>
+    </section>
   </main>
 {/if}
 
@@ -1218,5 +1207,380 @@
     inset: 0;
     z-index: 31;
     overflow-y: auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem 1rem;
+    padding-top: max(1.5rem, env(safe-area-inset-top));
+    padding-bottom: max(1.5rem, env(safe-area-inset-bottom));
+  }
+
+  /* Brief palette tokens — scoped to the sign-in surface so they don't
+     leak into the rest of the app. If we promote any of these to global
+     tokens later, do it in src/app.css alongside the existing
+     --color-* set rather than splitting the system. */
+  :global(.signin-card),
+  :global(.signin-scrim),
+  .signin-tiles,
+  .signin-footer {
+    --signin-ink: #0b0e14;
+    --signin-surface: #13171f;
+    --signin-elevated: #1b202b;
+    --signin-line: #262c3a;
+    --signin-flame: #f7931a;
+    --signin-ember: #ff5f1f;
+    --signin-cream: #f5ebdd;
+    --signin-wheat: #c5b8a3;
+    --signin-mute: #7e8597;
+  }
+
+  /* ───── Scrim ───── */
+
+  .signin-scrim {
+    position: absolute;
+    inset: 0;
+    background: rgba(11, 14, 20, 0.85);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+    z-index: -1;
+  }
+
+  /* ───── Card ───── */
+
+  .signin-card {
+    position: relative;
+    width: 100%;
+    max-width: 440px;
+    background: #13171f;
+    border: 1px solid #262c3a;
+    border-radius: 24px;
+    padding: 2.25rem 1.75rem 1.5rem;
+    box-shadow:
+      0 1px 0 rgba(245, 235, 221, 0.04) inset,
+      0 24px 64px rgba(0, 0, 0, 0.55),
+      0 4px 12px rgba(247, 147, 26, 0.06);
+    text-align: center;
+    color: #f5ebdd;
+    font-family: 'Albert Sans', 'Inter', system-ui, -apple-system, sans-serif;
+    animation: signinRise 320ms cubic-bezier(0.2, 0.8, 0.25, 1) both;
+  }
+
+  @keyframes signinRise {
+    from {
+      opacity: 0;
+      transform: translateY(8px) scale(0.985);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+
+  /* ───── Hero ───── */
+
+  .signin-eyebrow {
+    font-size: 0.75rem;
+    font-weight: 500;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: #7e8597;
+    margin: 0 0 0.5rem;
+  }
+
+  .signin-wordmark {
+    margin: 0 auto 0.875rem;
+    line-height: 0;
+  }
+
+  .signin-wordmark img {
+    width: 240px;
+    max-width: 100%;
+    height: auto;
+    display: block;
+    margin: 0 auto;
+  }
+
+  .signin-tagline {
+    font-size: 0.9375rem;
+    font-weight: 400;
+    color: #c5b8a3;
+    margin: 0 0 1.75rem;
+    line-height: 1.5;
+  }
+
+  /* ───── Primary CTA ───── */
+
+  .signin-cta-primary {
+    width: 100%;
+    height: 52px;
+    border-radius: 14px;
+    border: none;
+    background: linear-gradient(135deg, #f7931a 0%, #ff5f1f 100%);
+    color: #fff8ec;
+    font-family: inherit;
+    font-weight: 600;
+    font-size: 0.9375rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.625rem;
+    padding: 0 1.25rem;
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 0.18) inset,
+      0 8px 24px rgba(247, 147, 26, 0.36),
+      0 2px 6px rgba(255, 95, 31, 0.22);
+    transition: transform 120ms ease, box-shadow 200ms ease, opacity 200ms ease;
+  }
+
+  .signin-cta-primary:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 0.22) inset,
+      0 12px 30px rgba(247, 147, 26, 0.46),
+      0 2px 8px rgba(255, 95, 31, 0.28);
+  }
+
+  .signin-cta-primary:active:not(:disabled) {
+    transform: translateY(0);
+  }
+
+  .signin-cta-primary:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+
+  .signin-cta-primary:focus-visible {
+    outline: 2px solid #f5ebdd;
+    outline-offset: 3px;
+  }
+
+  /* ───── Secondary CTA ───── */
+
+  .signin-cta-secondary {
+    width: 100%;
+    height: 48px;
+    margin-top: 0.75rem;
+    border-radius: 14px;
+    border: 1px solid #262c3a;
+    background: #1b202b;
+    color: #f5ebdd;
+    font-family: inherit;
+    font-weight: 500;
+    font-size: 0.9375rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.625rem;
+    padding: 0 1.25rem;
+    transition: transform 120ms ease, border-color 200ms ease, background 200ms ease;
+  }
+
+  .signin-cta-secondary:hover:not(:disabled) {
+    transform: translateY(-1px);
+    border-color: rgba(247, 147, 26, 0.55);
+    background: #20262f;
+  }
+
+  .signin-cta-secondary:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+
+  .signin-cta-secondary:focus-visible {
+    outline: 2px solid #f7931a;
+    outline-offset: 2px;
+  }
+
+  .signin-icon {
+    color: currentColor;
+    flex-shrink: 0;
+  }
+
+  /* ───── Helper / notice / error ───── */
+
+  .signin-helper {
+    font-size: 0.75rem;
+    color: #7e8597;
+    margin: 0.625rem 0 0;
+    line-height: 1.5;
+  }
+
+  .signin-helper a,
+  .signin-notice a,
+  .signin-footer a {
+    color: #f7931a;
+    text-decoration: none;
+  }
+
+  .signin-helper a:hover,
+  .signin-notice a:hover,
+  .signin-footer a:hover {
+    text-decoration: underline;
+  }
+
+  .signin-notice {
+    margin-top: 0.625rem;
+    padding: 0.625rem 0.75rem;
+    border-radius: 10px;
+    background: #1b202b;
+    border: 1px solid #262c3a;
+    font-size: 0.8125rem;
+    color: #c5b8a3;
+    line-height: 1.5;
+    text-align: left;
+  }
+
+  .signin-error {
+    margin-top: 1rem;
+    padding: 0.625rem 0.75rem;
+    border-radius: 10px;
+    background: rgba(239, 68, 68, 0.1);
+    border: 1px solid rgba(239, 68, 68, 0.6);
+    font-size: 0.8125rem;
+    color: #fca5a5;
+    line-height: 1.5;
+  }
+
+  /* ───── Divider ───── */
+
+  .signin-divider {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 1.5rem 0 1rem;
+    color: #7e8597;
+    font-size: 0.6875rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+  }
+
+  .signin-divider::before,
+  .signin-divider::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: #262c3a;
+  }
+
+  /* ───── Tiles ───── */
+
+  .signin-tiles {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.625rem;
+  }
+
+  .signin-tile {
+    background: #1b202b;
+    border: 1px solid #262c3a;
+    border-radius: 14px;
+    padding: 0.875rem 0.5rem 0.75rem;
+    color: #f5ebdd;
+    font-family: inherit;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.375rem;
+    text-align: center;
+    transition: transform 120ms ease, border-color 200ms ease, background 200ms ease;
+  }
+
+  .signin-tile:hover:not(:disabled) {
+    transform: translateY(-1px);
+    border-color: rgba(247, 147, 26, 0.5);
+    background: #20262f;
+  }
+
+  .signin-tile:focus-visible {
+    outline: 2px solid #f7931a;
+    outline-offset: 2px;
+  }
+
+  .signin-tile:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+
+  .signin-tile-icon {
+    color: #f7931a;
+    margin-bottom: 0.125rem;
+  }
+
+  .signin-tile-title {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: #f5ebdd;
+    line-height: 1.2;
+  }
+
+  .signin-tile-sub {
+    font-size: 0.6875rem;
+    font-weight: 400;
+    color: #7e8597;
+    line-height: 1.2;
+  }
+
+  /* ───── Footer ───── */
+
+  .signin-footer {
+    margin-top: 1.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid #262c3a;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    font-size: 0.75rem;
+    color: #7e8597;
+  }
+
+  .signin-footer-tag {
+    font-weight: 500;
+    letter-spacing: 0.02em;
+  }
+
+  .signin-footer-links {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  /* ───── Mobile tuning ───── */
+
+  @media (max-width: 480px) {
+    .signin-card {
+      padding: 1.75rem 1.25rem 1.25rem;
+      border-radius: 20px;
+    }
+    .signin-wordmark img {
+      width: 200px;
+    }
+    .signin-tagline {
+      font-size: 0.875rem;
+      margin-bottom: 1.5rem;
+    }
+    .signin-tile {
+      padding: 0.75rem 0.375rem 0.625rem;
+    }
+    .signin-tile-title {
+      font-size: 0.75rem;
+    }
+    .signin-tile-sub {
+      font-size: 0.625rem;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .signin-card,
+    .signin-cta-primary,
+    .signin-cta-secondary,
+    .signin-tile {
+      animation: none !important;
+      transition: none !important;
+    }
   }
 </style>

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1143,7 +1143,7 @@
 
       <!-- Footer strip -->
       <footer class="signin-footer">
-        <span class="signin-footer-tag">Your identity · Your data</span>
+        <span class="signin-footer-tag">Your identity · Your data · Your money</span>
         <span class="signin-footer-links">
           <a href="/terms">Terms</a>
           <span aria-hidden="true">·</span>


### PR DESCRIPTION
**Draft.** UI-only refresh of `/login` per the revised brief (today's reissue, not yesterday's). All five existing sign-in handlers wired unchanged.

Supersedes #345 — that branch is left in place as reference; this is a fresh start off main.
Pairs with `investigate/signin-modal-refresh` (revised INVESTIGATION.md on that branch).

## Decisions confirmed before implementation

| # | Question | Direction |
|---|---|---|
| 1 | Mockup at `docs/design/signin-modal-final.html` | You're committing today; built from inline brief in the meantime |
| 2 | Albert Sans | Added via Google Fonts `<link>`, weights 300/400/500/600/700 |
| 3 | Wordmark | Existing `zap_cooking_logo_white.svg` (white, not the preview cream) |
| 4 | iOS QR tile | Dropped on iOS, 2-column grid for the remaining tiles |
| 5 | Background animated emojis | Left in place; scrim opacity tuned to 0.85 |
| 6 | Wordmark flame gradient | Source SVG untouched (out of scope for this PR) |
| 7 | Auth analytics | Not added (funnel stays uninstrumented per scope) |

## What this PR does

- `/login` entry-point view matches the revised brief: "Welcome to" eyebrow → wordmark → tagline → primary CTA → secondary CTA → divider → 3-tile grid → footer.
- Surface palette uses the brief's exact tokens (ink/surface/elevated/line/flame/ember/cream/wheat/mute) scoped to the sign-in card via CSS custom properties. Existing global `--color-*` tokens in `app.css` are untouched.
- `LoginFormIOS.svelte` mirrors the visual language with two adaptations: Create Profile as the primary CTA, and a 2-tile grid (Bunker URI + Import key) since QR/pair-phone can't ship on iOS per platform policy.
- `<Modal>` primitive gets a focus trap inline (~30 LOC, no new dep): focus capture on open → initial focus on first focusable → Tab/Shift-Tab cycle → focus restore on close.
- Albert Sans 300/400/500/600/700 added to the existing Google Fonts `<link>` block in `app.html` alongside Orbitron.

## What this PR does NOT touch

- All five sign-in handlers (`loginWithNIP07`, `useGeneratedKeys`, `startUniversalPairing`, `loginWithBunker`, `loginWithPrivateKey`) wired by reference; zero signature/body/flow changes.
- The four sub-modals (nsec, bunker, generate keys, NIP-46 universal) keep their existing markup, multi-step guards, and `<Modal>` usage.
- `authManager` call sites unchanged.
- `SuggestedFollowsModal` handoff after Create Profile unchanged.
- Wordmark source SVG (`zap_cooking_logo_white.svg`) — flame gradient stays `#FFAA00 → #FF0C1C` per call #6.
- No new dependencies.

## Acceptance criteria

- [ ] All five existing sign-in methods complete a successful sign-in (manual smoke per method)
- [ ] No analytics events lost (none existed; nothing to lose)
- [ ] Renders correctly at 320px / 375px / 768px / 1024px / 1440px
- [ ] Renders correctly inside iOS Capacitor build (safe-area insets handled via `env(safe-area-inset-*)`)
- [ ] Renders correctly inside Android Capacitor build
- [ ] Keyboard nav: Tab cycles all interactives in DOM order, focus rings visible (orange `#F7931A` outlines), ESC closes sub-modals, focus trap holds inside sub-modals
- [ ] Screen reader: dialog announced (`aria-modal`, `aria-labelledby`), close button labeled, all five methods have descriptive labels
- [ ] No console errors on open/close cycle
- [ ] Lighthouse a11y on `/login` ≥ existing baseline
- [ ] Dark-mode wordmark in place (existing asset, no new file needed)
- [ ] **`pnpm svelte-check`** clean — verified locally: 0 errors, 127 pre-existing warnings

## Why draft

Visual fidelity wants a manual smoke pass before promotion. The diff itself is reviewable in 60 seconds; the test plan above is the gating step. Once `docs/design/signin-modal-final.html` lands, I'll iterate against it in this same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)