### PR TITLE
feat(packs): browse page at /packs (Discover / Mine)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.308",
+  "version": "4.2.309",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.303",
+  "version": "4.2.304",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.309",
+  "version": "4.2.310",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.302",
+  "version": "4.2.303",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.305",
+  "version": "4.2.306",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.304",
+  "version": "4.2.305",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.301",
+  "version": "4.2.302",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.307",
+  "version": "4.2.308",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.306",
+  "version": "4.2.307",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/RecipePackCard.svelte
+++ b/src/components/RecipePackCard.svelte
@@ -6,7 +6,7 @@
   import ShareModal from './ShareModal.svelte';
   import BookmarkSimpleIcon from 'phosphor-svelte/lib/BookmarkSimple';
   import ChatTeardropTextIcon from 'phosphor-svelte/lib/ChatTeardropText';
-  import LinkSimpleIcon from 'phosphor-svelte/lib/LinkSimple';
+  import ShareIcon from 'phosphor-svelte/lib/Share';
   import { lazyLoad } from '$lib/lazyLoad';
   import { getImageOrPlaceholder } from '$lib/placeholderImages';
   import { savedPacksStore } from '$lib/savedPacksStore';
@@ -87,44 +87,51 @@
   style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
 >
   <!-- Image is the primary tap target into the pack -->
-  {#if viewUrl}
-    <a href={viewUrl} class="block relative w-full aspect-[16/9] pack-image-wrap group">
-      <div
-        use:lazyLoad={{ url: resolvedImage }}
-        class="absolute inset-0 pack-image group-hover:scale-[1.02] transition-transform duration-500 ease-in-out"
-      ></div>
-      <div
-        class="absolute top-3 left-3 flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-black/55 text-white text-xs font-medium backdrop-blur-sm"
-      >
-        <BookmarkSimpleIcon size={12} weight="fill" />
-        <span>Recipe Pack</span>
-      </div>
-      {#if preview}
+  <div class="relative w-full aspect-[16/9] pack-image-wrap">
+    {#if viewUrl}
+      <a href={viewUrl} class="absolute inset-0 group" aria-label={title || 'Open Recipe Pack'}>
         <div
-          class="absolute top-3 right-3 px-2.5 py-1 rounded-full bg-amber-500/90 text-white text-xs font-semibold shadow"
-        >
-          Preview
-        </div>
-      {/if}
-    </a>
-  {:else}
-    <div class="relative w-full aspect-[16/9] pack-image-wrap">
+          use:lazyLoad={{ url: resolvedImage }}
+          class="absolute inset-0 pack-image group-hover:scale-[1.02] transition-transform duration-500 ease-in-out"
+        ></div>
+      </a>
+    {:else}
       <div use:lazyLoad={{ url: resolvedImage }} class="absolute inset-0 pack-image"></div>
-      <div
-        class="absolute top-3 left-3 flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-black/55 text-white text-xs font-medium backdrop-blur-sm"
-      >
-        <BookmarkSimpleIcon size={12} weight="fill" />
-        <span>Recipe Pack</span>
-      </div>
-      {#if preview}
-        <div
-          class="absolute top-3 right-3 px-2.5 py-1 rounded-full bg-amber-500/90 text-white text-xs font-semibold shadow"
-        >
-          Preview
-        </div>
-      {/if}
+    {/if}
+
+    <!-- Top-left: Recipe Pack badge — non-interactive, sits over the link -->
+    <div
+      class="absolute top-3 left-3 flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-black/55 text-white text-xs font-medium backdrop-blur-sm pointer-events-none"
+    >
+      <BookmarkSimpleIcon size={12} weight="fill" />
+      <span>Recipe Pack</span>
     </div>
-  {/if}
+
+    <!-- Top-right: bookmark/save (matches recipe-card design language).
+         Hidden in preview mode (the modal preview shows a "Preview"
+         pill there instead). -->
+    {#if preview}
+      <div
+        class="absolute top-3 right-3 px-2.5 py-1 rounded-full bg-amber-500/90 text-white text-xs font-semibold shadow"
+      >
+        Preview
+      </div>
+    {:else if event}
+      <button
+        type="button"
+        on:click|preventDefault|stopPropagation={handleBookmark}
+        disabled={bookmarkBusy}
+        class="absolute top-3 right-3 w-9 h-9 flex items-center justify-center rounded-full bg-black/55 hover:bg-black/70 backdrop-blur-sm transition-colors disabled:opacity-50"
+        class:text-amber-400={isBookmarked}
+        style={isBookmarked ? '' : 'color: white;'}
+        title={isBookmarked ? 'Remove from saved' : 'Save pack'}
+        aria-label={isBookmarked ? 'Remove from saved' : 'Save pack'}
+        aria-pressed={isBookmarked}
+      >
+        <BookmarkSimpleIcon size={18} weight={isBookmarked ? 'fill' : 'regular'} />
+      </button>
+    {/if}
+  </div>
 
   <div class="p-3 sm:p-4 flex flex-col gap-2">
     <!-- Title (also clickable into pack) -->
@@ -173,12 +180,20 @@
          comment link to the generic NIP-19 viewer (which does support
          NIP-22 comments for kind 30004). -->
     {#if !preview && event}
+      <!-- Social action row.
+           Left:  reactions/repost/zap from NoteActionBar.
+           Right: comments + share — these were "View Pack →" before but
+           the image/title click already opens the pack, so the space is
+           better used for actions. Bookmark lives in the cover top-right
+           (matches recipe-card design). -->
       <div
         class="flex items-center justify-between gap-1 pt-1 border-t -mx-3 sm:-mx-4 px-3 sm:px-4 mt-1"
         style="border-color: var(--color-input-border);"
       >
         <div class="pt-2 flex items-center gap-1 flex-wrap">
           <NoteActionBar {event} variant="default" showComments={false} />
+        </div>
+        <div class="pt-2 flex items-center gap-1">
           {#if commentsHref}
             <a
               href={commentsHref}
@@ -196,30 +211,9 @@
             title="Share"
             aria-label="Share"
           >
-            <LinkSimpleIcon size={20} />
-          </button>
-          <button
-            type="button"
-            on:click={handleBookmark}
-            disabled={bookmarkBusy}
-            class="flex items-center gap-1 px-1.5 py-1 rounded transition-colors hover:bg-accent-gray disabled:opacity-50"
-            class:text-amber-500={isBookmarked}
-            style={isBookmarked ? '' : 'color: var(--color-text-secondary);'}
-            title={isBookmarked ? 'Remove from saved' : 'Save pack'}
-            aria-label={isBookmarked ? 'Remove from saved' : 'Save pack'}
-            aria-pressed={isBookmarked}
-          >
-            <BookmarkSimpleIcon size={20} weight={isBookmarked ? 'fill' : 'regular'} />
+            <ShareIcon size={20} />
           </button>
         </div>
-        {#if viewUrl}
-          <a
-            href={viewUrl}
-            class="text-xs sm:text-sm font-medium text-caption hover:text-primary transition-colors whitespace-nowrap pt-2"
-          >
-            View Pack →
-          </a>
-        {/if}
       </div>
     {/if}
   </div>

--- a/src/components/RecipePackCard.svelte
+++ b/src/components/RecipePackCard.svelte
@@ -5,7 +5,6 @@
   import NoteActionBar from './NoteActionBar.svelte';
   import ShareModal from './ShareModal.svelte';
   import BookmarkSimpleIcon from 'phosphor-svelte/lib/BookmarkSimple';
-  import ChatTeardropTextIcon from 'phosphor-svelte/lib/ChatTeardropText';
   import ShareIcon from 'phosphor-svelte/lib/Share';
   import { lazyLoad } from '$lib/lazyLoad';
   import { getImageOrPlaceholder } from '$lib/placeholderImages';
@@ -63,23 +62,6 @@
     }
   }
 
-  // Comments link target — the generic NIP-19 viewer at /<naddr>
-  // already supports NIP-22 comments for any addressable kind. Handle
-  // both relative ("/pack/<naddr>") and absolute ("https://…/pack/<naddr>")
-  // viewUrls that callers may pass.
-  $: commentsHref = (() => {
-    if (!viewUrl) return '';
-    try {
-      // Absolute URL — derive the local path then swap /pack/ → /
-      if (viewUrl.startsWith('http')) {
-        const path = new URL(viewUrl).pathname;
-        return path.replace(/^\/pack\//, '/');
-      }
-    } catch {
-      /* fall through */
-    }
-    return viewUrl.replace(/^\/pack\//, '/');
-  })();
 </script>
 
 <article
@@ -180,30 +162,18 @@
          comment link to the generic NIP-19 viewer (which does support
          NIP-22 comments for kind 30004). -->
     {#if !preview && event}
-      <!-- Social action row.
-           Left:  reactions/repost/zap from NoteActionBar.
-           Right: comments + share — these were "View Pack →" before but
-           the image/title click already opens the pack, so the space is
-           better used for actions. Bookmark lives in the cover top-right
-           (matches recipe-card design). -->
+      <!-- Social action row — same icon set and order as recipes:
+             reactions · comments · repost · zap   |   share
+           Bookmark lives in the cover top-right (matches recipe-card
+           design language). -->
       <div
         class="flex items-center justify-between gap-1 pt-1 border-t -mx-3 sm:-mx-4 px-3 sm:px-4 mt-1"
         style="border-color: var(--color-input-border);"
       >
         <div class="pt-2 flex items-center gap-1 flex-wrap">
-          <NoteActionBar {event} variant="default" showComments={false} />
+          <NoteActionBar {event} variant="default" />
         </div>
         <div class="pt-2 flex items-center gap-1">
-          {#if commentsHref}
-            <a
-              href={commentsHref}
-              class="flex items-center gap-1 px-1.5 py-1 rounded text-caption hover:bg-accent-gray transition-colors"
-              title="Open comments"
-              aria-label="Open comments"
-            >
-              <ChatTeardropTextIcon size={20} />
-            </a>
-          {/if}
           <button
             type="button"
             on:click={() => (shareModalOpen = true)}

--- a/src/components/RecipePackCard.svelte
+++ b/src/components/RecipePackCard.svelte
@@ -25,7 +25,7 @@
   } from '$lib/engagementCache';
   import { showToast } from '$lib/toast';
   import { goto } from '$app/navigation';
-  import { onMount } from 'svelte';
+  import { onMount, onDestroy } from 'svelte';
 
   /**
    * Pack metadata. Either pass a full NDKEvent (after publish) so the
@@ -46,10 +46,32 @@
   let zapModalOpen = false;
   let bookmarkBusy = false;
 
-  // Engagement store for the comment count. Same source NoteTotalComments
-  // uses, so the count matches what users see anywhere else for this
-  // event id. Subscribed reactively via the `$` prefix.
-  $: commentStore = event?.id ? getEngagementStore(event.id) : null;
+  // Reactive bindings — declared explicitly to satisfy strict TS /
+  // svelte-check. Svelte's `$:` will create implicit declarations in
+  // permissive mode but stricter tooling flags assignment to an
+  // undeclared identifier in <script lang="ts">.
+  type EngagementValue = { loading: boolean; comments: { count: number } };
+  let engagement: EngagementValue | null = null;
+  let commentsHref = '';
+  let resolvedImage = '';
+  let isBookmarked = false;
+
+  // Subscribe to the engagement store for this pack. Same source
+  // NoteTotalComments uses, so the count matches everywhere. Manual
+  // subscribe here (with cleanup) gives `engagement` a concrete type
+  // strict-mode templates can read without acrobatics.
+  let engagementUnsub: (() => void) | null = null;
+  $: {
+    engagementUnsub?.();
+    engagement = null;
+    if (event?.id) {
+      const store = getEngagementStore(event.id);
+      engagementUnsub = store.subscribe((v) => {
+        engagement = v as unknown as EngagementValue;
+      });
+    }
+  }
+  onDestroy(() => engagementUnsub?.());
 
   // Comments link target. The generic NIP-19 viewer at /<naddr> already
   // supports NIP-22 comments for any addressable kind. Handles both
@@ -92,7 +114,10 @@
 
   function packATag(e: NDKEvent): string {
     const dTag = e.tags?.find((t) => t[0] === 'd')?.[1] || '';
-    return `${e.kind}:${e.pubkey}:${dTag}`;
+    // Default to RECIPE_PACK_KIND (30004) when e.kind is missing —
+    // matches savedPacksStore.packATag so isSaved() comparisons agree.
+    const kind = e.kind ?? 30004;
+    return `${kind}:${e.pubkey}:${dTag}`;
   }
 
   async function handleBookmark() {
@@ -236,10 +261,10 @@
               aria-label="View comments"
             >
               <ChatTeardropTextIcon size={24} class="text-caption" />
-              {#if commentStore && $commentStore}
+              {#if engagement}
                 <span class="text-caption">
-                  {#if $commentStore.loading}<span class="opacity-0">0</span
-                    >{:else}{$commentStore.comments.count}{/if}
+                  {#if engagement.loading}<span class="opacity-0">0</span
+                    >{:else}{engagement.comments.count}{/if}
                 </span>
               {/if}
             </a>

--- a/src/components/RecipePackCard.svelte
+++ b/src/components/RecipePackCard.svelte
@@ -2,16 +2,30 @@
   import type { NDKEvent } from '@nostr-dev-kit/ndk';
   import Avatar from './Avatar.svelte';
   import CustomName from './CustomName.svelte';
-  import NoteActionBar from './NoteActionBar.svelte';
+  // Compose the social action row from the same primitives NoteActionBar
+  // uses, so we can replace its non-functional comments toggle with a
+  // working link to /<naddr> while keeping the same icon order recipes
+  // use (likes / comments / repost / zap).
+  import NoteTotalLikes from './NoteTotalLikes.svelte';
+  import NoteRepost from './NoteRepost.svelte';
+  import NoteTotalZaps from './NoteTotalZaps.svelte';
+  import ZapModal from './ZapModal.svelte';
   import ShareModal from './ShareModal.svelte';
   import BookmarkSimpleIcon from 'phosphor-svelte/lib/BookmarkSimple';
   import ShareIcon from 'phosphor-svelte/lib/Share';
+  import ChatTeardropTextIcon from 'phosphor-svelte/lib/ChatTeardropText';
   import { lazyLoad } from '$lib/lazyLoad';
   import { getImageOrPlaceholder } from '$lib/placeholderImages';
   import { savedPacksStore } from '$lib/savedPacksStore';
-  import { userPublickey } from '$lib/nostr';
+  import { ndk, userPublickey } from '$lib/nostr';
+  import {
+    fetchEngagement,
+    optimisticZapUpdate,
+    getEngagementStore
+  } from '$lib/engagementCache';
   import { showToast } from '$lib/toast';
   import { goto } from '$app/navigation';
+  import { onMount } from 'svelte';
 
   /**
    * Pack metadata. Either pass a full NDKEvent (after publish) so the
@@ -29,7 +43,48 @@
   export let preview: boolean = false;
 
   let shareModalOpen = false;
+  let zapModalOpen = false;
   let bookmarkBusy = false;
+
+  // Engagement store for the comment count. Same source NoteTotalComments
+  // uses, so the count matches what users see anywhere else for this
+  // event id. Subscribed reactively via the `$` prefix.
+  $: commentStore = event?.id ? getEngagementStore(event.id) : null;
+
+  // Comments link target. The generic NIP-19 viewer at /<naddr> already
+  // supports NIP-22 comments for any addressable kind. Handles both
+  // relative ("/pack/<naddr>") and absolute viewUrls.
+  $: commentsHref = (() => {
+    if (!viewUrl) return '';
+    try {
+      if (viewUrl.startsWith('http')) {
+        const path = new URL(viewUrl).pathname;
+        return path.replace(/^\/pack\//, '/');
+      }
+    } catch {
+      /* fall through */
+    }
+    return viewUrl.replace(/^\/pack\//, '/');
+  })();
+
+  onMount(() => {
+    if (event?.id) fetchEngagement($ndk, event.id, $userPublickey);
+  });
+
+  function openZapModal() {
+    if (!$userPublickey) {
+      goto('/login?redirect=' + encodeURIComponent(window.location.pathname));
+      return;
+    }
+    zapModalOpen = true;
+  }
+
+  function handleZapComplete(e: CustomEvent<{ amount: number }>) {
+    if (event?.id) {
+      optimisticZapUpdate(event.id, (e.detail.amount || 0) * 1000, $userPublickey);
+      fetchEngagement($ndk, event.id, $userPublickey);
+    }
+  }
 
   $: resolvedImage = getImageOrPlaceholder(image || '', `${creatorPubkey}:${title}`);
   // Live bookmark state — re-evaluates whenever the saved-packs store updates.
@@ -156,22 +211,45 @@
       </span>
     </div>
 
-    <!-- Social action row — only when we have a real published event.
-         showComments={false} because NoteTotalComments toggles an inline
-         <FeedComments> we don't render here; we surface a separate
-         comment link to the generic NIP-19 viewer (which does support
-         NIP-22 comments for kind 30004). -->
     {#if !preview && event}
       <!-- Social action row — same icon set and order as recipes:
              reactions · comments · repost · zap   |   share
-           Bookmark lives in the cover top-right (matches recipe-card
-           design language). -->
+           Built from the same primitives NoteActionBar uses, but with
+           the comments button replaced by a real link to the thread
+           page (the inline-toggle behavior NoteTotalComments expects
+           requires a per-card FeedComments container we don't render).
+           Bookmark lives in the cover top-right (recipe-card pattern). -->
       <div
         class="flex items-center justify-between gap-1 pt-1 border-t -mx-3 sm:-mx-4 px-3 sm:px-4 mt-1"
         style="border-color: var(--color-input-border);"
       >
-        <div class="pt-2 flex items-center gap-1 flex-wrap">
-          <NoteActionBar {event} variant="default" />
+        <div class="pt-2 flex items-center gap-3 flex-wrap text-caption">
+          <div class="hover:bg-accent-gray rounded px-1 py-0.5 transition-colors">
+            <NoteTotalLikes {event} />
+          </div>
+          {#if commentsHref}
+            <a
+              href={commentsHref}
+              class="flex items-center gap-1.5 hover:bg-accent-gray rounded px-1 py-0.5 transition-colors"
+              style="color: var(--color-text-primary)"
+              title="View comments"
+              aria-label="View comments"
+            >
+              <ChatTeardropTextIcon size={24} class="text-caption" />
+              {#if commentStore && $commentStore}
+                <span class="text-caption">
+                  {#if $commentStore.loading}<span class="opacity-0">0</span
+                    >{:else}{$commentStore.comments.count}{/if}
+                </span>
+              {/if}
+            </a>
+          {/if}
+          <div class="hover:bg-accent-gray rounded px-1 py-0.5 transition-colors">
+            <NoteRepost {event} />
+          </div>
+          <div class="hover:bg-amber-50/50 rounded px-1 py-0.5 transition-colors">
+            <NoteTotalZaps {event} onZapClick={openZapModal} />
+          </div>
         </div>
         <div class="pt-2 flex items-center gap-1">
           <button
@@ -200,6 +278,10 @@
     title={title || 'Recipe Pack'}
     imageUrl={image || ''}
   />
+{/if}
+
+{#if event && zapModalOpen}
+  <ZapModal bind:open={zapModalOpen} {event} on:zap-complete={handleZapComplete} />
 {/if}
 
 <style>

--- a/src/components/RecipePackCard.svelte
+++ b/src/components/RecipePackCard.svelte
@@ -2,15 +2,21 @@
   import type { NDKEvent } from '@nostr-dev-kit/ndk';
   import Avatar from './Avatar.svelte';
   import CustomName from './CustomName.svelte';
-  import ZapButton from './ZapButton.svelte';
-  import BookmarkIcon from 'phosphor-svelte/lib/BookmarkSimple';
-  import ArrowRightIcon from 'phosphor-svelte/lib/ArrowRight';
+  import NoteActionBar from './NoteActionBar.svelte';
+  import ShareModal from './ShareModal.svelte';
+  import BookmarkSimpleIcon from 'phosphor-svelte/lib/BookmarkSimple';
+  import ChatTeardropTextIcon from 'phosphor-svelte/lib/ChatTeardropText';
+  import LinkSimpleIcon from 'phosphor-svelte/lib/LinkSimple';
   import { lazyLoad } from '$lib/lazyLoad';
   import { getImageOrPlaceholder } from '$lib/placeholderImages';
+  import { savedPacksStore } from '$lib/savedPacksStore';
+  import { userPublickey } from '$lib/nostr';
+  import { showToast } from '$lib/toast';
+  import { goto } from '$app/navigation';
 
   /**
    * Pack metadata. Either pass a full NDKEvent (after publish) so the
-   * Zap button can target it, or pass plain props for a preview before
+   * action row can target it, or pass plain props for a preview before
    * publish.
    */
   export let event: NDKEvent | null = null;
@@ -20,78 +26,217 @@
   export let creatorPubkey: string = '';
   export let recipeCount: number = 0;
   export let viewUrl: string = '';
-  export let preview: boolean = false; // true → hide Zap/View, show "Preview" badge
+  /** Hide the social action row + show a "Preview" badge instead. */
+  export let preview: boolean = false;
+
+  let shareModalOpen = false;
+  let bookmarkBusy = false;
 
   $: resolvedImage = getImageOrPlaceholder(image || '', `${creatorPubkey}:${title}`);
+  // Live bookmark state — re-evaluates whenever the saved-packs store updates.
+  $: isBookmarked = event ? $savedPacksStore.saved.includes(packATag(event)) : false;
+
+  function packATag(e: NDKEvent): string {
+    const dTag = e.tags?.find((t) => t[0] === 'd')?.[1] || '';
+    return `${e.kind}:${e.pubkey}:${dTag}`;
+  }
+
+  async function handleBookmark() {
+    if (bookmarkBusy || !event) return;
+    if (!$userPublickey) {
+      goto('/login?redirect=' + encodeURIComponent(window.location.pathname));
+      return;
+    }
+    bookmarkBusy = true;
+    try {
+      if (isBookmarked) {
+        const ok = await savedPacksStore.unsave(event);
+        if (ok) showToast('info', 'Removed from saved packs.');
+        else showToast('error', 'Could not update saved packs.');
+      } else {
+        const ok = await savedPacksStore.save(event);
+        if (ok) showToast('success', 'Pack saved.');
+        else showToast('error', 'Could not save pack.');
+      }
+    } finally {
+      bookmarkBusy = false;
+    }
+  }
+
+  // Comments link target — the generic NIP-19 viewer at /<naddr>
+  // already supports NIP-22 comments for any addressable kind. Handle
+  // both relative ("/pack/<naddr>") and absolute ("https://…/pack/<naddr>")
+  // viewUrls that callers may pass.
+  $: commentsHref = (() => {
+    if (!viewUrl) return '';
+    try {
+      // Absolute URL — derive the local path then swap /pack/ → /
+      if (viewUrl.startsWith('http')) {
+        const path = new URL(viewUrl).pathname;
+        return path.replace(/^\/pack\//, '/');
+      }
+    } catch {
+      /* fall through */
+    }
+    return viewUrl.replace(/^\/pack\//, '/');
+  })();
 </script>
 
 <article
   class="rounded-2xl overflow-hidden flex flex-col"
   style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
 >
-  <div class="relative w-full aspect-[16/9] pack-image-wrap">
-    <div
-      use:lazyLoad={{ url: resolvedImage }}
-      class="absolute inset-0 pack-image"
-    ></div>
-    <div class="absolute top-3 left-3 flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-black/55 text-white text-xs font-medium backdrop-blur-sm">
-      <BookmarkIcon size={12} weight="fill" />
-      <span>Recipe Pack</span>
-    </div>
-    {#if preview}
-      <div class="absolute top-3 right-3 px-2.5 py-1 rounded-full bg-amber-500/90 text-white text-xs font-semibold shadow">
-        Preview
-      </div>
-    {/if}
-  </div>
-
-  <div class="p-4 flex flex-col gap-3">
-    <div>
-      <h3
-        class="text-lg sm:text-xl font-bold leading-snug line-clamp-2"
-        style="color: var(--color-text-primary)"
+  <!-- Image is the primary tap target into the pack -->
+  {#if viewUrl}
+    <a href={viewUrl} class="block relative w-full aspect-[16/9] pack-image-wrap group">
+      <div
+        use:lazyLoad={{ url: resolvedImage }}
+        class="absolute inset-0 pack-image group-hover:scale-[1.02] transition-transform duration-500 ease-in-out"
+      ></div>
+      <div
+        class="absolute top-3 left-3 flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-black/55 text-white text-xs font-medium backdrop-blur-sm"
       >
-        {title || 'Untitled pack'}
-      </h3>
+        <BookmarkSimpleIcon size={12} weight="fill" />
+        <span>Recipe Pack</span>
+      </div>
+      {#if preview}
+        <div
+          class="absolute top-3 right-3 px-2.5 py-1 rounded-full bg-amber-500/90 text-white text-xs font-semibold shadow"
+        >
+          Preview
+        </div>
+      {/if}
+    </a>
+  {:else}
+    <div class="relative w-full aspect-[16/9] pack-image-wrap">
+      <div use:lazyLoad={{ url: resolvedImage }} class="absolute inset-0 pack-image"></div>
+      <div
+        class="absolute top-3 left-3 flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-black/55 text-white text-xs font-medium backdrop-blur-sm"
+      >
+        <BookmarkSimpleIcon size={12} weight="fill" />
+        <span>Recipe Pack</span>
+      </div>
+      {#if preview}
+        <div
+          class="absolute top-3 right-3 px-2.5 py-1 rounded-full bg-amber-500/90 text-white text-xs font-semibold shadow"
+        >
+          Preview
+        </div>
+      {/if}
+    </div>
+  {/if}
+
+  <div class="p-3 sm:p-4 flex flex-col gap-2">
+    <!-- Title (also clickable into pack) -->
+    <div>
+      {#if viewUrl}
+        <a href={viewUrl} class="block hover:opacity-90 transition-opacity">
+          <h3
+            class="text-base sm:text-lg font-bold leading-snug line-clamp-2"
+            style="color: var(--color-text-primary)"
+          >
+            {title || 'Untitled pack'}
+          </h3>
+        </a>
+      {:else}
+        <h3
+          class="text-base sm:text-lg font-bold leading-snug line-clamp-2"
+          style="color: var(--color-text-primary)"
+        >
+          {title || 'Untitled pack'}
+        </h3>
+      {/if}
       {#if description}
-        <p class="text-sm text-caption mt-1 line-clamp-3 whitespace-pre-line">{description}</p>
+        <p class="text-sm text-caption mt-1 line-clamp-2 whitespace-pre-line">{description}</p>
       {/if}
     </div>
 
-    <div class="flex items-center gap-2 flex-wrap">
+    <!-- Creator + recipe count, single row -->
+    <div class="flex items-center gap-2 flex-wrap text-sm">
       {#if creatorPubkey}
         <div class="flex items-center gap-2 min-w-0">
-          <Avatar pubkey={creatorPubkey} size={28} showRing={false} />
-          <span class="text-sm truncate" style="color: var(--color-text-secondary)">
+          <Avatar pubkey={creatorPubkey} size={22} showRing={false} />
+          <span class="truncate text-xs sm:text-sm" style="color: var(--color-text-secondary)">
             <CustomName pubkey={creatorPubkey} />
           </span>
         </div>
         <span class="text-caption text-xs">·</span>
       {/if}
-      <span class="text-sm text-caption">
+      <span class="text-xs sm:text-sm text-caption">
         {recipeCount} {recipeCount === 1 ? 'recipe' : 'recipes'}
       </span>
     </div>
 
-    {#if !preview}
-      <div class="flex items-center gap-2 pt-1">
-        {#if event}
-          <ZapButton {event} variant="default" size="sm" />
-        {/if}
+    <!-- Social action row — only when we have a real published event.
+         showComments={false} because NoteTotalComments toggles an inline
+         <FeedComments> we don't render here; we surface a separate
+         comment link to the generic NIP-19 viewer (which does support
+         NIP-22 comments for kind 30004). -->
+    {#if !preview && event}
+      <div
+        class="flex items-center justify-between gap-1 pt-1 border-t -mx-3 sm:-mx-4 px-3 sm:px-4 mt-1"
+        style="border-color: var(--color-input-border);"
+      >
+        <div class="pt-2 flex items-center gap-1 flex-wrap">
+          <NoteActionBar {event} variant="default" showComments={false} />
+          {#if commentsHref}
+            <a
+              href={commentsHref}
+              class="flex items-center gap-1 px-1.5 py-1 rounded text-caption hover:bg-accent-gray transition-colors"
+              title="Open comments"
+              aria-label="Open comments"
+            >
+              <ChatTeardropTextIcon size={20} />
+            </a>
+          {/if}
+          <button
+            type="button"
+            on:click={() => (shareModalOpen = true)}
+            class="flex items-center gap-1 px-1.5 py-1 rounded text-caption hover:bg-accent-gray transition-colors"
+            title="Share"
+            aria-label="Share"
+          >
+            <LinkSimpleIcon size={20} />
+          </button>
+          <button
+            type="button"
+            on:click={handleBookmark}
+            disabled={bookmarkBusy}
+            class="flex items-center gap-1 px-1.5 py-1 rounded transition-colors hover:bg-accent-gray disabled:opacity-50"
+            class:text-amber-500={isBookmarked}
+            style={isBookmarked ? '' : 'color: var(--color-text-secondary);'}
+            title={isBookmarked ? 'Remove from saved' : 'Save pack'}
+            aria-label={isBookmarked ? 'Remove from saved' : 'Save pack'}
+            aria-pressed={isBookmarked}
+          >
+            <BookmarkSimpleIcon size={20} weight={isBookmarked ? 'fill' : 'regular'} />
+          </button>
+        </div>
         {#if viewUrl}
           <a
             href={viewUrl}
-            class="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors"
-            style="background-color: var(--color-bg-secondary); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+            class="text-xs sm:text-sm font-medium text-caption hover:text-primary transition-colors whitespace-nowrap pt-2"
           >
-            <span>View</span>
-            <ArrowRightIcon size={14} weight="bold" />
+            View Pack →
           </a>
         {/if}
       </div>
     {/if}
   </div>
 </article>
+
+{#if event && shareModalOpen}
+  <ShareModal
+    bind:open={shareModalOpen}
+    url={viewUrl
+      ? viewUrl.startsWith('http')
+        ? viewUrl
+        : `https://zap.cooking${viewUrl}`
+      : ''}
+    title={title || 'Recipe Pack'}
+    imageUrl={image || ''}
+  />
+{/if}
 
 <style>
   .pack-image-wrap {

--- a/src/lib/savedPacksStore.ts
+++ b/src/lib/savedPacksStore.ts
@@ -51,13 +51,28 @@ function createSavedPacksStore() {
 		}
 		if (!force && lastLoadedPubkey === pubkey) return;
 
-		update((s) => ({ ...s, loading: true }));
+		// When the load is for a *different* pubkey than the one we last
+		// hydrated, drop the previous account's saved/event before kicking
+		// off the fetch. Without this the previous user's bookmark state
+		// would briefly bleed into the new session — and if the fetch
+		// fails, the catch path would leave it in place permanently.
+		const isPubkeyChange = lastLoadedPubkey !== null && lastLoadedPubkey !== pubkey;
+		if (isPubkeyChange) {
+			set({ loaded: false, loading: true, saved: [], event: null });
+		} else {
+			update((s) => ({ ...s, loading: true }));
+		}
+
 		try {
 			const evt = await ndkInstance.fetchEvent({
 				kinds: [SAVED_PACKS_KIND],
 				authors: [pubkey],
 				'#d': [SAVED_PACKS_DTAG]
 			});
+			// Re-check the active pubkey at resolution — a fast user switch
+			// could have happened during the await; if so, drop this result.
+			if (get(userPublickey) !== pubkey) return;
+
 			const aTags = evt
 				? evt.tags.filter((t) => t[0] === 'a' && typeof t[1] === 'string').map((t) => t[1])
 				: [];
@@ -65,6 +80,10 @@ function createSavedPacksStore() {
 			lastLoadedPubkey = pubkey;
 		} catch (err) {
 			console.warn('[savedPacks] load failed', err);
+			// On error after a pubkey change, the optimistic clear above
+			// stays in effect — we never let the previous account's data
+			// linger. For a same-pubkey reload error, keep whatever was
+			// cached from the last successful load.
 			update((s) => ({ ...s, loading: false, loaded: true }));
 		}
 	}

--- a/src/lib/savedPacksStore.ts
+++ b/src/lib/savedPacksStore.ts
@@ -1,0 +1,175 @@
+/**
+ * Saved Recipe Packs — a per-user NIP-51 bookmark set (kind 30003)
+ * tracking which kind:30004 Recipe Packs the current user has saved.
+ *
+ * Stored as a single replaceable event with d-tag
+ * `zapcooking-saved-packs`. Each saved pack appears as an `a` tag in
+ * the standard `30004:<pubkey>:<dTag>` format. We keep this separate
+ * from the main cookbook list (which holds kind:30023 recipes) so the
+ * two concepts don't bleed into each other.
+ */
+
+import { writable, derived, get } from 'svelte/store';
+import { NDKEvent } from '@nostr-dev-kit/ndk';
+import { ndk, userPublickey } from '$lib/nostr';
+import { addClientTagToEvent } from '$lib/nip89';
+import { RECIPE_PACK_KIND } from '$lib/recipePack';
+
+const SAVED_PACKS_DTAG = 'zapcooking-saved-packs';
+const SAVED_PACKS_KIND = 30003;
+
+interface SavedPacksState {
+	loaded: boolean;
+	loading: boolean;
+	saved: string[]; // a-tags, e.g. "30004:pubkey:dTag"
+	event: NDKEvent | null; // the underlying NIP-51 event (for replace-on-publish)
+}
+
+function packATag(packEvent: NDKEvent): string | null {
+	const dTag = packEvent.tags?.find((t) => t[0] === 'd')?.[1];
+	if (!dTag || !packEvent.pubkey) return null;
+	return `${packEvent.kind ?? RECIPE_PACK_KIND}:${packEvent.pubkey}:${dTag}`;
+}
+
+function createSavedPacksStore() {
+	const { subscribe, set, update } = writable<SavedPacksState>({
+		loaded: false,
+		loading: false,
+		saved: [],
+		event: null
+	});
+
+	let lastLoadedPubkey: string | null = null;
+
+	async function load(force: boolean = false): Promise<void> {
+		const pubkey = get(userPublickey);
+		const ndkInstance = get(ndk);
+		if (!pubkey || !ndkInstance) {
+			set({ loaded: true, loading: false, saved: [], event: null });
+			lastLoadedPubkey = null;
+			return;
+		}
+		if (!force && lastLoadedPubkey === pubkey) return;
+
+		update((s) => ({ ...s, loading: true }));
+		try {
+			const evt = await ndkInstance.fetchEvent({
+				kinds: [SAVED_PACKS_KIND],
+				authors: [pubkey],
+				'#d': [SAVED_PACKS_DTAG]
+			});
+			const aTags = evt
+				? evt.tags.filter((t) => t[0] === 'a' && typeof t[1] === 'string').map((t) => t[1])
+				: [];
+			set({ loaded: true, loading: false, saved: aTags, event: evt || null });
+			lastLoadedPubkey = pubkey;
+		} catch (err) {
+			console.warn('[savedPacks] load failed', err);
+			update((s) => ({ ...s, loading: false, loaded: true }));
+		}
+	}
+
+	/** Build (and publish) the replaceable bookmark-set event with `nextSaved`. */
+	async function publish(nextSaved: string[], existing: NDKEvent | null): Promise<NDKEvent | null> {
+		const ndkInstance = get(ndk);
+		const pubkey = get(userPublickey);
+		if (!ndkInstance || !pubkey) return null;
+
+		const event = new NDKEvent(ndkInstance);
+		event.kind = SAVED_PACKS_KIND;
+		const tags: string[][] = [
+			['d', SAVED_PACKS_DTAG],
+			['title', 'Saved Recipe Packs'],
+			['t', 'recipe-pack'],
+			['t', 'zap-cooking']
+		];
+		// Carry forward any non-a/non-control tags from the existing event so
+		// we don't accidentally strip future fields (e.g. an image tag a user
+		// added in another client). Cheap forward-compat.
+		if (existing?.tags) {
+			for (const t of existing.tags) {
+				if (!t[0]) continue;
+				if (['d', 'title', 't', 'a', 'client'].includes(t[0])) continue;
+				tags.push([...t]);
+			}
+		}
+		for (const aTag of nextSaved) tags.push(['a', aTag]);
+		event.tags = tags;
+
+		addClientTagToEvent(event);
+		await event.publish();
+		return event;
+	}
+
+	async function save(packEvent: NDKEvent): Promise<boolean> {
+		const aTag = packATag(packEvent);
+		if (!aTag) return false;
+		await load();
+		const state = get({ subscribe });
+		if (state.saved.includes(aTag)) return true;
+		const next = [...state.saved, aTag];
+		// Optimistic
+		update((s) => ({ ...s, saved: next }));
+		try {
+			const evt = await publish(next, state.event);
+			if (evt) update((s) => ({ ...s, event: evt }));
+			return true;
+		} catch (err) {
+			console.error('[savedPacks] save failed', err);
+			update((s) => ({ ...s, saved: state.saved }));
+			return false;
+		}
+	}
+
+	async function unsave(packEvent: NDKEvent): Promise<boolean> {
+		const aTag = packATag(packEvent);
+		if (!aTag) return false;
+		await load();
+		const state = get({ subscribe });
+		if (!state.saved.includes(aTag)) return true;
+		const next = state.saved.filter((a) => a !== aTag);
+		update((s) => ({ ...s, saved: next }));
+		try {
+			const evt = await publish(next, state.event);
+			if (evt) update((s) => ({ ...s, event: evt }));
+			return true;
+		} catch (err) {
+			console.error('[savedPacks] unsave failed', err);
+			update((s) => ({ ...s, saved: state.saved }));
+			return false;
+		}
+	}
+
+	function isSaved(packEvent: NDKEvent | null | undefined): boolean {
+		if (!packEvent) return false;
+		const aTag = packATag(packEvent);
+		if (!aTag) return false;
+		return get({ subscribe }).saved.includes(aTag);
+	}
+
+	function reset() {
+		set({ loaded: false, loading: false, saved: [], event: null });
+		lastLoadedPubkey = null;
+	}
+
+	return { subscribe, load, save, unsave, isSaved, reset };
+}
+
+export const savedPacksStore = createSavedPacksStore();
+export const savedPackATags = derived(savedPacksStore, ($s) => $s.saved);
+export const savedPacksLoaded = derived(savedPacksStore, ($s) => $s.loaded);
+
+// Auto-reload when the signed-in user changes — `load()` early-returns
+// if the pubkey hasn't actually moved, so this is cheap.
+if (typeof window !== 'undefined') {
+	let lastPk = '';
+	userPublickey.subscribe((pk) => {
+		if (pk === lastPk) return;
+		lastPk = pk;
+		if (pk) {
+			savedPacksStore.load();
+		} else {
+			savedPacksStore.reset();
+		}
+	});
+}

--- a/src/lib/savedPacksStore.ts
+++ b/src/lib/savedPacksStore.ts
@@ -131,7 +131,15 @@ function createSavedPacksStore() {
 		update((s) => ({ ...s, saved: next }));
 		try {
 			const evt = await publish(next, state.event);
-			if (evt) update((s) => ({ ...s, event: evt }));
+			// Treat a null result the same as a thrown error — publish
+			// silently failed (e.g. no signer / no NDK / user logged out
+			// mid-flight). Roll back the optimistic update so the UI
+			// doesn't show a saved state that wasn't persisted to Nostr.
+			if (!evt) {
+				update((s) => ({ ...s, saved: state.saved }));
+				return false;
+			}
+			update((s) => ({ ...s, event: evt }));
 			return true;
 		} catch (err) {
 			console.error('[savedPacks] save failed', err);
@@ -150,7 +158,12 @@ function createSavedPacksStore() {
 		update((s) => ({ ...s, saved: next }));
 		try {
 			const evt = await publish(next, state.event);
-			if (evt) update((s) => ({ ...s, event: evt }));
+			// Same as save(): null publish = silent failure → roll back.
+			if (!evt) {
+				update((s) => ({ ...s, saved: state.saved }));
+				return false;
+			}
+			update((s) => ({ ...s, event: evt }));
 			return true;
 		} catch (err) {
 			console.error('[savedPacks] unsave failed', err);

--- a/src/lib/shortlinks/parse.server.ts
+++ b/src/lib/shortlinks/parse.server.ts
@@ -5,8 +5,15 @@
 
 import type { ShortLinkType } from './types';
 
-const ZAP_COOKING_ORIGIN = 'https://zap.cooking';
-const ZAP_ORIGIN_ALT = /^https?:\/\/(www\.)?zap\.cooking/i;
+/**
+ * Strict allowlist for the hostname we accept URLs from.
+ * Substring matches (e.g. `origin.includes('zap.cooking')`) would also
+ * accept `zap.cooking.evil.com` or `api.zap.cooking.attacker.tld`.
+ */
+function isZapCookingHost(u: URL): boolean {
+  const host = u.hostname.toLowerCase();
+  return host === 'zap.cooking' || host === 'www.zap.cooking';
+}
 
 /**
  * Extract naddr and type from a zap.cooking URL or raw naddr string.
@@ -23,26 +30,20 @@ export function parseUrlOrNaddr(input: string): { naddr: string; type: ShortLink
 
   try {
     const u = new URL(s);
-    const origin = u.origin.toLowerCase();
+    if (!isZapCookingHost(u)) return null;
     const path = u.pathname;
 
     // /r/naddr1... → recipe
     const rMatch = path.match(/^\/r\/(naddr1[a-zA-Z0-9]+)/);
-    if (rMatch && (origin.includes('zap.cooking') || ZAP_ORIGIN_ALT.test(u.href))) {
-      return { naddr: rMatch[1], type: 'recipe' };
-    }
+    if (rMatch) return { naddr: rMatch[1], type: 'recipe' };
 
     // /reads/naddr1... → article
     const readsMatch = path.match(/^\/reads\/(naddr1[a-zA-Z0-9]+)/);
-    if (readsMatch && (origin.includes('zap.cooking') || ZAP_ORIGIN_ALT.test(u.href))) {
-      return { naddr: readsMatch[1], type: 'article' };
-    }
+    if (readsMatch) return { naddr: readsMatch[1], type: 'article' };
 
     // /pack/naddr1... → recipe pack
     const packMatch = path.match(/^\/pack\/(naddr1[a-zA-Z0-9]+)/);
-    if (packMatch && (origin.includes('zap.cooking') || ZAP_ORIGIN_ALT.test(u.href))) {
-      return { naddr: packMatch[1], type: 'pack' };
-    }
+    if (packMatch) return { naddr: packMatch[1], type: 'pack' };
   } catch {
     // not a valid URL
   }

--- a/src/lib/shortlinks/parse.server.ts
+++ b/src/lib/shortlinks/parse.server.ts
@@ -37,6 +37,12 @@ export function parseUrlOrNaddr(input: string): { naddr: string; type: ShortLink
     if (readsMatch && (origin.includes('zap.cooking') || ZAP_ORIGIN_ALT.test(u.href))) {
       return { naddr: readsMatch[1], type: 'article' };
     }
+
+    // /pack/naddr1... → recipe pack
+    const packMatch = path.match(/^\/pack\/(naddr1[a-zA-Z0-9]+)/);
+    if (packMatch && (origin.includes('zap.cooking') || ZAP_ORIGIN_ALT.test(u.href))) {
+      return { naddr: packMatch[1], type: 'pack' };
+    }
   } catch {
     // not a valid URL
   }
@@ -48,5 +54,7 @@ export function parseUrlOrNaddr(input: string): { naddr: string; type: ShortLink
  * Build redirect path from stored naddr and type.
  */
 export function redirectPath(naddr: string, type: ShortLinkType): string {
-  return type === 'article' ? `/reads/${naddr}` : `/r/${naddr}`;
+  if (type === 'article') return `/reads/${naddr}`;
+  if (type === 'pack') return `/pack/${naddr}`;
+  return `/r/${naddr}`;
 }

--- a/src/lib/shortlinks/types.ts
+++ b/src/lib/shortlinks/types.ts
@@ -1,9 +1,9 @@
 /**
- * URL shortener types for zap.cooking recipe and Nostr long-form article links.
- * Short links use format: zap.cooking/s/:code
+ * URL shortener types for zap.cooking recipe, Nostr long-form article,
+ * and Recipe Pack links. Short links use format: zap.cooking/s/:code
  */
 
-export type ShortLinkType = 'recipe' | 'article';
+export type ShortLinkType = 'recipe' | 'article' | 'pack';
 
 export interface ShortenedURL {
   shortCode: string;

--- a/src/routes/api/shorten/+server.ts
+++ b/src/routes/api/shorten/+server.ts
@@ -13,7 +13,19 @@ import { parseUrlOrNaddr } from '$lib/shortlinks/parse.server';
 
 const SITE_ORIGIN = 'https://zap.cooking';
 const MAX_CUSTOM_SLUG_LENGTH = 20;
-const RESERVED_CODES = new Set(['info', 'api', 's', 'r', 'reads', 'create', 'about', 'login', 'settings']);
+const RESERVED_CODES = new Set([
+  'info',
+  'api',
+  's',
+  'r',
+  'reads',
+  'pack',
+  'packs',
+  'create',
+  'about',
+  'login',
+  'settings'
+]);
 
 function getShortUrl(code: string): string {
   return `${SITE_ORIGIN}/s/${code}`;
@@ -25,7 +37,12 @@ export const POST: RequestHandler = async ({ request, platform }) => {
     return json({ success: false, error: 'Short links are not configured' }, { status: 503 });
   }
 
-  let body: { url?: string; type?: 'recipe' | 'article'; customSlug?: string; createdBy?: string };
+  let body: {
+    url?: string;
+    type?: 'recipe' | 'article' | 'pack';
+    customSlug?: string;
+    createdBy?: string;
+  };
   try {
     body = await request.json();
   } catch {
@@ -39,7 +56,13 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 
   const parsed = parseUrlOrNaddr(rawUrl);
   if (!parsed) {
-    return json({ success: false, error: 'Invalid URL or naddr: use a zap.cooking /r/ or /reads/ link, or a raw naddr' }, { status: 400 });
+    return json(
+      {
+        success: false,
+        error: 'Invalid URL or naddr: use a zap.cooking /r/, /reads/, or /pack/ link, or a raw naddr'
+      },
+      { status: 400 }
+    );
   }
 
   const { naddr, type } = parsed;

--- a/src/routes/api/shorten/+server.ts
+++ b/src/routes/api/shorten/+server.ts
@@ -1,6 +1,15 @@
 /**
- * POST /api/shorten – create a short link for a zap.cooking recipe or Nostr long-form article.
- * Body: { url: string (naddr or zap.cooking URL), type?: 'recipe' | 'article', customSlug?: string, createdBy?: string }
+ * POST /api/shorten – create a short link for a zap.cooking recipe,
+ * Nostr long-form article, or Recipe Pack.
+ *
+ * Body: {
+ *   url: string,                           // raw naddr OR a zap.cooking
+ *                                          // /r/<naddr>, /reads/<naddr>,
+ *                                          // or /pack/<naddr> URL
+ *   type?: 'recipe' | 'article' | 'pack',
+ *   customSlug?: string,
+ *   createdBy?: string
+ * }
  * Returns: { success, shortCode?, shortUrl?, error? }
  *
  * Requires Cloudflare KV namespace bound as SHORTLINKS in the Pages project.

--- a/src/routes/packs/+page.svelte
+++ b/src/routes/packs/+page.svelte
@@ -5,7 +5,8 @@
   import { onMount } from 'svelte';
   import { nip19 } from 'nostr-tools';
   import { ndk, userPublickey, ensureNdkConnected } from '$lib/nostr';
-  import { NDKEvent } from '@nostr-dev-kit/ndk';
+  import { NDKEvent, NDKRelaySet } from '@nostr-dev-kit/ndk';
+  import { standardRelays } from '$lib/consts';
   import { RECIPE_PACK_KIND, RECIPE_PACK_TAG, ZAP_COOKING_TAG } from '$lib/recipePack';
   import RecipePackCard from '../../components/RecipePackCard.svelte';
   import PanLoader from '../../components/PanLoader.svelte';
@@ -68,11 +69,31 @@
         /* tolerate; fetchEvents will surface the error if relays are still down */
       }
 
-      const events = await $ndk.fetchEvents({
-        kinds: [RECIPE_PACK_KIND as number],
-        '#t': [ZAP_COOKING_TAG, RECIPE_PACK_TAG],
-        limit: 60
-      });
+      // CRITICAL: outbox model is enabled on this NDK instance. Filters
+      // without `authors` get an empty relay set ("No relays found for
+      // filter") and the subscription hangs forever — no relays → no
+      // EOSE → fetchEvents never resolves. Pass an explicit relay set
+      // built from the standard pool so unauthored discovery queries
+      // actually run. (`false` here means use existing pool connections;
+      // no extra WebSocket churn.)
+      const relaySet = NDKRelaySet.fromRelayUrls(standardRelays, $ndk, false);
+
+      // Race against a timeout so we never hang the UI even if every
+      // relay is silent. 8s is generous — typical EOSE arrives in 1-2s.
+      const fetchPromise = $ndk.fetchEvents(
+        {
+          kinds: [RECIPE_PACK_KIND as number],
+          '#t': [ZAP_COOKING_TAG, RECIPE_PACK_TAG],
+          limit: 60
+        },
+        { closeOnEose: true },
+        relaySet
+      );
+      const timeoutPromise = new Promise<Set<NDKEvent>>((_, reject) =>
+        setTimeout(() => reject(new Error('Relay timeout')), 8000)
+      );
+
+      const events = (await Promise.race([fetchPromise, timeoutPromise])) as Set<NDKEvent>;
       discoverEvents = sortAndDedupe(Array.from(events));
       discoverLoaded = true; // mark loaded only on success — error path leaves it false so Retry works
     } catch (e: any) {
@@ -101,11 +122,22 @@
         /* tolerate */
       }
 
-      const events = await $ndk.fetchEvents({
-        kinds: [RECIPE_PACK_KIND as number],
-        authors: [reqPubkey],
-        limit: 60
-      });
+      // Same timeout protection as loadDiscover. Outbox model usually
+      // handles authored queries fine, but a stalled relay can still hang
+      // fetchEvents indefinitely. Bound the wait so the spinner can't
+      // stick forever.
+      const fetchPromise = $ndk.fetchEvents(
+        {
+          kinds: [RECIPE_PACK_KIND as number],
+          authors: [reqPubkey],
+          limit: 60
+        },
+        { closeOnEose: true }
+      );
+      const timeoutPromise = new Promise<Set<NDKEvent>>((_, reject) =>
+        setTimeout(() => reject(new Error('Relay timeout')), 8000)
+      );
+      const events = (await Promise.race([fetchPromise, timeoutPromise])) as Set<NDKEvent>;
 
       // Drop the result if the user has logged out or switched accounts
       // since this fetch began — otherwise stale events from the previous

--- a/src/routes/packs/+page.svelte
+++ b/src/routes/packs/+page.svelte
@@ -8,17 +8,18 @@
   import { NDKEvent, NDKRelaySet } from '@nostr-dev-kit/ndk';
   import { standardRelays } from '$lib/consts';
   import { RECIPE_PACK_KIND, RECIPE_PACK_TAG, ZAP_COOKING_TAG } from '$lib/recipePack';
+  import { savedPacksStore, savedPackATags } from '$lib/savedPacksStore';
   import RecipePackCard from '../../components/RecipePackCard.svelte';
   import PanLoader from '../../components/PanLoader.svelte';
   import BookmarkIcon from 'phosphor-svelte/lib/BookmarkSimple';
 
-  type Tab = 'discover' | 'mine';
+  type Tab = 'discover' | 'mine' | 'saved';
   let tab: Tab = 'discover';
 
-  // Hydrate tab from ?tab= query param so links can deep-link to "Mine".
+  // Hydrate tab from ?tab= query param so links can deep-link to a sub-tab.
   $: {
     const t = $page.url.searchParams.get('tab');
-    if (t === 'mine' || t === 'discover') tab = t;
+    if (t === 'mine' || t === 'discover' || t === 'saved') tab = t;
   }
 
   function setTab(next: Tab) {
@@ -52,6 +53,15 @@
   // is dropped without overwriting state. Same idea as the relay-
   // generation guard in /recent.
   let mineRequestId = 0;
+
+  // Saved tab — same shape, separate state. Populated by resolving each
+  // bookmarked a-tag to its underlying kind 30004 event.
+  let savedEvents: NDKEvent[] = [];
+  let savedLoading = false;
+  let savedLoaded = false;
+  let savedError = '';
+  let savedRequestId = 0;
+  let lastResolvedSavedSig = '';
 
   async function loadDiscover() {
     if (discoverLoading) return;
@@ -184,6 +194,84 @@
     return Array.from(byKey.values()).sort((a, b) => (b.created_at || 0) - (a.created_at || 0));
   }
 
+  /**
+   * Resolve bookmarked pack a-tags to their underlying kind 30004
+   * events. Each a-tag is `30004:pubkey:dTag`. We fetch them in
+   * parallel via the standard pool (same outbox-bypass pattern as
+   * Discover) so the user always sees something even when there's no
+   * NIP-65 data for the pack creators.
+   */
+  async function loadSaved() {
+    if (savedLoading) return;
+    if (!$userPublickey) {
+      savedEvents = [];
+      savedLoaded = true;
+      return;
+    }
+    const reqId = ++savedRequestId;
+    savedLoading = true;
+    savedError = '';
+    try {
+      try {
+        await ensureNdkConnected();
+      } catch {
+        /* tolerate */
+      }
+      // Make sure the bookmark list itself is hydrated.
+      await savedPacksStore.load();
+      const aTags = $savedPackATags;
+      lastResolvedSavedSig = aTags.slice().sort().join(',');
+
+      if (aTags.length === 0) {
+        if (reqId === savedRequestId) {
+          savedEvents = [];
+          savedLoaded = true;
+        }
+        return;
+      }
+
+      // Build the OR-of-(authors,#d) filter set for one round-trip.
+      // We use REQ filters keyed by pubkey since `a`-tag filters aren't
+      // standardized; per-pack (kinds, authors, #d) is the safe form.
+      const relaySet = NDKRelaySet.fromRelayUrls(standardRelays, $ndk, false);
+      const fetched = await Promise.all(
+        aTags.map(async (aTag) => {
+          const parts = aTag.split(':');
+          if (parts.length !== 3) return null;
+          const [kindStr, pubkey, dTag] = parts;
+          const kind = Number(kindStr);
+          if (!Number.isFinite(kind) || !pubkey || !dTag) return null;
+          try {
+            const fetchPromise = $ndk.fetchEvent(
+              { kinds: [kind], authors: [pubkey], '#d': [dTag] },
+              { closeOnEose: true },
+              relaySet
+            );
+            const timeoutPromise = new Promise<null>((resolve) =>
+              setTimeout(() => resolve(null), 8000)
+            );
+            return (await Promise.race([fetchPromise, timeoutPromise])) as NDKEvent | null;
+          } catch {
+            return null;
+          }
+        })
+      );
+
+      // Drop result if user changed mid-fetch.
+      if (reqId !== savedRequestId) return;
+      const valid = fetched.filter((e): e is NDKEvent => e !== null);
+      savedEvents = sortAndDedupe(valid);
+      savedLoaded = true;
+    } catch (e: any) {
+      console.error('[packs] saved load failed', e);
+      if (reqId === savedRequestId) {
+        savedError = 'Could not load your saved Recipe Packs.';
+      }
+    } finally {
+      if (reqId === savedRequestId) savedLoading = false;
+    }
+  }
+
   function retryDiscover() {
     discoverError = '';
     discoverLoaded = false;
@@ -196,6 +284,12 @@
     loadMine();
   }
 
+  function retrySaved() {
+    savedError = '';
+    savedLoaded = false;
+    loadSaved();
+  }
+
   // Trigger loads on tab change (or first mount).
   $: if (browser && tab === 'discover' && !discoverLoaded && !discoverLoading && !discoverError) {
     loadDiscover();
@@ -203,8 +297,26 @@
   $: if (browser && tab === 'mine' && !mineLoaded && !mineLoading && !mineError) {
     loadMine();
   }
+  $: if (browser && tab === 'saved' && !savedLoaded && !savedLoading && !savedError) {
+    loadSaved();
+  }
 
-  // Re-load Mine when sign-in changes — bump the request id so any
+  // Re-resolve Saved when the underlying bookmark list changes — e.g.,
+  // user clicks bookmark on a card. Compare a stable signature of the
+  // a-tag list rather than reference, since the store always emits a
+  // fresh array.
+  $: if (browser && $userPublickey) {
+    const sig = $savedPackATags.slice().sort().join(',');
+    if (savedLoaded && sig !== lastResolvedSavedSig) {
+      lastResolvedSavedSig = sig;
+      savedLoaded = false;
+      // If the user is currently viewing the Saved tab, kick a refetch;
+      // otherwise the auto-load above will handle it on next visit.
+      if (tab === 'saved') loadSaved();
+    }
+  }
+
+  // Re-load Mine + Saved when sign-in changes — bump request ids so any
   // in-flight fetch for the previous pubkey is ignored on resolution.
   let lastUserPubkey = '';
   $: if (browser && $userPublickey !== lastUserPubkey) {
@@ -214,12 +326,19 @@
     mineError = '';
     mineRequestId++;
     mineLoading = false;
+    savedLoaded = false;
+    savedEvents = [];
+    savedError = '';
+    savedRequestId++;
+    savedLoading = false;
+    lastResolvedSavedSig = '';
   }
 
   onMount(() => {
     // Force first load even before reactive blocks fire.
     if (tab === 'discover') loadDiscover();
     if (tab === 'mine') loadMine();
+    if (tab === 'saved') loadSaved();
   });
 
   // Card-friendly view of a pack event.
@@ -253,10 +372,14 @@
   let activeLoading = false;
   let activeLoaded = false;
   let activeError = '';
-  $: activeEvents = tab === 'discover' ? discoverEvents : mineEvents;
-  $: activeLoading = tab === 'discover' ? discoverLoading : mineLoading;
-  $: activeLoaded = tab === 'discover' ? discoverLoaded : mineLoaded;
-  $: activeError = tab === 'discover' ? discoverError : mineError;
+  $: activeEvents =
+    tab === 'discover' ? discoverEvents : tab === 'mine' ? mineEvents : savedEvents;
+  $: activeLoading =
+    tab === 'discover' ? discoverLoading : tab === 'mine' ? mineLoading : savedLoading;
+  $: activeLoaded =
+    tab === 'discover' ? discoverLoaded : tab === 'mine' ? mineLoaded : savedLoaded;
+  $: activeError =
+    tab === 'discover' ? discoverError : tab === 'mine' ? mineError : savedError;
 </script>
 
 <svelte:head>
@@ -304,7 +427,7 @@
     </a>
   </div>
 
-  <!-- Sub-tabs: Discover / Mine -->
+  <!-- Sub-tabs: Discover / Mine / Saved -->
   <div class="flex w-full border-b" style="border-color: var(--color-input-border)">
     <button
       on:click={() => setTab('discover')}
@@ -334,10 +457,24 @@
         ></span>
       {/if}
     </button>
+    <button
+      on:click={() => setTab('saved')}
+      class="flex-1 py-2.5 text-sm font-medium transition-colors relative cursor-pointer text-center"
+      style="color: {tab === 'saved'
+        ? 'var(--color-text-primary)'
+        : 'var(--color-text-secondary)'}"
+    >
+      Saved
+      {#if tab === 'saved'}
+        <span
+          class="absolute bottom-0 left-0 right-0 h-0.5 bg-gradient-to-r from-orange-500 to-amber-500"
+        ></span>
+      {/if}
+    </button>
   </div>
 
   <!-- Body -->
-  {#if tab === 'mine' && !$userPublickey}
+  {#if (tab === 'mine' || tab === 'saved') && !$userPublickey}
     <div class="flex flex-col items-center justify-center py-16 px-4">
       <div
         class="w-16 h-16 rounded-full bg-gradient-to-br from-orange-100 to-amber-100 dark:from-orange-900/30 dark:to-amber-900/30 flex items-center justify-center mb-4"
@@ -348,7 +485,9 @@
         Sign in to see your packs
       </h2>
       <p class="text-caption text-center max-w-sm mb-4">
-        Once you're signed in, your published Recipe Packs will appear here.
+        {tab === 'mine'
+          ? "Once you're signed in, your published Recipe Packs will appear here."
+          : "Once you're signed in, packs you've saved will appear here."}
       </p>
       <a
         href="/login"
@@ -365,7 +504,8 @@
     <div class="flex flex-col items-center justify-center py-12 px-4 gap-3">
       <p class="text-caption text-sm text-center">{activeError}</p>
       <button
-        on:click={() => (tab === 'discover' ? retryDiscover() : retryMine())}
+        on:click={() =>
+          tab === 'discover' ? retryDiscover() : tab === 'mine' ? retryMine() : retrySaved()}
         class="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-colors"
         style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
       >
@@ -380,12 +520,18 @@
         <BookmarkIcon size={32} weight="regular" class="text-orange-500" />
       </div>
       <h2 class="text-lg font-medium mb-2" style="color: var(--color-text-primary)">
-        {tab === 'discover' ? 'No packs found yet' : "You haven't published any packs"}
+        {tab === 'discover'
+          ? 'No packs found yet'
+          : tab === 'mine'
+            ? "You haven't published any packs"
+            : 'No saved packs yet'}
       </h2>
       <p class="text-caption text-center max-w-sm mb-4">
         {tab === 'discover'
           ? "We couldn't find any Recipe Packs on the connected relays. Check back soon."
-          : 'Open a collection in your cookbook and tap "Share Pack" to publish your first one.'}
+          : tab === 'mine'
+            ? 'Open a collection in your cookbook and tap "Share Pack" to publish your first one.'
+            : 'Tap the bookmark icon on a pack to save it here.'}
       </p>
       <a
         href="/cookbook"

--- a/src/routes/packs/+page.svelte
+++ b/src/routes/packs/+page.svelte
@@ -1,0 +1,304 @@
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { page } from '$app/stores';
+  import { goto } from '$app/navigation';
+  import { onMount } from 'svelte';
+  import { nip19 } from 'nostr-tools';
+  import { ndk, userPublickey } from '$lib/nostr';
+  import { NDKEvent } from '@nostr-dev-kit/ndk';
+  import { RECIPE_PACK_KIND, RECIPE_PACK_TAG, ZAP_COOKING_TAG } from '$lib/recipePack';
+  import RecipePackCard from '../../components/RecipePackCard.svelte';
+  import PanLoader from '../../components/PanLoader.svelte';
+  import BookmarkIcon from 'phosphor-svelte/lib/BookmarkSimple';
+  import ArrowLeftIcon from 'phosphor-svelte/lib/ArrowLeft';
+
+  type Tab = 'discover' | 'mine';
+  let tab: Tab = 'discover';
+
+  // Hydrate tab from ?tab= query param so links can deep-link to "Mine".
+  $: {
+    const t = $page.url.searchParams.get('tab');
+    if (t === 'mine' || t === 'discover') tab = t;
+  }
+
+  function setTab(next: Tab) {
+    tab = next;
+    if (browser) {
+      const url = new URL(window.location.href);
+      if (next === 'discover') url.searchParams.delete('tab');
+      else url.searchParams.set('tab', next);
+      goto(url.pathname + (url.search || ''), {
+        replaceState: true,
+        keepFocus: true,
+        noScroll: true
+      });
+    }
+  }
+
+  // ===== Pack feeds =====
+  // Cache events so switching tabs is instant after first load.
+  let discoverEvents: NDKEvent[] = [];
+  let mineEvents: NDKEvent[] = [];
+  let discoverLoading = false;
+  let mineLoading = false;
+  let discoverLoaded = false;
+  let mineLoaded = false;
+  let discoverError = '';
+  let mineError = '';
+
+  async function loadDiscover() {
+    if (discoverLoading || discoverLoaded) return;
+    discoverLoading = true;
+    discoverError = '';
+    try {
+      const events = await $ndk.fetchEvents({
+        kinds: [RECIPE_PACK_KIND as number],
+        '#t': [ZAP_COOKING_TAG, RECIPE_PACK_TAG],
+        limit: 60
+      });
+      discoverEvents = sortAndDedupe(Array.from(events));
+    } catch (e: any) {
+      console.error('[packs] discover load failed', e);
+      discoverError = 'Could not load Recipe Packs. Try again in a moment.';
+    } finally {
+      discoverLoading = false;
+      discoverLoaded = true;
+    }
+  }
+
+  async function loadMine() {
+    if (mineLoading) return;
+    if (!$userPublickey) {
+      mineEvents = [];
+      mineLoaded = true;
+      return;
+    }
+    mineLoading = true;
+    mineError = '';
+    try {
+      const events = await $ndk.fetchEvents({
+        kinds: [RECIPE_PACK_KIND as number],
+        authors: [$userPublickey],
+        limit: 60
+      });
+      mineEvents = sortAndDedupe(Array.from(events));
+    } catch (e: any) {
+      console.error('[packs] mine load failed', e);
+      mineError = 'Could not load your Recipe Packs.';
+    } finally {
+      mineLoading = false;
+      mineLoaded = true;
+    }
+  }
+
+  // Replaceable events: keep only the newest event per (pubkey,d-tag).
+  // Then sort newest-first so the freshest packs surface at the top.
+  function sortAndDedupe(events: NDKEvent[]): NDKEvent[] {
+    const byKey = new Map<string, NDKEvent>();
+    for (const e of events) {
+      const dTag = e.tags?.find((t) => t[0] === 'd')?.[1] || '';
+      const key = `${e.pubkey}:${dTag}`;
+      const existing = byKey.get(key);
+      if (!existing || (e.created_at || 0) > (existing.created_at || 0)) {
+        byKey.set(key, e);
+      }
+    }
+    return Array.from(byKey.values())
+      .filter((e) => {
+        // Filter out empty packs (no recipe references) — they'd show as
+        // empty cards which is just noise.
+        return e.tags?.some((t) => t[0] === 'a');
+      })
+      .sort((a, b) => (b.created_at || 0) - (a.created_at || 0));
+  }
+
+  // Trigger loads on tab change (or first mount).
+  $: if (browser && tab === 'discover' && !discoverLoaded && !discoverLoading) {
+    loadDiscover();
+  }
+  $: if (browser && tab === 'mine' && !mineLoaded && !mineLoading) {
+    loadMine();
+  }
+
+  // Re-load Mine when sign-in changes
+  let lastUserPubkey = '';
+  $: if (browser && $userPublickey !== lastUserPubkey) {
+    lastUserPubkey = $userPublickey;
+    mineLoaded = false;
+    mineEvents = [];
+  }
+
+  onMount(() => {
+    // Force first load even before reactive blocks fire.
+    if (tab === 'discover') loadDiscover();
+    if (tab === 'mine') loadMine();
+  });
+
+  // Card-friendly view of a pack event.
+  function packCardData(e: NDKEvent) {
+    const find = (name: string) => e.tags?.find((t) => t[0] === name)?.[1];
+    const title = find('title') || find('d') || 'Recipe Pack';
+    const description = find('description') || '';
+    const image = find('image') || undefined;
+    const recipeCount = e.tags?.filter((t) => t[0] === 'a').length || 0;
+    const dTag = find('d') || '';
+    let viewUrl = '';
+    if (dTag && e.pubkey) {
+      try {
+        const naddr = nip19.naddrEncode({
+          identifier: dTag,
+          kind: RECIPE_PACK_KIND as number,
+          pubkey: e.pubkey
+        });
+        viewUrl = `/pack/${naddr}`;
+      } catch {
+        /* ignore */
+      }
+    }
+    return { title, description, image, recipeCount, viewUrl };
+  }
+
+  $: activeEvents = tab === 'discover' ? discoverEvents : mineEvents;
+  $: activeLoading = tab === 'discover' ? discoverLoading : mineLoading;
+  $: activeLoaded = tab === 'discover' ? discoverLoaded : mineLoaded;
+  $: activeError = tab === 'discover' ? discoverError : mineError;
+</script>
+
+<svelte:head>
+  <title>Recipe Packs — Zap Cooking</title>
+  <meta
+    name="description"
+    content="Browse curated, zappable Recipe Packs from chefs across Nostr."
+  />
+  <meta property="og:title" content="Recipe Packs — Zap Cooking" />
+  <meta
+    property="og:description"
+    content="Browse curated, zappable Recipe Packs from chefs across Nostr."
+  />
+  <meta property="og:image" content="https://zap.cooking/social-share.png" />
+  <meta property="og:url" content="https://zap.cooking/packs" />
+  <meta name="twitter:card" content="summary_large_image" />
+</svelte:head>
+
+<div class="flex flex-col gap-5">
+  <!-- Header -->
+  <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+    <div class="flex items-center gap-3">
+      <div
+        class="w-12 h-12 rounded-full bg-gradient-to-br from-orange-500 to-amber-500 flex items-center justify-center flex-shrink-0"
+      >
+        <BookmarkIcon size={24} weight="fill" class="text-white" />
+      </div>
+      <div>
+        <h1 class="text-2xl font-bold" style="color: var(--color-text-primary)">Recipe Packs</h1>
+        <p class="text-sm text-caption">Curated, zappable recipe collections from across Nostr.</p>
+      </div>
+    </div>
+    <a
+      href="/cookbook"
+      class="inline-flex items-center gap-1.5 text-sm text-caption hover:text-primary transition-colors"
+    >
+      <ArrowLeftIcon size={16} />
+      <span>My Cookbook</span>
+    </a>
+  </div>
+
+  <!-- Sub-tabs: Discover / Mine -->
+  <div class="flex w-full border-b" style="border-color: var(--color-input-border)">
+    <button
+      on:click={() => setTab('discover')}
+      class="flex-1 py-2.5 text-sm font-medium transition-colors relative cursor-pointer text-center"
+      style="color: {tab === 'discover'
+        ? 'var(--color-text-primary)'
+        : 'var(--color-text-secondary)'}"
+    >
+      Discover
+      {#if tab === 'discover'}
+        <span
+          class="absolute bottom-0 left-0 right-0 h-0.5 bg-gradient-to-r from-orange-500 to-amber-500"
+        ></span>
+      {/if}
+    </button>
+    <button
+      on:click={() => setTab('mine')}
+      class="flex-1 py-2.5 text-sm font-medium transition-colors relative cursor-pointer text-center"
+      style="color: {tab === 'mine'
+        ? 'var(--color-text-primary)'
+        : 'var(--color-text-secondary)'}"
+    >
+      Mine
+      {#if tab === 'mine'}
+        <span
+          class="absolute bottom-0 left-0 right-0 h-0.5 bg-gradient-to-r from-orange-500 to-amber-500"
+        ></span>
+      {/if}
+    </button>
+  </div>
+
+  <!-- Body -->
+  {#if tab === 'mine' && !$userPublickey}
+    <div class="flex flex-col items-center justify-center py-16 px-4">
+      <div
+        class="w-16 h-16 rounded-full bg-gradient-to-br from-orange-100 to-amber-100 dark:from-orange-900/30 dark:to-amber-900/30 flex items-center justify-center mb-4"
+      >
+        <BookmarkIcon size={32} weight="regular" class="text-orange-500" />
+      </div>
+      <h2 class="text-lg font-medium mb-2" style="color: var(--color-text-primary)">
+        Sign in to see your packs
+      </h2>
+      <p class="text-caption text-center max-w-sm mb-4">
+        Once you're signed in, your published Recipe Packs will appear here.
+      </p>
+      <a
+        href="/login"
+        class="flex items-center gap-2 px-5 py-2.5 bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 text-white rounded-full font-medium transition-all"
+      >
+        Sign in
+      </a>
+    </div>
+  {:else if !activeLoaded && activeLoading}
+    <div class="flex justify-center items-center py-16">
+      <PanLoader />
+    </div>
+  {:else if activeError}
+    <div class="text-caption text-sm text-center py-12">{activeError}</div>
+  {:else if activeEvents.length === 0}
+    <div class="flex flex-col items-center justify-center py-16 px-4">
+      <div
+        class="w-16 h-16 rounded-full bg-gradient-to-br from-orange-100 to-amber-100 dark:from-orange-900/30 dark:to-amber-900/30 flex items-center justify-center mb-4"
+      >
+        <BookmarkIcon size={32} weight="regular" class="text-orange-500" />
+      </div>
+      <h2 class="text-lg font-medium mb-2" style="color: var(--color-text-primary)">
+        {tab === 'discover' ? 'No packs found yet' : "You haven't published any packs"}
+      </h2>
+      <p class="text-caption text-center max-w-sm mb-4">
+        {tab === 'discover'
+          ? "We couldn't find any Recipe Packs on the connected relays. Check back soon."
+          : 'Open a collection in your cookbook and tap "Share Pack" to publish your first one.'}
+      </p>
+      <a
+        href="/cookbook"
+        class="flex items-center px-4 py-2 rounded-full font-medium text-sm transition-colors"
+        style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+      >
+        Open Cookbook
+      </a>
+    </div>
+  {:else}
+    <div class="grid gap-4 sm:gap-5 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+      {#each activeEvents as e (e.id)}
+        {@const card = packCardData(e)}
+        <RecipePackCard
+          event={e}
+          title={card.title}
+          description={card.description}
+          image={card.image}
+          creatorPubkey={e.pubkey}
+          recipeCount={card.recipeCount}
+          viewUrl={card.viewUrl}
+        />
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/src/routes/packs/+page.svelte
+++ b/src/routes/packs/+page.svelte
@@ -230,37 +230,50 @@
         return;
       }
 
-      // Build the OR-of-(authors,#d) filter set for one round-trip.
-      // We use REQ filters keyed by pubkey since `a`-tag filters aren't
-      // standardized; per-pack (kinds, authors, #d) is the safe form.
+      // Group the saved a-tags by (kind, pubkey) so all packs from the
+      // same author can be fetched with a single filter using a multi-
+      // value `#d`. This collapses N requests into "one filter per
+      // unique creator" — typical case is a handful of creators per
+      // user, so the result is usually 1-3 round trips total.
       const relaySet = NDKRelaySet.fromRelayUrls(standardRelays, $ndk, false);
-      const fetched = await Promise.all(
-        aTags.map(async (aTag) => {
-          const parts = aTag.split(':');
-          if (parts.length !== 3) return null;
-          const [kindStr, pubkey, dTag] = parts;
-          const kind = Number(kindStr);
-          if (!Number.isFinite(kind) || !pubkey || !dTag) return null;
-          try {
-            const fetchPromise = $ndk.fetchEvent(
-              { kinds: [kind], authors: [pubkey], '#d': [dTag] },
-              { closeOnEose: true },
-              relaySet
-            );
-            const timeoutPromise = new Promise<null>((resolve) =>
-              setTimeout(() => resolve(null), 8000)
-            );
-            return (await Promise.race([fetchPromise, timeoutPromise])) as NDKEvent | null;
-          } catch {
-            return null;
-          }
-        })
-      );
+      const groups = new Map<string, { kind: number; pubkey: string; dTags: Set<string> }>();
+      for (const aTag of aTags) {
+        const parts = aTag.split(':');
+        if (parts.length !== 3) continue;
+        const [kindStr, pubkey, dTag] = parts;
+        const kind = Number(kindStr);
+        if (!Number.isFinite(kind) || !pubkey || !dTag) continue;
+        const key = `${kind}:${pubkey}`;
+        const existing = groups.get(key);
+        if (existing) existing.dTags.add(dTag);
+        else groups.set(key, { kind, pubkey, dTags: new Set([dTag]) });
+      }
+
+      const filters = Array.from(groups.values()).map(({ kind, pubkey, dTags }) => ({
+        kinds: [kind],
+        authors: [pubkey],
+        '#d': Array.from(dTags)
+      }));
+
+      let fetched: NDKEvent[] = [];
+      if (filters.length > 0) {
+        try {
+          // NDK's fetchEvents accepts an array of filters → it issues a
+          // single REQ with all filters per relay (each filter is OR'd).
+          const fetchPromise = $ndk.fetchEvents(filters, { closeOnEose: true }, relaySet);
+          const timeoutPromise = new Promise<null>((resolve) =>
+            setTimeout(() => resolve(null), 8000)
+          );
+          const result = await Promise.race([fetchPromise, timeoutPromise]);
+          if (result) fetched = Array.from(result);
+        } catch {
+          fetched = [];
+        }
+      }
 
       // Drop result if user changed mid-fetch.
       if (reqId !== savedRequestId) return;
-      const valid = fetched.filter((e): e is NDKEvent => e !== null);
-      savedEvents = sortAndDedupe(valid);
+      savedEvents = sortAndDedupe(fetched);
       savedLoaded = true;
     } catch (e: any) {
       console.error('[packs] saved load failed', e);

--- a/src/routes/packs/+page.svelte
+++ b/src/routes/packs/+page.svelte
@@ -17,9 +17,13 @@
   let tab: Tab = 'discover';
 
   // Hydrate tab from ?tab= query param so links can deep-link to a sub-tab.
+  // Snap back to 'discover' when the param is missing or invalid so
+  // navigating /packs?tab=mine → /packs (or browser-back) doesn't leave
+  // the UI on the previous tab.
   $: {
     const t = $page.url.searchParams.get('tab');
     if (t === 'mine' || t === 'discover' || t === 'saved') tab = t;
+    else tab = 'discover';
   }
 
   function setTab(next: Tab) {

--- a/src/routes/packs/+page.svelte
+++ b/src/routes/packs/+page.svelte
@@ -11,7 +11,6 @@
   import RecipePackCard from '../../components/RecipePackCard.svelte';
   import PanLoader from '../../components/PanLoader.svelte';
   import BookmarkIcon from 'phosphor-svelte/lib/BookmarkSimple';
-  import ArrowLeftIcon from 'phosphor-svelte/lib/ArrowLeft';
 
   type Tab = 'discover' | 'mine';
   let tab: Tab = 'discover';
@@ -276,26 +275,32 @@
   <meta name="twitter:card" content="summary_large_image" />
 </svelte:head>
 
-<div class="flex flex-col gap-5">
-  <!-- Header -->
-  <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-    <div class="flex items-center gap-3">
-      <div
-        class="w-12 h-12 rounded-full bg-gradient-to-br from-orange-500 to-amber-500 flex items-center justify-center flex-shrink-0"
-      >
-        <BookmarkIcon size={24} weight="fill" class="text-white" />
-      </div>
-      <div>
-        <h1 class="text-2xl font-bold" style="color: var(--color-text-primary)">Recipe Packs</h1>
-        <p class="text-sm text-caption">Curated, zappable recipe collections from across Nostr.</p>
-      </div>
+<div class="flex flex-col gap-4 max-w-full md:max-w-none">
+  <!-- Top tab bar — mirrors /recent so navigation stays consistent.
+       Recent / Packs / Premium ⚡️ — Packs is active here. -->
+  <div class="flex w-full border-b" style="border-color: var(--color-input-border)">
+    <a
+      href="/recent"
+      class="flex-1 py-2.5 text-sm font-medium transition-colors relative cursor-pointer text-center"
+      style="color: var(--color-text-secondary)"
+    >
+      Recent
+    </a>
+    <div
+      class="flex-1 py-2.5 text-sm font-medium transition-colors relative text-center"
+      style="color: var(--color-text-primary)"
+    >
+      Packs
+      <span
+        class="absolute bottom-0 left-0 right-0 h-0.5 bg-gradient-to-r from-orange-500 to-amber-500"
+      ></span>
     </div>
     <a
-      href="/cookbook"
-      class="inline-flex items-center gap-1.5 text-sm text-caption hover:text-primary transition-colors"
+      href="/premium"
+      class="flex-1 py-2.5 text-sm font-medium transition-colors relative cursor-pointer text-center"
+      style="color: var(--color-text-secondary)"
     >
-      <ArrowLeftIcon size={16} />
-      <span>My Cookbook</span>
+      Premium ⚡️
     </a>
   </div>
 

--- a/src/routes/packs/+page.svelte
+++ b/src/routes/packs/+page.svelte
@@ -4,7 +4,7 @@
   import { goto } from '$app/navigation';
   import { onMount } from 'svelte';
   import { nip19 } from 'nostr-tools';
-  import { ndk, userPublickey } from '$lib/nostr';
+  import { ndk, userPublickey, ensureNdkConnected } from '$lib/nostr';
   import { NDKEvent } from '@nostr-dev-kit/ndk';
   import { RECIPE_PACK_KIND, RECIPE_PACK_TAG, ZAP_COOKING_TAG } from '$lib/recipePack';
   import RecipePackCard from '../../components/RecipePackCard.svelte';
@@ -41,28 +41,45 @@
   let mineEvents: NDKEvent[] = [];
   let discoverLoading = false;
   let mineLoading = false;
-  let discoverLoaded = false;
+  let discoverLoaded = false; // success-only; on error we leave this false so retry is possible
   let mineLoaded = false;
   let discoverError = '';
   let mineError = '';
 
+  // Per-load request id for the Mine fetch. Captured at the start of
+  // each load and re-checked when the network returns; if it doesn't
+  // match anymore (user signed out / switched accounts), the result
+  // is dropped without overwriting state. Same idea as the relay-
+  // generation guard in /recent.
+  let mineRequestId = 0;
+
   async function loadDiscover() {
-    if (discoverLoading || discoverLoaded) return;
+    if (discoverLoading) return;
     discoverLoading = true;
     discoverError = '';
     try {
+      // Make sure NDK has at least one connected relay before subscribing
+      // — mirrors /recent's pattern. Reduces cold-load failure rate when
+      // the page is loaded directly (rather than via SPA nav from the home
+      // feed which has already warmed connections).
+      try {
+        await ensureNdkConnected();
+      } catch {
+        /* tolerate; fetchEvents will surface the error if relays are still down */
+      }
+
       const events = await $ndk.fetchEvents({
         kinds: [RECIPE_PACK_KIND as number],
         '#t': [ZAP_COOKING_TAG, RECIPE_PACK_TAG],
         limit: 60
       });
       discoverEvents = sortAndDedupe(Array.from(events));
+      discoverLoaded = true; // mark loaded only on success — error path leaves it false so Retry works
     } catch (e: any) {
       console.error('[packs] discover load failed', e);
       discoverError = 'Could not load Recipe Packs. Try again in a moment.';
     } finally {
       discoverLoading = false;
-      discoverLoaded = true;
     }
   }
 
@@ -73,59 +90,99 @@
       mineLoaded = true;
       return;
     }
+    const reqId = ++mineRequestId;
+    const reqPubkey = $userPublickey;
     mineLoading = true;
     mineError = '';
     try {
+      try {
+        await ensureNdkConnected();
+      } catch {
+        /* tolerate */
+      }
+
       const events = await $ndk.fetchEvents({
         kinds: [RECIPE_PACK_KIND as number],
-        authors: [$userPublickey],
+        authors: [reqPubkey],
         limit: 60
       });
+
+      // Drop the result if the user has logged out or switched accounts
+      // since this fetch began — otherwise stale events from the previous
+      // pubkey would overwrite the current state.
+      if (reqId !== mineRequestId || reqPubkey !== $userPublickey) {
+        return;
+      }
+
       mineEvents = sortAndDedupe(Array.from(events));
+      mineLoaded = true;
     } catch (e: any) {
       console.error('[packs] mine load failed', e);
-      mineError = 'Could not load your Recipe Packs.';
+      if (reqId === mineRequestId) {
+        mineError = 'Could not load your Recipe Packs.';
+      }
     } finally {
-      mineLoading = false;
-      mineLoaded = true;
+      if (reqId === mineRequestId) {
+        mineLoading = false;
+      }
     }
   }
 
-  // Replaceable events: keep only the newest event per (pubkey,d-tag).
-  // Then sort newest-first so the freshest packs surface at the top.
+  // Replaceable events: drop anything missing a `d` tag (Recipe Packs are
+  // addressable so a missing `d` means malformed/spam — we'd also have no
+  // way to build a working /pack/<naddr> link), then keep only the newest
+  // event per (pubkey, d-tag), then sort newest-first.
   function sortAndDedupe(events: NDKEvent[]): NDKEvent[] {
+    const valid = events.filter((e) => {
+      const dTag = e.tags?.find((t) => t[0] === 'd')?.[1];
+      // Need a non-empty d-tag AND at least one recipe `a` reference.
+      // Empty packs would render as empty cards; bare-d packs would
+      // collide in the dedupe map by pubkey alone.
+      return !!dTag && e.tags?.some((t) => t[0] === 'a');
+    });
+
     const byKey = new Map<string, NDKEvent>();
-    for (const e of events) {
-      const dTag = e.tags?.find((t) => t[0] === 'd')?.[1] || '';
+    for (const e of valid) {
+      const dTag = e.tags!.find((t) => t[0] === 'd')![1];
       const key = `${e.pubkey}:${dTag}`;
       const existing = byKey.get(key);
       if (!existing || (e.created_at || 0) > (existing.created_at || 0)) {
         byKey.set(key, e);
       }
     }
-    return Array.from(byKey.values())
-      .filter((e) => {
-        // Filter out empty packs (no recipe references) — they'd show as
-        // empty cards which is just noise.
-        return e.tags?.some((t) => t[0] === 'a');
-      })
-      .sort((a, b) => (b.created_at || 0) - (a.created_at || 0));
+    return Array.from(byKey.values()).sort((a, b) => (b.created_at || 0) - (a.created_at || 0));
   }
 
-  // Trigger loads on tab change (or first mount).
-  $: if (browser && tab === 'discover' && !discoverLoaded && !discoverLoading) {
+  function retryDiscover() {
+    discoverError = '';
+    discoverLoaded = false;
     loadDiscover();
   }
-  $: if (browser && tab === 'mine' && !mineLoaded && !mineLoading) {
+
+  function retryMine() {
+    mineError = '';
+    mineLoaded = false;
     loadMine();
   }
 
-  // Re-load Mine when sign-in changes
+  // Trigger loads on tab change (or first mount).
+  $: if (browser && tab === 'discover' && !discoverLoaded && !discoverLoading && !discoverError) {
+    loadDiscover();
+  }
+  $: if (browser && tab === 'mine' && !mineLoaded && !mineLoading && !mineError) {
+    loadMine();
+  }
+
+  // Re-load Mine when sign-in changes — bump the request id so any
+  // in-flight fetch for the previous pubkey is ignored on resolution.
   let lastUserPubkey = '';
   $: if (browser && $userPublickey !== lastUserPubkey) {
     lastUserPubkey = $userPublickey;
     mineLoaded = false;
     mineEvents = [];
+    mineError = '';
+    mineRequestId++;
+    mineLoading = false;
   }
 
   onMount(() => {
@@ -158,6 +215,13 @@
     return { title, description, image, recipeCount, viewUrl };
   }
 
+  // Explicit declarations to satisfy strict-mode tooling (Svelte's `$:`
+  // creates an implicit binding, but eslint-svelte and svelte-check in
+  // strict TS configs sometimes flag it).
+  let activeEvents: NDKEvent[] = [];
+  let activeLoading = false;
+  let activeLoaded = false;
+  let activeError = '';
   $: activeEvents = tab === 'discover' ? discoverEvents : mineEvents;
   $: activeLoading = tab === 'discover' ? discoverLoading : mineLoading;
   $: activeLoaded = tab === 'discover' ? discoverLoaded : mineLoaded;
@@ -261,7 +325,16 @@
       <PanLoader />
     </div>
   {:else if activeError}
-    <div class="text-caption text-sm text-center py-12">{activeError}</div>
+    <div class="flex flex-col items-center justify-center py-12 px-4 gap-3">
+      <p class="text-caption text-sm text-center">{activeError}</p>
+      <button
+        on:click={() => (tab === 'discover' ? retryDiscover() : retryMine())}
+        class="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-colors"
+        style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+      >
+        Retry
+      </button>
+    </div>
   {:else if activeEvents.length === 0}
     <div class="flex flex-col items-center justify-center py-16 px-4">
       <div

--- a/src/routes/recent/+page.svelte
+++ b/src/routes/recent/+page.svelte
@@ -233,6 +233,13 @@
         {/if}
       </button>
       <a
+        href="/packs"
+        class="flex-1 py-2.5 text-sm font-medium transition-colors relative cursor-pointer text-center"
+        style="color: var(--color-text-secondary)"
+      >
+        Packs
+      </a>
+      <a
         href="/premium"
         class="flex-1 py-2.5 text-sm font-medium transition-colors relative cursor-pointer text-center"
         style="color: var(--color-text-secondary)"


### PR DESCRIPTION
## Summary

Adds a browsable home for Recipe Packs at `/packs` — a sibling to `/recent` — and gives Recipe Pack cards the same social-action behavior as recipes.

## What's in

- **`/packs` route** with three sub-tabs:
  - **Discover** (default) — `kinds:[30004]` filtered by `'#t': ['zap-cooking', 'recipe-pack']`, deduped by `(pubkey, d-tag)`, sorted newest-first, empty/d-tagless packs filtered out, queried via an explicit standard-relay set so unauthored discovery filters don't get stranded by NDK's outbox model.
  - **Mine** — same kind, `authors:[$userPublickey]`. Sign-in CTA when logged out. Per-load request-id guard so an in-flight fetch for a previous account can't overwrite state on sign-out / account switch.
  - **Saved** — packs the user has bookmarked (NIP-51 kind 30003 list with d-tag `zapcooking-saved-packs`). Resolves saved a-tags to their pack events in batched per-author fetches.
- **Tab state in `?tab=`** so `/packs?tab=mine` and `/packs?tab=saved` deep-link.
- **Tab on `/recent`**: new `Packs` link sits between Recent and Premium ⚡️. The `/packs` page mirrors `/recent`'s top-tab structure so navigation context is preserved.
- **Refactored `RecipePackCard`**:
  - Image is the primary tap target.
  - Bookmark icon top-right of cover (recipe-card design language).
  - Compact metadata block (title, description, creator, recipe count).
  - Social action row matches recipes: **Likes · Comments · Repost · Zap | Share**. Built from the same engagement primitives recipes use; comments link to `/<naddr>` (the generic NIP-19 viewer with NIP-22 comments) so the icon is functional, not a no-op.
- **`savedPacksStore`** — new NIP-51 30003 store for bookmark/save. Optimistic local update + publish + rollback on failure. Clears state on pubkey change so previous-account data can't bleed across sessions.
- **`/api/shorten` accepts `/pack/<naddr>` URLs** — the canonical pack URL was rejected by the shortlink API; now `/r/`, `/reads/`, and `/pack/` all parse, with redirects routed correctly via `redirectPath`.

## Test plan

- [ ] `/packs` loads, Discover shows recent packs.
- [ ] Replaceable packs show only once (latest revision).
- [ ] Empty / d-tag-less packs are filtered from the grid.
- [ ] Click a card → `/pack/<naddr>` opens.
- [ ] `/packs?tab=mine` and `/packs?tab=saved` deep-links work; tab state syncs to URL.
- [ ] Mine while signed out → "Sign in" CTA. Mine while signed in shows your published packs.
- [ ] Sign out from Mine → state clears (no stale events from previous user).
- [ ] Card cover top-right bookmark toggles; "Pack saved" / "Removed from saved packs" toasts.
- [ ] Bookmarked pack shows up in **Saved** tab. Saved tab loads in 1-3 relay round-trips even with many bookmarks (batched by author).
- [ ] `/recent` shows the new Packs tab next to Recent / Premium.
- [ ] Share on a pack card opens the recipe-style ShareModal; short link API now accepts the `/pack/<naddr>` URL cleanly.
- [ ] Comments icon on a pack card navigates to `/<naddr>` thread; count matches engagement-cache value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)