### PR TITLE
fix(packs): Publish Recipe Pack button silently no-op'd

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.296",
+  "version": "4.2.297",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/SharePackModal.svelte
+++ b/src/components/SharePackModal.svelte
@@ -71,6 +71,13 @@
   }
 
   async function handlePublish() {
+    console.log('[SharePackModal] handlePublish entered', {
+      titleLen: title.trim().length,
+      recipeCount,
+      hasUser: !!$userPublickey,
+      isSubmitting
+    });
+    if (isSubmitting) return;
     error = '';
     if (!title.trim()) {
       error = 'Please enter a title.';
@@ -144,7 +151,15 @@
   <h1 slot="title">Share Recipe Pack</h1>
 
   {#if !publishedUrl}
-    <form on:submit|preventDefault={handlePublish} class="flex flex-col gap-4">
+    <!--
+      Using a <div> + on:click on the Publish button rather than
+      <form on:submit>+<button type="submit">. The Modal portals
+      content into a <dialog> element, and inside <dialog> some
+      browsers swallow or reroute form-submit events depending on
+      focus/method state, which made the Publish button silently
+      no-op for some users. Direct on:click is unambiguous.
+    -->
+    <div class="flex flex-col gap-4">
       <p class="text-sm text-caption">
         Publish your saved recipes as a curated pack. Anyone on Nostr can open it,
         zap it, and zaps go to you.
@@ -221,11 +236,11 @@
 
       <div class="flex justify-end gap-2 pt-1">
         <Button on:click={handleClose} primary={false} disabled={isSubmitting}>Cancel</Button>
-        <Button type="submit" disabled={!canPublish}>
+        <Button on:click={handlePublish} disabled={!canPublish}>
           {isSubmitting ? 'Publishing…' : 'Publish Recipe Pack'}
         </Button>
       </div>
-    </form>
+    </div>
   {:else}
     <div class="flex flex-col gap-4">
       <p class="text-sm" style="color: var(--color-text-primary)">


### PR DESCRIPTION
## Summary

After #350 shipped, the **Publish Recipe Pack** button in `SharePackModal` was a no-op: clicking it produced no visible feedback, no log, and no published event. The Cancel button worked normally.

## Root cause

`Modal.svelte` portals its slot content into a `<dialog>` element. Inside `<dialog>`, a `<button type="submit">` inside a `<form>` can have its submit event swallowed or rerouted depending on focus state and dialog-method handling — known browser quirk. Cancel worked because it used a direct `on:click` handler, bypassing the form-submit path entirely.

## Fix

Drop the form-submit path. Replace `<form on:submit|preventDefault={handlePublish}>` with a `<div>` and switch the Publish button from `type="submit"` to `on:click={handlePublish}` — same pattern Cancel already used. Also added an entry log to `handlePublish` and an `isSubmitting` re-entry guard.

## Test plan

- [ ] Open `/cookbook`, click "Share Pack" on any non-empty collection.
- [ ] Confirm console shows `[SharePackModal] handlePublish entered { … }` when Publish is clicked.
- [ ] Pack publishes and the kind:1 announcement (when toggle is on) lands in feeds.
- [ ] Cancel still closes the modal.
- [ ] Publishing while already submitting does not double-fire (re-entry guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)