### PR TITLE
feat(relay): NIP-65 inbox routing for tagged-user events (R9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.324",
+  "version": "4.2.325",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.323",
+  "version": "4.2.324",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/comments/postComment.ts
+++ b/src/lib/comments/postComment.ts
@@ -22,6 +22,7 @@ import { NDKEvent, type NDKRelay } from '@nostr-dev-kit/ndk';
 import { buildNip22CommentTags } from '$lib/tagUtils';
 import { addClientTagToEvent } from '$lib/nip89';
 import { isAddressableRoot } from '$lib/commentFilters';
+import { buildInboxAwareRelaySet } from '$lib/nip65Routing';
 
 export type SigningStrategy = 'explicit-with-timeout' | 'implicit';
 
@@ -210,10 +211,17 @@ export async function postComment(
       throw new PostCommentError('sign-failed', 'Event was not signed — no id');
     }
 
+    // NIP-65 inbox routing — fan out to the parent author's (and any
+    // additional p-tagged users') read relays so the comment lands in
+    // their inbox. Falls back to the NDK pool when no recipient has
+    // published a kind:10002.
+    const inboxRelaySet =
+      (await buildInboxAwareRelaySet({ event: ev, ndk })) ?? undefined;
+
     let relaySet: Set<NDKRelay> | undefined;
     try {
       relaySet = await Promise.race([
-        ev.publish(),
+        ev.publish(inboxRelaySet),
         new Promise<never>((_, reject) =>
           setTimeout(
             () => reject(new Error(`Publish timeout after ${publishTimeoutMs}ms`)),
@@ -233,9 +241,13 @@ export async function postComment(
     return { event: ev, publishedRelays: extractRelayUrls(relaySet) };
   }
 
-  // 'implicit' — no explicit sign, no timeout. NDK signs internally.
+  // 'implicit' — no explicit sign, no timeout. NDK signs internally,
+  // but we can still pre-build an inbox-aware relay set since the event
+  // tags (which we built above) already determine recipients.
   try {
-    const relaySet = await ev.publish();
+    const inboxRelaySet =
+      (await buildInboxAwareRelaySet({ event: ev, ndk })) ?? undefined;
+    const relaySet = await ev.publish(inboxRelaySet);
     return { event: ev, publishedRelays: extractRelayUrls(relaySet) };
   } catch (e) {
     throw new PostCommentError('publish-failed', 'Publish failed', {

--- a/src/lib/nip65Routing.ts
+++ b/src/lib/nip65Routing.ts
@@ -24,6 +24,7 @@
 
 import type NDK from '@nostr-dev-kit/ndk';
 import type { NDKEvent, NDKRelaySet, NDKRelay } from '@nostr-dev-kit/ndk';
+import { normalizeRelayUrl } from '$lib/relayListCache';
 
 const HEX64_RE = /^[0-9a-fA-F]{64}$/;
 
@@ -47,33 +48,33 @@ export const INBOX_LOOKUP_TIMEOUT_MS = 1500;
  *   - The cache lookup fails / times out (additive feature, never blocks)
  */
 export async function getRecipientInboxRelays(event: NDKEvent): Promise<string[]> {
-	const targets = new Set<string>();
-	for (const tag of event.tags) {
-		if (tag[0] !== 'p' || !tag[1] || !HEX64_RE.test(tag[1])) continue;
-		// Skip self — no need to publish to our own inbox.
-		if (event.pubkey && tag[1] === event.pubkey) continue;
-		targets.add(tag[1]);
-	}
-	if (targets.size === 0) return [];
+  const targets = new Set<string>();
+  for (const tag of event.tags) {
+    if (tag[0] !== 'p' || !tag[1] || !HEX64_RE.test(tag[1])) continue;
+    // Skip self — no need to publish to our own inbox.
+    if (event.pubkey && tag[1] === event.pubkey) continue;
+    targets.add(tag[1]);
+  }
+  if (targets.size === 0) return [];
 
-	try {
-		const { relayListCache } = await import('$lib/relayListCache');
-		const lookupPromise = relayListCache.getMany([...targets]);
-		const timeoutPromise = new Promise<Map<string, { read: string[] }>>((resolve) =>
-			setTimeout(() => resolve(new Map()), INBOX_LOOKUP_TIMEOUT_MS)
-		);
-		const lists = await Promise.race([lookupPromise, timeoutPromise]);
+  try {
+    const { relayListCache } = await import('$lib/relayListCache');
+    const lookupPromise = relayListCache.getMany([...targets]);
+    const timeoutPromise = new Promise<Map<string, { read: string[] }>>((resolve) =>
+      setTimeout(() => resolve(new Map()), INBOX_LOOKUP_TIMEOUT_MS)
+    );
+    const lists = await Promise.race([lookupPromise, timeoutPromise]);
 
-		const inbox = new Set<string>();
-		for (const list of lists.values()) {
-			if (!list || !Array.isArray(list.read)) continue;
-			for (const url of list.read) inbox.add(url);
-		}
-		return [...inbox];
-	} catch (err) {
-		console.warn('[nip65Routing] inbox lookup failed:', err);
-		return [];
-	}
+    const inbox = new Set<string>();
+    for (const list of lists.values()) {
+      if (!list || !Array.isArray(list.read)) continue;
+      for (const url of list.read) inbox.add(url);
+    }
+    return [...inbox];
+  } catch (err) {
+    console.warn('[nip65Routing] inbox lookup failed:', err);
+    return [];
+  }
 }
 
 /**
@@ -82,21 +83,25 @@ export async function getRecipientInboxRelays(event: NDKEvent): Promise<string[]
  *
  * Order in the result favors the base URLs (caller's intent) so when
  * the cap kicks in, base relays are kept and inbox URLs may be dropped.
+ *
+ * Dedupes by normalized URL (`relayListCache.normalizeRelayUrl`) so
+ * `wss://example.com` and `wss://example.com/` don't both count toward
+ * the cap. The first-seen original spelling is preserved in the result
+ * — NDK's relay pool keys by raw URL, so passing the variant we've
+ * already seen elsewhere keeps the existing connection state intact.
  */
-export async function unionInboxRelayUrls(
-	event: NDKEvent,
-	baseUrls: string[]
-): Promise<string[]> {
-	const inboxUrls = await getRecipientInboxRelays(event);
-	const seen = new Set<string>();
-	const out: string[] = [];
-	for (const url of [...baseUrls, ...inboxUrls]) {
-		if (out.length >= MAX_PUBLISH_RELAYS) break;
-		if (seen.has(url)) continue;
-		seen.add(url);
-		out.push(url);
-	}
-	return out;
+export async function unionInboxRelayUrls(event: NDKEvent, baseUrls: string[]): Promise<string[]> {
+  const inboxUrls = await getRecipientInboxRelays(event);
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const url of [...baseUrls, ...inboxUrls]) {
+    if (out.length >= MAX_PUBLISH_RELAYS) break;
+    const key = normalizeRelayUrl(url);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(url);
+  }
+  return out;
 }
 
 /**
@@ -113,50 +118,52 @@ export async function unionInboxRelayUrls(
  * error, depending on context.
  */
 export async function buildInboxAwareRelaySet(opts: {
-	event: NDKEvent;
-	ndk: NDK;
-	baseUrls?: string[];
+  event: NDKEvent;
+  ndk: NDK;
+  baseUrls?: string[];
 }): Promise<NDKRelaySet | null> {
-	const { event, ndk } = opts;
+  const { event, ndk } = opts;
 
-	// Fall back to the pool's current relays when no base set is given.
-	let baseUrls = opts.baseUrls;
-	if (!baseUrls) {
-		baseUrls = [];
-		const poolRelays = (ndk as unknown as { pool?: { relays?: Map<string, unknown> } }).pool
-			?.relays;
-		if (poolRelays) {
-			for (const [url] of poolRelays) baseUrls.push(url);
-		}
-	}
+  // Fall back to the pool's current relays when no base set is given.
+  let baseUrls = opts.baseUrls;
+  if (!baseUrls) {
+    baseUrls = [];
+    const poolRelays = (ndk as unknown as { pool?: { relays?: Map<string, unknown> } }).pool
+      ?.relays;
+    if (poolRelays) {
+      for (const [url] of poolRelays) baseUrls.push(url);
+    }
+  }
 
-	const targetUrls = await unionInboxRelayUrls(event, baseUrls);
-	if (targetUrls.length === 0) return null;
+  const targetUrls = await unionInboxRelayUrls(event, baseUrls);
+  if (targetUrls.length === 0) return null;
 
-	const { NDKRelaySet } = await import('@nostr-dev-kit/ndk');
-	const pool = (ndk as unknown as {
-		pool: {
-			getRelay: (url: string, autoConnect: boolean, createIfMissing: boolean) => NDKRelay | null;
-		};
-	}).pool;
+  const { NDKRelaySet } = await import('@nostr-dev-kit/ndk');
+  const pool = (
+    ndk as unknown as {
+      pool: {
+        getRelay: (url: string, autoConnect: boolean, createIfMissing: boolean) => NDKRelay | null;
+      };
+    }
+  ).pool;
 
-	const relays: NDKRelay[] = [];
-	for (const url of targetUrls) {
-		const relay = pool.getRelay(url, true, true);
-		if (relay) relays.push(relay);
-	}
+  const relays: NDKRelay[] = [];
+  for (const url of targetUrls) {
+    const relay = pool.getRelay(url, true, true);
+    if (relay) relays.push(relay);
+  }
 
-	if (relays.length === 0) return null;
+  if (relays.length === 0) return null;
 
-	// Best-effort parallel connect; failures are tolerated because the
-	// NDKRelaySet publish path will skip relays that aren't ready and we
-	// just want fast-quorum confirmation, not strict all-relay delivery.
-	await Promise.all(
-		relays.map((r) =>
-			(r as unknown as { connect: () => Promise<unknown> }).connect().catch(() => {})
-		)
-	);
-	await new Promise((resolve) => setTimeout(resolve, 100));
+  // Best-effort parallel connect; failures are tolerated because the
+  // NDKRelaySet publish path will skip relays that aren't ready and we
+  // just want fast-quorum confirmation, not strict all-relay delivery.
+  await Promise.all(
+    relays.map((r) =>
+      (r as unknown as { connect: () => Promise<unknown> }).connect().catch(() => {})
+    )
+  );
+  await new Promise((resolve) => setTimeout(resolve, 100));
 
-	return new NDKRelaySet(new Set(relays), ndk);
+  return new NDKRelaySet(new Set(relays), ndk);
 }

--- a/src/lib/nip65Routing.ts
+++ b/src/lib/nip65Routing.ts
@@ -1,0 +1,162 @@
+/**
+ * NIP-65 inbox routing helpers.
+ *
+ * Per NIP-65, when an event tags users via `p` tags (replies, mentions,
+ * reactions, zap requests), clients SHOULD include those users' *read*
+ * (inbox) relays in the publish target set so the events actually land
+ * where the recipients read them.
+ *
+ * This module is the single source of truth for that augmentation. It
+ * sits on top of `relayListCache` (which already implements SWR caching
+ * with IndexedDB persistence), so the typical lookup is a memory hit.
+ *
+ * Callers fall into two shapes:
+ *   1. Resilient queue (publishQueue.ts) — supplies its own base relay
+ *      URLs from the user's relayMode and unions inbox URLs in.
+ *   2. Direct publishers (publishReaction.ts, comments/postComment.ts) —
+ *      fall back to the NDK pool's relays when no base set is supplied,
+ *      with inbox URLs unioned on top.
+ *
+ * Both paths cap the total at MAX_PUBLISH_RELAYS to prevent a heavily
+ * p-tagged event from fanning out to dozens of relays. NDK uses fast-
+ * quorum confirmation on publish, so the cap is mostly a sanity bound.
+ */
+
+import type NDK from '@nostr-dev-kit/ndk';
+import type { NDKEvent, NDKRelaySet, NDKRelay } from '@nostr-dev-kit/ndk';
+
+const HEX64_RE = /^[0-9a-fA-F]{64}$/;
+
+/** Bound for the total relay set per publish. */
+export const MAX_PUBLISH_RELAYS = 16;
+
+/**
+ * Bound for inbox-cache lookup. Cache is SWR-backed, so the typical
+ * path resolves in microseconds. The bound is for the network-fetch
+ * branch — a hung discovery relay can't stall the publish path.
+ */
+export const INBOX_LOOKUP_TIMEOUT_MS = 1500;
+
+/**
+ * Resolve recipient inbox (kind:10002 read) relay URLs for every
+ * non-self pubkey in the event's `p` tags.
+ *
+ * Returns an empty array when:
+ *   - The event has no `p` tags (no recipient targeting)
+ *   - All `p` tags reference the event's own author
+ *   - The cache lookup fails / times out (additive feature, never blocks)
+ */
+export async function getRecipientInboxRelays(event: NDKEvent): Promise<string[]> {
+	const targets = new Set<string>();
+	for (const tag of event.tags) {
+		if (tag[0] !== 'p' || !tag[1] || !HEX64_RE.test(tag[1])) continue;
+		// Skip self — no need to publish to our own inbox.
+		if (event.pubkey && tag[1] === event.pubkey) continue;
+		targets.add(tag[1]);
+	}
+	if (targets.size === 0) return [];
+
+	try {
+		const { relayListCache } = await import('$lib/relayListCache');
+		const lookupPromise = relayListCache.getMany([...targets]);
+		const timeoutPromise = new Promise<Map<string, { read: string[] }>>((resolve) =>
+			setTimeout(() => resolve(new Map()), INBOX_LOOKUP_TIMEOUT_MS)
+		);
+		const lists = await Promise.race([lookupPromise, timeoutPromise]);
+
+		const inbox = new Set<string>();
+		for (const list of lists.values()) {
+			if (!list || !Array.isArray(list.read)) continue;
+			for (const url of list.read) inbox.add(url);
+		}
+		return [...inbox];
+	} catch (err) {
+		console.warn('[nip65Routing] inbox lookup failed:', err);
+		return [];
+	}
+}
+
+/**
+ * Build a deduped, capped list of relay URLs unioning a caller-supplied
+ * base set with NIP-65 inbox relays for the event's tagged recipients.
+ *
+ * Order in the result favors the base URLs (caller's intent) so when
+ * the cap kicks in, base relays are kept and inbox URLs may be dropped.
+ */
+export async function unionInboxRelayUrls(
+	event: NDKEvent,
+	baseUrls: string[]
+): Promise<string[]> {
+	const inboxUrls = await getRecipientInboxRelays(event);
+	const seen = new Set<string>();
+	const out: string[] = [];
+	for (const url of [...baseUrls, ...inboxUrls]) {
+		if (out.length >= MAX_PUBLISH_RELAYS) break;
+		if (seen.has(url)) continue;
+		seen.add(url);
+		out.push(url);
+	}
+	return out;
+}
+
+/**
+ * Build an NDKRelaySet for an event using NIP-65 inbox routing.
+ *
+ * When `baseUrls` is omitted, falls back to the NDK pool's current
+ * relay list (matches the prior `event.publish()` no-args behavior),
+ * and adds recipient inbox relays on top. Best-effort connect with a
+ * short settle delay so freshly-instantiated relays have a chance to
+ * open before we hand them to NDK's publish.
+ *
+ * Returns null when no relays could be resolved at all — caller should
+ * either fall back to `event.publish()` (NDK default) or surface an
+ * error, depending on context.
+ */
+export async function buildInboxAwareRelaySet(opts: {
+	event: NDKEvent;
+	ndk: NDK;
+	baseUrls?: string[];
+}): Promise<NDKRelaySet | null> {
+	const { event, ndk } = opts;
+
+	// Fall back to the pool's current relays when no base set is given.
+	let baseUrls = opts.baseUrls;
+	if (!baseUrls) {
+		baseUrls = [];
+		const poolRelays = (ndk as unknown as { pool?: { relays?: Map<string, unknown> } }).pool
+			?.relays;
+		if (poolRelays) {
+			for (const [url] of poolRelays) baseUrls.push(url);
+		}
+	}
+
+	const targetUrls = await unionInboxRelayUrls(event, baseUrls);
+	if (targetUrls.length === 0) return null;
+
+	const { NDKRelaySet } = await import('@nostr-dev-kit/ndk');
+	const pool = (ndk as unknown as {
+		pool: {
+			getRelay: (url: string, autoConnect: boolean, createIfMissing: boolean) => NDKRelay | null;
+		};
+	}).pool;
+
+	const relays: NDKRelay[] = [];
+	for (const url of targetUrls) {
+		const relay = pool.getRelay(url, true, true);
+		if (relay) relays.push(relay);
+	}
+
+	if (relays.length === 0) return null;
+
+	// Best-effort parallel connect; failures are tolerated because the
+	// NDKRelaySet publish path will skip relays that aren't ready and we
+	// just want fast-quorum confirmation, not strict all-relay delivery.
+	await Promise.all(
+		relays.map((r) =>
+			(r as unknown as { connect: () => Promise<unknown> }).connect().catch(() => {})
+		)
+	);
+	await new Promise((resolve) => setTimeout(resolve, 100));
+
+	return new NDKRelaySet(new Set(relays), ndk);
+}

--- a/src/lib/nostr.ts
+++ b/src/lib/nostr.ts
@@ -602,6 +602,7 @@ export function resetCircuitBreaker(url: string) {
 // ═══════════════════════════════════════════════════════════════
 
 export const GARDEN_RELAY_URL = 'wss://garden.zap.cooking';
+export const PANTRY_RELAY_URL = 'wss://pantry.zap.cooking';
 
 export type GardenRelayStatus = 'disconnected' | 'connecting' | 'authenticating' | 'connected' | 'error';
 

--- a/src/lib/publishQueue.ts
+++ b/src/lib/publishQueue.ts
@@ -28,6 +28,10 @@ const MAX_RETRY_DELAY = 30000; // 30 seconds
 const PUBLISH_TIMEOUT = 10000; // 10 seconds per relay
 const STALE_ITEM_AGE = 30 * 60 * 1000; // 30 minutes - auto-cleanup stale items
 
+// NIP-65 inbox routing — shared helper handles the kind:10002 lookup
+// + capping. See $lib/nip65Routing for the algorithm details.
+import { unionInboxRelayUrls } from '$lib/nip65Routing';
+
 /**
  * Represents a pending publish operation
  */
@@ -403,7 +407,37 @@ class PublishQueueManager {
   }
 
   /**
-   * Attempt to publish an event with extended timeout
+   * Resolve the base relay URL list for a given relayMode. The user's
+   * intent (e.g. "publish to pantry only") takes precedence — NIP-65
+   * augmentation in attemptPublish is layered on top, never replaces.
+   */
+  private getBaseRelayUrls(relayMode: PendingPublish['relayMode'], ndkInstance: any): string[] {
+    if (relayMode === 'garden') return ['wss://garden.zap.cooking'];
+    if (relayMode === 'pantry') return ['wss://pantry.zap.cooking'];
+    if (relayMode === 'garden-pantry') {
+      return ['wss://garden.zap.cooking', 'wss://pantry.zap.cooking'];
+    }
+    // 'all' — every relay currently in the pool.
+    const urls: string[] = [];
+    if (ndkInstance?.pool?.relays) {
+      for (const [url] of ndkInstance.pool.relays) urls.push(url);
+    }
+    return urls;
+  }
+
+  /**
+   * Attempt to publish an event with extended timeout.
+   *
+   * Relay set construction:
+   *   1. Base URLs from `relayMode` (garden / pantry / garden-pantry / all)
+   *   2. NIP-65 augmentation: for every non-self pubkey in the event's `p`
+   *      tags, add their published *read* (inbox) relays. This is what
+   *      makes replies / mentions / reactions / zaps reach the recipient.
+   *      Lookups go through `relayListCache` (SWR + IndexedDB), so they're
+   *      typically a memory hit; bounded by INBOX_LOOKUP_TIMEOUT_MS so
+   *      a slow network can't block publishing.
+   *   3. Dedupe + cap at MAX_PUBLISH_RELAYS so a heavily p-tagged post
+   *      can't fan out to 50+ relays.
    */
   private async attemptPublish(
     event: NDKEvent,
@@ -433,73 +467,40 @@ class PublishQueueManager {
     console.log(`[PublishQueue] Publishing event (kind ${event.kind}) with mode: ${relayMode}`);
     console.log(`[PublishQueue] Event ID: ${event.id}`);
 
-    let publishPromise: Promise<Set<any>>;
-    let targetRelays: string[] = [];
+    // 1. Base URLs from relay mode (user's intent takes precedence).
+    const baseUrls = this.getBaseRelayUrls(relayMode, ndkInstance);
 
-    if (relayMode === 'garden') {
-      targetRelays = ['wss://garden.zap.cooking'];
-      const relay = ndkInstance.pool.getRelay('wss://garden.zap.cooking', true, true);
-      await relay.connect();
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      const relaySet = new NDKRelaySet(new Set([relay]), ndkInstance);
-      publishPromise = event.publish(relaySet, PUBLISH_TIMEOUT);
-    } else if (relayMode === 'pantry') {
-      targetRelays = ['wss://pantry.zap.cooking'];
-      const relay = ndkInstance.pool.getRelay('wss://pantry.zap.cooking', true, true);
-      await relay.connect();
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      const relaySet = new NDKRelaySet(new Set([relay]), ndkInstance);
-      publishPromise = event.publish(relaySet, PUBLISH_TIMEOUT);
-    } else if (relayMode === 'garden-pantry') {
-      targetRelays = ['wss://garden.zap.cooking', 'wss://pantry.zap.cooking'];
-      const gardenRelay = ndkInstance.pool.getRelay('wss://garden.zap.cooking', true, true);
-      const pantryRelay = ndkInstance.pool.getRelay('wss://pantry.zap.cooking', true, true);
-      await Promise.all([gardenRelay.connect(), pantryRelay.connect()]);
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      const relaySet = new NDKRelaySet(new Set([gardenRelay, pantryRelay]), ndkInstance);
-      publishPromise = event.publish(relaySet, PUBLISH_TIMEOUT);
-    } else {
-      // 'all' mode - get relay URLs from pool and use getRelay() to ensure proper initialization
-      console.log('[PublishQueue] Using "all" mode');
+    // 2. Union with NIP-65 recipient inbox relays. Capped at the helper's
+    //    MAX_PUBLISH_RELAYS so a heavily p-tagged post stays bounded.
+    const targetRelays = await unionInboxRelayUrls(event, baseUrls);
 
-      // Collect relay URLs from the pool
-      const relayUrls: string[] = [];
-      if (ndkInstance.pool && ndkInstance.pool.relays) {
-        for (const [url] of ndkInstance.pool.relays) {
-          relayUrls.push(url);
-        }
-      }
-
-      console.log(`[PublishQueue] Pool has ${relayUrls.length} relays:`, relayUrls);
-
-      if (relayUrls.length === 0) {
-        throw new Error('No relays available. Please check your internet connection.');
-      }
-
-      // Use getRelay() with autoConnect=true, createIfMissing=true to get properly initialized relays
-      const relaysToPublish: any[] = [];
-      for (const url of relayUrls) {
-        const relay = ndkInstance.pool.getRelay(url, true, true);
-        if (relay) {
-          relaysToPublish.push(relay);
-          targetRelays.push(url);
-        }
-      }
-
-      // Ensure connections are established
-      await Promise.all(relaysToPublish.map((r) => r.connect().catch(() => {})));
-      await new Promise((resolve) => setTimeout(resolve, 100));
-
-      // Log connection states
-      for (const relay of relaysToPublish) {
-        const status = relay.connectivity?.status;
-        const statusName = status === 1 ? 'OPEN' : status === 0 ? 'CONNECTING' : 'CLOSED';
-        console.log(`[PublishQueue] Relay ${relay.url}: ${statusName}`);
-      }
-
-      const relaySet = new NDKRelaySet(new Set(relaysToPublish), ndkInstance);
-      publishPromise = event.publish(relaySet, PUBLISH_TIMEOUT);
+    if (targetRelays.length === 0) {
+      throw new Error('No relays available. Please check your internet connection.');
     }
+
+    console.log(
+      `[PublishQueue] base=${baseUrls.length} → ${targetRelays.length} relays after NIP-65 union`
+    );
+
+    // Materialize relays via getRelay() with autoConnect=true, createIfMissing=true
+    const relaysToPublish: any[] = [];
+    for (const url of targetRelays) {
+      const relay = ndkInstance.pool.getRelay(url, true, true);
+      if (relay) relaysToPublish.push(relay);
+    }
+
+    // Best-effort parallel connect — failures don't block the publish.
+    await Promise.all(relaysToPublish.map((r) => r.connect().catch(() => {})));
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    for (const relay of relaysToPublish) {
+      const status = relay.connectivity?.status;
+      const statusName = status === 1 ? 'OPEN' : status === 0 ? 'CONNECTING' : 'CLOSED';
+      console.log(`[PublishQueue] Relay ${relay.url}: ${statusName}`);
+    }
+
+    const relaySet = new NDKRelaySet(new Set(relaysToPublish), ndkInstance);
+    const publishPromise = event.publish(relaySet, PUBLISH_TIMEOUT);
 
     console.log(`[PublishQueue] Publishing to relays:`, targetRelays);
     console.log(`[PublishQueue] Awaiting publish result (timeout: ${PUBLISH_TIMEOUT + 5000}ms)...`);

--- a/src/lib/publishQueue.ts
+++ b/src/lib/publishQueue.ts
@@ -31,6 +31,7 @@ const STALE_ITEM_AGE = 30 * 60 * 1000; // 30 minutes - auto-cleanup stale items
 // NIP-65 inbox routing — shared helper handles the kind:10002 lookup
 // + capping. See $lib/nip65Routing for the algorithm details.
 import { unionInboxRelayUrls } from '$lib/nip65Routing';
+import { GARDEN_RELAY_URL, PANTRY_RELAY_URL } from '$lib/nostr';
 
 /**
  * Represents a pending publish operation
@@ -410,13 +411,14 @@ class PublishQueueManager {
    * Resolve the base relay URL list for a given relayMode. The user's
    * intent (e.g. "publish to pantry only") takes precedence — NIP-65
    * augmentation in attemptPublish is layered on top, never replaces.
+   *
+   * Relay URLs come from the canonical exports in $lib/nostr so changes
+   * propagate everywhere instead of drifting between hardcoded literals.
    */
   private getBaseRelayUrls(relayMode: PendingPublish['relayMode'], ndkInstance: any): string[] {
-    if (relayMode === 'garden') return ['wss://garden.zap.cooking'];
-    if (relayMode === 'pantry') return ['wss://pantry.zap.cooking'];
-    if (relayMode === 'garden-pantry') {
-      return ['wss://garden.zap.cooking', 'wss://pantry.zap.cooking'];
-    }
+    if (relayMode === 'garden') return [GARDEN_RELAY_URL];
+    if (relayMode === 'pantry') return [PANTRY_RELAY_URL];
+    if (relayMode === 'garden-pantry') return [GARDEN_RELAY_URL, PANTRY_RELAY_URL];
     // 'all' — every relay currently in the pool.
     const urls: string[] = [];
     if (ndkInstance?.pool?.relays) {

--- a/src/lib/reactions/publishReaction.ts
+++ b/src/lib/reactions/publishReaction.ts
@@ -3,6 +3,7 @@ import { NDKEvent } from '@nostr-dev-kit/ndk';
 import type { TargetType } from '$lib/types/reactions';
 import { addClientTagToEvent } from '$lib/nip89';
 import { getAuthManager } from '$lib/authManager';
+import { buildInboxAwareRelaySet } from '$lib/nip65Routing';
 
 export interface PublishReactionOptions {
   ndk: NDK;
@@ -60,12 +61,19 @@ export async function publishReaction(
 
     // Sign and publish with timeout
     await reactionEvent.sign();
-    
-    const publishPromise = reactionEvent.publish();
+
+    // NIP-65 inbox routing — fan out to the reacted-to author's read
+    // relays so the reaction lands where they read. Falls back to the
+    // NDK pool's relays when the recipient hasn't published a kind:10002
+    // (cache returns no inbox URLs, and the pool itself is the base).
+    const relaySet =
+      (await buildInboxAwareRelaySet({ event: reactionEvent, ndk })) ?? undefined;
+
+    const publishPromise = reactionEvent.publish(relaySet);
     const timeoutPromise = new Promise<never>((_, reject) => {
       setTimeout(() => reject(new Error('Publishing timeout - signer may not be responding')), 30000);
     });
-    
+
     await Promise.race([publishPromise, timeoutPromise]);
 
     console.log(`Published reaction ${emoji} to ${targetType}:`, reactionEvent.id);


### PR DESCRIPTION
## Summary
Closes **R9** from \`docs/perf/2026-04-review.md\` (#341). Today, when a user replies to / mentions / reacts on / comments on someone's note, those events don't reach the recipient's NIP-65 inbox relays (kind:10002 read markers). The cache layer (\`relayListCache.ts\`) was already fully wired for read flows; nothing on the publish path consulted it.

This PR adds inbox routing to all three publish paths that fan out to specific recipients.

## Approach
New shared module \`src/lib/nip65Routing.ts\`:

- \`getRecipientInboxRelays(event)\` — extracts non-self 64-hex pubkeys from \`p\` tags, looks them up via \`relayListCache\` (SWR + IndexedDB; typical lookup is a memory hit). Bounded by 1.5s so a hung discovery relay can't stall publishing.
- \`unionInboxRelayUrls(event, baseUrls)\` — unions caller-supplied base URLs with inbox URLs, dedupes, caps at **16 relays total** so a heavily p-tagged post stays bounded. Base URLs are kept first so the user's chosen \`relayMode\` survives the cap.
- \`buildInboxAwareRelaySet(opts)\` — convenience for direct publishers that want an \`NDKRelaySet\`. Falls back to the NDK pool's relays when no base set is supplied (matches the prior \`event.publish()\` no-args default), with inbox URLs added on top.

## Wired into

1. **\`publishQueue.attemptPublish\`** — refactors the four-mode branched logic (\`garden\` / \`pantry\` / \`garden-pantry\` / \`all\`) into a unified URL-collection step. Mode still picks base relays exactly as today; inbox URLs are layered on. PostComposer (replies, mentions) and PollDisplay (votes) get the fix automatically.
2. **\`publishReaction.ts\` (kind 7)** — replaces \`reactionEvent.publish()\` with a publish to the inbox-aware set. Reactions now reach the reacted-to author's read relays.
3. **\`comments/postComment.ts\` (kind 1 / 1111)** — both signing strategies now publish to an inbox-aware set built from the event's full \`p\`-tag set (parent author + thread participants + @-mentions).

## Behavior is purely additive
- Events with no \`p\` tags fall through to existing relay strategy unchanged.
- Cache misses / lookup timeouts fall back to base relays only — inbox lookup never blocks the publish.
- \`relayMode\` selection still takes precedence; inbox URLs are augmentation, not replacement.

## Files changed
- **new** \`src/lib/nip65Routing.ts\` — shared helper (~150 lines)
- \`src/lib/publishQueue.ts\` — refactor 4-mode branches into unified flow + inbox augmentation
- \`src/lib/reactions/publishReaction.ts\` — publish to inbox-aware set
- \`src/lib/comments/postComment.ts\` — publish to inbox-aware set in both signing strategies

## Test plan
- [ ] Reply on a post from a user whose kind:10002 lists relays we don't connect to → reply lands on their inbox.
- [ ] React with an emoji → kind 7 lands on author's inbox.
- [ ] Comment (NIP-22 kind 1111) on a recipe → comment lands on author's inbox.
- [ ] Publishing a recipe (kind 30023, no \`p\` tags) — relay set unchanged from prior behavior.
- [ ] User without a kind:10002 — falls through to base relay set, no errors.
- [ ] Heavily p-tagged thread (e.g. 8 participants) — total relay count stays at or below 16.
- [ ] Discovery relay is slow / down — publish still succeeds within a few seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)