### PR TITLE
fix(packs): Publish button still silently no-oping after #352

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.297",
+  "version": "4.2.298",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/SharePackModal.svelte
+++ b/src/components/SharePackModal.svelte
@@ -38,7 +38,6 @@
   let copied = false;
 
   $: recipeCount = recipeATags.length;
-  $: canPublish = !isSubmitting && recipeCount > 0 && title.trim().length > 0;
 
   // Reset state every time the modal opens
   $: if (open) initStateOnOpen();
@@ -234,9 +233,16 @@
         <p class="text-sm text-red-500">{error}</p>
       {/if}
 
+      <!--
+        The Publish button is always clickable (only blocked while a
+        publish is in flight). Validation runs inside handlePublish and
+        surfaces user-readable error text — that way clicks never
+        silently no-op due to a stale `canPublish` reactive value or a
+        race between modal-open and the title prop landing.
+      -->
       <div class="flex justify-end gap-2 pt-1">
         <Button on:click={handleClose} primary={false} disabled={isSubmitting}>Cancel</Button>
-        <Button on:click={handlePublish} disabled={!canPublish}>
+        <Button on:click={handlePublish} disabled={isSubmitting}>
           {isSubmitting ? 'Publishing…' : 'Publish Recipe Pack'}
         </Button>
       </div>


### PR DESCRIPTION
## Summary

After #352 shipped, users still report the **Publish Recipe Pack** button does nothing on click — no log, no error, no published event. Cancel works.

## Root cause

The button is `disabled={!canPublish}`. The reactive \`canPublish\` value can briefly be false at the moment of click for several reasons:

- **Open-and-init reactive ordering.** When the parent flips \`open=true\`, props arrive in one tick but \`title\` only gets set inside \`initStateOnOpen()\`, which runs on the same tick. The first reactive computation of \`canPublish\` runs against the previous (empty) \`title\`, then a second pass updates it.
- **A premature click** (between modal open and the prop landing) hits the disabled state.
- **A disabled \`<button>\` dispatches no click events at all** — so \`handlePublish\` never fires and the user gets no feedback at all.

## Fix

Make the Publish button only disabled while a publish is in flight (\`disabled={isSubmitting}\`). The handler already validates title / recipe count / signed-in state and sets a visible error message for each — so a premature or invalid click now produces real feedback (\"Please enter a title.\" / \"There are no recipes to share.\" / \"Sign in to share a Recipe Pack.\") instead of silent failure.

Drop the now-unused \`canPublish\` derived state.

## Test plan

- [ ] Open Share Pack on a populated cookbook → click Publish → see \`[SharePackModal] handlePublish entered { … }\` in console and the success toast.
- [ ] Open Share Pack, clear the title, click Publish → see the \"Please enter a title.\" error in the modal.
- [ ] Open Share Pack on an empty collection (shouldn't be reachable in practice) → see the \"There are no recipes to share.\" error.
- [ ] Sign out, attempt → see the sign-in prompt error.
- [ ] Cancel still closes the modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)