### PR TITLE
feat(recipes): lazy-load older recipes via until-cursor pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.330",
+  "version": "4.2.331",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.331",
+  "version": "4.2.332",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/routes/recipes/+page.svelte
+++ b/src/routes/recipes/+page.svelte
@@ -28,6 +28,33 @@
   // Cache filter for consistent cache keys
   const cacheFilter = { kinds: [30023], '#t': RECIPE_TAGS };
 
+  // ─── Pagination ──────────────────────────────────────────────────
+  // The first page (loadRecipes) fetches 100 most-recent recipes via
+  // the existing path. Once that lands, an IntersectionObserver on a
+  // sentinel just below the feed fires loadMoreRecipes() to walk
+  // backwards in time — `until: oldestCreatedAt - 1` — and append
+  // older recipes 50 at a time until the relays return EOSE with no
+  // new events.
+  //
+  // Cache layer is unchanged: only the first page is persisted via
+  // feedCacheService. Subsequent pages re-fetch on every visit. This
+  // keeps the cache bounded at the cost of re-walking history when a
+  // user re-opens the page mid-deep-scroll. Acceptable for v1.
+  const FOLLOWUP_PAGE_SIZE = 50;
+  // Don't paginate until the first page has clearly landed. Without
+  // this, a sentinel that's already in-viewport on a tiny initial
+  // result set can fire a follow-up before EOSE on the first batch
+  // even reaches us.
+  const MIN_EVENTS_BEFORE_PAGINATION = 10;
+  let loadingMore = false;
+  let exhausted = false;
+  // Bumped on every fresh load (mount / pull-to-refresh) so an
+  // in-flight pagination request from a prior session can't write
+  // its results into the new state.
+  let paginationGeneration = 0;
+  let sentinelEl: HTMLDivElement | null = null;
+  let intersectionObserver: IntersectionObserver | null = null;
+
   // Sort events by created_at descending (most recent first)
   $: sortedEvents = [...events].sort((a, b) => (b.created_at || 0) - (a.created_at || 0));
 
@@ -42,6 +69,13 @@
       clearTimeout(loadTimeout);
       loadTimeout = null;
     }
+
+    // Invalidate any in-flight pagination so its results don't bleed
+    // into this fresh load. Reset exhaustion + spinner so the sentinel
+    // can re-fire once the first page settles.
+    paginationGeneration++;
+    loadingMore = false;
+    exhausted = false;
 
     // Capture relay generation at start to detect stale data from relay switches
     const startGeneration = getCurrentRelayGeneration();
@@ -169,6 +203,144 @@
     }
   }
 
+  /**
+   * Fetch older recipes by walking the `created_at` cursor backwards.
+   * Single-flight (loadingMore guards re-entry), relay-generation +
+   * paginationGeneration guards drop stale results from prior sessions
+   * or relay swaps. EOSE with zero new events flips `exhausted` so the
+   * sentinel stops firing.
+   */
+  async function loadMoreRecipes() {
+    if (!$ndk || loadingMore || exhausted) return;
+    if (!loaded) return;
+    if (events.length < MIN_EVENTS_BEFORE_PAGINATION) return;
+
+    // Find the oldest created_at currently displayed. `until` is
+    // exclusive in some relay implementations and inclusive in others,
+    // so we subtract 1 to be safe — we'd rather miss a duplicate event
+    // (deduped by id below anyway) than fetch the same recipe twice.
+    let oldest = Infinity;
+    for (const e of events) {
+      const ts = e.created_at || 0;
+      if (ts && ts < oldest) oldest = ts;
+    }
+    if (!isFinite(oldest)) return;
+
+    const startGeneration = getCurrentRelayGeneration();
+    const localGen = ++paginationGeneration;
+    loadingMore = true;
+
+    const filter: NDKFilter = {
+      kinds: [30023],
+      '#t': RECIPE_TAGS,
+      limit: FOLLOWUP_PAGE_SIZE,
+      until: oldest - 1
+    };
+
+    let sub: NDKSubscription | null = null;
+    let safetyTimeout: ReturnType<typeof setTimeout> | null = null;
+
+    try {
+      // closeOnEose so this subscription self-cleans after EOSE — we
+      // don't need a long-lived sub for a one-off pagination fetch.
+      sub = $ndk.subscribe(filter, { closeOnEose: true });
+      const newEvents: NDKEvent[] = [];
+      const seen = new Set(events.map((e) => e.id));
+
+      sub.on('event', (event: NDKEvent) => {
+        if (
+          getCurrentRelayGeneration() !== startGeneration ||
+          localGen !== paginationGeneration
+        ) {
+          return;
+        }
+        if (seen.has(event.id)) return;
+        seen.add(event.id);
+        if (validateMarkdownTemplate(event.content) !== null) {
+          newEvents.push(event);
+        }
+      });
+
+      await new Promise<void>((resolve) => {
+        const finish = () => {
+          if (safetyTimeout) {
+            clearTimeout(safetyTimeout);
+            safetyTimeout = null;
+          }
+          resolve();
+        };
+        sub!.on('eose', finish);
+        // Safety: some relay sets never EOSE for a small window of
+        // time. Cap the wait so the spinner can't spin forever.
+        safetyTimeout = setTimeout(finish, 8000);
+      });
+
+      if (
+        getCurrentRelayGeneration() !== startGeneration ||
+        localGen !== paginationGeneration
+      ) {
+        return;
+      }
+
+      if (newEvents.length === 0) {
+        exhausted = true;
+        console.log('[Recipes] pagination exhausted — no older recipes returned');
+      } else {
+        events = [...events, ...newEvents];
+        console.log(
+          `[Recipes] pagination +${newEvents.length} (total ${events.length}, until=${oldest})`
+        );
+      }
+    } catch (err) {
+      console.warn('[Recipes] pagination failed:', err);
+    } finally {
+      try {
+        sub?.stop();
+      } catch {
+        // Already stopped from closeOnEose — ignore.
+      }
+      if (safetyTimeout) clearTimeout(safetyTimeout);
+      loadingMore = false;
+    }
+  }
+
+  function setupIntersectionObserver() {
+    if (intersectionObserver || !sentinelEl) return;
+    if (typeof IntersectionObserver === 'undefined') return;
+    intersectionObserver = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            loadMoreRecipes();
+          }
+        }
+      },
+      // Pre-fetch when the sentinel is within 400px of the viewport so
+      // the next page lands before the user actually hits the bottom.
+      { rootMargin: '400px' }
+    );
+    intersectionObserver.observe(sentinelEl);
+  }
+
+  function teardownIntersectionObserver() {
+    if (intersectionObserver) {
+      intersectionObserver.disconnect();
+      intersectionObserver = null;
+    }
+  }
+
+  // Attach the observer once the first page has settled and the
+  // sentinel is in the DOM. Reactive on `loaded`, `events.length`, and
+  // `sentinelEl` so SPA navigations re-attach correctly.
+  $: if (
+    loaded &&
+    events.length >= MIN_EVENTS_BEFORE_PAGINATION &&
+    sentinelEl &&
+    !intersectionObserver
+  ) {
+    setupIntersectionObserver();
+  }
+
   async function handleRefresh() {
     try {
       // Skip cache on pull-to-refresh to get fresh data
@@ -196,6 +368,12 @@
       clearTimeout(loadTimeout);
       loadTimeout = null;
     }
+    // Detach the lazy-load observer so it doesn't fire callbacks
+    // against a destroyed component on SPA back-nav.
+    teardownIntersectionObserver();
+    // Bumping the generation invalidates any in-flight pagination
+    // promise so it short-circuits before mutating freed state.
+    paginationGeneration++;
   });
 </script>
 
@@ -260,6 +438,29 @@
 
   <div class="flex flex-col gap-2">
     <Feed events={displayEvents} hideHide={true} {loaded} />
+
+    {#if loaded && !exhausted}
+      <!-- Sentinel: when this scrolls into view (or within 400px of it)
+           the IntersectionObserver fires loadMoreRecipes(). The spinner
+           inside is a visible signal during the fetch; the empty state
+           when not loadingMore keeps the sentinel measurable so the
+           observer can detect intersection. -->
+      <div
+        bind:this={sentinelEl}
+        class="py-6 flex items-center justify-center text-caption text-sm"
+      >
+        {#if loadingMore}
+          <div
+            class="w-5 h-5 rounded-full border-2 border-orange-200 border-t-orange-500 animate-spin mr-2"
+          ></div>
+          <span>Loading more recipes…</span>
+        {/if}
+      </div>
+    {:else if exhausted && events.length > 0}
+      <p class="py-6 text-center text-xs text-caption">
+        That's every recipe we know about. ⚡️
+      </p>
+    {/if}
   </div>
 </div>
 </PullToRefresh>

--- a/src/routes/recipes/+page.svelte
+++ b/src/routes/recipes/+page.svelte
@@ -287,8 +287,11 @@
         console.log('[Recipes] pagination exhausted — no older recipes returned');
       } else {
         events = [...events, ...newEvents];
+        // Log the exact `until` we asked the relays for (oldest - 1) so
+        // log lines line up with the actual subscription filter when
+        // debugging "why didn't this older recipe come back?"
         console.log(
-          `[Recipes] pagination +${newEvents.length} (total ${events.length}, until=${oldest})`
+          `[Recipes] pagination +${newEvents.length} (total ${events.length}, oldest=${oldest}, until=${oldest - 1})`
         );
       }
     } catch (err) {
@@ -304,9 +307,18 @@
     }
   }
 
+  /** Tracks the DOM node we're currently observing so we can detect when
+   *  Svelte has remounted the sentinel (pull-to-refresh sets loaded=false
+   *  → {#if} unmounts → bind:this nulls → loaded flips back true → new
+   *  node → bind:this assigns a fresh reference) and re-observe it. */
+  let observedSentinel: HTMLDivElement | null = null;
+
   function setupIntersectionObserver() {
-    if (intersectionObserver || !sentinelEl) return;
+    if (!sentinelEl) return;
     if (typeof IntersectionObserver === 'undefined') return;
+    // Idempotent: if we're already observing the current sentinel, no-op.
+    if (intersectionObserver && observedSentinel === sentinelEl) return;
+    teardownIntersectionObserver();
     intersectionObserver = new IntersectionObserver(
       (entries) => {
         for (const entry of entries) {
@@ -320,6 +332,7 @@
       { rootMargin: '400px' }
     );
     intersectionObserver.observe(sentinelEl);
+    observedSentinel = sentinelEl;
   }
 
   function teardownIntersectionObserver() {
@@ -327,18 +340,24 @@
       intersectionObserver.disconnect();
       intersectionObserver = null;
     }
+    observedSentinel = null;
   }
 
-  // Attach the observer once the first page has settled and the
-  // sentinel is in the DOM. Reactive on `loaded`, `events.length`, and
-  // `sentinelEl` so SPA navigations re-attach correctly.
-  $: if (
-    loaded &&
-    events.length >= MIN_EVENTS_BEFORE_PAGINATION &&
-    sentinelEl &&
-    !intersectionObserver
-  ) {
-    setupIntersectionObserver();
+  // Attach / re-attach the observer based on the current sentinel.
+  // Pull-to-refresh and exhaustion both unmount the sentinel via the
+  // {#if loaded && !exhausted} block, which nulls `sentinelEl`. Without
+  // an explicit teardown branch the old observer would keep watching
+  // a now-detached node and lazy-load would silently stop working
+  // after the first refresh. Combining setup + teardown in one
+  // reactive statement closes that gap and also handles the case where
+  // the sentinel node is replaced (svelte unmount → remount produces
+  // a new HTMLElement reference).
+  $: if (loaded && events.length >= MIN_EVENTS_BEFORE_PAGINATION && sentinelEl) {
+    if (observedSentinel !== sentinelEl) {
+      setupIntersectionObserver();
+    }
+  } else if (intersectionObserver) {
+    teardownIntersectionObserver();
   }
 
   async function handleRefresh() {


### PR DESCRIPTION
## Summary
The `/recipes` page (renamed from `/recent` in #362) was capped at the first 100 events of the initial fetch with no path to anything older — users genuinely could not see recipe #101+. This PR adds infinite-scroll pagination via `until`-cursor walks so the recipe stream keeps going as far as the relays carry history.

## Mechanics
- **First page unchanged** — 100 events via the existing one-shot subscription. Cache layer untouched (still first-page-only).
- **IntersectionObserver sentinel** below the feed attaches once `loaded === true` and `events.length >= 10` (avoids triggering during the initial empty/skeleton phase). `rootMargin: '400px'` pre-fetches before the user actually hits the bottom.
- **Pagination fetch:** `closeOnEose` subscription with `{ kinds: [30023], '#t': RECIPE_TAGS, limit: 50, until: oldest - 1 }`. The `-1` defends against relay implementations that treat `until` as inclusive.
- **Dedupe + validate:** by event id against the current set; same `parseMarkdownForEditing` content gate as the first page.
- **Exhaustion:** EOSE with zero new events flips `exhausted` so the sentinel stops firing and the page shows the terminal state.
- **Single-flight + generation guards:** `loadingMore` guards re-entry; `paginationGeneration` is bumped on every fresh load (mount, pull-to-refresh, `onDestroy`) so an in-flight follow-up from a prior session can't write into freed state. Relay-generation guard mirrors the initial-load pattern.
- **Safety timeout (8s)** so a relay set that never EOSEs can't pin the spinner forever.

## UI
- "Loading more recipes…" spinner while paginating.
- "That's every recipe we know about. ⚡️" terminal state.

## Tag scope
Unchanged. `RECIPE_TAGS = ['zapcooking', 'nostrcooking']` is queried as an OR via `#t`, so both legacy `nostrcooking` and new `zapcooking`-tagged recipes flow through the entire pagination pipeline.

## Test plan
- [ ] Open `/recipes` — first 100 land via the existing path.
- [ ] Scroll to ~80% — spinner appears, ~50 more recipes append, spinner clears.
- [ ] Keep scrolling — pagination keeps firing until exhaustion.
- [ ] At exhaustion — "That's every recipe we know about." message appears, sentinel stops firing.
- [ ] Pull-to-refresh — first page re-loads, `exhausted` resets, lazy-load arms again.
- [ ] Navigate away mid-fetch — no console errors / no observer firing on destroyed component.
- [ ] Tag scope — recipes tagged `#nostrcooking` (legacy) appear alongside `#zapcooking` ones throughout the scroll.
- [ ] Mobile — sentinel triggers correctly on touch-scroll.

## Out of scope
- Persisting deep-scroll position across navigation (cache stays first-page-only).
- Pre-fetching pages 2+ on idle.
- Pagination for /premium and /packs (each has its own scroll story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)