### PR TITLE
fix(profile): correct anon fallback in feeds, comments, notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.340",
+  "version": "4.2.341",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/AuthorName.svelte
+++ b/src/components/AuthorName.svelte
@@ -54,11 +54,14 @@
         return;
       }
 
-      // Simple profile fetch with timeout
-      const profile = await Promise.race([
-        resolveProfileByPubkey(pubkey, ndkInstance),
-        new Promise<null>((r) => setTimeout(() => r(null), 3000))
-      ]);
+      // No outer timeout — `resolveProfileByPubkey` (and the
+      // `fetchProfileFromRelays` it calls) already cap the fetch at
+      // 5s and return null on timeout. The previous 3s outer race
+      // here fired *before* the underlying 5s could complete, so
+      // slow-but-eventual profile fetches landed in the cache while
+      // this component had already rendered the anon fallback —
+      // requiring a refresh to pick up the now-cached profile.
+      const profile = await resolveProfileByPubkey(pubkey, ndkInstance);
 
       if (profile) {
         // formatDisplayName already returns a stable anon-chef name when

--- a/src/lib/profileResolver.ts
+++ b/src/lib/profileResolver.ts
@@ -79,6 +79,21 @@ export function decodeNostrProfile(nostrString: string): string | null {
 // Profile fetch timeout
 const PROFILE_FETCH_TIMEOUT = 5000; // 5 seconds
 
+/**
+ * Relays we'll always consult for kind:0 lookups, in addition to NDK's
+ * default pool. Purplepag.es is the de-facto Nostr profile relay —
+ * many users publish kind:0 there (or it's the only relay their
+ * NIP-65 client targeted). Without including it, profiles that don't
+ * happen to live on garden / nos.lol / damus / primal silently 404
+ * and render as the anon-chef fallback. nostr.band + nostr.wine are
+ * common secondary mirrors.
+ */
+const PROFILE_RELAY_URLS = [
+  'wss://purplepag.es',
+  'wss://relay.nostr.band',
+  'wss://nostr.wine'
+];
+
 // Fetch profile data from relays
 async function fetchProfileFromRelays(pubkey: string, ndkInstance: NDK): Promise<ProfileData | null> {
   try {
@@ -90,34 +105,74 @@ async function fetchProfileFromRelays(pubkey: string, ndkInstance: NDK): Promise
       return null;
     }
 
-    // Use NDK's built-in fetchProfile method
-    // It handles relay selection via outbox model when enabled
-    const user = ndkInstance.getUser({ hexpubkey: pubkey });
-    
-    // Don't clear cached profile - let NDK use its cache
-    // This prevents unnecessary network requests
-    
-    // Add timeout to prevent hanging
-    const fetchPromise = user.fetchProfile();
-    const timeoutPromise = new Promise<null>((resolve) => 
+    // Build an explicit relay set: NDK's connected pool relays
+    // (whatever the page already has open — garden, nos.lol, damus,
+    // primal in default mode) plus the canonical profile relays.
+    // NDK's `user.fetchProfile()` doesn't let us widen the relay set,
+    // so we drop down to fetchEvent + parse the kind:0 manually.
+    const { NDKRelaySet } = await import('@nostr-dev-kit/ndk');
+    const relayUrls = new Set<string>();
+    if (ndkInstance.pool?.relays) {
+      for (const [url] of ndkInstance.pool.relays) relayUrls.add(url);
+    }
+    for (const url of PROFILE_RELAY_URLS) relayUrls.add(url);
+
+    const relays = [];
+    for (const url of relayUrls) {
+      // autoConnect=true, createIfMissing=true — purplepag.es etc.
+      // may not be in the pool yet; this opens a connection in the
+      // background. fetchEvent will queue against not-yet-ready
+      // relays and resolve when any of them returns.
+      const relay = ndkInstance.pool?.getRelay(url, true, true);
+      if (relay) relays.push(relay);
+    }
+    const relaySet = relays.length > 0 ? new NDKRelaySet(new Set(relays), ndkInstance) : undefined;
+
+    const fetchPromise = ndkInstance.fetchEvent(
+      { kinds: [0], authors: [pubkey] },
+      undefined,
+      relaySet
+    );
+    const timeoutPromise = new Promise<null>((resolve) =>
       setTimeout(() => resolve(null), PROFILE_FETCH_TIMEOUT)
     );
-    
-    await Promise.race([fetchPromise, timeoutPromise]);
-    
-    const profile = user.profile;
-    if (!profile) {
+
+    const event = await Promise.race([fetchPromise, timeoutPromise]);
+    if (!event) {
       return null;
     }
 
-    const profileData = {
+    let parsed: Record<string, unknown> = {};
+    try {
+      parsed = JSON.parse(event.content || '{}');
+    } catch {
+      // Malformed kind:0 content — return null rather than a
+      // half-populated profile that would obscure the user's identity.
+      return null;
+    }
+
+    // Nostr profile field naming has historically varied: NIP-01 says
+    // `name`, but many clients also (or only) populate `display_name`,
+    // and a few use camelCase `displayName`. Read all three so we
+    // surface the user's identity regardless of which client wrote
+    // their kind:0.
+    const name =
+      typeof parsed.name === 'string' ? parsed.name : undefined;
+    const displayName =
+      typeof parsed.display_name === 'string'
+        ? (parsed.display_name as string)
+        : typeof parsed.displayName === 'string'
+        ? (parsed.displayName as string)
+        : undefined;
+
+    const profileData: ProfileData = {
       pubkey,
-      name: profile.name,
-      display_name: profile.displayName,
-      picture: profile.image,
-      about: profile.bio,
-      nip05: profile.nip05,
-      lud16: profile.lud16,
+      name,
+      display_name: displayName,
+      picture: typeof parsed.picture === 'string' ? parsed.picture : undefined,
+      about: typeof parsed.about === 'string' ? parsed.about : undefined,
+      nip05: typeof parsed.nip05 === 'string' ? parsed.nip05 : undefined,
+      lud16: typeof parsed.lud16 === 'string' ? parsed.lud16 : undefined,
       lastFetched: Date.now()
     };
 
@@ -229,10 +284,20 @@ export function getDisplayName(profile: ProfileData | null): string {
 }
 
 // Get username for a profile (without @ prefix). Same fallback policy
-// as getDisplayName.
+// as getDisplayName: display_name → name → anon. Previously this only
+// checked `name`, which silently fell back to the anon helper for
+// profiles that set only `display_name` (a common shape on Nostr —
+// "display_name" is the human-readable identity, "name" is the optional
+// short handle). formatDisplayName, AuthorName, ProfileLink, and the
+// feed all flow through here, so the fix lights up display_name-only
+// profiles everywhere at once.
 export function getUsername(profile: ProfileData | null): string {
   if (!profile) {
     return getAnonChefName(null);
+  }
+
+  if (profile.display_name) {
+    return profile.display_name;
   }
 
   if (profile.name) {


### PR DESCRIPTION
## Summary
Three converging bugs caused valid profiles to render as Anon Chef across feeds, comments, AuthorName, and ProfileLink — even though the same profiles loaded fine on other Nostr clients. All three fixed here.

## What was happening

Reproduced via MCP for npub1gehj8x...y0zgszxg6wt — kind:0 returns:
```
name: "pipefocker"
display_name: "Uncle Ted ⚡️"
```
…on nos.lol, damus, primal, and purplepag.es in 400-1000ms. Rendered as Anon Chef on Zap Cooking until refresh, then rendered correctly.

## The three bugs

### 1. `getUsername` ignored `display_name`
`formatDisplayName` is just `getUsername`. Most rendering paths in the app (feed, comments, AuthorName, ProfileLink) flow through it. The function only checked `profile.name` — for any profile with **only `display_name`** set (a common shape on Nostr), it skipped straight to the anon fallback. \`getDisplayName\` was correct, which is why notifications (which call `getDisplayName` directly) were unaffected.

**Fix:** mirror `getDisplayName`'s priority order — `display_name` → `name` → anon.

### 2. AuthorName's 3s outer timeout fired before the inner 5s completed
\`\`\`ts
// Before
const profile = await Promise.race([
  resolveProfileByPubkey(pubkey, ndkInstance),  // already 5s-capped
  new Promise<null>((r) => setTimeout(() => r(null), 3000))  // 3s
]);
\`\`\`
On slow networks / relays, the outer 3s fired first, AuthorName rendered the anon fallback, then the underlying fetch completed (~4s) and cached the profile. AuthorName uses \`onMount\`, not reactive — never re-read. Page refresh re-mounts, hits the cache, renders correctly. Matches the "rendered with a reset" symptom.

**Fix:** drop the outer race. Let the resolver's 5s timeout do its job.

### 3. Profile fetch was bound to whatever NDK had connected
\`user.fetchProfile()\` queries the connected pool — `[garden, nos.lol, damus, primal]` in default mode. **Purplepag.es is the de-facto Nostr profile relay** but isn't in the default pool (it's only in the `profiles` / `discovery` relay sets, used elsewhere). Profiles that live only on purplepag.es / their own outbox relays returned null after timeout → anon.

**Fix:** drop down from `user.fetchProfile()` to `ndk.fetchEvent({kinds: [0], authors: [pubkey]}, undefined, relaySet)` with an explicit relay set unioning the connected pool with **purplepag.es + relay.nostr.band + nostr.wine**. Plus the manual JSON parse now also reads `displayName` (camelCase) in addition to `display_name` (snake_case) — some clients only write the camelCase form.

## Files changed
- \`src/lib/profileResolver.ts\` — `getUsername` priority fix; \`fetchProfileFromRelays\` rewritten to use explicit relay set + manual parse.
- \`src/components/AuthorName.svelte\` — drop redundant 3s outer race.

## Validation
- \`pnpm test\` 77 / 77 passing
- \`pnpm check\` 0 errors
- \`pnpm build\` clean

## Test plan
- [ ] Open the feed / a comment thread / a recipe authored by a profile with only `display_name` set → renders the actual name, not Anon Chef.
- [ ] Open a comment thread by a slow-to-resolve user → name renders correctly on first load (no refresh needed).
- [ ] Open a profile that lives only on purplepag.es → renders correctly.
- [ ] Notifications mention resolution still works (was already correct via `getDisplayName`).
- [ ] Profile with neither name nor display_name → still shows the friendly per-pubkey anon name (e.g. "Sat Chef") not "Anon Chef" generic.

## Out of scope
- **Reactive re-read** when the profile cache populates after a component mounts. Would let the rare slow case "anon → real name" upgrade live without a re-mount. Needs a Svelte store-backed cache; tracked as a follow-up. The faster + wider lookups in this PR cover the vast majority of cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)