### PR TITLE
feat(login): copy-link toast, nsec security note, modal cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.293",
+  "version": "4.2.294",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/LoginFormIOS.svelte
+++ b/src/components/LoginFormIOS.svelte
@@ -398,6 +398,11 @@
 <Modal bind:open={nsecModal} on:close={modalCleanup}>
   <svelte:fragment slot="title">🔑 Log in with Private Key</svelte:fragment>
   <div class="flex flex-col gap-4">
+    <div class="bg-input border rounded-lg p-3" style="border-color: var(--color-input-border)">
+      <p class="text-sm text-caption">
+        Your key stays on this device only — it isn't sent to any server. Keep a backup of your nsec; if you lose it, you lose access to your account.
+      </p>
+    </div>
     <div class="text-sm text-caption">Enter your private key (nsec1...) or hex format</div>
     <input
       bind:value={nsecInput}
@@ -412,7 +417,6 @@
       <Button on:click={loginWithPrivateKey} primary={true} disabled={authState.isLoading}>
         {authState.isLoading ? '⚡ Connecting...' : '⚡ Login'}
       </Button>
-      <Button on:click={modalCleanup} primary={false} disabled={authState.isLoading}>Cancel</Button>
     </div>
   </div>
 </Modal>
@@ -478,9 +482,6 @@
       >
         {bunkerConnecting ? '⏳ Connecting...' : '🔐 Connect'}
       </Button>
-      <Button on:click={modalCleanup} primary={false} disabled={bunkerConnecting || authState.isLoading}
-        >Cancel</Button
-      >
     </div>
   </div>
 </Modal>

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -15,6 +15,7 @@
   import { platformIsIOS } from '$lib/platform';
   import LoginFormIOS from '../../components/LoginFormIOS.svelte';
   import SuggestedFollowsModal from '../../components/SuggestedFollowsModal.svelte';
+  import { showToast } from '$lib/toast';
 
   let authManager: any = null;
   let authState: AuthState = {
@@ -297,9 +298,13 @@
     }
   }
 
-  function copyToClipboard(text: string) {
-    if (browser) {
-      navigator.clipboard.writeText(text);
+  async function copyToClipboard(text: string) {
+    if (!browser) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      showToast('success', 'Link copied');
+    } catch {
+      showToast('error', 'Could not copy — copy the link manually');
     }
   }
 
@@ -489,6 +494,11 @@
   <Modal bind:open={nsecModal} on:close={modalCleanup}>
     <svelte:fragment slot="title">🔑 Log in with Private Key</svelte:fragment>
     <div class="flex flex-col gap-4">
+      <div class="bg-input border rounded-lg p-3" style="border-color: var(--color-input-border)">
+        <p class="text-sm text-caption">
+          Your key stays in this browser only — it isn't sent to any server. Keep a backup of your nsec; if you lose it, you lose access to your account.
+        </p>
+      </div>
       <div class="text-sm text-caption">Enter your private key (nsec1...) or hex format</div>
       <input
         bind:value={nsecInput}
@@ -503,9 +513,6 @@
         <Button on:click={loginWithPrivateKey} primary={true} disabled={authState.isLoading}>
           {authState.isLoading ? '⚡ Connecting...' : '⚡ Login'}
         </Button>
-        <Button on:click={modalCleanup} primary={false} disabled={authState.isLoading}
-          >Cancel</Button
-        >
       </div>
     </div>
   </Modal>
@@ -579,14 +586,13 @@
         >
           {bunkerConnecting ? '⏳ Connecting...' : '🔐 Connect'}
         </Button>
-        <Button on:click={modalCleanup} primary={false} disabled={bunkerConnecting}>Cancel</Button>
       </div>
     </div>
   </Modal>
 
   <!-- Universal NIP-46 Pairing Modal -->
   <Modal bind:open={nip46UniversalModal} on:close={modalCleanup}>
-    <svelte:fragment slot="title">📷 Scan QR / Universal pairing</svelte:fragment>
+    <svelte:fragment slot="title"><span class="mr-2">📷</span>Scan QR / Universal pairing</svelte:fragment>
     <div class="flex flex-col gap-4">
       <div class="bg-input border rounded-lg p-3" style="border-color: var(--color-input-border)">
         <p class="text-sm text-caption">
@@ -651,9 +657,6 @@
         </div>
       {/if}
 
-      <div class="flex gap-2">
-        <Button on:click={modalCleanup} primary={false} disabled={false}>Cancel</Button>
-      </div>
     </div>
   </Modal>
 


### PR DESCRIPTION
## Summary

Three small login UX improvements plus one consistency cleanup.

### 1. Toast feedback when copying the NIP-46 pairing link

Previously \`copyToClipboard\` fired \`navigator.clipboard.writeText\` and gave no signal — the user had no way to tell whether the link reached the clipboard. Now wires \`showToast\` from \`\$lib/toast\` with success ("Link copied") and error ("Could not copy — copy the link manually") variants.

### 2. Inline security note in the nsec import modal (desktop + iOS)

Sets expectations before the user pastes their private key — that it stays in this browser / device only and that they should keep a backup. Uses the project's existing \`bg-input border rounded-lg p-3\` note pattern, matching the bunker modal's info block. Applied to both \`src/routes/login/+page.svelte\` and \`src/components/LoginFormIOS.svelte\`.

### 3. Camera emoji spacing on the Universal Pairing modal title

The 📷 emoji was rendering flush against "Scan QR / …". Wrapped it in \`<span class="mr-2">\` so the title reads with breathing room.

### 4. Drop redundant Cancel buttons from login modals

Modal.svelte already renders an X close icon in the header. The login modals (nsec, bunker-paste, universal-pairing — on both desktop and iOS, five places total) also had a "Cancel" button — a second dismiss affordance for the same action. Removed; the X is the single dismiss path now.

## Scope

- 2 files: \`src/routes/login/+page.svelte\`, \`src/components/LoginFormIOS.svelte\`.
- No new dependencies, no API changes, no behavior changes outside the explicit improvements above.

## Test plan

- [x] \`bun run check\` — 0 errors, no new warnings.
- [ ] \`/login\` (desktop): open *Scan QR / Universal pairing*, click *Copy Link* → success toast appears.
- [ ] \`/login\` (desktop): open *Log in with Private Key* → security note visible at the top of the modal.
- [ ] \`/login\` (desktop): open *Paste bunker URI* → no Cancel button (X dismisses).
- [ ] \`/login\` (desktop): *Scan QR / Universal pairing* title shows clear space between camera emoji and "Scan QR".
- [ ] iOS: same checks against \`LoginFormIOS\` (nsec note present, Cancel buttons gone).