### PR TITLE
feat(pack): Export as Cookbook — Pro PDF export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.314",
+  "version": "4.2.315",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.312",
+  "version": "4.2.313",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.319",
+  "version": "4.2.320",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.313",
+  "version": "4.2.314",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.310",
+  "version": "4.2.311",
   "private": true,
   "scripts": {
     "dev": "vite dev",
@@ -64,6 +64,7 @@
     "google-translate-api-browser": "^3.0.1",
     "html2canvas": "^1.4.1",
     "hurdak": "^0.2.5",
+    "jspdf": "^4.2.1",
     "jsqr": "^1.4.0",
     "libretranslate": "^1.0.1",
     "markdown-it": "^13.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.317",
+  "version": "4.2.318",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.316",
+  "version": "4.2.317",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.318",
+  "version": "4.2.319",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.311",
+  "version": "4.2.312",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.315",
+  "version": "4.2.316",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       hurdak:
         specifier: ^0.2.5
         version: 0.2.10
+      jspdf:
+        specifier: ^4.2.1
+        version: 4.2.1
       jsqr:
         specifier: ^1.4.0
         version: 1.4.0
@@ -278,6 +281,10 @@ packages:
 
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
   '@branta-ops/branta@1.0.0':
@@ -1554,11 +1561,17 @@ packages:
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
+  '@types/pako@2.0.4':
+    resolution: {integrity: sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==}
+
   '@types/pluralize@0.0.29':
     resolution: {integrity: sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA==}
 
   '@types/pug@2.0.10':
     resolution: {integrity: sha512-Sk/uYFOBAB7mb74XcpizmH0KOR2Pv3D2Hmrh1Dmy5BmK3MpdSa5kqZcg6EKBdklU0bFXX9gCfzvpnyUehrPIuA==}
+
+  '@types/raf@3.4.3':
+    resolution: {integrity: sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==}
 
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
@@ -1988,6 +2001,10 @@ packages:
   caniuse-lite@1.0.30001683:
     resolution: {integrity: sha512-iqmNnThZ0n70mNwvxpEC2nBJ037ZHZUoBI5Gorh1Mw6IlEAZujEoU1tXA628iZfzm7R9FvFzxbfdgml82a3k8Q==}
 
+  canvg@3.0.11:
+    resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
+    engines: {node: '>=10.0.0'}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -2159,6 +2176,9 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -2614,6 +2634,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-png@6.4.0:
+    resolution: {integrity: sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==}
+
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
@@ -2623,6 +2646,9 @@ packages:
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
@@ -2930,6 +2956,9 @@ packages:
     resolution: {integrity: sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  iobuffer@5.4.0:
+    resolution: {integrity: sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==}
+
   ip-address@9.0.5:
     resolution: {integrity: sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==}
     engines: {node: '>= 12'}
@@ -3081,6 +3110,9 @@ packages:
   jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
+
+  jspdf@4.2.1:
+    resolution: {integrity: sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==}
 
   jsqr@1.4.0:
     resolution: {integrity: sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==}
@@ -3658,6 +3690,9 @@ packages:
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
+  pako@2.1.0:
+    resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -3724,6 +3759,9 @@ packages:
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
+  performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
   periscopic@3.1.0:
     resolution: {integrity: sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==}
@@ -4025,6 +4063,9 @@ packages:
     resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
     engines: {node: '>=8'}
 
+  raf@3.4.1:
+    resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
+
   ramda@0.29.1:
     resolution: {integrity: sha512-OfxIeWzd4xdUNxlWhgFazxsA/nl3mS4/jGZI5n00uWOoSSFRhC1b6gl6xvmzUamgmqELraWp0J/qqVlXYPDPyA==}
 
@@ -4073,6 +4114,9 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+
   regexp-to-ast@0.5.0:
     resolution: {integrity: sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==}
 
@@ -4112,6 +4156,10 @@ packages:
   reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rgbcolor@1.0.1:
+    resolution: {integrity: sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==}
+    engines: {node: '>= 0.8.15'}
 
   rimraf@2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
@@ -4320,6 +4368,10 @@ packages:
     resolution: {integrity: sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
+  stackblur-canvas@2.7.0:
+    resolution: {integrity: sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==}
+    engines: {node: '>=0.1.14'}
+
   stoppable@1.1.0:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
     engines: {node: '>=4', npm: '>=6'}
@@ -4456,6 +4508,10 @@ packages:
   svelte@4.2.20:
     resolution: {integrity: sha512-eeEgGc2DtiUil5ANdtd8vPwt9AgaMdnuUFnPft9F5oMvU/FHu5IHFic+p1dR/UOB7XU2mX2yHW+NcTch4DCh5Q==}
     engines: {node: '>=16'}
+
+  svg-pathdata@6.0.3:
+    resolution: {integrity: sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==}
+    engines: {node: '>=12.0.0'}
 
   syllable@5.0.1:
     resolution: {integrity: sha512-HWtNCp6v7J8H0lrT8j1HHjfOLltRoDcC7QRFVu25p4BE52JqetXG65nqC7CsatT8WQRfY4Qvh93BWJIUxbmXFg==}
@@ -5017,6 +5073,8 @@ snapshots:
       picocolors: 1.1.1
 
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/runtime@7.29.2': {}
 
   '@branta-ops/branta@1.0.0': {}
 
@@ -6273,9 +6331,14 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
+  '@types/pako@2.0.4': {}
+
   '@types/pluralize@0.0.29': {}
 
   '@types/pug@2.0.10': {}
+
+  '@types/raf@3.4.3':
+    optional: true
 
   '@types/semver@7.5.8': {}
 
@@ -6759,6 +6822,18 @@ snapshots:
 
   caniuse-lite@1.0.30001683: {}
 
+  canvg@3.0.11:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@types/raf': 3.4.3
+      core-js: 3.49.0
+      raf: 3.4.1
+      regenerator-runtime: 0.13.11
+      rgbcolor: 1.0.1
+      stackblur-canvas: 2.7.0
+      svg-pathdata: 6.0.3
+    optional: true
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -6973,6 +7048,9 @@ snapshots:
   cookie@0.6.0: {}
 
   cookie@1.1.1: {}
+
+  core-js@3.49.0:
+    optional: true
 
   core-util-is@1.0.3: {}
 
@@ -7504,6 +7582,12 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-png@6.4.0:
+    dependencies:
+      '@types/pako': 2.0.4
+      iobuffer: 5.4.0
+      pako: 2.1.0
+
   fastq@1.17.1:
     dependencies:
       reusify: 1.0.4
@@ -7516,6 +7600,8 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
+
+  fflate@0.8.2: {}
 
   file-entry-cache@6.0.1:
     dependencies:
@@ -7860,6 +7946,8 @@ snapshots:
 
   ini@4.1.3: {}
 
+  iobuffer@5.4.0: {}
+
   ip-address@9.0.5:
     dependencies:
       jsbn: 1.1.0
@@ -7983,6 +8071,17 @@ snapshots:
       graceful-fs: 4.2.11
 
   jsonparse@1.3.1: {}
+
+  jspdf@4.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      fast-png: 6.4.0
+      fflate: 0.8.2
+    optionalDependencies:
+      canvg: 3.0.11
+      core-js: 3.49.0
+      dompurify: 3.3.1
+      html2canvas: 1.4.1
 
   jsqr@1.4.0: {}
 
@@ -8589,6 +8688,8 @@ snapshots:
 
   pako@1.0.11: {}
 
+  pako@2.1.0: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -8655,6 +8756,9 @@ snapshots:
       to-buffer: 1.2.2
 
   pend@1.2.0: {}
+
+  performance-now@2.1.0:
+    optional: true
 
   periscopic@3.1.0:
     dependencies:
@@ -8975,6 +9079,11 @@ snapshots:
 
   quick-lru@4.0.1: {}
 
+  raf@3.4.1:
+    dependencies:
+      performance-now: 2.1.0
+    optional: true
+
   ramda@0.29.1: {}
 
   randombytes@2.1.0:
@@ -9044,6 +9153,9 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  regenerator-runtime@0.13.11:
+    optional: true
+
   regexp-to-ast@0.5.0: {}
 
   regexparam@3.0.0: {}
@@ -9071,6 +9183,9 @@ snapshots:
   retry@0.12.0: {}
 
   reusify@1.0.4: {}
+
+  rgbcolor@1.0.1:
+    optional: true
 
   rimraf@2.7.1:
     dependencies:
@@ -9349,6 +9464,9 @@ snapshots:
     dependencies:
       minipass: 3.3.6
 
+  stackblur-canvas@2.7.0:
+    optional: true
+
   stoppable@1.1.0: {}
 
   stream-browserify@3.0.0:
@@ -9487,6 +9605,9 @@ snapshots:
       locate-character: 3.0.0
       magic-string: 0.30.19
       periscopic: 3.1.0
+
+  svg-pathdata@6.0.3:
+    optional: true
 
   syllable@5.0.1:
     dependencies:

--- a/src/components/ExportCookbookModal.svelte
+++ b/src/components/ExportCookbookModal.svelte
@@ -5,6 +5,8 @@
   import Button from './Button.svelte';
   import { ndk, userPublickey } from '$lib/nostr';
   import { showToast } from '$lib/toast';
+  import { lightningService } from '$lib/lightningService';
+  import { copyToClipboard } from '$lib/utils/share';
   import {
     buildCookbookPdf,
     cookbookFilename,
@@ -23,6 +25,12 @@
   export let packDescription: string = '';
   export let packCoverImage: string | undefined = undefined;
   export let creatorPubkey: string = '';
+  /** naddr1… for the pack — used to key the recently-paid cache. */
+  export let packNaddr: string = '';
+  /** Canonical pack URL for the success-state Share button. */
+  export let packShareUrl: string = '';
+  /** Whether the current user is a Pro Kitchen / Founders member. Free unlimited exports if true. */
+  export let isProMember: boolean = false;
   export let open = false;
 
   const dispatch = createEventDispatcher();
@@ -36,8 +44,8 @@
   let includeIntroduction = true;
   let style: 'classic' | 'modern' | 'simple' = 'modern';
 
-  // Stage state
-  type Stage = 'form' | 'generating' | 'success' | 'error';
+  // Stage machine
+  type Stage = 'form' | 'invoice' | 'generating' | 'success' | 'error';
   let stage: Stage = 'form';
   let stageMessage = '';
   let resultBlob: Blob | null = null;
@@ -46,11 +54,32 @@
   let resultSkipped = 0;
   let usedAi = false;
 
+  // ===== Payment state =====
+  // Recently-paid cache so a refresh / retry inside ~15 minutes doesn't
+  // re-charge. Keyed by naddr — buying export for one pack doesn't unlock
+  // another.
+  const RECENT_PAY_TTL_MS = 15 * 60 * 1000;
+  const RECENT_PAY_KEY_PREFIX = 'zc:cookbook-export-paid:';
+  const COOKBOOK_EXPORT_SATS = 2100;
+
+  let invoiceLoading = false;
+  let invoiceError = '';
+  let invoice = '';
+  let exportId = '';
+  let receiveRequestId = '';
+  let invoicePollInterval: ReturnType<typeof setInterval> | null = null;
+  let invoiceCopied = false;
+  /** True once payment is confirmed in this session. */
+  let paymentUnlocked = false;
+
   $: missingRecipes = Math.max(0, totalRecipeCount - recipeEvents.length);
+  /** Either the user is a Pro member OR they've already paid for this pack. */
+  $: canExport = isProMember || paymentUnlocked;
 
   // Reset per-open
   $: if (open) initStateOnOpen();
   $: if (!open) {
+    stopInvoicePolling();
     stage = 'form';
     stageMessage = '';
     resultBlob = null;
@@ -58,18 +87,47 @@
     resultIncluded = 0;
     resultSkipped = 0;
     usedAi = false;
+    invoiceError = '';
+    invoice = '';
+    exportId = '';
+    receiveRequestId = '';
+    invoiceCopied = false;
+    // Note: don't reset paymentUnlocked — let the user generate, fail,
+    // and retry without re-paying.
   }
 
   function initStateOnOpen() {
     title = packTitle || 'My Recipe Pack';
     subtitle = packDescription || '';
+    paymentUnlocked = isRecentlyPaid();
   }
 
-  /**
-   * Look up the pack creator's display name via NDK on the client.
-   * Best-effort — any failure returns undefined and the cover renders
-   * without the "Curated by" line.
-   */
+  // ===== Recently-paid cache =====
+  function recentPayKey(): string {
+    return `${RECENT_PAY_KEY_PREFIX}${packNaddr}`;
+  }
+  function isRecentlyPaid(): boolean {
+    if (!packNaddr || typeof window === 'undefined') return false;
+    try {
+      const raw = window.sessionStorage.getItem(recentPayKey());
+      if (!raw) return false;
+      const ts = Number(raw);
+      if (!Number.isFinite(ts)) return false;
+      return Date.now() - ts < RECENT_PAY_TTL_MS;
+    } catch {
+      return false;
+    }
+  }
+  function markRecentlyPaid() {
+    if (!packNaddr || typeof window === 'undefined') return;
+    try {
+      window.sessionStorage.setItem(recentPayKey(), String(Date.now()));
+    } catch {
+      /* ignore */
+    }
+  }
+
+  // ===== Profile / AI helpers (unchanged) =====
   async function fetchCreatorName(): Promise<string | undefined> {
     if (!creatorPubkey) return undefined;
     try {
@@ -88,16 +146,18 @@
     }
   }
 
-  /**
-   * Optional AI polish for the introduction. Best-effort: any failure
-   * falls back to the raw pack description so the export still ships.
-   */
   async function fetchPolishedIntroduction(
     creatorName: string | undefined,
     recipes: CookbookRecipe[]
   ): Promise<{ text: string; aiUsed: boolean }> {
     const fallback = packDescription || '';
     if (!includeIntroduction) return { text: fallback, aiUsed: false };
+    if (!isProMember) {
+      // Pay-per-use customers get the export but the AI intro endpoint
+      // is gated to Pro. Use the raw description so they still get an
+      // intro if they checked the toggle.
+      return { text: fallback, aiUsed: false };
+    }
     if (!$userPublickey) return { text: fallback, aiUsed: false };
     try {
       const res = await fetch('/api/cookbook-intro', {
@@ -122,7 +182,151 @@
     return { text: fallback, aiUsed: false };
   }
 
-  async function handleGenerate() {
+  // ===== Pay-per-export flow =====
+  async function handleUnlockClick() {
+    if (invoiceLoading) return;
+    if (!$userPublickey) {
+      showToast('info', 'Sign in to unlock cookbook export.');
+      return;
+    }
+    if (!packNaddr) {
+      showToast('error', 'Missing pack reference. Please reload the page.');
+      return;
+    }
+    invoiceError = '';
+    invoiceLoading = true;
+    try {
+      const res = await fetch('/api/cookbook-export/create-invoice', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          buyerPubkey: $userPublickey,
+          packNaddr,
+          packTitle: title.trim() || packTitle
+        })
+      });
+      if (!res.ok) {
+        let msg = 'Failed to create Lightning invoice.';
+        try {
+          const data = await res.json();
+          msg = data?.error || msg;
+        } catch {}
+        throw new Error(msg);
+      }
+      const data = (await res.json()) as {
+        exportId: string;
+        invoice: string;
+        paymentHash: string;
+        receiveRequestId: string;
+        invoiceExpiresAt: number;
+        amountSats: number;
+      };
+      exportId = data.exportId;
+      receiveRequestId = data.receiveRequestId;
+      invoice = data.invoice;
+      stage = 'invoice';
+
+      // Hand the invoice to Bitcoin Connect / Alby's modal — gives us
+      // the QR + copy + WebLN button without us having to draw it.
+      try {
+        const { setPaid } = await lightningService.launchPayment({
+          invoice,
+          onPaid: async () => {
+            stopInvoicePolling();
+            await onPaymentConfirmed();
+          },
+          onCancelled: () => {
+            stopInvoicePolling();
+            // User dismissed the modal without paying — leave them on
+            // the invoice screen so they can retry / copy the invoice.
+          }
+        });
+        startInvoicePolling(setPaid);
+      } catch (err) {
+        console.error('[ExportCookbookModal] launchPayment failed', err);
+        // Still allow polling — the user can copy the invoice manually
+        // from the screen and pay from any wallet.
+        startInvoicePolling(null);
+      }
+    } catch (err: any) {
+      console.error('[ExportCookbookModal] create-invoice failed', err);
+      invoiceError = err?.message || 'Failed to create Lightning invoice.';
+    } finally {
+      invoiceLoading = false;
+    }
+  }
+
+  function startInvoicePolling(setPaid: ((r: { preimage: string }) => void) | null) {
+    stopInvoicePolling();
+    invoicePollInterval = setInterval(async () => {
+      if (!exportId || !receiveRequestId) return;
+      try {
+        const res = await fetch('/api/cookbook-export/verify-payment', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ exportId, receiveRequestId })
+        });
+        if (res.ok) {
+          const data = await res.json();
+          if (data.success) {
+            stopInvoicePolling();
+            // Tell Alby's modal we paid (it'll auto-close).
+            if (setPaid) setPaid({ preimage: 'strike-confirmed' });
+            await onPaymentConfirmed();
+          }
+        } else if (res.status !== 402) {
+          // Permanent failure (404/500) — give up the poll.
+          stopInvoicePolling();
+        }
+      } catch {
+        /* network blip — keep polling */
+      }
+    }, 3000);
+  }
+
+  function stopInvoicePolling() {
+    if (invoicePollInterval) {
+      clearInterval(invoicePollInterval);
+      invoicePollInterval = null;
+    }
+  }
+
+  async function onPaymentConfirmed() {
+    paymentUnlocked = true;
+    markRecentlyPaid();
+    showToast('success', 'Payment received ⚡ Generating your cookbook…');
+    // Move directly into PDF generation — no extra click required.
+    await runGenerate();
+  }
+
+  async function copyInvoice() {
+    if (!invoice) return;
+    const ok = await copyToClipboard(invoice);
+    if (ok) {
+      invoiceCopied = true;
+      setTimeout(() => (invoiceCopied = false), 1800);
+    }
+  }
+
+  function cancelInvoice() {
+    stopInvoicePolling();
+    invoice = '';
+    exportId = '';
+    receiveRequestId = '';
+    stage = 'form';
+  }
+
+  // ===== Generate flow =====
+  async function handleGenerateClick() {
+    if (!canExport) {
+      // Non-Pro and no recent pay — kick off the unlock flow.
+      await handleUnlockClick();
+      return;
+    }
+    await runGenerate();
+  }
+
+  async function runGenerate() {
     if (stage === 'generating') return;
     if (!packEvent) {
       showToast('error', 'Pack event not loaded yet.');
@@ -141,25 +345,12 @@
     stageMessage = 'Formatting your cookbook…';
 
     try {
-      // Resolve creator name (best-effort, parallel to the rest below).
       const creatorNamePromise = fetchCreatorName();
-
-      // Convert each event into our normalized recipe shape. We don't
-      // know per-recipe creator names without per-author profile fetches,
-      // so we only resolve the pack-creator name and leave per-recipe
-      // attribution unset for v1.
       const recipes: CookbookRecipe[] = recipeEvents.map((e) => recipeEventToCookbookRecipe(e));
-
       const creatorName = await creatorNamePromise;
-
-      // AI polish (best-effort).
-      const { text: introduction, aiUsed } = await fetchPolishedIntroduction(
-        creatorName,
-        recipes
-      );
+      const { text: introduction, aiUsed } = await fetchPolishedIntroduction(creatorName, recipes);
       usedAi = aiUsed;
 
-      // Build the PDF.
       const result = await buildCookbookPdf({
         title: title.trim(),
         subtitle: subtitle.trim() || undefined,
@@ -199,6 +390,12 @@
     dispatch('downloaded');
   }
 
+  async function copyShareUrl() {
+    if (!packShareUrl) return;
+    const ok = await copyToClipboard(packShareUrl);
+    if (ok) showToast('success', 'Recipe Pack link copied');
+  }
+
   function handleClose() {
     open = false;
   }
@@ -214,9 +411,32 @@
 
   {#if stage === 'form'}
     <div class="flex flex-col gap-4">
-      <p class="text-sm text-caption">
-        Turn this Recipe Pack into a printable cookbook PDF.
-      </p>
+      <p class="text-sm text-caption">Turn this Recipe Pack into a printable cookbook PDF.</p>
+
+      {#if !canExport}
+        <!-- Pay-per-use hint for non-Pro users. Kept compact so it doesn't
+             dominate the form. -->
+        <div
+          class="flex items-start gap-3 p-3 rounded-lg"
+          style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+        >
+          <div
+            class="w-8 h-8 rounded-full bg-gradient-to-br from-orange-500 to-amber-500 flex items-center justify-center flex-shrink-0 text-white font-bold"
+            aria-hidden="true"
+          >
+            ⚡
+          </div>
+          <div class="flex flex-col gap-1">
+            <p class="text-sm" style="color: var(--color-text-primary)">
+              <span class="font-medium">Free with Pro Kitchen membership</span>
+              <span class="text-caption"> — or unlock once for {COOKBOOK_EXPORT_SATS} sats.</span>
+            </p>
+            <a href="/membership" class="text-xs text-primary hover:underline">
+              See Pro Kitchen
+            </a>
+          </div>
+        </div>
+      {/if}
 
       <div class="flex flex-col gap-2">
         <label
@@ -277,12 +497,18 @@
             class="w-4 h-4 accent-orange-500"
           />
           <span style="color: var(--color-text-primary)">Introduction</span>
-          <span class="text-xs text-caption">— polished automatically when possible</span>
+          {#if isProMember}
+            <span class="text-xs text-caption">— polished automatically when possible</span>
+          {/if}
         </label>
       </fieldset>
 
       <div class="flex flex-col gap-2">
-        <label for="cookbook-style" class="text-sm font-medium" style="color: var(--color-text-primary)">
+        <label
+          for="cookbook-style"
+          class="text-sm font-medium"
+          style="color: var(--color-text-primary)"
+        >
           Style
         </label>
         <select id="cookbook-style" class="input" bind:value={style}>
@@ -299,22 +525,80 @@
         </p>
       {/if}
 
+      {#if invoiceError}
+        <p class="text-sm text-red-500">{invoiceError}</p>
+      {/if}
+
       <div class="flex justify-end gap-2 pt-1">
         <Button on:click={handleClose} primary={false}>Cancel</Button>
-        <Button on:click={handleGenerate} disabled={!packEvent || recipeEvents.length === 0}>
-          Generate Cookbook
+        <Button
+          on:click={handleGenerateClick}
+          disabled={invoiceLoading || !packEvent || recipeEvents.length === 0}
+        >
+          {#if invoiceLoading}
+            Creating invoice…
+          {:else if canExport}
+            Generate Cookbook
+          {:else}
+            Unlock Cookbook for {COOKBOOK_EXPORT_SATS} sats ⚡
+          {/if}
         </Button>
+      </div>
+    </div>
+  {:else if stage === 'invoice'}
+    <div class="flex flex-col gap-4">
+      <p class="text-sm" style="color: var(--color-text-primary)">
+        Pay <span class="font-semibold">{COOKBOOK_EXPORT_SATS} sats</span> to unlock cookbook export
+        for this pack.
+      </p>
+      <p class="text-xs text-caption">
+        A wallet picker should have opened in another window. If not, copy the invoice and pay from
+        any Lightning wallet.
+      </p>
+
+      <div
+        class="flex items-center gap-2 p-2 rounded-lg overflow-hidden"
+        style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+      >
+        <code
+          class="text-xs flex-1 truncate"
+          style="color: var(--color-text-secondary); font-family: monospace;"
+          title={invoice}
+        >
+          {invoice}
+        </code>
+        <button
+          type="button"
+          on:click={copyInvoice}
+          class="flex-shrink-0 px-3 py-1.5 rounded text-xs font-medium transition-colors"
+          style="background-color: var(--color-bg-secondary); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+        >
+          {invoiceCopied ? 'Copied' : 'Copy'}
+        </button>
+      </div>
+
+      <div class="flex items-center gap-2 text-sm">
+        <div
+          class="w-4 h-4 rounded-full border-2 border-orange-200 border-t-orange-500 animate-spin"
+        ></div>
+        <span class="text-caption">Waiting for payment…</span>
+      </div>
+
+      <div class="flex justify-end gap-2 pt-1">
+        <Button on:click={cancelInvoice} primary={false}>Cancel</Button>
       </div>
     </div>
   {:else if stage === 'generating'}
     <div class="flex flex-col items-center justify-center gap-4 py-10">
-      <div class="w-10 h-10 rounded-full border-4 border-orange-200 border-t-orange-500 animate-spin"></div>
+      <div
+        class="w-10 h-10 rounded-full border-4 border-orange-200 border-t-orange-500 animate-spin"
+      ></div>
       <p class="text-sm" style="color: var(--color-text-primary)">
         {stageMessage || 'Formatting your cookbook…'}
       </p>
       <p class="text-xs text-caption text-center max-w-sm">
-        Generation runs in your browser. Depending on the number of recipes and image
-        sizes, this can take 10–30 seconds.
+        Generation runs in your browser. Depending on the number of recipes and image sizes, this
+        can take 10–30 seconds.
       </p>
     </div>
   {:else if stage === 'success'}
@@ -327,11 +611,11 @@
           class="w-10 h-10 rounded-full bg-gradient-to-br from-orange-500 to-amber-500 flex items-center justify-center flex-shrink-0 text-white text-lg"
           aria-hidden="true"
         >
-          ✓
+          📚
         </div>
         <div class="flex flex-col">
           <p class="text-sm font-medium" style="color: var(--color-text-primary)">
-            Cookbook ready
+            Your cookbook is ready
           </p>
           <p class="text-xs text-caption">
             {resultIncluded} {resultIncluded === 1 ? 'recipe' : 'recipes'} included
@@ -345,7 +629,10 @@
         </div>
       </div>
 
-      <div class="flex justify-end gap-2 pt-1">
+      <div class="flex flex-wrap justify-end gap-2 pt-1">
+        {#if packShareUrl}
+          <Button on:click={copyShareUrl} primary={false}>Share Recipe Pack</Button>
+        {/if}
         <Button on:click={handleClose} primary={false}>Close</Button>
         <Button on:click={handleDownload}>Download PDF</Button>
       </div>
@@ -355,6 +642,11 @@
       <p class="text-sm" style="color: var(--color-text-primary)">
         {stageMessage || 'Something went wrong while building the PDF.'}
       </p>
+      {#if paymentUnlocked && !isProMember}
+        <p class="text-xs text-caption">
+          Your payment is still valid — retry won't charge again.
+        </p>
+      {/if}
       <div class="flex justify-end gap-2">
         <Button on:click={handleClose} primary={false}>Close</Button>
         <Button on:click={handleRetry}>Try again</Button>

--- a/src/components/ExportCookbookModal.svelte
+++ b/src/components/ExportCookbookModal.svelte
@@ -452,7 +452,13 @@
       const creatorNamePromise = fetchCreatorName();
       const recipes: CookbookRecipe[] = recipeEvents.map((e) => recipeEventToCookbookRecipe(e));
       const creatorName = await creatorNamePromise;
-      const { text: introduction, aiUsed } = await fetchPolishedIntroduction(creatorName, recipes);
+      // Skip the polish call entirely when the user unchecked the
+      // introduction. Previously we always fetched (returning the pack
+      // description as fallback) and then passed `!!introduction` to
+      // the builder — which silently re-included the page.
+      const { text: introduction, aiUsed } = includeIntroduction
+        ? await fetchPolishedIntroduction(creatorName, recipes)
+        : { text: '', aiUsed: false };
       usedAi = aiUsed;
 
       const result = await buildCookbookPdf({
@@ -465,7 +471,7 @@
         includeCover,
         includeToc,
         includeImages,
-        includeIntroduction: !!introduction,
+        includeIntroduction,
         style
       });
 

--- a/src/components/ExportCookbookModal.svelte
+++ b/src/components/ExportCookbookModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
+  import { createEventDispatcher, onDestroy } from 'svelte';
   import type { NDKEvent } from '@nostr-dev-kit/ndk';
   import Modal from './Modal.svelte';
   import Button from './Button.svelte';
@@ -125,12 +125,11 @@
     subtitle = packDescription || '';
     paymentUnlocked = isRecentlyPaid();
 
-    // ───── Membership debug ─────
-    // Until the founders/pro detection edge cases are nailed down, log
-    // enough to diagnose without leaking sensitive data. Pubkey is
-    // truncated to first 8 chars so the log is usable but not a
-    // re-identifier all on its own.
-    if (typeof window !== 'undefined') {
+    // Dev-only membership snapshot. Helpful when iterating on tier
+    // detection edge cases; silenced in production so signed-in users
+    // don't see noisy console output or have their tier metadata
+    // surfaced to whatever else listens to console.info.
+    if (import.meta.env.DEV && typeof window !== 'undefined') {
       const pkPreview = $userPublickey ? `${$userPublickey.slice(0, 8)}…` : '(anon)';
       console.info('[ExportCookbookModal] membership check', {
         pubkey: pkPreview,
@@ -397,6 +396,14 @@
       invoicePollInterval = null;
     }
   }
+
+  // Defensive cleanup — `open` flipping false also stops polling, but
+  // an SPA route change can destroy this component while the invoice
+  // poll is still active. Without this, the interval keeps firing
+  // every 3s in the background and re-hits the verify endpoint.
+  onDestroy(() => {
+    stopInvoicePolling();
+  });
 
   async function onPaymentConfirmed() {
     paymentUnlocked = true;

--- a/src/components/ExportCookbookModal.svelte
+++ b/src/components/ExportCookbookModal.svelte
@@ -30,7 +30,9 @@
   export let packNaddr: string = '';
   /** Canonical pack URL for the success-state Share button. */
   export let packShareUrl: string = '';
-  /** Whether the current user is a Pro Kitchen / Founders member. Free unlimited exports if true. */
+  /** Pro Kitchen / Founders member. Cookbook export is paid for every
+   *  account, but Pro members get the AI introduction polish; non-Pro
+   *  users fall back to the raw pack description. */
   export let isProMember: boolean = false;
   /** Optional — passed through for debug logs only, not used in gating. */
   export let membershipTier: string | undefined = undefined;
@@ -88,8 +90,9 @@
   } | null = null;
 
   $: missingRecipes = Math.max(0, totalRecipeCount - recipeEvents.length);
-  /** Either the user is a Pro member OR they've already paid for this pack OR the promo is free. */
-  $: canExport = isProMember || paymentUnlocked || (promoApplied?.free ?? false);
+  /** Cookbook export is a paid feature for every account. The user can
+   *  unlock it via Lightning payment OR by applying a 100%-off promo. */
+  $: canExport = paymentUnlocked || (promoApplied?.free ?? false);
   /** Effective price the CTA should display. */
   $: priceSats = promoApplied?.finalSats ?? COOKBOOK_EXPORT_SATS;
 
@@ -135,7 +138,7 @@
         active: membershipActive ?? '(not passed)',
         isProMember,
         recentlyPaid: paymentUnlocked,
-        canExport: isProMember || paymentUnlocked
+        canExport: paymentUnlocked || (promoApplied?.free ?? false)
       });
     }
   }
@@ -524,8 +527,8 @@
       <p class="text-sm text-caption">Turn this Recipe Pack into a printable cookbook PDF.</p>
 
       {#if !canExport}
-        <!-- Pay-per-use hint for non-Pro users. Kept compact so it doesn't
-             dominate the form. -->
+        <!-- Unlock hint — cookbook export is a paid feature for every
+             account. Compact so it doesn't dominate the form. -->
         <div
           class="flex items-start gap-3 p-3 rounded-lg"
           style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
@@ -536,15 +539,10 @@
           >
             ⚡
           </div>
-          <div class="flex flex-col gap-1">
-            <p class="text-sm" style="color: var(--color-text-primary)">
-              <span class="font-medium">Free with Pro Kitchen membership</span>
-              <span class="text-caption"> — or unlock once for {COOKBOOK_EXPORT_SATS} sats.</span>
-            </p>
-            <a href="/membership" class="text-xs text-primary hover:underline">
-              See Pro Kitchen
-            </a>
-          </div>
+          <p class="text-sm" style="color: var(--color-text-primary)">
+            <span class="font-medium">Unlock this cookbook for {COOKBOOK_EXPORT_SATS} sats</span>
+            <span class="text-caption"> — one-time Lightning payment.</span>
+          </p>
         </div>
 
         <!-- Promo code -->
@@ -788,7 +786,7 @@
         </div>
         <div class="flex flex-col">
           <p class="text-sm font-medium" style="color: var(--color-text-primary)">
-            {paymentUnlocked && !isProMember
+            {paymentUnlocked
               ? 'Payment received ⚡ Your cookbook is ready.'
               : '📚 Your cookbook is ready'}
           </p>
@@ -816,7 +814,7 @@
       <p class="text-sm" style="color: var(--color-text-primary)">
         {stageMessage || 'Something went wrong while building the PDF.'}
       </p>
-      {#if paymentUnlocked && !isProMember}
+      {#if paymentUnlocked}
         <p class="text-xs text-caption">
           Your payment is still valid — retry won't charge again.
         </p>

--- a/src/components/ExportCookbookModal.svelte
+++ b/src/components/ExportCookbookModal.svelte
@@ -1,0 +1,364 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import type { NDKEvent } from '@nostr-dev-kit/ndk';
+  import Modal from './Modal.svelte';
+  import Button from './Button.svelte';
+  import { ndk, userPublickey } from '$lib/nostr';
+  import { showToast } from '$lib/toast';
+  import {
+    buildCookbookPdf,
+    cookbookFilename,
+    recipeEventToCookbookRecipe,
+    type CookbookRecipe
+  } from '$lib/cookbookExport';
+
+  /** The pack event itself — needed for title/description/cover/creator. */
+  export let packEvent: NDKEvent | null = null;
+  /** Already-resolved recipe events from the pack page. */
+  export let recipeEvents: NDKEvent[] = [];
+  /** Total recipe count from the pack (may exceed recipeEvents.length on partial load). */
+  export let totalRecipeCount: number = 0;
+  /** Already-computed pack metadata (title etc) so we don't re-parse here. */
+  export let packTitle: string = '';
+  export let packDescription: string = '';
+  export let packCoverImage: string | undefined = undefined;
+  export let creatorPubkey: string = '';
+  export let open = false;
+
+  const dispatch = createEventDispatcher();
+
+  // Form state
+  let title = '';
+  let subtitle = '';
+  let includeCover = true;
+  let includeToc = true;
+  let includeImages = true;
+  let includeIntroduction = true;
+  let style: 'classic' | 'modern' | 'simple' = 'modern';
+
+  // Stage state
+  type Stage = 'form' | 'generating' | 'success' | 'error';
+  let stage: Stage = 'form';
+  let stageMessage = '';
+  let resultBlob: Blob | null = null;
+  let resultFilename = '';
+  let resultIncluded = 0;
+  let resultSkipped = 0;
+  let usedAi = false;
+
+  $: missingRecipes = Math.max(0, totalRecipeCount - recipeEvents.length);
+
+  // Reset per-open
+  $: if (open) initStateOnOpen();
+  $: if (!open) {
+    stage = 'form';
+    stageMessage = '';
+    resultBlob = null;
+    resultFilename = '';
+    resultIncluded = 0;
+    resultSkipped = 0;
+    usedAi = false;
+  }
+
+  function initStateOnOpen() {
+    title = packTitle || 'My Recipe Pack';
+    subtitle = packDescription || '';
+  }
+
+  /**
+   * Look up the pack creator's display name via NDK on the client.
+   * Best-effort — any failure returns undefined and the cover renders
+   * without the "Curated by" line.
+   */
+  async function fetchCreatorName(): Promise<string | undefined> {
+    if (!creatorPubkey) return undefined;
+    try {
+      const evt = await $ndk.fetchEvent({ kinds: [0], authors: [creatorPubkey] });
+      if (!evt?.content) return undefined;
+      const parsed = JSON.parse(evt.content);
+      const name =
+        typeof parsed.display_name === 'string' && parsed.display_name.trim()
+          ? parsed.display_name.trim()
+          : typeof parsed.name === 'string' && parsed.name.trim()
+            ? parsed.name.trim()
+            : undefined;
+      return name;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Optional AI polish for the introduction. Best-effort: any failure
+   * falls back to the raw pack description so the export still ships.
+   */
+  async function fetchPolishedIntroduction(
+    creatorName: string | undefined,
+    recipes: CookbookRecipe[]
+  ): Promise<{ text: string; aiUsed: boolean }> {
+    const fallback = packDescription || '';
+    if (!includeIntroduction) return { text: fallback, aiUsed: false };
+    if (!$userPublickey) return { text: fallback, aiUsed: false };
+    try {
+      const res = await fetch('/api/cookbook-intro', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          pubkey: $userPublickey,
+          packTitle: title,
+          packDescription: subtitle,
+          creatorName,
+          recipeCount: recipes.length,
+          recipeTitles: recipes.slice(0, 10).map((r) => r.title)
+        })
+      });
+      const data = (await res.json()) as { success: boolean; introduction?: string; error?: string };
+      if (data.success && data.introduction) {
+        return { text: data.introduction, aiUsed: true };
+      }
+    } catch (err) {
+      console.warn('[ExportCookbookModal] intro polish failed', err);
+    }
+    return { text: fallback, aiUsed: false };
+  }
+
+  async function handleGenerate() {
+    if (stage === 'generating') return;
+    if (!packEvent) {
+      showToast('error', 'Pack event not loaded yet.');
+      return;
+    }
+    if (recipeEvents.length === 0) {
+      showToast('error', 'No recipes available to export.');
+      return;
+    }
+    if (!title.trim()) {
+      showToast('error', 'Please enter a cookbook title.');
+      return;
+    }
+
+    stage = 'generating';
+    stageMessage = 'Formatting your cookbook…';
+
+    try {
+      // Resolve creator name (best-effort, parallel to the rest below).
+      const creatorNamePromise = fetchCreatorName();
+
+      // Convert each event into our normalized recipe shape. We don't
+      // know per-recipe creator names without per-author profile fetches,
+      // so we only resolve the pack-creator name and leave per-recipe
+      // attribution unset for v1.
+      const recipes: CookbookRecipe[] = recipeEvents.map((e) => recipeEventToCookbookRecipe(e));
+
+      const creatorName = await creatorNamePromise;
+
+      // AI polish (best-effort).
+      const { text: introduction, aiUsed } = await fetchPolishedIntroduction(
+        creatorName,
+        recipes
+      );
+      usedAi = aiUsed;
+
+      // Build the PDF.
+      const result = await buildCookbookPdf({
+        title: title.trim(),
+        subtitle: subtitle.trim() || undefined,
+        coverImage: includeCover ? packCoverImage : undefined,
+        creatorName,
+        introduction,
+        recipes,
+        includeCover,
+        includeToc,
+        includeImages,
+        includeIntroduction: !!introduction,
+        style
+      });
+
+      resultBlob = result.blob;
+      resultIncluded = result.included;
+      resultSkipped = result.skipped.length + missingRecipes;
+      resultFilename = cookbookFilename(title);
+      stage = 'success';
+    } catch (err: any) {
+      console.error('[ExportCookbookModal] generate failed', err);
+      stage = 'error';
+      stageMessage = err?.message || 'Something went wrong while building the PDF.';
+    }
+  }
+
+  function handleDownload() {
+    if (!resultBlob) return;
+    const url = URL.createObjectURL(resultBlob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = resultFilename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setTimeout(() => URL.revokeObjectURL(url), 1500);
+    dispatch('downloaded');
+  }
+
+  function handleClose() {
+    open = false;
+  }
+
+  function handleRetry() {
+    stage = 'form';
+    stageMessage = '';
+  }
+</script>
+
+<Modal cleanup={handleClose} bind:open>
+  <h1 slot="title">Export as Cookbook</h1>
+
+  {#if stage === 'form'}
+    <div class="flex flex-col gap-4">
+      <p class="text-sm text-caption">
+        Turn this Recipe Pack into a printable cookbook PDF.
+      </p>
+
+      <div class="flex flex-col gap-2">
+        <label
+          for="cookbook-title"
+          class="text-sm font-medium"
+          style="color: var(--color-text-primary)"
+        >
+          Cookbook title <span class="text-red-500">*</span>
+        </label>
+        <input
+          id="cookbook-title"
+          type="text"
+          class="input"
+          bind:value={title}
+          maxlength="120"
+          placeholder="e.g., Weeknight Dinners"
+        />
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <label
+          for="cookbook-subtitle"
+          class="text-sm font-medium"
+          style="color: var(--color-text-primary)"
+        >
+          Subtitle / description
+        </label>
+        <textarea
+          id="cookbook-subtitle"
+          class="input"
+          rows="3"
+          bind:value={subtitle}
+          maxlength="500"
+          placeholder="A short description of your cookbook…"
+        />
+      </div>
+
+      <fieldset class="flex flex-col gap-2 pt-1">
+        <legend class="text-sm font-medium pb-2" style="color: var(--color-text-primary)">
+          Include
+        </legend>
+        <label class="flex items-center gap-2 cursor-pointer text-sm">
+          <input type="checkbox" bind:checked={includeCover} class="w-4 h-4 accent-orange-500" />
+          <span style="color: var(--color-text-primary)">Cover page</span>
+        </label>
+        <label class="flex items-center gap-2 cursor-pointer text-sm">
+          <input type="checkbox" bind:checked={includeToc} class="w-4 h-4 accent-orange-500" />
+          <span style="color: var(--color-text-primary)">Table of contents</span>
+        </label>
+        <label class="flex items-center gap-2 cursor-pointer text-sm">
+          <input type="checkbox" bind:checked={includeImages} class="w-4 h-4 accent-orange-500" />
+          <span style="color: var(--color-text-primary)">Recipe images</span>
+        </label>
+        <label class="flex items-center gap-2 cursor-pointer text-sm">
+          <input
+            type="checkbox"
+            bind:checked={includeIntroduction}
+            class="w-4 h-4 accent-orange-500"
+          />
+          <span style="color: var(--color-text-primary)">Introduction</span>
+          <span class="text-xs text-caption">— polished automatically when possible</span>
+        </label>
+      </fieldset>
+
+      <div class="flex flex-col gap-2">
+        <label for="cookbook-style" class="text-sm font-medium" style="color: var(--color-text-primary)">
+          Style
+        </label>
+        <select id="cookbook-style" class="input" bind:value={style}>
+          <option value="modern">Modern</option>
+          <option value="classic">Classic (coming soon)</option>
+          <option value="simple">Simple (coming soon)</option>
+        </select>
+      </div>
+
+      {#if missingRecipes > 0}
+        <p class="text-xs text-caption">
+          {recipeEvents.length} of {totalRecipeCount} recipes are loaded. The remaining
+          {missingRecipes} weren't reachable on the connected relays and won't be in the PDF.
+        </p>
+      {/if}
+
+      <div class="flex justify-end gap-2 pt-1">
+        <Button on:click={handleClose} primary={false}>Cancel</Button>
+        <Button on:click={handleGenerate} disabled={!packEvent || recipeEvents.length === 0}>
+          Generate Cookbook
+        </Button>
+      </div>
+    </div>
+  {:else if stage === 'generating'}
+    <div class="flex flex-col items-center justify-center gap-4 py-10">
+      <div class="w-10 h-10 rounded-full border-4 border-orange-200 border-t-orange-500 animate-spin"></div>
+      <p class="text-sm" style="color: var(--color-text-primary)">
+        {stageMessage || 'Formatting your cookbook…'}
+      </p>
+      <p class="text-xs text-caption text-center max-w-sm">
+        Generation runs in your browser. Depending on the number of recipes and image
+        sizes, this can take 10–30 seconds.
+      </p>
+    </div>
+  {:else if stage === 'success'}
+    <div class="flex flex-col gap-4">
+      <div
+        class="flex items-start gap-3 p-3 rounded-lg"
+        style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+      >
+        <div
+          class="w-10 h-10 rounded-full bg-gradient-to-br from-orange-500 to-amber-500 flex items-center justify-center flex-shrink-0 text-white text-lg"
+          aria-hidden="true"
+        >
+          ✓
+        </div>
+        <div class="flex flex-col">
+          <p class="text-sm font-medium" style="color: var(--color-text-primary)">
+            Cookbook ready
+          </p>
+          <p class="text-xs text-caption">
+            {resultIncluded} {resultIncluded === 1 ? 'recipe' : 'recipes'} included
+            {#if resultSkipped > 0}
+              · {resultSkipped} couldn't be loaded
+            {/if}
+            {#if usedAi}
+              · introduction polished
+            {/if}
+          </p>
+        </div>
+      </div>
+
+      <div class="flex justify-end gap-2 pt-1">
+        <Button on:click={handleClose} primary={false}>Close</Button>
+        <Button on:click={handleDownload}>Download PDF</Button>
+      </div>
+    </div>
+  {:else if stage === 'error'}
+    <div class="flex flex-col gap-4">
+      <p class="text-sm" style="color: var(--color-text-primary)">
+        {stageMessage || 'Something went wrong while building the PDF.'}
+      </p>
+      <div class="flex justify-end gap-2">
+        <Button on:click={handleClose} primary={false}>Close</Button>
+        <Button on:click={handleRetry}>Try again</Button>
+      </div>
+    </div>
+  {/if}
+</Modal>

--- a/src/components/ExportCookbookModal.svelte
+++ b/src/components/ExportCookbookModal.svelte
@@ -7,6 +7,7 @@
   import { showToast } from '$lib/toast';
   import { lightningService } from '$lib/lightningService';
   import { copyToClipboard } from '$lib/utils/share';
+  import { COOKBOOK_EXPORT_SATS } from '$lib/cookbookPricing';
   import {
     buildCookbookPdf,
     cookbookFilename,
@@ -31,6 +32,9 @@
   export let packShareUrl: string = '';
   /** Whether the current user is a Pro Kitchen / Founders member. Free unlimited exports if true. */
   export let isProMember: boolean = false;
+  /** Optional — passed through for debug logs only, not used in gating. */
+  export let membershipTier: string | undefined = undefined;
+  export let membershipActive: boolean | undefined = undefined;
   export let open = false;
 
   const dispatch = createEventDispatcher();
@@ -60,7 +64,6 @@
   // another.
   const RECENT_PAY_TTL_MS = 15 * 60 * 1000;
   const RECENT_PAY_KEY_PREFIX = 'zc:cookbook-export-paid:';
-  const COOKBOOK_EXPORT_SATS = 2100;
 
   let invoiceLoading = false;
   let invoiceError = '';
@@ -72,9 +75,23 @@
   /** True once payment is confirmed in this session. */
   let paymentUnlocked = false;
 
+  // ===== Promo state =====
+  let promoInput = '';
+  let promoLoading = false;
+  let promoError = '';
+  let promoApplied: {
+    code: string;
+    label: string;
+    originalSats: number;
+    finalSats: number;
+    free: boolean;
+  } | null = null;
+
   $: missingRecipes = Math.max(0, totalRecipeCount - recipeEvents.length);
-  /** Either the user is a Pro member OR they've already paid for this pack. */
-  $: canExport = isProMember || paymentUnlocked;
+  /** Either the user is a Pro member OR they've already paid for this pack OR the promo is free. */
+  $: canExport = isProMember || paymentUnlocked || (promoApplied?.free ?? false);
+  /** Effective price the CTA should display. */
+  $: priceSats = promoApplied?.finalSats ?? COOKBOOK_EXPORT_SATS;
 
   // Reset per-open
   $: if (open) initStateOnOpen();
@@ -92,6 +109,10 @@
     exportId = '';
     receiveRequestId = '';
     invoiceCopied = false;
+    promoInput = '';
+    promoApplied = null;
+    promoError = '';
+    promoLoading = false;
     // Note: don't reset paymentUnlocked — let the user generate, fail,
     // and retry without re-paying.
   }
@@ -100,6 +121,23 @@
     title = packTitle || 'My Recipe Pack';
     subtitle = packDescription || '';
     paymentUnlocked = isRecentlyPaid();
+
+    // ───── Membership debug ─────
+    // Until the founders/pro detection edge cases are nailed down, log
+    // enough to diagnose without leaking sensitive data. Pubkey is
+    // truncated to first 8 chars so the log is usable but not a
+    // re-identifier all on its own.
+    if (typeof window !== 'undefined') {
+      const pkPreview = $userPublickey ? `${$userPublickey.slice(0, 8)}…` : '(anon)';
+      console.info('[ExportCookbookModal] membership check', {
+        pubkey: pkPreview,
+        tier: membershipTier ?? '(not passed)',
+        active: membershipActive ?? '(not passed)',
+        isProMember,
+        recentlyPaid: paymentUnlocked,
+        canExport: isProMember || paymentUnlocked
+      });
+    }
   }
 
   // ===== Recently-paid cache =====
@@ -182,6 +220,55 @@
     return { text: fallback, aiUsed: false };
   }
 
+  // ===== Promo flow =====
+  async function handleApplyPromo() {
+    const code = promoInput.trim();
+    if (!code || promoLoading) return;
+    promoError = '';
+    promoLoading = true;
+    try {
+      const res = await fetch('/api/cookbook-export/apply-promo', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code })
+      });
+      const data = (await res.json()) as
+        | {
+            success: true;
+            code: string;
+            label: string;
+            originalSats: number;
+            finalSats: number;
+            free: boolean;
+          }
+        | { success: false; error: string };
+      if (!('success' in data) || !data.success) {
+        promoApplied = null;
+        promoError = 'Promo code not valid';
+        return;
+      }
+      promoApplied = {
+        code: data.code,
+        label: data.label,
+        originalSats: data.originalSats,
+        finalSats: data.finalSats,
+        free: data.free
+      };
+    } catch (err) {
+      console.error('[ExportCookbookModal] apply-promo failed', err);
+      promoApplied = null;
+      promoError = 'Promo code not valid';
+    } finally {
+      promoLoading = false;
+    }
+  }
+
+  function handleClearPromo() {
+    promoInput = '';
+    promoApplied = null;
+    promoError = '';
+  }
+
   // ===== Pay-per-export flow =====
   async function handleUnlockClick() {
     if (invoiceLoading) return;
@@ -202,7 +289,8 @@
         body: JSON.stringify({
           buyerPubkey: $userPublickey,
           packNaddr,
-          packTitle: title.trim() || packTitle
+          packTitle: title.trim() || packTitle,
+          promoCode: promoApplied?.code
         })
       });
       if (!res.ok) {
@@ -215,12 +303,28 @@
       }
       const data = (await res.json()) as {
         exportId: string;
-        invoice: string;
-        paymentHash: string;
-        receiveRequestId: string;
-        invoiceExpiresAt: number;
+        // Paid path
+        invoice?: string;
+        paymentHash?: string;
+        receiveRequestId?: string;
+        invoiceExpiresAt?: number;
         amountSats: number;
+        // Free-promo path
+        free?: boolean;
+        promo?: unknown;
       };
+
+      // 100%-off promo path: the server marked it paid; jump straight
+      // to PDF generation, no Lightning round-trip.
+      if (data.free) {
+        exportId = data.exportId;
+        await onPaymentConfirmed();
+        return;
+      }
+
+      if (!data.invoice || !data.receiveRequestId) {
+        throw new Error('Invoice response was missing fields.');
+      }
       exportId = data.exportId;
       receiveRequestId = data.receiveRequestId;
       invoice = data.invoice;
@@ -436,6 +540,66 @@
             </a>
           </div>
         </div>
+
+        <!-- Promo code -->
+        <div class="flex flex-col gap-1">
+          <label
+            for="cookbook-promo"
+            class="text-xs font-medium"
+            style="color: var(--color-text-secondary)"
+          >
+            Promo code
+          </label>
+          {#if promoApplied}
+            <div
+              class="flex items-center justify-between gap-2 p-2 rounded-lg"
+              style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+            >
+              <p class="text-sm" style="color: var(--color-text-primary)">
+                <span class="font-semibold">{promoApplied.code}</span>
+                <span class="text-caption"> — promo applied: {promoApplied.label}</span>
+              </p>
+              <button
+                type="button"
+                on:click={handleClearPromo}
+                class="text-xs underline"
+                style="color: var(--color-text-secondary)"
+              >
+                Remove
+              </button>
+            </div>
+          {:else}
+            <div class="flex items-center gap-2">
+              <input
+                id="cookbook-promo"
+                type="text"
+                class="input flex-1"
+                bind:value={promoInput}
+                placeholder="e.g., LAUNCH"
+                maxlength="32"
+                autocomplete="off"
+                on:keydown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    handleApplyPromo();
+                  }
+                }}
+              />
+              <button
+                type="button"
+                on:click={handleApplyPromo}
+                disabled={promoLoading || !promoInput.trim()}
+                class="px-3 py-2 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+              >
+                {promoLoading ? 'Checking…' : 'Apply'}
+              </button>
+            </div>
+            {#if promoError}
+              <p class="text-xs text-red-500">{promoError}</p>
+            {/if}
+          {/if}
+        </div>
       {/if}
 
       <div class="flex flex-col gap-2">
@@ -540,7 +704,7 @@
           {:else if canExport}
             Generate Cookbook
           {:else}
-            Unlock Cookbook for {COOKBOOK_EXPORT_SATS} sats ⚡
+            Unlock Cookbook for {priceSats} sats ⚡
           {/if}
         </Button>
       </div>
@@ -548,8 +712,11 @@
   {:else if stage === 'invoice'}
     <div class="flex flex-col gap-4">
       <p class="text-sm" style="color: var(--color-text-primary)">
-        Pay <span class="font-semibold">{COOKBOOK_EXPORT_SATS} sats</span> to unlock cookbook export
-        for this pack.
+        Pay <span class="font-semibold">{priceSats} sats</span> to unlock cookbook export for this
+        pack.
+        {#if promoApplied}
+          <span class="text-caption">(Promo {promoApplied.code} applied — {promoApplied.label}.)</span>
+        {/if}
       </p>
       <p class="text-xs text-caption">
         A wallet picker should have opened in another window. If not, copy the invoice and pay from
@@ -615,16 +782,17 @@
         </div>
         <div class="flex flex-col">
           <p class="text-sm font-medium" style="color: var(--color-text-primary)">
-            Your cookbook is ready
+            {paymentUnlocked && !isProMember
+              ? 'Payment received ⚡ Your cookbook is ready.'
+              : '📚 Your cookbook is ready'}
           </p>
           <p class="text-xs text-caption">
-            {resultIncluded} {resultIncluded === 1 ? 'recipe' : 'recipes'} included
-            {#if resultSkipped > 0}
+            Turned your Recipe Pack into a printable cookbook. {resultIncluded}
+            {resultIncluded === 1 ? 'recipe' : 'recipes'} included{#if resultSkipped > 0}
               · {resultSkipped} couldn't be loaded
-            {/if}
-            {#if usedAi}
+            {/if}{#if usedAi}
               · introduction polished
-            {/if}
+            {/if}.
           </p>
         </div>
       </div>

--- a/src/lib/cookbookExport.ts
+++ b/src/lib/cookbookExport.ts
@@ -168,8 +168,12 @@ export async function buildCookbookPdf(opts: BuildOptions): Promise<BuildResult>
 	const recipeImagePromises = opts.recipes.map((r) =>
 		opts.includeImages && r.image ? imageUrlToDataUri(r.image) : Promise.resolve(null)
 	);
-	const [coverDataUri, ...recipeImages] = await Promise.all([
+	// Brand mark — same-origin fetch from /icon.png. If it 404s or fetch
+	// fails we just render text-only branding, which is the v0 behavior.
+	const brandLogoPromise = imageUrlToDataUri('/icon.png');
+	const [coverDataUri, brandLogoDataUri, ...recipeImages] = await Promise.all([
 		coverImagePromise,
+		brandLogoPromise,
 		...recipeImagePromises
 	]);
 
@@ -184,7 +188,8 @@ export async function buildCookbookPdf(opts: BuildOptions): Promise<BuildResult>
 			subtitle: sanitizeForPdf(opts.subtitle),
 			creatorName: sanitizeForPdf(opts.creatorName),
 			coverDataUri,
-			recipeCount: opts.recipes.length
+			recipeCount: opts.recipes.length,
+			brandLogoDataUri
 		});
 	}
 
@@ -253,8 +258,8 @@ export async function buildCookbookPdf(opts: BuildOptions): Promise<BuildResult>
 	// Add small "Created with Zap Cooking" footer to every page except cover
 	const nonCoverStart = opts.includeCover ? 2 : 1;
 	addFooters(doc, nonCoverStart);
-	// Running header (pack title) on every non-cover page
-	addRunningHeaders(doc, sanitizeForPdf(opts.title), nonCoverStart);
+	// Running header (pack title + brand mark) on every non-cover page
+	addRunningHeaders(doc, sanitizeForPdf(opts.title), brandLogoDataUri, nonCoverStart);
 
 	const blob = doc.output('blob') as unknown as Blob;
 	return { blob, included, skipped };
@@ -288,7 +293,8 @@ interface JsPdfDoc {
 		x: number,
 		y: number,
 		w: number,
-		h: number
+		h: number,
+		alias?: string
 	) => void;
 	addPage: () => void;
 	rect: (x: number, y: number, w: number, h: number, style?: string) => void;
@@ -306,6 +312,7 @@ function drawCoverPage(
 		creatorName: string;
 		coverDataUri: string | null;
 		recipeCount: number;
+		brandLogoDataUri: string | null;
 	}
 ) {
 	// Page background — soft warm tint
@@ -395,7 +402,26 @@ function drawCoverPage(
 		doc.text(`Curated by ${opts.creatorName}`, CENTER_X, PAGE_H - 92, { align: 'center' });
 	}
 
-	// "Created with Zap Cooking" footer brand
+	// Brand mark — small logo sits above the wordmark, then a thin
+	// separator rule, then the "Created with Zap Cooking" line. Whole
+	// stack stays in the bottom 90pt so it reads as a publisher mark.
+	if (opts.brandLogoDataUri) {
+		try {
+			const logoSize = 26;
+			doc.addImage(
+				opts.brandLogoDataUri,
+				imageFormatFromDataUri(opts.brandLogoDataUri),
+				CENTER_X - logoSize / 2,
+				PAGE_H - 96,
+				logoSize,
+				logoSize,
+				'zc-brand'
+			);
+		} catch {
+			// Logo couldn't render — just fall back to the text wordmark.
+		}
+	}
+
 	doc.setFont('helvetica', 'bold');
 	doc.setFontSize(10);
 	doc.setTextColor(180, 95, 30);
@@ -761,25 +787,52 @@ function addFooters(doc: JsPdfDoc, fromPage: number) {
 }
 
 /**
- * Subtle running header — pack title, top of page, with a hairline rule.
- * Skipped for the cover (which has its own typography). Drawn after all
- * pages exist so we can iterate by page number.
+ * Subtle running header — pack title (left) + Zap Cooking logo (right),
+ * with a hairline rule below. Skipped for the cover (which has its own
+ * typography). Drawn after all pages exist so we iterate by page number.
+ *
+ * The logo is added with a stable alias ('zc-brand') so jsPDF dedupes
+ * the image data across every page rather than embedding it N times.
  */
-function addRunningHeaders(doc: JsPdfDoc, packTitle: string, fromPage: number) {
+function addRunningHeaders(
+	doc: JsPdfDoc,
+	packTitle: string,
+	brandLogoDataUri: string | null,
+	fromPage: number
+) {
 	const trimmed = (packTitle || '').trim();
-	if (!trimmed) return;
+	if (!trimmed && !brandLogoDataUri) return;
 	const total = doc.getNumberOfPages();
+	const logoSize = 12;
+	const logoFmt = brandLogoDataUri ? imageFormatFromDataUri(brandLogoDataUri) : 'PNG';
 	for (let p = fromPage; p <= total; p++) {
 		doc.setPage(p);
-		doc.setFont('helvetica', 'normal');
-		doc.setFontSize(8);
-		doc.setTextColor(160, 150, 145);
-		// Truncate over-long titles so they don't collide with margins.
-		let label = trimmed;
-		if (label.length > 60) label = label.slice(0, 57) + '...';
-		doc.text(label, MARGIN_LEFT, 38, { charSpace: 1.5 } as any);
+		if (trimmed) {
+			doc.setFont('helvetica', 'normal');
+			doc.setFontSize(8);
+			doc.setTextColor(160, 150, 145);
+			// Truncate over-long titles so they don't collide with the logo.
+			let label = trimmed;
+			if (label.length > 50) label = label.slice(0, 47) + '...';
+			doc.text(label, MARGIN_LEFT, 38, { charSpace: 1.5 } as any);
+		}
+		if (brandLogoDataUri) {
+			try {
+				doc.addImage(
+					brandLogoDataUri,
+					logoFmt,
+					CONTENT_RIGHT - logoSize,
+					30,
+					logoSize,
+					logoSize,
+					'zc-brand'
+				);
+			} catch {
+				// Logo failed — header text alone is enough.
+			}
+		}
 		doc.setDrawColor(230, 220, 215);
 		doc.setLineWidth(0.4);
-		doc.line(MARGIN_LEFT, 44, CONTENT_RIGHT, 44);
+		doc.line(MARGIN_LEFT, 46, CONTENT_RIGHT, 46);
 	}
 }

--- a/src/lib/cookbookExport.ts
+++ b/src/lib/cookbookExport.ts
@@ -94,8 +94,13 @@ function sanitizeForPdf(s: string | undefined | null): string {
 		.replace(/🔥/g, '')
 		.replace(/—/g, '-')
 		.replace(/–/g, '-')
-		.replace(/'|'/g, "'")
-		.replace(/"|"/g, '"')
+		// Curly quote / ellipsis → straight ASCII. Written as explicit \u
+		// escapes so the source is unambiguous in any editor; jsPDF's
+		// Latin-1 strip a few lines down would otherwise drop these
+		// codepoints entirely (U+2018–U+201D, U+2026 are outside basic
+		// Latin-1) and the printed text would lose punctuation.
+		.replace(/[‘’]/g, "'")
+		.replace(/[“”]/g, '"')
 		.replace(/…/g, '...');
 	// Drop anything still outside basic Latin-1 (jsPDF's default fonts
 	// don't cover wider Unicode without bundling a custom font).

--- a/src/lib/cookbookExport.ts
+++ b/src/lib/cookbookExport.ts
@@ -392,14 +392,18 @@ function drawCoverPage(
 		doc.setTextColor(140, 130, 125);
 		const noun = opts.recipeCount === 1 ? 'recipe' : 'recipes';
 		doc.text(`${opts.recipeCount} ${noun}`, CENTER_X, cursorY, { align: 'center' });
+		cursorY += 14;
 	}
 
-	// Creator
+	// Creator — anchored to the title block (just below the recipe count)
+	// rather than the bottom of the page, so it can't crash into the
+	// brand mark / wordmark stack down at PAGE_H-96.
 	if (opts.creatorName) {
+		cursorY += 14;
 		doc.setFont('helvetica', 'italic');
 		doc.setFontSize(12);
 		doc.setTextColor(100, 90, 85);
-		doc.text(`Curated by ${opts.creatorName}`, CENTER_X, PAGE_H - 92, { align: 'center' });
+		doc.text(`Curated by ${opts.creatorName}`, CENTER_X, cursorY, { align: 'center' });
 	}
 
 	// Brand mark — small logo sits above the wordmark, then a thin

--- a/src/lib/cookbookExport.ts
+++ b/src/lib/cookbookExport.ts
@@ -188,7 +188,6 @@ export async function buildCookbookPdf(opts: BuildOptions): Promise<BuildResult>
 			subtitle: sanitizeForPdf(opts.subtitle),
 			creatorName: sanitizeForPdf(opts.creatorName),
 			coverDataUri,
-			recipeCount: opts.recipes.length,
 			brandLogoDataUri
 		});
 	}
@@ -311,7 +310,6 @@ function drawCoverPage(
 		subtitle: string;
 		creatorName: string;
 		coverDataUri: string | null;
-		recipeCount: number;
 		brandLogoDataUri: string | null;
 	}
 ) {
@@ -353,17 +351,6 @@ function drawCoverPage(
 	// a proper book jacket rather than a page with a photo on it.
 	const titleY = coverWindowTop + coverWindowH + 80;
 
-	// "RECIPE PACK" eyebrow with thin centered rule
-	doc.setFont('helvetica', 'bold');
-	doc.setFontSize(10);
-	doc.setTextColor(180, 95, 30);
-	doc.text('A RECIPE PACK', CENTER_X, titleY - 38, { align: 'center', charSpace: 2 } as any);
-
-	// Decorative rule under the eyebrow
-	doc.setDrawColor(180, 95, 30);
-	doc.setLineWidth(0.6);
-	doc.line(CENTER_X - 18, titleY - 28, CENTER_X + 18, titleY - 28);
-
 	// Title
 	doc.setFont('helvetica', 'bold');
 	doc.setFontSize(38);
@@ -384,22 +371,11 @@ function drawCoverPage(
 		cursorY += subLines.length * 18;
 	}
 
-	// Recipe count badge
-	if (opts.recipeCount > 0) {
-		cursorY += 10;
-		doc.setFont('helvetica', 'normal');
-		doc.setFontSize(11);
-		doc.setTextColor(140, 130, 125);
-		const noun = opts.recipeCount === 1 ? 'recipe' : 'recipes';
-		doc.text(`${opts.recipeCount} ${noun}`, CENTER_X, cursorY, { align: 'center' });
-		cursorY += 14;
-	}
-
-	// Creator — anchored to the title block (just below the recipe count)
-	// rather than the bottom of the page, so it can't crash into the
-	// brand mark / wordmark stack down at PAGE_H-96.
+	// Creator — anchored to the title block (right under the title /
+	// subtitle) rather than the bottom of the page, so it can't crash
+	// into the brand mark / wordmark stack down at PAGE_H-96.
 	if (opts.creatorName) {
-		cursorY += 14;
+		cursorY += 18;
 		doc.setFont('helvetica', 'italic');
 		doc.setFontSize(12);
 		doc.setTextColor(100, 90, 85);

--- a/src/lib/cookbookExport.ts
+++ b/src/lib/cookbookExport.ts
@@ -172,7 +172,8 @@ export async function buildCookbookPdf(opts: BuildOptions): Promise<BuildResult>
 			title: sanitizeForPdf(opts.title),
 			subtitle: sanitizeForPdf(opts.subtitle),
 			creatorName: sanitizeForPdf(opts.creatorName),
-			coverDataUri
+			coverDataUri,
+			recipeCount: opts.recipes.length
 		});
 	}
 
@@ -290,106 +291,183 @@ function drawCoverPage(
 		subtitle: string;
 		creatorName: string;
 		coverDataUri: string | null;
+		recipeCount: number;
 	}
 ) {
 	// Page background — soft warm tint
 	doc.setFillColor(252, 248, 243);
 	doc.rect(0, 0, PAGE_W, PAGE_H, 'F');
 
-	// Image fills upper half if present
+	// Cover image, if present, sits in a clean centered window in the
+	// upper third — not edge-bleed and not page-dominating. Gives it a
+	// "framed plate" feel and leaves room for typography.
+	const coverWindowTop = MARGIN + 32;
+	const coverWindowH = 280;
+	const coverWindowW = PAGE_W - MARGIN * 2 - 32;
+	const coverWindowX = (PAGE_W - coverWindowW) / 2;
+
 	if (opts.coverDataUri) {
 		try {
 			doc.addImage(
 				opts.coverDataUri,
 				imageFormatFromDataUri(opts.coverDataUri),
-				0,
-				0,
-				PAGE_W,
-				PAGE_H * 0.55
+				coverWindowX,
+				coverWindowTop,
+				coverWindowW,
+				coverWindowH
 			);
-			// Soft fade overlay at the bottom of the image
-			doc.setFillColor(252, 248, 243);
-			doc.rect(0, PAGE_H * 0.5, PAGE_W, PAGE_H * 0.05, 'F');
 		} catch {
 			/* skip */
 		}
+	} else {
+		// No image: tasteful empty frame so the page still looks intentional.
+		doc.setDrawColor(220, 200, 190);
+		doc.setLineWidth(1);
+		doc.rect(coverWindowX, coverWindowTop, coverWindowW, coverWindowH);
 	}
 
-	const titleY = opts.coverDataUri ? PAGE_H * 0.62 : PAGE_H * 0.42;
+	// Title block sits in the lower third — gives the cover the feel of
+	// a proper book jacket rather than a page with a photo on it.
+	const titleY = coverWindowTop + coverWindowH + 80;
 
-	// "RECIPE PACK" eyebrow
+	// "RECIPE PACK" eyebrow with thin centered rule
 	doc.setFont('helvetica', 'bold');
-	doc.setFontSize(11);
+	doc.setFontSize(10);
 	doc.setTextColor(180, 95, 30);
-	doc.text('RECIPE PACK', PAGE_W / 2, titleY - 36, { align: 'center' });
+	doc.text('A RECIPE PACK', PAGE_W / 2, titleY - 38, { align: 'center', charSpace: 2 } as any);
+
+	// Decorative rule under the eyebrow
+	doc.setDrawColor(180, 95, 30);
+	doc.setLineWidth(0.6);
+	doc.line(PAGE_W / 2 - 18, titleY - 28, PAGE_W / 2 + 18, titleY - 28);
 
 	// Title
 	doc.setFont('helvetica', 'bold');
-	doc.setFontSize(34);
+	doc.setFontSize(38);
 	doc.setTextColor(28, 22, 18);
 	const titleLines = doc.splitTextToSize(opts.title || 'Recipe Pack', CONTENT_W * 0.85);
 	doc.text(titleLines, PAGE_W / 2, titleY, { align: 'center' });
 
-	// Subtitle
+	let cursorY = titleY + titleLines.length * 40;
+
+	// Subtitle (italic for a published-cookbook feel)
 	if (opts.subtitle) {
-		doc.setFont('helvetica', 'normal');
-		doc.setFontSize(14);
+		cursorY += 12;
+		doc.setFont('helvetica', 'italic');
+		doc.setFontSize(13);
 		doc.setTextColor(80, 70, 65);
-		const subLines = doc.splitTextToSize(opts.subtitle, CONTENT_W * 0.8);
-		doc.text(subLines, PAGE_W / 2, titleY + 24 + titleLines.length * 38, { align: 'center' });
+		const subLines = doc.splitTextToSize(opts.subtitle, CONTENT_W * 0.75);
+		doc.text(subLines, PAGE_W / 2, cursorY, { align: 'center' });
+		cursorY += subLines.length * 18;
+	}
+
+	// Recipe count badge
+	if (opts.recipeCount > 0) {
+		cursorY += 10;
+		doc.setFont('helvetica', 'normal');
+		doc.setFontSize(11);
+		doc.setTextColor(140, 130, 125);
+		const noun = opts.recipeCount === 1 ? 'recipe' : 'recipes';
+		doc.text(`${opts.recipeCount} ${noun}`, PAGE_W / 2, cursorY, { align: 'center' });
 	}
 
 	// Creator
 	if (opts.creatorName) {
 		doc.setFont('helvetica', 'italic');
-		doc.setFontSize(13);
+		doc.setFontSize(12);
 		doc.setTextColor(100, 90, 85);
-		doc.text(`Curated by ${opts.creatorName}`, PAGE_W / 2, PAGE_H - 110, { align: 'center' });
+		doc.text(`Curated by ${opts.creatorName}`, PAGE_W / 2, PAGE_H - 92, { align: 'center' });
 	}
 
 	// "Created with Zap Cooking" footer brand
 	doc.setFont('helvetica', 'bold');
-	doc.setFontSize(11);
+	doc.setFontSize(10);
 	doc.setTextColor(180, 95, 30);
-	doc.text('zap.cooking', PAGE_W / 2, PAGE_H - 64, { align: 'center' });
+	doc.text('zap.cooking', PAGE_W / 2, PAGE_H - 60, { align: 'center', charSpace: 1 } as any);
 	doc.setFont('helvetica', 'normal');
 	doc.setFontSize(9);
 	doc.setTextColor(140, 130, 125);
-	doc.text('Created with Zap Cooking', PAGE_W / 2, PAGE_H - 48, { align: 'center' });
+	doc.text('Created with Zap Cooking', PAGE_W / 2, PAGE_H - 46, { align: 'center' });
 }
 
 function drawTocPage(doc: JsPdfDoc, titles: string[], pageNumbers: number[]) {
 	doc.setFillColor(255, 255, 255);
 	doc.rect(0, 0, PAGE_W, PAGE_H, 'F');
 
+	// Eyebrow
 	doc.setFont('helvetica', 'bold');
-	doc.setFontSize(24);
-	doc.setTextColor(28, 22, 18);
-	doc.text('Contents', MARGIN, 110);
+	doc.setFontSize(9);
+	doc.setTextColor(180, 95, 30);
+	doc.text('TABLE OF CONTENTS', MARGIN, 92, { charSpace: 2 } as any);
 
+	// Heading
+	doc.setFont('helvetica', 'bold');
+	doc.setFontSize(28);
+	doc.setTextColor(28, 22, 18);
+	doc.text('Contents', MARGIN, 124);
+
+	// Heading rule
 	doc.setDrawColor(220, 200, 190);
-	doc.setLineWidth(1);
-	doc.line(MARGIN, 124, PAGE_W - MARGIN, 124);
+	doc.setLineWidth(0.8);
+	doc.line(MARGIN, 138, PAGE_W - MARGIN, 138);
 
 	doc.setFont('helvetica', 'normal');
-	doc.setFontSize(13);
+	doc.setFontSize(12);
 	doc.setTextColor(40, 30, 25);
 
-	let y = 160;
-	const rowHeight = 24;
+	let y = 176;
+	const rowHeight = 22;
+	const pageColX = PAGE_W - MARGIN;
+	const titleMaxW = CONTENT_W - 56; // leaves room for the page number
+
 	for (let i = 0; i < titles.length; i++) {
 		const title = titles[i];
 		if (!title) continue;
 		const pageStr = pageNumbers[i] > 0 ? String(pageNumbers[i]) : '';
-		// Title (left, may wrap to one short line)
-		const lines = doc.splitTextToSize(title, CONTENT_W - 50);
-		doc.text(lines[0], MARGIN, y);
-		// Page number (right)
-		if (pageStr) {
-			doc.text(pageStr, PAGE_W - MARGIN, y, { align: 'right' });
+
+		// Long titles wrap to a second line; we keep the page number on the
+		// last line so the dot leaders read naturally.
+		const lines = doc.splitTextToSize(title, titleMaxW);
+		const lastLineIdx = lines.length - 1;
+
+		for (let li = 0; li < lines.length; li++) {
+			if (y > PAGE_H - 90) {
+				// Overflow into a second TOC page if the pack is huge.
+				doc.addPage();
+				doc.setFillColor(255, 255, 255);
+				doc.rect(0, 0, PAGE_W, PAGE_H, 'F');
+				doc.setFont('helvetica', 'normal');
+				doc.setFontSize(12);
+				doc.setTextColor(40, 30, 25);
+				y = MARGIN + 16;
+			}
+			doc.text(lines[li], MARGIN, y);
+
+			if (li === lastLineIdx && pageStr) {
+				// Dot leaders between title end and page number
+				const titleW = (doc as any).getTextWidth
+					? (doc as any).getTextWidth(lines[li])
+					: lines[li].length * 6;
+				const pageW = (doc as any).getTextWidth
+					? (doc as any).getTextWidth(pageStr)
+					: pageStr.length * 6;
+				const leaderStart = MARGIN + titleW + 6;
+				const leaderEnd = pageColX - pageW - 6;
+				if (leaderEnd > leaderStart) {
+					doc.setTextColor(200, 190, 185);
+					const dotW = (doc as any).getTextWidth ? (doc as any).getTextWidth('.') : 3;
+					const space = Math.max(3, dotW + 2);
+					let dx = leaderStart;
+					while (dx < leaderEnd) {
+						doc.text('.', dx, y);
+						dx += space;
+					}
+					doc.setTextColor(40, 30, 25);
+				}
+				doc.text(pageStr, pageColX, y, { align: 'right' });
+			}
+			y += rowHeight;
 		}
-		y += rowHeight;
-		if (y > PAGE_H - 80) break; // overflow safety; rare
 	}
 }
 
@@ -397,30 +475,53 @@ function drawIntroductionPage(doc: JsPdfDoc, intro: string) {
 	doc.setFillColor(255, 255, 255);
 	doc.rect(0, 0, PAGE_W, PAGE_H, 'F');
 
+	// Eyebrow
 	doc.setFont('helvetica', 'bold');
-	doc.setFontSize(24);
+	doc.setFontSize(9);
+	doc.setTextColor(180, 95, 30);
+	doc.text('INTRODUCTION', PAGE_W / 2, 110, { align: 'center', charSpace: 2 } as any);
+
+	// Decorative rule
+	doc.setDrawColor(180, 95, 30);
+	doc.setLineWidth(0.6);
+	doc.line(PAGE_W / 2 - 18, 122, PAGE_W / 2 + 18, 122);
+
+	// Heading
+	doc.setFont('helvetica', 'bold');
+	doc.setFontSize(28);
 	doc.setTextColor(28, 22, 18);
-	doc.text('Introduction', MARGIN, 110);
-	doc.setDrawColor(220, 200, 190);
-	doc.setLineWidth(1);
-	doc.line(MARGIN, 124, PAGE_W - MARGIN, 124);
+	doc.text('A Note on This Pack', PAGE_W / 2, 158, { align: 'center' });
+
+	// Body — narrower measure for readability (~70 chars per line at 12pt)
+	const colW = Math.min(CONTENT_W, 380);
+	const colX = (PAGE_W - colW) / 2;
 
 	doc.setFont('helvetica', 'normal');
 	doc.setFontSize(12);
-	doc.setTextColor(40, 30, 25);
+	doc.setTextColor(50, 40, 35);
+
 	const paragraphs = intro.split(/\n\s*\n/);
-	let y = 160;
+	let y = 200;
+	const lineH = 17;
+	const paragraphGap = 12;
 	for (const p of paragraphs) {
-		const lines = doc.splitTextToSize(p.trim(), CONTENT_W);
+		const text = p.trim();
+		if (!text) continue;
+		const lines = doc.splitTextToSize(text, colW);
 		for (const line of lines) {
 			if (y > PAGE_H - 90) {
 				doc.addPage();
-				y = MARGIN;
+				doc.setFillColor(255, 255, 255);
+				doc.rect(0, 0, PAGE_W, PAGE_H, 'F');
+				doc.setFont('helvetica', 'normal');
+				doc.setFontSize(12);
+				doc.setTextColor(50, 40, 35);
+				y = MARGIN + 16;
 			}
-			doc.text(line, MARGIN, y);
-			y += 18;
+			doc.text(line, colX, y);
+			y += lineH;
 		}
-		y += 10;
+		y += paragraphGap;
 	}
 }
 
@@ -441,7 +542,19 @@ function drawRecipePages(
 	doc.setFillColor(255, 255, 255);
 	doc.rect(0, 0, PAGE_W, PAGE_H, 'F');
 
-	let y = MARGIN + 16;
+	const PAGE_BOTTOM = PAGE_H - 90;
+	const PAGE_TOP = MARGIN + 16;
+
+	// Continue onto a fresh page and reset to a known-safe state. Used by
+	// the orphan-heading guards below.
+	const newPage = (): number => {
+		doc.addPage();
+		doc.setFillColor(255, 255, 255);
+		doc.rect(0, 0, PAGE_W, PAGE_H, 'F');
+		return PAGE_TOP;
+	};
+
+	let y = PAGE_TOP;
 
 	// Title
 	doc.setFont('helvetica', 'bold');
@@ -450,6 +563,11 @@ function drawRecipePages(
 	const titleLines = doc.splitTextToSize(r.title || 'Recipe', CONTENT_W);
 	doc.text(titleLines, MARGIN, y);
 	y += titleLines.length * 26;
+
+	// Accent rule under the title
+	doc.setDrawColor(180, 95, 30);
+	doc.setLineWidth(1.2);
+	doc.line(MARGIN, y - 18, MARGIN + 36, y - 18);
 
 	// Creator attribution
 	if (r.creatorName) {
@@ -460,16 +578,17 @@ function drawRecipePages(
 		y += 16;
 	}
 
-	// Image
+	// Image — graceful fallthrough on addImage failure (e.g. malformed
+	// data URI), keeping y where it was so the rest of the page reflows.
 	if (r.imageDataUri) {
-		y += 4;
+		y += 6;
 		try {
 			const imgW = CONTENT_W;
 			const imgH = imgW * 0.55; // 16:9-ish
 			doc.addImage(r.imageDataUri, imageFormatFromDataUri(r.imageDataUri), MARGIN, y, imgW, imgH);
 			y += imgH + 14;
 		} catch {
-			/* skip image */
+			// Image failed: continue without consuming vertical space.
 		}
 	}
 
@@ -480,99 +599,128 @@ function drawRecipePages(
 		r.cookTime ? `Cook ${r.cookTime}` : ''
 	]
 		.filter(Boolean)
-		.join('  •  ');
+		.join('   •   ');
 	if (meta) {
 		doc.setFont('helvetica', 'normal');
-		doc.setFontSize(11);
+		doc.setFontSize(10);
 		doc.setTextColor(110, 100, 95);
-		doc.text(meta, MARGIN, y);
-		y += 18;
+		doc.text(meta, MARGIN, y, { charSpace: 0.5 } as any);
+		y += 20;
 	}
 
-	// Chef's notes (italic)
+	// Chef's notes (italic, indented quote-style)
 	if (r.chefNotes) {
-		y += 6;
+		y += 4;
 		doc.setFont('helvetica', 'italic');
 		doc.setFontSize(11);
-		doc.setTextColor(80, 70, 65);
-		const notesLines = doc.splitTextToSize(r.chefNotes, CONTENT_W);
+		doc.setTextColor(85, 75, 70);
+		// Subtle left rule
+		const notesLines = doc.splitTextToSize(r.chefNotes, CONTENT_W - 18);
+		const notesStartY = y;
 		for (const line of notesLines) {
-			if (y > PAGE_H - 90) {
-				doc.addPage();
-				y = MARGIN + 16;
+			if (y > PAGE_BOTTOM) {
+				y = newPage();
+				doc.setFont('helvetica', 'italic');
+				doc.setFontSize(11);
+				doc.setTextColor(85, 75, 70);
 			}
-			doc.text(line, MARGIN, y);
-			y += 14;
+			doc.text(line, MARGIN + 14, y);
+			y += 15;
 		}
-		y += 8;
+		// Draw the quote rule once at the end (covers wrapped lines).
+		doc.setDrawColor(220, 200, 190);
+		doc.setLineWidth(1.5);
+		doc.line(MARGIN + 2, notesStartY - 10, MARGIN + 2, y - 10);
+		y += 10;
 	}
+
+	const sectionHeading = (label: string) => {
+		doc.setFont('helvetica', 'bold');
+		doc.setFontSize(13);
+		doc.setTextColor(180, 95, 30);
+		doc.text(label.toUpperCase(), MARGIN, y, { charSpace: 1.5 } as any);
+		// thin rule across the column
+		doc.setDrawColor(220, 200, 190);
+		doc.setLineWidth(0.5);
+		doc.line(MARGIN, y + 6, PAGE_W - MARGIN, y + 6);
+		y += 22;
+	};
 
 	// Ingredients
 	if (r.ingredients.length) {
-		if (y > PAGE_H - 160) {
-			doc.addPage();
-			y = MARGIN + 16;
+		// Orphan-heading guard: the heading + at least 2 lines of body must
+		// fit on the current page; otherwise start fresh.
+		if (y > PAGE_BOTTOM - 60) {
+			y = newPage();
 		}
 		y += 6;
-		doc.setFont('helvetica', 'bold');
-		doc.setFontSize(14);
-		doc.setTextColor(28, 22, 18);
-		doc.text('Ingredients', MARGIN, y);
-		y += 18;
+		sectionHeading('Ingredients');
 		doc.setFont('helvetica', 'normal');
 		doc.setFontSize(11);
 		doc.setTextColor(40, 30, 25);
 		for (const item of r.ingredients) {
-			const lines = doc.splitTextToSize(`•  ${item}`, CONTENT_W - 12);
+			const lines = doc.splitTextToSize(item, CONTENT_W - 18);
 			for (let i = 0; i < lines.length; i++) {
-				if (y > PAGE_H - 90) {
-					doc.addPage();
-					y = MARGIN + 16;
+				if (y > PAGE_BOTTOM) {
+					y = newPage();
+					doc.setFont('helvetica', 'normal');
+					doc.setFontSize(11);
+					doc.setTextColor(40, 30, 25);
 				}
-				doc.text(lines[i], MARGIN + (i === 0 ? 0 : 12), y);
+				if (i === 0) {
+					doc.setTextColor(180, 95, 30);
+					doc.text('•', MARGIN, y);
+					doc.setTextColor(40, 30, 25);
+				}
+				doc.text(lines[i], MARGIN + 14, y);
 				y += 15;
 			}
 		}
-		y += 8;
+		y += 10;
 	}
 
 	// Directions
 	if (r.directions.length) {
-		if (y > PAGE_H - 200) {
-			doc.addPage();
-			y = MARGIN + 16;
+		// Same orphan guard for the Directions heading.
+		if (y > PAGE_BOTTOM - 60) {
+			y = newPage();
 		}
-		y += 6;
-		doc.setFont('helvetica', 'bold');
-		doc.setFontSize(14);
-		doc.setTextColor(28, 22, 18);
-		doc.text('Directions', MARGIN, y);
-		y += 18;
+		y += 4;
+		sectionHeading('Directions');
 		doc.setFont('helvetica', 'normal');
 		doc.setFontSize(11);
 		doc.setTextColor(40, 30, 25);
 		for (let i = 0; i < r.directions.length; i++) {
 			const step = r.directions[i];
-			const numStr = `${i + 1}.`;
+			const numStr = `${i + 1}`;
+			const lines = doc.splitTextToSize(step, CONTENT_W - 32);
+
+			// Keep the step number with at least the first line of its body
+			// to avoid a stranded number at page bottom.
+			if (y > PAGE_BOTTOM - 18) {
+				y = newPage();
+				doc.setFont('helvetica', 'normal');
+				doc.setFontSize(11);
+				doc.setTextColor(40, 30, 25);
+			}
+
 			doc.setFont('helvetica', 'bold');
 			doc.setTextColor(180, 95, 30);
-			if (y > PAGE_H - 90) {
-				doc.addPage();
-				y = MARGIN + 16;
-			}
 			doc.text(numStr, MARGIN, y);
 			doc.setFont('helvetica', 'normal');
 			doc.setTextColor(40, 30, 25);
-			const lines = doc.splitTextToSize(step, CONTENT_W - 28);
+
 			for (let j = 0; j < lines.length; j++) {
-				if (j > 0 && y > PAGE_H - 90) {
-					doc.addPage();
-					y = MARGIN + 16;
+				if (j > 0 && y > PAGE_BOTTOM) {
+					y = newPage();
+					doc.setFont('helvetica', 'normal');
+					doc.setFontSize(11);
+					doc.setTextColor(40, 30, 25);
 				}
 				doc.text(lines[j], MARGIN + 28, y);
 				y += 16;
 			}
-			y += 4;
+			y += 6;
 		}
 	}
 }

--- a/src/lib/cookbookExport.ts
+++ b/src/lib/cookbookExport.ts
@@ -132,8 +132,19 @@ function imageFormatFromDataUri(dataUri: string): 'JPEG' | 'PNG' | 'WEBP' {
 
 const PAGE_W = 612; // 8.5"
 const PAGE_H = 792; // 11"
-const MARGIN = 56; // ~0.78"
-const CONTENT_W = PAGE_W - MARGIN * 2;
+// Asymmetric margins — extra room on the left for a 3-ring binder gutter,
+// so users who print + bind the cookbook don't lose text to the hole punch.
+const MARGIN_LEFT = 88; // ~1.22"
+const MARGIN_RIGHT = 56; // ~0.78"
+const MARGIN_TOP = 56;
+const MARGIN_BOTTOM = 56;
+const CONTENT_W = PAGE_W - MARGIN_LEFT - MARGIN_RIGHT;
+// Visual centerline of the printable area (between the gutters), so
+// "centered" content stays visually centered relative to the actual
+// content area rather than the physical page edges.
+const CENTER_X = (MARGIN_LEFT + (PAGE_W - MARGIN_RIGHT)) / 2;
+// Aliases retained for ergonomic edge calls.
+const CONTENT_RIGHT = PAGE_W - MARGIN_RIGHT;
 
 /** Build the cookbook PDF. Returns blob + per-recipe failure list. */
 export async function buildCookbookPdf(opts: BuildOptions): Promise<BuildResult> {
@@ -240,7 +251,10 @@ export async function buildCookbookPdf(opts: BuildOptions): Promise<BuildResult>
 	}
 
 	// Add small "Created with Zap Cooking" footer to every page except cover
-	addFooters(doc, opts.includeCover ? 2 : 1);
+	const nonCoverStart = opts.includeCover ? 2 : 1;
+	addFooters(doc, nonCoverStart);
+	// Running header (pack title) on every non-cover page
+	addRunningHeaders(doc, sanitizeForPdf(opts.title), nonCoverStart);
 
 	const blob = doc.output('blob') as unknown as Blob;
 	return { blob, included, skipped };
@@ -301,10 +315,12 @@ function drawCoverPage(
 	// Cover image, if present, sits in a clean centered window in the
 	// upper third — not edge-bleed and not page-dominating. Gives it a
 	// "framed plate" feel and leaves room for typography.
-	const coverWindowTop = MARGIN + 32;
+	// Centered between the actual content margins (gutter-aware), so the
+	// cover stays balanced even with the binder gutter offset.
+	const coverWindowTop = MARGIN_TOP + 32;
 	const coverWindowH = 280;
-	const coverWindowW = PAGE_W - MARGIN * 2 - 32;
-	const coverWindowX = (PAGE_W - coverWindowW) / 2;
+	const coverWindowW = CONTENT_W - 32;
+	const coverWindowX = CENTER_X - coverWindowW / 2;
 
 	if (opts.coverDataUri) {
 		try {
@@ -334,19 +350,19 @@ function drawCoverPage(
 	doc.setFont('helvetica', 'bold');
 	doc.setFontSize(10);
 	doc.setTextColor(180, 95, 30);
-	doc.text('A RECIPE PACK', PAGE_W / 2, titleY - 38, { align: 'center', charSpace: 2 } as any);
+	doc.text('A RECIPE PACK', CENTER_X, titleY - 38, { align: 'center', charSpace: 2 } as any);
 
 	// Decorative rule under the eyebrow
 	doc.setDrawColor(180, 95, 30);
 	doc.setLineWidth(0.6);
-	doc.line(PAGE_W / 2 - 18, titleY - 28, PAGE_W / 2 + 18, titleY - 28);
+	doc.line(CENTER_X - 18, titleY - 28, CENTER_X + 18, titleY - 28);
 
 	// Title
 	doc.setFont('helvetica', 'bold');
 	doc.setFontSize(38);
 	doc.setTextColor(28, 22, 18);
-	const titleLines = doc.splitTextToSize(opts.title || 'Recipe Pack', CONTENT_W * 0.85);
-	doc.text(titleLines, PAGE_W / 2, titleY, { align: 'center' });
+	const titleLines = doc.splitTextToSize(opts.title || 'Recipe Pack', CONTENT_W * 0.92);
+	doc.text(titleLines, CENTER_X, titleY, { align: 'center' });
 
 	let cursorY = titleY + titleLines.length * 40;
 
@@ -356,8 +372,8 @@ function drawCoverPage(
 		doc.setFont('helvetica', 'italic');
 		doc.setFontSize(13);
 		doc.setTextColor(80, 70, 65);
-		const subLines = doc.splitTextToSize(opts.subtitle, CONTENT_W * 0.75);
-		doc.text(subLines, PAGE_W / 2, cursorY, { align: 'center' });
+		const subLines = doc.splitTextToSize(opts.subtitle, CONTENT_W * 0.8);
+		doc.text(subLines, CENTER_X, cursorY, { align: 'center' });
 		cursorY += subLines.length * 18;
 	}
 
@@ -368,7 +384,7 @@ function drawCoverPage(
 		doc.setFontSize(11);
 		doc.setTextColor(140, 130, 125);
 		const noun = opts.recipeCount === 1 ? 'recipe' : 'recipes';
-		doc.text(`${opts.recipeCount} ${noun}`, PAGE_W / 2, cursorY, { align: 'center' });
+		doc.text(`${opts.recipeCount} ${noun}`, CENTER_X, cursorY, { align: 'center' });
 	}
 
 	// Creator
@@ -376,18 +392,18 @@ function drawCoverPage(
 		doc.setFont('helvetica', 'italic');
 		doc.setFontSize(12);
 		doc.setTextColor(100, 90, 85);
-		doc.text(`Curated by ${opts.creatorName}`, PAGE_W / 2, PAGE_H - 92, { align: 'center' });
+		doc.text(`Curated by ${opts.creatorName}`, CENTER_X, PAGE_H - 92, { align: 'center' });
 	}
 
 	// "Created with Zap Cooking" footer brand
 	doc.setFont('helvetica', 'bold');
 	doc.setFontSize(10);
 	doc.setTextColor(180, 95, 30);
-	doc.text('zap.cooking', PAGE_W / 2, PAGE_H - 60, { align: 'center', charSpace: 1 } as any);
+	doc.text('zap.cooking', CENTER_X, PAGE_H - 60, { align: 'center', charSpace: 1 } as any);
 	doc.setFont('helvetica', 'normal');
 	doc.setFontSize(9);
 	doc.setTextColor(140, 130, 125);
-	doc.text('Created with Zap Cooking', PAGE_W / 2, PAGE_H - 46, { align: 'center' });
+	doc.text('Created with Zap Cooking', CENTER_X, PAGE_H - 46, { align: 'center' });
 }
 
 function drawTocPage(doc: JsPdfDoc, titles: string[], pageNumbers: number[]) {
@@ -398,18 +414,18 @@ function drawTocPage(doc: JsPdfDoc, titles: string[], pageNumbers: number[]) {
 	doc.setFont('helvetica', 'bold');
 	doc.setFontSize(9);
 	doc.setTextColor(180, 95, 30);
-	doc.text('TABLE OF CONTENTS', MARGIN, 92, { charSpace: 2 } as any);
+	doc.text('TABLE OF CONTENTS', MARGIN_LEFT, 92, { charSpace: 2 } as any);
 
 	// Heading
 	doc.setFont('helvetica', 'bold');
 	doc.setFontSize(28);
 	doc.setTextColor(28, 22, 18);
-	doc.text('Contents', MARGIN, 124);
+	doc.text('Contents', MARGIN_LEFT, 124);
 
 	// Heading rule
 	doc.setDrawColor(220, 200, 190);
 	doc.setLineWidth(0.8);
-	doc.line(MARGIN, 138, PAGE_W - MARGIN, 138);
+	doc.line(MARGIN_LEFT, 138, CONTENT_RIGHT, 138);
 
 	doc.setFont('helvetica', 'normal');
 	doc.setFontSize(12);
@@ -417,7 +433,7 @@ function drawTocPage(doc: JsPdfDoc, titles: string[], pageNumbers: number[]) {
 
 	let y = 176;
 	const rowHeight = 22;
-	const pageColX = PAGE_W - MARGIN;
+	const pageColX = CONTENT_RIGHT;
 	const titleMaxW = CONTENT_W - 56; // leaves room for the page number
 
 	for (let i = 0; i < titles.length; i++) {
@@ -439,9 +455,9 @@ function drawTocPage(doc: JsPdfDoc, titles: string[], pageNumbers: number[]) {
 				doc.setFont('helvetica', 'normal');
 				doc.setFontSize(12);
 				doc.setTextColor(40, 30, 25);
-				y = MARGIN + 16;
+				y = MARGIN_TOP + 16;
 			}
-			doc.text(lines[li], MARGIN, y);
+			doc.text(lines[li], MARGIN_LEFT, y);
 
 			if (li === lastLineIdx && pageStr) {
 				// Dot leaders between title end and page number
@@ -451,7 +467,7 @@ function drawTocPage(doc: JsPdfDoc, titles: string[], pageNumbers: number[]) {
 				const pageW = (doc as any).getTextWidth
 					? (doc as any).getTextWidth(pageStr)
 					: pageStr.length * 6;
-				const leaderStart = MARGIN + titleW + 6;
+				const leaderStart = MARGIN_LEFT + titleW + 6;
 				const leaderEnd = pageColX - pageW - 6;
 				if (leaderEnd > leaderStart) {
 					doc.setTextColor(200, 190, 185);
@@ -479,22 +495,22 @@ function drawIntroductionPage(doc: JsPdfDoc, intro: string) {
 	doc.setFont('helvetica', 'bold');
 	doc.setFontSize(9);
 	doc.setTextColor(180, 95, 30);
-	doc.text('INTRODUCTION', PAGE_W / 2, 110, { align: 'center', charSpace: 2 } as any);
+	doc.text('INTRODUCTION', CENTER_X, 110, { align: 'center', charSpace: 2 } as any);
 
 	// Decorative rule
 	doc.setDrawColor(180, 95, 30);
 	doc.setLineWidth(0.6);
-	doc.line(PAGE_W / 2 - 18, 122, PAGE_W / 2 + 18, 122);
+	doc.line(CENTER_X - 18, 122, CENTER_X + 18, 122);
 
 	// Heading
 	doc.setFont('helvetica', 'bold');
 	doc.setFontSize(28);
 	doc.setTextColor(28, 22, 18);
-	doc.text('A Note on This Pack', PAGE_W / 2, 158, { align: 'center' });
+	doc.text('A Note on This Pack', CENTER_X, 158, { align: 'center' });
 
 	// Body — narrower measure for readability (~70 chars per line at 12pt)
 	const colW = Math.min(CONTENT_W, 380);
-	const colX = (PAGE_W - colW) / 2;
+	const colX = CENTER_X - colW / 2;
 
 	doc.setFont('helvetica', 'normal');
 	doc.setFontSize(12);
@@ -516,7 +532,7 @@ function drawIntroductionPage(doc: JsPdfDoc, intro: string) {
 				doc.setFont('helvetica', 'normal');
 				doc.setFontSize(12);
 				doc.setTextColor(50, 40, 35);
-				y = MARGIN + 16;
+				y = MARGIN_TOP + 16;
 			}
 			doc.text(line, colX, y);
 			y += lineH;
@@ -543,7 +559,7 @@ function drawRecipePages(
 	doc.rect(0, 0, PAGE_W, PAGE_H, 'F');
 
 	const PAGE_BOTTOM = PAGE_H - 90;
-	const PAGE_TOP = MARGIN + 16;
+	const PAGE_TOP = MARGIN_TOP + 16;
 
 	// Continue onto a fresh page and reset to a known-safe state. Used by
 	// the orphan-heading guards below.
@@ -561,20 +577,20 @@ function drawRecipePages(
 	doc.setFontSize(22);
 	doc.setTextColor(28, 22, 18);
 	const titleLines = doc.splitTextToSize(r.title || 'Recipe', CONTENT_W);
-	doc.text(titleLines, MARGIN, y);
+	doc.text(titleLines, MARGIN_LEFT, y);
 	y += titleLines.length * 26;
 
 	// Accent rule under the title
 	doc.setDrawColor(180, 95, 30);
 	doc.setLineWidth(1.2);
-	doc.line(MARGIN, y - 18, MARGIN + 36, y - 18);
+	doc.line(MARGIN_LEFT, y - 18, MARGIN_LEFT + 36, y - 18);
 
 	// Creator attribution
 	if (r.creatorName) {
 		doc.setFont('helvetica', 'italic');
 		doc.setFontSize(11);
 		doc.setTextColor(110, 100, 95);
-		doc.text(`by ${r.creatorName}`, MARGIN, y);
+		doc.text(`by ${r.creatorName}`, MARGIN_LEFT, y);
 		y += 16;
 	}
 
@@ -585,7 +601,14 @@ function drawRecipePages(
 		try {
 			const imgW = CONTENT_W;
 			const imgH = imgW * 0.55; // 16:9-ish
-			doc.addImage(r.imageDataUri, imageFormatFromDataUri(r.imageDataUri), MARGIN, y, imgW, imgH);
+			doc.addImage(
+				r.imageDataUri,
+				imageFormatFromDataUri(r.imageDataUri),
+				MARGIN_LEFT,
+				y,
+				imgW,
+				imgH
+			);
 			y += imgH + 14;
 		} catch {
 			// Image failed: continue without consuming vertical space.
@@ -604,7 +627,7 @@ function drawRecipePages(
 		doc.setFont('helvetica', 'normal');
 		doc.setFontSize(10);
 		doc.setTextColor(110, 100, 95);
-		doc.text(meta, MARGIN, y, { charSpace: 0.5 } as any);
+		doc.text(meta, MARGIN_LEFT, y, { charSpace: 0.5 } as any);
 		y += 20;
 	}
 
@@ -624,13 +647,13 @@ function drawRecipePages(
 				doc.setFontSize(11);
 				doc.setTextColor(85, 75, 70);
 			}
-			doc.text(line, MARGIN + 14, y);
+			doc.text(line, MARGIN_LEFT + 14, y);
 			y += 15;
 		}
 		// Draw the quote rule once at the end (covers wrapped lines).
 		doc.setDrawColor(220, 200, 190);
 		doc.setLineWidth(1.5);
-		doc.line(MARGIN + 2, notesStartY - 10, MARGIN + 2, y - 10);
+		doc.line(MARGIN_LEFT + 2, notesStartY - 10, MARGIN_LEFT + 2, y - 10);
 		y += 10;
 	}
 
@@ -638,11 +661,11 @@ function drawRecipePages(
 		doc.setFont('helvetica', 'bold');
 		doc.setFontSize(13);
 		doc.setTextColor(180, 95, 30);
-		doc.text(label.toUpperCase(), MARGIN, y, { charSpace: 1.5 } as any);
+		doc.text(label.toUpperCase(), MARGIN_LEFT, y, { charSpace: 1.5 } as any);
 		// thin rule across the column
 		doc.setDrawColor(220, 200, 190);
 		doc.setLineWidth(0.5);
-		doc.line(MARGIN, y + 6, PAGE_W - MARGIN, y + 6);
+		doc.line(MARGIN_LEFT, y + 6, CONTENT_RIGHT, y + 6);
 		y += 22;
 	};
 
@@ -669,10 +692,10 @@ function drawRecipePages(
 				}
 				if (i === 0) {
 					doc.setTextColor(180, 95, 30);
-					doc.text('•', MARGIN, y);
+					doc.text('•', MARGIN_LEFT, y);
 					doc.setTextColor(40, 30, 25);
 				}
-				doc.text(lines[i], MARGIN + 14, y);
+				doc.text(lines[i], MARGIN_LEFT + 14, y);
 				y += 15;
 			}
 		}
@@ -706,7 +729,7 @@ function drawRecipePages(
 
 			doc.setFont('helvetica', 'bold');
 			doc.setTextColor(180, 95, 30);
-			doc.text(numStr, MARGIN, y);
+			doc.text(numStr, MARGIN_LEFT, y);
 			doc.setFont('helvetica', 'normal');
 			doc.setTextColor(40, 30, 25);
 
@@ -717,7 +740,7 @@ function drawRecipePages(
 					doc.setFontSize(11);
 					doc.setTextColor(40, 30, 25);
 				}
-				doc.text(lines[j], MARGIN + 28, y);
+				doc.text(lines[j], MARGIN_LEFT + 28, y);
 				y += 16;
 			}
 			y += 6;
@@ -732,7 +755,31 @@ function addFooters(doc: JsPdfDoc, fromPage: number) {
 		doc.setFont('helvetica', 'normal');
 		doc.setFontSize(9);
 		doc.setTextColor(160, 150, 145);
-		doc.text('Created with Zap Cooking', PAGE_W / 2, PAGE_H - 28, { align: 'center' });
-		doc.text(String(p), PAGE_W - MARGIN, PAGE_H - 28, { align: 'right' });
+		doc.text('Created with Zap Cooking', CENTER_X, PAGE_H - 28, { align: 'center' });
+		doc.text(String(p), CONTENT_RIGHT, PAGE_H - 28, { align: 'right' });
+	}
+}
+
+/**
+ * Subtle running header — pack title, top of page, with a hairline rule.
+ * Skipped for the cover (which has its own typography). Drawn after all
+ * pages exist so we can iterate by page number.
+ */
+function addRunningHeaders(doc: JsPdfDoc, packTitle: string, fromPage: number) {
+	const trimmed = (packTitle || '').trim();
+	if (!trimmed) return;
+	const total = doc.getNumberOfPages();
+	for (let p = fromPage; p <= total; p++) {
+		doc.setPage(p);
+		doc.setFont('helvetica', 'normal');
+		doc.setFontSize(8);
+		doc.setTextColor(160, 150, 145);
+		// Truncate over-long titles so they don't collide with margins.
+		let label = trimmed;
+		if (label.length > 60) label = label.slice(0, 57) + '...';
+		doc.text(label, MARGIN_LEFT, 38, { charSpace: 1.5 } as any);
+		doc.setDrawColor(230, 220, 215);
+		doc.setLineWidth(0.4);
+		doc.line(MARGIN_LEFT, 44, CONTENT_RIGHT, 44);
 	}
 }

--- a/src/lib/cookbookExport.ts
+++ b/src/lib/cookbookExport.ts
@@ -1,0 +1,590 @@
+/**
+ * Recipe Pack → printable cookbook PDF.
+ *
+ * Client-side generator. jsPDF is heavy (~150KB gzipped) and only
+ * used by Pro members on demand, so the dependency is dynamically
+ * imported at call time — no impact on the rest of the app's bundle.
+ *
+ * Layout (single style for v1; the modal exposes a style selector
+ * with the other options TODO'd):
+ *
+ *     Page 1     — Cover
+ *     Page 2     — Table of contents
+ *     Page 3     — Introduction (optional, AI-polished or raw)
+ *     Page 4..N  — Recipes (one starts a new page; soft-flows over
+ *                  multiple pages if long)
+ *
+ * Image rendering uses a fetch-then-base64 path. CORS failures are
+ * tolerated — the recipe page just renders without its image.
+ *
+ * Caller passes already-resolved recipe events (parsed metadata).
+ * Returns the PDF as a Blob and a small report of any per-recipe
+ * failures so the UI can surface a "X of Y included" notice.
+ */
+
+import type { NDKEvent } from '@nostr-dev-kit/ndk';
+import { extractRecipeDetails, parseMarkdownForEditing } from '$lib/parser';
+
+export interface CookbookRecipe {
+	id: string; // a-tag for stable identity
+	title: string;
+	image?: string;
+	creatorName?: string;
+	prepTime?: string;
+	cookTime?: string;
+	servings?: string;
+	ingredients: string[];
+	directions: string[];
+	chefNotes?: string;
+}
+
+export interface BuildOptions {
+	title: string;
+	subtitle?: string;
+	coverImage?: string;
+	creatorName?: string;
+	introduction?: string; // markdown / plain text — light formatting only
+	recipes: CookbookRecipe[];
+	includeCover: boolean;
+	includeToc: boolean;
+	includeImages: boolean;
+	includeIntroduction: boolean;
+	style: 'classic' | 'modern' | 'simple'; // v1 only renders 'modern'
+}
+
+export interface BuildResult {
+	blob: Blob;
+	included: number;
+	skipped: { id: string; reason: string }[];
+}
+
+/** Convert an NDKEvent (kind 30023) to the parsed CookbookRecipe shape. */
+export function recipeEventToCookbookRecipe(event: NDKEvent, creatorName?: string): CookbookRecipe {
+	const tags = event.tags || [];
+	const find = (name: string) => tags.find((t) => t[0] === name)?.[1];
+	const title = find('title') || find('d') || 'Untitled recipe';
+	const image = find('image') || undefined;
+	const dTag = find('d') || event.id || title;
+
+	const parsed = parseMarkdownForEditing(event.content || '');
+	const details = extractRecipeDetails(event.content || '');
+
+	return {
+		id: `${event.kind ?? 30023}:${event.pubkey}:${dTag}`,
+		title,
+		image,
+		creatorName,
+		prepTime: parsed.information?.prepTime || details.prepTime || undefined,
+		cookTime: parsed.information?.cookTime || details.cookTime || undefined,
+		servings: parsed.information?.servings || details.servings || undefined,
+		ingredients: parsed.ingredients || [],
+		directions: parsed.directions || [],
+		chefNotes: parsed.chefNotes
+	};
+}
+
+/** Strip emoji + control chars jsPDF's default fonts can't render. */
+function sanitizeForPdf(s: string | undefined | null): string {
+	if (!s) return '';
+	// Replace common cooking glyphs with words rather than dropping them
+	let out = s
+		.replace(/⏲️|⏱️/g, '')
+		.replace(/🍳/g, '')
+		.replace(/🍽️|🍽/g, '')
+		.replace(/🔥/g, '')
+		.replace(/—/g, '-')
+		.replace(/–/g, '-')
+		.replace(/'|'/g, "'")
+		.replace(/"|"/g, '"')
+		.replace(/…/g, '...');
+	// Drop anything still outside basic Latin-1 (jsPDF's default fonts
+	// don't cover wider Unicode without bundling a custom font).
+	out = out.replace(/[^\x09\x0A\x0D\x20-\xFF]/g, '');
+	return out.trim();
+}
+
+/** Fetch an image URL and return as data URI. Returns null on CORS / 404. */
+async function imageUrlToDataUri(url: string, signal?: AbortSignal): Promise<string | null> {
+	try {
+		const res = await fetch(url, { signal, mode: 'cors' });
+		if (!res.ok) return null;
+		const blob = await res.blob();
+		// Cap image size to keep the PDF reasonable. 5MB raw is a rough
+		// upper bound; most recipe photos are 200-800KB.
+		if (blob.size > 5 * 1024 * 1024) return null;
+		const reader = new FileReader();
+		return await new Promise((resolve) => {
+			reader.onload = () => resolve(typeof reader.result === 'string' ? reader.result : null);
+			reader.onerror = () => resolve(null);
+			reader.readAsDataURL(blob);
+		});
+	} catch {
+		return null;
+	}
+}
+
+/** Detect image format from a data URI for jsPDF's addImage signature. */
+function imageFormatFromDataUri(dataUri: string): 'JPEG' | 'PNG' | 'WEBP' {
+	if (dataUri.startsWith('data:image/png')) return 'PNG';
+	if (dataUri.startsWith('data:image/webp')) return 'WEBP';
+	return 'JPEG';
+}
+
+const PAGE_W = 612; // 8.5"
+const PAGE_H = 792; // 11"
+const MARGIN = 56; // ~0.78"
+const CONTENT_W = PAGE_W - MARGIN * 2;
+
+/** Build the cookbook PDF. Returns blob + per-recipe failure list. */
+export async function buildCookbookPdf(opts: BuildOptions): Promise<BuildResult> {
+	// Lazy-load jsPDF so it's only in the bundle when this function is
+	// actually called (Pro members exporting a cookbook).
+	const { jsPDF } = await import('jspdf');
+
+	const doc = new jsPDF({
+		unit: 'pt',
+		format: [PAGE_W, PAGE_H],
+		orientation: 'portrait',
+		compress: true
+	});
+
+	const skipped: { id: string; reason: string }[] = [];
+
+	// Pre-resolve images in parallel — failures fall through to "no image"
+	// and we keep generating. Skip entirely when includeImages is off.
+	const coverImagePromise =
+		opts.includeCover && opts.coverImage ? imageUrlToDataUri(opts.coverImage) : Promise.resolve(null);
+	const recipeImagePromises = opts.recipes.map((r) =>
+		opts.includeImages && r.image ? imageUrlToDataUri(r.image) : Promise.resolve(null)
+	);
+	const [coverDataUri, ...recipeImages] = await Promise.all([
+		coverImagePromise,
+		...recipeImagePromises
+	]);
+
+	// First record where each recipe starts so we can write page numbers
+	// into the TOC later.
+	const recipePageStart: number[] = new Array(opts.recipes.length).fill(0);
+
+	// === Page 1: Cover ===
+	if (opts.includeCover) {
+		drawCoverPage(doc, {
+			title: sanitizeForPdf(opts.title),
+			subtitle: sanitizeForPdf(opts.subtitle),
+			creatorName: sanitizeForPdf(opts.creatorName),
+			coverDataUri
+		});
+	}
+
+	// === Page 2: Table of Contents ===
+	let tocPage = 0;
+	if (opts.includeToc) {
+		if (opts.includeCover) doc.addPage();
+		tocPage = doc.getCurrentPageInfo().pageNumber;
+		// Draw a placeholder TOC; we'll re-render it after we know page numbers.
+		drawTocPage(
+			doc,
+			opts.recipes.map((r) => sanitizeForPdf(r.title)),
+			recipePageStart
+		);
+	}
+
+	// === Introduction ===
+	if (opts.includeIntroduction && opts.introduction && opts.introduction.trim()) {
+		if (opts.includeCover || opts.includeToc) doc.addPage();
+		drawIntroductionPage(doc, sanitizeForPdf(opts.introduction));
+	}
+
+	// === Recipe pages ===
+	let included = 0;
+	for (let i = 0; i < opts.recipes.length; i++) {
+		const r = opts.recipes[i];
+		const ingredientsClean = r.ingredients.map(sanitizeForPdf).filter(Boolean);
+		const directionsClean = r.directions.map(sanitizeForPdf).filter(Boolean);
+
+		if (ingredientsClean.length === 0 && directionsClean.length === 0) {
+			skipped.push({ id: r.id, reason: 'no ingredients or directions' });
+			continue;
+		}
+
+		if (i > 0 || opts.includeCover || opts.includeToc || opts.includeIntroduction) {
+			doc.addPage();
+		}
+		recipePageStart[i] = doc.getCurrentPageInfo().pageNumber;
+		drawRecipePages(doc, {
+			title: sanitizeForPdf(r.title),
+			creatorName: sanitizeForPdf(r.creatorName),
+			prepTime: sanitizeForPdf(r.prepTime),
+			cookTime: sanitizeForPdf(r.cookTime),
+			servings: sanitizeForPdf(r.servings),
+			imageDataUri: recipeImages[i] || null,
+			ingredients: ingredientsClean,
+			directions: directionsClean,
+			chefNotes: sanitizeForPdf(r.chefNotes)
+		});
+		included++;
+	}
+
+	// === Re-render TOC now that we know page numbers ===
+	if (opts.includeToc && tocPage > 0) {
+		doc.setPage(tocPage);
+		// Wipe by drawing a white rectangle over the page area.
+		doc.setFillColor(255, 255, 255);
+		doc.rect(0, 0, PAGE_W, PAGE_H, 'F');
+		drawTocPage(
+			doc,
+			opts.recipes.map((r, i) => (recipePageStart[i] > 0 ? sanitizeForPdf(r.title) : '')),
+			recipePageStart
+		);
+	}
+
+	// Add small "Created with Zap Cooking" footer to every page except cover
+	addFooters(doc, opts.includeCover ? 2 : 1);
+
+	const blob = doc.output('blob') as unknown as Blob;
+	return { blob, included, skipped };
+}
+
+/** Build a sensible filename from a pack title. */
+export function cookbookFilename(packTitle: string): string {
+	const slug = packTitle
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '')
+		.slice(0, 40);
+	return `zap-cooking-${slug || 'recipe-pack'}-cookbook.pdf`;
+}
+
+// ===== Drawing helpers =====
+
+interface JsPdfDoc {
+	setFont: (font: string, style?: string) => void;
+	setFontSize: (size: number) => void;
+	setTextColor: (r: number, g: number, b: number) => void;
+	setFillColor: (r: number, g: number, b: number) => void;
+	setDrawColor: (r: number, g: number, b: number) => void;
+	setLineWidth: (w: number) => void;
+	text: (text: string | string[], x: number, y: number, opts?: any) => void;
+	splitTextToSize: (text: string, maxWidth: number) => string[];
+	addImage: (
+		data: string,
+		format: string,
+		x: number,
+		y: number,
+		w: number,
+		h: number
+	) => void;
+	addPage: () => void;
+	rect: (x: number, y: number, w: number, h: number, style?: string) => void;
+	line: (x1: number, y1: number, x2: number, y2: number) => void;
+	getCurrentPageInfo: () => { pageNumber: number };
+	getNumberOfPages: () => number;
+	setPage: (n: number) => void;
+}
+
+function drawCoverPage(
+	doc: JsPdfDoc,
+	opts: {
+		title: string;
+		subtitle: string;
+		creatorName: string;
+		coverDataUri: string | null;
+	}
+) {
+	// Page background — soft warm tint
+	doc.setFillColor(252, 248, 243);
+	doc.rect(0, 0, PAGE_W, PAGE_H, 'F');
+
+	// Image fills upper half if present
+	if (opts.coverDataUri) {
+		try {
+			doc.addImage(
+				opts.coverDataUri,
+				imageFormatFromDataUri(opts.coverDataUri),
+				0,
+				0,
+				PAGE_W,
+				PAGE_H * 0.55
+			);
+			// Soft fade overlay at the bottom of the image
+			doc.setFillColor(252, 248, 243);
+			doc.rect(0, PAGE_H * 0.5, PAGE_W, PAGE_H * 0.05, 'F');
+		} catch {
+			/* skip */
+		}
+	}
+
+	const titleY = opts.coverDataUri ? PAGE_H * 0.62 : PAGE_H * 0.42;
+
+	// "RECIPE PACK" eyebrow
+	doc.setFont('helvetica', 'bold');
+	doc.setFontSize(11);
+	doc.setTextColor(180, 95, 30);
+	doc.text('RECIPE PACK', PAGE_W / 2, titleY - 36, { align: 'center' });
+
+	// Title
+	doc.setFont('helvetica', 'bold');
+	doc.setFontSize(34);
+	doc.setTextColor(28, 22, 18);
+	const titleLines = doc.splitTextToSize(opts.title || 'Recipe Pack', CONTENT_W * 0.85);
+	doc.text(titleLines, PAGE_W / 2, titleY, { align: 'center' });
+
+	// Subtitle
+	if (opts.subtitle) {
+		doc.setFont('helvetica', 'normal');
+		doc.setFontSize(14);
+		doc.setTextColor(80, 70, 65);
+		const subLines = doc.splitTextToSize(opts.subtitle, CONTENT_W * 0.8);
+		doc.text(subLines, PAGE_W / 2, titleY + 24 + titleLines.length * 38, { align: 'center' });
+	}
+
+	// Creator
+	if (opts.creatorName) {
+		doc.setFont('helvetica', 'italic');
+		doc.setFontSize(13);
+		doc.setTextColor(100, 90, 85);
+		doc.text(`Curated by ${opts.creatorName}`, PAGE_W / 2, PAGE_H - 110, { align: 'center' });
+	}
+
+	// "Created with Zap Cooking" footer brand
+	doc.setFont('helvetica', 'bold');
+	doc.setFontSize(11);
+	doc.setTextColor(180, 95, 30);
+	doc.text('zap.cooking', PAGE_W / 2, PAGE_H - 64, { align: 'center' });
+	doc.setFont('helvetica', 'normal');
+	doc.setFontSize(9);
+	doc.setTextColor(140, 130, 125);
+	doc.text('Created with Zap Cooking', PAGE_W / 2, PAGE_H - 48, { align: 'center' });
+}
+
+function drawTocPage(doc: JsPdfDoc, titles: string[], pageNumbers: number[]) {
+	doc.setFillColor(255, 255, 255);
+	doc.rect(0, 0, PAGE_W, PAGE_H, 'F');
+
+	doc.setFont('helvetica', 'bold');
+	doc.setFontSize(24);
+	doc.setTextColor(28, 22, 18);
+	doc.text('Contents', MARGIN, 110);
+
+	doc.setDrawColor(220, 200, 190);
+	doc.setLineWidth(1);
+	doc.line(MARGIN, 124, PAGE_W - MARGIN, 124);
+
+	doc.setFont('helvetica', 'normal');
+	doc.setFontSize(13);
+	doc.setTextColor(40, 30, 25);
+
+	let y = 160;
+	const rowHeight = 24;
+	for (let i = 0; i < titles.length; i++) {
+		const title = titles[i];
+		if (!title) continue;
+		const pageStr = pageNumbers[i] > 0 ? String(pageNumbers[i]) : '';
+		// Title (left, may wrap to one short line)
+		const lines = doc.splitTextToSize(title, CONTENT_W - 50);
+		doc.text(lines[0], MARGIN, y);
+		// Page number (right)
+		if (pageStr) {
+			doc.text(pageStr, PAGE_W - MARGIN, y, { align: 'right' });
+		}
+		y += rowHeight;
+		if (y > PAGE_H - 80) break; // overflow safety; rare
+	}
+}
+
+function drawIntroductionPage(doc: JsPdfDoc, intro: string) {
+	doc.setFillColor(255, 255, 255);
+	doc.rect(0, 0, PAGE_W, PAGE_H, 'F');
+
+	doc.setFont('helvetica', 'bold');
+	doc.setFontSize(24);
+	doc.setTextColor(28, 22, 18);
+	doc.text('Introduction', MARGIN, 110);
+	doc.setDrawColor(220, 200, 190);
+	doc.setLineWidth(1);
+	doc.line(MARGIN, 124, PAGE_W - MARGIN, 124);
+
+	doc.setFont('helvetica', 'normal');
+	doc.setFontSize(12);
+	doc.setTextColor(40, 30, 25);
+	const paragraphs = intro.split(/\n\s*\n/);
+	let y = 160;
+	for (const p of paragraphs) {
+		const lines = doc.splitTextToSize(p.trim(), CONTENT_W);
+		for (const line of lines) {
+			if (y > PAGE_H - 90) {
+				doc.addPage();
+				y = MARGIN;
+			}
+			doc.text(line, MARGIN, y);
+			y += 18;
+		}
+		y += 10;
+	}
+}
+
+function drawRecipePages(
+	doc: JsPdfDoc,
+	r: {
+		title: string;
+		creatorName: string;
+		prepTime: string;
+		cookTime: string;
+		servings: string;
+		imageDataUri: string | null;
+		ingredients: string[];
+		directions: string[];
+		chefNotes: string;
+	}
+) {
+	doc.setFillColor(255, 255, 255);
+	doc.rect(0, 0, PAGE_W, PAGE_H, 'F');
+
+	let y = MARGIN + 16;
+
+	// Title
+	doc.setFont('helvetica', 'bold');
+	doc.setFontSize(22);
+	doc.setTextColor(28, 22, 18);
+	const titleLines = doc.splitTextToSize(r.title || 'Recipe', CONTENT_W);
+	doc.text(titleLines, MARGIN, y);
+	y += titleLines.length * 26;
+
+	// Creator attribution
+	if (r.creatorName) {
+		doc.setFont('helvetica', 'italic');
+		doc.setFontSize(11);
+		doc.setTextColor(110, 100, 95);
+		doc.text(`by ${r.creatorName}`, MARGIN, y);
+		y += 16;
+	}
+
+	// Image
+	if (r.imageDataUri) {
+		y += 4;
+		try {
+			const imgW = CONTENT_W;
+			const imgH = imgW * 0.55; // 16:9-ish
+			doc.addImage(r.imageDataUri, imageFormatFromDataUri(r.imageDataUri), MARGIN, y, imgW, imgH);
+			y += imgH + 14;
+		} catch {
+			/* skip image */
+		}
+	}
+
+	// Servings + times row
+	const meta = [
+		r.servings ? `Serves ${r.servings}` : '',
+		r.prepTime ? `Prep ${r.prepTime}` : '',
+		r.cookTime ? `Cook ${r.cookTime}` : ''
+	]
+		.filter(Boolean)
+		.join('  •  ');
+	if (meta) {
+		doc.setFont('helvetica', 'normal');
+		doc.setFontSize(11);
+		doc.setTextColor(110, 100, 95);
+		doc.text(meta, MARGIN, y);
+		y += 18;
+	}
+
+	// Chef's notes (italic)
+	if (r.chefNotes) {
+		y += 6;
+		doc.setFont('helvetica', 'italic');
+		doc.setFontSize(11);
+		doc.setTextColor(80, 70, 65);
+		const notesLines = doc.splitTextToSize(r.chefNotes, CONTENT_W);
+		for (const line of notesLines) {
+			if (y > PAGE_H - 90) {
+				doc.addPage();
+				y = MARGIN + 16;
+			}
+			doc.text(line, MARGIN, y);
+			y += 14;
+		}
+		y += 8;
+	}
+
+	// Ingredients
+	if (r.ingredients.length) {
+		if (y > PAGE_H - 160) {
+			doc.addPage();
+			y = MARGIN + 16;
+		}
+		y += 6;
+		doc.setFont('helvetica', 'bold');
+		doc.setFontSize(14);
+		doc.setTextColor(28, 22, 18);
+		doc.text('Ingredients', MARGIN, y);
+		y += 18;
+		doc.setFont('helvetica', 'normal');
+		doc.setFontSize(11);
+		doc.setTextColor(40, 30, 25);
+		for (const item of r.ingredients) {
+			const lines = doc.splitTextToSize(`•  ${item}`, CONTENT_W - 12);
+			for (let i = 0; i < lines.length; i++) {
+				if (y > PAGE_H - 90) {
+					doc.addPage();
+					y = MARGIN + 16;
+				}
+				doc.text(lines[i], MARGIN + (i === 0 ? 0 : 12), y);
+				y += 15;
+			}
+		}
+		y += 8;
+	}
+
+	// Directions
+	if (r.directions.length) {
+		if (y > PAGE_H - 200) {
+			doc.addPage();
+			y = MARGIN + 16;
+		}
+		y += 6;
+		doc.setFont('helvetica', 'bold');
+		doc.setFontSize(14);
+		doc.setTextColor(28, 22, 18);
+		doc.text('Directions', MARGIN, y);
+		y += 18;
+		doc.setFont('helvetica', 'normal');
+		doc.setFontSize(11);
+		doc.setTextColor(40, 30, 25);
+		for (let i = 0; i < r.directions.length; i++) {
+			const step = r.directions[i];
+			const numStr = `${i + 1}.`;
+			doc.setFont('helvetica', 'bold');
+			doc.setTextColor(180, 95, 30);
+			if (y > PAGE_H - 90) {
+				doc.addPage();
+				y = MARGIN + 16;
+			}
+			doc.text(numStr, MARGIN, y);
+			doc.setFont('helvetica', 'normal');
+			doc.setTextColor(40, 30, 25);
+			const lines = doc.splitTextToSize(step, CONTENT_W - 28);
+			for (let j = 0; j < lines.length; j++) {
+				if (j > 0 && y > PAGE_H - 90) {
+					doc.addPage();
+					y = MARGIN + 16;
+				}
+				doc.text(lines[j], MARGIN + 28, y);
+				y += 16;
+			}
+			y += 4;
+		}
+	}
+}
+
+function addFooters(doc: JsPdfDoc, fromPage: number) {
+	const total = doc.getNumberOfPages();
+	for (let p = fromPage; p <= total; p++) {
+		doc.setPage(p);
+		doc.setFont('helvetica', 'normal');
+		doc.setFontSize(9);
+		doc.setTextColor(160, 150, 145);
+		doc.text('Created with Zap Cooking', PAGE_W / 2, PAGE_H - 28, { align: 'center' });
+		doc.text(String(p), PAGE_W - MARGIN, PAGE_H - 28, { align: 'right' });
+	}
+}

--- a/src/lib/cookbookExportStore.server.ts
+++ b/src/lib/cookbookExportStore.server.ts
@@ -1,0 +1,110 @@
+/**
+ * Cookbook export payment record store (server-side, Cloudflare KV with
+ * in-memory dev fallback).
+ *
+ * Stores pending Lightning-paid cookbook export sessions so the
+ * /api/cookbook-export/verify-payment endpoint can confirm the buyer
+ * actually paid before the client unlocks PDF generation.
+ *
+ * Design mirrors `boostStore.server.ts`. Same `GATED_CONTENT` KV
+ * binding; just a different key prefix.
+ *
+ * KV key scheme:
+ *   ckbk-export:{id}                    → CookbookExportRecord JSON  (TTL 24h)
+ *   ckbk-export-inv:{receiveRequestId}  → export ID string           (TTL 24h)
+ *
+ * 24-hour TTL is plenty: clients normally pay within seconds, and we
+ * don't need long-lived records — a paid export is a one-shot unlock,
+ * not an ongoing subscription.
+ */
+
+export interface CookbookExportRecord {
+	id: string;
+	buyerPubkey: string;
+	packNaddr: string;
+	packTitle: string;
+	amountSats: number;
+	receiveRequestId: string;
+	paymentHash: string;
+	status: 'pending' | 'paid';
+	createdAt: number;
+	paidAt: number | null;
+}
+
+/** Same KV shape boost uses. */
+export type CookbookExportKV =
+	| {
+			get(key: string, type?: 'text' | 'json'): Promise<string | unknown | null>;
+			put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>;
+			delete(key: string): Promise<void>;
+	  }
+	| null
+	| undefined;
+
+const KV_TTL_SECONDS = 24 * 60 * 60; // 24 hours
+
+function recordKey(id: string) {
+	return `ckbk-export:${id}`;
+}
+function invKey(receiveRequestId: string) {
+	return `ckbk-export-inv:${receiveRequestId}`;
+}
+
+// Dev-only in-memory fallback (no KV binding).
+const memRecords = new Map<string, CookbookExportRecord>();
+const memInvIndex = new Map<string, string>();
+
+export async function storeExport(
+	kv: CookbookExportKV,
+	rec: CookbookExportRecord
+): Promise<void> {
+	const opts = { expirationTtl: KV_TTL_SECONDS };
+	if (kv) {
+		await kv.put(recordKey(rec.id), JSON.stringify(rec), opts);
+		await kv.put(invKey(rec.receiveRequestId), rec.id, opts);
+	} else {
+		memRecords.set(rec.id, rec);
+		memInvIndex.set(rec.receiveRequestId, rec.id);
+	}
+}
+
+export async function getExport(
+	kv: CookbookExportKV,
+	id: string
+): Promise<CookbookExportRecord | null> {
+	if (kv) {
+		const raw = (await kv.get(recordKey(id), 'text')) as string | null;
+		if (!raw) return null;
+		try {
+			return JSON.parse(raw) as CookbookExportRecord;
+		} catch {
+			await kv.delete(recordKey(id));
+			return null;
+		}
+	}
+	return memRecords.get(id) ?? null;
+}
+
+/** Mark a pending record as paid. Idempotent. */
+export async function markExportPaid(
+	kv: CookbookExportKV,
+	id: string
+): Promise<CookbookExportRecord | null> {
+	const rec = await getExport(kv, id);
+	if (!rec) return null;
+	if (rec.status === 'paid') return rec;
+
+	const updated: CookbookExportRecord = {
+		...rec,
+		status: 'paid',
+		paidAt: Date.now()
+	};
+
+	const opts = { expirationTtl: KV_TTL_SECONDS };
+	if (kv) {
+		await kv.put(recordKey(id), JSON.stringify(updated), opts);
+	} else {
+		memRecords.set(id, updated);
+	}
+	return updated;
+}

--- a/src/lib/cookbookPricing.ts
+++ b/src/lib/cookbookPricing.ts
@@ -1,0 +1,54 @@
+/**
+ * Cookbook export pricing — shared by client UI and server endpoints
+ * so labels, invoice amounts, and promo math all stay in lockstep.
+ */
+
+export const COOKBOOK_EXPORT_SATS = 2100;
+
+export interface PromoApplied {
+	code: string; // canonicalized (uppercase)
+	originalSats: number;
+	discountSats: number;
+	finalSats: number;
+	free: boolean;
+	label: string; // "50% off", "Free", "1000 sats off"
+}
+
+/**
+ * Apply a promo to a base price.
+ * Pure / sync / no I/O — safe on both client and server.
+ *
+ * Server **must** still validate the code via `getPromoConfig` before
+ * trusting it, since this helper is happy to apply any percentage.
+ */
+export function applyPromoMath(
+	baseSats: number,
+	percentOff: number,
+	flatOff: number,
+	code: string
+): PromoApplied {
+	const discountSats = Math.min(
+		baseSats,
+		Math.round((baseSats * percentOff) / 100) + flatOff
+	);
+	const finalSats = Math.max(0, baseSats - discountSats);
+	const free = finalSats === 0;
+	let label: string;
+	if (free) {
+		label = 'Free';
+	} else if (percentOff > 0 && flatOff === 0) {
+		label = `${percentOff}% off`;
+	} else if (flatOff > 0 && percentOff === 0) {
+		label = `${flatOff} sats off`;
+	} else {
+		label = `${baseSats - finalSats} sats off`;
+	}
+	return {
+		code: code.toUpperCase(),
+		originalSats: baseSats,
+		discountSats,
+		finalSats,
+		free,
+		label
+	};
+}

--- a/src/lib/cookbookPromo.server.ts
+++ b/src/lib/cookbookPromo.server.ts
@@ -1,0 +1,64 @@
+/**
+ * Cookbook export promo codes — server-side only.
+ *
+ * V1 lives as a static config map in this file. There's no admin UI
+ * yet; rotating codes means a code change + redeploy. That's fine for
+ * launch usage; the goal is to have the *enforcement* path validated
+ * server-side so the client can never just claim a promo it didn't
+ * earn.
+ *
+ * TODO(promo-admin): replace the static config with a KV-backed store
+ * + admin endpoints once we want non-engineers to manage codes.
+ */
+
+import { applyPromoMath, type PromoApplied } from '$lib/cookbookPricing';
+
+interface PromoConfig {
+	/** Percent discount, 0-100. */
+	percentOff: number;
+	/** Flat sat discount applied AFTER the percent. */
+	flatOff: number;
+	/** Optional sunset; codes don't auto-expire if undefined. */
+	expiresAt?: number; // unix ms
+	/** Optional human-readable note for logs. */
+	note?: string;
+}
+
+const PROMO_CONFIG: Record<string, PromoConfig> = {
+	LAUNCH: {
+		percentOff: 50,
+		flatOff: 0,
+		note: 'launch promo: 50% off cookbook export'
+	},
+	FREEPACK: {
+		percentOff: 100,
+		flatOff: 0,
+		note: '100% off — free cookbook export (limited use)'
+	}
+};
+
+export interface PromoLookup {
+	ok: boolean;
+	error?: 'unknown_code' | 'expired';
+	applied?: PromoApplied;
+}
+
+export function applyPromo(rawCode: string, baseSats: number): PromoLookup {
+	const code = String(rawCode || '')
+		.trim()
+		.toUpperCase();
+	if (!code) return { ok: false, error: 'unknown_code' };
+
+	const cfg = PROMO_CONFIG[code];
+	if (!cfg) return { ok: false, error: 'unknown_code' };
+	if (cfg.expiresAt && Date.now() > cfg.expiresAt) {
+		return { ok: false, error: 'expired' };
+	}
+	const applied = applyPromoMath(baseSats, cfg.percentOff, cfg.flatOff, code);
+	return { ok: true, applied };
+}
+
+/** Sentinel value used by create-invoice to bypass Strike for free codes. */
+export function isFreePromoApplied(applied: PromoApplied | null | undefined): boolean {
+	return !!applied && applied.free;
+}

--- a/src/lib/cookbookPromo.server.ts
+++ b/src/lib/cookbookPromo.server.ts
@@ -7,10 +7,18 @@
  * server-side so the client can never just claim a promo it didn't
  * earn.
  *
+ * To disable a single code: remove its entry from PROMO_CONFIG below
+ * (or set its expiresAt to a past date).
+ *
+ * To disable ALL promos without a code change: set the env var
+ * COOKBOOK_PROMOS_DISABLED=true. The server will then reject every
+ * code with `unknown_code`, regardless of what's in PROMO_CONFIG.
+ *
  * TODO(promo-admin): replace the static config with a KV-backed store
  * + admin endpoints once we want non-engineers to manage codes.
  */
 
+import { env } from '$env/dynamic/private';
 import { applyPromoMath, type PromoApplied } from '$lib/cookbookPricing';
 
 interface PromoConfig {
@@ -43,7 +51,16 @@ export interface PromoLookup {
 	applied?: PromoApplied;
 }
 
+function promosDisabled(): boolean {
+	const flag = (env.COOKBOOK_PROMOS_DISABLED || '').trim().toLowerCase();
+	return flag === '1' || flag === 'true' || flag === 'yes';
+}
+
 export function applyPromo(rawCode: string, baseSats: number): PromoLookup {
+	// Global kill switch — flip this on in env config to reject every
+	// code without redeploying or editing PROMO_CONFIG.
+	if (promosDisabled()) return { ok: false, error: 'unknown_code' };
+
 	const code = String(rawCode || '')
 		.trim()
 		.toUpperCase();

--- a/src/lib/cookbookPromo.server.ts
+++ b/src/lib/cookbookPromo.server.ts
@@ -1,72 +1,99 @@
 /**
- * Cookbook export promo codes — server-side only.
+ * Cookbook export promo codes — server-side validation.
  *
- * V1 lives as a static config map in this file. There's no admin UI
- * yet; rotating codes means a code change + redeploy. That's fine for
- * launch usage; the goal is to have the *enforcement* path validated
- * server-side so the client can never just claim a promo it didn't
- * earn.
+ * Source of truth: the KV-backed `cookbookPromoStore.server.ts`. When
+ * KV is empty (first deploy, or never written by an admin) we fall
+ * back to `DEFAULT_PROMO_CONFIG` below so the system keeps working
+ * without an explicit migration. Once the admin saves any change via
+ * `/admin/promos`, KV becomes the single source of truth.
  *
- * To disable a single code: remove its entry from PROMO_CONFIG below
- * (or set its expiresAt to a past date).
+ * Override hierarchy (most aggressive first):
+ *   1. env COOKBOOK_PROMOS_DISABLED=true   — break-glass, ignores KV
+ *   2. KV `enabled: false`                 — soft disable from admin UI
+ *   3. KV `codes` map                      — admin-curated codes
+ *   4. DEFAULT_PROMO_CONFIG (this file)    — fallback for empty KV
  *
- * To disable ALL promos without a code change: set the env var
- * COOKBOOK_PROMOS_DISABLED=true. The server will then reject every
- * code with `unknown_code`, regardless of what's in PROMO_CONFIG.
- *
- * TODO(promo-admin): replace the static config with a KV-backed store
- * + admin endpoints once we want non-engineers to manage codes.
+ * The goal is that the enforcement path is server-side so the client
+ * can never claim a promo it didn't earn. The admin UI changes the
+ * source data; the validation path is identical for both KV and
+ * default-backed entries.
  */
 
 import { env } from '$env/dynamic/private';
 import { applyPromoMath, type PromoApplied } from '$lib/cookbookPricing';
+import {
+	loadPromoConfig,
+	type PromoConfigState,
+	type PromoEntry,
+	type PromoKV
+} from '$lib/cookbookPromoStore.server';
 
-interface PromoConfig {
-	/** Percent discount, 0-100. */
-	percentOff: number;
-	/** Flat sat discount applied AFTER the percent. */
-	flatOff: number;
-	/** Optional sunset; codes don't auto-expire if undefined. */
-	expiresAt?: number; // unix ms
-	/** Optional human-readable note for logs. */
-	note?: string;
-}
-
-const PROMO_CONFIG: Record<string, PromoConfig> = {
-	LAUNCH: {
-		percentOff: 50,
-		flatOff: 0,
-		note: 'launch promo: 50% off cookbook export'
-	},
-	FREEPACK: {
-		percentOff: 100,
-		flatOff: 0,
-		note: '100% off — free cookbook export (limited use)'
+/**
+ * Hardcoded default config — used when KV is empty. Admin writes via
+ * /admin/promos persist to KV and override these. Editing this map
+ * also re-seeds for any deployment whose KV happens to be empty.
+ */
+export const DEFAULT_PROMO_CONFIG: PromoConfigState = {
+	enabled: true,
+	codes: {
+		LAUNCH: {
+			percentOff: 50,
+			flatOff: 0,
+			note: 'launch promo: 50% off cookbook export'
+		},
+		FREEPACK: {
+			percentOff: 100,
+			flatOff: 0,
+			note: '100% off — free cookbook export (limited use)'
+		}
 	}
 };
 
 export interface PromoLookup {
 	ok: boolean;
-	error?: 'unknown_code' | 'expired';
+	error?: 'unknown_code' | 'expired' | 'disabled';
 	applied?: PromoApplied;
 }
 
-function promosDisabled(): boolean {
+function envKillSwitch(): boolean {
 	const flag = (env.COOKBOOK_PROMOS_DISABLED || '').trim().toLowerCase();
 	return flag === '1' || flag === 'true' || flag === 'yes';
 }
 
-export function applyPromo(rawCode: string, baseSats: number): PromoLookup {
-	// Global kill switch — flip this on in env config to reject every
-	// code without redeploying or editing PROMO_CONFIG.
-	if (promosDisabled()) return { ok: false, error: 'unknown_code' };
+/**
+ * Resolve the effective config: KV override if present, otherwise the
+ * hardcoded defaults. Exposed so the admin endpoint can render a
+ * "current state" snapshot without re-implementing the precedence.
+ */
+export async function resolvePromoConfig(kv: PromoKV): Promise<PromoConfigState> {
+	const stored = await loadPromoConfig(kv);
+	return stored ?? DEFAULT_PROMO_CONFIG;
+}
+
+/**
+ * Validate a user-submitted code against the resolved config.
+ *
+ * Async because KV is the source of truth. Callers (the public
+ * apply-promo + create-invoice endpoints) pass through `platform.env`'s
+ * `GATED_CONTENT` binding.
+ */
+export async function applyPromo(
+	kv: PromoKV,
+	rawCode: string,
+	baseSats: number
+): Promise<PromoLookup> {
+	// Break-glass env override wins over everything else.
+	if (envKillSwitch()) return { ok: false, error: 'disabled' };
+
+	const config = await resolvePromoConfig(kv);
+	if (!config.enabled) return { ok: false, error: 'disabled' };
 
 	const code = String(rawCode || '')
 		.trim()
 		.toUpperCase();
 	if (!code) return { ok: false, error: 'unknown_code' };
 
-	const cfg = PROMO_CONFIG[code];
+	const cfg: PromoEntry | undefined = config.codes[code];
 	if (!cfg) return { ok: false, error: 'unknown_code' };
 	if (cfg.expiresAt && Date.now() > cfg.expiresAt) {
 		return { ok: false, error: 'expired' };

--- a/src/lib/cookbookPromoStore.server.ts
+++ b/src/lib/cookbookPromoStore.server.ts
@@ -1,0 +1,120 @@
+/**
+ * Cookbook promo config store — KV-backed admin storage.
+ *
+ * Single-key layout in `GATED_CONTENT`:
+ *   cb_promo_config → { enabled, codes: { CODE: PromoEntry } }
+ *
+ * The single-key shape is deliberate. There's at most a handful of
+ * promo codes at any one time, and a single read-modify-write keeps
+ * the admin operations trivial — no list pagination, no cross-key
+ * consistency to worry about. KV is single-writer here (the admin),
+ * so the read-modify-write race window is small enough to ignore.
+ *
+ * If the key is empty (first deploy, or KV was wiped) the lookup path
+ * falls back to the hardcoded `DEFAULT_PROMO_CONFIG` in
+ * `cookbookPromo.server.ts`, so the system keeps working without an
+ * explicit migration step.
+ *
+ * Note: KV propagation is eventually consistent across CF edges (~60s
+ * worst case). An admin toggle may not be immediately visible to all
+ * workers — acceptable for promo management; a stale read at worst
+ * extends a code's life by a minute.
+ */
+
+export interface PromoEntry {
+	percentOff: number; // 0-100
+	flatOff: number; // sats removed AFTER percent
+	expiresAt?: number; // unix ms — undefined = never expires
+	note?: string;
+}
+
+export interface PromoConfigState {
+	enabled: boolean;
+	codes: Record<string, PromoEntry>;
+}
+
+export type PromoKV =
+	| {
+			get(key: string, type?: 'text' | 'json'): Promise<string | unknown | null>;
+			put(key: string, value: string): Promise<void>;
+			delete(key: string): Promise<void>;
+	  }
+	| null
+	| undefined;
+
+const KEY = 'cb_promo_config';
+
+// Dev-only in-memory fallback when no KV binding is bound.
+let memState: PromoConfigState | null = null;
+
+/**
+ * Load the full promo config. Returns `null` when no override has been
+ * stored yet — the caller is responsible for falling back to defaults.
+ */
+export async function loadPromoConfig(kv: PromoKV): Promise<PromoConfigState | null> {
+	if (kv) {
+		const raw = (await kv.get(KEY, 'text')) as string | null;
+		if (!raw) return null;
+		try {
+			const parsed = JSON.parse(raw) as PromoConfigState;
+			// Defensive: missing fields → treat as null so caller falls
+			// back to defaults rather than rendering a broken config.
+			if (typeof parsed?.enabled !== 'boolean' || !parsed?.codes) return null;
+			return parsed;
+		} catch {
+			return null;
+		}
+	}
+	return memState;
+}
+
+export async function savePromoConfig(kv: PromoKV, state: PromoConfigState): Promise<void> {
+	if (kv) {
+		await kv.put(KEY, JSON.stringify(state));
+	} else {
+		memState = state;
+	}
+}
+
+/** Toggle the global enabled flag. Returns the new state. */
+export async function setPromoEnabled(
+	kv: PromoKV,
+	enabled: boolean,
+	defaults: PromoConfigState
+): Promise<PromoConfigState> {
+	const current = (await loadPromoConfig(kv)) ?? defaults;
+	const next: PromoConfigState = { ...current, enabled };
+	await savePromoConfig(kv, next);
+	return next;
+}
+
+/** Create or update a single code. Returns the new state. */
+export async function upsertPromoCode(
+	kv: PromoKV,
+	code: string,
+	entry: PromoEntry,
+	defaults: PromoConfigState
+): Promise<PromoConfigState> {
+	const current = (await loadPromoConfig(kv)) ?? defaults;
+	const next: PromoConfigState = {
+		...current,
+		codes: { ...current.codes, [code]: entry }
+	};
+	await savePromoConfig(kv, next);
+	return next;
+}
+
+/** Delete a code. No-op if it doesn't exist. Returns the new state. */
+export async function deletePromoCode(
+	kv: PromoKV,
+	code: string,
+	defaults: PromoConfigState
+): Promise<PromoConfigState> {
+	const current = (await loadPromoConfig(kv)) ?? defaults;
+	if (!(code in current.codes)) return current;
+	const { [code]: _removed, ...rest } = current.codes;
+	void _removed;
+	const next: PromoConfigState = { ...current, codes: rest };
+	await savePromoConfig(kv, next);
+	return next;
+}

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  /**
+   * /admin — index hub linking the admin sub-pages.
+   *
+   * Lightweight directory page; each sub-route owns its own auth gate
+   * (NIP-98 on write endpoints, header check on read endpoints) so
+   * this page is intentionally just a list of links — visiting
+   * unauthenticated still renders, but the linked endpoints reject.
+   */
+  import { isAdmin } from '$lib/adminAuth';
+  import { userPublickey } from '$lib/nostr';
+
+  $: authed = isAdmin($userPublickey);
+</script>
+
+<svelte:head>
+  <title>Admin — Zap Cooking</title>
+</svelte:head>
+
+<div class="page">
+  <h1>Admin</h1>
+
+  {#if !authed}
+    <div class="unauthorized">
+      <p>Sign in with the admin account to use these tools.</p>
+    </div>
+  {:else}
+    <ul class="links">
+      <li>
+        <a href="/admin/promos">
+          <span class="title">Cookbook promos</span>
+          <span class="desc">Toggle promos on/off, create and disable codes.</span>
+        </a>
+      </li>
+      <li>
+        <a href="/admin/nourish-flags">
+          <span class="title">Nourish flags</span>
+          <span class="desc">Review user flags + rescore stale recipes.</span>
+        </a>
+      </li>
+    </ul>
+  {/if}
+</div>
+
+<style>
+  .page {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 2rem 1.25rem;
+    color: var(--color-text-primary);
+  }
+  h1 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin: 0 0 1.25rem;
+  }
+  .unauthorized {
+    padding: 2rem;
+    text-align: center;
+    color: var(--color-text-secondary);
+  }
+  .links {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .links a {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 1rem 1.25rem;
+    border: 1px solid var(--color-input-border);
+    border-radius: 0.5rem;
+    background: var(--color-bg-secondary);
+    text-decoration: none;
+    color: inherit;
+    transition: border-color 120ms ease;
+  }
+  .links a:hover {
+    border-color: var(--color-primary);
+  }
+  .title {
+    font-weight: 600;
+  }
+  .desc {
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
+  }
+</style>

--- a/src/routes/admin/promos/+page.svelte
+++ b/src/routes/admin/promos/+page.svelte
@@ -1,0 +1,607 @@
+<script lang="ts">
+  /**
+   * /admin/promos — manage cookbook export promo codes.
+   *
+   * Loads the resolved config from /api/admin/promos (KV override or
+   * hardcoded defaults), then offers:
+   *   - Global enable/disable toggle
+   *   - Per-code create / edit / delete
+   *
+   * All requests are NIP-98 signed (kind 27235) and verified server-
+   * side. The signing pubkey must equal ADMIN_PUBKEY — the public
+   * admin pubkey alone isn't enough auth, since it's, well, public.
+   *
+   * KV reads/writes are eventually consistent across CF edges (~60s
+   * worst case); we surface this in the UI so the admin doesn't
+   * panic when a fresh code takes a moment to validate.
+   */
+  import { onMount } from 'svelte';
+  import { ndk, userPublickey } from '$lib/nostr';
+  import { isAdmin } from '$lib/adminAuth';
+  import { signNip98AuthHeader } from '$lib/nip98';
+
+  interface PromoEntry {
+    percentOff: number;
+    flatOff: number;
+    expiresAt?: number;
+    note?: string;
+  }
+  interface PromoConfigState {
+    enabled: boolean;
+    codes: Record<string, PromoEntry>;
+  }
+
+  let loading = true;
+  let loadError = '';
+  let config: PromoConfigState | null = null;
+  let defaults: PromoConfigState | null = null;
+
+  // Per-code submission state — keyed by code (or 'new' for the create row).
+  let busyCode: string | null = null;
+  let actionError = '';
+
+  // Add-code form
+  let newCode = '';
+  let newPercentOff = '50';
+  let newFlatOff = '0';
+  let newNote = '';
+  let newExpiresAt = ''; // ISO date string from <input type=date>
+
+  // Inline edit state — only one row in edit mode at a time
+  let editingCode: string | null = null;
+  let editPercentOff = '';
+  let editFlatOff = '';
+  let editNote = '';
+  let editExpiresAt = '';
+
+  $: authed = isAdmin($userPublickey);
+
+  onMount(() => {
+    if (authed) loadConfig();
+  });
+
+  // Reload after sign-in (page might mount before pubkey settles).
+  $: if (authed && config === null && !loading && !loadError) {
+    loadConfig();
+  }
+
+  async function signedFetch(
+    method: 'GET' | 'POST',
+    path: string,
+    bodyString?: string
+  ): Promise<Response> {
+    const url = new URL(path, window.location.origin).toString();
+    const auth = await signNip98AuthHeader($ndk, { method, url, bodyString });
+    const headers: Record<string, string> = { Authorization: auth };
+    if (bodyString !== undefined) headers['Content-Type'] = 'application/json';
+    return fetch(url, { method, headers, body: bodyString });
+  }
+
+  async function loadConfig() {
+    loading = true;
+    loadError = '';
+    try {
+      const res = await signedFetch('GET', '/api/admin/promos');
+      if (res.status === 403) throw new Error('Forbidden');
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as {
+        config: PromoConfigState;
+        defaults: PromoConfigState;
+      };
+      config = data.config;
+      defaults = data.defaults;
+    } catch (err) {
+      loadError = err instanceof Error ? err.message : String(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function postAction(payload: Record<string, unknown>): Promise<boolean> {
+    actionError = '';
+    const bodyString = JSON.stringify(payload);
+    try {
+      const res = await signedFetch('POST', '/api/admin/promos', bodyString);
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        actionError =
+          typeof data?.error === 'string' ? data.error : `HTTP ${res.status}`;
+        return false;
+      }
+      if (data?.config) config = data.config;
+      return true;
+    } catch (err) {
+      actionError = err instanceof Error ? err.message : String(err);
+      return false;
+    }
+  }
+
+  async function handleToggle() {
+    if (!config) return;
+    busyCode = '__toggle';
+    await postAction({ action: 'toggle', enabled: !config.enabled });
+    busyCode = null;
+  }
+
+  function parseExpiresInput(value: string): number | undefined {
+    const v = value.trim();
+    if (!v) return undefined;
+    // <input type=date> gives YYYY-MM-DD; store as end-of-day local ms.
+    const ms = Date.parse(`${v}T23:59:59`);
+    return Number.isFinite(ms) ? ms : undefined;
+  }
+
+  function formatExpiresForInput(ms?: number): string {
+    if (!ms) return '';
+    const d = new Date(ms);
+    if (Number.isNaN(d.getTime())) return '';
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+  }
+
+  function formatExpiresLabel(ms?: number): string {
+    if (!ms) return 'never';
+    return new Date(ms).toLocaleDateString();
+  }
+
+  async function handleAddCode() {
+    const code = newCode.trim().toUpperCase();
+    if (!/^[A-Z0-9_-]{2,32}$/.test(code)) {
+      actionError = 'Code must be 2–32 chars, A–Z 0–9 _ -';
+      return;
+    }
+    busyCode = '__add';
+    const ok = await postAction({
+      action: 'upsert',
+      code,
+      percentOff: Number(newPercentOff),
+      flatOff: Number(newFlatOff || 0),
+      note: newNote.trim() || undefined,
+      expiresAt: parseExpiresInput(newExpiresAt) ?? null
+    });
+    busyCode = null;
+    if (ok) {
+      newCode = '';
+      newPercentOff = '50';
+      newFlatOff = '0';
+      newNote = '';
+      newExpiresAt = '';
+    }
+  }
+
+  function startEdit(code: string, entry: PromoEntry) {
+    editingCode = code;
+    editPercentOff = String(entry.percentOff);
+    editFlatOff = String(entry.flatOff);
+    editNote = entry.note ?? '';
+    editExpiresAt = formatExpiresForInput(entry.expiresAt);
+    actionError = '';
+  }
+
+  function cancelEdit() {
+    editingCode = null;
+  }
+
+  async function saveEdit(code: string) {
+    busyCode = code;
+    const ok = await postAction({
+      action: 'upsert',
+      code,
+      percentOff: Number(editPercentOff),
+      flatOff: Number(editFlatOff || 0),
+      note: editNote.trim() || undefined,
+      expiresAt: parseExpiresInput(editExpiresAt) ?? null
+    });
+    busyCode = null;
+    if (ok) editingCode = null;
+  }
+
+  async function deleteCode(code: string) {
+    if (!confirm(`Delete promo code "${code}"? Active uses will fail next time.`)) {
+      return;
+    }
+    busyCode = code;
+    await postAction({ action: 'delete', code });
+    busyCode = null;
+  }
+
+  $: codeEntries = config
+    ? Object.entries(config.codes).sort(([a], [b]) => a.localeCompare(b))
+    : [];
+</script>
+
+<svelte:head>
+  <title>Cookbook Promos — Admin</title>
+</svelte:head>
+
+<div class="page">
+  <a class="back" href="/admin">← Admin</a>
+  <h1>Cookbook Promos</h1>
+  <p class="lede">
+    Toggle promos on/off, create new codes, edit or remove existing ones. Changes
+    propagate to all edges within ~1 minute (Cloudflare KV).
+  </p>
+
+  {#if !authed}
+    <div class="unauthorized">
+      <p>Sign in with the admin account to manage promos.</p>
+    </div>
+  {:else if loading}
+    <p class="status">Loading promo config…</p>
+  {:else if loadError}
+    <p class="status status-error">Couldn't load: {loadError}</p>
+    <button class="btn" type="button" on:click={loadConfig}>Retry</button>
+  {:else if config}
+    <section class="card">
+      <div class="card-row">
+        <div>
+          <div class="card-title">Promos globally</div>
+          <div class="card-desc">
+            {#if config.enabled}
+              Enabled — codes work as configured below.
+            {:else}
+              Disabled — every code is rejected with <code>unknown_code</code>.
+            {/if}
+          </div>
+        </div>
+        <button
+          class="btn btn-primary"
+          type="button"
+          disabled={busyCode === '__toggle'}
+          on:click={handleToggle}
+        >
+          {#if busyCode === '__toggle'}…{:else}
+            {config.enabled ? 'Disable all' : 'Enable all'}
+          {/if}
+        </button>
+      </div>
+      <p class="hint">
+        Tip: the env var <code>COOKBOOK_PROMOS_DISABLED=true</code> is a
+        break-glass override. When set, this page can still toggle KV state,
+        but every public lookup returns <code>disabled</code>.
+      </p>
+    </section>
+
+    <section class="card">
+      <div class="card-title">Add code</div>
+      <div class="form-grid">
+        <label>
+          <span>Code</span>
+          <input
+            type="text"
+            placeholder="LAUNCH"
+            bind:value={newCode}
+            maxlength="32"
+            class="mono"
+          />
+        </label>
+        <label>
+          <span>Percent off</span>
+          <input
+            type="number"
+            min="0"
+            max="100"
+            bind:value={newPercentOff}
+          />
+        </label>
+        <label>
+          <span>Flat off (sats)</span>
+          <input type="number" min="0" bind:value={newFlatOff} />
+        </label>
+        <label>
+          <span>Expires (optional)</span>
+          <input type="date" bind:value={newExpiresAt} />
+        </label>
+        <label class="full">
+          <span>Note (admin only)</span>
+          <input
+            type="text"
+            placeholder="e.g. partner promo, winter campaign"
+            bind:value={newNote}
+            maxlength="200"
+          />
+        </label>
+      </div>
+      <div class="actions">
+        <button
+          class="btn btn-primary"
+          type="button"
+          disabled={busyCode === '__add' || !newCode.trim()}
+          on:click={handleAddCode}
+        >
+          {busyCode === '__add' ? 'Saving…' : 'Add code'}
+        </button>
+      </div>
+    </section>
+
+    {#if actionError}
+      <p class="status status-error">{actionError}</p>
+    {/if}
+
+    <section class="card">
+      <div class="card-title">Codes</div>
+      {#if codeEntries.length === 0}
+        <p class="hint">No codes yet. Add one above.</p>
+      {:else}
+        <ul class="codes">
+          {#each codeEntries as [code, entry] (code)}
+            <li class="code-row">
+              {#if editingCode === code}
+                <div class="form-grid">
+                  <label>
+                    <span>Code</span>
+                    <input type="text" value={code} disabled class="mono" />
+                  </label>
+                  <label>
+                    <span>Percent off</span>
+                    <input
+                      type="number"
+                      min="0"
+                      max="100"
+                      bind:value={editPercentOff}
+                    />
+                  </label>
+                  <label>
+                    <span>Flat off (sats)</span>
+                    <input type="number" min="0" bind:value={editFlatOff} />
+                  </label>
+                  <label>
+                    <span>Expires</span>
+                    <input type="date" bind:value={editExpiresAt} />
+                  </label>
+                  <label class="full">
+                    <span>Note</span>
+                    <input
+                      type="text"
+                      bind:value={editNote}
+                      maxlength="200"
+                    />
+                  </label>
+                </div>
+                <div class="actions">
+                  <button class="btn" type="button" on:click={cancelEdit}>
+                    Cancel
+                  </button>
+                  <button
+                    class="btn btn-primary"
+                    type="button"
+                    disabled={busyCode === code}
+                    on:click={() => saveEdit(code)}
+                  >
+                    {busyCode === code ? 'Saving…' : 'Save'}
+                  </button>
+                </div>
+              {:else}
+                <div class="code-summary">
+                  <div class="code-id">
+                    <span class="code-name mono">{code}</span>
+                    {#if entry.percentOff === 100}
+                      <span class="badge badge-free">FREE</span>
+                    {:else}
+                      <span class="badge">{entry.percentOff}% off</span>
+                    {/if}
+                    {#if entry.flatOff > 0}
+                      <span class="badge">−{entry.flatOff} sats</span>
+                    {/if}
+                  </div>
+                  <div class="code-meta">
+                    <span>Expires: {formatExpiresLabel(entry.expiresAt)}</span>
+                    {#if entry.note}<span>· {entry.note}</span>{/if}
+                  </div>
+                </div>
+                <div class="actions">
+                  <button
+                    class="btn"
+                    type="button"
+                    on:click={() => startEdit(code, entry)}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    class="btn btn-danger"
+                    type="button"
+                    disabled={busyCode === code}
+                    on:click={() => deleteCode(code)}
+                  >
+                    {busyCode === code ? '…' : 'Delete'}
+                  </button>
+                </div>
+              {/if}
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+  {/if}
+</div>
+
+<style>
+  .page {
+    max-width: 760px;
+    margin: 0 auto;
+    padding: 2rem 1.25rem 4rem;
+    color: var(--color-text-primary);
+  }
+  .back {
+    display: inline-block;
+    margin-bottom: 0.75rem;
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
+    text-decoration: none;
+  }
+  .back:hover {
+    color: var(--color-text-primary);
+  }
+  h1 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin: 0 0 0.5rem;
+  }
+  .lede {
+    color: var(--color-text-secondary);
+    margin: 0 0 1.5rem;
+    font-size: 0.875rem;
+  }
+  .unauthorized,
+  .status {
+    padding: 2rem;
+    text-align: center;
+    color: var(--color-text-secondary);
+  }
+  .status-error {
+    color: #ef4444;
+  }
+  .card {
+    border: 1px solid var(--color-input-border);
+    border-radius: 0.5rem;
+    background: var(--color-bg-secondary);
+    padding: 1rem 1.25rem;
+    margin-bottom: 1rem;
+  }
+  .card-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+  }
+  .card-title {
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+  }
+  .card-desc {
+    font-size: 0.875rem;
+    color: var(--color-text-secondary);
+  }
+  .hint {
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
+    margin: 0.75rem 0 0;
+  }
+  .form-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+  }
+  .form-grid label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
+  }
+  .form-grid label.full {
+    grid-column: 1 / -1;
+  }
+  .form-grid input {
+    padding: 0.5rem 0.625rem;
+    border: 1px solid var(--color-input-border);
+    border-radius: 0.375rem;
+    background: var(--color-bg-primary, transparent);
+    color: var(--color-text-primary);
+    font-size: 0.875rem;
+  }
+  .mono {
+    font-family: ui-monospace, monospace;
+    text-transform: uppercase;
+  }
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+  }
+  .btn {
+    padding: 0.5rem 1rem;
+    border-radius: 0.375rem;
+    border: 1px solid var(--color-input-border);
+    background: var(--color-bg-primary, transparent);
+    color: var(--color-text-primary);
+    font-size: 0.875rem;
+    cursor: pointer;
+  }
+  .btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  .btn-primary {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    color: white;
+  }
+  .btn-danger {
+    color: #ef4444;
+    border-color: rgba(239, 68, 68, 0.4);
+  }
+  .codes {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .code-row {
+    border: 1px solid var(--color-input-border);
+    border-radius: 0.375rem;
+    padding: 0.75rem 0.875rem;
+  }
+  .code-summary {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+  .code-id {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+  .code-name {
+    font-weight: 600;
+    font-size: 0.9375rem;
+  }
+  .badge {
+    display: inline-block;
+    padding: 0.125rem 0.5rem;
+    border-radius: 9999px;
+    background: var(--color-bg-tertiary, rgba(255, 255, 255, 0.06));
+    color: var(--color-text-secondary);
+    font-size: 0.6875rem;
+    font-weight: 500;
+  }
+  .badge-free {
+    background: rgba(180, 95, 30, 0.15);
+    color: #b45f1e;
+  }
+  .code-meta {
+    margin-top: 0.25rem;
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+  .code-row .code-summary + .actions {
+    margin-top: 0.5rem;
+  }
+  code {
+    font-family: ui-monospace, monospace;
+    font-size: 0.8125rem;
+    padding: 0.0625rem 0.25rem;
+    background: var(--color-bg-tertiary, rgba(255, 255, 255, 0.06));
+    border-radius: 0.1875rem;
+  }
+
+  @media (max-width: 540px) {
+    .form-grid {
+      grid-template-columns: 1fr;
+    }
+    .code-summary {
+      flex-direction: column;
+    }
+  }
+</style>

--- a/src/routes/api/admin/promos/+server.ts
+++ b/src/routes/api/admin/promos/+server.ts
@@ -1,0 +1,156 @@
+/**
+ * /api/admin/promos — admin CRUD for cookbook export promo codes.
+ *
+ * GET   → returns the resolved config (KV override, else hardcoded
+ *         defaults) so the admin UI can render the current state in
+ *         a single round trip.
+ * POST  → mutate. The body's `action` field discriminates:
+ *           - { action: 'toggle', enabled: boolean }
+ *           - { action: 'upsert', code, percentOff, flatOff,
+ *               expiresAt?, note? }
+ *           - { action: 'delete', code }
+ *
+ * Both verbs are gated by NIP-98 HTTP Auth — the caller signs a
+ * kind-27235 event bound to this URL, the request method, and (for
+ * POST) the exact request body bytes. Server checks signature, ±60s
+ * timestamp skew, URL/method match, body hash, and that the signing
+ * pubkey === ADMIN_PUBKEY. Header-only auth would be too weak here:
+ * the admin pubkey is public, so a forged x-admin-pubkey header would
+ * be enough to read or rewrite live promo config.
+ *
+ * KV binding: GATED_CONTENT (shared with the cookbook export store).
+ * KV propagation across CF edges is eventually consistent (~60s
+ * worst case) — admin writes may take that long to be seen by every
+ * worker. Acceptable for promo management; we surface this in the UI
+ * via a "may take ~1m to propagate" hint.
+ */
+
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { ADMIN_PUBKEY } from '$lib/adminAuth';
+import { verifyNip98 } from '$lib/nip98.server';
+import {
+	DEFAULT_PROMO_CONFIG,
+	resolvePromoConfig
+} from '$lib/cookbookPromo.server';
+import {
+	deletePromoCode,
+	setPromoEnabled,
+	upsertPromoCode,
+	type PromoEntry
+} from '$lib/cookbookPromoStore.server';
+
+const CODE_RE = /^[A-Z0-9_-]{2,32}$/;
+
+export const GET: RequestHandler = async ({ request, platform }) => {
+	const auth = await verifyNip98(request, { expectedPubkey: ADMIN_PUBKEY });
+	if (!auth.ok) {
+		console.warn('[admin.promos.auth-failed]', { method: 'GET', reason: auth.reason });
+		return json({ error: 'forbidden' }, { status: 403 });
+	}
+
+	const kv = platform?.env?.GATED_CONTENT ?? null;
+	const config = await resolvePromoConfig(kv);
+	return json({ config, defaults: DEFAULT_PROMO_CONFIG });
+};
+
+interface ToggleAction {
+	action: 'toggle';
+	enabled: boolean;
+}
+interface UpsertAction {
+	action: 'upsert';
+	code: string;
+	percentOff: number;
+	flatOff?: number;
+	expiresAt?: number | null;
+	note?: string;
+}
+interface DeleteAction {
+	action: 'delete';
+	code: string;
+}
+type AdminAction = ToggleAction | UpsertAction | DeleteAction;
+
+export const POST: RequestHandler = async ({ request, platform }) => {
+	// Read body bytes ONCE — the bytes back the NIP-98 payload check
+	// AND the JSON parse below. Cloudflare Workers' request.clone()
+	// has subtle body-consumption semantics that aren't worth depending
+	// on when a single read is enough.
+	const bodyBytes = new Uint8Array(await request.arrayBuffer());
+	const auth = await verifyNip98(request, {
+		expectedPubkey: ADMIN_PUBKEY,
+		bodyBytes
+	});
+	if (!auth.ok) {
+		console.warn('[admin.promos.auth-failed]', { method: 'POST', reason: auth.reason });
+		return json({ error: 'forbidden' }, { status: 403 });
+	}
+
+	const kv = platform?.env?.GATED_CONTENT ?? null;
+
+	let body: AdminAction;
+	try {
+		body = JSON.parse(new TextDecoder().decode(bodyBytes)) as AdminAction;
+	} catch {
+		return json({ error: 'Invalid JSON' }, { status: 400 });
+	}
+
+	try {
+		if (body.action === 'toggle') {
+			if (typeof body.enabled !== 'boolean') {
+				return json({ error: 'enabled must be boolean' }, { status: 400 });
+			}
+			const next = await setPromoEnabled(kv, body.enabled, DEFAULT_PROMO_CONFIG);
+			console.log(`[admin.promos] toggle enabled=${body.enabled} by=${auth.pubkey}`);
+			return json({ success: true, config: next });
+		}
+
+		if (body.action === 'upsert') {
+			const code = String(body.code || '').trim().toUpperCase();
+			if (!CODE_RE.test(code)) {
+				return json(
+					{ error: 'Code must be 2–32 chars, A–Z 0–9 _ -' },
+					{ status: 400 }
+				);
+			}
+			const percentOff = Number(body.percentOff);
+			if (!Number.isFinite(percentOff) || percentOff < 0 || percentOff > 100) {
+				return json({ error: 'percentOff must be 0–100' }, { status: 400 });
+			}
+			const flatOff = Number(body.flatOff ?? 0);
+			if (!Number.isFinite(flatOff) || flatOff < 0) {
+				return json({ error: 'flatOff must be ≥ 0' }, { status: 400 });
+			}
+			const entry: PromoEntry = {
+				percentOff,
+				flatOff
+			};
+			if (typeof body.expiresAt === 'number' && body.expiresAt > 0) {
+				entry.expiresAt = body.expiresAt;
+			}
+			if (typeof body.note === 'string' && body.note.trim()) {
+				entry.note = body.note.trim().slice(0, 200);
+			}
+			const next = await upsertPromoCode(kv, code, entry, DEFAULT_PROMO_CONFIG);
+			console.log(
+				`[admin.promos] upsert code=${code} percent=${percentOff} flat=${flatOff} by=${auth.pubkey}`
+			);
+			return json({ success: true, config: next });
+		}
+
+		if (body.action === 'delete') {
+			const code = String(body.code || '').trim().toUpperCase();
+			if (!CODE_RE.test(code)) {
+				return json({ error: 'Invalid code' }, { status: 400 });
+			}
+			const next = await deletePromoCode(kv, code, DEFAULT_PROMO_CONFIG);
+			console.log(`[admin.promos] delete code=${code} by=${auth.pubkey}`);
+			return json({ success: true, config: next });
+		}
+
+		return json({ error: 'Unknown action' }, { status: 400 });
+	} catch (err) {
+		console.error('[admin.promos] error:', err);
+		return json({ error: 'server_error' }, { status: 500 });
+	}
+};

--- a/src/routes/api/cookbook-export/apply-promo/+server.ts
+++ b/src/routes/api/cookbook-export/apply-promo/+server.ts
@@ -19,7 +19,7 @@ import { json, type RequestHandler } from '@sveltejs/kit';
 import { COOKBOOK_EXPORT_SATS } from '$lib/cookbookPricing';
 import { applyPromo } from '$lib/cookbookPromo.server';
 
-export const POST: RequestHandler = async ({ request }) => {
+export const POST: RequestHandler = async ({ request, platform }) => {
 	let body: { code?: string };
 	try {
 		body = (await request.json()) as { code?: string };
@@ -27,7 +27,8 @@ export const POST: RequestHandler = async ({ request }) => {
 		return json({ success: false, error: 'unknown_code' });
 	}
 
-	const result = applyPromo(body?.code || '', COOKBOOK_EXPORT_SATS);
+	const kv = platform?.env?.GATED_CONTENT ?? null;
+	const result = await applyPromo(kv, body?.code || '', COOKBOOK_EXPORT_SATS);
 	if (!result.ok || !result.applied) {
 		return json({ success: false, error: result.error || 'unknown_code' });
 	}

--- a/src/routes/api/cookbook-export/apply-promo/+server.ts
+++ b/src/routes/api/cookbook-export/apply-promo/+server.ts
@@ -1,0 +1,45 @@
+/**
+ * POST /api/cookbook-export/apply-promo
+ *
+ * Validates a promo code against the server-side config and returns
+ * the resulting price for the cookbook export. The client uses the
+ * response to update its CTA label; the actual price gate still
+ * lives in /api/cookbook-export/create-invoice (which re-validates
+ * the code), so a tampered client can't claim a free unlock.
+ *
+ * Body:
+ *   { code: string }
+ *
+ * Returns:
+ *   200 { success: true, finalSats, originalSats, discountSats, free, label, code }
+ *   200 { success: false, error: 'unknown_code' | 'expired' }
+ */
+
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { COOKBOOK_EXPORT_SATS } from '$lib/cookbookPricing';
+import { applyPromo } from '$lib/cookbookPromo.server';
+
+export const POST: RequestHandler = async ({ request }) => {
+	let body: { code?: string };
+	try {
+		body = (await request.json()) as { code?: string };
+	} catch {
+		return json({ success: false, error: 'unknown_code' });
+	}
+
+	const result = applyPromo(body?.code || '', COOKBOOK_EXPORT_SATS);
+	if (!result.ok || !result.applied) {
+		return json({ success: false, error: result.error || 'unknown_code' });
+	}
+
+	const a = result.applied;
+	return json({
+		success: true,
+		code: a.code,
+		originalSats: a.originalSats,
+		discountSats: a.discountSats,
+		finalSats: a.finalSats,
+		free: a.free,
+		label: a.label
+	});
+};

--- a/src/routes/api/cookbook-export/create-invoice/+server.ts
+++ b/src/routes/api/cookbook-export/create-invoice/+server.ts
@@ -67,8 +67,10 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 			finalSats: number;
 		} | null = null;
 
+		const kv = platform?.env?.GATED_CONTENT ?? null;
+
 		if (typeof promoCode === 'string' && promoCode.trim()) {
-			const lookup = applyPromo(promoCode, COOKBOOK_EXPORT_SATS);
+			const lookup = await applyPromo(kv, promoCode, COOKBOOK_EXPORT_SATS);
 			if (!lookup.ok || !lookup.applied) {
 				return json(
 					{ error: 'Promo code not valid', promoError: lookup.error || 'unknown_code' },
@@ -90,7 +92,6 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 				: 'Recipe Pack';
 
 		const exportId = crypto.randomUUID();
-		const kv = platform?.env?.GATED_CONTENT ?? null;
 		if (!kv && env.NODE_ENV === 'production') {
 			console.error('[cookbook-export] GATED_CONTENT KV binding missing in production');
 			return json({ error: 'Service temporarily unavailable' }, { status: 503 });

--- a/src/routes/api/cookbook-export/create-invoice/+server.ts
+++ b/src/routes/api/cookbook-export/create-invoice/+server.ts
@@ -1,0 +1,117 @@
+/**
+ * Create Lightning invoice for a one-shot cookbook export.
+ *
+ * POST /api/cookbook-export/create-invoice
+ *
+ * Body:
+ *   {
+ *     buyerPubkey: string,   // hex pubkey of buyer (signed-in user)
+ *     packNaddr: string,     // naddr1... — the pack being exported
+ *     packTitle?: string     // optional, used in invoice description
+ *   }
+ *
+ * Returns:
+ *   200 {
+ *     exportId: string,
+ *     invoice: string,           // BOLT11
+ *     paymentHash: string,
+ *     receiveRequestId: string,
+ *     invoiceExpiresAt: number,  // unix seconds
+ *     amountSats: number
+ *   }
+ *
+ * Mirrors /api/boost/create-invoice. Same Strike API + GATED_CONTENT
+ * KV binding, different key prefix.
+ */
+
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import { createInvoice as createStrikeInvoice } from '$lib/strikeService.server';
+import {
+	storeExport,
+	type CookbookExportRecord
+} from '$lib/cookbookExportStore.server';
+
+const HEX64_RE = /^[0-9a-fA-F]{64}$/;
+const COOKBOOK_EXPORT_SATS = 2100;
+
+export const POST: RequestHandler = async ({ request, platform }) => {
+	try {
+		const body = await request.json();
+		const { buyerPubkey, packNaddr, packTitle } = body ?? {};
+
+		if (!buyerPubkey || typeof buyerPubkey !== 'string' || !HEX64_RE.test(buyerPubkey)) {
+			return json({ error: 'Invalid buyerPubkey format' }, { status: 400 });
+		}
+		if (!packNaddr || typeof packNaddr !== 'string' || !packNaddr.startsWith('naddr1')) {
+			return json({ error: 'A valid packNaddr is required' }, { status: 400 });
+		}
+
+		const safeTitle =
+			typeof packTitle === 'string' && packTitle.trim()
+				? packTitle.trim().slice(0, 80)
+				: 'Recipe Pack';
+		const description = `zap.cooking · Cookbook export: "${safeTitle}"`;
+		const amountSats = COOKBOOK_EXPORT_SATS;
+		const btcAmount = (amountSats / 100_000_000).toFixed(8);
+
+		const strikeResponse = await createStrikeInvoice(btcAmount, 'BTC', description, platform);
+		const bolt11Data = (strikeResponse as any).bolt11;
+		const invoice = bolt11Data?.invoice || strikeResponse.invoice;
+		if (!invoice) {
+			throw new Error('Strike API did not return a BOLT11 invoice');
+		}
+
+		const paymentHash = bolt11Data?.paymentHash || strikeResponse.paymentHash || '';
+		const receiveRequestId = strikeResponse.receiveRequestId;
+
+		let invoiceExpiresAt: number;
+		const expiresString = bolt11Data?.expires || strikeResponse.expires;
+		if (expiresString) {
+			invoiceExpiresAt = Math.floor(new Date(expiresString).getTime() / 1000);
+		} else {
+			invoiceExpiresAt = Math.floor(Date.now() / 1000) + 3600;
+		}
+
+		const exportId = crypto.randomUUID();
+		const kv = platform?.env?.GATED_CONTENT ?? null;
+		if (!kv && env.NODE_ENV === 'production') {
+			console.error('[cookbook-export] GATED_CONTENT KV binding missing in production');
+			return json({ error: 'Service temporarily unavailable' }, { status: 503 });
+		}
+
+		const record: CookbookExportRecord = {
+			id: exportId,
+			buyerPubkey,
+			packNaddr,
+			packTitle: safeTitle,
+			amountSats,
+			receiveRequestId,
+			paymentHash,
+			status: 'pending',
+			createdAt: Date.now(),
+			paidAt: null
+		};
+		await storeExport(kv, record);
+
+		return json({
+			exportId,
+			invoice,
+			paymentHash,
+			receiveRequestId,
+			invoiceExpiresAt,
+			amountSats
+		});
+	} catch (error: any) {
+		console.error('[cookbook-export] create-invoice error:', error);
+		let errorMessage = 'Failed to create Lightning invoice';
+		if (error.message?.includes('STRIKE_API_KEY')) {
+			errorMessage = 'Lightning payment service is not configured.';
+		} else if (error.message?.includes('Strike API error')) {
+			errorMessage = 'Lightning payment service error. Please try again.';
+		} else if (error.message) {
+			errorMessage = error.message;
+		}
+		return json({ error: errorMessage }, { status: 500 });
+	}
+};

--- a/src/routes/api/cookbook-export/create-invoice/+server.ts
+++ b/src/routes/api/cookbook-export/create-invoice/+server.ts
@@ -7,17 +7,25 @@
  *   {
  *     buyerPubkey: string,   // hex pubkey of buyer (signed-in user)
  *     packNaddr: string,     // naddr1... — the pack being exported
- *     packTitle?: string     // optional, used in invoice description
+ *     packTitle?: string,    // optional, used in invoice description
+ *     promoCode?: string     // optional discount code (server-validated)
  *   }
  *
  * Returns:
- *   200 {
+ *   200 (paid path) {
  *     exportId: string,
  *     invoice: string,           // BOLT11
  *     paymentHash: string,
  *     receiveRequestId: string,
  *     invoiceExpiresAt: number,  // unix seconds
- *     amountSats: number
+ *     amountSats: number,
+ *     promo?: { code, label, originalSats, finalSats }
+ *   }
+ *   200 (free-promo path) {
+ *     exportId: string,
+ *     free: true,                // client should treat as paid
+ *     amountSats: 0,
+ *     promo: { code, label, originalSats: COOKBOOK_EXPORT_SATS, finalSats: 0 }
  *   }
  *
  * Mirrors /api/boost/create-invoice. Same Strike API + GATED_CONTENT
@@ -29,16 +37,18 @@ import { env } from '$env/dynamic/private';
 import { createInvoice as createStrikeInvoice } from '$lib/strikeService.server';
 import {
 	storeExport,
+	markExportPaid,
 	type CookbookExportRecord
 } from '$lib/cookbookExportStore.server';
+import { COOKBOOK_EXPORT_SATS } from '$lib/cookbookPricing';
+import { applyPromo } from '$lib/cookbookPromo.server';
 
 const HEX64_RE = /^[0-9a-fA-F]{64}$/;
-const COOKBOOK_EXPORT_SATS = 2100;
 
 export const POST: RequestHandler = async ({ request, platform }) => {
 	try {
 		const body = await request.json();
-		const { buyerPubkey, packNaddr, packTitle } = body ?? {};
+		const { buyerPubkey, packNaddr, packTitle, promoCode } = body ?? {};
 
 		if (!buyerPubkey || typeof buyerPubkey !== 'string' || !HEX64_RE.test(buyerPubkey)) {
 			return json({ error: 'Invalid buyerPubkey format' }, { status: 400 });
@@ -47,21 +57,82 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 			return json({ error: 'A valid packNaddr is required' }, { status: 400 });
 		}
 
+		// Server-side promo validation. The client may send a code string,
+		// but only this validation determines the actual price.
+		let amountSats = COOKBOOK_EXPORT_SATS;
+		let promo: {
+			code: string;
+			label: string;
+			originalSats: number;
+			finalSats: number;
+		} | null = null;
+
+		if (typeof promoCode === 'string' && promoCode.trim()) {
+			const lookup = applyPromo(promoCode, COOKBOOK_EXPORT_SATS);
+			if (!lookup.ok || !lookup.applied) {
+				return json(
+					{ error: 'Promo code not valid', promoError: lookup.error || 'unknown_code' },
+					{ status: 400 }
+				);
+			}
+			amountSats = lookup.applied.finalSats;
+			promo = {
+				code: lookup.applied.code,
+				label: lookup.applied.label,
+				originalSats: lookup.applied.originalSats,
+				finalSats: lookup.applied.finalSats
+			};
+		}
+
 		const safeTitle =
 			typeof packTitle === 'string' && packTitle.trim()
 				? packTitle.trim().slice(0, 80)
 				: 'Recipe Pack';
-		const description = `zap.cooking · Cookbook export: "${safeTitle}"`;
-		const amountSats = COOKBOOK_EXPORT_SATS;
-		const btcAmount = (amountSats / 100_000_000).toFixed(8);
 
+		const exportId = crypto.randomUUID();
+		const kv = platform?.env?.GATED_CONTENT ?? null;
+		if (!kv && env.NODE_ENV === 'production') {
+			console.error('[cookbook-export] GATED_CONTENT KV binding missing in production');
+			return json({ error: 'Service temporarily unavailable' }, { status: 503 });
+		}
+
+		// 100%-off promo path: skip Strike, write a paid record directly,
+		// return free=true. The verify-payment endpoint will idempotently
+		// see status='paid' if the client double-checks.
+		if (amountSats === 0) {
+			const record: CookbookExportRecord = {
+				id: exportId,
+				buyerPubkey,
+				packNaddr,
+				packTitle: safeTitle,
+				amountSats: 0,
+				receiveRequestId: `promo:${exportId}`,
+				paymentHash: '',
+				status: 'paid',
+				createdAt: Date.now(),
+				paidAt: Date.now()
+			};
+			await storeExport(kv, record);
+			// Note: no need to call markExportPaid — record is created paid.
+			void markExportPaid; // tree-shake hint kept for symmetry with verify path
+
+			return json({
+				exportId,
+				free: true,
+				amountSats: 0,
+				promo
+			});
+		}
+
+		// Paid path — create the Strike invoice.
+		const description = `zap.cooking · Cookbook export: "${safeTitle}"`;
+		const btcAmount = (amountSats / 100_000_000).toFixed(8);
 		const strikeResponse = await createStrikeInvoice(btcAmount, 'BTC', description, platform);
 		const bolt11Data = (strikeResponse as any).bolt11;
 		const invoice = bolt11Data?.invoice || strikeResponse.invoice;
 		if (!invoice) {
 			throw new Error('Strike API did not return a BOLT11 invoice');
 		}
-
 		const paymentHash = bolt11Data?.paymentHash || strikeResponse.paymentHash || '';
 		const receiveRequestId = strikeResponse.receiveRequestId;
 
@@ -71,13 +142,6 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 			invoiceExpiresAt = Math.floor(new Date(expiresString).getTime() / 1000);
 		} else {
 			invoiceExpiresAt = Math.floor(Date.now() / 1000) + 3600;
-		}
-
-		const exportId = crypto.randomUUID();
-		const kv = platform?.env?.GATED_CONTENT ?? null;
-		if (!kv && env.NODE_ENV === 'production') {
-			console.error('[cookbook-export] GATED_CONTENT KV binding missing in production');
-			return json({ error: 'Service temporarily unavailable' }, { status: 503 });
 		}
 
 		const record: CookbookExportRecord = {
@@ -100,7 +164,8 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 			paymentHash,
 			receiveRequestId,
 			invoiceExpiresAt,
-			amountSats
+			amountSats,
+			promo
 		});
 	} catch (error: any) {
 		console.error('[cookbook-export] create-invoice error:', error);

--- a/src/routes/api/cookbook-export/verify-payment/+server.ts
+++ b/src/routes/api/cookbook-export/verify-payment/+server.ts
@@ -1,0 +1,66 @@
+/**
+ * Verify a Lightning-paid cookbook export.
+ *
+ * POST /api/cookbook-export/verify-payment
+ *
+ * Body:
+ *   { exportId: string, receiveRequestId: string }
+ *
+ * Returns:
+ *   200 { success: true, paidAt: number }
+ *   402 { error: 'Payment not yet completed', paid: false }
+ *   404 { error: 'Export not found or expired' }
+ *
+ * Mirrors /api/boost/verify-payment. Same Strike API check.
+ */
+
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import { getReceiveRequestReceives } from '$lib/strikeService.server';
+import { getExport, markExportPaid } from '$lib/cookbookExportStore.server';
+
+export const POST: RequestHandler = async ({ request, platform }) => {
+	try {
+		const body = await request.json();
+		const { exportId, receiveRequestId } = body ?? {};
+
+		if (!exportId) return json({ error: 'exportId is required' }, { status: 400 });
+		if (!receiveRequestId)
+			return json({ error: 'receiveRequestId is required' }, { status: 400 });
+
+		const kv = platform?.env?.GATED_CONTENT ?? null;
+		if (!kv && env.NODE_ENV === 'production') {
+			console.error('[cookbook-export verify] GATED_CONTENT KV binding missing in production');
+			return json({ error: 'Service unavailable' }, { status: 503 });
+		}
+
+		const rec = await getExport(kv, exportId);
+		if (!rec) {
+			return json(
+				{ error: 'Export not found or expired. Please create a new invoice.' },
+				{ status: 404 }
+			);
+		}
+
+		// Idempotent — already paid is a success.
+		if (rec.status === 'paid') {
+			return json({ success: true, paidAt: rec.paidAt });
+		}
+
+		if (rec.receiveRequestId !== receiveRequestId) {
+			return json({ error: 'receiveRequestId does not match' }, { status: 403 });
+		}
+
+		const receives = await getReceiveRequestReceives(receiveRequestId, platform);
+		const completed = receives.find((r) => r.state === 'COMPLETED');
+		if (!completed) {
+			return json({ error: 'Payment not yet completed', paid: false }, { status: 402 });
+		}
+
+		const updated = await markExportPaid(kv, exportId);
+		return json({ success: true, paidAt: updated?.paidAt ?? Date.now() });
+	} catch (error: any) {
+		console.error('[cookbook-export verify] error:', error);
+		return json({ error: error.message || 'Failed to verify payment' }, { status: 500 });
+	}
+};

--- a/src/routes/api/cookbook-intro/+server.ts
+++ b/src/routes/api/cookbook-intro/+server.ts
@@ -35,6 +35,7 @@ import { json, type RequestHandler } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 
 const MAX_INTRO_TOKENS = 220;
+const HEX64_RE = /^[0-9a-fA-F]{64}$/;
 
 export const POST: RequestHandler = async ({ request, platform }) => {
 	const OPENAI_API_KEY = platform?.env?.OPENAI_API_KEY || env.OPENAI_API_KEY;
@@ -59,8 +60,17 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 		? body.recipeTitles.filter((t): t is string => typeof t === 'string').slice(0, 10)
 		: [];
 
+	// Pubkey is a required hex-64 identifier. Note that the value is
+	// client-supplied and not signature-verified — same trust model as
+	// /api/extract-recipe today. A non-member could still claim a known
+	// Pro pubkey to obtain free AI compute. Tightening this requires
+	// migrating both endpoints to NIP-98 in a follow-up; see
+	// FOLLOWUPS-auth-migration.
 	if (!pubkey) {
-		return json({ success: false, error: 'Pro Kitchen membership required' }, { status: 401 });
+		return json({ success: false, error: 'pubkey is required' }, { status: 400 });
+	}
+	if (!HEX64_RE.test(pubkey)) {
+		return json({ success: false, error: 'pubkey must be 64-char hex' }, { status: 400 });
 	}
 	if (!packTitle) {
 		return json({ success: false, error: 'packTitle is required' }, { status: 400 });
@@ -70,21 +80,35 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 	const MEMBERSHIP_ENABLED = platform?.env?.MEMBERSHIP_ENABLED || env.MEMBERSHIP_ENABLED;
 	if (MEMBERSHIP_ENABLED?.toLowerCase() === 'true') {
 		const API_SECRET = platform?.env?.RELAY_API_SECRET || env.RELAY_API_SECRET;
-		if (API_SECRET) {
-			try {
-				const { hasActiveMembership } = await import('$lib/membershipApi.server');
-				const isActive = await hasActiveMembership(pubkey, API_SECRET);
-				if (!isActive) {
-					return json(
-						{ success: false, error: 'Pro Kitchen membership required' },
-						{ status: 403 }
-					);
-				}
-			} catch (err) {
-				console.error('[cookbook-intro] membership check failed', err);
-				// Fail open on membership-API outage — same convention as
-				// /api/extract-recipe.
+		// Fail closed on misconfiguration. A missing API secret while
+		// gating is enabled is a deployment error — silently skipping
+		// the membership check would let any caller through to OpenAI
+		// on the server's dime.
+		if (!API_SECRET) {
+			console.error(
+				'[cookbook-intro] MEMBERSHIP_ENABLED=true but RELAY_API_SECRET is not configured'
+			);
+			return json(
+				{ success: false, error: 'Membership service not configured' },
+				{ status: 503 }
+			);
+		}
+		try {
+			const { hasActiveMembership } = await import('$lib/membershipApi.server');
+			const isActive = await hasActiveMembership(pubkey, API_SECRET);
+			if (!isActive) {
+				return json(
+					{ success: false, error: 'Pro Kitchen membership required' },
+					{ status: 403 }
+				);
 			}
+		} catch (err) {
+			console.error('[cookbook-intro] membership check failed', err);
+			// Fail open on membership-API *outage* (transient network
+			// errors etc.) — same convention as /api/extract-recipe. The
+			// distinction matters: a misconfigured secret is admin error
+			// and should fail closed; a flaky upstream relay shouldn't
+			// nuke a paid feature for every active member.
 		}
 	}
 

--- a/src/routes/api/cookbook-intro/+server.ts
+++ b/src/routes/api/cookbook-intro/+server.ts
@@ -1,0 +1,152 @@
+/**
+ * POST /api/cookbook-intro — Pro-gated AI helper that polishes a Recipe
+ * Pack description into a short cookbook-style introduction.
+ *
+ * Body:
+ *   {
+ *     pubkey: string,         // signed-in user's pubkey, required
+ *     packTitle: string,
+ *     packDescription?: string,
+ *     creatorName?: string,
+ *     recipeCount: number,
+ *     recipeTitles?: string[] // first ~10, used as light context only
+ *   }
+ *
+ * Returns: { success: true, introduction: string } | { success: false, error }
+ *
+ * Membership gating: matches the image/text path in
+ * /api/extract-recipe — Pro Kitchen + Founders are the intended
+ * audience but we use the same `hasActiveMembership` check (any
+ * active tier) since that's the established server-side primitive.
+ * The client-side check on the modal only opens this for Pro/Founders,
+ * so anyone reaching this endpoint with cook_plus is either bypassing
+ * the UI or has a stale tier — fail-closed on the modal side keeps
+ * the UX clean either way.
+ *
+ * AI is treated as best-effort polish: the caller falls back to the
+ * raw description on any failure here. Rules:
+ *   - Don't invent facts about recipes.
+ *   - Don't change recipe content.
+ *   - Keep it short (≈80-130 words).
+ *   - Plain text. No markdown headers. No emojis.
+ */
+
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+
+const MAX_INTRO_TOKENS = 220;
+
+export const POST: RequestHandler = async ({ request, platform }) => {
+	const OPENAI_API_KEY = platform?.env?.OPENAI_API_KEY || env.OPENAI_API_KEY;
+	if (!OPENAI_API_KEY) {
+		return json({ success: false, error: 'OpenAI API key not configured' }, { status: 500 });
+	}
+
+	let body: Record<string, unknown>;
+	try {
+		body = (await request.json()) as Record<string, unknown>;
+	} catch {
+		return json({ success: false, error: 'Invalid JSON body' }, { status: 400 });
+	}
+
+	const pubkey = typeof body.pubkey === 'string' ? body.pubkey.trim() : '';
+	const packTitle = typeof body.packTitle === 'string' ? body.packTitle.trim() : '';
+	const packDescription =
+		typeof body.packDescription === 'string' ? body.packDescription.trim() : '';
+	const creatorName = typeof body.creatorName === 'string' ? body.creatorName.trim() : '';
+	const recipeCount = Number(body.recipeCount) || 0;
+	const recipeTitles = Array.isArray(body.recipeTitles)
+		? body.recipeTitles.filter((t): t is string => typeof t === 'string').slice(0, 10)
+		: [];
+
+	if (!pubkey) {
+		return json({ success: false, error: 'Pro Kitchen membership required' }, { status: 401 });
+	}
+	if (!packTitle) {
+		return json({ success: false, error: 'packTitle is required' }, { status: 400 });
+	}
+
+	// Gate — same pattern as /api/extract-recipe image/text path.
+	const MEMBERSHIP_ENABLED = platform?.env?.MEMBERSHIP_ENABLED || env.MEMBERSHIP_ENABLED;
+	if (MEMBERSHIP_ENABLED?.toLowerCase() === 'true') {
+		const API_SECRET = platform?.env?.RELAY_API_SECRET || env.RELAY_API_SECRET;
+		if (API_SECRET) {
+			try {
+				const { hasActiveMembership } = await import('$lib/membershipApi.server');
+				const isActive = await hasActiveMembership(pubkey, API_SECRET);
+				if (!isActive) {
+					return json(
+						{ success: false, error: 'Pro Kitchen membership required' },
+						{ status: 403 }
+					);
+				}
+			} catch (err) {
+				console.error('[cookbook-intro] membership check failed', err);
+				// Fail open on membership-API outage — same convention as
+				// /api/extract-recipe.
+			}
+		}
+	}
+
+	const userMsg = [
+		`Pack title: ${packTitle}`,
+		creatorName ? `Curated by: ${creatorName}` : '',
+		packDescription ? `Existing description (use as the basis):\n${packDescription}` : '',
+		`Recipe count: ${recipeCount}`,
+		recipeTitles.length ? `Recipe titles: ${recipeTitles.join(' · ')}` : ''
+	]
+		.filter(Boolean)
+		.join('\n\n');
+
+	try {
+		const res = await fetch('https://api.openai.com/v1/chat/completions', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${OPENAI_API_KEY}`
+			},
+			body: JSON.stringify({
+				model: 'gpt-4o-mini',
+				temperature: 0.6,
+				max_tokens: MAX_INTRO_TOKENS,
+				messages: [
+					{
+						role: 'system',
+						content: [
+							'You write short, warm, cookbook-style introductions for personal recipe collections.',
+							'Rules:',
+							'- Tone: warm, humble, natural. Not marketing copy.',
+							'- ≈80-130 words, two short paragraphs.',
+							'- Plain text only. No markdown headers. No emojis. No exclamation marks.',
+							"- Use the existing description as the basis when one is provided — don't override the curator's voice.",
+							"- Don't invent facts about specific recipes you weren't given.",
+							"- Don't promise anything (e.g. 'these are the best…').",
+							'- It is fine to say very little if there is little to say.'
+						].join('\n')
+					},
+					{
+						role: 'user',
+						content: userMsg
+					}
+				]
+			})
+		});
+
+		if (!res.ok) {
+			console.error('[cookbook-intro] openai non-2xx', res.status);
+			return json({ success: false, error: 'AI request failed' }, { status: 502 });
+		}
+
+		const data = (await res.json()) as {
+			choices?: { message?: { content?: string } }[];
+		};
+		const intro = data.choices?.[0]?.message?.content?.trim() || '';
+		if (!intro) {
+			return json({ success: false, error: 'No content returned' }, { status: 502 });
+		}
+		return json({ success: true, introduction: intro });
+	} catch (err) {
+		console.error('[cookbook-intro] error', err);
+		return json({ success: false, error: 'AI request failed' }, { status: 502 });
+	}
+};

--- a/src/routes/api/membership/+server.ts
+++ b/src/routes/api/membership/+server.ts
@@ -75,6 +75,14 @@ export const GET: RequestHandler = async ({ url, platform }) => {
 
         // Founders get lifetime access — ensure expiry is at least 10 years out
         let expiresAt = lookup.member?.subscription_end || undefined;
+        // Founders also need their `active` flag forced to true. The pantry
+        // record sometimes has a stale `subscription_end` in the past
+        // (lifetime members weren't always inserted with a far-future
+        // expiry), and `lookupMember` flips `isActive` to false in that
+        // case. Without this override, founders would silently fall into
+        // the paywall path on any feature gated on `active && tier ===
+        // 'founders'`.
+        let active = lookup.isActive;
         if (tier === 'founders') {
           const tenYearsFromNow = new Date();
           tenYearsFromNow.setFullYear(tenYearsFromNow.getFullYear() + 10);
@@ -82,10 +90,11 @@ export const GET: RequestHandler = async ({ url, platform }) => {
           if (currentExpiry < tenYearsFromNow) {
             expiresAt = tenYearsFromNow.toISOString();
           }
+          active = true;
         }
 
         results[pubkey] = {
-          active: lookup.isActive,
+          active,
           tier,
           expiresAt
         };

--- a/src/routes/pack/[naddr]/+page.svelte
+++ b/src/routes/pack/[naddr]/+page.svelte
@@ -320,9 +320,11 @@
   $: isProMember =
     !!tierStatus?.active && (tierStatus.tier === 'pro_kitchen' || tierStatus.tier === 'founders');
 
-  // Debug log for membership-detection edge cases. Truncates pubkey to
-  // first 8 chars so it's diagnosable without leaking identity.
-  $: if (browser && $userPublickey) {
+  // Dev-only membership snapshot — useful when iterating on tier
+  // detection edge cases, silenced in production so signed-in users
+  // don't see noisy console output (and so tier metadata isn't
+  // surfaced to whatever else the browser console pipes into).
+  $: if (import.meta.env.DEV && browser && $userPublickey) {
     console.info('[pack page] membership snapshot', {
       pubkey: `${$userPublickey.slice(0, 8)}…`,
       tierStatus,

--- a/src/routes/pack/[naddr]/+page.svelte
+++ b/src/routes/pack/[naddr]/+page.svelte
@@ -28,7 +28,6 @@
   import Avatar from '../../../components/Avatar.svelte';
   import CustomName from '../../../components/CustomName.svelte';
   import ShareModal from '../../../components/ShareModal.svelte';
-  import Modal from '../../../components/Modal.svelte';
   import ExportCookbookModal from '../../../components/ExportCookbookModal.svelte';
   import { showToast } from '$lib/toast';
   import { lazyLoad } from '$lib/lazyLoad';
@@ -47,7 +46,6 @@
   import BookmarkIcon from 'phosphor-svelte/lib/BookmarkSimple';
   import BookmarkSimpleIcon from 'phosphor-svelte/lib/BookmarkSimple';
   import BookOpenIcon from 'phosphor-svelte/lib/BookOpen';
-  import LockKeyIcon from 'phosphor-svelte/lib/LockKey';
   import CheckCircleIcon from 'phosphor-svelte/lib/CheckCircle';
   import CircleNotchIcon from 'phosphor-svelte/lib/CircleNotch';
   import ChatTeardropTextIcon from 'phosphor-svelte/lib/ChatTeardropText';
@@ -307,13 +305,12 @@
   // Share modal (short link + social share + QR), reused from recipe page.
   let shareModalOpen = false;
 
-  // ===== Export-as-Cookbook (Pro feature) =====
+  // ===== Export-as-Cookbook =====
+  // Pro Kitchen / Founders → free unlimited exports.
+  // Non-members signed in → pay 2100 sats per export, handled inside
+  // the modal (paywall stage). Signed-out users get bounced to login.
   let exportModalOpen = false;
-  let upgradeModalOpen = false;
 
-  // Mirror the existing isPremiumTier convention from LandingImportHero:
-  // "Pro" === pro_kitchen + founders. cook_plus and others see the
-  // upgrade prompt instead of the full export modal.
   let membershipMap: Record<string, MembershipStatus> = {};
   const unsubMembership = membershipStatusMap.subscribe((v) => {
     membershipMap = v;
@@ -330,10 +327,8 @@
       goto('/login?redirect=' + encodeURIComponent(window.location.pathname));
       return;
     }
-    if (!isProMember) {
-      upgradeModalOpen = true;
-      return;
-    }
+    // Whether the user is Pro or not, the modal handles the right path
+    // (Pro → straight to form; non-Pro → form with paywall CTA).
     exportModalOpen = true;
   }
 </script>
@@ -370,7 +365,7 @@
   imageUrl={image || ''}
 />
 
-<!-- Export as Cookbook (Pro) -->
+<!-- Export as Cookbook (free for Pro / 2100 sats for everyone else) -->
 {#if packEvent}
   <ExportCookbookModal
     bind:open={exportModalOpen}
@@ -381,49 +376,10 @@
     packDescription={description}
     packCoverImage={image}
     {creatorPubkey}
+    packNaddr={$page.params.naddr}
+    packShareUrl={viewUrl}
+    {isProMember}
   />
-{/if}
-
-<!-- Upgrade prompt for non-Pro members who tap the locked Export button -->
-{#if upgradeModalOpen}
-  <Modal cleanup={() => (upgradeModalOpen = false)} bind:open={upgradeModalOpen}>
-    <h1 slot="title">Pro Kitchen feature</h1>
-    <div class="flex flex-col gap-4">
-      <div
-        class="flex items-start gap-3 p-3 rounded-lg"
-        style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
-      >
-        <div
-          class="w-10 h-10 rounded-full bg-gradient-to-br from-orange-500 to-amber-500 flex items-center justify-center flex-shrink-0"
-        >
-          <BookOpenIcon size={20} weight="fill" class="text-white" />
-        </div>
-        <div class="flex flex-col">
-          <p class="text-sm font-medium" style="color: var(--color-text-primary)">
-            Export as Cookbook
-          </p>
-          <p class="text-sm text-caption">
-            Export Recipe Packs as printable cookbooks with Pro Kitchen.
-          </p>
-        </div>
-      </div>
-      <div class="flex justify-end gap-2 pt-1">
-        <button
-          on:click={() => (upgradeModalOpen = false)}
-          class="px-4 py-2 rounded-full text-sm font-medium transition-colors"
-          style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
-        >
-          Maybe later
-        </button>
-        <a
-          href="/membership"
-          class="flex items-center gap-2 px-5 py-2.5 bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 text-white rounded-full font-semibold transition-all shadow-md shadow-orange-500/25"
-        >
-          See Pro Kitchen
-        </a>
-      </div>
-    </div>
-  </Modal>
 {/if}
 
 {#if !loaded}
@@ -619,19 +575,25 @@
           style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
           title={isProMember
             ? 'Export this pack as a printable cookbook PDF'
-            : 'Pro Kitchen members can export Recipe Packs as printable cookbooks'}
+            : 'Free with Pro Kitchen — or unlock once for 2100 sats'}
         >
-          {#if isProMember}
-            <BookOpenIcon size={16} />
-          {:else}
-            <LockKeyIcon size={16} class="text-amber-500" />
-          {/if}
+          <BookOpenIcon size={16} />
           <span>Export as Cookbook</span>
-          <span
-            class="text-[10px] uppercase tracking-wide font-bold px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-600 dark:text-amber-400"
-          >
-            Pro
-          </span>
+          {#if isProMember}
+            <span
+              class="text-[10px] uppercase tracking-wide font-bold px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-600 dark:text-amber-400"
+              title="Free for Pro Kitchen members"
+            >
+              Pro
+            </span>
+          {:else}
+            <span
+              class="text-[10px] uppercase tracking-wide font-bold px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-600 dark:text-amber-400"
+              title="Pay 2100 sats per export — or upgrade to Pro Kitchen for unlimited"
+            >
+              2100 sats ⚡
+            </span>
+          {/if}
         </button>
       {/if}
     </div>

--- a/src/routes/pack/[naddr]/+page.svelte
+++ b/src/routes/pack/[naddr]/+page.svelte
@@ -6,7 +6,7 @@
   import { NDKEvent } from '@nostr-dev-kit/ndk';
   import { nip19 } from 'nostr-tools';
   import { get } from 'svelte/store';
-  import { onMount } from 'svelte';
+  import { onMount, onDestroy } from 'svelte';
   import type { PageData } from './$types';
 
   // SSR-resolved OG metadata. Always present; falls back to safe
@@ -28,6 +28,8 @@
   import Avatar from '../../../components/Avatar.svelte';
   import CustomName from '../../../components/CustomName.svelte';
   import ShareModal from '../../../components/ShareModal.svelte';
+  import Modal from '../../../components/Modal.svelte';
+  import ExportCookbookModal from '../../../components/ExportCookbookModal.svelte';
   import { showToast } from '$lib/toast';
   import { lazyLoad } from '$lib/lazyLoad';
   import { getImageOrPlaceholder } from '$lib/placeholderImages';
@@ -35,10 +37,17 @@
   import { isOnline } from '$lib/connectionMonitor';
   import { cookbookStore, cookbookLists } from '$lib/stores/cookbookStore';
   import { buildPackUrl } from '$lib/recipePack';
+  import {
+    membershipStatusMap,
+    queueMembershipLookup,
+    type MembershipStatus
+  } from '$lib/stores/membershipStatus';
 
   import ArrowLeftIcon from 'phosphor-svelte/lib/ArrowLeft';
   import BookmarkIcon from 'phosphor-svelte/lib/BookmarkSimple';
   import BookmarkSimpleIcon from 'phosphor-svelte/lib/BookmarkSimple';
+  import BookOpenIcon from 'phosphor-svelte/lib/BookOpen';
+  import LockKeyIcon from 'phosphor-svelte/lib/LockKey';
   import CheckCircleIcon from 'phosphor-svelte/lib/CheckCircle';
   import CircleNotchIcon from 'phosphor-svelte/lib/CircleNotch';
   import ChatTeardropTextIcon from 'phosphor-svelte/lib/ChatTeardropText';
@@ -297,6 +306,36 @@
 
   // Share modal (short link + social share + QR), reused from recipe page.
   let shareModalOpen = false;
+
+  // ===== Export-as-Cookbook (Pro feature) =====
+  let exportModalOpen = false;
+  let upgradeModalOpen = false;
+
+  // Mirror the existing isPremiumTier convention from LandingImportHero:
+  // "Pro" === pro_kitchen + founders. cook_plus and others see the
+  // upgrade prompt instead of the full export modal.
+  let membershipMap: Record<string, MembershipStatus> = {};
+  const unsubMembership = membershipStatusMap.subscribe((v) => {
+    membershipMap = v;
+  });
+  $: if ($userPublickey) queueMembershipLookup($userPublickey);
+  $: tierStatus = $userPublickey ? membershipMap[$userPublickey] : undefined;
+  $: isProMember =
+    !!tierStatus?.active && (tierStatus.tier === 'pro_kitchen' || tierStatus.tier === 'founders');
+
+  onDestroy(() => unsubMembership());
+
+  function handleExportClick() {
+    if (!$userPublickey) {
+      goto('/login?redirect=' + encodeURIComponent(window.location.pathname));
+      return;
+    }
+    if (!isProMember) {
+      upgradeModalOpen = true;
+      return;
+    }
+    exportModalOpen = true;
+  }
 </script>
 
 <svelte:head>
@@ -330,6 +369,62 @@
   title={title || 'Recipe Pack'}
   imageUrl={image || ''}
 />
+
+<!-- Export as Cookbook (Pro) -->
+{#if packEvent}
+  <ExportCookbookModal
+    bind:open={exportModalOpen}
+    {packEvent}
+    {recipeEvents}
+    totalRecipeCount={recipeCount}
+    packTitle={title}
+    packDescription={description}
+    packCoverImage={image}
+    {creatorPubkey}
+  />
+{/if}
+
+<!-- Upgrade prompt for non-Pro members who tap the locked Export button -->
+{#if upgradeModalOpen}
+  <Modal cleanup={() => (upgradeModalOpen = false)} bind:open={upgradeModalOpen}>
+    <h1 slot="title">Pro Kitchen feature</h1>
+    <div class="flex flex-col gap-4">
+      <div
+        class="flex items-start gap-3 p-3 rounded-lg"
+        style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+      >
+        <div
+          class="w-10 h-10 rounded-full bg-gradient-to-br from-orange-500 to-amber-500 flex items-center justify-center flex-shrink-0"
+        >
+          <BookOpenIcon size={20} weight="fill" class="text-white" />
+        </div>
+        <div class="flex flex-col">
+          <p class="text-sm font-medium" style="color: var(--color-text-primary)">
+            Export as Cookbook
+          </p>
+          <p class="text-sm text-caption">
+            Export Recipe Packs as printable cookbooks with Pro Kitchen.
+          </p>
+        </div>
+      </div>
+      <div class="flex justify-end gap-2 pt-1">
+        <button
+          on:click={() => (upgradeModalOpen = false)}
+          class="px-4 py-2 rounded-full text-sm font-medium transition-colors"
+          style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+        >
+          Maybe later
+        </button>
+        <a
+          href="/membership"
+          class="flex items-center gap-2 px-5 py-2.5 bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 text-white rounded-full font-semibold transition-all shadow-md shadow-orange-500/25"
+        >
+          See Pro Kitchen
+        </a>
+      </div>
+    </div>
+  </Modal>
+{/if}
 
 {#if !loaded}
   <div class="flex justify-center items-center page-loader">
@@ -512,6 +607,31 @@
             <BookmarkIcon size={16} weight="fill" />
             <span>Save Pack to Cookbook</span>
           {/if}
+        </button>
+      {/if}
+
+      <!-- Export as Cookbook — Pro feature. Visible to everyone (so the
+           value is discoverable) but locked for non-Pro members. -->
+      {#if recipeEvents.length > 0}
+        <button
+          on:click={handleExportClick}
+          class="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-colors"
+          style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+          title={isProMember
+            ? 'Export this pack as a printable cookbook PDF'
+            : 'Pro Kitchen members can export Recipe Packs as printable cookbooks'}
+        >
+          {#if isProMember}
+            <BookOpenIcon size={16} />
+          {:else}
+            <LockKeyIcon size={16} class="text-amber-500" />
+          {/if}
+          <span>Export as Cookbook</span>
+          <span
+            class="text-[10px] uppercase tracking-wide font-bold px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-600 dark:text-amber-400"
+          >
+            Pro
+          </span>
         </button>
       {/if}
     </div>

--- a/src/routes/pack/[naddr]/+page.svelte
+++ b/src/routes/pack/[naddr]/+page.svelte
@@ -320,6 +320,16 @@
   $: isProMember =
     !!tierStatus?.active && (tierStatus.tier === 'pro_kitchen' || tierStatus.tier === 'founders');
 
+  // Debug log for membership-detection edge cases. Truncates pubkey to
+  // first 8 chars so it's diagnosable without leaking identity.
+  $: if (browser && $userPublickey) {
+    console.info('[pack page] membership snapshot', {
+      pubkey: `${$userPublickey.slice(0, 8)}…`,
+      tierStatus,
+      isProMember
+    });
+  }
+
   onDestroy(() => unsubMembership());
 
   function handleExportClick() {
@@ -379,6 +389,8 @@
     packNaddr={$page.params.naddr}
     packShareUrl={viewUrl}
     {isProMember}
+    membershipTier={tierStatus?.tier}
+    membershipActive={tierStatus?.active}
   />
 {/if}
 


### PR DESCRIPTION
## Summary

A new Pro-tier export action on `/pack/<naddr>` that turns a Recipe Pack into a downloadable cookbook PDF — cover page, table of contents, optional AI-polished introduction, and one recipe per page.

> "Turn your Recipe Pack into a real cookbook."

The AI layer is intentionally quiet — it polishes the introduction when it can and silently falls back to the raw pack description on any failure. Recipe content is never modified.

## Files

| File | What it does |
|---|---|
| **`src/lib/cookbookExport.ts`** (new) | Client-side PDF builder. `jspdf` is dynamically imported inside the call so the ~150KB dep stays off the main bundle and only ships when a Pro member actually exports. Layout: cover → TOC → intro → recipes. Pre-resolves images in parallel; fetch failures fall through to imageless rendering. Two-pass page-number resolution writes real page numbers into the TOC. |
| **`src/components/ExportCookbookModal.svelte`** (new) | Form per spec: cookbook title, subtitle, include-cover / TOC / images / introduction toggles, style selector. `Generate` → `Formatting your cookbook…` → success card with included/skipped counts and a `Download PDF` button. AI is best-effort. |
| **`src/routes/api/cookbook-intro/+server.ts`** (new) | Pro-gated AI helper that polishes the pack description into a short cookbook-style intro. Mirrors the membership pattern from `/api/extract-recipe` (image/text path) — `hasActiveMembership` via pantry API, fail-open on outage. Hard prompt rules: don't invent facts, don't change recipe content, ≈80-130 words, plain text only. |
| **`src/routes/pack/[naddr]/+page.svelte`** | Adds the `Export as Cookbook` button to the primary action row, next to `Save Pack to Cookbook`. Visible to everyone (value is discoverable); non-Pro tap → upgrade prompt linking to `/membership`; Pro tap → export modal. |

## Membership gating

- **Tier**: `pro_kitchen` + `founders` (matches the existing `isPremiumTier` convention from `LandingImportHero`).
- **Client-side**: button is shown to everyone, tap dispatches based on `tierStatus.active && (tier === 'pro_kitchen' || 'founders')`. Non-Pro users see an upgrade prompt; the AI endpoint is never called.
- **Server-side**: `/api/cookbook-intro` enforces membership via `hasActiveMembership(pubkey, RELAY_API_SECRET)` — same pattern `/api/extract-recipe` uses for image/text imports. Fail-open on membership-API outage to match the existing convention.

## V1 scope decisions (TODO'd in code)

- Style selector exposes `Classic` / `Simple` but only `Modern` renders. Others marked "coming soon".
- AI is intro-polish only. Recipes pass through `parseMarkdownForEditing` (the existing recipe parser) untouched — meaning preserved.
- No meal-plan / shopping-list export.
- No custom AI cover image generation.

## Risks

- **Bundle**: `jspdf` is added but lazy-imported. The main bundle is unaffected; the dep loads only when a Pro member clicks Generate.
- **CORS on recipe images**: failures fall through to imageless recipes, not export errors.
- **Mobile**: PDF generation runs in-browser. Tested via build; large packs (50+ recipes with images) may take 30s on mid-range mobile.
- **Existing functionality**: pack save/import/share/zap/bookmark all unchanged.

## Test plan

- [ ] Pro member: tap `Export as Cookbook` → modal opens.
- [ ] Non-Pro signed-in member: tap → upgrade prompt opens with link to `/membership`.
- [ ] Signed-out user: tap → redirected to `/login?redirect=`.
- [ ] Generate: cover renders with image (or gradient when no cover), TOC has recipe titles + page numbers, intro page is present (AI or fallback), each recipe on its own page with title, image (if available), servings/prep/cook, ingredients, numbered directions.
- [ ] Toggle each include-* off → corresponding section omitted.
- [ ] Pack with 1 / 5 / 20 / 50 recipes — generation completes without errors.
- [ ] Pack with no images: imageless cover + recipes still render.
- [ ] Pack with partial recipe load (some `a`-tags unreachable): "X of Y included" notice.
- [ ] AI endpoint failure (e.g. OpenAI key missing): export still completes with raw description.
- [ ] Filename matches `zap-cooking-{slug}-cookbook.pdf`.
- [ ] `pnpm check` 0 errors, `pnpm build` ✅ (verified locally).

## Follow-up recommendations

- Add `Classic` and `Simple` style implementations.
- AI-normalize recipe formatting where source is messy (kept out for v1 to avoid changing meaning).
- Server-side PDF rendering via Cloudflare Workers for very large packs.
- "Family cookbook" cover variant.
- Meal plan / shopping list export from pack contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)