### PR TITLE
feat(recipes): rename /recent to /recipes + 301 redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.329",
+  "version": "4.2.330",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.328",
+  "version": "4.2.329",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/BottomNav.svelte
+++ b/src/components/BottomNav.svelte
@@ -55,7 +55,11 @@
     <FlameIcon class="self-center" size={22} />
     <span class="sr-only">Feed</span>
   </a>
-  <a href="/recent" class="nav-tab" class:active={pathname.startsWith('/recent')}>
+  <a
+    href="/recipes"
+    class="nav-tab"
+    class:active={pathname.startsWith('/recipes') || pathname.startsWith('/recent')}
+  >
     <ForkKnifeIcon class="self-center" size={22} />
     <span class="sr-only">Recipes</span>
   </a>

--- a/src/components/DesktopSideNav.svelte
+++ b/src/components/DesktopSideNav.svelte
@@ -51,10 +51,13 @@
       match: (p) => p === '/' || p.startsWith('/community')
     },
     {
-      href: '/recent',
+      href: '/recipes',
       label: 'Recipes',
       icon: ForkKnifeIcon,
-      match: (p) => p.startsWith('/recent')
+      // Match /recent too so the nav stays highlighted while the legacy
+      // URL redirects through to /recipes — avoids a flash of unhighlighted
+      // tab during the 301 round-trip on cold links.
+      match: (p) => p.startsWith('/recipes') || p.startsWith('/recent')
     },
     {
       href: '/polls',

--- a/src/components/Feed.svelte
+++ b/src/components/Feed.svelte
@@ -142,7 +142,7 @@
       {/if}
 
       <a
-        href="/recent"
+        href="/recipes"
         class="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-full transition-colors hover:opacity-80"
         style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
       >

--- a/src/components/TagsSearchAutocomplete.svelte
+++ b/src/components/TagsSearchAutocomplete.svelte
@@ -102,7 +102,7 @@
     }, 300);
   }
 
-  // Load recipes progressively using subscription (like /recent page)
+  // Load recipes progressively using subscription (like /recipes page)
   async function preloadRecipes() {
     if (recipeCacheLoading || recipeCacheLoaded) {
       return;
@@ -111,7 +111,7 @@
     recipeCacheLoading = true;
 
     try {
-      // Try to get cached recipes from IndexedDB (same cache as /recent page)
+      // Try to get cached recipes from IndexedDB (same cache as /recipes page)
       const cacheFilter = { kinds: [30023], '#t': RECIPE_TAGS };
       const cachedEvents = await feedCacheService.getCachedFeed({
         filter: cacheFilter,

--- a/src/routes/cookbook/+page.svelte
+++ b/src/routes/cookbook/+page.svelte
@@ -1440,7 +1440,7 @@
             Create Collection
           </button>
           <a
-            href="/recent"
+            href="/recipes"
             class="flex items-center px-5 py-2.5 rounded-full font-medium transition-colors"
             style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
           >
@@ -1466,7 +1466,7 @@
               : 'Save recipes to this collection to see them here.'}
           </p>
           <a
-            href="/recent"
+            href="/recipes"
             class="flex items-center px-4 py-2 rounded-full font-medium text-sm transition-colors"
             style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
           >

--- a/src/routes/cookbook/[naddr]/+page.svelte
+++ b/src/routes/cookbook/[naddr]/+page.svelte
@@ -1107,7 +1107,7 @@
             </button>
           {/if}
           <a
-            href="/recent"
+            href="/recipes"
             class="flex items-center px-4 py-2 rounded-full font-medium text-sm transition-colors"
             style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
           >

--- a/src/routes/packs/+page.svelte
+++ b/src/routes/packs/+page.svelte
@@ -55,7 +55,7 @@
   // each load and re-checked when the network returns; if it doesn't
   // match anymore (user signed out / switched accounts), the result
   // is dropped without overwriting state. Same idea as the relay-
-  // generation guard in /recent.
+  // generation guard in /recipes.
   let mineRequestId = 0;
 
   // Saved tab — same shape, separate state. Populated by resolving each
@@ -73,7 +73,7 @@
     discoverError = '';
     try {
       // Make sure NDK has at least one connected relay before subscribing
-      // — mirrors /recent's pattern. Reduces cold-load failure rate when
+      // — mirrors /recipes's pattern. Reduces cold-load failure rate when
       // the page is loaded directly (rather than via SPA nav from the home
       // feed which has already warmed connections).
       try {
@@ -416,15 +416,15 @@
 </svelte:head>
 
 <div class="flex flex-col gap-4 max-w-full md:max-w-none">
-  <!-- Top tab bar — mirrors /recent so navigation stays consistent.
-       Recent / Packs / Premium ⚡️ — Packs is active here. -->
+  <!-- Top tab bar — mirrors /recipes so navigation stays consistent.
+       Recipes / Packs / Premium ⚡️ — Packs is active here. -->
   <div class="flex w-full border-b" style="border-color: var(--color-input-border)">
     <a
-      href="/recent"
+      href="/recipes"
       class="flex-1 py-2.5 text-sm font-medium transition-colors relative cursor-pointer text-center"
       style="color: var(--color-text-secondary)"
     >
-      Recent
+      Recipes
     </a>
     <div
       class="flex-1 py-2.5 text-sm font-medium transition-colors relative text-center"

--- a/src/routes/packs/+page.svelte
+++ b/src/routes/packs/+page.svelte
@@ -73,7 +73,7 @@
     discoverError = '';
     try {
       // Make sure NDK has at least one connected relay before subscribing
-      // — mirrors /recipes's pattern. Reduces cold-load failure rate when
+      // — mirrors /recipes' pattern. Reduces cold-load failure rate when
       // the page is loaded directly (rather than via SPA nav from the home
       // feed which has already warmed connections).
       try {

--- a/src/routes/premium/+page.svelte
+++ b/src/routes/premium/+page.svelte
@@ -196,19 +196,19 @@
 
 <PullToRefresh bind:this={pullToRefreshEl} on:refresh={handleRefresh}>
 <div class="flex flex-col gap-4 max-w-full md:max-w-none">
-  <!-- Tabs (shared with /recent) -->
+  <!-- Tabs (shared with /recipes) -->
   <div class="flex flex-col gap-3">
     <div class="flex items-center justify-between gap-4">
       <div class="flex gap-1 border-b" style="border-color: var(--color-input-border)">
         <a
-          href="/recent"
+          href="/recipes"
           class="px-4 py-2 text-sm font-medium transition-colors relative cursor-pointer"
           style="color: var(--color-text-secondary)"
         >
           Recent
         </a>
         <a
-          href="/recent"
+          href="/recipes"
           class="px-4 py-2 text-sm font-medium transition-colors relative cursor-pointer"
           style="color: var(--color-text-secondary)"
         >

--- a/src/routes/r/[naddr]/+page.server.ts
+++ b/src/routes/r/[naddr]/+page.server.ts
@@ -224,7 +224,7 @@ export const load: PageServerLoad = async ({ params, url }) => {
 
 	// Validate naddr format
 	if (!naddr?.startsWith('naddr1')) {
-		throw redirect(302, '/recent');
+		throw redirect(302, '/recipes');
 	}
 
 	// Skip if WebSocket is not available (e.g., some Node.js environments)

--- a/src/routes/recent/+page.server.ts
+++ b/src/routes/recent/+page.server.ts
@@ -1,0 +1,17 @@
+/**
+ * Permanent redirect from the legacy `/recent` URL to `/recipes`.
+ *
+ * The page used to live at `/recent`; renamed to `/recipes` once Recipe
+ * Packs landed at `/packs` and we wanted clearer naming for the recipe
+ * stream. Existing bookmarks, shared links (PR #354 OG cards, blog
+ * posts, etc.) and search-engine indices still point at `/recent`, so
+ * we keep this server-side 301 indefinitely. SvelteKit will preserve
+ * the query string and any hash on the redirect.
+ */
+
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = ({ url }) => {
+	throw redirect(301, `/recipes${url.search}${url.hash}`);
+};

--- a/src/routes/recent/+page.server.ts
+++ b/src/routes/recent/+page.server.ts
@@ -5,13 +5,18 @@
  * Packs landed at `/packs` and we wanted clearer naming for the recipe
  * stream. Existing bookmarks, shared links (PR #354 OG cards, blog
  * posts, etc.) and search-engine indices still point at `/recent`, so
- * we keep this server-side 301 indefinitely. SvelteKit will preserve
- * the query string and any hash on the redirect.
+ * we keep this server-side 301 indefinitely.
+ *
+ * Preserves the query string. URL fragments (the part after `#`) are
+ * NOT available in a server load — browsers don't include them in
+ * HTTP requests — but every major browser re-attaches the original
+ * fragment to the redirect target client-side, so deep-link anchors
+ * keep working without us doing anything.
  */
 
 import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = ({ url }) => {
-	throw redirect(301, `/recipes${url.search}${url.hash}`);
+	throw redirect(301, `/recipes${url.search}`);
 };

--- a/src/routes/recent/+page.svelte
+++ b/src/routes/recent/+page.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  /**
+   * Redirect-only route: the server `load` in +page.server.ts throws a
+   * 301 to `/recipes` before this component would ever render. This
+   * placeholder exists because SvelteKit pairs `+page.server.ts` with
+   * a page component to register the route reliably across SSR + SPA
+   * navigation; same pattern as `/bookmarks` and `/list/create`.
+   *
+   * On the off-chance a client-side nav reaches here without the
+   * server load running (eg. during a malformed prefetch), a goto()
+   * fallback ensures the user still lands on `/recipes`.
+   */
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+
+  onMount(() => {
+    goto('/recipes', { replaceState: true });
+  });
+</script>
+
+<svelte:head>
+  <title>Redirecting… — zap.cooking</title>
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<p style="padding: 2rem; color: var(--color-text-secondary)">
+  Redirecting to <a href="/recipes" style="color: var(--color-primary)">/recipes</a>…
+</p>

--- a/src/routes/recipes/+page.svelte
+++ b/src/routes/recipes/+page.svelte
@@ -151,7 +151,7 @@
 
       // Safety timeout: flip loaded after 10s if neither an event nor EOSE
       // reached us. Prevents a stuck skeleton when SvelteKit nav lands on
-      // /recent and NDK's cache replay emits before handlers can attach,
+      // /recipes and NDK's cache replay emits before handlers can attach,
       // or when EOSE is otherwise delayed. Mirrors /polls' timeout pattern.
       // Tracked in `loadTimeout` so a subsequent loadRecipes() call or
       // onDestroy can cancel it.
@@ -202,7 +202,7 @@
 <svelte:head>
   <title>Recipes - zap.cooking</title>
   <meta name="description" content="Browse all recipes on zap.cooking" />
-  <meta property="og:url" content="https://zap.cooking/recent" />
+  <meta property="og:url" content="https://zap.cooking/recipes" />
   <meta property="og:type" content="website" />
   <meta property="og:title" content="Recipes - zap.cooking" />
   <meta property="og:description" content="Browse all recipes on zap.cooking" />
@@ -210,7 +210,7 @@
 
   <meta name="twitter:card" content="summary_large_image" />
   <meta property="twitter:domain" content="zap.cooking" />
-  <meta property="twitter:url" content="https://zap.cooking/recent" />
+  <meta property="twitter:url" content="https://zap.cooking/recipes" />
   <meta name="twitter:title" content="Recipes - zap.cooking" />
   <meta name="twitter:description" content="Browse all recipes on zap.cooking" />
   <meta property="twitter:image" content="https://zap.cooking/social-share.png" />
@@ -227,7 +227,7 @@
         class="flex-1 py-2.5 text-sm font-medium transition-colors relative cursor-pointer text-center"
         style="color: {activeTab === 'recent' ? 'var(--color-text-primary)' : 'var(--color-text-secondary)'}"
       >
-        Recent
+        Recipes
         {#if activeTab === 'recent'}
           <span class="absolute bottom-0 left-0 right-0 h-0.5 bg-gradient-to-r from-orange-500 to-amber-500"></span>
         {/if}

--- a/src/routes/s/[code]/+page.server.ts
+++ b/src/routes/s/[code]/+page.server.ts
@@ -18,14 +18,14 @@ export const load: PageServerLoad = async ({ params, platform }) => {
 
   const code = params?.code?.trim();
   if (!code) {
-    throw redirect(302, '/recent');
+    throw redirect(302, '/recipes');
   }
 
   const key = normalizeShortCode(code);
   const record = await kv.get(key, 'json') as ShortenedURL | null;
   
   if (!record) {
-    throw redirect(302, '/recent');
+    throw redirect(302, '/recipes');
   }
 
   // Increment click count (best-effort; don't block redirect on write failure)

--- a/src/routes/s/[code]/+server.ts
+++ b/src/routes/s/[code]/+server.ts
@@ -16,13 +16,13 @@ export const GET: RequestHandler = async ({ params, platform }) => {
 
   const code = params?.code?.trim();
   if (!code) {
-    throw redirect(302, '/recent');
+    throw redirect(302, '/recipes');
   }
 
   const key = normalizeShortCode(code);
   const record = await kv.get(key, 'json') as ShortenedURL | null;
   if (!record) {
-    throw redirect(302, '/recent');
+    throw redirect(302, '/recipes');
   }
 
   // Increment click count (best-effort; don't block redirect on write failure)

--- a/src/routes/s/[code]/info/+page.server.ts
+++ b/src/routes/s/[code]/info/+page.server.ts
@@ -12,13 +12,13 @@ export const load: PageServerLoad = async ({ params, platform }) => {
 
   const code = params?.code?.trim();
   if (!code) {
-    throw redirect(302, '/recent');
+    throw redirect(302, '/recipes');
   }
 
   const key = normalizeShortCode(code);
   const record = await kv.get(key, 'json') as ShortenedURL | null;
   if (!record) {
-    throw redirect(302, '/recent');
+    throw redirect(302, '/recipes');
   }
 
   const targetPath = redirectPath(record.naddr, record.type);


### PR DESCRIPTION
## Summary
Now that pack browsing lives at \`/packs\`, the recipe stream's URL was the leftover \"Recent\" label. Renamed to \`/recipes\` for clearer naming. Behavior is purely additive — no fetching logic changed; the 100-recipe cap + missing pagination is the next PR.

## Changes
- **Move** \`src/routes/recent/+page.svelte\` → \`src/routes/recipes/+page.svelte\`.
- **New 301 redirect** at \`src/routes/recent/+page.server.ts\` → \`/recipes\`, preserving query string + hash. Existing bookmarks, the OG link previews shipped in PR #354, blog/news mentions, and search-engine indices all keep working.
- **Inbound link sweep:**
  - \`BottomNav.svelte\` / \`DesktopSideNav.svelte\` — link to \`/recipes\`. Active-match keeps \`/recent\` in the predicate so the nav stays highlighted during the 301 round-trip on cold links.
  - \`Feed.svelte\` empty-state, \`/cookbook\`, \`/cookbook/[naddr]\`, \`/premium\`, \`/packs\` tab — all updated to \`/recipes\`.
- **Server-side fallback redirects** in \`/s/[code]/*\` (4 files) and \`/r/[naddr]\` updated to point directly at \`/recipes\` so a missing short-link doesn't go through an extra 301 hop.
- **On-page tab label** updated from \"Recent\" → \"Recipes\" on \`/recipes\` itself and on \`/packs\` for consistency. The internal \`activeTab\` state value stays \`'recent'\` (purely internal, no externalized).
- **OG / Twitter meta** \`og:url\` / \`twitter:url\` updated to \`https://zap.cooking/recipes\`.

## Test plan
- [ ] Visit \`/recent\` → 301s to \`/recipes\`, query string + hash preserved.
- [ ] Visit \`/recipes\` → loads recipe stream as before.
- [ ] Bottom nav \"Recipes\" tab highlights on both \`/recipes\` and \`/recent\` (during redirect).
- [ ] \`/packs\` page shows the \"Recipes\" tab linking to \`/recipes\`.
- [ ] Empty-state \"Browse recipes\" / \"Browse Recipes\" buttons in Feed, \`/cookbook\`, \`/cookbook/[naddr]\` route to \`/recipes\`.
- [ ] OG card preview for \`/recipes\` resolves with the new \`og:url\`.
- [ ] No console errors / no broken layouts.

## Out of scope (next PR)
- Lazy load older recipes past the current 100-event cap.
- Tag scope is already correct: \`RECIPE_TAGS = ['zapcooking', 'nostrcooking']\` is queried as an OR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)