### PR TITLE
chore(signin): drop helper line + dead DEFAULT_PROFILE_IMAGE import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.291",
+  "version": "4.2.292",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.290",
+  "version": "4.2.291",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1017,16 +1017,7 @@
         <span>{authState.isLoading ? 'Connecting…' : 'Sign in with Browser Signer'}</span>
       </button>
 
-      <!-- Extension helper / missing-signer notice -->
-      {#if !showMissingSignerNotice && authManager?.isNIP07Available() === false}
-        <p class="signin-helper">
-          Works with
-          <a href="https://getalby.com" target="_blank" rel="noopener noreferrer">Alby</a>,
-          <a href="https://github.com/fiatjaf/nos2x" target="_blank" rel="noopener noreferrer"
-            >nos2x</a
-          >, and similar.
-        </p>
-      {/if}
+      <!-- Missing-signer notice (only after the user clicks and no extension is detected). -->
       {#if showMissingSignerNotice}
         <div class="signin-notice" role="alert">
           No browser signer detected. Install
@@ -1377,21 +1368,12 @@
 
   /* ───── Helper / notice / error ───── */
 
-  .signin-helper {
-    font-size: 0.75rem;
-    color: var(--signin-mute);
-    margin: 0.625rem 0 0;
-    line-height: 1.5;
-  }
-
-  .signin-helper a,
   .signin-notice a,
   .signin-footer a {
     color: var(--signin-flame);
     text-decoration: none;
   }
 
-  .signin-helper a:hover,
   .signin-notice a:hover,
   .signin-footer a:hover {
     text-decoration: underline;

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -12,7 +12,6 @@
   import { nip19 } from 'nostr-tools';
   import { createAuthManager, type AuthState } from '$lib/authManager';
   import { onMount, onDestroy } from 'svelte';
-  import { DEFAULT_PROFILE_IMAGE } from '$lib/consts';
   import { platformIsIOS } from '$lib/platform';
   import LoginFormIOS from '../../components/LoginFormIOS.svelte';
   import SuggestedFollowsModal from '../../components/SuggestedFollowsModal.svelte';


### PR DESCRIPTION
## Summary
Two-commit follow-up to #346. Pure cleanup — no behavior change, no visual change to the merged card except the removal of the helper line below the primary CTA.

### Commits

1. **Drop the "Works with Alby, nos2x, and similar." helper.** This was the proactive helper line that rendered under "Sign in with Browser Signer" when no extension was detected. It was originally on PR #346's branch (`b5cc8c0`) but was added after the PR merged at `1667067`, so it never reached `main`. Cherry-picked here. The post-click missing-signer notice (`showMissingSignerNotice`) is unchanged — that's the corrective UX when someone actually clicks and the extension isn't found.

2. **Drop unused `DEFAULT_PROFILE_IMAGE` import** in `src/routes/login/+page.svelte`. Imported but never referenced. Generate Profile manages its own picture state via `newAccountPicture` and doesn't fall back to a default. Leftover from an earlier draft.

## Diff
```
src/routes/login/+page.svelte | 23 +----------------------
```

## Test plan
- [ ] `/login` no longer shows the "Works with Alby, nos2x, and similar." sentence below the primary CTA when no extension is installed
- [ ] Clicking "Sign in with Browser Signer" with no extension still surfaces the corrective missing-signer notice with the install links
- [ ] `npm run check` clean — verified locally: 0 errors, 127 pre-existing warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)