### PR TITLE
perf(feed): batch engagement for anon viewers too (R2 from #341)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.310",
+  "version": "4.2.311",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -4850,8 +4850,17 @@
   let lastBatchedIds = new Set<string>();
   let engagementPreloadTimeout: ReturnType<typeof setTimeout> | null = null;
 
-  // Preload engagement only for rendered (near-viewport) events — not ALL events
-  $: if (typeof window !== 'undefined' && $ndk && $userPublickey && events.length > 0 && !loading && renderedNotes.size > 0) {
+  // Preload engagement only for rendered (near-viewport) events — not ALL events.
+  // Note: NOT gated on `$userPublickey`. Per-card children (NoteTotalLikes,
+  // NoteTotalComments, NoteRepost, NoteTotalZaps, ReactionPills) each call
+  // fetchEngagement on mount regardless of sign-in state, so anonymous
+  // viewers were paying the full per-card fan-out cost while signed-in
+  // viewers got batched. The batch path (server counts API + NDK
+  // subscription) doesn't require auth — userPublickey only feeds the
+  // userReacted / userReposted flags, which stay false for anon users
+  // either way. Letting the batch run for everyone preempts the per-card
+  // fetches via the 5-min freshness gate in batchFetchEngagement.
+  $: if (typeof window !== 'undefined' && $ndk && events.length > 0 && !loading && renderedNotes.size > 0) {
     // Clear any pending preload
     if (engagementPreloadTimeout) {
       clearTimeout(engagementPreloadTimeout);
@@ -4895,11 +4904,12 @@
     }, 200); // Small delay to let cached data load first
   }
 
-  // VISIBILITY UPDATE: When items become visible, ensure they're fresh
+  // VISIBILITY UPDATE: When items become visible, ensure they're fresh.
+  // Same anon-friendly rationale as the preload reactive above — batching
+  // benefits everyone, not just logged-in users.
   $: if (
     typeof window !== 'undefined' &&
     $ndk &&
-    $userPublickey &&
     visibleNotes.size > 0 &&
     events.length > 0
   ) {

--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -4858,8 +4858,9 @@
   // viewers got batched. The batch path (server counts API + NDK
   // subscription) doesn't require auth — userPublickey only feeds the
   // userReacted / userReposted flags, which stay false for anon users
-  // either way. Letting the batch run for everyone preempts the per-card
-  // fetches via the 5-min freshness gate in batchFetchEngagement.
+  // either way. Letting the batch run for everyone warms/populates the
+  // engagement store first, so subsequent per-card fetchEngagement calls can
+  // see already-fetched fresh data and no-op instead of fanning out.
   $: if (typeof window !== 'undefined' && $ndk && events.length > 0 && !loading && renderedNotes.size > 0) {
     // Clear any pending preload
     if (engagementPreloadTimeout) {


### PR DESCRIPTION
## Summary

Closes the last outstanding Stage-2 recommendation from the perf review in #341. R1 (feed remount → prop-driven mode) shipped as #344 and R4 (ReactionPills key) shipped as #342; this PR finishes the trio with R2.

## Problem

\`FoodstrFeedOptimized.svelte\` already imports and calls \`batchFetchEngagement\` at two sites — a rendered-near-viewport preload and a visibility-update reactive. **Both gate on \`\$userPublickey\`**, so:

- **Signed-in viewers**: batch path runs. Per-card \`fetchEngagement\` calls hit the 5-min freshness gate inside the batch helper and bail.
- **Anonymous viewers**: batch path is skipped entirely. Per-card children fan out individually.

For each rendered note, the per-card fan-out is up to 5×:

| Component | mount-time call |
|---|---|
| \`NoteTotalLikes\` | \`fetchEngagement(eventId)\` |
| \`NoteTotalComments\` | \`fetchEngagement(eventId)\` |
| \`NoteRepost\` | \`fetchEngagement(eventId)\` |
| \`NoteTotalZaps\` | \`fetchEngagement(eventId)\` |
| \`ReactionPills\` | \`fetchEngagement(eventId)\` |

Multiply by a 30-event feed window on every cold paint and every newly-rendered card. The cache singleton dedups the actual network query, but the active-subscription counter still climbs.

## Why the gate isn't load-bearing

- \`batchFetchEngagement\` → \`batchFetchFromServerAPI\` doesn't require auth.
- The NDK subscription fallback only uses \`userPublickey\` to flag \`userReacted\` / \`userReposted\` — for anonymous users those flags correctly stay false either way.
- The per-card children themselves don't gate on sign-in. Only the batch did.

## Fix

Drop the \`\$userPublickey\` check from both reactive blocks. Same code path runs for signed-in and anonymous viewers; signed-in behavior is unchanged because the gate was always passing for them.

\`\`\`diff
- $: if (… && \$ndk && \$userPublickey && events.length > 0 && !loading && renderedNotes.size > 0) {
+ $: if (… && \$ndk && events.length > 0 && !loading && renderedNotes.size > 0) {

- $: if (… && \$ndk && \$userPublickey && visibleNotes.size > 0 && events.length > 0) {
+ $: if (… && \$ndk && visibleNotes.size > 0 && events.length > 0) {
\`\`\`

Comments inline document the reasoning so the next reader doesn't re-add the gate.

## Risk

- **Counts / groups**: unchanged. Same cache, same subscription, same 5-min TTL.
- **Subscription count for anonymous**: drops from up to 5×N (per-card fan-out) to roughly 1 batch per visible window — matches signed-in behavior.
- **No regression to PR #321 / #323 count-correctness**: those land in the cache layer, which this PR does not touch.

## Test plan

- [ ] Open Foodstr feed signed out → counts populate with no observed regression.
- [ ] Open Foodstr feed signed in → counts populate as before.
- [ ] DevTools → Network: confirm only one server-counts batch request fires per visible window (signed in and signed out).
- [ ] Scroll the feed signed out → new visible notes resolve their counts in batched calls, not 5× per-card.
- [ ] React / repost / zap interactions still work for signed-in users (engagement updates flow through the same store).
- [ ] \`pnpm check\` 0 errors, \`pnpm build\` ✅ (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)