### PR TITLE
feat(pack): cookbook content normalization layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.327",
+  "version": "4.2.328",
   "private": true,
   "scripts": {
     "dev": "vite dev",
@@ -9,6 +9,8 @@
     "build:mobile": "SKIP_ENV_VALIDATION=1 ADAPTER=static vite build",
     "build:android": "SKIP_ENV_VALIDATION=1 CAPACITOR=true vite build",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "dev:cloudflare": "pnpm build && wrangler pages dev .svelte-kit/cloudflare --compatibility-date=2025-01-01 --compatibility-flags=nodejs_compat",
     "test:og": "pnpm build && wrangler pages dev .svelte-kit/cloudflare --compatibility-date=2025-01-01 --compatibility-flags=nodejs_compat",
     "test:notification": "curl \"http://localhost:5174/api/cron/test-notification?npub=npub1aeh2zw4elewy5682lxc6xnlqzjnxksq303gwu2npfaxd49vmde6qcq4nwx\"",
@@ -111,6 +113,7 @@
     "typescript": "^5.0.0",
     "vite": "^5.0.0",
     "vite-plugin-node-polyfills": "^0.24.0",
+    "vitest": "^2",
     "wrangler": "^4.42.0"
   },
   "packageManager": "pnpm@9.12.1+sha512.e5a7e52a4183a02d5931057f7a0dbff9d5e9ce3161e33fa68ae392125b79282a8a8a470a51dfc8a0ed86221442eb2fb57019b0990ed24fab519bf0e1bc5ccfc4"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.325",
+  "version": "4.2.326",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.326",
+  "version": "4.2.327",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,6 +261,9 @@ importers:
       vite-plugin-node-polyfills:
         specifier: ^0.24.0
         version: 0.24.0(rollup@4.50.2)(vite@5.4.20(@types/node@18.19.64)(lightningcss@1.30.1))
+      vitest:
+        specifier: ^2
+        version: 2.1.9(@types/node@18.19.64)(lightningcss@1.30.1)
       wrangler:
         specifier: ^4.42.0
         version: 4.42.0(@cloudflare/workers-types@4.20251217.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -1651,6 +1654,35 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
   '@xml-tools/parser@1.0.11':
     resolution: {integrity: sha512-aKqQ077XnR+oQtHJlrAflaZaL7qZsulWc/i/ZEooar5JiWj1eLt0+Wg28cpa+XLney107wXqneC+oG1IZvxkTA==}
 
@@ -1773,6 +1805,10 @@ packages:
 
   assert@2.1.0:
     resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -1970,6 +2006,10 @@ packages:
   builtin-status-codes@3.0.0:
     resolution: {integrity: sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   cacache@16.1.3:
     resolution: {integrity: sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -2005,6 +2045,10 @@ packages:
     resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
     engines: {node: '>=10.0.0'}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -2012,6 +2056,10 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chevrotain@7.1.1:
     resolution: {integrity: sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==}
@@ -2313,6 +2361,10 @@ packages:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -2479,6 +2531,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -2608,6 +2663,10 @@ packages:
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.1:
     resolution: {integrity: sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==}
@@ -3257,6 +3316,9 @@ packages:
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -3750,8 +3812,15 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   pbkdf2@3.1.5:
     resolution: {integrity: sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==}
@@ -4285,6 +4354,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -4368,9 +4440,15 @@ packages:
     resolution: {integrity: sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stackblur-canvas@2.7.0:
     resolution: {integrity: sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==}
     engines: {node: '>=0.1.14'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stoppable@1.1.0:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
@@ -4584,6 +4662,24 @@ packages:
     resolution: {integrity: sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==}
     engines: {node: '>=0.6.0'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
   tmp@0.2.5:
     resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
     engines: {node: '>=14.14'}
@@ -4788,6 +4884,11 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite-plugin-node-polyfills@0.24.0:
     resolution: {integrity: sha512-GA9QKLH+vIM8NPaGA+o2t8PDfFUl32J8rUp1zQfMKVJQiNkOX4unE51tR6ppl6iKw5yOrDAdSH7r/UIFLCVhLw==}
     peerDependencies:
@@ -4832,6 +4933,31 @@ packages:
       vite:
         optional: true
 
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vm-browserify@1.1.2:
     resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
 
@@ -4868,6 +4994,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wide-align@1.1.5:
@@ -6456,6 +6587,46 @@ snapshots:
       - rollup
       - supports-color
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.20(@types/node@18.19.64)(lightningcss@1.30.1))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.20(@types/node@18.19.64)(lightningcss@1.30.1)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   '@xml-tools/parser@1.0.11':
     dependencies:
       chevrotain: 7.1.1
@@ -6562,6 +6733,8 @@ snapshots:
       object-is: 1.1.6
       object.assign: 4.1.7
       util: 0.12.5
+
+  assertion-error@2.0.1: {}
 
   astral-regex@2.0.0: {}
 
@@ -6770,6 +6943,8 @@ snapshots:
 
   builtin-status-codes@3.0.0: {}
 
+  cac@6.7.14: {}
+
   cacache@16.1.3:
     dependencies:
       '@npmcli/fs': 2.1.2
@@ -6834,6 +7009,14 @@ snapshots:
       svg-pathdata: 6.0.3
     optional: true
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -6844,6 +7027,8 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  check-error@2.1.3: {}
 
   chevrotain@7.1.1:
     dependencies:
@@ -7178,6 +7363,8 @@ snapshots:
     dependencies:
       mimic-response: 3.1.0
 
+  deep-eql@5.0.2: {}
+
   deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
@@ -7340,6 +7527,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@1.7.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -7557,6 +7746,8 @@ snapshots:
   exit-hook@2.2.1: {}
 
   expand-template@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   exponential-backoff@3.1.1: {}
 
@@ -8200,6 +8391,8 @@ snapshots:
 
   lodash@4.17.21: {}
 
+  loupe@3.2.1: {}
+
   lru-cache@10.4.3: {}
 
   lru-cache@11.2.4: {}
@@ -8744,7 +8937,11 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   pbkdf2@3.1.5:
     dependencies:
@@ -9372,6 +9569,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   simple-concat@1.0.1: {}
@@ -9464,8 +9663,12 @@ snapshots:
     dependencies:
       minipass: 3.3.6
 
+  stackback@0.0.2: {}
+
   stackblur-canvas@2.7.0:
     optional: true
+
+  std-env@3.10.0: {}
 
   stoppable@1.1.0: {}
 
@@ -9713,6 +9916,16 @@ snapshots:
     dependencies:
       setimmediate: 1.0.5
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
+
   tmp@0.2.5: {}
 
   to-buffer@1.2.2:
@@ -9890,6 +10103,24 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
+  vite-node@2.1.9(@types/node@18.19.64)(lightningcss@1.30.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.20(@types/node@18.19.64)(lightningcss@1.30.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-plugin-node-polyfills@0.24.0(rollup@4.50.2)(vite@5.4.20(@types/node@18.19.64)(lightningcss@1.30.1)):
     dependencies:
       '@rollup/plugin-inject': 5.0.5(rollup@4.50.2)
@@ -9911,6 +10142,41 @@ snapshots:
   vitefu@0.2.5(vite@5.4.20(@types/node@18.19.64)(lightningcss@1.30.1)):
     optionalDependencies:
       vite: 5.4.20(@types/node@18.19.64)(lightningcss@1.30.1)
+
+  vitest@2.1.9(@types/node@18.19.64)(lightningcss@1.30.1):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.20(@types/node@18.19.64)(lightningcss@1.30.1))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.20(@types/node@18.19.64)(lightningcss@1.30.1)
+      vite-node: 2.1.9(@types/node@18.19.64)(lightningcss@1.30.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 18.19.64
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vm-browserify@1.1.2: {}
 
@@ -9962,6 +10228,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wide-align@1.1.5:
     dependencies:

--- a/src/lib/cookbookExport.ts
+++ b/src/lib/cookbookExport.ts
@@ -769,14 +769,30 @@ function drawRecipePages(
 /**
  * Footer: pack title (left) + page number (right). Replaces the prior
  * "Created with Zap Cooking" center text — the cover already carries
- * the brand prominently, so per-page repetition felt noisy. Title is
- * truncated to fit alongside the page number without crowding.
+ * the brand prominently, so per-page repetition felt noisy.
+ *
+ * Title truncation is width-measured (via splitTextToSize) rather than
+ * a hard character cap, so wide-glyph titles can't collide with the
+ * right-aligned page number and narrow-glyph titles aren't cut short.
+ * Reserves ~36pt for the page number column (covers up to 4 digits at
+ * 9pt with breathing room).
  */
 function addFooters(doc: JsPdfDoc, packTitle: string, fromPage: number) {
 	const total = doc.getNumberOfPages();
 	const trimmedTitle = (packTitle || '').trim();
-	let label = trimmedTitle;
-	if (label.length > 60) label = label.slice(0, 57) + '...';
+
+	// Width-fit the title against the available footer column.
+	doc.setFont('helvetica', 'normal');
+	doc.setFontSize(9);
+	const PAGE_NUMBER_RESERVE = 36;
+	const maxTitleWidth = CONTENT_RIGHT - MARGIN_LEFT - PAGE_NUMBER_RESERVE;
+	let label = '';
+	if (trimmedTitle && maxTitleWidth > 0) {
+		const fittedLines = doc.splitTextToSize(trimmedTitle, maxTitleWidth);
+		// First line of the fit; ellipsis when the title overflowed.
+		label = fittedLines.length > 1 ? `${fittedLines[0]}...` : fittedLines[0];
+	}
+
 	for (let p = fromPage; p <= total; p++) {
 		doc.setPage(p);
 		doc.setFont('helvetica', 'normal');

--- a/src/lib/cookbookExport.ts
+++ b/src/lib/cookbookExport.ts
@@ -23,7 +23,7 @@
  */
 
 import type { NDKEvent } from '@nostr-dev-kit/ndk';
-import { extractRecipeDetails, parseMarkdownForEditing } from '$lib/parser';
+import { normalizeRecipeForCookbook } from '$lib/cookbookNormalize';
 
 export interface CookbookRecipe {
 	id: string; // a-tag for stable identity
@@ -58,29 +58,14 @@ export interface BuildResult {
 	skipped: { id: string; reason: string }[];
 }
 
-/** Convert an NDKEvent (kind 30023) to the parsed CookbookRecipe shape. */
+/**
+ * Convert an NDKEvent (kind 30023) to the parsed CookbookRecipe shape.
+ * Delegates to the normalization layer, which handles markdown stripping,
+ * duplicate-section removal, placeholder-direction detection, and other
+ * print-readiness cleanup.
+ */
 export function recipeEventToCookbookRecipe(event: NDKEvent, creatorName?: string): CookbookRecipe {
-	const tags = event.tags || [];
-	const find = (name: string) => tags.find((t) => t[0] === name)?.[1];
-	const title = find('title') || find('d') || 'Untitled recipe';
-	const image = find('image') || undefined;
-	const dTag = find('d') || event.id || title;
-
-	const parsed = parseMarkdownForEditing(event.content || '');
-	const details = extractRecipeDetails(event.content || '');
-
-	return {
-		id: `${event.kind ?? 30023}:${event.pubkey}:${dTag}`,
-		title,
-		image,
-		creatorName,
-		prepTime: parsed.information?.prepTime || details.prepTime || undefined,
-		cookTime: parsed.information?.cookTime || details.cookTime || undefined,
-		servings: parsed.information?.servings || details.servings || undefined,
-		ingredients: parsed.ingredients || [],
-		directions: parsed.directions || [],
-		chefNotes: parsed.chefNotes
-	};
+	return normalizeRecipeForCookbook(event, creatorName);
 }
 
 /** Strip emoji + control chars jsPDF's default fonts can't render. */
@@ -259,11 +244,12 @@ export async function buildCookbookPdf(opts: BuildOptions): Promise<BuildResult>
 		);
 	}
 
-	// Add small "Created with Zap Cooking" footer to every page except cover
+	// Footer (pack title left, page number right) and minimal running
+	// header (hairline rule only) on every non-cover page. Cover keeps
+	// the prominent brand mark; per-page chrome stays subtle.
 	const nonCoverStart = opts.includeCover ? 2 : 1;
-	addFooters(doc, nonCoverStart);
-	// Running header (pack title + brand mark) on every non-cover page
-	addRunningHeaders(doc, sanitizeForPdf(opts.title), brandLogoDataUri, nonCoverStart);
+	addFooters(doc, sanitizeForPdf(opts.title), nonCoverStart);
+	addRunningHeaders(doc, nonCoverStart);
 
 	const blob = doc.output('blob') as unknown as Blob;
 	return { blob, included, skipped };
@@ -754,68 +740,66 @@ function drawRecipePages(
 				doc.text(lines[j], MARGIN_LEFT + 28, y);
 				y += 16;
 			}
-			y += 6;
+			// Inter-step spacing — bumped from 6 to 12 so long, dense
+			// directions read more like a recipe and less like a wall of
+			// text. The orphan guard above already handles page-bottom.
+			y += 12;
 		}
+	} else {
+		// No usable directions in the source. Show a clear, italicized
+		// fallback so the recipe page doesn't end mid-thought after the
+		// ingredients list. Same orphan guard as above.
+		if (y > PAGE_BOTTOM - 40) {
+			y = newPage();
+		}
+		y += 4;
+		sectionHeading('Directions');
+		doc.setFont('helvetica', 'italic');
+		doc.setFontSize(11);
+		doc.setTextColor(110, 100, 95);
+		doc.text(
+			'Directions were not included in the original recipe.',
+			MARGIN_LEFT,
+			y
+		);
+		y += 16;
 	}
 }
 
-function addFooters(doc: JsPdfDoc, fromPage: number) {
+/**
+ * Footer: pack title (left) + page number (right). Replaces the prior
+ * "Created with Zap Cooking" center text — the cover already carries
+ * the brand prominently, so per-page repetition felt noisy. Title is
+ * truncated to fit alongside the page number without crowding.
+ */
+function addFooters(doc: JsPdfDoc, packTitle: string, fromPage: number) {
 	const total = doc.getNumberOfPages();
+	const trimmedTitle = (packTitle || '').trim();
+	let label = trimmedTitle;
+	if (label.length > 60) label = label.slice(0, 57) + '...';
 	for (let p = fromPage; p <= total; p++) {
 		doc.setPage(p);
 		doc.setFont('helvetica', 'normal');
 		doc.setFontSize(9);
 		doc.setTextColor(160, 150, 145);
-		doc.text('Created with Zap Cooking', CENTER_X, PAGE_H - 28, { align: 'center' });
+		if (label) {
+			doc.text(label, MARGIN_LEFT, PAGE_H - 28);
+		}
 		doc.text(String(p), CONTENT_RIGHT, PAGE_H - 28, { align: 'right' });
 	}
 }
 
 /**
- * Subtle running header — pack title (left) + Zap Cooking logo (right),
- * with a hairline rule below. Skipped for the cover (which has its own
- * typography). Drawn after all pages exist so we iterate by page number.
- *
- * The logo is added with a stable alias ('zc-brand') so jsPDF dedupes
- * the image data across every page rather than embedding it N times.
+ * Minimal running header — a single hairline rule at the top of every
+ * non-cover page. The previous version repeated the pack title and a
+ * brand icon on every page, which compounded against the same title
+ * now in the footer. Visual separator only; identity content lives
+ * on the cover and in the footer.
  */
-function addRunningHeaders(
-	doc: JsPdfDoc,
-	packTitle: string,
-	brandLogoDataUri: string | null,
-	fromPage: number
-) {
-	const trimmed = (packTitle || '').trim();
-	if (!trimmed && !brandLogoDataUri) return;
+function addRunningHeaders(doc: JsPdfDoc, fromPage: number) {
 	const total = doc.getNumberOfPages();
-	const logoSize = 12;
-	const logoFmt = brandLogoDataUri ? imageFormatFromDataUri(brandLogoDataUri) : 'PNG';
 	for (let p = fromPage; p <= total; p++) {
 		doc.setPage(p);
-		if (trimmed) {
-			doc.setFont('helvetica', 'normal');
-			doc.setFontSize(8);
-			doc.setTextColor(160, 150, 145);
-			// Truncate over-long titles so they don't collide with the logo.
-			let label = trimmed;
-			if (label.length > 50) label = label.slice(0, 47) + '...';
-			doc.text(label, MARGIN_LEFT, 38, { charSpace: 1.5 } as any);
-		}
-		if (brandLogoDataUri) {
-			try {
-				doc.addImage(
-					brandLogoDataUri,
-					logoFmt,
-					CONTENT_RIGHT - logoSize,
-					30,
-					logoSize,
-					logoSize,
-					'zc-brand'
-				);
-			} catch {
-				// Logo failed — header text alone is enough.
-			}
-		}
 		doc.setDrawColor(230, 220, 215);
 		doc.setLineWidth(0.4);
 		doc.line(MARGIN_LEFT, 46, CONTENT_RIGHT, 46);

--- a/src/lib/cookbookExport.ts
+++ b/src/lib/cookbookExport.ts
@@ -628,30 +628,40 @@ function drawRecipePages(
 		y += 20;
 	}
 
-	// Chef's notes (italic, indented quote-style)
+	// Chef's notes (italic, indented quote-style). Split on blank-line
+	// boundaries so multi-paragraph notes don't render as a wall of
+	// text — each paragraph wraps independently with 8pt of breathing
+	// room between paragraphs.
 	if (r.chefNotes) {
-		y += 4;
-		doc.setFont('helvetica', 'italic');
-		doc.setFontSize(11);
-		doc.setTextColor(85, 75, 70);
-		// Subtle left rule
-		const notesLines = doc.splitTextToSize(r.chefNotes, CONTENT_W - 18);
-		const notesStartY = y;
-		for (const line of notesLines) {
-			if (y > PAGE_BOTTOM) {
-				y = newPage();
-				doc.setFont('helvetica', 'italic');
-				doc.setFontSize(11);
-				doc.setTextColor(85, 75, 70);
+		const paragraphs = r.chefNotes.split(/\n\s*\n+/).map((p) => p.trim()).filter(Boolean);
+		if (paragraphs.length > 0) {
+			y += 4;
+			doc.setFont('helvetica', 'italic');
+			doc.setFontSize(11);
+			doc.setTextColor(85, 75, 70);
+			const notesStartY = y;
+			for (let p = 0; p < paragraphs.length; p++) {
+				const lines = doc.splitTextToSize(paragraphs[p], CONTENT_W - 18);
+				for (const line of lines) {
+					if (y > PAGE_BOTTOM) {
+						y = newPage();
+						doc.setFont('helvetica', 'italic');
+						doc.setFontSize(11);
+						doc.setTextColor(85, 75, 70);
+					}
+					doc.text(line, MARGIN_LEFT + 14, y);
+					y += 15;
+				}
+				// Inter-paragraph spacing — skip after the last paragraph
+				// so the trailing quote rule sits flush with the text.
+				if (p < paragraphs.length - 1) y += 8;
 			}
-			doc.text(line, MARGIN_LEFT + 14, y);
-			y += 15;
+			// Draw the quote rule once at the end (covers all paragraphs).
+			doc.setDrawColor(220, 200, 190);
+			doc.setLineWidth(1.5);
+			doc.line(MARGIN_LEFT + 2, notesStartY - 10, MARGIN_LEFT + 2, y - 10);
+			y += 10;
 		}
-		// Draw the quote rule once at the end (covers wrapped lines).
-		doc.setDrawColor(220, 200, 190);
-		doc.setLineWidth(1.5);
-		doc.line(MARGIN_LEFT + 2, notesStartY - 10, MARGIN_LEFT + 2, y - 10);
-		y += 10;
 	}
 
 	const sectionHeading = (label: string) => {

--- a/src/lib/cookbookNormalize.test.ts
+++ b/src/lib/cookbookNormalize.test.ts
@@ -1,0 +1,507 @@
+/**
+ * Tests for the cookbook content normalization layer.
+ *
+ * These lock in the contract between raw recipe input (the markdown
+ * users write on relays) and the print-ready data shape the PDF
+ * renderer consumes. They exist so that future iteration on the PDF
+ * layout can't silently regress the formatting cleanup.
+ *
+ * Scope is the normalizer only — no PDF rendering, no jsPDF, no UI.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { NDKEvent } from '@nostr-dev-kit/ndk';
+import {
+  cleanDirectionLine,
+  cleanIngredientLine,
+  cleanNotesBlock,
+  cleanNotesIntoParagraphs,
+  isPlaceholderDirection,
+  normalizeRecipeForCookbook,
+  stripDuplicateRecipeBlocks,
+  stripMarkdownFormatting
+} from './cookbookNormalize';
+
+/**
+ * Build a minimal NDKEvent-shaped object from a recipe markdown string
+ * + tag list. Only the fields the normalizer reads are populated.
+ */
+function makeRecipeEvent(opts: {
+  pubkey?: string;
+  kind?: number;
+  content: string;
+  tags?: string[][];
+}): NDKEvent {
+  return {
+    kind: opts.kind ?? 30023,
+    pubkey: opts.pubkey ?? 'a'.repeat(64),
+    content: opts.content,
+    tags: opts.tags ?? [],
+    id: 'test-event-id',
+    sig: '',
+    created_at: 0
+  } as unknown as NDKEvent;
+}
+
+// ─── Phase 2: markdown cleanup ────────────────────────────────
+
+describe('stripMarkdownFormatting', () => {
+  it('strips bold (**)', () => {
+    expect(stripMarkdownFormatting('**Optional** flaky salt')).toBe('Optional flaky salt');
+  });
+
+  it('strips bold (__)', () => {
+    expect(stripMarkdownFormatting('__Optional__ flaky salt')).toBe('Optional flaky salt');
+  });
+
+  it('strips italic (*)', () => {
+    expect(stripMarkdownFormatting('use *good* olive oil')).toBe('use good olive oil');
+  });
+
+  it('strips inline code', () => {
+    expect(stripMarkdownFormatting('run `pnpm test` first')).toBe('run pnpm test first');
+  });
+
+  it('strips strikethrough', () => {
+    expect(stripMarkdownFormatting('~~deprecated~~ ingredient')).toBe('deprecated ingredient');
+  });
+
+  it('strips heading markers', () => {
+    expect(stripMarkdownFormatting('## Ingredients')).toBe('Ingredients');
+    expect(stripMarkdownFormatting('### Notes')).toBe('Notes');
+  });
+
+  it('unwraps non-localhost links to their label', () => {
+    expect(stripMarkdownFormatting('[Bitcoin Beans](https://example.com)')).toBe('Bitcoin Beans');
+  });
+
+  it('drops localhost links entirely (label + URL)', () => {
+    expect(stripMarkdownFormatting('[demo](http://localhost:5173/recipe/123)')).toBe('');
+    expect(stripMarkdownFormatting('[x](http://127.0.0.1:8080)')).toBe('');
+    expect(stripMarkdownFormatting('[y](http://0.0.0.0/test)')).toBe('');
+  });
+
+  it('drops bare localhost URLs', () => {
+    expect(stripMarkdownFormatting('see http://127.0.0.1:8080/test for details')).toBe(
+      'see for details'
+    );
+    expect(stripMarkdownFormatting('http://localhost:5173/recipe/123')).toBe('');
+  });
+
+  it('collapses double-dashes to a single hyphen', () => {
+    expect(stripMarkdownFormatting('Cook for 1--2 minutes')).toBe('Cook for 1-2 minutes');
+  });
+
+  it('collapses internal whitespace but preserves newlines', () => {
+    expect(stripMarkdownFormatting('a   b\n\nc   d')).toBe('a b\n\nc d');
+  });
+
+  it('preserves blank-line paragraph breaks', () => {
+    const input = 'first paragraph\n\nsecond paragraph';
+    expect(stripMarkdownFormatting(input)).toBe(input);
+  });
+
+  it('collapses 3+ blank lines to a single blank line', () => {
+    expect(stripMarkdownFormatting('first\n\n\n\nsecond')).toBe('first\n\nsecond');
+  });
+
+  it('preserves snake_case identifiers (italic _ should not match)', () => {
+    expect(stripMarkdownFormatting('use my_secret_sauce variable')).toBe('use my_secret_sauce variable');
+  });
+
+  it('handles empty / nullish input', () => {
+    expect(stripMarkdownFormatting('')).toBe('');
+    expect(stripMarkdownFormatting(undefined as unknown as string)).toBe('');
+  });
+});
+
+// ─── Phase 3: ingredient cleaning ─────────────────────────────
+
+describe('cleanIngredientLine', () => {
+  it('strips leading dash bullets', () => {
+    expect(cleanIngredientLine('- 1 cup sugar')).toBe('1 cup sugar');
+  });
+
+  it('strips leading bullet character', () => {
+    expect(cleanIngredientLine('• 2 eggs')).toBe('2 eggs');
+  });
+
+  it('strips leading asterisk bullets', () => {
+    expect(cleanIngredientLine('* 1 tbsp olive oil')).toBe('1 tbsp olive oil');
+  });
+
+  it('trims surrounding whitespace and collapses internal whitespace', () => {
+    expect(cleanIngredientLine('  - 3 tbsp   honey  ')).toBe('3 tbsp honey');
+  });
+
+  it('strips leading numeric prefix when present', () => {
+    expect(cleanIngredientLine('1. flour')).toBe('flour');
+    expect(cleanIngredientLine('1) flour')).toBe('flour');
+  });
+
+  it('strips inline markdown emphasis', () => {
+    expect(cleanIngredientLine('- **Optional** flaky salt')).toBe('Optional flaky salt');
+  });
+
+  it('drops localhost link wrappers', () => {
+    expect(cleanIngredientLine('- [demo](http://localhost:5173) cinnamon')).toBe('cinnamon');
+  });
+});
+
+// ─── Phase 4: direction cleaning ──────────────────────────────
+
+describe('cleanDirectionLine', () => {
+  it('strips leading numeric prefix (period)', () => {
+    expect(cleanDirectionLine('1. Mix ingredients')).toBe('Mix ingredients');
+  });
+
+  it('strips leading numeric prefix (paren)', () => {
+    expect(cleanDirectionLine('  2) Bake at 350')).toBe('Bake at 350');
+  });
+
+  it('strips leading bullet markers', () => {
+    expect(cleanDirectionLine('- Whisk thoroughly')).toBe('Whisk thoroughly');
+    expect(cleanDirectionLine('• Set aside to rest')).toBe('Set aside to rest');
+  });
+
+  it('strips inline markdown emphasis', () => {
+    expect(cleanDirectionLine('1. Add **half** the sugar')).toBe('Add half the sugar');
+  });
+
+  it('preserves natural sentence content', () => {
+    const sentence = 'Combine the flour and salt, then whisk until smooth.';
+    expect(cleanDirectionLine(sentence)).toBe(sentence);
+  });
+});
+
+// ─── Phase 5: placeholder detection ───────────────────────────
+
+describe('isPlaceholderDirection', () => {
+  const placeholders = ['See above', 'see above', 'See above.', 'N/A', 'na', 'TBD', 'To do', 'Same as above'];
+  for (const s of placeholders) {
+    it(`detects placeholder: ${s}`, () => {
+      expect(isPlaceholderDirection(s)).toBe(true);
+    });
+  }
+
+  it('does not flag legitimate one-liners that contain placeholder words', () => {
+    expect(isPlaceholderDirection('See above for the dressing instructions')).toBe(false);
+    expect(isPlaceholderDirection('Mix and bake at 350')).toBe(false);
+  });
+
+  it('does not flag long content even if it starts like a placeholder', () => {
+    expect(
+      isPlaceholderDirection('See above — also pre-warm the oven before mixing')
+    ).toBe(false);
+  });
+});
+
+// ─── Phase 6: duplicate block removal ─────────────────────────
+
+describe('stripDuplicateRecipeBlocks', () => {
+  const notesWithSubBlocks = [
+    'Some intro text from the chef.',
+    '',
+    '## Ingredients',
+    '- sugar',
+    '- flour',
+    '',
+    '## Directions',
+    '1. Mix',
+    '2. Bake',
+    '',
+    'Closing thought.'
+  ].join('\n');
+
+  it('removes embedded ## Ingredients block when structured ingredients exist', () => {
+    const out = stripDuplicateRecipeBlocks(notesWithSubBlocks, true, false);
+    expect(out).not.toMatch(/##\s*Ingredients/i);
+    expect(out).not.toMatch(/sugar/i);
+  });
+
+  it('removes embedded ## Directions block when structured directions exist', () => {
+    const out = stripDuplicateRecipeBlocks(notesWithSubBlocks, false, true);
+    expect(out).not.toMatch(/##\s*Directions/i);
+    expect(out).not.toMatch(/Bake/i);
+  });
+
+  it('removes both when both structured sections exist', () => {
+    const out = stripDuplicateRecipeBlocks(notesWithSubBlocks, true, true);
+    expect(out).not.toMatch(/##\s*Ingredients/i);
+    expect(out).not.toMatch(/##\s*Directions/i);
+    // Surrounding chef prose survives.
+    expect(out).toContain('Some intro text from the chef.');
+    expect(out).toContain('Closing thought.');
+  });
+
+  it('also removes ## Steps and ## Method aliases', () => {
+    const withMethod = '## Method\n1. Mix\n2. Bake\n\nNote.';
+    const out = stripDuplicateRecipeBlocks(withMethod, false, true);
+    expect(out).not.toMatch(/##\s*Method/i);
+    expect(out).toContain('Note.');
+  });
+
+  it('preserves notes-only recipes (no structured sections)', () => {
+    const out = stripDuplicateRecipeBlocks(notesWithSubBlocks, false, false);
+    expect(out).toBe(notesWithSubBlocks);
+  });
+
+  it('does not terminate early at letter Z (regression — JS has no \\Z anchor)', () => {
+    const notes = [
+      '## Ingredients',
+      '- Zucchini',
+      '- Zaatar',
+      '- Zinc supplement'
+    ].join('\n');
+    const out = stripDuplicateRecipeBlocks(notes, true, false);
+    // The whole block should be gone, including the Z-prefixed items.
+    expect(out).not.toMatch(/Zucchini|Zaatar|Zinc/);
+  });
+});
+
+// ─── Phase 7: end-to-end normalization ────────────────────────
+
+describe('normalizeRecipeForCookbook', () => {
+  it('cleans ingredients and directions, drops markdown, removes duplicate blocks', () => {
+    const content = [
+      '## Details',
+      '- ⏲️ Prep time: 10 minutes',
+      '- 🍳 Cook time: 30 minutes',
+      '- 🍽️ Servings: 4',
+      '',
+      '## Ingredients',
+      '- **2 cups** flour',
+      '- 1 cup [Bitcoin Beans](https://example.com/beans)',
+      '- 3 tbsp [demo](http://localhost:5173) honey',
+      '',
+      '## Directions',
+      '1. Mix all ingredients',
+      '2. Bake for 1--2 hours at 350F',
+      '',
+      "## Chef's notes",
+      'A short note about the recipe.',
+      '',
+      '## Ingredients',
+      '- duplicate sub-block',
+      '',
+      '## Directions',
+      '1. duplicate sub-step'
+    ].join('\n');
+
+    const event = makeRecipeEvent({
+      content,
+      tags: [
+        ['title', '**Test** Recipe'],
+        ['d', 'test-recipe'],
+        ['image', 'https://example.com/img.jpg']
+      ]
+    });
+
+    const recipe = normalizeRecipeForCookbook(event, 'Alice');
+
+    expect(recipe.title).toBe('Test Recipe');
+    expect(recipe.image).toBe('https://example.com/img.jpg');
+    expect(recipe.creatorName).toBe('Alice');
+    expect(recipe.servings).toBe('4');
+    expect(recipe.prepTime).toBe('10 minutes');
+    expect(recipe.cookTime).toBe('30 minutes');
+
+    // Ingredient line cleanup: bold stripped, link unwrapped, localhost dropped.
+    expect(recipe.ingredients).toEqual([
+      '2 cups flour',
+      '1 cup Bitcoin Beans',
+      '3 tbsp honey'
+    ]);
+
+    // Direction cleanup: numeric prefix stripped, double-dash collapsed.
+    expect(recipe.directions).toEqual([
+      'Mix all ingredients',
+      'Bake for 1-2 hours at 350F'
+    ]);
+
+    // Notes survive but the duplicate Ingredients/Directions sub-blocks
+    // that followed Chef's notes are gone.
+    expect(recipe.chefNotes).toBeTruthy();
+    expect(recipe.chefNotes!).not.toMatch(/duplicate sub-block/);
+    expect(recipe.chefNotes!).not.toMatch(/duplicate sub-step/);
+    expect(recipe.chefNotes!).toContain('A short note about the recipe.');
+  });
+
+  it('drops a single-placeholder direction set so the renderer can show the fallback', () => {
+    const content = [
+      '## Ingredients',
+      '- 1 cup sugar',
+      '',
+      '## Directions',
+      '1. See above'
+    ].join('\n');
+
+    const event = makeRecipeEvent({
+      content,
+      tags: [['title', 'Placeholder Recipe']]
+    });
+
+    const recipe = normalizeRecipeForCookbook(event);
+    expect(recipe.ingredients).toEqual(['1 cup sugar']);
+    expect(recipe.directions).toEqual([]);
+  });
+
+  it('strips embedded ## Directions block from notes even when filtered list is empty', () => {
+    // Regression for the placeholder-vs-notes interaction: the parsed
+    // directions had content (so notes cleanup should run), but the
+    // post-filter directions array is empty.
+    const content = [
+      '## Ingredients',
+      '- 1 cup sugar',
+      '',
+      '## Directions',
+      '1. See above',
+      '',
+      "## Chef's notes",
+      'Real notes here.',
+      '',
+      '## Directions',
+      '1. duplicate sub-step that should be stripped'
+    ].join('\n');
+
+    const event = makeRecipeEvent({ content, tags: [['title', 'X']] });
+    const recipe = normalizeRecipeForCookbook(event);
+
+    expect(recipe.directions).toEqual([]);
+    expect(recipe.chefNotes).toBeTruthy();
+    expect(recipe.chefNotes!).not.toMatch(/duplicate sub-step/);
+    expect(recipe.chefNotes!).toContain('Real notes here.');
+  });
+});
+
+// ─── Phase 8: edge cases ──────────────────────────────────────
+
+describe('normalizeRecipeForCookbook — edge cases', () => {
+  it('handles empty content without crashing', () => {
+    const event = makeRecipeEvent({ content: '', tags: [['title', 'Empty']] });
+    const recipe = normalizeRecipeForCookbook(event);
+    expect(recipe.title).toBe('Empty');
+    expect(recipe.ingredients).toEqual([]);
+    expect(recipe.directions).toEqual([]);
+    expect(recipe.chefNotes).toBeUndefined();
+  });
+
+  it('handles missing title tag (falls back to d-tag)', () => {
+    const event = makeRecipeEvent({ content: '', tags: [['d', 'fallback-d']] });
+    expect(normalizeRecipeForCookbook(event).title).toBe('fallback-d');
+  });
+
+  it('handles fully missing title/d tags (falls back to "Untitled recipe")', () => {
+    // Title resolution is title-tag → d-tag → "Untitled recipe". The
+    // event.id fallback is for the recipe ID only, not the printable
+    // title — so empty tags always surface "Untitled recipe" regardless
+    // of whether the event has an id.
+    const event = makeRecipeEvent({ content: '', tags: [] });
+    expect(normalizeRecipeForCookbook(event).title).toBe('Untitled recipe');
+  });
+
+  it('handles malformed markdown without throwing', () => {
+    const malformed = '** unmatched bold *italic without close [link with no close';
+    const event = makeRecipeEvent({
+      content: `## Chef's notes\n${malformed}`,
+      tags: [['title', 'Malformed']]
+    });
+    // Just needs to not throw and produce a string.
+    const recipe = normalizeRecipeForCookbook(event);
+    expect(typeof (recipe.chefNotes ?? '')).toBe('string');
+  });
+
+  it('handles notes-only recipes (no structured sections)', () => {
+    const event = makeRecipeEvent({
+      content: "## Chef's notes\nJust some thoughts about cooking.",
+      tags: [['title', 'Notes Only']]
+    });
+    const recipe = normalizeRecipeForCookbook(event);
+    expect(recipe.ingredients).toEqual([]);
+    expect(recipe.directions).toEqual([]);
+    expect(recipe.chefNotes).toContain('Just some thoughts about cooking.');
+  });
+});
+
+// ─── Phase 10: paragraph handling ─────────────────────────────
+
+describe('cleanNotesIntoParagraphs', () => {
+  it('returns one entry per blank-line-separated paragraph', () => {
+    const notes = 'first paragraph.\n\nsecond paragraph.';
+    expect(cleanNotesIntoParagraphs(notes, false, false)).toEqual([
+      'first paragraph.',
+      'second paragraph.'
+    ]);
+  });
+
+  it('strips markdown but preserves paragraph breaks', () => {
+    const notes = '**Note 1**: do this.\n\n*Note 2*: do that.';
+    expect(cleanNotesIntoParagraphs(notes, false, false)).toEqual([
+      'Note 1: do this.',
+      'Note 2: do that.'
+    ]);
+  });
+
+  it('drops empty paragraphs (whitespace-only or after stripping)', () => {
+    const notes = 'first.\n\n   \n\n[demo](http://localhost:5173)\n\nsecond.';
+    expect(cleanNotesIntoParagraphs(notes, false, false)).toEqual(['first.', 'second.']);
+  });
+
+  it('still removes duplicate Ingredients/Directions blocks', () => {
+    const notes = [
+      'Intro paragraph.',
+      '',
+      '## Ingredients',
+      '- sugar',
+      '',
+      'Closing paragraph.'
+    ].join('\n');
+    const paragraphs = cleanNotesIntoParagraphs(notes, true, false);
+    expect(paragraphs).toContain('Intro paragraph.');
+    expect(paragraphs).toContain('Closing paragraph.');
+    expect(paragraphs.some((p) => /Ingredients|sugar/i.test(p))).toBe(false);
+  });
+
+  it('returns empty array for undefined / empty notes', () => {
+    expect(cleanNotesIntoParagraphs(undefined, false, false)).toEqual([]);
+    expect(cleanNotesIntoParagraphs('', false, false)).toEqual([]);
+    expect(cleanNotesIntoParagraphs('   \n\n  ', false, false)).toEqual([]);
+  });
+});
+
+describe('cleanNotesBlock', () => {
+  it("preserves the `\\n\\n` separators in its string output", () => {
+    const notes = 'first.\n\nsecond.\n\nthird.';
+    const cleaned = cleanNotesBlock(notes, false, false);
+    // The exact separator: blank line between paragraphs.
+    expect(cleaned).toContain('first.\n\nsecond.');
+    expect(cleaned).toContain('second.\n\nthird.');
+  });
+
+  it('returns empty string for undefined input', () => {
+    expect(cleanNotesBlock(undefined, false, false)).toBe('');
+  });
+});
+
+describe('normalizeRecipeForCookbook — paragraph-aware notes', () => {
+  it('joins paragraphs with `\\n\\n` so the renderer can split + space them', () => {
+    const content = [
+      '## Ingredients',
+      '- 1 cup sugar',
+      '',
+      "## Chef's notes",
+      'Paragraph one talks about the prep.',
+      '',
+      'Paragraph two talks about the bake.'
+    ].join('\n');
+
+    const event = makeRecipeEvent({ content, tags: [['title', 'X']] });
+    const recipe = normalizeRecipeForCookbook(event);
+
+    expect(recipe.chefNotes).toBeDefined();
+    const paragraphs = recipe.chefNotes!.split(/\n\s*\n+/);
+    expect(paragraphs).toHaveLength(2);
+    expect(paragraphs[0]).toContain('prep');
+    expect(paragraphs[1]).toContain('bake');
+  });
+});

--- a/src/lib/cookbookNormalize.ts
+++ b/src/lib/cookbookNormalize.ts
@@ -1,0 +1,266 @@
+/**
+ * Cookbook content normalization layer.
+ *
+ * The recipe markdown stored on relays is authored by humans. It can contain
+ * markdown emphasis, raw links, embedded sub-headings, accidental duplicate
+ * section markers, and the occasional "1. See above" placeholder. Rendering
+ * that text directly into a printed cookbook surfaces every artifact.
+ *
+ * This module is the single seam between raw recipe input and the PDF
+ * renderer. It runs `parseMarkdownForEditing` for the structural extraction,
+ * then layers cleanup on top:
+ *
+ *   - Strip markdown formatting (bold, italic, links, headers, code) while
+ *     preserving the underlying text.
+ *   - Drop localhost / loopback URLs; preserve real attribution links as
+ *     plain text.
+ *   - Strip duplicate `## Ingredients` / `## Directions` blocks from notes
+ *     when structured equivalents already exist (the source of the visible
+ *     "duplicate ingredients section" bug).
+ *   - Detect placeholder directions ("see above", "n/a", "tbd") and drop
+ *     them so the renderer can show a clean "directions not included"
+ *     fallback instead of a misleading single step.
+ *
+ * Importantly, the normalizer is allowed to remove and clean. It is NOT
+ * allowed to invent ingredients, rewrite directions, or change recipe
+ * meaning. Every transformation is conservative.
+ */
+
+import type { NDKEvent } from '@nostr-dev-kit/ndk';
+import { extractRecipeDetails, parseMarkdownForEditing } from '$lib/parser';
+import type { CookbookRecipe } from '$lib/cookbookExport';
+
+// ─── Markdown stripping ────────────────────────────────────────────
+
+/**
+ * Loopback / localhost host fragment regex. Matches the common cases —
+ * full hostnames or trailing-port forms. Anything matching this in a
+ * URL means the link is useless to a reader and gets dropped entirely.
+ */
+const LOCALHOST_HOST_RE = /(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])/i;
+
+/** Full localhost URL match — used to delete bare instances of the URL. */
+const LOCALHOST_URL_RE =
+	/\bhttps?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?(?:\/[^\s]*)?/gi;
+
+/**
+ * Strip markdown formatting characters while preserving the underlying
+ * text. Conservative: only the syntactic tokens are removed; any text
+ * inside emphasis spans, link labels, or headings is kept.
+ *
+ * Order matters here:
+ *   1. Headings first — entire leading `#` markers go.
+ *   2. Code spans before emphasis — `` `**foo**` `` shouldn't have its
+ *      asterisks consumed before the backticks are stripped.
+ *   3. Localhost-link deletion before generic link unwrap, so the label
+ *      is dropped along with the URL when the destination is unusable.
+ *   4. Bare localhost URLs after, in case any survived without a label.
+ *   5. Generic links last — `[label](url)` → `label`.
+ */
+export function stripMarkdownFormatting(input: string): string {
+	if (!input) return '';
+	let out = input;
+
+	// Drop heading markers (line-level)
+	out = out.replace(/^#{1,6}\s+/gm, '');
+
+	// Inline code first
+	out = out.replace(/`([^`\n]+)`/g, '$1');
+
+	// Strikethrough
+	out = out.replace(/~~([^~\n]+)~~/g, '$1');
+
+	// Bold (**foo**, __foo__)
+	out = out.replace(/\*\*([^*\n]+)\*\*/g, '$1');
+	out = out.replace(/__([^_\n]+)__/g, '$1');
+
+	// Italic (*foo*, _foo_) — restrict to forms unlikely to collide with
+	// regular punctuation usage. Underscore variant only when bordered by
+	// whitespace/start/end so we don't break snake_case identifiers.
+	out = out.replace(/(?<![*\w])\*([^\s*][^*\n]*?[^\s*])\*(?!\w)/g, '$1');
+	out = out.replace(/(?<![\w_])_([^\s_][^_\n]*?[^\s_])_(?!\w)/g, '$1');
+
+	// Drop links whose destination is localhost/loopback entirely —
+	// label and URL both gone, since the reader can't follow them.
+	out = out.replace(/\[([^\]\n]*)\]\(([^)\s]+)\)/g, (_match, label: string, url: string) => {
+		if (LOCALHOST_HOST_RE.test(url)) return '';
+		// Otherwise unwrap to the label text.
+		return label;
+	});
+
+	// Bare localhost URLs (no markdown wrapper) — drop.
+	out = out.replace(LOCALHOST_URL_RE, '');
+
+	// Blockquote markers
+	out = out.replace(/^>\s+/gm, '');
+
+	// Collapse double-dashes to a single hyphen. The PDF font doesn't
+	// render en/em dashes (sanitizeForPdf strips them), so a single ASCII
+	// hyphen is the cleanest outcome for ranges like "1--2".
+	out = out.replace(/-{2,}/g, '-');
+
+	// Collapse runs of internal whitespace within a line, but preserve
+	// newlines so paragraphs stay readable.
+	out = out.replace(/[ \t]+/g, ' ');
+
+	// Collapse triple+ blank lines to a single blank line.
+	out = out.replace(/\n{3,}/g, '\n\n');
+
+	return out.trim();
+}
+
+// ─── Per-line cleaners ────────────────────────────────────────────
+
+/**
+ * Clean a single ingredient string. Strips markdown, leading bullets,
+ * accidental leading numbers (when an author wrote "1. flour" inside a
+ * bulleted list), and collapses whitespace.
+ */
+export function cleanIngredientLine(raw: string): string {
+	return stripMarkdownFormatting(raw)
+		.replace(/^[-*•]\s+/, '')
+		.replace(/^\d+[.)]\s+/, '')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+/**
+ * Clean a single direction step. Strips markdown, leading numbers /
+ * bullets that survived the parser, and collapses whitespace.
+ */
+export function cleanDirectionLine(raw: string): string {
+	return stripMarkdownFormatting(raw)
+		.replace(/^\d+[.)]\s+/, '')
+		.replace(/^[-*•]\s+/, '')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+// ─── Placeholder detection ────────────────────────────────────────
+
+/**
+ * Phrases that pretend to be a direction step but carry no information.
+ * Conservative — only matches the entire stripped step, not a substring,
+ * and only when paired with very short content (so "See above for the
+ * dressing" still survives).
+ */
+const PLACEHOLDER_DIRECTION_RE =
+	/^(?:see\s+above|see\s+notes?|n\/?a|tbd|tba|to\s+do|coming\s+soon|same\s+as\s+above)\.?$/i;
+
+/**
+ * A direction step is "placeholder" when it's short AND its trimmed text
+ * matches one of the known placeholder phrases. The length cap prevents
+ * legitimate one-step recipes (rare but possible) from being suppressed.
+ */
+export function isPlaceholderDirection(step: string): boolean {
+	const t = step.trim().replace(/^\d+[.)]?\s*/, '');
+	if (t.length > 24) return false;
+	return PLACEHOLDER_DIRECTION_RE.test(t);
+}
+
+// ─── Notes cleanup ────────────────────────────────────────────────
+
+/**
+ * Strip embedded ingredient / direction sub-blocks from a notes string.
+ * Without this, a Chef's notes block that contains `## Ingredients` as
+ * an inline sub-heading (or any author reference to those sections)
+ * causes the renderer to print the same content twice — once via the
+ * structured ingredients list and again as part of the notes.
+ *
+ * Only runs the strip when the structured equivalent is present, so a
+ * notes-only recipe (no parsed ingredients) keeps its content intact as
+ * the fallback path.
+ */
+export function stripDuplicateRecipeBlocks(
+	notes: string,
+	hasIngredients: boolean,
+	hasDirections: boolean
+): string {
+	let out = notes;
+	if (hasIngredients) {
+		// Match `## Ingredients` (any header level) up to the next header
+		// of any level OR the end of input.
+		out = out.replace(/^#{1,6}\s*ingredients\b[\s\S]*?(?=^#{1,6}\s|\Z)/gim, '');
+	}
+	if (hasDirections) {
+		out = out.replace(/^#{1,6}\s*directions\b[\s\S]*?(?=^#{1,6}\s|\Z)/gim, '');
+		// Also catch the "Steps" / "Method" variants that some recipes use.
+		out = out.replace(/^#{1,6}\s*(?:steps|method)\b[\s\S]*?(?=^#{1,6}\s|\Z)/gim, '');
+	}
+	return out;
+}
+
+/**
+ * Full notes cleanup. Strips duplicate sub-blocks first (otherwise the
+ * heading marker would already be removed by stripMarkdownFormatting and
+ * we'd have no anchor to match against), then runs the general markdown
+ * cleanup.
+ */
+export function cleanNotesBlock(
+	notes: string | undefined,
+	hasIngredients: boolean,
+	hasDirections: boolean
+): string {
+	if (!notes) return '';
+	const dedup = stripDuplicateRecipeBlocks(notes, hasIngredients, hasDirections);
+	return stripMarkdownFormatting(dedup);
+}
+
+// ─── Public entry point ───────────────────────────────────────────
+
+/**
+ * Normalize an NDKEvent into a print-ready CookbookRecipe. Replaces the
+ * inline shape-only conversion previously in `recipeEventToCookbookRecipe`.
+ *
+ * Pipeline:
+ *   1. Pull the basics from event tags (title, image, identity).
+ *   2. Run `parseMarkdownForEditing` for structured fields.
+ *   3. Clean each ingredient / direction line individually.
+ *   4. Drop placeholder direction sets (single "see above" etc).
+ *   5. Build cleaned chefNotes by stripping any embedded ingredient /
+ *      direction sub-blocks, then running general markdown cleanup.
+ */
+export function normalizeRecipeForCookbook(
+	event: NDKEvent,
+	creatorName?: string
+): CookbookRecipe {
+	const tags = event.tags || [];
+	const find = (name: string) => tags.find((t) => t[0] === name)?.[1];
+	const rawTitle = find('title') || find('d') || 'Untitled recipe';
+	const title = stripMarkdownFormatting(rawTitle).replace(/\s+/g, ' ').trim() || 'Untitled recipe';
+	const image = find('image') || undefined;
+	const dTag = find('d') || event.id || rawTitle;
+
+	const parsed = parseMarkdownForEditing(event.content || '');
+	const details = extractRecipeDetails(event.content || '');
+
+	const ingredients = (parsed.ingredients || [])
+		.map(cleanIngredientLine)
+		.filter((s) => s.length > 0);
+
+	let directions = (parsed.directions || [])
+		.map(cleanDirectionLine)
+		.filter((s) => s.length > 0);
+
+	// Single-placeholder direction set → drop entirely so the renderer
+	// can show its "directions not included" message rather than printing
+	// "1. See above" verbatim.
+	if (directions.length <= 1 && directions.some(isPlaceholderDirection)) {
+		directions = [];
+	}
+
+	const chefNotes = cleanNotesBlock(parsed.chefNotes, ingredients.length > 0, directions.length > 0);
+
+	return {
+		id: `${event.kind ?? 30023}:${event.pubkey}:${dTag}`,
+		title,
+		image,
+		creatorName,
+		prepTime: parsed.information?.prepTime || details.prepTime || undefined,
+		cookTime: parsed.information?.cookTime || details.cookTime || undefined,
+		servings: parsed.information?.servings || details.servings || undefined,
+		ingredients,
+		directions,
+		chefNotes: chefNotes || undefined
+	};
+}

--- a/src/lib/cookbookNormalize.ts
+++ b/src/lib/cookbookNormalize.ts
@@ -177,15 +177,28 @@ export function stripDuplicateRecipeBlocks(
 	hasDirections: boolean
 ): string {
 	let out = notes;
+	// End-of-input lookahead: JavaScript regex has no `\Z` anchor (it
+	// would match a literal `Z`). `(?![\s\S])` asserts "no character
+	// follows" — the JS-compatible way to say end-of-string. With the
+	// `m` flag, `$` matches end-of-line which would terminate the block
+	// at the wrong place, so we explicitly match-or-terminate via the
+	// negative lookahead instead.
 	if (hasIngredients) {
-		// Match `## Ingredients` (any header level) up to the next header
-		// of any level OR the end of input.
-		out = out.replace(/^#{1,6}\s*ingredients\b[\s\S]*?(?=^#{1,6}\s|\Z)/gim, '');
+		out = out.replace(
+			/^#{1,6}\s*ingredients\b[\s\S]*?(?=^#{1,6}\s|(?![\s\S]))/gim,
+			''
+		);
 	}
 	if (hasDirections) {
-		out = out.replace(/^#{1,6}\s*directions\b[\s\S]*?(?=^#{1,6}\s|\Z)/gim, '');
-		// Also catch the "Steps" / "Method" variants that some recipes use.
-		out = out.replace(/^#{1,6}\s*(?:steps|method)\b[\s\S]*?(?=^#{1,6}\s|\Z)/gim, '');
+		out = out.replace(
+			/^#{1,6}\s*directions\b[\s\S]*?(?=^#{1,6}\s|(?![\s\S]))/gim,
+			''
+		);
+		// Also catch the "Steps" / "Method" variants some recipes use.
+		out = out.replace(
+			/^#{1,6}\s*(?:steps|method)\b[\s\S]*?(?=^#{1,6}\s|(?![\s\S]))/gim,
+			''
+		);
 	}
 	return out;
 }
@@ -242,6 +255,15 @@ export function normalizeRecipeForCookbook(
 		.map(cleanDirectionLine)
 		.filter((s) => s.length > 0);
 
+	// Capture the *parsed* presence before placeholder filtering. Notes
+	// cleanup needs to know whether a `## Directions` block existed in
+	// the source so it can strip the duplicate from notes — otherwise a
+	// placeholder-only recipe would have its `## Directions` block leak
+	// back into the notes section, reintroducing the very text we just
+	// suppressed at the structured-list level.
+	const parsedHadIngredients = (parsed.ingredients || []).length > 0;
+	const parsedHadDirections = (parsed.directions || []).length > 0;
+
 	// Single-placeholder direction set → drop entirely so the renderer
 	// can show its "directions not included" message rather than printing
 	// "1. See above" verbatim.
@@ -249,7 +271,7 @@ export function normalizeRecipeForCookbook(
 		directions = [];
 	}
 
-	const chefNotes = cleanNotesBlock(parsed.chefNotes, ingredients.length > 0, directions.length > 0);
+	const chefNotes = cleanNotesBlock(parsed.chefNotes, parsedHadIngredients, parsedHadDirections);
 
 	return {
 		id: `${event.kind ?? 30023}:${event.pubkey}:${dTag}`,

--- a/src/lib/cookbookNormalize.ts
+++ b/src/lib/cookbookNormalize.ts
@@ -177,26 +177,26 @@ export function stripDuplicateRecipeBlocks(
 	hasDirections: boolean
 ): string {
 	let out = notes;
-	// End-of-input lookahead: JavaScript regex has no `\Z` anchor (it
-	// would match a literal `Z`). `(?![\s\S])` asserts "no character
-	// follows" — the JS-compatible way to say end-of-string. With the
-	// `m` flag, `$` matches end-of-line which would terminate the block
-	// at the wrong place, so we explicitly match-or-terminate via the
-	// negative lookahead instead.
+	// Termination conditions (lookahead alternatives):
+	//
+	//   1. `^#{1,6}\s` — another markdown heading begins.
+	//   2. `\n\s*\n(?=[^\s\-*\d#])` — blank line followed by prose that
+	//      doesn't look like a list item or heading. Treats the next
+	//      free-form paragraph as the chef's notes resuming, not part
+	//      of the embedded sub-block.
+	//   3. `(?![\s\S])` — end of input. JS regex has no `\Z`; this is
+	//      the JS-compatible way to say "no character follows". `$`
+	//      with the `m` flag matches end-of-line, not end-of-string,
+	//      so it'd terminate at the wrong place.
+	const TERM = '(?=^#{1,6}\\s|\\n\\s*\\n(?=[^\\s\\-*\\d#])|(?![\\s\\S]))';
 	if (hasIngredients) {
-		out = out.replace(
-			/^#{1,6}\s*ingredients\b[\s\S]*?(?=^#{1,6}\s|(?![\s\S]))/gim,
-			''
-		);
+		out = out.replace(new RegExp(`^#{1,6}\\s*ingredients\\b[\\s\\S]*?${TERM}`, 'gim'), '');
 	}
 	if (hasDirections) {
-		out = out.replace(
-			/^#{1,6}\s*directions\b[\s\S]*?(?=^#{1,6}\s|(?![\s\S]))/gim,
-			''
-		);
+		out = out.replace(new RegExp(`^#{1,6}\\s*directions\\b[\\s\\S]*?${TERM}`, 'gim'), '');
 		// Also catch the "Steps" / "Method" variants some recipes use.
 		out = out.replace(
-			/^#{1,6}\s*(?:steps|method)\b[\s\S]*?(?=^#{1,6}\s|(?![\s\S]))/gim,
+			new RegExp(`^#{1,6}\\s*(?:steps|method)\\b[\\s\\S]*?${TERM}`, 'gim'),
 			''
 		);
 	}
@@ -208,6 +208,10 @@ export function stripDuplicateRecipeBlocks(
  * heading marker would already be removed by stripMarkdownFormatting and
  * we'd have no anchor to match against), then runs the general markdown
  * cleanup.
+ *
+ * The returned string preserves paragraph breaks as `\n\n`. Use
+ * `cleanNotesIntoParagraphs` when you want a structured list of
+ * paragraphs (e.g. for rendering each with its own spacing).
  */
 export function cleanNotesBlock(
 	notes: string | undefined,
@@ -217,6 +221,30 @@ export function cleanNotesBlock(
 	if (!notes) return '';
 	const dedup = stripDuplicateRecipeBlocks(notes, hasIngredients, hasDirections);
 	return stripMarkdownFormatting(dedup);
+}
+
+/**
+ * Same cleanup as `cleanNotesBlock`, but returns the result split on
+ * blank-line boundaries with empty paragraphs filtered. Lets the
+ * renderer (or any caller that cares about prose structure) treat
+ * paragraphs as discrete units — important for adding spacing between
+ * them without bloating single-paragraph notes.
+ *
+ * Splitting happens after markdown cleanup so any leading-`>` blockquotes
+ * or headings have been normalized first; otherwise their syntactic
+ * markers would leak into the boundary detection.
+ */
+export function cleanNotesIntoParagraphs(
+	notes: string | undefined,
+	hasIngredients: boolean,
+	hasDirections: boolean
+): string[] {
+	const cleaned = cleanNotesBlock(notes, hasIngredients, hasDirections);
+	if (!cleaned) return [];
+	return cleaned
+		.split(/\n\s*\n+/)
+		.map((p) => p.replace(/\s+/g, ' ').trim())
+		.filter((p) => p.length > 0);
 }
 
 // ─── Public entry point ───────────────────────────────────────────
@@ -271,7 +299,15 @@ export function normalizeRecipeForCookbook(
 		directions = [];
 	}
 
-	const chefNotes = cleanNotesBlock(parsed.chefNotes, parsedHadIngredients, parsedHadDirections);
+	// Split into paragraphs (collapsing internal whitespace within each)
+	// and join with `\n\n` so the renderer can split on blank lines and
+	// add spacing between paragraphs without re-collapsing them.
+	const noteParagraphs = cleanNotesIntoParagraphs(
+		parsed.chefNotes,
+		parsedHadIngredients,
+		parsedHadDirections
+	);
+	const chefNotes = noteParagraphs.length > 0 ? noteParagraphs.join('\n\n') : undefined;
 
 	return {
 		id: `${event.kind ?? 30023}:${event.pubkey}:${dTag}`,
@@ -283,6 +319,6 @@ export function normalizeRecipeForCookbook(
 		servings: parsed.information?.servings || details.servings || undefined,
 		ingredients,
 		directions,
-		chefNotes: chefNotes || undefined
+		chefNotes
 	};
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+/**
+ * Vitest configuration.
+ *
+ * `clientTag.test.ts` and `zapAmount.test.ts` predate vitest in this
+ * repo — they're standalone tsx scripts that use `console.assert` and
+ * have no `describe` / `it` blocks. Vitest can't discover tests inside
+ * them and reports "No test suite found". They're excluded here so
+ * `pnpm test` runs cleanly; the underlying scripts remain runnable
+ * with `npx tsx <file>` per the comment at the top of each file. A
+ * future cleanup can port them to vitest's API.
+ *
+ * Standalone config (not merged from vite.config.ts) because the main
+ * vite config wires up the SvelteKit plugin + Cloudflare-targeted SSR
+ * options that aren't relevant for unit-testing pure-TS modules. We
+ * just need the `$lib` alias matched to SvelteKit's default so test
+ * files can import via the same path the app code uses.
+ */
+export default defineConfig({
+	resolve: {
+		alias: {
+			$lib: path.resolve('./src/lib'),
+			$app: path.resolve('./.svelte-kit/dev/runtime/app')
+		}
+	},
+	test: {
+		include: ['src/**/*.test.ts'],
+		exclude: ['src/lib/clientTag.test.ts', 'src/lib/zapAmount.test.ts', 'node_modules/**']
+	}
+});


### PR DESCRIPTION
## Summary
Cleans raw recipe content before it hits the PDF renderer so exported cookbooks read like a finished book, not a paste of a markdown source. Layout is unchanged outside of the footer / running-header simplification.

## Problems addressed
| Problem | Fix |
| --- | --- |
| \`## Ingredients\` rendered literally inside Chef's notes | \`stripDuplicateRecipeBlocks\` removes embedded \`## Ingredients\` / \`## Directions\` / \`## Steps\` / \`## Method\` sub-blocks from notes when the structured equivalents already exist |
| Bold markdown like \`**Optional**\` printed verbatim | \`stripMarkdownFormatting\` drops emphasis tokens but preserves inner text |
| Raw \`[label](url)\` link syntax in printed text | Generic links unwrap to their label; localhost / loopback links (label + URL) are dropped entirely |
| Bare \`http://localhost:5173/...\` URLs in printed text | Stripped via dedicated regex |
| \`1. See above\` direction placeholders | \`isPlaceholderDirection\` detects "see above", "n/a", "tbd", "to do" etc; the renderer shows "Directions were not included in the original recipe." instead |
| Long, dense directions cramped together | Inter-step spacing bumped from 6pt to 12pt |
| Repetitive footer ("Created with Zap Cooking" + page on every page) plus a per-page running-header repeat of the title + brand icon | Footer = title left + page right. Running header = hairline rule only. Cover keeps the prominent brand mark. |

## Architecture
New \`src/lib/cookbookNormalize.ts\` is the single seam between raw recipe input and the PDF renderer:

- \`stripMarkdownFormatting(s)\` — header / bold / italic / code / strikethrough / blockquote / dash collapse. Italic + underscore matchers are conservative so \`snake_case\` identifiers and accidental token-like substrings don't get mangled.
- \`cleanIngredientLine\` / \`cleanDirectionLine\` — per-item markdown strip + trim residual bullet / number prefixes.
- \`isPlaceholderDirection\` — short-string check for known placeholder phrases. The 24-char cap protects the unlikely-but-possible legitimate one-step recipe.
- \`stripDuplicateRecipeBlocks\` — only runs when structured ingredients / directions exist. Notes-only recipes keep their content intact as the fallback path.
- \`normalizeRecipeForCookbook(event)\` — orchestrates the pipeline. \`recipeEventToCookbookRecipe\` is now a thin wrapper around it.

\`pnpm check\` 0 errors / \`pnpm build\` clean.

## Files changed
- **new** \`src/lib/cookbookNormalize.ts\` — normalization pipeline (~220 lines)
- \`src/lib/cookbookExport.ts\` — \`recipeEventToCookbookRecipe\` delegates to the normalizer; empty-directions fallback in \`drawRecipePages\`; bigger inter-step spacing; simpler footer + running header

## Test plan
- [ ] Export a Recipe Pack that previously showed duplicate \`## Ingredients\` — confirm only one structured section renders.
- [ ] Recipe with \`**Optional**\` in an ingredient — renders as plain "Optional".
- [ ] Recipe with \`[Bitcoin Beans](https://...)\` in directions — renders as "Bitcoin Beans".
- [ ] Recipe with a raw \`http://localhost:5173/...\` reference — URL is gone.
- [ ] Recipe whose only direction is "1. See above" — page shows the italic "Directions were not included in the original recipe." instead.
- [ ] Long multi-page recipe — inter-step spacing readable, no orphan headings.
- [ ] Footer reads "Pack Title" left, page number right; cover still has the prominent brand mark.
- [ ] Payment gate, promo flow, membership detection unchanged.

## Out of scope
- Recipe Pack event schema (untouched)
- Payment / Lightning gate (untouched)
- Promo code system (untouched)
- Membership detection (untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)