### PR TITLE
fix(publish): force every Zap Cooking recipe onto garden + retry queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.337",
+  "version": "4.2.338",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.336",
+  "version": "4.2.337",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/publishQueue.ts
+++ b/src/lib/publishQueue.ts
@@ -671,3 +671,73 @@ class PublishQueueManager {
 
 // Export singleton instance
 export const publishQueue = new PublishQueueManager();
+
+/**
+ * Confirm that a freshly-published event actually landed on Zap Cooking's
+ * own relay (garden), and queue a targeted republish if it didn't.
+ *
+ * Why this exists: NDK 2.x's outbox model on writes routes a publish to
+ * the AUTHOR's NIP-65 write relays. For authors whose NIP-65 doesn't
+ * include garden, our normal `event.publish()` call can land everywhere
+ * EXCEPT garden — and then `/r/<naddr>` can't find the event because
+ * our default fetch path only consults the standard pool. Verifying
+ * post-publish makes garden the durable source of truth for everything
+ * authored on Zap Cooking, regardless of the author's NIP-65.
+ *
+ * Best-effort: a verification miss queues a retry but does not throw.
+ * The caller's primary publish path is unchanged — this is layered on
+ * top.
+ */
+export async function ensureLandedOnGarden(
+  event: NDKEvent,
+  opts: { verifyTimeoutMs?: number } = {}
+): Promise<{ onGarden: boolean; queuedRetry: boolean }> {
+  const verifyTimeoutMs = opts.verifyTimeoutMs ?? 4000;
+
+  if (!event?.id || !event?.pubkey) {
+    return { onGarden: false, queuedRetry: false };
+  }
+
+  try {
+    const { ndk } = await import('$lib/nostr');
+    const { NDKRelaySet } = await import('@nostr-dev-kit/ndk');
+    const ndkInstance = get(ndk);
+    if (!ndkInstance) return { onGarden: false, queuedRetry: false };
+
+    const gardenRelay = ndkInstance.pool.getRelay(GARDEN_RELAY_URL, true, true);
+    if (!gardenRelay) return { onGarden: false, queuedRetry: false };
+
+    // Best-effort connect; even if connect resolves slowly, the timeout
+    // below caps the wait.
+    await gardenRelay.connect().catch(() => {});
+
+    const relaySet = new NDKRelaySet(new Set([gardenRelay]), ndkInstance);
+
+    const fetchPromise = ndkInstance.fetchEvent(
+      { ids: [event.id] },
+      undefined,
+      relaySet
+    );
+    const timeoutPromise = new Promise<null>((resolve) =>
+      setTimeout(() => resolve(null), verifyTimeoutMs)
+    );
+
+    const found = await Promise.race([fetchPromise, timeoutPromise]);
+    if (found) {
+      console.log(`[publishQueue] ✅ event ${event.id.slice(0, 12)}… confirmed on garden`);
+      return { onGarden: true, queuedRetry: false };
+    }
+
+    // Garden didn't have the event after the verification window. Queue
+    // a targeted republish so it lands eventually (with backoff). This
+    // is exactly what `relayMode: 'garden'` does in attemptPublish.
+    console.warn(
+      `[publishQueue] ⚠️ event ${event.id.slice(0, 12)}… missed garden — queuing retry`
+    );
+    await publishQueue.publishWithRetry(event, 'garden');
+    return { onGarden: false, queuedRetry: true };
+  } catch (err) {
+    console.warn('[publishQueue] ensureLandedOnGarden failed', err);
+    return { onGarden: false, queuedRetry: false };
+  }
+}

--- a/src/lib/publishQueue.ts
+++ b/src/lib/publishQueue.ts
@@ -707,9 +707,12 @@ export async function ensureLandedOnGarden(
     const gardenRelay = ndkInstance.pool.getRelay(GARDEN_RELAY_URL, true, true);
     if (!gardenRelay) return { onGarden: false, queuedRetry: false };
 
-    // Best-effort connect; even if connect resolves slowly, the timeout
-    // below caps the wait.
-    await gardenRelay.connect().catch(() => {});
+    // getRelay(url, autoConnect=true, createIfMissing=true) starts the
+    // connection in the background. We DON'T await it — a hung
+    // connect would otherwise block past `verifyTimeoutMs`. fetchEvent
+    // tolerates an in-progress connection (queues until ready), and
+    // the Promise.race below caps the total wait at verifyTimeoutMs
+    // regardless of where the time was spent.
 
     const relaySet = new NDKRelaySet(new Set([gardenRelay]), ndkInstance);
 

--- a/src/routes/create/+page.svelte
+++ b/src/routes/create/+page.svelte
@@ -380,20 +380,41 @@
         if (!publishResult.success && !publishResult.queued) {
           throw new Error(publishResult.error || 'Publish failed');
         }
-        resultMessage = 'Success!';
 
-        // Belt + suspenders: confirm the event actually landed on
-        // garden specifically. If not, queue a targeted republish so
-        // garden ends up holding every Zap Cooking-authored recipe
-        // regardless of the author's NIP-65 preferences. Best-effort —
-        // doesn't block the user-facing success path.
-        ensureLandedOnGarden(event).catch((e) =>
-          console.warn('[create] garden verification failed', e)
-        );
+        // Distinguish "succeeded immediately" from "queued for retry".
+        // When the initial attempt fails (signer not ready, relay
+        // connectivity blip), publishWithRetry signs+queues the event
+        // for IndexedDB-backed retry — but the event might not have a
+        // valid pubkey/sig yet. We surface this honestly to the user
+        // so they don't think it's already on relays, and we skip the
+        // garden verify (nothing to verify yet).
+        if (publishResult.queued) {
+          resultMessage =
+            'Publish queued. Your recipe will be published as soon as relays are reachable.';
+        } else {
+          resultMessage = 'Success!';
+          // Belt + suspenders: confirm the event actually landed on
+          // garden specifically. If not, queue a targeted republish so
+          // garden ends up holding every Zap Cooking-authored recipe
+          // regardless of the author's NIP-65 preferences. Best-effort —
+          // doesn't block the user-facing success path.
+          ensureLandedOnGarden(event).catch((e) =>
+            console.warn('[create] garden verification failed', e)
+          );
+        }
+
+        // Use the signed-in user's pubkey for the naddr — event.pubkey
+        // can be undefined when the publish was queued before signing
+        // completed. $userPublickey is always populated at this point
+        // (handlePublish already gated on it).
+        const recipePubkey = event.pubkey || $userPublickey;
+        if (!recipePubkey) {
+          throw new Error('Unable to determine author pubkey for recipe address');
+        }
 
         const naddr = nip19.naddrEncode({
           identifier: title.toLowerCase().replaceAll(' ', '-'),
-          pubkey: event.pubkey,
+          pubkey: recipePubkey,
           kind: 30023
         });
 

--- a/src/routes/create/+page.svelte
+++ b/src/routes/create/+page.svelte
@@ -12,6 +12,7 @@
   import { nip19 } from 'nostr-tools';
   import MediaUploader from '../../components/MediaUploader.svelte';
   import { addClientTagToEvent } from '$lib/nip89';
+  import { publishQueue, ensureLandedOnGarden } from '$lib/publishQueue';
   import Button from '../../components/Button.svelte';
   import MarkdownEditor from '../../components/MarkdownEditor.svelte';
   import { onMount, onDestroy, tick } from 'svelte';
@@ -366,19 +367,29 @@
         // Add NIP-89 client tag
         addClientTagToEvent(event);
 
-        // Publish with timeout to avoid hanging if relays are down
-        let publishTimeoutId: ReturnType<typeof setTimeout> | undefined;
-        const publishTimeout: Promise<never> = new Promise((_, reject) => {
-          publishTimeoutId = setTimeout(
-            () => reject(new Error('Publish timed out after 15 seconds')),
-            15000
-          );
-        });
-        await Promise.race([event.publish(), publishTimeout]);
-        if (publishTimeoutId !== undefined) {
-          clearTimeout(publishTimeoutId);
+        // Publish via publishQueue.
+        //
+        // Why not bare event.publish(): NDK 2.x's outbox model on writes
+        // routes a publish to the AUTHOR's NIP-65 write relays. For
+        // authors whose NIP-65 doesn't include garden, that path lands
+        // the event on niche relays and skips garden entirely — and
+        // /r/<naddr> readers can't find it. publishQueue's "all" mode
+        // explicitly fans out to every pool relay (garden included),
+        // and persists a retry queue in IndexedDB if any of them flake.
+        const publishResult = await publishQueue.publishWithRetry(event, 'all');
+        if (!publishResult.success && !publishResult.queued) {
+          throw new Error(publishResult.error || 'Publish failed');
         }
         resultMessage = 'Success!';
+
+        // Belt + suspenders: confirm the event actually landed on
+        // garden specifically. If not, queue a targeted republish so
+        // garden ends up holding every Zap Cooking-authored recipe
+        // regardless of the author's NIP-65 preferences. Best-effort —
+        // doesn't block the user-facing success path.
+        ensureLandedOnGarden(event).catch((e) =>
+          console.warn('[create] garden verification failed', e)
+        );
 
         const naddr = nip19.naddrEncode({
           identifier: title.toLowerCase().replaceAll(' ', '-'),

--- a/src/routes/create/gated/+page.svelte
+++ b/src/routes/create/gated/+page.svelte
@@ -12,6 +12,7 @@
   import { nip19 } from 'nostr-tools';
   import MediaUploader from '../../../components/MediaUploader.svelte';
   import { addClientTagToEvent } from '$lib/nip89';
+  import { publishQueue, ensureLandedOnGarden } from '$lib/publishQueue';
   import Button from '../../../components/Button.svelte';
   import MarkdownEditor from '../../../components/MarkdownEditor.svelte';
   import { onMount, onDestroy } from 'svelte';
@@ -228,8 +229,19 @@
         // Replace content with preview-only for relay (full content is encrypted on server)
         event.content = gatePreview || summary || 'This is a premium recipe. Visit zap.cooking to unlock.';
 
-        // Publish the recipe with gated tag (content is now preview-only)
-        await event.publish();
+        // Publish via publishQueue (see /create/+page.svelte for the
+        // full rationale). "all" mode fans out to every pool relay
+        // including garden — guarantees the kind:30023 preview wrapper
+        // lands on Zap Cooking infrastructure regardless of the
+        // author's NIP-65 outbox preferences.
+        const gatedPublishResult = await publishQueue.publishWithRetry(event, 'all');
+        if (!gatedPublishResult.success && !gatedPublishResult.queued) {
+          throw new Error(gatedPublishResult.error || 'Publish failed');
+        }
+        // Best-effort garden verification + retry-on-miss.
+        ensureLandedOnGarden(event).catch((e) =>
+          console.warn('[create-gated] garden verification failed', e)
+        );
         
         const naddr = nip19.naddrEncode({
           identifier: title.toLowerCase().replaceAll(' ', '-'),

--- a/src/routes/create/gated/+page.svelte
+++ b/src/routes/create/gated/+page.svelte
@@ -238,14 +238,27 @@
         if (!gatedPublishResult.success && !gatedPublishResult.queued) {
           throw new Error(gatedPublishResult.error || 'Publish failed');
         }
-        // Best-effort garden verification + retry-on-miss.
-        ensureLandedOnGarden(event).catch((e) =>
-          console.warn('[create-gated] garden verification failed', e)
-        );
-        
+        // When the initial publish fails and gets queued for retry, the
+        // event may not be signed yet, so event.author.hexpubkey is
+        // undefined and the garden verify has nothing to look up.
+        // Surface "queued" honestly and skip the verify; otherwise run
+        // the belt-and-suspenders check.
+        if (!gatedPublishResult.queued) {
+          ensureLandedOnGarden(event).catch((e) =>
+            console.warn('[create-gated] garden verification failed', e)
+          );
+        }
+
+        // Always derive the naddr from $userPublickey rather than
+        // event.author.hexpubkey — the latter is only populated after
+        // signing, which can be deferred when queued.
+        const gatedPubkey = event.pubkey || $userPublickey;
+        if (!gatedPubkey) {
+          throw new Error('Unable to determine author pubkey for recipe address');
+        }
         const naddr = nip19.naddrEncode({
           identifier: title.toLowerCase().replaceAll(' ', '-'),
-          pubkey: event.author.hexpubkey,
+          pubkey: gatedPubkey,
           kind: GATED_RECIPE_KIND
         });
         
@@ -263,19 +276,27 @@
           // Non-critical: naddr update failed
         }
         
-        resultMessage = 'Premium recipe created! Redirecting...';
-        
-        // Delete the draft since it's now published
+        resultMessage = gatedPublishResult.queued
+          ? 'Publish queued. Your premium recipe will publish as soon as relays are reachable.'
+          : 'Premium recipe created! Redirecting...';
+
+        // Delete the draft since it's now published (or queued — either
+        // way the user can't usefully edit the same draft anymore).
         if (currentDraftId) {
           deleteDraft(currentDraftId);
           currentDraftId = null;
         }
-        
-        // Redirect to the premium recipe page
-        setTimeout(() => {
-          goto(`/premium/recipe/${naddr}`);
-        }, 1500);
-        return; // Don't reset disablePublishButton - keep it disabled until redirect
+
+        // Only auto-redirect on actual publish success. When queued,
+        // /premium/recipe/<naddr> would 404 because the event isn't on
+        // any relay yet — let the user stay on the create page to see
+        // the queued status, and they can navigate manually later.
+        if (!gatedPublishResult.queued) {
+          setTimeout(() => {
+            goto(`/premium/recipe/${naddr}`);
+          }, 1500);
+          return; // Don't reset disablePublishButton - keep it disabled until redirect
+        }
       }
     } catch (err) {
       resultMessage = 'Error: Something went wrong, Error: ' + String(err);

--- a/src/routes/fork/[slug]/+page.svelte
+++ b/src/routes/fork/[slug]/+page.svelte
@@ -265,21 +265,42 @@
         if (!forkPublishResult.success && !forkPublishResult.queued) {
           throw new Error(forkPublishResult.error || 'Publish failed');
         }
+
+        // When the publish was queued for retry, the event may not be
+        // signed yet, so event.pubkey is undefined. Surface "queued"
+        // honestly to the user, skip the garden verify (nothing to
+        // look up), skip the redirect (the recipe URL would 404 since
+        // no relay has it yet). Let them stay on the fork page until
+        // the retry queue lands.
+        if (forkPublishResult.queued) {
+          resultMessage =
+            'Publish queued. Your fork will publish as soon as relays are reachable.';
+          disablePublishButton = false;
+          return;
+        }
+
         // Best-effort garden verification + retry-on-miss.
         ensureLandedOnGarden(event).catch((e) =>
           console.warn('[fork] garden verification failed', e)
         );
 
+        // Use $userPublickey as a fallback in case event.pubkey is
+        // somehow unset post-publish — defensive against signer races.
+        const recipePubkey = event.pubkey || $userPublickey;
+        if (!recipePubkey) {
+          throw new Error('Missing author pubkey for recipe address');
+        }
+
         const naddr = nip19.naddrEncode({
           identifier: identifier || title.toLowerCase().replaceAll(' ', '-'),
-          pubkey: event.pubkey,
+          pubkey: recipePubkey,
           kind: 30023
         });
         resultMessage = 'Success! Redirecting to your recipe...';
-        
+
         // Clear the preview to show the user it worked
         previewEvent = undefined;
-        
+
         // Redirect to the recipe page
         setTimeout(() => {
           goto(`/recipe/${naddr}`);

--- a/src/routes/fork/[slug]/+page.svelte
+++ b/src/routes/fork/[slug]/+page.svelte
@@ -16,6 +16,7 @@
   import Button from '../../../components/Button.svelte';
   import MarkdownEditor from '../../../components/MarkdownEditor.svelte';
   import { RECIPE_TAG_PREFIX_NEW, RECIPE_TAG_PREFIX_LEGACY } from '$lib/consts';
+  import { publishQueue, ensureLandedOnGarden } from '$lib/publishQueue';
 
   let currentSlug = '';
 
@@ -256,7 +257,19 @@
             event.tags.push(['t', `${RECIPE_TAG_PREFIX_NEW}-${t.title.toLowerCase().replaceAll(' ', '-')}`]);
           }
         });
-        await event.publish();
+        // Publish via publishQueue (see /create/+page.svelte for the
+        // full rationale). "all" mode fans out to every pool relay
+        // including garden — guarantees forks land on Zap Cooking
+        // infrastructure regardless of the forker's NIP-65 outbox.
+        const forkPublishResult = await publishQueue.publishWithRetry(event, 'all');
+        if (!forkPublishResult.success && !forkPublishResult.queued) {
+          throw new Error(forkPublishResult.error || 'Publish failed');
+        }
+        // Best-effort garden verification + retry-on-miss.
+        ensureLandedOnGarden(event).catch((e) =>
+          console.warn('[fork] garden verification failed', e)
+        );
+
         const naddr = nip19.naddrEncode({
           identifier: identifier || title.toLowerCase().replaceAll(' ', '-'),
           pubkey: event.pubkey,


### PR DESCRIPTION
## Summary
Recipes published via the platform were silently bypassing our own relay. Real-world symptom we just hit:

- Author *chris21million* published a chicken-curry recipe via Zap Cooking (`client: zap.cooking` tag set).
- The event landed on **9 niche relays** from her NIP-65 (nostr.mom, jeffg.fyi, premium.primal.net, …) but on **zero** of `garden / damus / primal / nos.lol`.
- Anyone else opening `/r/<naddr>` queries our default fetch path, gets nothing in 10s, sees "Recipe loading timeout."

The recipe never made it to Zap Cooking's own infrastructure.

## Root cause
\`/create\`, \`/create/gated\`, and \`/fork/[slug]\` all call bare \`event.publish()\` with no relay set. NDK 2.x's outbox model on writes routes the publish to the **author's** NIP-65 write relays. Authors whose NIP-65 doesn't include garden land their events anywhere except us. The publish call returns "success" because *some* relay accepted — but garden is silently skipped.

## Fix (two layers)

### 1. Switch from bare publish to \`publishQueue.publishWithRetry(event, 'all')\`
The queue's "all" mode iterates the **explicit pool** (garden, nos.lol, damus, primal) and publishes to each — the author's NIP-65 cannot override. Plus IndexedDB-persisted retry on transient relay failures (3 attempts, exponential backoff). This alone gets us most of the way.

### 2. New \`ensureLandedOnGarden()\` helper
After the publish call resolves, fetches the event back **from garden specifically** (4s timeout). If garden didn't accept, queues a targeted republish with \`relayMode: 'garden'\`. Retry loop hammers garden-only until the event lands. Best-effort, runs after the user-facing "Success!" so a slow verify doesn't block the redirect to \`/r/<naddr>\`.

## Files changed
| File | Change |
| --- | --- |
| \`src/lib/publishQueue.ts\` | Export new \`ensureLandedOnGarden()\` helper. ~70 LOC. |
| \`src/routes/create/+page.svelte\` | Switch to \`publishQueue.publishWithRetry\` + verify on garden. |
| \`src/routes/create/gated/+page.svelte\` | Same fix for premium recipes. |
| \`src/routes/fork/[slug]/+page.svelte\` | Same fix for the fork path. |

## What this guarantees going forward
- Every recipe authored on Zap Cooking lands on garden.
- \`/r/<naddr>\` always finds the event via our standard fetch path because garden is in the default relay set.
- Authors with no NIP-65 (or with NIP-65 lists that exclude garden) no longer get silently dropped from the platform.
- If garden is down at publish time, the event sits in the IndexedDB retry queue and re-attempts on reconnect.

## Validation
- \`pnpm test\` 77 / 77 passing
- \`pnpm check\` 0 errors
- \`pnpm build\` clean

## Test plan
- [ ] Sign in as a user whose NIP-65 doesn't include garden → publish a recipe → confirm event lands on garden via WebSocket inspector.
- [ ] Disable garden in DevTools (block the wss connection) → publish → recipe lands on other relays + IndexedDB queue holds a pending publish targeted at garden.
- [ ] Re-enable garden → background retry succeeds.
- [ ] Publish a gated/premium recipe → preview wrapper lands on garden.
- [ ] Fork an existing recipe → fork lands on garden.
- [ ] Open the published recipe at \`/r/<naddr>\` → loads via garden, no 10s timeout.

## Out of scope
- **Pantry durability for premium recipes.** Premium content (encrypted via NIP-108) is server-side; the kind:30023 wrapper goes to garden via this fix. If we want explicit pantry redundancy too, that's a small follow-up — \`relayMode: 'garden-pantry'\` already exists.
- **Read-side outbox on \`/r/<naddr>\`.** Until this fix is deployed, existing recipes already missing from garden won't be reachable. A read-side fallback (look up author's NIP-65, query their write relays) is the cleanup story for legacy events. Tracking as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)