### PR TITLE
fix(signin): replace Create Profile key icon with user-plus

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.292",
+  "version": "4.2.293",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1036,13 +1036,21 @@
         aria-label="Create a new Zap Cooking profile"
         class="signin-cta-secondary"
       >
+        <!-- user-plus, not a key — keeps semantic distance from the
+             Import key tile below where a key icon already lives. -->
         <svg class="signin-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <circle cx="9" cy="8" r="3.5" stroke="currentColor" stroke-width="1.75" />
           <path
-            d="M21 14l-4-4m0 0l-3 3m3-3l-7 7-4-4 7-7m1-1l4 4-1 1M3 17v4h4l11-11"
+            d="M3 20c0-3.5 2.7-6 6-6s6 2.5 6 6"
             stroke="currentColor"
             stroke-width="1.75"
             stroke-linecap="round"
-            stroke-linejoin="round"
+          />
+          <path
+            d="M18 7v6m-3-3h6"
+            stroke="currentColor"
+            stroke-width="1.75"
+            stroke-linecap="round"
           />
         </svg>
         <span>Create Profile</span>


### PR DESCRIPTION
## Summary

The Create Profile CTA on `/login` was rendering a key icon — same glyph as the Import key tile directly below it in the same card. Two adjacent buttons sharing iconography while doing opposite things (generate new vs. supply existing) is a real UX trip hazard.

This PR swaps the Create Profile glyph to a user-plus (head silhouette + small `+` on the shoulder). One commit, ~14 lines.

## Why

- **Differentiates** from the key in the Import tile below
- **Matches the verb** "Create" — additive, not unlock
- **Matches the action** — generates a new keypair AND publishes a fresh kind:0 profile metadata event

## What this PR does NOT touch

- iOS form (`LoginFormIOS.svelte`) — its Create Profile is the primary CTA and uses a lightning bolt to match the desktop primary's action-rhythm. No key conflict on iOS because the Import tile is in a different visual position with an unambiguous key glyph
- Any handler, behavior, or accessibility attribute
- The other glyphs in the card (lightning bolt on Sign in with Browser Signer, QR/lock/key on the three tiles)

## Test plan

- [ ] `/login` Create Profile button shows the user-plus icon (head + `+`) instead of the previous key
- [ ] Import key tile still shows its key icon
- [ ] At-a-glance, the two buttons look semantically different
- [ ] `npm run check` clean — verified locally: 0 errors, 127 pre-existing warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)