### PR TITLE
fix(profile): route reads to /reads and hide deleted longform events

### DIFF
--- a/src/routes/reads/[naddr]/+page.svelte
+++ b/src/routes/reads/[naddr]/+page.svelte
@@ -7,7 +7,8 @@
   import Recipe from '../../../components/Recipe/Recipe.svelte';
   import PanLoader from '../../../components/PanLoader.svelte';
   import type { PageData } from './$types';
-  import { ARTICLE_TAG } from '$lib/articleEditor';
+  import { RECIPE_TAGS } from '$lib/consts';
+  import { validateMarkdownTemplate } from '$lib/parser';
   import ArrowLeftIcon from 'phosphor-svelte/lib/ArrowLeft';
 
   export let data: PageData;
@@ -58,10 +59,13 @@
 
         const e = await Promise.race<NDKEvent | null>([fetchPromise, timeoutPromise]);
         if (e) {
-          // Verify it's an article (has zapreads tag)
-          const hasZapreadsTag = e.tags.some((t: string[]) => t[0] === 't' && t[1] === ARTICLE_TAG);
-          if (!hasZapreadsTag) {
-            throw new Error('This is not an article');
+          // Reject recipe-shaped events; anything else is treated as an article
+          const hasRecipeTag = e.tags.some(
+            (t: string[]) => t[0] === 't' && RECIPE_TAGS.includes(t[1]?.toLowerCase() || '')
+          );
+          const isRecipeShaped = typeof validateMarkdownTemplate(e.content) !== 'string';
+          if (hasRecipeTag || isRecipeShaped) {
+            throw new Error('This is a recipe, not an article');
           }
           event = e;
           loading = false;

--- a/src/routes/user/[slug]/+page.svelte
+++ b/src/routes/user/[slug]/+page.svelte
@@ -268,6 +268,7 @@
         let subscription = $ndk.subscribe(filter);
 
         subscription.on('event', (ev: NDKEvent) => {
+          if (isDeletedEvent(ev)) return;
           if (validateMarkdownTemplate(ev.content) != null) {
             events.push(ev);
             events = events;
@@ -498,6 +499,7 @@
         let resolved = false;
 
         subscription.on('event', (ev: NDKEvent) => {
+          if (isDeletedEvent(ev)) return;
           if (validateMarkdownTemplate(ev.content) != null) {
             newRecipes.push(ev);
           }
@@ -622,6 +624,14 @@
     return cleaned.trim().substring(0, 150);
   }
 
+  function isDeletedEvent(ev: NDKEvent): boolean {
+    return (
+      ev.tags.some((t) => t[0] === 'deleted') ||
+      !ev.content ||
+      ev.content.trim() === ''
+    );
+  }
+
   function getArticleUrl(event: NDKEvent): string {
     if (event.kind === 30023) {
       const dTag = event.tags.find((t) => t[0] === 'd')?.[1];
@@ -632,7 +642,7 @@
             kind: 30023,
             pubkey: event.pubkey
           });
-          return `/recipe/${naddr}`;
+          return `/reads/${naddr}`;
         } catch (e) {
           console.warn('Failed to encode naddr:', e);
         }
@@ -702,6 +712,8 @@
         subscription.on('event', (ev: NDKEvent) => {
           if (seenIds.has(ev.id)) return;
           seenIds.add(ev.id);
+
+          if (isDeletedEvent(ev)) return;
 
           // Exclude recipes (events with recipe tags)
           const hasRecipeTag = ev.tags.some(
@@ -774,6 +786,8 @@
 
         subscription.on('event', (ev: NDKEvent) => {
           if (existingIds.has(ev.id)) return;
+
+          if (isDeletedEvent(ev)) return;
 
           // Exclude recipes
           const hasRecipeTag = ev.tags.some(


### PR DESCRIPTION
## Summary
- Reads tab on the profile page linked every kind 30023 event to
  `/recipe/[naddr]`, so non-recipe articles ended up at the recipe
  route. Now they go to `/reads/[naddr]`.
- Deleted longform events (events tagged `['deleted', …]` or with
  empty content) were still appearing in the Reads and Recipes
  listings as "[Deleted]" cards. They are now filtered out from the
  initial load and from infinite-scroll pagination on both tabs.

All changes are scoped to `src/routes/user/[slug]/+page.svelte`.

## Test plan
- [ ] Visit a profile with non-recipe articles → Reads tab cards link
      to `/reads/<naddr>` and load via the article route.
- [ ] Visit a profile with a deleted article → "[Deleted]" card no
      longer appears in the Reads tab.
- [ ] Visit a profile with a deleted recipe → "[Deleted]" card no
      longer appears in the Recipes tab.
- [ ] Scroll to trigger pagination on both tabs → newly loaded pages
      also exclude deleted events.
- [ ] Existing recipe links from the Recipes tab still go to
      `/recipe/<naddr>` (unchanged).