### PR TITLE
feat(cookbook): Recipe Packs + cookbook UX refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.293",
+  "version": "4.2.294",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.294",
+  "version": "4.2.295",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.295",
+  "version": "4.2.296",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/RecipePackCard.svelte
+++ b/src/components/RecipePackCard.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+  import type { NDKEvent } from '@nostr-dev-kit/ndk';
+  import Avatar from './Avatar.svelte';
+  import CustomName from './CustomName.svelte';
+  import ZapButton from './ZapButton.svelte';
+  import BookmarkIcon from 'phosphor-svelte/lib/BookmarkSimple';
+  import ArrowRightIcon from 'phosphor-svelte/lib/ArrowRight';
+  import { lazyLoad } from '$lib/lazyLoad';
+  import { getImageOrPlaceholder } from '$lib/placeholderImages';
+
+  /**
+   * Pack metadata. Either pass a full NDKEvent (after publish) so the
+   * Zap button can target it, or pass plain props for a preview before
+   * publish.
+   */
+  export let event: NDKEvent | null = null;
+  export let title: string;
+  export let description: string = '';
+  export let image: string | undefined = undefined;
+  export let creatorPubkey: string = '';
+  export let recipeCount: number = 0;
+  export let viewUrl: string = '';
+  export let preview: boolean = false; // true → hide Zap/View, show "Preview" badge
+
+  $: resolvedImage = getImageOrPlaceholder(image || '', `${creatorPubkey}:${title}`);
+</script>
+
+<article
+  class="rounded-2xl overflow-hidden flex flex-col"
+  style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+>
+  <div class="relative w-full aspect-[16/9] pack-image-wrap">
+    <div
+      use:lazyLoad={{ url: resolvedImage }}
+      class="absolute inset-0 pack-image"
+    ></div>
+    <div class="absolute top-3 left-3 flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-black/55 text-white text-xs font-medium backdrop-blur-sm">
+      <BookmarkIcon size={12} weight="fill" />
+      <span>Recipe Pack</span>
+    </div>
+    {#if preview}
+      <div class="absolute top-3 right-3 px-2.5 py-1 rounded-full bg-amber-500/90 text-white text-xs font-semibold shadow">
+        Preview
+      </div>
+    {/if}
+  </div>
+
+  <div class="p-4 flex flex-col gap-3">
+    <div>
+      <h3
+        class="text-lg sm:text-xl font-bold leading-snug line-clamp-2"
+        style="color: var(--color-text-primary)"
+      >
+        {title || 'Untitled pack'}
+      </h3>
+      {#if description}
+        <p class="text-sm text-caption mt-1 line-clamp-3 whitespace-pre-line">{description}</p>
+      {/if}
+    </div>
+
+    <div class="flex items-center gap-2 flex-wrap">
+      {#if creatorPubkey}
+        <div class="flex items-center gap-2 min-w-0">
+          <Avatar pubkey={creatorPubkey} size={28} showRing={false} />
+          <span class="text-sm truncate" style="color: var(--color-text-secondary)">
+            <CustomName pubkey={creatorPubkey} />
+          </span>
+        </div>
+        <span class="text-caption text-xs">·</span>
+      {/if}
+      <span class="text-sm text-caption">
+        {recipeCount} {recipeCount === 1 ? 'recipe' : 'recipes'}
+      </span>
+    </div>
+
+    {#if !preview}
+      <div class="flex items-center gap-2 pt-1">
+        {#if event}
+          <ZapButton {event} variant="default" size="sm" />
+        {/if}
+        {#if viewUrl}
+          <a
+            href={viewUrl}
+            class="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors"
+            style="background-color: var(--color-bg-secondary); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+          >
+            <span>View</span>
+            <ArrowRightIcon size={14} weight="bold" />
+          </a>
+        {/if}
+      </div>
+    {/if}
+  </div>
+</article>
+
+<style>
+  .pack-image-wrap {
+    background-color: var(--color-accent-gray);
+  }
+  .pack-image {
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    opacity: 0;
+    transition: opacity 0.3s ease-in;
+  }
+  .pack-image:global(.image-loaded) {
+    opacity: 1;
+  }
+</style>

--- a/src/components/SharePackModal.svelte
+++ b/src/components/SharePackModal.svelte
@@ -1,0 +1,283 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import Modal from './Modal.svelte';
+  import Button from './Button.svelte';
+  import RecipePackCard from './RecipePackCard.svelte';
+  import CopyIcon from 'phosphor-svelte/lib/Copy';
+  import CheckIcon from 'phosphor-svelte/lib/Check';
+  import { userPublickey } from '$lib/nostr';
+  import { showToast } from '$lib/toast';
+  import {
+    publishRecipePack,
+    publishPackAnnouncement,
+    resolveFirstRecipeImage,
+    type RecipePackSource
+  } from '$lib/recipePack';
+  import { copyToClipboard } from '$lib/utils/share';
+
+  export let open = false;
+  export let source: RecipePackSource;
+  export let recipeATags: string[] = [];
+  export let initialTitle: string = '';
+  export let initialDescription: string = '';
+  export let initialImage: string | undefined = undefined;
+
+  const dispatch = createEventDispatcher();
+
+  let title = '';
+  let description = '';
+  let effectiveImage: string | undefined = undefined;
+  let isResolvingImage = false;
+  let alsoShareToFeed = true;
+  let isSubmitting = false;
+  let announcementFailed = false;
+  let error = '';
+  let publishedUrl = '';
+  let publishedNaddr = '';
+  let publishedEvent: import('@nostr-dev-kit/ndk').NDKEvent | null = null;
+  let copied = false;
+
+  $: recipeCount = recipeATags.length;
+  $: canPublish = !isSubmitting && recipeCount > 0 && title.trim().length > 0;
+
+  // Reset state every time the modal opens
+  $: if (open) initStateOnOpen();
+  $: if (!open) {
+    publishedUrl = '';
+    publishedNaddr = '';
+    publishedEvent = null;
+    copied = false;
+    error = '';
+    announcementFailed = false;
+  }
+
+  function initStateOnOpen() {
+    if (!publishedUrl) {
+      title = initialTitle || '';
+      description = initialDescription || '';
+      effectiveImage = initialImage;
+      // If no cover image was passed in, derive one from the first
+      // recipe that has an image. Cache-first so this is usually instant.
+      if (!effectiveImage && recipeATags.length > 0) {
+        isResolvingImage = true;
+        resolveFirstRecipeImage(recipeATags)
+          .then((img) => {
+            if (img && !effectiveImage) effectiveImage = img;
+          })
+          .catch((e) => console.warn('[SharePackModal] resolve image failed', e))
+          .finally(() => (isResolvingImage = false));
+      }
+    }
+  }
+
+  async function handlePublish() {
+    error = '';
+    if (!title.trim()) {
+      error = 'Please enter a title.';
+      return;
+    }
+    if (recipeCount === 0) {
+      error = 'There are no recipes to share.';
+      return;
+    }
+    if (!$userPublickey) {
+      error = 'Sign in to share a Recipe Pack.';
+      return;
+    }
+    isSubmitting = true;
+    announcementFailed = false;
+    try {
+      const result = await publishRecipePack({
+        source,
+        title: title.trim(),
+        description: description.trim() || undefined,
+        image: effectiveImage,
+        recipeATags
+      });
+      publishedEvent = result.event;
+      publishedNaddr = result.naddr;
+      publishedUrl = result.url;
+
+      // Optional kind:1 announcement so the pack also surfaces in feed-only clients.
+      if (alsoShareToFeed) {
+        try {
+          await publishPackAnnouncement(result, {
+            title: title.trim(),
+            description: description.trim() || undefined,
+            recipeCount
+          });
+          showToast('success', 'Recipe Pack published & posted to feed.');
+        } catch (annErr) {
+          console.warn('[SharePackModal] announcement failed', annErr);
+          announcementFailed = true;
+          showToast('info', 'Pack published. Feed announcement failed — you can copy the link manually.');
+        }
+      } else {
+        showToast('success', 'Recipe Pack published.');
+      }
+
+      dispatch('published', { event: result.event, naddr: result.naddr, url: result.url });
+    } catch (e: any) {
+      console.error('[SharePackModal] publish failed', e);
+      error = e?.message || 'Failed to publish Recipe Pack.';
+      showToast('error', error);
+    } finally {
+      isSubmitting = false;
+    }
+  }
+
+  async function handleCopyUrl() {
+    if (!publishedUrl) return;
+    const ok = await copyToClipboard(publishedUrl);
+    if (ok) {
+      copied = true;
+      setTimeout(() => (copied = false), 1800);
+    }
+  }
+
+  function handleClose() {
+    open = false;
+  }
+</script>
+
+<Modal cleanup={handleClose} bind:open>
+  <h1 slot="title">Share Recipe Pack</h1>
+
+  {#if !publishedUrl}
+    <form on:submit|preventDefault={handlePublish} class="flex flex-col gap-4">
+      <p class="text-sm text-caption">
+        Publish your saved recipes as a curated pack. Anyone on Nostr can open it,
+        zap it, and zaps go to you.
+      </p>
+
+      <div class="flex flex-col gap-2">
+        <label for="pack-title" class="text-sm font-medium" style="color: var(--color-text-primary)">
+          Title <span class="text-red-500">*</span>
+        </label>
+        <input
+          id="pack-title"
+          type="text"
+          class="input"
+          bind:value={title}
+          placeholder="e.g., Weeknight Dinners"
+          maxlength="120"
+          disabled={isSubmitting}
+        />
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <label
+          for="pack-description"
+          class="text-sm font-medium"
+          style="color: var(--color-text-primary)"
+        >
+          Description
+        </label>
+        <textarea
+          id="pack-description"
+          class="input"
+          rows="3"
+          bind:value={description}
+          placeholder="Tell people what's in this pack…"
+          maxlength="500"
+          disabled={isSubmitting}
+        />
+      </div>
+
+      <!-- Live preview -->
+      <div class="flex flex-col gap-2">
+        <span class="text-sm font-medium" style="color: var(--color-text-primary)">Preview</span>
+        <RecipePackCard
+          title={title || 'Untitled pack'}
+          description={description}
+          image={effectiveImage}
+          creatorPubkey={$userPublickey}
+          recipeCount={recipeCount}
+          preview={true}
+        />
+      </div>
+
+      <!-- Distribution toggle -->
+      <label class="flex items-start gap-2 cursor-pointer select-none">
+        <input
+          type="checkbox"
+          bind:checked={alsoShareToFeed}
+          disabled={isSubmitting}
+          class="mt-0.5 w-4 h-4 accent-orange-500"
+        />
+        <span class="flex flex-col gap-0.5">
+          <span class="text-sm font-medium" style="color: var(--color-text-primary)">
+            Also share to feed
+          </span>
+          <span class="text-xs text-caption">
+            Posts a regular note linking to your pack so it appears in standard Nostr feeds.
+          </span>
+        </span>
+      </label>
+
+      {#if error}
+        <p class="text-sm text-red-500">{error}</p>
+      {/if}
+
+      <div class="flex justify-end gap-2 pt-1">
+        <Button on:click={handleClose} primary={false} disabled={isSubmitting}>Cancel</Button>
+        <Button type="submit" disabled={!canPublish}>
+          {isSubmitting ? 'Publishing…' : 'Publish Recipe Pack'}
+        </Button>
+      </div>
+    </form>
+  {:else}
+    <div class="flex flex-col gap-4">
+      <p class="text-sm" style="color: var(--color-text-primary)">
+        Recipe Pack published to Nostr. Share the link or zap the pack from any client.
+      </p>
+      {#if announcementFailed}
+        <p class="text-xs px-3 py-2 rounded-lg" style="background-color: var(--color-input-bg); color: var(--color-text-secondary); border: 1px solid var(--color-input-border);">
+          The optional feed announcement didn't publish. The pack itself is live —
+          you can paste the link below into any Nostr client.
+        </p>
+      {/if}
+
+      {#if publishedEvent}
+        <RecipePackCard
+          event={publishedEvent}
+          {title}
+          {description}
+          image={effectiveImage}
+          creatorPubkey={$userPublickey}
+          recipeCount={recipeCount}
+          viewUrl={publishedUrl}
+        />
+      {/if}
+
+      <div class="flex items-center gap-2">
+        <input
+          type="text"
+          class="input flex-1 text-sm"
+          readonly
+          value={publishedUrl}
+          on:focus={(e) => (e.currentTarget).select()}
+        />
+        <button
+          type="button"
+          on:click={handleCopyUrl}
+          class="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors"
+          style="background-color: var(--color-bg-secondary); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+          aria-label="Copy share link"
+        >
+          {#if copied}
+            <CheckIcon size={14} weight="bold" />
+            <span>Copied</span>
+          {:else}
+            <CopyIcon size={14} weight="bold" />
+            <span>Copy</span>
+          {/if}
+        </button>
+      </div>
+
+      <div class="flex justify-end gap-2 pt-1">
+        <Button on:click={handleClose}>Done</Button>
+      </div>
+    </div>
+  {/if}
+</Modal>

--- a/src/lib/recipePack.ts
+++ b/src/lib/recipePack.ts
@@ -1,0 +1,275 @@
+/**
+ * Recipe Packs — shareable curated lists of recipes published as
+ * NIP-51 curation sets (kind 30004).
+ *
+ * A pack references existing recipes by `a` tags (addressable events,
+ * kind 30023 / 35000) and never duplicates recipe content. Zaps on the
+ * pack event flow to the creator (the event author) via the standard
+ * NIP-57 path.
+ */
+
+import { NDKEvent, type NDKKind } from '@nostr-dev-kit/ndk';
+import { nip19 } from 'nostr-tools';
+import { ndk, userPublickey, GARDEN_RELAY_URL } from '$lib/nostr';
+import { addClientTagToEvent } from '$lib/nip89';
+import { RECIPE_TAG_PREFIX_NEW } from '$lib/consts';
+import { offlineStorage } from '$lib/offlineStorage';
+import { get } from 'svelte/store';
+
+export const RECIPE_PACK_KIND: NDKKind = 30004 as NDKKind;
+export const COOKBOOK_PACK_DTAG = 'zapcooking-cookbook';
+export const COLLECTION_PACK_DTAG_PREFIX = 'zapcooking-pack-';
+export const RECIPE_PACK_TAG = 'recipe-pack';
+export const ZAP_COOKING_TAG = 'zap-cooking';
+
+export type RecipePackSource =
+  | { type: 'cookbook' }
+  | { type: 'collection'; collectionDTag: string };
+
+export interface BuildPackInput {
+  source: RecipePackSource;
+  title: string;
+  description?: string;
+  image?: string;
+  /** Recipe references in `a`-tag form: `${kind}:${pubkey}:${dTag}`. */
+  recipeATags: string[];
+}
+
+export interface PublishedPack {
+  event: NDKEvent;
+  naddr: string;
+  url: string;
+}
+
+/** Compute the d-tag for a pack source. Replaceable per source. */
+export function packDTag(source: RecipePackSource): string {
+  if (source.type === 'cookbook') return COOKBOOK_PACK_DTAG;
+  return `${COLLECTION_PACK_DTAG_PREFIX}${source.collectionDTag}`;
+}
+
+/** Build the social-post style content body for the pack event. */
+export function buildPackContent(opts: {
+  title: string;
+  description?: string;
+  recipeCount: number;
+  url: string;
+}): string {
+  const lines: string[] = [];
+  lines.push(`I made a Recipe Pack on Zap Cooking: ${opts.title}`);
+  if (opts.description && opts.description.trim()) {
+    lines.push('');
+    lines.push(opts.description.trim());
+  }
+  lines.push('');
+  const noun = opts.recipeCount === 1 ? 'recipe' : 'recipes';
+  lines.push(`Includes ${opts.recipeCount} ${noun}. Open it on Zap Cooking:`);
+  lines.push(opts.url);
+  return lines.join('\n');
+}
+
+/** Build a /pack/<naddr> URL on the canonical Zap Cooking origin. */
+export function buildPackUrl(naddr: string, origin?: string): string {
+  const base = origin || (typeof window !== 'undefined' ? window.location.origin : 'https://zap.cooking');
+  return `${base}/pack/${naddr}`;
+}
+
+/**
+ * Resolve a usable cover image for a pack by looking through the
+ * referenced recipes. Cache-first so it returns instantly when the
+ * recipes are already cached (and never blocks if offline). Falls
+ * back to network. Returns the first non-empty `image` tag found.
+ */
+export async function resolveFirstRecipeImage(aTags: string[]): Promise<string | undefined> {
+  if (!aTags.length) return undefined;
+
+  // 1) Cache lookup — same order as aTags
+  try {
+    const cached = await offlineStorage.getRecipes(aTags);
+    const cachedById = new Map(cached.map((c) => [c.id, c]));
+    for (const aTag of aTags) {
+      const c = cachedById.get(aTag);
+      if (c?.image) return c.image;
+    }
+  } catch {
+    // empty cache is fine
+  }
+
+  // 2) Network — query in order, return on first hit
+  const ndkInstance = get(ndk);
+  if (!ndkInstance) return undefined;
+  for (const aTag of aTags) {
+    const parts = aTag.split(':');
+    if (parts.length !== 3) continue;
+    const [kind, pubkey, identifier] = parts;
+    try {
+      const e = await ndkInstance.fetchEvent({
+        kinds: [Number(kind)],
+        authors: [pubkey],
+        '#d': [identifier]
+      });
+      const img = e?.tags?.find((t) => t[0] === 'image')?.[1];
+      if (img) {
+        // Opportunistically cache so future opens are instant.
+        try {
+          if (e) await offlineStorage.saveRecipeFromEvent(e);
+        } catch {}
+        return img;
+      }
+    } catch {
+      /* try next */
+    }
+  }
+  return undefined;
+}
+
+/** Validate a recipe a-tag (kind:pubkey:dTag). */
+function isValidATag(aTag: string): boolean {
+  const parts = aTag.split(':');
+  if (parts.length !== 3) return false;
+  const [kind, pubkey, dTag] = parts;
+  if (!kind || !/^\d+$/.test(kind)) return false;
+  if (!pubkey || !/^[0-9a-f]{64}$/i.test(pubkey)) return false;
+  if (!dTag) return false;
+  return true;
+}
+
+/**
+ * Build (but do not sign/publish) a Recipe Pack event.
+ * Caller is responsible for `addClientTagToEvent` + `publish` if using
+ * directly. The exported `publishRecipePack` does both.
+ */
+export function buildRecipePackEvent(input: BuildPackInput): NDKEvent {
+  const ndkInstance = get(ndk);
+  if (!ndkInstance) throw new Error('NDK not initialized');
+
+  const dedupedATags = Array.from(new Set(input.recipeATags.filter(isValidATag)));
+  if (dedupedATags.length === 0) {
+    throw new Error('Cannot publish a Recipe Pack with no recipes.');
+  }
+
+  const event = new NDKEvent(ndkInstance);
+  event.kind = RECIPE_PACK_KIND as number;
+
+  const tags: string[][] = [];
+  tags.push(['d', packDTag(input.source)]);
+  tags.push(['title', input.title]);
+  if (input.description && input.description.trim()) {
+    tags.push(['description', input.description.trim()]);
+  }
+  if (input.image && input.image.trim()) {
+    tags.push(['image', input.image.trim()]);
+  }
+  tags.push(['t', RECIPE_PACK_TAG]);
+  tags.push(['t', ZAP_COOKING_TAG]);
+  tags.push(['t', RECIPE_TAG_PREFIX_NEW]);
+
+  for (const aTag of dedupedATags) {
+    tags.push(['a', aTag, GARDEN_RELAY_URL]);
+  }
+
+  event.tags = tags;
+  return event;
+}
+
+/**
+ * Build content for an optional kind:1 announcement that fans the
+ * pack out to feed-only clients. The body links back to the pack via
+ * a `nostr:` reference; clients that don't render kind 30004 can still
+ * surface the announcement.
+ */
+export function buildAnnouncementContent(opts: {
+  title: string;
+  description?: string;
+  recipeCount: number;
+  naddr: string;
+}): string {
+  const lines: string[] = [];
+  lines.push(`I just shared a Recipe Pack on Zap Cooking: ${opts.title}`);
+  if (opts.description && opts.description.trim()) {
+    lines.push('');
+    lines.push(opts.description.trim());
+  }
+  lines.push('');
+  const noun = opts.recipeCount === 1 ? 'recipe' : 'recipes';
+  lines.push(`Includes ${opts.recipeCount} ${noun}.`);
+  lines.push('');
+  lines.push(`nostr:${opts.naddr}`);
+  return lines.join('\n');
+}
+
+/**
+ * Publish a kind:1 announcement that references a Recipe Pack.
+ * Caller passes the published pack so we can derive `a`-tag and naddr.
+ */
+export async function publishPackAnnouncement(pack: PublishedPack, input: {
+  title: string;
+  description?: string;
+  recipeCount: number;
+}): Promise<NDKEvent> {
+  const ndkInstance = get(ndk);
+  const pubkey = get(userPublickey);
+  if (!ndkInstance) throw new Error('NDK not initialized');
+  if (!pubkey) throw new Error('Sign in required to publish announcement.');
+
+  const dTag = pack.event.tags.find((t) => t[0] === 'd')?.[1];
+  if (!dTag) throw new Error('Pack event missing d-tag');
+
+  const announcement = new NDKEvent(ndkInstance);
+  announcement.kind = 1;
+  announcement.content = buildAnnouncementContent({
+    title: input.title,
+    description: input.description,
+    recipeCount: input.recipeCount,
+    naddr: pack.naddr
+  });
+  announcement.tags = [
+    ['a', `${RECIPE_PACK_KIND}:${pubkey}:${dTag}`, GARDEN_RELAY_URL],
+    ['t', RECIPE_PACK_TAG],
+    ['t', ZAP_COOKING_TAG],
+    ['t', RECIPE_TAG_PREFIX_NEW]
+  ];
+  addClientTagToEvent(announcement);
+  await announcement.publish();
+  return announcement;
+}
+
+/**
+ * Build, sign, and publish a Recipe Pack event. Returns the published
+ * event along with its naddr and a Zap Cooking pack URL.
+ *
+ * Throws if there are no recipes, the user isn't signed in, or the
+ * publish call fails.
+ */
+export async function publishRecipePack(input: BuildPackInput): Promise<PublishedPack> {
+  const ndkInstance = get(ndk);
+  const pubkey = get(userPublickey);
+  if (!ndkInstance) throw new Error('NDK not initialized');
+  if (!pubkey) throw new Error('Sign in required to publish a Recipe Pack.');
+
+  const event = buildRecipePackEvent(input);
+  const dTag = packDTag(input.source);
+
+  // Build content. We need the URL to embed inside content, which
+  // requires the naddr — which requires the d-tag and author pubkey
+  // (both known here).
+  const naddr = nip19.naddrEncode({
+    identifier: dTag,
+    kind: RECIPE_PACK_KIND as number,
+    pubkey
+  });
+  const url = buildPackUrl(naddr);
+  const recipeCount = event.tags.filter((t) => t[0] === 'a').length;
+
+  event.content = buildPackContent({
+    title: input.title,
+    description: input.description,
+    recipeCount,
+    url
+  });
+
+  addClientTagToEvent(event);
+
+  await event.publish();
+
+  return { event, naddr, url };
+}

--- a/src/lib/stores/cookbookStore.ts
+++ b/src/lib/stores/cookbookStore.ts
@@ -774,6 +774,115 @@ function createCookbookStore() {
     },
 
     /**
+     * Bulk add many recipes to a list with a single Nostr publish.
+     *
+     * Returns counts so callers can show "Added X, skipped Y already saved".
+     * Skips a-tags already present in the list. Persists locally first
+     * so partial failures still leave the cookbook in a usable state.
+     */
+    async bulkAddRecipesToList(
+      listId: string,
+      recipeEvents: NDKEvent[]
+    ): Promise<{ added: number; skipped: number; failed: number }> {
+      const state = get({ subscribe });
+      const list = state.lists.find(l => l.id === listId);
+      const pubkey = get(userPublickey);
+      const ndkInstance = get(ndk);
+
+      if (!list || !pubkey || !ndkInstance) {
+        return { added: 0, skipped: 0, failed: recipeEvents.length };
+      }
+
+      const existing = new Set(list.recipes);
+      const toAdd: string[] = [];
+      let skipped = 0;
+      for (const ev of recipeEvents) {
+        if (!ev) continue;
+        const dTag = ev.replaceableDTag?.() || ev.tags?.find(t => t[0] === 'd')?.[1] || '';
+        if (!dTag || !ev.kind || !ev.pubkey) continue;
+        const aTag = `${ev.kind}:${ev.pubkey}:${dTag}`;
+        if (existing.has(aTag)) { skipped++; continue; }
+        if (toAdd.includes(aTag)) { skipped++; continue; }
+        toAdd.push(aTag);
+      }
+
+      if (toAdd.length === 0) {
+        return { added: 0, skipped, failed: 0 };
+      }
+
+      const mergedRecipes = [...list.recipes, ...toAdd];
+      const isFirstBatch = list.recipes.length === 0;
+      const updatedList: CookbookList = {
+        ...list,
+        recipes: mergedRecipes,
+        recipeCount: mergedRecipes.length,
+        coverRecipeId: isFirstBatch && !list.coverRecipeId ? toAdd[0] : list.coverRecipeId,
+        pendingSync: true
+      };
+
+      update(s => ({
+        ...s,
+        lists: s.lists.map(l => (l.id === listId ? updatedList : l))
+      }));
+
+      await persistLocally(updatedList, pubkey, false);
+
+      if (isCurrentlyOnline()) {
+        try {
+          const event = new NDKEvent(ndkInstance);
+          event.kind = 30001;
+
+          const tagsToKeep = ['d', 'title', 'summary', 'image', 't'];
+          list.event.tags.forEach(tag => {
+            if (tagsToKeep.includes(tag[0])) {
+              event.tags.push([...tag]);
+            }
+          });
+
+          // Preserve cover (or seed it from first added recipe)
+          const coverId = updatedList.coverRecipeId;
+          if (coverId) event.tags.push(['cover', coverId]);
+
+          mergedRecipes.forEach(r => event.tags.push(['a', r]));
+
+          const { addClientTagToEvent } = await import('$lib/nip89');
+          addClientTagToEvent(event);
+          await event.publish();
+
+          update(s => ({
+            ...s,
+            lists: s.lists.map(l =>
+              l.id === listId ? { ...updatedList, event, pendingSync: false } : l
+            )
+          }));
+          await offlineStorage.markCookbookSynced(listId, pubkey);
+        } catch (error) {
+          console.error('[CookbookStore] bulkAddRecipesToList publish failed:', error);
+          // Queue each as a separate add_recipe op so retry logic stays simple.
+          for (const aTag of toAdd) {
+            await offlineStorage.queueOperation('add_recipe', listId, { aTag });
+          }
+          update(s => ({
+            ...s,
+            syncStatus: 'pending',
+            pendingOperations: s.pendingOperations + toAdd.length
+          }));
+        }
+      } else {
+        for (const aTag of toAdd) {
+          await offlineStorage.queueOperation('add_recipe', listId, { aTag });
+        }
+        update(s => ({
+          ...s,
+          syncStatus: 'pending',
+          pendingOperations: s.pendingOperations + toAdd.length
+        }));
+      }
+
+      return { added: toAdd.length, skipped, failed: 0 };
+    },
+
+    /**
      * Quick save to default list (one-tap bookmark)
      */
     async quickSave(recipeEvent: NDKEvent): Promise<boolean> {

--- a/src/routes/cookbook/+page.svelte
+++ b/src/routes/cookbook/+page.svelte
@@ -99,23 +99,45 @@
     { value: 'az', label: SORT_LABELS['az'] }
   ];
 
-  // Hydrate from URL once on mount; thereafter we drive URL from state.
-  let hydrated = false;
-  $: if (!hydrated && typeof window !== 'undefined') {
-    const params = $page.url.searchParams;
+  // ----- URL ↔ state sync -----
+  //
+  // We hydrate state from $page.url.searchParams whenever the URL
+  // changes (back/forward, deep link, programmatic goto). Writes are
+  // only triggered by the explicit setters, which avoids the
+  // hydrate-then-overwrite-with-stale-state loop you'd get with a
+  // catch-all reactive sync.
+  //
+  // Internal flow: setX → state changes → syncUrl() → goto() →
+  // $page.url updates → hydrate sees URL matches state → no-op.
+
+  function readParams(params: URLSearchParams): {
+    view: ViewMode;
+    sort: SortMode;
+    collection: 'all' | string;
+  } {
     const v = params.get('view');
-    // Accept legacy 'grid' alias for the renamed 'packs' value.
-    if (v === 'feed') viewMode = 'feed';
-    else if (v === 'packs' || v === 'grid') viewMode = 'packs';
+    let view: ViewMode = 'packs';
+    if (v === 'feed') view = 'feed';
+    else if (v === 'packs' || v === 'grid') view = 'packs'; // legacy 'grid' alias
     const s = params.get('sort');
-    if (s === 'recent-added' || s === 'recent-updated' || s === 'az') sortMode = s;
+    const sort: SortMode =
+      s === 'recent-added' || s === 'recent-updated' || s === 'az' ? s : 'recent-added';
     const c = params.get('collection');
-    if (c) collectionFilter = c;
-    hydrated = true;
+    const collection = c || 'all';
+    return { view, sort, collection };
+  }
+
+  // Re-hydrate from URL on every $page change. Idempotent — updates
+  // local state only when URL values disagree with current state.
+  $: if (typeof window !== 'undefined') {
+    const next = readParams($page.url.searchParams);
+    if (next.view !== viewMode) viewMode = next.view;
+    if (next.sort !== sortMode) sortMode = next.sort;
+    if (next.collection !== collectionFilter) collectionFilter = next.collection;
   }
 
   function syncUrl() {
-    if (typeof window === 'undefined' || !hydrated) return;
+    if (typeof window === 'undefined') return;
     const url = new URL(window.location.href);
     if (viewMode === 'packs') url.searchParams.delete('view');
     else url.searchParams.set('view', viewMode);
@@ -128,24 +150,19 @@
     goto(target, { replaceState: true, keepFocus: true, noScroll: true });
   }
 
-  $: if (hydrated) {
-    // Touch the inputs to force reactivity
-    void viewMode;
-    void sortMode;
-    void collectionFilter;
-    syncUrl();
-  }
-
   function setView(v: ViewMode) {
     viewMode = v;
+    syncUrl();
   }
   function setSort(s: SortMode) {
     sortMode = s;
     sortMenuOpen = false;
+    syncUrl();
   }
   function setCollectionFilter(c: 'all' | string) {
     collectionFilter = c;
     filterMenuOpen = false;
+    syncUrl();
   }
 
   // Pull-to-refresh ref
@@ -733,10 +750,24 @@
     }
   }
 
-  // Trigger fetch when feed becomes active or the underlying recipe set changes
+  // Cheap signature for the underlying cookbook state. We use this
+  // instead of `filteredATags.join(',')` so the change detector stays
+  // O(number of lists) instead of O(number of recipes) — a join over
+  // hundreds of saved a-tags reallocates a multi-KB string on every
+  // reactive run. Folding list count + per-list size + per-list update
+  // time covers add/remove/reassign without the allocation cost.
+  $: cookbookSignature =
+    $cookbookLists.length +
+    ':' +
+    $cookbookLists.reduce(
+      (acc, l) => acc + l.recipes.length * 31 + (l.event?.created_at || 0),
+      0
+    );
+
+  // Trigger fetch when feed becomes active or the underlying recipe set changes.
   let lastFeedKey = '';
   $: {
-    const key = viewMode === 'feed' ? `${collectionFilter}:${filteredATags.join(',')}` : '';
+    const key = viewMode === 'feed' ? `${collectionFilter}:${cookbookSignature}` : '';
     if (viewMode === 'feed' && key !== lastFeedKey) {
       lastFeedKey = key;
       feedLoaded = false;

--- a/src/routes/cookbook/+page.svelte
+++ b/src/routes/cookbook/+page.svelte
@@ -1,10 +1,19 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
   import { onMount, onDestroy } from 'svelte';
   import { userPublickey } from '$lib/nostr';
-  import { cookbookStore, cookbookLists, cookbookLoading, cookbookSyncStatus, cookbookPendingOps, getCookbookCoverImage, type CookbookList } from '$lib/stores/cookbookStore';
+  import {
+    cookbookStore,
+    cookbookLists,
+    cookbookLoading,
+    cookbookSyncStatus,
+    cookbookPendingOps,
+    getCookbookCoverImage,
+    type CookbookList
+  } from '$lib/stores/cookbookStore';
   import { ndk } from '$lib/nostr';
-  import type { NDKEvent } from '@nostr-dev-kit/ndk';
+  import { NDKEvent } from '@nostr-dev-kit/ndk';
   import { isOnline } from '$lib/connectionMonitor';
   import PlusIcon from 'phosphor-svelte/lib/Plus';
   import BookmarkIcon from 'phosphor-svelte/lib/BookmarkSimple';
@@ -18,13 +27,126 @@
   import ArrowsClockwiseIcon from 'phosphor-svelte/lib/ArrowsClockwise';
   import CheckCircleIcon from 'phosphor-svelte/lib/CheckCircle';
   import CircleNotchIcon from 'phosphor-svelte/lib/CircleNotch';
+  import SquaresFourIcon from 'phosphor-svelte/lib/SquaresFour';
+  import ListBulletsIcon from 'phosphor-svelte/lib/ListBullets';
+  import SortAscendingIcon from 'phosphor-svelte/lib/SortAscending';
+  import FunnelSimpleIcon from 'phosphor-svelte/lib/FunnelSimple';
+  import ForkKnifeIcon from 'phosphor-svelte/lib/ForkKnife';
+  import MagicWandIcon from 'phosphor-svelte/lib/MagicWand';
+  import CaretDownIcon from 'phosphor-svelte/lib/CaretDown';
   import { offlineStorage } from '$lib/offlineStorage';
+  import { nip19 } from 'nostr-tools';
+  import { getImageOrPlaceholder } from '$lib/placeholderImages';
+  import { lazyLoad } from '$lib/lazyLoad';
   import Modal from '../../components/Modal.svelte';
   import Button from '../../components/Button.svelte';
+  import SharePackModal from '../../components/SharePackModal.svelte';
   import ImagesComboBox from '../../components/ImagesComboBox.svelte';
+  import ShareNetworkIcon from 'phosphor-svelte/lib/ShareNetwork';
   import { writable, type Writable, get } from 'svelte/store';
   import { clickOutside } from '$lib/clickOutside';
   import PullToRefresh from '../../components/PullToRefresh.svelte';
+
+  // ===== View / sort / filter state (synced with URL query params) =====
+  type ViewMode = 'packs' | 'feed';
+  type SortMode = 'recent-added' | 'recent-updated' | 'az';
+
+  let viewMode: ViewMode = 'packs';
+  let sortMode: SortMode = 'recent-added';
+  let collectionFilter: 'all' | string = 'all';
+  let sortMenuOpen = false;
+  let filterMenuOpen = false;
+  let createMenuOpen = false;
+
+  // Share-as-Pack modal state
+  let sharePackOpen = false;
+  let sharePackSource: import('$lib/recipePack').RecipePackSource = { type: 'cookbook' };
+  let sharePackATags: string[] = [];
+  let sharePackTitle = '';
+  let sharePackDescription = '';
+  let sharePackImage: string | undefined = undefined;
+
+  function openShareCookbook() {
+    if (totalUniqueSaved === 0) return;
+    sharePackSource = { type: 'cookbook' };
+    sharePackATags = aggregatedRecipes.map((r) => r.aTag);
+    sharePackTitle = 'My Zap Cooking Cookbook';
+    sharePackDescription = '';
+    sharePackImage = savedCollection ? coverImages.get(savedCollection.id) : undefined;
+    sharePackOpen = true;
+  }
+
+  function openShareCollection(list: CookbookList, e?: Event) {
+    if (e) e.stopPropagation();
+    if (list.recipes.length === 0) return;
+    sharePackSource = { type: 'collection', collectionDTag: list.id };
+    sharePackATags = [...list.recipes];
+    sharePackTitle = list.title;
+    sharePackDescription = list.summary || '';
+    sharePackImage = coverImages.get(list.id) || list.image;
+    hoveredListId = null;
+    sharePackOpen = true;
+  }
+
+  const SORT_LABELS: Record<SortMode, string> = {
+    'recent-added': 'Recently added',
+    'recent-updated': 'Recently updated',
+    az: 'A–Z'
+  };
+  const SORT_OPTIONS: { value: SortMode; label: string }[] = [
+    { value: 'recent-added', label: SORT_LABELS['recent-added'] },
+    { value: 'recent-updated', label: SORT_LABELS['recent-updated'] },
+    { value: 'az', label: SORT_LABELS['az'] }
+  ];
+
+  // Hydrate from URL once on mount; thereafter we drive URL from state.
+  let hydrated = false;
+  $: if (!hydrated && typeof window !== 'undefined') {
+    const params = $page.url.searchParams;
+    const v = params.get('view');
+    // Accept legacy 'grid' alias for the renamed 'packs' value.
+    if (v === 'feed') viewMode = 'feed';
+    else if (v === 'packs' || v === 'grid') viewMode = 'packs';
+    const s = params.get('sort');
+    if (s === 'recent-added' || s === 'recent-updated' || s === 'az') sortMode = s;
+    const c = params.get('collection');
+    if (c) collectionFilter = c;
+    hydrated = true;
+  }
+
+  function syncUrl() {
+    if (typeof window === 'undefined' || !hydrated) return;
+    const url = new URL(window.location.href);
+    if (viewMode === 'packs') url.searchParams.delete('view');
+    else url.searchParams.set('view', viewMode);
+    if (sortMode === 'recent-added') url.searchParams.delete('sort');
+    else url.searchParams.set('sort', sortMode);
+    if (collectionFilter === 'all') url.searchParams.delete('collection');
+    else url.searchParams.set('collection', collectionFilter);
+    const target = url.pathname + (url.search || '');
+    if (target === window.location.pathname + window.location.search) return;
+    goto(target, { replaceState: true, keepFocus: true, noScroll: true });
+  }
+
+  $: if (hydrated) {
+    // Touch the inputs to force reactivity
+    void viewMode;
+    void sortMode;
+    void collectionFilter;
+    syncUrl();
+  }
+
+  function setView(v: ViewMode) {
+    viewMode = v;
+  }
+  function setSort(s: SortMode) {
+    sortMode = s;
+    sortMenuOpen = false;
+  }
+  function setCollectionFilter(c: 'all' | string) {
+    collectionFilter = c;
+    filterMenuOpen = false;
+  }
 
   // Pull-to-refresh ref
   let pullToRefreshEl: PullToRefresh;
@@ -97,12 +219,12 @@
 
       // Check which recipes are already cached
       const existingRecipes = await offlineStorage.getAllRecipes();
-      const cachedIds = new Set(existingRecipes.map(r => r.id));
+      const cachedIds = new Set(existingRecipes.map((r) => r.id));
 
       // Fetch and cache each recipe that isn't already cached
       for (const aTag of allRecipeATags) {
         syncProgress.current++;
-        
+
         // Skip if already cached
         if (cachedIds.has(aTag)) {
           console.log(`[Cookbook] Recipe already cached: ${aTag}`);
@@ -149,10 +271,10 @@
   let selectedList: CookbookList | null = null;
   let hoveredListId: string | null = null;
   let selectedCoverRecipeATag: string | null = null; // Track selected recipe in modal
-  
+
   // Cover images cache: listId -> imageUrl
   let coverImages: Map<string, string> = new Map();
-  
+
   // Form state
   let newListTitle = '';
   let newListSummary = '';
@@ -182,16 +304,16 @@
       goto('/login');
       return;
     }
-    
+
     // Load cookbook lists
     await cookbookStore.load();
-    
+
     // Ensure default list exists
     await cookbookStore.ensureDefaultList();
-    
+
     // Load cover images
     await loadCoverImages();
-    
+
     // Load cached recipe count for sync indicator
     await updateCachedRecipeCount();
   });
@@ -338,7 +460,7 @@
   async function shareList(list: CookbookList, e?: Event) {
     if (e) e.stopPropagation();
     const url = `${window.location.origin}/cookbook/${list.naddr}`;
-    
+
     if (navigator.share) {
       try {
         await navigator.share({
@@ -399,11 +521,14 @@
       });
 
       // Add timeout wrapper to prevent infinite hanging
-      const setCoverPromise = cookbookStore.setCoverRecipe(selectedList.id, selectedCoverRecipeATag);
-      const timeoutPromise = new Promise<boolean>((_, reject) => 
+      const setCoverPromise = cookbookStore.setCoverRecipe(
+        selectedList.id,
+        selectedCoverRecipeATag
+      );
+      const timeoutPromise = new Promise<boolean>((_, reject) =>
         setTimeout(() => reject(new Error('Operation timed out after 15 seconds')), 15000)
       );
-      
+
       let success: boolean;
       try {
         success = await Promise.race([setCoverPromise, timeoutPromise]);
@@ -413,18 +538,18 @@
         isSubmitting = false;
         return;
       }
-      
+
       if (success) {
         console.log('Cover recipe updated successfully');
         const selectedListId = selectedList.id;
-        
+
         // Clear cover image cache for this list
         coverImages.delete(selectedListId);
-        
+
         // Get updated list from store
         const updatedStoreState = get(cookbookStore);
-        const updatedList = updatedStoreState.lists.find(l => l.id === selectedListId);
-        
+        const updatedList = updatedStoreState.lists.find((l) => l.id === selectedListId);
+
         if (updatedList) {
           // Reload cover image immediately with cache-busting
           const newCoverImage = await getCookbookCoverImage(updatedList, $ndk, true);
@@ -436,7 +561,7 @@
           // Fallback: reload all cover images
           await loadCoverImages();
         }
-        
+
         closeChangeCoverModal();
       } else {
         errorMessage = 'Failed to update cover image. Please try again.';
@@ -458,11 +583,11 @@
 
   async function loadRecipeEvents(list: CookbookList): Promise<NDKEvent[]> {
     const events: NDKEvent[] = [];
-    
+
     for (const aTag of list.recipes) {
       const parts = aTag.split(':');
       if (parts.length !== 3) continue;
-      
+
       const [kind, pubkey, identifier] = parts;
       try {
         const recipeEvent = await $ndk.fetchEvent({
@@ -477,7 +602,7 @@
         console.warn('Failed to fetch recipe:', aTag, error);
       }
     }
-    
+
     return events;
   }
 
@@ -487,8 +612,195 @@
   }
 
   // Separate saved collection from custom collections
-  $: savedCollection = $cookbookLists.find(l => l.isDefault);
-  $: customCollections = $cookbookLists.filter(l => !l.isDefault);
+  $: savedCollection = $cookbookLists.find((l) => l.isDefault);
+  $: customCollections = $cookbookLists.filter((l) => !l.isDefault);
+
+  // ===== Aggregated feed across all collections =====
+  type AggregatedRecipe = {
+    aTag: string;
+    collections: string[]; // list IDs containing this recipe
+    primaryListUpdatedAt: number; // most-recent list-update time it appears in
+    positionInPrimaryList: number; // index within that list (later = newer)
+  };
+
+  function aggregateRecipes(lists: CookbookList[]): AggregatedRecipe[] {
+    const map = new Map<string, AggregatedRecipe>();
+    for (const list of lists) {
+      const listTime = list.event?.created_at || list.createdAt || 0;
+      list.recipes.forEach((aTag, idx) => {
+        const existing = map.get(aTag);
+        if (!existing) {
+          map.set(aTag, {
+            aTag,
+            collections: [list.id],
+            primaryListUpdatedAt: listTime,
+            positionInPrimaryList: idx
+          });
+        } else {
+          if (!existing.collections.includes(list.id)) existing.collections.push(list.id);
+          if (listTime > existing.primaryListUpdatedAt) {
+            existing.primaryListUpdatedAt = listTime;
+            existing.positionInPrimaryList = idx;
+          }
+        }
+      });
+    }
+    return Array.from(map.values());
+  }
+
+  $: aggregatedRecipes = aggregateRecipes($cookbookLists);
+  $: totalUniqueSaved = aggregatedRecipes.length;
+
+  // Filtered + ordered a-tag list to load
+  $: filteredATags = (
+    collectionFilter === 'all'
+      ? aggregatedRecipes
+      : aggregatedRecipes.filter((r) => r.collections.includes(collectionFilter))
+  ).map((r) => r.aTag);
+
+  // Cached map of NDKEvent by a-tag for the feed view
+  let feedEventByATag: Map<string, NDKEvent> = new Map();
+  let feedLoading = false;
+  let feedLoaded = false;
+
+  function eventToAggregateKey(e: NDKEvent): string {
+    const dTag = e.tags?.find((t) => t[0] === 'd')?.[1] || '';
+    return `${e.kind}:${e.pubkey}:${dTag}`;
+  }
+
+  function buildFakeEventFromCache(cached: any): NDKEvent {
+    const fake = new NDKEvent($ndk);
+    fake.kind = cached.eventKind;
+    fake.pubkey = cached.authorPubkey;
+    fake.created_at = cached.createdAt;
+    fake.content = cached.content;
+    fake.tags = cached.eventTags;
+    fake.id = cached.id; // a-tag-based stable id
+    return fake;
+  }
+
+  async function ensureFeedEvents() {
+    if (filteredATags.length === 0) {
+      feedEventByATag = new Map();
+      feedLoaded = true;
+      return;
+    }
+    feedLoading = true;
+    try {
+      // 1) Cache-first
+      const missing: string[] = [];
+      const cached = await offlineStorage.getRecipes(filteredATags);
+      const cachedById = new Map(cached.map((c) => [c.id, c]));
+      for (const aTag of filteredATags) {
+        if (feedEventByATag.has(aTag)) continue;
+        const c = cachedById.get(aTag);
+        if (c) feedEventByATag.set(aTag, buildFakeEventFromCache(c));
+        else missing.push(aTag);
+      }
+      // Show cached results immediately
+      feedEventByATag = new Map(feedEventByATag);
+
+      // 2) Fetch missing if online
+      if (missing.length > 0 && $isOnline) {
+        await Promise.all(
+          missing.map(async (aTag) => {
+            const parts = aTag.split(':');
+            if (parts.length !== 3) return;
+            const [kind, pubkey, identifier] = parts;
+            try {
+              const e = await $ndk.fetchEvent({
+                kinds: [Number(kind)],
+                '#d': [identifier],
+                authors: [pubkey]
+              });
+              if (e) {
+                feedEventByATag.set(aTag, e);
+                // Cache for offline
+                try {
+                  await offlineStorage.saveRecipeFromEvent(e);
+                } catch {}
+              }
+            } catch (err) {
+              console.warn('[Cookbook feed] Failed to fetch', aTag, err);
+            }
+          })
+        );
+        feedEventByATag = new Map(feedEventByATag);
+      }
+    } finally {
+      feedLoading = false;
+      feedLoaded = true;
+    }
+  }
+
+  // Trigger fetch when feed becomes active or the underlying recipe set changes
+  let lastFeedKey = '';
+  $: {
+    const key = viewMode === 'feed' ? `${collectionFilter}:${filteredATags.join(',')}` : '';
+    if (viewMode === 'feed' && key !== lastFeedKey) {
+      lastFeedKey = key;
+      feedLoaded = false;
+      ensureFeedEvents();
+    } else if (viewMode !== 'feed') {
+      lastFeedKey = '';
+    }
+  }
+
+  // Build the displayed event list with sort applied
+  $: displayedEvents = (() => {
+    const events: NDKEvent[] = [];
+    for (const aTag of filteredATags) {
+      const e = feedEventByATag.get(aTag);
+      if (e) events.push(e);
+    }
+    if (sortMode === 'az') {
+      events.sort((a, b) => {
+        const ta = (a.tags?.find((t) => t[0] === 'title')?.[1] || '').toLowerCase();
+        const tb = (b.tags?.find((t) => t[0] === 'title')?.[1] || '').toLowerCase();
+        return ta.localeCompare(tb);
+      });
+    } else if (sortMode === 'recent-updated') {
+      events.sort((a, b) => (b.created_at || 0) - (a.created_at || 0));
+    } else {
+      // 'recent-added' — order by aggregate primaryListUpdatedAt DESC, then position DESC
+      const orderByATag = new Map<string, [number, number]>();
+      for (const r of aggregatedRecipes) {
+        orderByATag.set(r.aTag, [r.primaryListUpdatedAt, r.positionInPrimaryList]);
+      }
+      events.sort((a, b) => {
+        const ka = orderByATag.get(eventToAggregateKey(a)) || [0, 0];
+        const kb = orderByATag.get(eventToAggregateKey(b)) || [0, 0];
+        if (kb[0] !== ka[0]) return kb[0] - ka[0];
+        return kb[1] - ka[1];
+      });
+    }
+    return events;
+  })();
+
+  $: collectionFilterLabel =
+    collectionFilter === 'all'
+      ? 'All collections'
+      : $cookbookLists.find((l) => l.id === collectionFilter)?.title || 'Collection';
+
+  // Feed-card metadata
+  function feedCardData(e: NDKEvent) {
+    const dTag = e.tags?.find((t) => t[0] === 'd')?.[1] || '';
+    const title = e.tags?.find((t) => t[0] === 'title')?.[1] || dTag || 'Untitled';
+    const summary = e.tags?.find((t) => t[0] === 'summary')?.[1] || '';
+    const rawImage = e.tags?.find((t) => t[0] === 'image')?.[1] || '';
+    const image = getImageOrPlaceholder(rawImage, e.id || dTag);
+    let link = '';
+    if (dTag && (e.author?.pubkey || e.pubkey)) {
+      try {
+        link = `/recipe/${nip19.naddrEncode({
+          identifier: dTag,
+          kind: e.kind || 30023,
+          pubkey: e.author?.pubkey || e.pubkey
+        })}`;
+      } catch {}
+    }
+    return { title, summary, image, link };
+  }
 </script>
 
 <svelte:head>
@@ -499,7 +811,7 @@
 <!-- Create List Modal -->
 <Modal cleanup={closeCreateModal} open={createModalOpen}>
   <h1 slot="title">Create New Collection</h1>
-  
+
   <form on:submit|preventDefault={createList} class="flex flex-col gap-4">
     <div class="flex flex-col gap-2">
       <label for="title" class="text-sm font-medium" style="color: var(--color-text-primary)">
@@ -541,9 +853,7 @@
     {/if}
 
     <div class="flex justify-end gap-2 pt-2">
-      <Button on:click={closeCreateModal} primary={false} disabled={isSubmitting}>
-        Cancel
-      </Button>
+      <Button on:click={closeCreateModal} primary={false} disabled={isSubmitting}>Cancel</Button>
       <Button type="submit" disabled={isSubmitting}>
         {isSubmitting ? 'Creating...' : 'Create Collection'}
       </Button>
@@ -554,7 +864,7 @@
 <!-- Edit List Modal -->
 <Modal cleanup={closeEditModal} open={editModalOpen}>
   <h1 slot="title">Edit Collection</h1>
-  
+
   <form on:submit|preventDefault={updateList} class="flex flex-col gap-4">
     <div class="flex flex-col gap-2">
       <label for="edit-title" class="text-sm font-medium" style="color: var(--color-text-primary)">
@@ -574,7 +884,11 @@
     </div>
 
     <div class="flex flex-col gap-2">
-      <label for="edit-summary" class="text-sm font-medium" style="color: var(--color-text-primary)">
+      <label
+        for="edit-summary"
+        class="text-sm font-medium"
+        style="color: var(--color-text-primary)"
+      >
         Description
       </label>
       <textarea
@@ -599,9 +913,7 @@
     {/if}
 
     <div class="flex justify-end gap-2 pt-2">
-      <Button on:click={closeEditModal} primary={false} disabled={isSubmitting}>
-        Cancel
-      </Button>
+      <Button on:click={closeEditModal} primary={false} disabled={isSubmitting}>Cancel</Button>
       <Button type="submit" disabled={isSubmitting}>
         {isSubmitting ? 'Saving...' : 'Save Changes'}
       </Button>
@@ -612,17 +924,15 @@
 <!-- Delete Confirmation Modal -->
 <Modal cleanup={closeDeleteConfirm} open={deleteConfirmOpen}>
   <h1 slot="title">Delete Collection</h1>
-  
+
   <div class="flex flex-col gap-4">
     <p style="color: var(--color-text-primary)">
-      Are you sure you want to delete "<strong>{selectedList?.title}</strong>"? 
-      This will remove the collection but won't delete the recipes themselves.
+      Are you sure you want to delete "<strong>{selectedList?.title}</strong>"? This will remove the
+      collection but won't delete the recipes themselves.
     </p>
-    
+
     <div class="flex justify-end gap-2">
-      <Button on:click={closeDeleteConfirm} primary={false} disabled={isSubmitting}>
-        Cancel
-      </Button>
+      <Button on:click={closeDeleteConfirm} primary={false} disabled={isSubmitting}>Cancel</Button>
       <button
         on:click={deleteList}
         disabled={isSubmitting}
@@ -637,14 +947,12 @@
 <!-- Change Cover Modal -->
 <Modal cleanup={closeChangeCoverModal} open={changeCoverModalOpen}>
   <h1 slot="title">Choose Cover Image</h1>
-  
+
   {#if selectedList}
     {#await loadRecipeEvents(selectedList) then recipeEvents}
       <div class="flex flex-col gap-4">
-        <p class="text-sm text-caption">
-          Select a recipe to use as your cookbook cover
-        </p>
-        
+        <p class="text-sm text-caption">Select a recipe to use as your cookbook cover</p>
+
         {#if recipeEvents.length === 0}
           <p class="text-caption text-center py-8">
             No recipes in this collection yet. Add recipes to choose a cover image.
@@ -653,31 +961,38 @@
           <div class="grid grid-cols-3 gap-3 max-h-96 overflow-y-auto p-1">
             {#each recipeEvents as recipeEvent}
               {@const recipeATag = `${recipeEvent.kind}:${recipeEvent.pubkey}:${recipeEvent.replaceableDTag()}`}
-              {@const recipeImage = recipeEvent.tags.find(t => t[0] === 'image')?.[1]}
-              {@const recipeTitle = recipeEvent.tags.find(t => t[0] === 'title')?.[1] || 'Untitled'}
+              {@const recipeImage = recipeEvent.tags.find((t) => t[0] === 'image')?.[1]}
+              {@const recipeTitle =
+                recipeEvent.tags.find((t) => t[0] === 'title')?.[1] || 'Untitled'}
               {@const isSelected = selectedCoverRecipeATag === recipeATag}
-              
+
               <button
                 type="button"
                 on:click|stopPropagation={() => selectCoverRecipe(recipeATag)}
                 disabled={isSubmitting}
-                class="relative aspect-square rounded-lg overflow-hidden border-2 transition-all cursor-pointer {isSelected ? 'border-orange-500 ring-2 ring-orange-200' : 'border-transparent hover:border-orange-300'}"
+                class="relative aspect-square rounded-lg overflow-hidden border-2 transition-all cursor-pointer {isSelected
+                  ? 'border-orange-500 ring-2 ring-orange-200'
+                  : 'border-transparent hover:border-orange-300'}"
                 aria-label="Select {recipeTitle} as cover"
               >
                 {#if recipeImage}
-                  <img 
-                    src={recipeImage} 
+                  <img
+                    src={recipeImage}
                     alt={recipeTitle}
                     class="w-full h-full object-cover pointer-events-none"
                   />
                 {:else}
-                  <div class="w-full h-full bg-gradient-to-br from-gray-200 to-gray-300 dark:from-gray-700 dark:to-gray-800 flex items-center justify-center pointer-events-none">
+                  <div
+                    class="w-full h-full bg-gradient-to-br from-gray-200 to-gray-300 dark:from-gray-700 dark:to-gray-800 flex items-center justify-center pointer-events-none"
+                  >
                     <span class="text-xs text-caption text-center px-2">{recipeTitle}</span>
                   </div>
                 {/if}
-                
+
                 {#if isSelected}
-                  <div class="absolute bottom-2 right-2 bg-orange-500 text-white text-xs px-2 py-1 rounded font-semibold">
+                  <div
+                    class="absolute bottom-2 right-2 bg-orange-500 text-white text-xs px-2 py-1 rounded font-semibold"
+                  >
                     ✓ Selected
                   </div>
                 {/if}
@@ -685,19 +1000,16 @@
             {/each}
           </div>
         {/if}
-        
+
         {#if errorMessage}
           <p class="text-red-500 text-sm">{errorMessage}</p>
         {/if}
-        
+
         <div class="flex justify-end gap-2 pt-2">
           <Button on:click={closeChangeCoverModal} primary={false} disabled={isSubmitting}>
             Cancel
           </Button>
-          <Button 
-            on:click={saveCoverRecipe} 
-            disabled={isSubmitting || !selectedCoverRecipeATag}
-          >
+          <Button on:click={saveCoverRecipe} disabled={isSubmitting || !selectedCoverRecipeATag}>
             {isSubmitting ? 'Saving...' : 'Save'}
           </Button>
         </div>
@@ -705,335 +1017,696 @@
     {:catch error}
       <p class="text-red-500 text-sm">Error loading recipes: {error}</p>
       <div class="flex justify-end gap-2 pt-2">
-        <Button on:click={closeChangeCoverModal} primary={false}>
-          Close
-        </Button>
+        <Button on:click={closeChangeCoverModal} primary={false}>Close</Button>
       </div>
     {/await}
   {/if}
 </Modal>
 
-<PullToRefresh bind:this={pullToRefreshEl} on:refresh={handleRefresh}>
-<div class="flex flex-col gap-6">
-  <!-- Offline/Sync Status Banner -->
-  {#if !$isOnline}
-    <div class="flex items-center gap-3 px-4 py-3 rounded-xl bg-amber-500/10 border border-amber-500/30">
-      <CloudSlashIcon size={20} class="text-amber-500 flex-shrink-0" />
-      <div class="flex-1">
-        <p class="text-sm font-medium" style="color: var(--color-text-primary)">You're offline</p>
-        <p class="text-xs text-caption">Your cookbooks are saved locally. Changes will sync when you're back online.</p>
-      </div>
-    </div>
-  {:else if $cookbookSyncStatus === 'syncing'}
-    <div class="flex items-center gap-3 px-4 py-3 rounded-xl bg-blue-500/10 border border-blue-500/30">
-      <ArrowsClockwiseIcon size={20} class="text-blue-500 flex-shrink-0 animate-spin" />
-      <div class="flex-1">
-        <p class="text-sm font-medium" style="color: var(--color-text-primary)">Syncing changes...</p>
-        <p class="text-xs text-caption">Your cookbooks are being updated.</p>
-      </div>
-    </div>
-  {:else if $cookbookSyncStatus === 'pending' && $cookbookPendingOps > 0}
-    <div class="flex items-center gap-3 px-4 py-3 rounded-xl bg-amber-500/10 border border-amber-500/30">
-      <CloudArrowUpIcon size={20} class="text-amber-500 flex-shrink-0" />
-      <div class="flex-1">
-        <p class="text-sm font-medium" style="color: var(--color-text-primary)">{$cookbookPendingOps} pending {$cookbookPendingOps === 1 ? 'change' : 'changes'}</p>
-        <p class="text-xs text-caption">Some changes haven't synced yet.</p>
-      </div>
-      <button
-        on:click={handleSyncNow}
-        class="px-3 py-1.5 text-xs font-semibold rounded-lg bg-amber-500 hover:bg-amber-600 text-white transition-colors"
-      >
-        Sync Now
-      </button>
-    </div>
-  {/if}
+<!-- Share as Recipe Pack Modal -->
+<SharePackModal
+  bind:open={sharePackOpen}
+  source={sharePackSource}
+  recipeATags={sharePackATags}
+  initialTitle={sharePackTitle}
+  initialDescription={sharePackDescription}
+  initialImage={sharePackImage}
+/>
 
-  <!-- Header -->
-  <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-    <!-- Left: Title and Icon -->
-    <div class="flex items-center gap-3">
-      <div class="w-12 h-12 rounded-full bg-gradient-to-br from-orange-500 to-amber-500 flex items-center justify-center flex-shrink-0">
-        <BookmarkIcon size={24} weight="fill" class="text-white" />
+<PullToRefresh bind:this={pullToRefreshEl} on:refresh={handleRefresh}>
+  <div class="flex flex-col gap-6">
+    <!-- Offline/Sync Status Banner -->
+    {#if !$isOnline}
+      <div
+        class="flex items-center gap-3 px-4 py-3 rounded-xl bg-amber-500/10 border border-amber-500/30"
+      >
+        <CloudSlashIcon size={20} class="text-amber-500 flex-shrink-0" />
+        <div class="flex-1">
+          <p class="text-sm font-medium" style="color: var(--color-text-primary)">You're offline</p>
+          <p class="text-xs text-caption">
+            Your cookbooks are saved locally. Changes will sync when you're back online.
+          </p>
+        </div>
       </div>
-      <div>
-        <h1 class="text-2xl font-bold" style="color: var(--color-text-primary)">My Cookbook</h1>
-        <p class="text-sm text-caption">Your saved recipes & collections</p>
+    {:else if $cookbookSyncStatus === 'syncing'}
+      <div
+        class="flex items-center gap-3 px-4 py-3 rounded-xl bg-blue-500/10 border border-blue-500/30"
+      >
+        <ArrowsClockwiseIcon size={20} class="text-blue-500 flex-shrink-0 animate-spin" />
+        <div class="flex-1">
+          <p class="text-sm font-medium" style="color: var(--color-text-primary)">
+            Syncing changes...
+          </p>
+          <p class="text-xs text-caption">Your cookbooks are being updated.</p>
+        </div>
       </div>
-    </div>
-    
-    <!-- Right: Status Pill + Sync Button + New Collection -->
-    <div class="flex items-center gap-2 flex-wrap">
-      <!-- Status Pill -->
-      {#if isSyncingRecipes}
-        <div class="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm bg-blue-500/10 border border-blue-500/30">
-          <CircleNotchIcon size={16} weight="bold" class="text-blue-500 animate-spin" />
-          <span class="text-blue-600 dark:text-blue-400 font-medium">Syncing</span>
-          <span class="text-blue-400 dark:text-blue-500">•</span>
-          <span class="text-blue-600 dark:text-blue-400">{syncProgress.current}/{syncProgress.total}</span>
+    {:else if $cookbookSyncStatus === 'pending' && $cookbookPendingOps > 0}
+      <div
+        class="flex items-center gap-3 px-4 py-3 rounded-xl bg-amber-500/10 border border-amber-500/30"
+      >
+        <CloudArrowUpIcon size={20} class="text-amber-500 flex-shrink-0" />
+        <div class="flex-1">
+          <p class="text-sm font-medium" style="color: var(--color-text-primary)">
+            {$cookbookPendingOps} pending {$cookbookPendingOps === 1 ? 'change' : 'changes'}
+          </p>
+          <p class="text-xs text-caption">Some changes haven't synced yet.</p>
         </div>
-      {:else if syncState === 'synced'}
-        <div class="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm bg-green-500/10 border border-green-500/30">
-          <CheckCircleIcon size={16} weight="fill" class="text-green-500" />
-          <span class="text-green-600 dark:text-green-400 font-medium">Offline Ready</span>
-          <span class="text-green-400 dark:text-green-500">•</span>
-          <span class="text-green-600 dark:text-green-400">{cachedRecipeCount} recipes</span>
-        </div>
-      {:else if syncState === 'syncing'}
-        <div class="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm bg-blue-500/10 border border-blue-500/30">
-          <CircleNotchIcon size={16} weight="bold" class="text-blue-500 animate-spin" />
-          <span class="text-blue-600 dark:text-blue-400 font-medium">Syncing</span>
-          <span class="text-blue-400 dark:text-blue-500">•</span>
-          <span class="text-blue-600 dark:text-blue-400">{cachedRecipeCount} recipes</span>
-        </div>
-      {:else if syncState === 'offline'}
-        <div class="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm bg-gray-500/10 border border-gray-500/30">
-          <CloudSlashIcon size={16} weight="fill" class="text-gray-400" />
-          <span class="text-gray-500 dark:text-gray-400 font-medium">Offline Mode</span>
-          <span class="text-gray-400 dark:text-gray-500">•</span>
-          <span class="text-gray-500 dark:text-gray-400">{cachedRecipeCount} recipes</span>
-        </div>
-      {:else if syncState === 'pending'}
         <button
           on:click={handleSyncNow}
-          class="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm bg-amber-500/10 border border-amber-500/30 hover:bg-amber-500/20 transition-colors cursor-pointer"
+          class="px-3 py-1.5 text-xs font-semibold rounded-lg bg-amber-500 hover:bg-amber-600 text-white transition-colors"
         >
-          <CloudArrowUpIcon size={16} weight="fill" class="text-amber-500" />
-          <span class="text-amber-600 dark:text-amber-400 font-medium">{$cookbookPendingOps} Pending</span>
-          <span class="text-amber-400 dark:text-amber-500">•</span>
-          <span class="text-amber-600 dark:text-amber-400">Tap to sync</span>
+          Sync Now
         </button>
-      {/if}
-      
-      <!-- Sync All Button -->
-      {#if $isOnline && !isSyncingRecipes}
-        <button
-          on:click={syncAllRecipes}
-          class="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-full transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
-          style="color: var(--color-text-secondary); border: 1px solid var(--color-input-border);"
-          title="Sync all recipes for offline use"
-        >
-          <ArrowsClockwiseIcon size={16} weight="bold" />
-          <span>Sync All</span>
-        </button>
-      {/if}
-      
-      <!-- New Collection Button -->
-      <button
-        on:click={openCreateModal}
-        class="flex items-center gap-2 px-4 py-1.5 bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 text-white rounded-full font-medium transition-all text-sm"
-        aria-label="Create new collection"
-      >
-        <PlusIcon size={18} weight="bold" />
-        <span class="hidden sm:inline">New Collection</span>
-      </button>
-    </div>
-  </div>
-
-  <!-- Loading State -->
-  {#if $cookbookLoading}
-    <div class="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-      {#each Array(4) as _}
-        <div class="h-40 rounded-2xl animate-pulse" style="background-color: var(--color-input-bg);"></div>
-      {/each}
-    </div>
-  {:else if $cookbookLists.length === 0}
-    <!-- Empty State -->
-    <div class="flex flex-col items-center justify-center py-16 px-4">
-      <div class="w-20 h-20 rounded-full bg-gradient-to-br from-orange-100 to-amber-100 dark:from-orange-900/30 dark:to-amber-900/30 flex items-center justify-center mb-4">
-        <BookmarkIcon size={40} weight="regular" class="text-orange-500" />
       </div>
-      <h2 class="text-xl font-semibold mb-2" style="color: var(--color-text-primary)">
-        Start Your Cookbook
-      </h2>
-      <p class="text-caption text-center max-w-md mb-6">
-        Save recipes you love and organize them into collections. Your cookbook is private to you.
-      </p>
-      <div class="flex gap-3">
-        <button
-          on:click={openCreateModal}
-          class="flex items-center gap-2 px-5 py-2.5 bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 text-white rounded-full font-medium transition-all"
+    {/if}
+
+    <!-- Header -->
+    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <!-- Left: Title and Icon -->
+      <div class="flex items-center gap-3">
+        <div
+          class="w-12 h-12 rounded-full bg-gradient-to-br from-orange-500 to-amber-500 flex items-center justify-center flex-shrink-0"
         >
-          <PlusIcon size={18} weight="bold" />
-          Create Collection
-        </button>
-        <a
-          href="/recent"
-          class="flex items-center px-5 py-2.5 rounded-full font-medium transition-colors"
-          style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
-        >
-          Browse Recipes
-        </a>
+          <BookmarkIcon size={24} weight="fill" class="text-white" />
+        </div>
+        <div>
+          <h1 class="text-2xl font-bold" style="color: var(--color-text-primary)">My Cookbook</h1>
+          <p class="text-sm text-caption">Your saved recipes & collections</p>
+        </div>
       </div>
-    </div>
-  {:else}
-    <!-- Collections Grid -->
-    <div class="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-      <!-- Saved Collection (Always First, Special Styling) -->
-      {#if savedCollection}
-        {@const list = savedCollection}
-        <button
-          on:click={() => openList(list)}
-          on:mouseenter={() => hoveredListId = list.id}
-          on:mouseleave={() => hoveredListId = null}
-          class="group relative h-48 sm:h-56 rounded-2xl overflow-hidden cursor-pointer transition-all duration-200 hover:scale-[1.02] hover:shadow-xl text-left collection-card saved-collection"
-          style="box-shadow: {hoveredListId === list.id ? '0 8px 24px rgba(255, 107, 53, 0.3)' : '0 2px 8px rgba(0,0,0,0.1)'};"
-          aria-label="Saved collection with {list.recipeCount} recipes"
-        >
-          <!-- Background -->
-          <div 
-            class="absolute inset-0"
-            style={getListCoverImage(list)
-              ? `background-image: url('${getListCoverImage(list)}'); background-size: cover; background-position: center;` 
-              : 'background: linear-gradient(135deg, #FF6B35 0%, #F7931E 100%);'}
+
+      <!-- Right: Status Pill + Sync Button + New Collection -->
+      <div class="flex items-center gap-2 flex-wrap">
+        <!-- Status Pill -->
+        {#if isSyncingRecipes}
+          <div
+            class="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm bg-blue-500/10 border border-blue-500/30"
           >
-            <div class="absolute inset-0 bg-black/30 group-hover:bg-black/20 transition-colors"></div>
+            <CircleNotchIcon size={16} weight="bold" class="text-blue-500 animate-spin" />
+            <span class="text-blue-600 dark:text-blue-400 font-medium">Syncing</span>
+            <span class="text-blue-400 dark:text-blue-500">•</span>
+            <span class="text-blue-600 dark:text-blue-400"
+              >{syncProgress.current}/{syncProgress.total}</span
+            >
           </div>
-
-          <!-- Content -->
-          <div class="relative h-full flex flex-col justify-between p-4">
-            <div class="flex justify-between items-start">
-              <div class="flex items-center gap-2">
-                <PinIcon size={20} weight="fill" class="text-white drop-shadow-lg" />
-                <span class="text-white/90 text-xs font-medium drop-shadow">Quick Saves</span>
-              </div>
-              <!-- Pending sync badge -->
-              {#if list.pendingSync}
-                <div class="flex items-center gap-1 px-2 py-1 rounded-full bg-amber-500/90 text-white text-xs font-medium shadow-lg">
-                  <CloudArrowUpIcon size={12} />
-                  <span>Pending</span>
-                </div>
-              {/if}
-            </div>
-
-            <div>
-              <h3 class="text-white text-xl font-bold mb-1 drop-shadow-lg">{list.title}</h3>
-              <p class="text-white/90 text-sm drop-shadow">
-                <span class="text-lg font-semibold">{list.recipeCount}</span> {list.recipeCount === 1 ? 'recipe' : 'recipes'}
-              </p>
-            </div>
-          </div>
-        </button>
-      {/if}
-
-      <!-- Custom Collections -->
-      {#each customCollections as list (list.id)}
-        <button
-          on:click={() => openList(list)}
-          on:mouseenter={() => hoveredListId = list.id}
-          on:mouseleave={() => hoveredListId = null}
-          class="group relative h-40 rounded-2xl overflow-hidden cursor-pointer transition-all duration-200 hover:scale-[1.02] hover:shadow-xl text-left collection-card"
-          style="box-shadow: {hoveredListId === list.id ? '0 8px 24px rgba(0,0,0,0.3)' : '0 2px 8px rgba(0,0,0,0.1)'}; transform: {hoveredListId === list.id ? 'translateY(-4px)' : 'translateY(0)'};"
-          aria-label="{list.title} collection with {list.recipeCount} recipes"
-        >
-          <!-- Background -->
-          <div 
-            class="absolute inset-0"
-            style={getListCoverImage(list)
-              ? `background-image: url('${getListCoverImage(list)}'); background-size: cover; background-position: center;` 
-              : 'background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'}
+        {:else if syncState === 'synced'}
+          <div
+            class="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm bg-green-500/10 border border-green-500/30"
           >
-            <div class="absolute inset-0 bg-black/30 group-hover:bg-black/20 transition-colors"></div>
+            <CheckCircleIcon size={16} weight="fill" class="text-green-500" />
+            <span class="text-green-600 dark:text-green-400 font-medium">Offline Ready</span>
+            <span class="text-green-400 dark:text-green-500">•</span>
+            <span class="text-green-600 dark:text-green-400">{cachedRecipeCount} recipes</span>
           </div>
+        {:else if syncState === 'syncing'}
+          <div
+            class="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm bg-blue-500/10 border border-blue-500/30"
+          >
+            <CircleNotchIcon size={16} weight="bold" class="text-blue-500 animate-spin" />
+            <span class="text-blue-600 dark:text-blue-400 font-medium">Syncing</span>
+            <span class="text-blue-400 dark:text-blue-500">•</span>
+            <span class="text-blue-600 dark:text-blue-400">{cachedRecipeCount} recipes</span>
+          </div>
+        {:else if syncState === 'offline'}
+          <div
+            class="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm bg-gray-500/10 border border-gray-500/30"
+          >
+            <CloudSlashIcon size={16} weight="fill" class="text-gray-400" />
+            <span class="text-gray-500 dark:text-gray-400 font-medium">Offline Mode</span>
+            <span class="text-gray-400 dark:text-gray-500">•</span>
+            <span class="text-gray-500 dark:text-gray-400">{cachedRecipeCount} recipes</span>
+          </div>
+        {:else if syncState === 'pending'}
+          <button
+            on:click={handleSyncNow}
+            class="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm bg-amber-500/10 border border-amber-500/30 hover:bg-amber-500/20 transition-colors cursor-pointer"
+          >
+            <CloudArrowUpIcon size={16} weight="fill" class="text-amber-500" />
+            <span class="text-amber-600 dark:text-amber-400 font-medium"
+              >{$cookbookPendingOps} Pending</span
+            >
+            <span class="text-amber-400 dark:text-amber-500">•</span>
+            <span class="text-amber-600 dark:text-amber-400">Tap to sync</span>
+          </button>
+        {/if}
 
-          <!-- Empty Collection Placeholder Grid -->
-          {#if list.recipeCount === 0}
-            <div class="absolute inset-0 flex items-center justify-center p-4">
-              <div class="grid grid-cols-3 gap-2 w-full max-w-[200px] opacity-40">
-                {#each Array(6) as _}
-                  <div class="aspect-square rounded-lg border-2 border-dashed border-white/50 flex items-center justify-center">
-                    <PlusIcon size={16} class="text-white/50" />
-                  </div>
-                {/each}
-              </div>
+        <!-- Sync All Button -->
+        {#if $isOnline && !isSyncingRecipes}
+          <button
+            on:click={syncAllRecipes}
+            class="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-full transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
+            style="color: var(--color-text-secondary); border: 1px solid var(--color-input-border);"
+            title="Sync all recipes for offline use"
+          >
+            <ArrowsClockwiseIcon size={16} weight="bold" />
+            <span>Sync All</span>
+          </button>
+        {/if}
+
+        <!-- Add menu (Add recipe / Import / New collection) -->
+        <div class="relative" use:clickOutside on:click_outside={() => (createMenuOpen = false)}>
+          <button
+            on:click={() => (createMenuOpen = !createMenuOpen)}
+            class="flex items-center gap-1.5 pl-4 pr-3 py-1.5 bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 text-white rounded-full font-medium transition-all text-sm"
+            aria-haspopup="true"
+            aria-expanded={createMenuOpen}
+            aria-label="Add to cookbook"
+          >
+            <PlusIcon size={18} weight="bold" />
+            <span class="hidden sm:inline">Add</span>
+            <CaretDownIcon size={14} weight="bold" class="opacity-90" />
+          </button>
+          {#if createMenuOpen}
+            <div
+              class="absolute right-0 top-[calc(100%+0.5rem)] z-50 min-w-[200px] rounded-xl py-1 shadow-xl"
+              style="background-color: var(--color-bg-secondary); border: 1px solid var(--color-input-border);"
+            >
+              <button
+                on:click={() => {
+                  createMenuOpen = false;
+                  goto('/create');
+                }}
+                class="w-full flex items-center gap-2 px-3 py-2 text-sm transition-colors hover:bg-accent-gray text-left"
+                style="color: var(--color-text-primary);"
+              >
+                <ForkKnifeIcon size={16} weight="regular" />
+                <span>Add recipe</span>
+              </button>
+              <button
+                on:click={() => {
+                  createMenuOpen = false;
+                  goto('/souschef');
+                }}
+                class="w-full flex items-center gap-2 px-3 py-2 text-sm transition-colors hover:bg-accent-gray text-left"
+                style="color: var(--color-text-primary);"
+              >
+                <MagicWandIcon size={16} weight="regular" />
+                <span>Import recipe</span>
+              </button>
+              <button
+                on:click={() => {
+                  createMenuOpen = false;
+                  openCreateModal();
+                }}
+                class="w-full flex items-center gap-2 px-3 py-2 text-sm transition-colors hover:bg-accent-gray text-left"
+                style="color: var(--color-text-primary);"
+              >
+                <BookmarkIcon size={16} weight="regular" />
+                <span>New collection</span>
+              </button>
             </div>
           {/if}
+        </div>
+      </div>
+    </div>
 
-          <!-- Content -->
-          <div class="relative h-full flex flex-col justify-between p-4">
-            <div class="flex justify-between items-start">
-              <!-- Pending sync badge -->
-              {#if list.pendingSync}
-                <div class="flex items-center gap-1 px-2 py-1 rounded-full bg-amber-500/90 text-white text-xs font-medium shadow-lg">
-                  <CloudArrowUpIcon size={12} />
-                  <span>Pending</span>
+    <!-- View Toggle + (feed) Sort/Filter Toolbar -->
+    {#if !$cookbookLoading && $cookbookLists.length > 0}
+      <div class="flex flex-wrap items-center gap-2 justify-between">
+        <!-- View toggle -->
+        <div
+          class="inline-flex p-0.5 rounded-full"
+          style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+          role="tablist"
+          aria-label="Cookbook view"
+        >
+          <button
+            type="button"
+            role="tab"
+            aria-selected={viewMode === 'packs'}
+            on:click={() => setView('packs')}
+            class="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors {viewMode ===
+            'packs'
+              ? 'bg-gradient-to-r from-orange-500 to-amber-500 text-white shadow-sm'
+              : ''}"
+            style={viewMode === 'packs' ? '' : 'color: var(--color-text-secondary);'}
+          >
+            <SquaresFourIcon size={16} weight={viewMode === 'packs' ? 'fill' : 'regular'} />
+            <span>Packs</span>
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={viewMode === 'feed'}
+            on:click={() => setView('feed')}
+            class="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors {viewMode ===
+            'feed'
+              ? 'bg-gradient-to-r from-orange-500 to-amber-500 text-white shadow-sm'
+              : ''}"
+            style={viewMode === 'feed' ? '' : 'color: var(--color-text-secondary);'}
+            disabled={totalUniqueSaved === 0}
+            aria-disabled={totalUniqueSaved === 0}
+            title={totalUniqueSaved === 0 ? 'No saved recipes yet' : 'Browse all saved recipes'}
+          >
+            <ListBulletsIcon size={16} weight={viewMode === 'feed' ? 'fill' : 'regular'} />
+            <span>Feed</span>
+            {#if totalUniqueSaved > 0}
+              <span class="text-xs opacity-80">·&nbsp;{totalUniqueSaved}</span>
+            {/if}
+          </button>
+        </div>
+
+        <!-- Sort + Filter (feed only) -->
+        {#if viewMode === 'feed'}
+          <div class="flex items-center gap-2 flex-wrap">
+            <!-- Share Cookbook -->
+            <button
+              on:click={openShareCookbook}
+              disabled={totalUniqueSaved === 0}
+              class="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+              style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+              title="Share your saved recipes as a Recipe Pack"
+              aria-label="Share cookbook as Recipe Pack"
+            >
+              <ShareNetworkIcon size={16} />
+              <span>Share Cookbook</span>
+            </button>
+
+            <!-- Sort dropdown -->
+            <div class="relative" use:clickOutside on:click_outside={() => (sortMenuOpen = false)}>
+              <button
+                on:click={() => (sortMenuOpen = !sortMenuOpen)}
+                class="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
+                style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+                aria-haspopup="true"
+                aria-expanded={sortMenuOpen}
+              >
+                <SortAscendingIcon size={16} />
+                <span>{SORT_LABELS[sortMode]}</span>
+                <CaretDownIcon size={12} weight="bold" class="opacity-70" />
+              </button>
+              {#if sortMenuOpen}
+                <div
+                  class="absolute right-0 top-[calc(100%+0.4rem)] z-40 min-w-[180px] rounded-xl py-1 shadow-xl"
+                  style="background-color: var(--color-bg-secondary); border: 1px solid var(--color-input-border);"
+                >
+                  {#each SORT_OPTIONS as opt}
+                    <button
+                      on:click={() => setSort(opt.value)}
+                      class="w-full text-left px-3 py-2 text-sm transition-colors hover:bg-accent-gray {sortMode ===
+                      opt.value
+                        ? 'text-primary font-medium'
+                        : ''}"
+                      style={sortMode === opt.value ? '' : 'color: var(--color-text-primary);'}
+                    >
+                      {opt.label}
+                    </button>
+                  {/each}
                 </div>
-              {:else}
-                <span></span>
               {/if}
-              
-              <!-- Quick Actions Overlay (Desktop Hover) -->
-              {#if hoveredListId === list.id && list.recipeCount > 0}
-                <div 
-                  class="flex gap-2"
-                  on:click|stopPropagation
+            </div>
+
+            <!-- Collection filter dropdown -->
+            <div
+              class="relative"
+              use:clickOutside
+              on:click_outside={() => (filterMenuOpen = false)}
+            >
+              <button
+                on:click={() => (filterMenuOpen = !filterMenuOpen)}
+                class="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
+                style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+                aria-haspopup="true"
+                aria-expanded={filterMenuOpen}
+              >
+                <FunnelSimpleIcon size={16} />
+                <span class="max-w-[140px] truncate">{collectionFilterLabel}</span>
+                <CaretDownIcon size={12} weight="bold" class="opacity-70" />
+              </button>
+              {#if filterMenuOpen}
+                <div
+                  class="absolute right-0 top-[calc(100%+0.4rem)] z-40 min-w-[200px] max-h-[60vh] overflow-y-auto rounded-xl py-1 shadow-xl"
+                  style="background-color: var(--color-bg-secondary); border: 1px solid var(--color-input-border);"
                 >
                   <button
-                    on:click={(e) => openChangeCoverModal(list, e)}
-                    class="w-8 h-8 flex items-center justify-center rounded-full bg-white/90 hover:bg-white text-gray-800 transition-colors shadow-lg"
-                    aria-label="Change cover image"
-                    title="Change Cover"
+                    on:click={() => setCollectionFilter('all')}
+                    class="w-full text-left px-3 py-2 text-sm transition-colors hover:bg-accent-gray {collectionFilter ===
+                    'all'
+                      ? 'text-primary font-medium'
+                      : ''}"
+                    style={collectionFilter === 'all' ? '' : 'color: var(--color-text-primary);'}
                   >
-                    <ImageIcon size={16} weight="bold" />
+                    All collections <span class="text-xs opacity-70">· {totalUniqueSaved}</span>
                   </button>
-                  <button
-                    on:click={(e) => openEditModal(list, e)}
-                    class="w-8 h-8 flex items-center justify-center rounded-full bg-white/90 hover:bg-white text-gray-800 transition-colors shadow-lg"
-                    aria-label="Edit collection"
-                    title="Edit"
-                  >
-                    <PencilSimpleIcon size={16} weight="bold" />
-                  </button>
-                  <button
-                    on:click={(e) => shareList(list, e)}
-                    class="w-8 h-8 flex items-center justify-center rounded-full bg-white/90 hover:bg-white text-gray-800 transition-colors shadow-lg"
-                    aria-label="Share collection"
-                    title="Share"
-                  >
-                    <ShareIcon size={16} weight="bold" />
-                  </button>
-                  <button
-                    on:click={(e) => openDeleteConfirm(list, e)}
-                    class="w-8 h-8 flex items-center justify-center rounded-full bg-red-500/90 hover:bg-red-600 text-white transition-colors shadow-lg"
-                    aria-label="Delete collection"
-                    title="Delete"
-                  >
-                    <TrashIcon size={16} weight="bold" />
-                  </button>
+                  {#each $cookbookLists as list (list.id)}
+                    <button
+                      on:click={() => setCollectionFilter(list.id)}
+                      class="w-full text-left px-3 py-2 text-sm transition-colors hover:bg-accent-gray flex items-center justify-between gap-2 {collectionFilter ===
+                      list.id
+                        ? 'text-primary font-medium'
+                        : ''}"
+                      style={collectionFilter === list.id
+                        ? ''
+                        : 'color: var(--color-text-primary);'}
+                    >
+                      <span class="truncate flex items-center gap-1.5">
+                        {#if list.isDefault}
+                          <PinIcon size={12} weight="fill" class="text-orange-500 flex-shrink-0" />
+                        {/if}
+                        {list.title}
+                      </span>
+                      <span class="text-xs opacity-70 flex-shrink-0">{list.recipeCount}</span>
+                    </button>
+                  {/each}
                 </div>
               {/if}
             </div>
-
-            <div>
-              <h3 class="text-white text-lg font-bold mb-1 drop-shadow-lg truncate">{list.title}</h3>
-              <p class="text-white/90 text-sm drop-shadow">
-                {list.recipeCount} {list.recipeCount === 1 ? 'recipe' : 'recipes'}
-              </p>
-            </div>
           </div>
-        </button>
-      {/each}
-    </div>
-  {/if}
-</div>
+        {/if}
+      </div>
+    {/if}
+
+    <!-- Loading State -->
+    {#if $cookbookLoading}
+      <div class="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {#each Array(4) as _}
+          <div
+            class="h-40 rounded-2xl animate-pulse"
+            style="background-color: var(--color-input-bg);"
+          ></div>
+        {/each}
+      </div>
+    {:else if $cookbookLists.length === 0}
+      <!-- Empty State -->
+      <div class="flex flex-col items-center justify-center py-16 px-4">
+        <div
+          class="w-20 h-20 rounded-full bg-gradient-to-br from-orange-100 to-amber-100 dark:from-orange-900/30 dark:to-amber-900/30 flex items-center justify-center mb-4"
+        >
+          <BookmarkIcon size={40} weight="regular" class="text-orange-500" />
+        </div>
+        <h2 class="text-xl font-semibold mb-2" style="color: var(--color-text-primary)">
+          Start Your Cookbook
+        </h2>
+        <p class="text-caption text-center max-w-md mb-6">
+          Save recipes you love and organize them into collections. Your cookbook is private to you.
+        </p>
+        <div class="flex gap-3">
+          <button
+            on:click={openCreateModal}
+            class="flex items-center gap-2 px-5 py-2.5 bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 text-white rounded-full font-medium transition-all"
+          >
+            <PlusIcon size={18} weight="bold" />
+            Create Collection
+          </button>
+          <a
+            href="/recent"
+            class="flex items-center px-5 py-2.5 rounded-full font-medium transition-colors"
+            style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+          >
+            Browse Recipes
+          </a>
+        </div>
+      </div>
+    {:else if viewMode === 'feed'}
+      <!-- Feed view: all saved recipes -->
+      {#if filteredATags.length === 0}
+        <div class="flex flex-col items-center justify-center py-12 px-4">
+          <div
+            class="w-16 h-16 rounded-full bg-gradient-to-br from-orange-100 to-amber-100 dark:from-orange-900/30 dark:to-amber-900/30 flex items-center justify-center mb-4"
+          >
+            <BookmarkIcon size={32} weight="regular" class="text-orange-500" />
+          </div>
+          <h3 class="text-lg font-medium mb-2" style="color: var(--color-text-primary)">
+            {collectionFilter === 'all' ? 'No saved recipes yet' : 'No recipes in this collection'}
+          </h3>
+          <p class="text-caption text-center max-w-sm mb-4">
+            {collectionFilter === 'all'
+              ? "Save recipes from anywhere on Zap.cooking and they'll show up here."
+              : 'Save recipes to this collection to see them here.'}
+          </p>
+          <a
+            href="/recent"
+            class="flex items-center px-4 py-2 rounded-full font-medium text-sm transition-colors"
+            style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+          >
+            Browse Recipes
+          </a>
+        </div>
+      {:else}
+        <!-- Big-card feed: 1 col mobile, 2 col tablet, 3 col desktop -->
+        <div class="grid gap-4 sm:gap-5 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+          {#each displayedEvents as e (e.id || feedCardData(e).link)}
+            {@const card = feedCardData(e)}
+            {#if card.link}
+              <a
+                href={card.link}
+                class="group flex flex-col rounded-2xl overflow-hidden transition-transform duration-200 hover:scale-[1.01] hover:shadow-xl"
+                style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+              >
+                <div class="relative w-full aspect-[4/3] overflow-hidden feed-card-image-wrap">
+                  <div
+                    use:lazyLoad={{ url: card.image }}
+                    class="absolute inset-0 feed-card-image group-hover:scale-105 transition-transform duration-700 ease-in-out"
+                  ></div>
+                </div>
+                <div class="p-3 sm:p-4 flex flex-col gap-1">
+                  <h3
+                    class="text-base sm:text-lg font-semibold leading-snug line-clamp-2"
+                    style="color: var(--color-text-primary);"
+                  >
+                    {card.title}
+                  </h3>
+                  {#if card.summary}
+                    <p class="text-sm text-caption line-clamp-2">{card.summary}</p>
+                  {/if}
+                </div>
+              </a>
+            {/if}
+          {/each}
+
+          <!-- Loading skeletons for not-yet-fetched recipes -->
+          {#if feedLoading && displayedEvents.length < filteredATags.length}
+            {#each Array(Math.min(3, filteredATags.length - displayedEvents.length)) as _}
+              <div
+                class="rounded-2xl overflow-hidden animate-pulse"
+                style="background-color: var(--color-input-bg);"
+              >
+                <div class="w-full aspect-[4/3]" style="background-color: var(--color-accent-gray);"></div>
+                <div class="p-3 sm:p-4 flex flex-col gap-2">
+                  <div
+                    class="h-4 w-3/4 rounded"
+                    style="background-color: var(--color-accent-gray);"
+                  ></div>
+                  <div
+                    class="h-3 w-1/2 rounded"
+                    style="background-color: var(--color-accent-gray);"
+                  ></div>
+                </div>
+              </div>
+            {/each}
+          {/if}
+        </div>
+      {/if}
+    {:else}
+      <!-- Collections Grid -->
+      <div class="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        <!-- Saved Collection (Always First, Special Styling) -->
+        {#if savedCollection}
+          {@const list = savedCollection}
+          {@const hasAnySaved = totalUniqueSaved > 0}
+          <button
+            on:click={() => (hasAnySaved ? setView('feed') : openList(list))}
+            on:mouseenter={() => (hoveredListId = list.id)}
+            on:mouseleave={() => (hoveredListId = null)}
+            class="group relative h-40 rounded-2xl overflow-hidden cursor-pointer transition-all duration-200 hover:scale-[1.02] hover:shadow-xl text-left collection-card saved-collection"
+            style="box-shadow: {hoveredListId === list.id
+              ? '0 8px 24px rgba(255, 107, 53, 0.3)'
+              : '0 2px 8px rgba(0,0,0,0.1)'};"
+            aria-label={hasAnySaved
+              ? `View all ${totalUniqueSaved} of my recipes`
+              : 'My Recipes (empty)'}
+          >
+            <!-- Background -->
+            <div
+              class="absolute inset-0"
+              style={getListCoverImage(list)
+                ? `background-image: url('${getListCoverImage(list)}'); background-size: cover; background-position: center;`
+                : 'background: linear-gradient(135deg, #FF6B35 0%, #F7931E 100%);'}
+            >
+              <div
+                class="absolute inset-0 bg-black/30 group-hover:bg-black/20 transition-colors"
+              ></div>
+            </div>
+
+            <!-- Content -->
+            <div class="relative h-full flex flex-col justify-between p-4">
+              <div class="flex justify-between items-start">
+                <div class="flex items-center gap-2">
+                  {#if hasAnySaved}
+                    <ListBulletsIcon size={20} weight="fill" class="text-white drop-shadow-lg" />
+                    <span class="text-white/90 text-xs font-medium drop-shadow">My Recipes</span>
+                  {:else}
+                    <PinIcon size={20} weight="fill" class="text-white drop-shadow-lg" />
+                    <span class="text-white/90 text-xs font-medium drop-shadow">Quick Saves</span>
+                  {/if}
+                </div>
+                <!-- Pending sync badge -->
+                {#if list.pendingSync}
+                  <div
+                    class="flex items-center gap-1 px-2 py-1 rounded-full bg-amber-500/90 text-white text-xs font-medium shadow-lg"
+                  >
+                    <CloudArrowUpIcon size={12} />
+                    <span>Pending</span>
+                  </div>
+                {/if}
+              </div>
+
+              <div>
+                {#if hasAnySaved}
+                  <h3 class="text-white text-lg font-bold mb-1 drop-shadow-lg truncate">My Recipes</h3>
+                  <p class="text-white/90 text-sm drop-shadow">
+                    {totalUniqueSaved} {totalUniqueSaved === 1 ? 'recipe' : 'recipes'}
+                  </p>
+                {:else}
+                  <h3 class="text-white text-lg font-bold mb-1 drop-shadow-lg truncate">
+                    Start saving recipes
+                  </h3>
+                  <p class="text-white/90 text-sm drop-shadow">Tap the bookmark on any recipe.</p>
+                {/if}
+              </div>
+            </div>
+          </button>
+        {/if}
+
+        <!-- Custom Collections -->
+        {#each customCollections as list (list.id)}
+          <button
+            on:click={() => openList(list)}
+            on:mouseenter={() => (hoveredListId = list.id)}
+            on:mouseleave={() => (hoveredListId = null)}
+            class="group relative h-40 rounded-2xl overflow-hidden cursor-pointer transition-all duration-200 hover:scale-[1.02] hover:shadow-xl text-left collection-card"
+            style="box-shadow: {hoveredListId === list.id
+              ? '0 8px 24px rgba(0,0,0,0.3)'
+              : '0 2px 8px rgba(0,0,0,0.1)'}; transform: {hoveredListId === list.id
+              ? 'translateY(-4px)'
+              : 'translateY(0)'};"
+            aria-label="{list.title} collection with {list.recipeCount} recipes"
+          >
+            <!-- Background -->
+            <div
+              class="absolute inset-0"
+              style={getListCoverImage(list)
+                ? `background-image: url('${getListCoverImage(list)}'); background-size: cover; background-position: center;`
+                : 'background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'}
+            >
+              <div
+                class="absolute inset-0 bg-black/30 group-hover:bg-black/20 transition-colors"
+              ></div>
+            </div>
+
+            <!-- Empty Collection Placeholder Grid -->
+            {#if list.recipeCount === 0}
+              <div class="absolute inset-0 flex items-center justify-center p-4">
+                <div class="grid grid-cols-3 gap-2 w-full max-w-[200px] opacity-40">
+                  {#each Array(6) as _}
+                    <div
+                      class="aspect-square rounded-lg border-2 border-dashed border-white/50 flex items-center justify-center"
+                    >
+                      <PlusIcon size={16} class="text-white/50" />
+                    </div>
+                  {/each}
+                </div>
+              </div>
+            {/if}
+
+            <!-- Content -->
+            <div class="relative h-full flex flex-col justify-between p-4">
+              <div class="flex justify-between items-start">
+                <!-- Pending sync badge -->
+                {#if list.pendingSync}
+                  <div
+                    class="flex items-center gap-1 px-2 py-1 rounded-full bg-amber-500/90 text-white text-xs font-medium shadow-lg"
+                  >
+                    <CloudArrowUpIcon size={12} />
+                    <span>Pending</span>
+                  </div>
+                {:else}
+                  <span></span>
+                {/if}
+
+                <!-- Quick Actions Overlay (Desktop Hover) -->
+                {#if hoveredListId === list.id && list.recipeCount > 0}
+                  <div class="flex gap-2" on:click|stopPropagation>
+                    <button
+                      on:click={(e) => openChangeCoverModal(list, e)}
+                      class="w-8 h-8 flex items-center justify-center rounded-full bg-white/90 hover:bg-white text-gray-800 transition-colors shadow-lg"
+                      aria-label="Change cover image"
+                      title="Change Cover"
+                    >
+                      <ImageIcon size={16} weight="bold" />
+                    </button>
+                    <button
+                      on:click={(e) => openEditModal(list, e)}
+                      class="w-8 h-8 flex items-center justify-center rounded-full bg-white/90 hover:bg-white text-gray-800 transition-colors shadow-lg"
+                      aria-label="Edit collection"
+                      title="Edit"
+                    >
+                      <PencilSimpleIcon size={16} weight="bold" />
+                    </button>
+                    <button
+                      on:click={(e) => shareList(list, e)}
+                      class="w-8 h-8 flex items-center justify-center rounded-full bg-white/90 hover:bg-white text-gray-800 transition-colors shadow-lg"
+                      aria-label="Share collection link"
+                      title="Share link"
+                    >
+                      <ShareIcon size={16} weight="bold" />
+                    </button>
+                    <button
+                      on:click={(e) => openShareCollection(list, e)}
+                      disabled={list.recipes.length === 0}
+                      class="w-8 h-8 flex items-center justify-center rounded-full bg-white/90 hover:bg-white text-gray-800 transition-colors shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
+                      aria-label="Share as Recipe Pack"
+                      title="Share as Recipe Pack"
+                    >
+                      <ShareNetworkIcon size={16} weight="bold" />
+                    </button>
+                    <button
+                      on:click={(e) => openDeleteConfirm(list, e)}
+                      class="w-8 h-8 flex items-center justify-center rounded-full bg-red-500/90 hover:bg-red-600 text-white transition-colors shadow-lg"
+                      aria-label="Delete collection"
+                      title="Delete"
+                    >
+                      <TrashIcon size={16} weight="bold" />
+                    </button>
+                  </div>
+                {/if}
+              </div>
+
+              <div>
+                <h3 class="text-white text-lg font-bold mb-1 drop-shadow-lg truncate">
+                  {list.title}
+                </h3>
+                <p class="text-white/90 text-sm drop-shadow">
+                  {list.recipeCount}
+                  {list.recipeCount === 1 ? 'recipe' : 'recipes'}
+                </p>
+              </div>
+            </div>
+          </button>
+        {/each}
+      </div>
+    {/if}
+  </div>
 </PullToRefresh>
 
 <style>
   .collection-card {
     position: relative;
-  }
-
-  .saved-collection {
-    /* Saved collection can be slightly larger on desktop */
-  }
-
-  @media (min-width: 1280px) {
-    .saved-collection {
-      grid-column: span 1;
-    }
-  }
-
-  /* Smooth transitions */
-  .collection-card {
     will-change: transform;
+  }
+
+  /* Feed view large image cards */
+  .feed-card-image-wrap {
+    background-color: var(--color-accent-gray);
+  }
+  .feed-card-image {
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    opacity: 0;
+    transition: opacity 0.3s ease-in;
+  }
+  .feed-card-image:global(.image-loaded) {
+    opacity: 1;
   }
 </style>

--- a/src/routes/cookbook/[naddr]/+page.svelte
+++ b/src/routes/cookbook/[naddr]/+page.svelte
@@ -14,6 +14,10 @@
   import PencilSimpleIcon from 'phosphor-svelte/lib/PencilSimple';
   import TrashIcon from 'phosphor-svelte/lib/Trash';
   import ShareIcon from 'phosphor-svelte/lib/Share';
+  import ShareNetworkIcon from 'phosphor-svelte/lib/ShareNetwork';
+  import DotsThreeIcon from 'phosphor-svelte/lib/DotsThree';
+  import SharePackModal from '../../../components/SharePackModal.svelte';
+  import type { RecipePackSource } from '$lib/recipePack';
   import BookmarkIcon from 'phosphor-svelte/lib/BookmarkSimple';
   import PinIcon from 'phosphor-svelte/lib/PushPin';
   import CloudSlashIcon from 'phosphor-svelte/lib/CloudSlash';
@@ -25,6 +29,8 @@
   import { isOnline } from '$lib/connectionMonitor';
   import { offlineStorage, type CachedRecipe } from '$lib/offlineStorage';
   import { NDKEvent } from '@nostr-dev-kit/ndk';
+  import { clickOutside } from '$lib/clickOutside';
+  import { formatDistanceToNow } from 'date-fns';
 
   let loaded = false;
   let event: NDKEvent | null = null;
@@ -53,6 +59,39 @@
   let changeCoverModalOpen = false;
   let coverImage: string | undefined = undefined;
   let selectedCoverRecipeATag: string | null = null; // Track selected recipe in modal
+
+  // Share-as-Pack modal
+  let sharePackOpen = false;
+  let sharePackSource: RecipePackSource = { type: 'cookbook' };
+  let sharePackATags: string[] = [];
+  let sharePackTitle = '';
+  let sharePackDescription = '';
+  let sharePackImage: string | undefined = undefined;
+
+  // Overflow ("…") menu state
+  let overflowMenuOpen = false;
+
+  // Relative "Updated …" string from the list event's last replaceable timestamp
+  $: updatedLabel = (() => {
+    const t = event?.created_at;
+    if (!t) return '';
+    try {
+      return `Updated ${formatDistanceToNow(new Date(t * 1000), { addSuffix: true })}`;
+    } catch {
+      return '';
+    }
+  })();
+
+  function openSharePackModal() {
+    if (!event || events.length === 0) return;
+    const dTag = event.tags.find((t) => t[0] === 'd')?.[1] || '';
+    sharePackSource = { type: 'collection', collectionDTag: dTag };
+    sharePackATags = event.tags.filter((t) => t[0] === 'a').map((t) => t[1]);
+    sharePackTitle = getListTitle();
+    sharePackDescription = getListSummary() || '';
+    sharePackImage = coverImage || event.tags.find((t) => t[0] === 'image')?.[1];
+    sharePackOpen = true;
+  }
 
   $: {
     if ($page.params.naddr) {
@@ -835,130 +874,189 @@
   </div>
 </Modal>
 
+<!-- Share as Recipe Pack Modal -->
+<SharePackModal
+  bind:open={sharePackOpen}
+  source={sharePackSource}
+  recipeATags={sharePackATags}
+  initialTitle={sharePackTitle}
+  initialDescription={sharePackDescription}
+  initialImage={sharePackImage}
+/>
+
 {#if !loaded}
   <div class="flex justify-center items-center page-loader">
     <PanLoader />
   </div>
 {:else if event}
-  <div class="flex flex-col gap-6">
-    <!-- Header with cover image -->
-    {#if listImage}
-      <div class="relative h-48 sm:h-64 -mx-4 sm:-mx-6 lg:-mx-8 -mt-4 sm:-mt-6 rounded-b-3xl overflow-hidden">
-        <img 
-          src={listImage + (coverImage ? '?t=' + Date.now() : '')} 
+  {@const recipeCountDisplay = offlineMode ? cachedRecipeCount : events.length}
+  <div class="flex flex-col gap-5">
+    <!-- Hero header (always wide; uses cover image when available, gradient when not) -->
+    <div
+      class="relative h-52 sm:h-72 -mx-4 sm:-mx-6 lg:-mx-8 -mt-4 sm:-mt-6 rounded-b-3xl overflow-hidden"
+    >
+      {#if listImage}
+        <img
+          src={listImage + (coverImage ? '?t=' + Date.now() : '')}
           alt={listTitle}
-          class="w-full h-full object-cover"
+          class="absolute inset-0 w-full h-full object-cover"
         />
-        <div class="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-transparent"></div>
-        
-        <!-- Back button overlay -->
-        <a 
-          href="/cookbook" 
-          class="absolute top-4 left-4 w-10 h-10 flex items-center justify-center rounded-full bg-black/30 hover:bg-black/50 text-white transition-colors"
-        >
-          <ArrowLeftIcon size={20} weight="bold" />
-        </a>
-        
-        <!-- Title overlay -->
-        <div class="absolute bottom-4 left-4 right-4">
-          <div class="flex items-end justify-between gap-4">
-            <div>
-              <div class="flex items-center gap-2 mb-1">
-                {#if isDefaultList()}
-                  <div class="flex items-center gap-1.5 px-2 py-0.5 bg-white/20 backdrop-blur-sm rounded-full">
-                    <PinIcon size={14} weight="fill" class="text-white" />
-                    <span class="text-xs text-white font-medium">Quick Saves</span>
-                  </div>
-                {/if}
-              </div>
-              <h1 class="text-2xl sm:text-3xl font-bold text-white">{listTitle}</h1>
-              <p class="text-white/80 text-sm mt-1">
-                {offlineMode ? cachedRecipeCount : events.length} {(offlineMode ? cachedRecipeCount : events.length) === 1 ? 'recipe' : 'recipes'}
-              </p>
+      {:else}
+        <div
+          class="absolute inset-0"
+          style="background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 50%, #f97316 100%);"
+        ></div>
+      {/if}
+      <div class="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-black/10"></div>
+
+      <!-- Back button -->
+      <a
+        href="/cookbook"
+        class="absolute top-4 left-4 w-10 h-10 flex items-center justify-center rounded-full bg-black/35 hover:bg-black/55 text-white transition-colors backdrop-blur-sm"
+        aria-label="Back to cookbook"
+      >
+        <ArrowLeftIcon size={20} weight="bold" />
+      </a>
+
+      <!-- Title block -->
+      <div class="absolute bottom-4 left-4 right-4">
+        <div class="flex items-center gap-2 mb-1.5 flex-wrap">
+          {#if isDefaultList()}
+            <div class="flex items-center gap-1.5 px-2 py-0.5 bg-white/20 backdrop-blur-sm rounded-full">
+              <PinIcon size={14} weight="fill" class="text-white" />
+              <span class="text-xs text-white font-medium">Quick Saves</span>
             </div>
-          </div>
+          {/if}
         </div>
+        <h1 class="text-2xl sm:text-4xl font-bold text-white drop-shadow-lg leading-tight">
+          {listTitle}
+        </h1>
+        <p class="text-white/90 text-sm mt-1.5 drop-shadow">
+          {recipeCountDisplay}
+          {recipeCountDisplay === 1 ? 'recipe' : 'recipes'}
+          {#if updatedLabel}
+            <span class="text-white/60">·</span>
+            <span>{updatedLabel}</span>
+          {/if}
+        </p>
       </div>
-    {:else}
-      <!-- Simple header without image -->
-      <div class="flex items-center gap-4">
-        <a 
-          href="/cookbook" 
-          class="w-10 h-10 flex items-center justify-center rounded-full transition-colors hover:bg-accent-gray"
-          style="background-color: var(--color-input-bg);"
-        >
-          <ArrowLeftIcon size={20} />
-        </a>
-        <div class="flex-1">
-          <div class="flex items-center gap-2">
-            {#if isDefaultList()}
-              <div class="flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-orange-100 dark:bg-orange-900/30">
-                <PinIcon size={14} weight="fill" class="text-orange-600 dark:text-orange-400" />
-                <span class="text-xs font-medium text-orange-700 dark:text-orange-300">Quick Saves</span>
-              </div>
-            {/if}
-            <h1 class="text-2xl font-bold" style="color: var(--color-text-primary)">{listTitle}</h1>
-          </div>
-          <p class="text-caption text-sm">
-            {offlineMode ? cachedRecipeCount : events.length} {(offlineMode ? cachedRecipeCount : events.length) === 1 ? 'recipe' : 'recipes'}
-          </p>
-        </div>
-      </div>
-    {/if}
+    </div>
 
-    <!-- Summary -->
+    <!-- Description (if provided) -->
     {#if listSummary}
-      <p class="text-caption leading-relaxed {listImage ? '' : '-mt-2'}">{listSummary}</p>
+      <p class="text-caption leading-relaxed -mt-1">{listSummary}</p>
     {/if}
 
-    <!-- Action buttons (hidden when offline since they require network) -->
+    <!-- Action row: primary Share Pack + secondary Manage + overflow menu -->
     {#if isOwner && !offlineMode}
-      <div class="flex flex-wrap gap-2 {listImage ? '-mt-2' : ''}">
-        {#if events.length > 0}
-          <button
-            on:click={openChangeCoverModal}
-            class="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-colors"
-            style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
-          >
-            <ImageIcon size={16} />
-            Change Cover
-          </button>
-        {/if}
+      <div class="flex flex-wrap items-center gap-2 -mt-1">
+        <!-- Primary: Share Pack -->
         <button
-          on:click={openEditModal}
-          class="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-colors"
-          style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+          on:click={openSharePackModal}
+          disabled={events.length === 0}
+          class="flex items-center gap-2 px-5 py-2.5 rounded-full text-sm font-semibold text-white bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 transition-all shadow-md shadow-orange-500/25 disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none"
+          title={events.length === 0
+            ? 'Add recipes first'
+            : 'Publish this collection as a zappable Recipe Pack'}
         >
-          <PencilSimpleIcon size={16} />
-          Edit Details
+          <ShareNetworkIcon size={16} weight="bold" />
+          <span>Share Pack</span>
         </button>
+
+        <!-- Secondary: Manage Recipes -->
         <button
           on:click={openManageModal}
-          class="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-colors"
+          class="flex items-center gap-2 px-4 py-2.5 rounded-full text-sm font-medium transition-colors"
           style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
         >
           <BookmarkIcon size={16} />
-          Manage Recipes
+          <span>Manage Recipes</span>
         </button>
-        <button
-          on:click={shareList}
-          class="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-colors"
-          style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+
+        <!-- Overflow menu -->
+        <div
+          class="relative"
+          use:clickOutside
+          on:click_outside={() => (overflowMenuOpen = false)}
         >
-          <ShareIcon size={16} />
-          Share
-        </button>
-        {#if !isDefaultList()}
           <button
-            on:click={openDeleteConfirm}
-            class="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium text-red-500 transition-colors hover:bg-red-50 dark:hover:bg-red-900/20"
-            style="border: 1px solid currentColor;"
+            on:click={() => (overflowMenuOpen = !overflowMenuOpen)}
+            class="w-10 h-10 flex items-center justify-center rounded-full text-sm font-medium transition-colors"
+            style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+            aria-haspopup="true"
+            aria-expanded={overflowMenuOpen}
+            aria-label="More actions"
           >
-            <TrashIcon size={16} />
-            Delete
+            <DotsThreeIcon size={20} weight="bold" />
           </button>
-        {/if}
+          {#if overflowMenuOpen}
+            <div
+              class="absolute right-0 top-[calc(100%+0.5rem)] z-40 min-w-[200px] rounded-xl py-1 shadow-xl"
+              style="background-color: var(--color-bg-secondary); border: 1px solid var(--color-input-border);"
+              role="menu"
+            >
+              <button
+                role="menuitem"
+                on:click={() => {
+                  overflowMenuOpen = false;
+                  openEditModal();
+                }}
+                class="w-full flex items-center gap-2 px-3 py-2 text-sm transition-colors hover:bg-accent-gray text-left"
+                style="color: var(--color-text-primary);"
+              >
+                <PencilSimpleIcon size={16} />
+                <span>Edit Details</span>
+              </button>
+              {#if events.length > 0}
+                <button
+                  role="menuitem"
+                  on:click={() => {
+                    overflowMenuOpen = false;
+                    openChangeCoverModal();
+                  }}
+                  class="w-full flex items-center gap-2 px-3 py-2 text-sm transition-colors hover:bg-accent-gray text-left"
+                  style="color: var(--color-text-primary);"
+                >
+                  <ImageIcon size={16} />
+                  <span>Change Cover</span>
+                </button>
+              {/if}
+              <button
+                role="menuitem"
+                on:click={() => {
+                  overflowMenuOpen = false;
+                  shareList();
+                }}
+                class="w-full flex items-center gap-2 px-3 py-2 text-sm transition-colors hover:bg-accent-gray text-left"
+                style="color: var(--color-text-primary);"
+              >
+                <ShareIcon size={16} />
+                <span>Share Link</span>
+              </button>
+              {#if !isDefaultList()}
+                <div class="my-1 mx-2 h-px" style="background-color: var(--color-input-border);"></div>
+                <button
+                  role="menuitem"
+                  on:click={() => {
+                    overflowMenuOpen = false;
+                    openDeleteConfirm();
+                  }}
+                  class="w-full flex items-center gap-2 px-3 py-2 text-sm transition-colors text-left text-red-500 hover:bg-red-500/10"
+                >
+                  <TrashIcon size={16} />
+                  <span>Delete Collection</span>
+                </button>
+              {/if}
+            </div>
+          {/if}
+        </div>
       </div>
+
+      {#if events.length > 0}
+        <p class="text-xs text-caption -mt-1">
+          Share this collection as a zappable Recipe Pack — anyone on Nostr can save it.
+        </p>
+      {/if}
     {/if}
 
     <!-- Recipes Feed -->
@@ -983,26 +1081,39 @@
       <Feed {events} {loaded} />
     {:else}
       <div class="flex flex-col items-center justify-center py-12 px-4">
-        <div class="w-16 h-16 rounded-full bg-gradient-to-br from-orange-100 to-amber-100 dark:from-orange-900/30 dark:to-amber-900/30 flex items-center justify-center mb-4">
+        <div
+          class="w-16 h-16 rounded-full bg-gradient-to-br from-orange-100 to-amber-100 dark:from-orange-900/30 dark:to-amber-900/30 flex items-center justify-center mb-4"
+        >
           <BookmarkIcon size={32} weight="regular" class="text-orange-500" />
         </div>
         <h3 class="text-lg font-medium mb-2" style="color: var(--color-text-primary)">
-          No recipes yet
+          No recipes in this collection yet.
         </h3>
         <p class="text-caption text-center max-w-sm mb-4">
           {#if isOwner}
-            Start adding recipes to this collection by tapping the save button on any recipe.
+            Add recipes by pasting their naddr, or save them from the recipe page.
           {:else}
             This collection doesn't have any recipes yet.
           {/if}
         </p>
-        <a
-          href="/recent"
-          class="flex items-center px-4 py-2 rounded-full font-medium text-sm transition-colors"
-          style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
-        >
-          Browse Recipes
-        </a>
+        <div class="flex flex-wrap items-center justify-center gap-2">
+          {#if isOwner && !offlineMode}
+            <button
+              on:click={openManageModal}
+              class="flex items-center gap-2 px-4 py-2 rounded-full font-medium text-sm text-white bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 transition-all"
+            >
+              <BookmarkIcon size={16} />
+              Manage Recipes
+            </button>
+          {/if}
+          <a
+            href="/recent"
+            class="flex items-center px-4 py-2 rounded-full font-medium text-sm transition-colors"
+            style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+          >
+            Browse Recipes
+          </a>
+        </div>
       </div>
     {/if}
   </div>

--- a/src/routes/pack/[naddr]/+page.svelte
+++ b/src/routes/pack/[naddr]/+page.svelte
@@ -33,7 +33,6 @@
   let notFound = false;
   let packEvent: NDKEvent | null = null;
   let recipeEvents: NDKEvent[] = [];
-  let recipeATagsToFetch: string[] = [];
   let isImporting = false;
   let importProgress = { current: 0, total: 0 };
   let lastSlug: string | null = null;
@@ -68,7 +67,6 @@
     notFound = false;
     packEvent = null;
     recipeEvents = [];
-    recipeATagsToFetch = [];
 
     const slug = $page.params.naddr;
     if (!slug?.startsWith('naddr1')) {
@@ -104,7 +102,6 @@
       }
       packEvent = found;
       const tags = found.tags.filter((t) => t[0] === 'a').map((t) => t[1]);
-      recipeATagsToFetch = tags;
       loaded = true; // header can render now
       await resolveRecipes(tags);
     } catch (err) {
@@ -396,7 +393,20 @@
         <!-- Subtle social action row -->
         <div class="flex items-center justify-between gap-3 pt-1 border-t" style="border-color: var(--color-input-border);">
           <div class="pt-2 flex items-center gap-2">
-            <NoteActionBar event={packEvent} variant="default" showComments={false} />
+            <!--
+              showRepost={false}: NoteRepost publishes a NIP-18 kind:6 wrapping
+              the inner event. The food feed renders kind:6 reposts only when
+              the inner kind is 1 or 1068 (see FoodstrFeedOptimized.expandRepostEvent),
+              so reposting a kind:30004 pack would silently drop in feeds.
+              TODO: when we persist a back-reference to the kind:1 announcement,
+              route repost to that event instead so it surfaces in feeds.
+            -->
+            <NoteActionBar
+              event={packEvent}
+              variant="default"
+              showComments={false}
+              showRepost={false}
+            />
             <!-- Comments link → generic event viewer (supports NIP-22 comments) -->
             <a
               href={naviewUrl}

--- a/src/routes/pack/[naddr]/+page.svelte
+++ b/src/routes/pack/[naddr]/+page.svelte
@@ -1,0 +1,555 @@
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { page } from '$app/stores';
+  import { goto } from '$app/navigation';
+  import { ndk, userPublickey } from '$lib/nostr';
+  import { NDKEvent } from '@nostr-dev-kit/ndk';
+  import { nip19 } from 'nostr-tools';
+  import { get } from 'svelte/store';
+
+  import PanLoader from '../../../components/PanLoader.svelte';
+  import NoteActionBar from '../../../components/NoteActionBar.svelte';
+  import Avatar from '../../../components/Avatar.svelte';
+  import CustomName from '../../../components/CustomName.svelte';
+  import ShareModal from '../../../components/ShareModal.svelte';
+  import { showToast } from '$lib/toast';
+  import { lazyLoad } from '$lib/lazyLoad';
+  import { getImageOrPlaceholder } from '$lib/placeholderImages';
+  import { offlineStorage } from '$lib/offlineStorage';
+  import { isOnline } from '$lib/connectionMonitor';
+  import { cookbookStore, cookbookLists } from '$lib/stores/cookbookStore';
+  import { buildPackUrl } from '$lib/recipePack';
+
+  import ArrowLeftIcon from 'phosphor-svelte/lib/ArrowLeft';
+  import BookmarkIcon from 'phosphor-svelte/lib/BookmarkSimple';
+  import BookmarkSimpleIcon from 'phosphor-svelte/lib/BookmarkSimple';
+  import CheckCircleIcon from 'phosphor-svelte/lib/CheckCircle';
+  import CircleNotchIcon from 'phosphor-svelte/lib/CircleNotch';
+  import ChatTeardropTextIcon from 'phosphor-svelte/lib/ChatTeardropText';
+  import LinkIcon from 'phosphor-svelte/lib/LinkSimple';
+  import WarningIcon from 'phosphor-svelte/lib/Warning';
+
+  let loaded = false;
+  let notFound = false;
+  let packEvent: NDKEvent | null = null;
+  let recipeEvents: NDKEvent[] = [];
+  let recipeATagsToFetch: string[] = [];
+  let isImporting = false;
+  let importProgress = { current: 0, total: 0 };
+  let lastSlug: string | null = null;
+
+  // Derived metadata
+  $: title = packEvent?.tags.find((t) => t[0] === 'title')?.[1] || 'Recipe Pack';
+  $: description = packEvent?.tags.find((t) => t[0] === 'description')?.[1] || '';
+  $: image = packEvent?.tags.find((t) => t[0] === 'image')?.[1];
+  $: creatorPubkey = packEvent?.pubkey || '';
+  $: aTags = packEvent?.tags.filter((t) => t[0] === 'a').map((t) => t[1]) || [];
+  $: recipeCount = aTags.length;
+  $: viewUrl = $page.params.naddr ? buildPackUrl($page.params.naddr) : '';
+
+  // OG meta
+  $: ogMeta = packEvent
+    ? {
+        title: `${title} — Recipe Pack on Zap Cooking`,
+        description:
+          description ||
+          `A curated Recipe Pack with ${recipeCount} ${recipeCount === 1 ? 'recipe' : 'recipes'}.`,
+        image: image || 'https://zap.cooking/social-share.png'
+      }
+    : null;
+
+  $: if (browser && $page.params.naddr && $page.params.naddr !== lastSlug) {
+    lastSlug = $page.params.naddr;
+    loadPack();
+  }
+
+  async function loadPack() {
+    loaded = false;
+    notFound = false;
+    packEvent = null;
+    recipeEvents = [];
+    recipeATagsToFetch = [];
+
+    const slug = $page.params.naddr;
+    if (!slug?.startsWith('naddr1')) {
+      notFound = true;
+      loaded = true;
+      return;
+    }
+
+    let pointer: nip19.AddressPointer;
+    try {
+      const decoded = nip19.decode(slug);
+      if (decoded.type !== 'naddr') throw new Error('not naddr');
+      pointer = decoded.data as nip19.AddressPointer;
+    } catch {
+      notFound = true;
+      loaded = true;
+      return;
+    }
+
+    try {
+      const fetchPromise = $ndk.fetchEvent({
+        kinds: [pointer.kind],
+        authors: [pointer.pubkey],
+        '#d': [pointer.identifier]
+      });
+      const timeout = new Promise<null>((resolve) => setTimeout(() => resolve(null), 12000));
+      const found = (await Promise.race([fetchPromise, timeout])) as NDKEvent | null;
+
+      if (!found) {
+        notFound = true;
+        loaded = true;
+        return;
+      }
+      packEvent = found;
+      const tags = found.tags.filter((t) => t[0] === 'a').map((t) => t[1]);
+      recipeATagsToFetch = tags;
+      loaded = true; // header can render now
+      await resolveRecipes(tags);
+    } catch (err) {
+      console.error('[pack] load failed', err);
+      notFound = true;
+      loaded = true;
+    }
+  }
+
+  async function resolveRecipes(aTags: string[]) {
+    if (aTags.length === 0) return;
+    // Cache-first
+    try {
+      const cached = await offlineStorage.getRecipes(aTags);
+      const cachedById = new Map(cached.map((c) => [c.id, c]));
+      const found: NDKEvent[] = [];
+      for (const aTag of aTags) {
+        const c = cachedById.get(aTag);
+        if (!c) continue;
+        const fake = new NDKEvent($ndk);
+        fake.kind = c.eventKind;
+        fake.pubkey = c.authorPubkey;
+        fake.created_at = c.createdAt;
+        fake.content = c.content;
+        fake.tags = c.eventTags;
+        fake.id = c.id;
+        found.push(fake);
+      }
+      recipeEvents = found;
+    } catch {
+      /* empty cache is fine */
+    }
+
+    if (!$isOnline) return;
+
+    // Fetch any missing
+    const haveIds = new Set(recipeEvents.map((e) => e.id));
+    const missing = aTags.filter((a) => !haveIds.has(a));
+    if (missing.length === 0) return;
+
+    await Promise.all(
+      missing.map(async (aTag) => {
+        const parts = aTag.split(':');
+        if (parts.length !== 3) return;
+        const [kind, pubkey, identifier] = parts;
+        try {
+          const e = await $ndk.fetchEvent({
+            kinds: [Number(kind)],
+            authors: [pubkey],
+            '#d': [identifier]
+          });
+          if (e) {
+            recipeEvents = [...recipeEvents, e];
+            try {
+              await offlineStorage.saveRecipeFromEvent(e);
+            } catch {}
+          }
+        } catch (err) {
+          console.warn('[pack] failed to fetch recipe', aTag, err);
+        }
+      })
+    );
+  }
+
+  function feedCardData(e: NDKEvent) {
+    const dTag = e.tags?.find((t) => t[0] === 'd')?.[1] || '';
+    const t = e.tags?.find((t) => t[0] === 'title')?.[1] || dTag || 'Untitled';
+    const summary = e.tags?.find((t) => t[0] === 'summary')?.[1] || '';
+    const rawImage = e.tags?.find((t) => t[0] === 'image')?.[1] || '';
+    const img = getImageOrPlaceholder(rawImage, e.id || dTag);
+    let link = '';
+    if (dTag && (e.author?.pubkey || e.pubkey)) {
+      try {
+        link = `/recipe/${nip19.naddrEncode({
+          identifier: dTag,
+          kind: e.kind || 30023,
+          pubkey: e.author?.pubkey || e.pubkey
+        })}`;
+      } catch {}
+    }
+    return { title: t, summary, image: img, link };
+  }
+
+  // ===== Import flow =====
+  async function importPack() {
+    if (isImporting) return;
+    if (!$userPublickey) {
+      showToast('info', 'Sign in to save this Recipe Pack to your cookbook.');
+      goto('/login');
+      return;
+    }
+    if (recipeEvents.length === 0) {
+      showToast('error', 'No recipes resolved yet — try again in a moment.');
+      return;
+    }
+
+    isImporting = true;
+    importProgress = { current: 0, total: recipeEvents.length };
+
+    try {
+      // Make sure we have the cookbook + default list ready
+      const state = get(cookbookStore);
+      if (!state.initialized) {
+        await cookbookStore.load();
+      }
+      const defaultList = await cookbookStore.ensureDefaultList();
+      if (!defaultList) {
+        showToast('error', 'Could not access your cookbook. Try again.');
+        return;
+      }
+
+      // Cache recipes for offline use as we go
+      for (let i = 0; i < recipeEvents.length; i++) {
+        importProgress.current = i + 1;
+        try {
+          await offlineStorage.saveRecipeFromEvent(recipeEvents[i]);
+        } catch {}
+      }
+
+      const result = await cookbookStore.bulkAddRecipesToList(defaultList.id, recipeEvents);
+      const { added, skipped, failed } = result;
+
+      if (added === 0 && skipped > 0) {
+        showToast('info', 'Already in your cookbook.');
+      } else if (added > 0 && skipped === 0) {
+        showToast('success', `Added ${added} ${added === 1 ? 'recipe' : 'recipes'} to your cookbook.`);
+      } else if (added > 0 && skipped > 0) {
+        showToast('success', `Added ${added}, skipped ${skipped} already saved.`);
+      } else if (failed > 0) {
+        showToast('error', 'Could not save the pack. Try again.');
+      }
+    } catch (err) {
+      console.error('[pack] import failed', err);
+      showToast('error', 'Failed to save Recipe Pack.');
+    } finally {
+      isImporting = false;
+      importProgress = { current: 0, total: 0 };
+    }
+  }
+
+  // Did the user already save every recipe in this pack?
+  $: allSaved = (() => {
+    if (!$userPublickey || aTags.length === 0) return false;
+    const allTags = new Set<string>();
+    for (const list of $cookbookLists) {
+      for (const r of list.recipes) allTags.add(r);
+    }
+    return aTags.every((a) => allTags.has(a));
+  })();
+
+  $: isOwnPack = !!$userPublickey && creatorPubkey === $userPublickey;
+
+  // Share modal (short link + social share + QR), reused from recipe page.
+  let shareModalOpen = false;
+</script>
+
+<svelte:head>
+  <title>{ogMeta?.title || 'Recipe Pack — Zap Cooking'}</title>
+  {#if ogMeta}
+    <meta name="description" content={ogMeta.description} />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content={ogMeta.title} />
+    <meta property="og:description" content={ogMeta.description} />
+    <meta property="og:image" content={ogMeta.image} />
+    <meta property="og:url" content={`https://zap.cooking/pack/${$page.params.naddr}`} />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={ogMeta.title} />
+    <meta name="twitter:description" content={ogMeta.description} />
+    <meta name="twitter:image" content={ogMeta.image} />
+  {/if}
+</svelte:head>
+
+<!-- Share modal (short link / native / social / QR) — same one recipes use -->
+<ShareModal
+  bind:open={shareModalOpen}
+  url={viewUrl}
+  title={title || 'Recipe Pack'}
+  imageUrl={image || ''}
+/>
+
+{#if !loaded}
+  <div class="flex justify-center items-center page-loader">
+    <PanLoader />
+  </div>
+{:else if notFound || !packEvent}
+  <div class="flex flex-col items-center justify-center py-16 px-4">
+    <div
+      class="w-16 h-16 rounded-full bg-amber-100 dark:bg-amber-900/30 flex items-center justify-center mb-4"
+    >
+      <WarningIcon size={32} class="text-amber-600 dark:text-amber-400" />
+    </div>
+    <h1 class="text-xl font-semibold mb-2" style="color: var(--color-text-primary)">
+      Recipe Pack not found
+    </h1>
+    <p class="text-caption text-center max-w-md mb-4">
+      This pack may have been deleted, or your relays don't have it yet. Try again later, or browse
+      your cookbook.
+    </p>
+    <a
+      href="/cookbook"
+      class="flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 text-white rounded-full font-medium transition-all"
+    >
+      <ArrowLeftIcon size={18} />
+      Go to Cookbook
+    </a>
+  </div>
+{:else}
+  {@const naviewUrl = `/${$page.params.naddr}`}
+  {@const stillLoadingRecipes = recipeEvents.length < recipeCount}
+  <div class="flex flex-col gap-4">
+    <!-- Back link -->
+    <div>
+      <a
+        href="/cookbook"
+        class="inline-flex items-center gap-1.5 text-sm text-caption hover:text-primary transition-colors"
+      >
+        <ArrowLeftIcon size={16} />
+        <span>Cookbook</span>
+      </a>
+    </div>
+
+    <!-- Compact pack header -->
+    <header
+      class="relative rounded-2xl overflow-hidden"
+      style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+    >
+      <!-- Banner -->
+      <div class="relative w-full h-[140px] sm:h-[200px] pack-banner">
+        {#if image}
+          <div use:lazyLoad={{ url: getImageOrPlaceholder(image, packEvent.id || title) }} class="absolute inset-0 pack-banner-img"></div>
+        {:else}
+          <div
+            class="absolute inset-0"
+            style="background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 50%, #f97316 100%);"
+          ></div>
+        {/if}
+        <div class="absolute inset-0 bg-gradient-to-t from-black/55 via-black/15 to-transparent"></div>
+        <div class="absolute top-3 left-3 flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-black/55 text-white text-xs font-medium backdrop-blur-sm">
+          <BookmarkSimpleIcon size={12} weight="fill" />
+          <span>Recipe Pack</span>
+        </div>
+        {#if isOwnPack}
+          <div class="absolute top-3 right-3 px-2.5 py-1 rounded-full bg-white/15 text-white text-xs font-semibold backdrop-blur-sm">
+            This is your pack
+          </div>
+        {/if}
+      </div>
+
+      <!-- Metadata -->
+      <div class="p-4 sm:p-5 flex flex-col gap-3">
+        <div class="flex flex-col gap-1">
+          <h1
+            class="text-xl sm:text-2xl font-bold leading-tight"
+            style="color: var(--color-text-primary)"
+          >
+            {title}
+          </h1>
+          {#if description}
+            <p class="text-sm text-caption whitespace-pre-line line-clamp-3">{description}</p>
+          {/if}
+        </div>
+
+        <!-- Creator + count line -->
+        <div class="flex items-center gap-2 flex-wrap text-sm">
+          {#if creatorPubkey}
+            <a
+              href={`/user/${nip19.npubEncode(creatorPubkey)}`}
+              class="flex items-center gap-2 min-w-0 hover:opacity-80 transition-opacity"
+            >
+              <Avatar pubkey={creatorPubkey} size={24} showRing={false} />
+              <span class="truncate" style="color: var(--color-text-secondary)">
+                <CustomName pubkey={creatorPubkey} />
+              </span>
+            </a>
+            <span class="text-caption">·</span>
+          {/if}
+          <span class="text-caption">
+            {recipeCount} {recipeCount === 1 ? 'recipe' : 'recipes'}
+          </span>
+          {#if stillLoadingRecipes}
+            <span class="text-caption">·</span>
+            <span class="text-caption flex items-center gap-1">
+              <CircleNotchIcon size={12} class="animate-spin" />
+              Loading {recipeCount - recipeEvents.length} more
+            </span>
+          {/if}
+        </div>
+
+        <!-- Subtle social action row -->
+        <div class="flex items-center justify-between gap-3 pt-1 border-t" style="border-color: var(--color-input-border);">
+          <div class="pt-2 flex items-center gap-2">
+            <NoteActionBar event={packEvent} variant="default" showComments={false} />
+            <!-- Comments link → generic event viewer (supports NIP-22 comments) -->
+            <a
+              href={naviewUrl}
+              class="flex items-center gap-1.5 px-1.5 py-1 rounded text-caption hover:bg-accent-gray transition-colors"
+              title="Open comments"
+              aria-label="Open comments"
+            >
+              <ChatTeardropTextIcon size={20} />
+            </a>
+            <!-- Share (short link, social, QR) -->
+            <button
+              type="button"
+              on:click={() => (shareModalOpen = true)}
+              class="flex items-center gap-1.5 px-1.5 py-1 rounded text-caption hover:bg-accent-gray transition-colors"
+              title="Share"
+              aria-label="Share"
+            >
+              <LinkIcon size={20} />
+            </button>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <!-- Primary CTA -->
+    <div class="flex flex-wrap gap-2 items-center">
+      {#if isOwnPack}
+        <a
+          href="/cookbook"
+          class="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-colors"
+          style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+        >
+          <BookmarkIcon size={16} />
+          Open your cookbook
+        </a>
+      {:else if allSaved}
+        <span
+          class="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium"
+          style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+        >
+          <CheckCircleIcon size={16} weight="fill" class="text-green-500" />
+          Saved in your cookbook
+        </span>
+      {:else}
+        <button
+          on:click={importPack}
+          disabled={isImporting || recipeEvents.length === 0}
+          class="flex items-center gap-2 px-5 py-2.5 bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 text-white rounded-full font-semibold transition-all shadow-md shadow-orange-500/25 disabled:opacity-60 disabled:cursor-not-allowed disabled:shadow-none"
+        >
+          {#if isImporting}
+            <CircleNotchIcon size={16} class="animate-spin" />
+            <span>Saving {importProgress.current}/{importProgress.total}…</span>
+          {:else}
+            <BookmarkIcon size={16} weight="fill" />
+            <span>Save Pack to Cookbook</span>
+          {/if}
+        </button>
+      {/if}
+    </div>
+
+    <!-- Recipe grid (matches cookbook feed view) -->
+    {#if recipeCount === 0}
+      <div class="text-caption text-sm text-center py-8">This pack has no recipes.</div>
+    {:else}
+      <div class="flex items-center justify-between gap-2 pt-1">
+        <h2 class="text-sm font-semibold uppercase tracking-wide text-caption">
+          {recipeCount} {recipeCount === 1 ? 'recipe' : 'recipes'} included
+        </h2>
+        {#if recipeEvents.length > 0 && recipeEvents.length < recipeCount}
+          <span class="text-xs text-caption">
+            Showing {recipeEvents.length} so far — some recipes are still loading from relays.
+          </span>
+        {/if}
+      </div>
+      <div class="grid gap-4 sm:gap-5 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+        {#each recipeEvents as e (e.id || feedCardData(e).link)}
+          {@const card = feedCardData(e)}
+          {#if card.link}
+            <a
+              href={card.link}
+              class="group flex flex-col rounded-2xl overflow-hidden transition-transform duration-200 hover:scale-[1.01] hover:shadow-xl"
+              style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+            >
+              <div class="relative w-full aspect-[4/3] overflow-hidden pack-recipe-image-wrap">
+                <div
+                  use:lazyLoad={{ url: card.image }}
+                  class="absolute inset-0 pack-recipe-image group-hover:scale-105 transition-transform duration-700 ease-in-out"
+                ></div>
+              </div>
+              <div class="p-3 sm:p-4 flex flex-col gap-1">
+                <h3
+                  class="text-base sm:text-lg font-semibold leading-snug line-clamp-2"
+                  style="color: var(--color-text-primary);"
+                >
+                  {card.title}
+                </h3>
+                {#if card.summary}
+                  <p class="text-sm text-caption line-clamp-2">{card.summary}</p>
+                {/if}
+              </div>
+            </a>
+          {/if}
+        {/each}
+
+        <!-- Skeletons for unresolved recipes -->
+        {#if recipeEvents.length < recipeCount}
+          {#each Array(Math.min(3, recipeCount - recipeEvents.length)) as _}
+            <div
+              class="rounded-2xl overflow-hidden animate-pulse"
+              style="background-color: var(--color-input-bg);"
+            >
+              <div
+                class="w-full aspect-[4/3]"
+                style="background-color: var(--color-accent-gray);"
+              ></div>
+              <div class="p-3 sm:p-4 flex flex-col gap-2">
+                <div class="h-4 w-3/4 rounded" style="background-color: var(--color-accent-gray);"></div>
+                <div class="h-3 w-1/2 rounded" style="background-color: var(--color-accent-gray);"></div>
+              </div>
+            </div>
+          {/each}
+        {/if}
+      </div>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .pack-banner {
+    background-color: var(--color-accent-gray);
+  }
+  .pack-banner-img {
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    opacity: 0;
+    transition: opacity 0.3s ease-in;
+  }
+  .pack-banner-img:global(.image-loaded) {
+    opacity: 1;
+  }
+
+  .pack-recipe-image-wrap {
+    background-color: var(--color-accent-gray);
+  }
+  .pack-recipe-image {
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    opacity: 0;
+    transition: opacity 0.3s ease-in;
+  }
+  .pack-recipe-image:global(.image-loaded) {
+    opacity: 1;
+  }
+</style>

--- a/src/routes/pack/[naddr]/+page.svelte
+++ b/src/routes/pack/[naddr]/+page.svelte
@@ -6,6 +6,7 @@
   import { NDKEvent } from '@nostr-dev-kit/ndk';
   import { nip19 } from 'nostr-tools';
   import { get } from 'svelte/store';
+  import { onMount } from 'svelte';
 
   import PanLoader from '../../../components/PanLoader.svelte';
   import NoteActionBar from '../../../components/NoteActionBar.svelte';
@@ -213,9 +214,10 @@
         return;
       }
 
-      // Cache recipes for offline use as we go
+      // Cache recipes for offline use as we go.
+      // Reassign importProgress (don't mutate in place) so Svelte re-renders the label.
       for (let i = 0; i < recipeEvents.length; i++) {
-        importProgress.current = i + 1;
+        importProgress = { current: i + 1, total: recipeEvents.length };
         try {
           await offlineStorage.saveRecipeFromEvent(recipeEvents[i]);
         } catch {}
@@ -242,9 +244,29 @@
     }
   }
 
+  // Subscribe to the store so we know when it's been hydrated from
+  // Nostr/IndexedDB. Without this, `allSaved` would compute against an
+  // empty list and the "Save Pack" CTA could mislead users who already
+  // have these recipes.
+  $: cookbookInitialized = $cookbookStore.initialized;
+
+  // Trigger a load on mount when logged in so allSaved reflects reality
+  // before the user has to click anything.
+  onMount(() => {
+    if (browser && $userPublickey && !get(cookbookStore).initialized) {
+      cookbookStore.load();
+    }
+  });
+
+  // Re-check if the user logs in after the page is already mounted.
+  $: if (browser && $userPublickey && !cookbookInitialized) {
+    cookbookStore.load();
+  }
+
   // Did the user already save every recipe in this pack?
   $: allSaved = (() => {
     if (!$userPublickey || aTags.length === 0) return false;
+    if (!cookbookInitialized) return false;
     const allTags = new Set<string>();
     for (const list of $cookbookLists) {
       for (const r of list.recipes) allTags.add(r);


### PR DESCRIPTION
## Summary

Adds **Recipe Packs** — shareable, zappable curated lists of recipes published as NIP-51 curation sets (kind 30004) — and refreshes the cookbook UX around them.

### Cookbook (`/cookbook`)
- **Packs / Feed view toggle** (URL-synced via `?view=`).
- **Sort** (Recently added · Recently updated · A–Z) and **per-collection filter** in feed view; both URL-synced.
- **Big-image feed cards** — 1 col mobile, 2–3 col desktop; cache-first via `offlineStorage`.
- The **"My Recipes" tile** flips into feed view when there are any saves and shows a clear empty CTA when there aren't.
- Header **"Add" dropdown** — Add recipe / Import recipe / New collection.

### Collection page (`/cookbook/[naddr]`)
- Tighter hero with cover or branded gradient + "Updated …" relative timestamp from the list event's `created_at`.
- **Primary "Share Pack"** button (gradient) + secondary "Manage Recipes" + overflow `…` menu (Edit Details / Change Cover / Share Link / Delete).
- Empty state with Manage Recipes CTA.

### Recipe Packs
- `src/lib/recipePack.ts` — `buildRecipePackEvent` / `publishRecipePack` (kind 30004 with `a`-tag refs to recipes, `t: recipe-pack`, social-readable `content`), optional `publishPackAnnouncement` (kind:1 with `nostr:naddr`), `resolveFirstRecipeImage` for the cover fallback.
- **`SharePackModal`** — title / description form, live preview (`RecipePackCard`), "Also share to feed" toggle (default on), reuses the recipe `ShareModal` post-publish for short link / native share / social / QR.
- **`RecipePackCard`** — reusable card (cover, title, description, creator, recipe count, optional Zap + View) for in-app rendering.
- One **`bulkAddRecipesToList`** added to `cookbookStore` so imports publish a single merged 30001 event instead of N.

### Public pack page (`/pack/[naddr]`)
- Compact hero (140 / 200px banner), creator profile, recipe count, "This is your pack" badge for owners.
- **Subtle social action row** via the existing `NoteActionBar` (likes / repost / zap-to-creator) plus a Comments link to the generic `/<naddr>` viewer (NIP-22) and a Share button that opens the recipe-style `ShareModal`.
- **"Save Pack to Cookbook"** primary CTA — uses `bulkAddRecipesToList`, dedupes, shows added / skipped / already-saved states.
- Cache-first recipe resolution; partial-load and not-found states.

## Schema

| | kind | tags |
|---|---|---|
| Pack | `30004` | `d` (`zapcooking-cookbook` for cookbook share, `zapcooking-pack-<dTag>` for collection share), `title`, `description`, `image`, `t: recipe-pack`, `t: zap-cooking`, `t: zapcooking`, `a` per recipe with relay hint, `client` |
| Announcement (optional) | `1` | `a` → pack, `t: recipe-pack`, `t: zap-cooking`, `client`; content links via `nostr:naddr...` |

## Test plan

- [ ] Cookbook `Packs / Feed` toggle, sort, and filter all stick across reload (via URL).
- [ ] My Recipes tile click → feed view; empty state shows Save CTA.
- [ ] "Share Cookbook" / "Share Pack" → modal previews with auto-resolved cover, publishes pack (and optional kind:1) cleanly.
- [ ] Open `/pack/<naddr>`: hero is compact, recipes appear above the fold, Like / Repost / Zap render counts, Zap targets the creator.
- [ ] Save Pack imports recipes via one cookbook publish; re-import shows "Saved in your cookbook"; own pack shows "This is your pack".
- [ ] Generic Nostr clients render the kind:1 announcement; clients that recognize 30004 render the pack content as readable text.
- [ ] Offline: cookbook + pack page load from cache; sync queue absorbs offline imports.
- [ ] Mobile layouts: hero, action rows, dropdowns wrap cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)