### PR TITLE
feat(profile): "Share My Recipes as Pack" — one-click authored-recipe pack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.335",
+  "version": "4.2.336",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.334",
+  "version": "4.2.335",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/ShareMyRecipesAction.svelte
+++ b/src/components/ShareMyRecipesAction.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+  /**
+   * "Share My Recipes as Pack" — one-click action that turns every
+   * recipe a user has authored on Nostr into a single replaceable
+   * Recipe Pack at d-tag `zapcooking-my-recipes`.
+   *
+   * Self-contained: owns its own button + loading + empty-state +
+   * SharePackModal wiring, so any page that wants the action just
+   * mounts <ShareMyRecipesAction pubkey={…} displayName={…} /> with
+   * minimal page-side state.
+   *
+   * Flow on click:
+   *   1. Fetch all kind:30023 recipes authored by `pubkey` via
+   *      fetchMyAuthoredRecipes.
+   *   2. If zero recipes → show empty-state inline (with /recipe/create CTA).
+   *   3. Otherwise → open SharePackModal pre-populated with sensible
+   *      defaults (title from displayName, description, cover image)
+   *      and pass the rich recipe list so the user can deselect any
+   *      they don't want in the pack.
+   *
+   * The modal handles publish, signing, and the optional kind:1 feed
+   * announcement — same path as cookbook/collection shares. Re-publishing
+   * replaces the existing "My Recipes" pack at the same d-tag.
+   */
+  import ShareNetworkIcon from 'phosphor-svelte/lib/ShareNetwork';
+  import SharePackModal from './SharePackModal.svelte';
+  import Button from './Button.svelte';
+  import { ndk } from '$lib/nostr';
+  import { showToast } from '$lib/toast';
+  import { fetchMyAuthoredRecipes, type MyRecipeForPack } from '$lib/myRecipesPack';
+
+  /** Pubkey of the author whose recipes we're packaging. Always the
+   *  signed-in user's pubkey in practice — the parent page is
+   *  responsible for only mounting this on the own-profile path. */
+  export let pubkey: string;
+  /** Display name used to pre-fill default title + description. */
+  export let displayName: string = '';
+  /**
+   * Optional class hook for the trigger button so the parent page can
+   * make it match local nav/sort/share controls without us baking in
+   * a specific style.
+   */
+  export let buttonClass: string = '';
+
+  let modalOpen = false;
+  let recipes: MyRecipeForPack[] = [];
+  let isLoading = false;
+  let lastError = '';
+  /**
+   * The fetch can resolve to "no recipes published yet". We surface
+   * that inline rather than opening an empty modal, since the modal
+   * is review-and-publish UX and there's nothing to publish.
+   */
+  let showEmptyState = false;
+
+  function defaultTitle(): string {
+    const name = displayName.trim();
+    return name ? `${name}'s Recipes` : 'My Recipes';
+  }
+
+  function defaultDescription(): string {
+    const name = displayName.trim();
+    return name
+      ? `A collection of recipes shared by ${name} on Zap Cooking.`
+      : 'A collection of recipes shared on Zap Cooking.';
+  }
+
+  async function handleClick() {
+    if (isLoading || modalOpen) return;
+    if (!pubkey) {
+      showToast('error', 'Sign in to share your recipes.');
+      return;
+    }
+    if (!$ndk) {
+      showToast('error', 'Not connected — try again in a moment.');
+      return;
+    }
+    isLoading = true;
+    lastError = '';
+    showEmptyState = false;
+    try {
+      recipes = await fetchMyAuthoredRecipes($ndk, pubkey);
+      if (recipes.length === 0) {
+        showEmptyState = true;
+        return;
+      }
+      modalOpen = true;
+    } catch (e: any) {
+      console.error('[ShareMyRecipesAction] fetch failed', e);
+      lastError = e?.message || 'Could not load your recipes.';
+      showToast('error', lastError);
+    } finally {
+      isLoading = false;
+    }
+  }
+</script>
+
+<button
+  type="button"
+  on:click={handleClick}
+  disabled={isLoading || !pubkey}
+  class={buttonClass ||
+    'flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed'}
+  style={buttonClass
+    ? ''
+    : 'background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);'}
+  title="Share every recipe you've published as a single Recipe Pack"
+  aria-label="Share my recipes as a Recipe Pack"
+>
+  <ShareNetworkIcon size={16} />
+  {#if isLoading}
+    <span>Loading…</span>
+  {:else}
+    <span>Share My Recipes</span>
+  {/if}
+</button>
+
+{#if showEmptyState}
+  <!-- Inline empty-state (vs. opening an empty modal). Anchored just
+       below the button so it reads as a response to the click. -->
+  <div
+    class="mt-2 p-3 rounded-lg flex flex-col gap-2 text-sm"
+    style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border); color: var(--color-text-primary);"
+  >
+    <p>You haven't published any recipes yet.</p>
+    <div class="flex">
+      <Button
+        on:click={() => {
+          showEmptyState = false;
+          window.location.href = '/recipe/create';
+        }}
+      >
+        Create a Recipe
+      </Button>
+    </div>
+  </div>
+{/if}
+
+<SharePackModal
+  bind:open={modalOpen}
+  source={{ type: 'my-recipes' }}
+  recipes={recipes.map((r) => ({ aTag: r.aTag, title: r.title, image: r.image }))}
+  recipeATags={recipes.map((r) => r.aTag)}
+  initialTitle={defaultTitle()}
+  initialDescription={defaultDescription()}
+/>

--- a/src/components/SharePackModal.svelte
+++ b/src/components/SharePackModal.svelte
@@ -18,6 +18,15 @@
   export let open = false;
   export let source: RecipePackSource;
   export let recipeATags: string[] = [];
+  /**
+   * Optional rich recipe list for the preview. When supplied, the
+   * modal renders a checkbox-list of titles so the user can deselect
+   * individual recipes before publishing. When omitted, the modal
+   * stays in the legacy "trust caller's recipeATags" shape used by
+   * cookbook + collection share buttons. Backwards-compatible: any
+   * caller still passing only `recipeATags` gets the same UI as today.
+   */
+  export let recipes: { aTag: string; title: string; image?: string }[] | undefined = undefined;
   export let initialTitle: string = '';
   export let initialDescription: string = '';
   export let initialImage: string | undefined = undefined;
@@ -37,7 +46,37 @@
   let publishedEvent: import('@nostr-dev-kit/ndk').NDKEvent | null = null;
   let copied = false;
 
-  $: recipeCount = recipeATags.length;
+  /**
+   * Selected a-tags from the rich recipe list. Default = all selected.
+   * Only used when `recipes` is provided; when not, the publish path
+   * uses `recipeATags` directly.
+   */
+  let selectedATags = new Set<string>();
+
+  /** Toggle a single recipe's selection. Extracted from the template
+   *  so the cast stays in TS-land — Svelte's inline expression parser
+   *  doesn't reliably handle `as HTMLInputElement` mid-template. */
+  function toggleRecipeSelection(aTag: string, checked: boolean) {
+    const next = new Set(selectedATags);
+    if (checked) next.add(aTag);
+    else next.delete(aTag);
+    selectedATags = next;
+  }
+
+  // Reset selection whenever a new `recipes` list arrives. Without this,
+  // closing + reopening the modal with a different recipe set would
+  // carry stale selections forward.
+  $: if (recipes) {
+    selectedATags = new Set(recipes.map((r) => r.aTag));
+  }
+
+  /** A-tags actually included in the publish: derived from the selection
+   *  when the rich recipe list is in play, or the prop directly otherwise. */
+  $: effectiveRecipeATags = recipes
+    ? recipes.filter((r) => selectedATags.has(r.aTag)).map((r) => r.aTag)
+    : recipeATags;
+
+  $: recipeCount = effectiveRecipeATags.length;
 
   // Reset state every time the modal opens
   $: if (open) initStateOnOpen();
@@ -55,11 +94,20 @@
       title = initialTitle || '';
       description = initialDescription || '';
       effectiveImage = initialImage;
-      // If no cover image was passed in, derive one from the first
-      // recipe that has an image. Cache-first so this is usually instant.
-      if (!effectiveImage && recipeATags.length > 0) {
+
+      // Cover image resolution. When the caller passed the rich recipe
+      // list we already have image URLs in memory — pick the first one
+      // synchronously and skip the network round-trip. Otherwise fall
+      // back to resolveFirstRecipeImage's cache-first lookup.
+      if (!effectiveImage && recipes && recipes.length > 0) {
+        const firstWithImage = recipes.find((r) => r.image);
+        if (firstWithImage?.image) {
+          effectiveImage = firstWithImage.image;
+        }
+      }
+      if (!effectiveImage && effectiveRecipeATags.length > 0) {
         isResolvingImage = true;
-        resolveFirstRecipeImage(recipeATags)
+        resolveFirstRecipeImage(effectiveRecipeATags)
           .then((img) => {
             if (img && !effectiveImage) effectiveImage = img;
           })
@@ -98,7 +146,9 @@
         title: title.trim(),
         description: description.trim() || undefined,
         image: effectiveImage,
-        recipeATags
+        // Use the user's current selection when the rich list is in
+        // play, otherwise fall through to the caller-supplied a-tags.
+        recipeATags: effectiveRecipeATags
       });
       publishedEvent = result.event;
       publishedNaddr = result.naddr;
@@ -197,6 +247,64 @@
           disabled={isSubmitting}
         />
       </div>
+
+      {#if recipes && recipes.length > 0}
+        <!-- Per-recipe checkbox list. Only rendered when the caller
+             passed a rich `recipes` prop; cookbook + collection share
+             paths still use the legacy preview-only flow. Default-all-
+             selected, capped at a max-height so a 200-recipe author
+             doesn't get a runaway scroll inside the modal. -->
+        <div class="flex flex-col gap-2">
+          <div class="flex items-center justify-between">
+            <span class="text-sm font-medium" style="color: var(--color-text-primary)">
+              Recipes ({recipeCount} of {recipes.length} selected)
+            </span>
+            {#if recipeCount < recipes.length}
+              <button
+                type="button"
+                class="text-xs underline"
+                style="color: var(--color-text-secondary)"
+                disabled={isSubmitting}
+                on:click={() => (selectedATags = new Set((recipes ?? []).map((r) => r.aTag)))}
+              >
+                Select all
+              </button>
+            {:else if recipeCount > 0}
+              <button
+                type="button"
+                class="text-xs underline"
+                style="color: var(--color-text-secondary)"
+                disabled={isSubmitting}
+                on:click={() => (selectedATags = new Set())}
+              >
+                Clear
+              </button>
+            {/if}
+          </div>
+          <div
+            class="flex flex-col gap-1 max-h-56 overflow-y-auto rounded-lg p-1"
+            style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+          >
+            {#each recipes as recipe (recipe.aTag)}
+              <label
+                class="flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer hover:bg-black/5 dark:hover:bg-white/5"
+              >
+                <input
+                  type="checkbox"
+                  class="w-4 h-4 accent-orange-500 flex-shrink-0"
+                  checked={selectedATags.has(recipe.aTag)}
+                  disabled={isSubmitting}
+                  on:change={(e) =>
+                    toggleRecipeSelection(recipe.aTag, e.currentTarget.checked)}
+                />
+                <span class="text-sm truncate" style="color: var(--color-text-primary)">
+                  {recipe.title}
+                </span>
+              </label>
+            {/each}
+          </div>
+        </div>
+      {/if}
 
       <!-- Live preview -->
       <div class="flex flex-col gap-2">

--- a/src/lib/myRecipesPack.ts
+++ b/src/lib/myRecipesPack.ts
@@ -1,0 +1,116 @@
+/**
+ * "My Recipes" pack — fetch all kind:30023 recipes authored by a single
+ * pubkey, validated and shaped for the SharePackModal preview.
+ *
+ * Used by the user-profile "Share My Recipes as Pack" action. We fetch
+ * all of the author's recipes in one shot (bounded by MAX_RECIPES; user
+ * authored counts are bounded in practice), validate the markdown so
+ * malformed events don't enter the pack, dedupe by addressable a-tag,
+ * and return them sorted newest-first.
+ *
+ * The shape is deliberately small — just what the modal preview + the
+ * publish path need (a-tag for the pack reference, title for the
+ * checkbox list, image so the pack cover can be picked from the most
+ * recent recipe with one).
+ */
+
+import type NDK from '@nostr-dev-kit/ndk';
+import type { NDKEvent, NDKFilter } from '@nostr-dev-kit/ndk';
+import { validateMarkdownTemplate } from '$lib/parser';
+import { RECIPE_TAGS } from '$lib/consts';
+
+export interface MyRecipeForPack {
+	/** Addressable a-tag in `kind:pubkey:dTag` form, ready to drop into a Recipe Pack event. */
+	aTag: string;
+	/** Display title (from the `title` tag, falling back to the d-tag). */
+	title: string;
+	/** First image URL on the recipe, when present. */
+	image?: string;
+	/** Original event timestamp, used for newest-first sort. */
+	createdAt: number;
+}
+
+const RECIPE_KIND = 30023;
+/**
+ * One-shot fetch upper bound. The vast majority of authors will have
+ * far fewer recipes than this; a few power users could approach it.
+ * The cap avoids unbounded memory if a relay returns huge result sets,
+ * but isn't intended to be a load-more boundary — extending it later
+ * doesn't break compatibility.
+ */
+const MAX_RECIPES = 500;
+/** Hard cap on subscription wait so a slow relay can't pin the UI. */
+const SUBSCRIPTION_TIMEOUT_MS = 10_000;
+
+/**
+ * Fetch every recipe authored by `pubkey` and return them in a shape
+ * suitable for the share-pack flow. Resolves with an empty array if
+ * the user hasn't authored any recipes (the caller surfaces an empty
+ * state rather than treating this as an error).
+ *
+ * Implementation mirrors the user-profile recipes-tab pattern in
+ * `routes/user/[slug]/+page.svelte`: subscribe with the standard
+ * RECIPE_TAGS filter, validate content via `parseMarkdownForEditing`'s
+ * looser sibling, dedupe by a-tag, sort newest-first.
+ */
+export async function fetchMyAuthoredRecipes(
+	ndk: NDK,
+	pubkey: string
+): Promise<MyRecipeForPack[]> {
+	if (!ndk) throw new Error('NDK not initialized');
+	if (!pubkey) throw new Error('Pubkey required');
+
+	const filter: NDKFilter = {
+		authors: [pubkey],
+		kinds: [RECIPE_KIND],
+		'#t': RECIPE_TAGS,
+		limit: MAX_RECIPES
+	};
+
+	// Track by a-tag so a republished recipe (same d-tag, newer
+	// created_at) keeps only the latest version. NDK delivers events as
+	// they arrive — when two come in for the same address we keep
+	// whichever has the higher created_at.
+	const byATag = new Map<string, MyRecipeForPack>();
+
+	await new Promise<void>((resolve) => {
+		const subscription = ndk.subscribe(filter, { closeOnEose: true });
+
+		const safetyTimeout = setTimeout(() => {
+			try {
+				subscription.stop();
+			} catch {
+				// already stopped
+			}
+			resolve();
+		}, SUBSCRIPTION_TIMEOUT_MS);
+
+		subscription.on('event', (event: NDKEvent) => {
+			if (validateMarkdownTemplate(event.content) == null) return;
+			const dTag = event.tags.find((t) => t[0] === 'd')?.[1];
+			if (!dTag) return;
+			const aTag = `${RECIPE_KIND}:${pubkey}:${dTag}`;
+			const existing = byATag.get(aTag);
+			const createdAt = event.created_at || 0;
+			if (existing && existing.createdAt >= createdAt) return;
+
+			const title =
+				event.tags.find((t) => t[0] === 'title')?.[1]?.trim() || dTag;
+			const image = event.tags.find((t) => t[0] === 'image')?.[1] || undefined;
+
+			byATag.set(aTag, { aTag, title, image, createdAt });
+		});
+
+		subscription.on('eose', () => {
+			clearTimeout(safetyTimeout);
+			try {
+				subscription.stop();
+			} catch {
+				// already stopped
+			}
+			resolve();
+		});
+	});
+
+	return Array.from(byATag.values()).sort((a, b) => b.createdAt - a.createdAt);
+}

--- a/src/lib/myRecipesPack.ts
+++ b/src/lib/myRecipesPack.ts
@@ -20,14 +20,14 @@ import { validateMarkdownTemplate } from '$lib/parser';
 import { RECIPE_TAGS } from '$lib/consts';
 
 export interface MyRecipeForPack {
-	/** Addressable a-tag in `kind:pubkey:dTag` form, ready to drop into a Recipe Pack event. */
-	aTag: string;
-	/** Display title (from the `title` tag, falling back to the d-tag). */
-	title: string;
-	/** First image URL on the recipe, when present. */
-	image?: string;
-	/** Original event timestamp, used for newest-first sort. */
-	createdAt: number;
+  /** Addressable a-tag in `kind:pubkey:dTag` form, ready to drop into a Recipe Pack event. */
+  aTag: string;
+  /** Display title (from the `title` tag, falling back to the d-tag). */
+  title: string;
+  /** First image URL on the recipe, when present. */
+  image?: string;
+  /** Original event timestamp, used for newest-first sort. */
+  createdAt: number;
 }
 
 const RECIPE_KIND = 30023;
@@ -53,64 +53,68 @@ const SUBSCRIPTION_TIMEOUT_MS = 10_000;
  * RECIPE_TAGS filter, validate content via `parseMarkdownForEditing`'s
  * looser sibling, dedupe by a-tag, sort newest-first.
  */
-export async function fetchMyAuthoredRecipes(
-	ndk: NDK,
-	pubkey: string
-): Promise<MyRecipeForPack[]> {
-	if (!ndk) throw new Error('NDK not initialized');
-	if (!pubkey) throw new Error('Pubkey required');
+export async function fetchMyAuthoredRecipes(ndk: NDK, pubkey: string): Promise<MyRecipeForPack[]> {
+  if (!ndk) throw new Error('NDK not initialized');
+  if (!pubkey) throw new Error('Pubkey required');
 
-	const filter: NDKFilter = {
-		authors: [pubkey],
-		kinds: [RECIPE_KIND],
-		'#t': RECIPE_TAGS,
-		limit: MAX_RECIPES
-	};
+  const filter: NDKFilter = {
+    authors: [pubkey],
+    kinds: [RECIPE_KIND],
+    '#t': RECIPE_TAGS,
+    limit: MAX_RECIPES
+  };
 
-	// Track by a-tag so a republished recipe (same d-tag, newer
-	// created_at) keeps only the latest version. NDK delivers events as
-	// they arrive — when two come in for the same address we keep
-	// whichever has the higher created_at.
-	const byATag = new Map<string, MyRecipeForPack>();
+  // Track by a-tag so a republished recipe (same d-tag, newer
+  // created_at) keeps only the latest version. NDK delivers events as
+  // they arrive — when two come in for the same address we keep
+  // whichever has the higher created_at.
+  const byATag = new Map<string, MyRecipeForPack>();
 
-	await new Promise<void>((resolve) => {
-		const subscription = ndk.subscribe(filter, { closeOnEose: true });
+  await new Promise<void>((resolve) => {
+    const subscription = ndk.subscribe(filter, { closeOnEose: true });
 
-		const safetyTimeout = setTimeout(() => {
-			try {
-				subscription.stop();
-			} catch {
-				// already stopped
-			}
-			resolve();
-		}, SUBSCRIPTION_TIMEOUT_MS);
+    const safetyTimeout = setTimeout(() => {
+      try {
+        subscription.stop();
+      } catch {
+        // already stopped
+      }
+      resolve();
+    }, SUBSCRIPTION_TIMEOUT_MS);
 
-		subscription.on('event', (event: NDKEvent) => {
-			if (validateMarkdownTemplate(event.content) == null) return;
-			const dTag = event.tags.find((t) => t[0] === 'd')?.[1];
-			if (!dTag) return;
-			const aTag = `${RECIPE_KIND}:${pubkey}:${dTag}`;
-			const existing = byATag.get(aTag);
-			const createdAt = event.created_at || 0;
-			if (existing && existing.createdAt >= createdAt) return;
+    subscription.on('event', (event: NDKEvent) => {
+      // validateMarkdownTemplate returns MarkdownTemplate | string —
+      // it never returns null. A string return is an error message
+      // describing what's wrong with the markdown. Filter on that
+      // shape so malformed events stay out of the pack. (The wider
+      // codebase uses an `!= null` check that's always true; we
+      // don't fix it here to keep this PR scoped, but we use the
+      // correct check for new code.)
+      const validation = validateMarkdownTemplate(event.content);
+      if (typeof validation === 'string') return;
+      const dTag = event.tags.find((t) => t[0] === 'd')?.[1];
+      if (!dTag) return;
+      const aTag = `${RECIPE_KIND}:${pubkey}:${dTag}`;
+      const existing = byATag.get(aTag);
+      const createdAt = event.created_at || 0;
+      if (existing && existing.createdAt >= createdAt) return;
 
-			const title =
-				event.tags.find((t) => t[0] === 'title')?.[1]?.trim() || dTag;
-			const image = event.tags.find((t) => t[0] === 'image')?.[1] || undefined;
+      const title = event.tags.find((t) => t[0] === 'title')?.[1]?.trim() || dTag;
+      const image = event.tags.find((t) => t[0] === 'image')?.[1] || undefined;
 
-			byATag.set(aTag, { aTag, title, image, createdAt });
-		});
+      byATag.set(aTag, { aTag, title, image, createdAt });
+    });
 
-		subscription.on('eose', () => {
-			clearTimeout(safetyTimeout);
-			try {
-				subscription.stop();
-			} catch {
-				// already stopped
-			}
-			resolve();
-		});
-	});
+    subscription.on('eose', () => {
+      clearTimeout(safetyTimeout);
+      try {
+        subscription.stop();
+      } catch {
+        // already stopped
+      }
+      resolve();
+    });
+  });
 
-	return Array.from(byATag.values()).sort((a, b) => b.createdAt - a.createdAt);
+  return Array.from(byATag.values()).sort((a, b) => b.createdAt - a.createdAt);
 }

--- a/src/lib/recipePack.ts
+++ b/src/lib/recipePack.ts
@@ -19,12 +19,19 @@ import { get } from 'svelte/store';
 export const RECIPE_PACK_KIND: NDKKind = 30004 as NDKKind;
 export const COOKBOOK_PACK_DTAG = 'zapcooking-cookbook';
 export const COLLECTION_PACK_DTAG_PREFIX = 'zapcooking-pack-';
+export const MY_RECIPES_PACK_DTAG = 'zapcooking-my-recipes';
 export const RECIPE_PACK_TAG = 'recipe-pack';
 export const ZAP_COOKING_TAG = 'zap-cooking';
+export const MY_RECIPES_TAG = 'my-recipes';
 
 export type RecipePackSource =
   | { type: 'cookbook' }
-  | { type: 'collection'; collectionDTag: string };
+  | { type: 'collection'; collectionDTag: string }
+  // Pack of recipes the current user has personally authored
+  // (kind 30023 events with `authors: [pubkey]`). Replaceable per
+  // pubkey via the fixed d-tag, so re-publishing updates a single
+  // canonical "My Recipes" pack rather than spawning new ones.
+  | { type: 'my-recipes' };
 
 export interface BuildPackInput {
   source: RecipePackSource;
@@ -44,6 +51,7 @@ export interface PublishedPack {
 /** Compute the d-tag for a pack source. Replaceable per source. */
 export function packDTag(source: RecipePackSource): string {
   if (source.type === 'cookbook') return COOKBOOK_PACK_DTAG;
+  if (source.type === 'my-recipes') return MY_RECIPES_PACK_DTAG;
   return `${COLLECTION_PACK_DTAG_PREFIX}${source.collectionDTag}`;
 }
 
@@ -162,6 +170,13 @@ export function buildRecipePackEvent(input: BuildPackInput): NDKEvent {
   tags.push(['t', RECIPE_PACK_TAG]);
   tags.push(['t', ZAP_COOKING_TAG]);
   tags.push(['t', RECIPE_TAG_PREFIX_NEW]);
+  // Per-source discriminator tag — lets feed clients filter for "my
+  // recipes" packs specifically without scanning d-tags. Cookbook and
+  // collection packs don't get an extra discriminator; they're already
+  // visually distinct via title/description on the pack page.
+  if (input.source.type === 'my-recipes') {
+    tags.push(['t', MY_RECIPES_TAG]);
+  }
 
   for (const aTag of dedupedATags) {
     tags.push(['a', aTag, GARDEN_RELAY_URL]);

--- a/src/routes/user/[slug]/+page.svelte
+++ b/src/routes/user/[slug]/+page.svelte
@@ -30,6 +30,7 @@
   import ProfileDrafts from '../../../components/ProfileDrafts.svelte';
   import Modal from '../../../components/Modal.svelte';
   import FoodstrFeedOptimized from '../../../components/FoodstrFeedOptimized.svelte';
+  import ShareMyRecipesAction from '../../../components/ShareMyRecipesAction.svelte';
   import FloppyDiskIcon from 'phosphor-svelte/lib/FloppyDisk';
   import BookOpenIcon from 'phosphor-svelte/lib/BookOpen';
   import ImageSquareIcon from 'phosphor-svelte/lib/ImageSquare';
@@ -2122,6 +2123,18 @@
         </div>
       </div>
     {:else}
+      {#if hexpubkey && $userPublickey === hexpubkey}
+        <!-- Own-profile-only "Share My Recipes" action. Mounts inline
+             above the Feed so the entry point lives where users
+             already think of "my recipes". The component owns its
+             own loading + empty-state + modal — page stays slim. -->
+        <div class="mb-3 flex">
+          <ShareMyRecipesAction
+            pubkey={hexpubkey}
+            displayName={String(profile?.display_name ?? profile?.name ?? '')}
+          />
+        </div>
+      {/if}
       <Feed {events} {loaded} isProfileView={true} isOwnProfile={$userPublickey === hexpubkey} />
       {#if hasMoreRecipes}
         <div bind:this={recipeSentinel} class="py-4 text-center">


### PR DESCRIPTION
## Summary
Adds a one-click action on the user's own profile that turns every recipe they've authored on Nostr into a single replaceable Recipe Pack. Existing pack publish flow handles the rest (signing, optional kind:1 announcement, share URL, \`/pack/[naddr]\` page handles all social actions).

It feels like: **"Here are all the recipes I've shared on Zap Cooking."**

## Phase 1 review
The existing Recipe Pack stack (kind 30004, \`SharePackModal\`, \`publishRecipePack\`, \`publishPackAnnouncement\`) is already reusable — only needed a new \`RecipePackSource\` variant + a fetcher. The \`{ authors, kinds: [30023], '#t': RECIPE_TAGS }\` filter is the established pattern for per-author recipes; same one used by the profile Recipes tab.

## What I added
- **`src/lib/recipePack.ts`** — extends \`RecipePackSource\` with \`{ type: 'my-recipes' }\`. Fixed d-tag \`zapcooking-my-recipes\` so re-publishing replaces the existing pack. Adds \`['t', 'my-recipes']\` discriminator tag for feed clients that want to filter for these specifically.
- **`src/lib/myRecipesPack.ts`** *(new)* — \`fetchMyAuthoredRecipes(ndk, pubkey)\`. Validates content via \`validateMarkdownTemplate\`, dedupes by a-tag (keeps the latest republish), sorts newest-first. Bounded by 500 events + 10s safety timeout.
- **`src/components/SharePackModal.svelte`** — backwards-compatible \`recipes?: { aTag, title, image? }[]\` prop. When supplied, renders a checkbox list above the preview (default all selected, with Select-all / Clear shortcuts). Cookbook + collection share buttons keep the legacy preview-only UI. Cover image picks up synchronously from the rich list when available.
- **`src/components/ShareMyRecipesAction.svelte`** *(new)* — self-contained trigger button + loading + empty-state + modal wiring. Default title \`"{displayName}'s Recipes"\` / fallback \`"My Recipes"\`. Empty state when 0 recipes renders inline with a CTA to \`/recipe/create\` (vs. opening an empty modal).
- **`src/routes/user/[slug]/+page.svelte`** — mounts the action above the Feed in the Recipes tab, gated to own-profile (\`$userPublickey === hexpubkey\`).

## Event shape
Replaceable Recipe Pack at \`kind:30004:<pubkey>:zapcooking-my-recipes\`:
- \`['d', 'zapcooking-my-recipes']\`
- \`['title', '<title>']\`
- \`['description', '<description>']\` *(when set)*
- \`['image', '<cover_url>']\` *(when set)*
- \`['t', 'recipe-pack']\`, \`['t', 'zap-cooking']\`, \`['t', 'zapcooking']\`, \`['t', 'my-recipes']\`
- One \`['a', '30023:<pubkey>:<recipe-dtag>', GARDEN_RELAY_URL]\` per included recipe

Re-publishing replaces it — same canonical \"My Recipes\" pack at the same address.

## UI placement decisions
- **Yes**: own-profile Recipes tab (mounted above the existing Feed). The natural place users think of \"my recipes\".
- **No (V1)**: cookbook page next to \"Share Cookbook\". Easy follow-up — just mount the same component. Kept this PR focused.
- **No (V1)**: any feed/global placement.

## Validation
- \`pnpm test\` — 77 / 77 passing
- \`pnpm check\` — 0 errors
- \`pnpm build\` — clean

## Test plan
- [ ] Sign in. Visit own profile → Recipes tab → \"Share My Recipes\" button visible above feed.
- [ ] Click → recipes fetch, modal opens with title pre-filled, all recipes checked.
- [ ] Uncheck a few recipes → preview count updates; \"Select all\" / \"Clear\" shortcuts work.
- [ ] Publish → success toast + share link + optional kind:1 feed announcement.
- [ ] Open published pack at \`/pack/[naddr]\` → renders, zappable, repostable, exportable as cookbook.
- [ ] Re-publish (edit title, click again) → replaces same pack, updated content.
- [ ] Brand new account with 0 recipes → click → inline empty-state with \"Create a Recipe\" CTA, no empty modal.
- [ ] Visit someone else's profile → button does NOT render.

## Out of scope (follow-ups from the spec)
- AI-generated titles / descriptions
- \"This year's recipes\" / \"High-Nourish recipes\" pack variants
- Auto-update reminders when user posts new recipes
- Cookbook-page placement (drop-in addition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)