### PR TITLE
feat(pack): NIP-09 delete request for own Recipe Packs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.339",
+  "version": "4.2.340",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.338",
+  "version": "4.2.339",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/DeletePackModal.svelte
+++ b/src/components/DeletePackModal.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  /**
+   * Recipe Pack deletion confirmation modal.
+   *
+   * Self-contained: owns the destructive confirm step, dispatches
+   * publishPackDeletion, and emits a `deleted` event on success so
+   * the page can redirect / refresh state. Mount-and-forget.
+   *
+   * UX notes:
+   * - Destructive action, so we use a red secondary button styling on
+   *   "Delete pack" and require an explicit click on the confirm button
+   *   (no enter-key shortcut, no auto-focus).
+   * - We're honest in the copy that NIP-09 is a request relays may
+   *   honor — we can't promise instant disappearance everywhere. Most
+   *   modern relays + clients respect it; some don't.
+   * - Optimistic UX: as soon as publish resolves we dispatch `deleted`.
+   *   Non-compliant relay caches will still serve the event for a bit;
+   *   the redirect target lists the user's other packs so the user
+   *   doesn't sit on a "pack still exists" view.
+   */
+  import { createEventDispatcher } from 'svelte';
+  import type { NDKEvent } from '@nostr-dev-kit/ndk';
+  import Modal from './Modal.svelte';
+  import Button from './Button.svelte';
+  import { publishPackDeletion } from '$lib/recipePack';
+  import { showToast } from '$lib/toast';
+
+  export let open = false;
+  /** The Recipe Pack event being deleted. We re-check authorship inside
+   *  publishPackDeletion as a defense-in-depth guard. */
+  export let packEvent: NDKEvent | null = null;
+  /** Title to show in the confirmation copy — defaults to "this pack"
+   *  if the caller doesn't have a title to pass. */
+  export let packTitle: string = '';
+
+  const dispatch = createEventDispatcher();
+
+  let isSubmitting = false;
+  let error = '';
+
+  // Reset error every time the modal reopens so a prior failure doesn't
+  // shadow a fresh attempt.
+  $: if (open) error = '';
+
+  async function handleConfirm() {
+    if (!packEvent || isSubmitting) return;
+    isSubmitting = true;
+    error = '';
+    try {
+      await publishPackDeletion(packEvent);
+      showToast('success', 'Deletion request published.');
+      dispatch('deleted');
+      open = false;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Failed to delete pack.';
+      error = msg;
+      showToast('error', msg);
+    } finally {
+      isSubmitting = false;
+    }
+  }
+
+  function handleClose() {
+    if (isSubmitting) return;
+    open = false;
+  }
+</script>
+
+<Modal cleanup={handleClose} bind:open compact={true}>
+  <h1 slot="title">Delete Recipe Pack?</h1>
+
+  <div class="flex flex-col gap-3">
+    <p class="text-sm" style="color: var(--color-text-primary)">
+      This will publish a NIP-09 deletion request for
+      {#if packTitle}
+        <span class="font-semibold">{packTitle}</span>
+      {:else}
+        this pack
+      {/if}.
+    </p>
+
+    <p class="text-xs text-caption">
+      Most relays and clients honor deletion requests and will stop showing
+      the pack within a few minutes. A small number of older relays may
+      keep serving cached copies — there's no way to fully recall a
+      published Nostr event.
+    </p>
+
+    {#if error}
+      <p class="text-sm text-red-500">{error}</p>
+    {/if}
+
+    <div class="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 pt-1">
+      <Button on:click={handleClose} primary={false} disabled={isSubmitting}>Cancel</Button>
+      <button
+        type="button"
+        on:click={handleConfirm}
+        disabled={isSubmitting || !packEvent}
+        class="px-4 py-2.5 rounded-full font-semibold text-white whitespace-nowrap transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+        style="background-color: #dc2626;"
+      >
+        {isSubmitting ? 'Deleting…' : 'Delete pack'}
+      </button>
+    </div>
+  </div>
+</Modal>

--- a/src/components/DeletePackModal.svelte
+++ b/src/components/DeletePackModal.svelte
@@ -47,9 +47,21 @@
     isSubmitting = true;
     error = '';
     try {
-      await publishPackDeletion(packEvent);
-      showToast('success', 'Deletion request published.');
-      dispatch('deleted');
+      const { queued } = await publishPackDeletion(packEvent);
+      // publishWithRetry can resolve in a queued-for-retry state when
+      // no relay has confirmed yet (signer race, relay flake). Surface
+      // honest copy + a different downstream signal so the page can
+      // skip a redirect that would land the user on /packs while the
+      // pack is still visible there.
+      if (queued) {
+        showToast(
+          'info',
+          'Deletion request queued. It will publish as soon as relays are reachable.'
+        );
+      } else {
+        showToast('success', 'Deletion request published.');
+      }
+      dispatch('deleted', { queued });
       open = false;
     } catch (e) {
       const msg = e instanceof Error ? e.message : 'Failed to delete pack.';

--- a/src/lib/recipePack.ts
+++ b/src/lib/recipePack.ts
@@ -212,6 +212,16 @@ export function buildAnnouncementContent(opts: {
   return lines.join('\n');
 }
 
+/** Result shape from publishPackDeletion. `queued` is true when the
+ *  initial publish attempt failed and the deletion was persisted to
+ *  the IndexedDB retry queue — relays haven't acknowledged it yet,
+ *  so the UI should distinguish this from a confirmed publish. */
+export interface PackDeletionResult {
+  deletion: NDKEvent;
+  /** True if no relay confirmed yet; false on immediate publish success. */
+  queued: boolean;
+}
+
 /**
  * Publish a NIP-09 deletion request (kind:5) for a Recipe Pack the
  * caller authored. Anyone hitting the pack page after relays honor
@@ -233,8 +243,14 @@ export function buildAnnouncementContent(opts: {
  * lands on garden + the explicit pool, matching where the original
  * pack was published. Caller is responsible for ensuring the user
  * actually authored the pack (we re-check pubkey here as a guard).
+ *
+ * Returns { deletion, queued } so the UI can distinguish "published
+ * immediately" from "queued for IndexedDB retry" — the latter shouldn't
+ * show a confirmed-published toast or redirect away from the pack.
  */
-export async function publishPackDeletion(packEvent: NDKEvent): Promise<NDKEvent> {
+export async function publishPackDeletion(
+  packEvent: NDKEvent
+): Promise<PackDeletionResult> {
   const ndkInstance = get(ndk);
   const pubkey = get(userPublickey);
   if (!ndkInstance) throw new Error('NDK not initialized');
@@ -264,7 +280,7 @@ export async function publishPackDeletion(packEvent: NDKEvent): Promise<NDKEvent
   if (!result.success && !result.queued) {
     throw new Error(result.error || 'Failed to publish deletion request.');
   }
-  return deletion;
+  return { deletion, queued: !result.success };
 }
 
 /**

--- a/src/lib/recipePack.ts
+++ b/src/lib/recipePack.ts
@@ -213,6 +213,61 @@ export function buildAnnouncementContent(opts: {
 }
 
 /**
+ * Publish a NIP-09 deletion request (kind:5) for a Recipe Pack the
+ * caller authored. Anyone hitting the pack page after relays honor
+ * the deletion will see "pack not found" instead of the cached event.
+ *
+ * Important: NIP-09 is a *request*. Compliant relays drop the event;
+ * non-compliant relays don't. Compliant clients hide it on render;
+ * non-compliant clients still display it. We can't actually erase
+ * the event from the network — only the strongest possible signal
+ * that the author wants it gone.
+ *
+ * Tags follow NIP-09 latest:
+ *   - e: specific event id (current addressable revision)
+ *   - a: addressable form `${kind}:${pubkey}:${dTag}` so future
+ *       republishes at the same address are also covered
+ *   - k: kind number, helps relays index deletion requests
+ *
+ * Publishes via publishQueue's "all" mode so the deletion request
+ * lands on garden + the explicit pool, matching where the original
+ * pack was published. Caller is responsible for ensuring the user
+ * actually authored the pack (we re-check pubkey here as a guard).
+ */
+export async function publishPackDeletion(packEvent: NDKEvent): Promise<NDKEvent> {
+  const ndkInstance = get(ndk);
+  const pubkey = get(userPublickey);
+  if (!ndkInstance) throw new Error('NDK not initialized');
+  if (!pubkey) throw new Error('Sign in required to delete a Recipe Pack.');
+  if (packEvent.pubkey !== pubkey) {
+    throw new Error('Only the author can delete this Recipe Pack.');
+  }
+
+  const dTag = packEvent.tags.find((t) => t[0] === 'd')?.[1];
+  if (!dTag) throw new Error('Pack event missing d-tag — cannot reference for deletion.');
+
+  const deletion = new NDKEvent(ndkInstance);
+  deletion.kind = 5;
+  deletion.content = 'Deleted by author';
+  deletion.tags = [
+    ['e', packEvent.id],
+    ['a', `${RECIPE_PACK_KIND}:${pubkey}:${dTag}`],
+    ['k', String(RECIPE_PACK_KIND)]
+  ];
+  addClientTagToEvent(deletion);
+
+  // Use the resilient queue + 'all' mode so the deletion lands on
+  // garden + the standard pool, same write surface as the original
+  // pack publish.
+  const { publishQueue } = await import('$lib/publishQueue');
+  const result = await publishQueue.publishWithRetry(deletion, 'all');
+  if (!result.success && !result.queued) {
+    throw new Error(result.error || 'Failed to publish deletion request.');
+  }
+  return deletion;
+}
+
+/**
  * Publish a kind:1 announcement that references a Recipe Pack.
  * Caller passes the published pack so we can derive `a`-tag and naddr.
  */

--- a/src/routes/pack/[naddr]/+page.svelte
+++ b/src/routes/pack/[naddr]/+page.svelte
@@ -313,11 +313,20 @@
   let exportModalOpen = false;
 
   // ===== Delete pack (own-pack only) =====
-  // NIP-09 deletion request. Opens a confirm modal; on success the
-  // pack page redirects to /packs since the displayed event is now
-  // a deletion candidate (and may still cache here briefly).
+  // NIP-09 deletion request. Opens a confirm modal; on confirmed
+  // publish the page redirects to /packs since the displayed event
+  // is now a deletion candidate (and may still cache here briefly).
+  // For QUEUED deletes (publishWithRetry → IndexedDB retry queue),
+  // we stay on the pack page — redirecting to /packs would land the
+  // user on a list that still shows the pack they just queued.
   let deleteModalOpen = false;
-  function handlePackDeleted() {
+  function handlePackDeleted(e: CustomEvent<{ queued: boolean }>) {
+    if (e.detail?.queued) {
+      // Stay put. The toast in the modal already explained that
+      // relays haven't confirmed yet; the page will reflect the
+      // deletion once the retry queue lands and the user reloads.
+      return;
+    }
     // Most relays drop the event within a few seconds, but caches in
     // this tab + intermediate proxies can linger. Redirecting to
     // /packs avoids the user staring at a "still here" view of the
@@ -412,8 +421,12 @@
 
 <!-- NIP-09 deletion confirmation. Self-contained: the modal handles
      publishing the kind:5 deletion request and emits `deleted` on
-     success — we redirect to /packs to clear the stale view. -->
-{#if packEvent}
+     success — we redirect to /packs only when the publish is
+     confirmed (queued state stays on the page).
+     Mount is gated on isOwnPack so a non-owner toggling
+     deleteModalOpen via devtools can't get a confusing
+     "Only the author..." error from publishPackDeletion. -->
+{#if packEvent && isOwnPack}
   <DeletePackModal
     bind:open={deleteModalOpen}
     {packEvent}

--- a/src/routes/pack/[naddr]/+page.svelte
+++ b/src/routes/pack/[naddr]/+page.svelte
@@ -29,6 +29,7 @@
   import CustomName from '../../../components/CustomName.svelte';
   import ShareModal from '../../../components/ShareModal.svelte';
   import ExportCookbookModal from '../../../components/ExportCookbookModal.svelte';
+  import DeletePackModal from '../../../components/DeletePackModal.svelte';
   import { showToast } from '$lib/toast';
   import { lazyLoad } from '$lib/lazyLoad';
   import { getImageOrPlaceholder } from '$lib/placeholderImages';
@@ -311,6 +312,19 @@
   // the modal (paywall stage). Signed-out users get bounced to login.
   let exportModalOpen = false;
 
+  // ===== Delete pack (own-pack only) =====
+  // NIP-09 deletion request. Opens a confirm modal; on success the
+  // pack page redirects to /packs since the displayed event is now
+  // a deletion candidate (and may still cache here briefly).
+  let deleteModalOpen = false;
+  function handlePackDeleted() {
+    // Most relays drop the event within a few seconds, but caches in
+    // this tab + intermediate proxies can linger. Redirecting to
+    // /packs avoids the user staring at a "still here" view of the
+    // pack they just asked to delete.
+    goto('/packs');
+  }
+
   let membershipMap: Record<string, MembershipStatus> = {};
   const unsubMembership = membershipStatusMap.subscribe((v) => {
     membershipMap = v;
@@ -393,6 +407,18 @@
     {isProMember}
     membershipTier={tierStatus?.tier}
     membershipActive={tierStatus?.active}
+  />
+{/if}
+
+<!-- NIP-09 deletion confirmation. Self-contained: the modal handles
+     publishing the kind:5 deletion request and emits `deleted` on
+     success — we redirect to /packs to clear the stale view. -->
+{#if packEvent}
+  <DeletePackModal
+    bind:open={deleteModalOpen}
+    {packEvent}
+    packTitle={title}
+    on:deleted={handlePackDeleted}
   />
 {/if}
 
@@ -556,6 +582,19 @@
           <BookmarkIcon size={16} />
           Open your cookbook
         </a>
+        <!-- Delete (NIP-09 deletion request). Secondary destructive
+             styling so the action is reachable but not the focal CTA;
+             confirmation lives in DeletePackModal. -->
+        <button
+          type="button"
+          on:click={() => (deleteModalOpen = true)}
+          class="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-colors hover:opacity-80"
+          style="background-color: var(--color-input-bg); color: #dc2626; border: 1px solid rgba(220, 38, 38, 0.4);"
+          title="Publish a NIP-09 deletion request for this Recipe Pack"
+          aria-label="Delete pack"
+        >
+          Delete
+        </button>
       {:else if allSaved}
         <span
           class="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium"


### PR DESCRIPTION
## Summary
Adds a self-serve **Delete** action on \`/pack/[naddr]\` so the author can publish a NIP-09 deletion request for their Recipe Pack. Compliant relays + clients honor the request and stop showing the pack.

## What ships
- **`src/lib/recipePack.ts`** — new \`publishPackDeletion(packEvent)\`. Builds a kind:5 with the NIP-09 latest tag set:
  - \`e\` — current event id
  - \`a\` — addressable form \`30004:<pubkey>:<dTag>\` so future republishes at the same address are also covered by the request
  - \`k\` — \`30004\` (helps relays index deletion requests)

  Defense-in-depth pubkey check before publish (only the author can delete their own pack). Goes through \`publishQueue.publishWithRetry(_, 'all')\` so the deletion lands on garden + the standard pool — same write surface as the original pack publish.

- **`src/components/DeletePackModal.svelte`** *(new)* — destructive confirmation modal. Honest copy: NIP-09 is a *request* relays may honor, not a guaranteed erase. Red-styled confirm button, no enter-key shortcut, no auto-focus on the destructive action. Self-contained: dispatches \`deleted\` on success.

- **`src/routes/pack/[naddr]/+page.svelte`** — adds a discreet **Delete** button next to the existing "Open your cookbook" CTA in the \`isOwnPack\` cluster. Mounts \`DeletePackModal\`. On the \`deleted\` event, redirects to \`/packs\` (the pack page would otherwise still show the cached event in this tab + intermediate proxies for a few minutes — redirect avoids the stale view).

## NIP-09 caveats called out in the UI
- Most modern relays + clients honor deletion requests within a few minutes.
- A small number of older relays may keep serving cached copies — there's no way to fully recall a published Nostr event. The modal copy is honest about this.

## Out of scope
- **Auto-deleting the optional kind:1 feed announcement.** The share-pack flow can publish a kind:1 wrapper; we don't store its event id at publish time, and post-hoc lookups add a relay round-trip + edge cases. The announcement becomes a stale link; clients already 404 broken naddrs gracefully. Easy follow-up if you want it.
- **Pack edit.** Out of scope for this PR — users can re-share with the same d-tag (replaces the existing pack).

## Validation
- \`pnpm test\` 77 / 77 passing
- \`pnpm check\` 0 errors
- \`pnpm build\` clean

## Test plan
- [ ] Sign in as pack author → visit \`/pack/<naddr>\` → "Delete" button visible next to "Open your cookbook".
- [ ] Click → confirm modal opens with the pack title in the body.
- [ ] Click "Delete pack" → toast says deletion request published → redirects to \`/packs\`.
- [ ] Inspect the published kind:5 → has \`e\`, \`a\`, \`k\` tags pointing at the pack.
- [ ] Sign in as a different user → visit the same pack \`/pack/<naddr>\` → no "Delete" button (own-pack only).
- [ ] Wait a minute, refresh \`/pack/<naddr>\` → relays that honor NIP-09 stop serving the event; the page shows the existing not-found state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)