### PR TITLE
fix(pack-og): make link previews actually render across platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.300",
+  "version": "4.2.301",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -63,11 +63,17 @@
   const ogImage = `${siteUrl}/social-share.png`;
   $: canonical = `${siteUrl}${$page.url.pathname === '/' ? '' : $page.url.pathname}`;
 
-  // Skip layout OG tags on pages that set their own (recipe pages, note pages)
+  // Skip layout OG tags on pages that set their own (recipe pages, note pages,
+  // pack pages). When a page provides custom OG tags AND the layout also
+  // emits its generic ones, scrapers see two `og:title` etc. and most pick
+  // the first occurrence — which would be the layout's generic tags. Adding
+  // a path here ensures the page's own SSR OG meta is the only set scrapers
+  // see.
   $: pathSegment = $page.url.pathname.split('/')[1] || '';
   $: hasCustomOgTags =
     $page.url.pathname.startsWith('/recipe/') ||
     $page.url.pathname.startsWith('/r/') ||
+    $page.url.pathname.startsWith('/pack/') ||
     pathSegment.startsWith('note1') ||
     pathSegment.startsWith('nevent1');
 

--- a/src/routes/pack/[naddr]/+page.server.ts
+++ b/src/routes/pack/[naddr]/+page.server.ts
@@ -1,7 +1,7 @@
 import type { PageServerLoad } from './$types';
 import { nip19 } from 'nostr-tools';
 import { redirect } from '@sveltejs/kit';
-import { fetchPackMetadata } from '$lib/recipePackOg.server';
+import { fetchPackMetadata, fetchRecipePreviews } from '$lib/recipePackOg.server';
 
 const TRACKING_PARAMS = [
 	'fbclid',
@@ -18,6 +18,11 @@ const TRACKING_PARAMS = [
 
 const FALLBACK_TITLE = 'Recipe Pack on Zap Cooking';
 const FALLBACK_DESCRIPTION = 'A zappable recipe collection curated on Zap Cooking.';
+// Static branded raster fallback. Used when a pack has no cover image
+// AND no recipe in it has an image either. Real raster URL — works on
+// every OG-supporting platform (Twitter/X, Facebook, LinkedIn, Signal,
+// Slack, Discord, Telegram, iMessage).
+const FALLBACK_IMAGE = '/social-share.png';
 
 interface PackOgMeta {
 	title: string;
@@ -31,7 +36,7 @@ function safeFallback(naddr: string, baseUrl: string): { ogMeta: PackOgMeta; nad
 		ogMeta: {
 			title: FALLBACK_TITLE,
 			description: FALLBACK_DESCRIPTION,
-			image: `${baseUrl}/api/og/recipe-pack/${naddr}`,
+			image: `${baseUrl}${FALLBACK_IMAGE}`,
 			url: `${baseUrl}/pack/${naddr}`
 		},
 		naddr
@@ -77,11 +82,23 @@ export const load: PageServerLoad = async ({ params, url }) => {
 				? `A zappable Recipe Pack with ${meta.recipeCount} ${recipeWord}, curated on Zap Cooking.`
 				: FALLBACK_DESCRIPTION;
 
-		// Always use the dynamic OG endpoint as og:image — it composes the
-		// branded card and falls back to the pack's cover or static image
-		// internally. This way social platforms always get consistent
-		// branding rather than a raw recipe photo.
-		const ogImage = `${baseUrl}/api/og/recipe-pack/${naddr}`;
+		// og:image needs to be a real raster image (PNG/JPG/WebP). Twitter/X,
+		// Facebook, and LinkedIn don't render SVG og:image, so we point at:
+		//   1. the pack's own cover image tag, if any
+		//   2. otherwise, the first referenced recipe's image, if any
+		//   3. otherwise, the static branded social-share.png
+		// This matches the pattern that already works on /r/<naddr>.
+		let imageUrl = meta.image || '';
+		if (!imageUrl && meta.recipeATags.length > 0) {
+			try {
+				const previews = await fetchRecipePreviews(meta.recipeATags, 4);
+				const firstWithImage = previews.find((r) => r.image);
+				if (firstWithImage?.image) imageUrl = firstWithImage.image;
+			} catch {
+				/* tolerate failure — fall back to static */
+			}
+		}
+		if (!imageUrl) imageUrl = `${baseUrl}${FALLBACK_IMAGE}`;
 
 		return {
 			ogMeta: {
@@ -90,7 +107,7 @@ export const load: PageServerLoad = async ({ params, url }) => {
 						? `${title} — Recipe Pack on Zap Cooking`
 						: FALLBACK_TITLE,
 				description,
-				image: ogImage,
+				image: imageUrl,
 				url: `${baseUrl}/pack/${naddr}`
 			},
 			naddr
@@ -100,4 +117,3 @@ export const load: PageServerLoad = async ({ params, url }) => {
 		return safeFallback(naddr, baseUrl);
 	}
 };
-

--- a/src/routes/pack/[naddr]/+page.svelte
+++ b/src/routes/pack/[naddr]/+page.svelte
@@ -309,8 +309,6 @@
     <meta property="og:description" content={ogMeta.description} />
     <meta property="og:image" content={ogMeta.image} />
     <meta property="og:image:secure_url" content={ogMeta.image} />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content={ogMeta.title} />
     <meta
       property="og:url"


### PR DESCRIPTION
## Problem

After #354 merged, sharing `/pack/<naddr>` URLs **still doesn't render link previews on Twitter/X, Facebook, LinkedIn, or Signal**. Tested live on the production-deployed pack URL.

Two real bugs:

### 1. Duplicate `og:title` (and friends)

\`+layout.svelte\` conditionally suppresses its generic site OG tags via \`hasCustomOgTags\`, but the path check only covered \`/recipe/\`, \`/r/\`, and note paths. \`/pack/\` was missing. As a result the pack page emits **both** the layout's generic tags AND its own page-specific tags, with the generic ones first.

```bash
$ curl -A 'facebookexternalhit/1.1' https://zap.cooking/pack/<naddr> | grep -oE 'og:title[^>]*'
og:title" content="Zap Cooking - Food. Friends. Freedom."        # ← layout (first wins for most scrapers)
og:title" content="Delicious Desserts — Recipe Pack on Zap Cooking"
```

Most scrapers pick the first occurrence per property, so previews showed the generic site title instead of the pack title. **Fix:** add `/pack/` to `hasCustomOgTags`.

### 2. `og:image` pointed at an SVG endpoint

#354 pointed `og:image` at `/api/og/recipe-pack/<naddr>`, which returns `image/svg+xml`. Twitter/X, Facebook, and LinkedIn don't render SVG `og:image` and silently fall back to a generic preview (or none at all).

The recipe pages already work because they point `og:image` at the recipe's own raster cover. **Fix:** mirror that pattern. `og:image` now resolves through this fallback chain:

1. Pack `image` tag (cover) — JPG/PNG already hosted on Blossom / nostr.build / etc.
2. First referenced recipe's image, if the pack itself has none.
3. `/social-share.png` (static branded fallback).

Also dropped the fixed `og:image:width=1200, height=630` hint since the resolved image's dimensions now vary.

## What stayed

The SVG endpoint at `/api/og/recipe-pack/<naddr>` is still alive — it's useful for direct sharing on Slack/Discord/Telegram (which do render SVG `og:image`) and for future use. It's just no longer the `og:image` target.

A future PR could convert it to PNG via `@resvg/resvg-wasm` to get the branded card on Twitter/X — listed as a follow-up in #354. This PR optimizes for "previews work everywhere now" over "previews look perfectly branded everywhere."

## Test plan

- [ ] `curl -A facebookexternalhit/1.1 https://<deploy>/pack/<naddr> | grep -c og:title` returns **1**, not 2.
- [ ] Open in [Facebook's Sharing Debugger](https://developers.facebook.com/tools/debug/) — preview shows pack title + cover image.
- [ ] Open in [Twitter/X Card Validator](https://cards-dev.twitter.com/validator) (or Tweet preview) — `summary_large_image` renders with cover.
- [ ] Paste into LinkedIn post composer — preview renders.
- [ ] Paste into Signal — preview renders.
- [ ] Paste into Slack/Discord — preview renders.
- [ ] Pack with no cover, no recipe images → static `social-share.png` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)