### PR TITLE
fix(relays): drop failing relay.nostr.band and stale kitchen.zap.cooking

### DIFF
--- a/docs/dev/FEED_CONSISTENCY_VERIFICATION.md
+++ b/docs/dev/FEED_CONSISTENCY_VERIFICATION.md
@@ -168,7 +168,6 @@ typeof validateMarkdownTemplate(event.content) === 'string' // Invalid recipe
 ```typescript
 export const standardRelays = [
   'wss://relay.damus.io',
-  'wss://kitchen.zap.cooking',
   'wss://garden.zap.cooking',
   'wss://nos.lol',
   'wss://purplepag.es',
@@ -179,18 +178,18 @@ export const standardRelays = [
 
 **Status**: ✅ Good selection
 - Mix of popular public relays (damus, primal, nos.lol)
-- App-specific relays (kitchen, garden)
+- App-specific relay (garden)
 - Specialized relays (purplepag.es for profiles, nostr.wine)
 
 ### Default Outbox Relays
 **Defined in**: `src/lib/nostr.ts` (Line 16)
 ```typescript
-const DEFAULT_OUTBOX_RELAY_URLS = ["wss://purplepag.es", "wss://kitchen.zap.cooking"];
+const DEFAULT_OUTBOX_RELAY_URLS = ["wss://purplepag.es", "wss://nos.lol"];
 ```
 
 **Status**: ✅ Appropriate
 - purplepag.es: Profile/metadata relay
-- kitchen.zap.cooking: App-specific relay
+- nos.lol: Fast general relay
 
 ### Relay Set Support
 **Files**: `src/lib/relays/relaySets.ts`

--- a/docs/dev/FEED_INVENTORY.md
+++ b/docs/dev/FEED_INVENTORY.md
@@ -39,7 +39,7 @@
 ```typescript
 [
   'wss://relay.damus.io',      // Fastest
-  'wss://kitchen.zap.cooking', // Your relay
+  'wss://garden.zap.cooking',  // Garden relay
   'wss://nos.lol',
   'wss://purplepag.es',
   'wss://relay.primal.net',
@@ -50,7 +50,7 @@
 ### Relay Pools (from `FoodstrFeedOptimized.svelte`)
 ```typescript
 RELAY_POOLS = {
-  recipes: ['wss://kitchen.zap.cooking'],      // Curated recipe content
+  recipes: ['wss://nos.lol', 'wss://relay.damus.io'],   // General relays with recipe content
   fallback: ['wss://nos.lol', 'wss://relay.damus.io'],  // Fast general relays
   discovery: ['wss://nostr.wine', 'wss://relay.primal.net', 'wss://purplepag.es'],  // Additional relays
   profiles: ['wss://purplepag.es']             // Profile metadata
@@ -59,7 +59,7 @@ RELAY_POOLS = {
 
 ### Outbox Relays (NDK config)
 ```typescript
-outboxRelayUrls: ["wss://purplepag.es", "wss://kitchen.zap.cooking"]
+outboxRelayUrls: ["wss://purplepag.es", "wss://nos.lol"]
 ```
 
 ### Blocked Relays (from `followOutbox.ts`)

--- a/docs/dev/RELAY_STRATEGY_MCP_REVIEW.md
+++ b/docs/dev/RELAY_STRATEGY_MCP_REVIEW.md
@@ -143,7 +143,6 @@ export const RELAY_SETS = {
   default: {
     id: 'default',
     relays: [
-      'wss://kitchen.zap.cooking',
       'wss://garden.zap.cooking',
       'wss://nos.lol',
       'wss://relay.damus.io'

--- a/docs/mobile/UX_DEV_NOTES.md
+++ b/docs/mobile/UX_DEV_NOTES.md
@@ -335,10 +335,8 @@ allZaps.forEach(processZapEvent);
 - **Current Relays**:
   - wss://relay.damus.io
   - wss://nostr.mom
-  - wss://kitchen.zap.cooking
   - wss://nos.lol
   - wss://purplepag.es
-  - wss://relay.nostr.band
 - **Future**: Consider adding wss://relay.primal.net, wss://nostr.wine
 
 ### 2. Swipe Threshold

--- a/garden-relay/garden-invite.js
+++ b/garden-relay/garden-invite.js
@@ -7,7 +7,7 @@
 
   // --- Config ---
   var PROFILE_RELAYS = ['wss://purplepag.es', 'wss://relay.damus.io'];
-  var SEARCH_RELAY = 'wss://relay.nostr.band';
+  var SEARCH_RELAY = 'wss://search.nos.today';
   var DEBOUNCE_MS = 200;
   var SEARCH_DEBOUNCE_MS = 300;
   var SEARCH_TIMEOUT_MS = 4000;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.367",
+  "version": "4.2.368",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -456,7 +456,7 @@
   const SEVEN_DAYS_SECONDS = 7 * 24 * 60 * 60;
 
   // Relay pools by purpose - optimized based on speed test results
-  // Speed test: nostr.wine (305ms) > nos.lol (342ms) > purplepag.es (356ms) > relay.damus.io (394ms) > relay.nostr.band (514ms)
+  // Speed test: nostr.wine (305ms) > nos.lol (342ms) > purplepag.es (356ms) > relay.damus.io (394ms)
   // NOTE: All URLs are normalized (no trailing slashes) to prevent duplicate connections
   const RELAY_POOLS = {
     recipes: ['wss://nos.lol', 'wss://relay.damus.io'], // General relays with recipe content

--- a/src/components/LongformFoodFeed.svelte
+++ b/src/components/LongformFoodFeed.svelte
@@ -77,8 +77,7 @@
         'wss://relay.primal.net',
         'wss://relay.damus.io',
         'wss://nos.lol',
-        'wss://nostr.wine',
-        'wss://relay.nostr.band'
+        'wss://nostr.wine'
       ];
       const relaySet = NDKRelaySet.fromRelayUrls(articleRelays, $ndk, true);
       subscription = $ndk.subscribe(filter, { closeOnEose: true }, relaySet);

--- a/src/lib/articleOutbox.ts
+++ b/src/lib/articleOutbox.ts
@@ -88,7 +88,6 @@ const CONFIG = {
     'wss://nos.lol',                 // Popular relay with good uptime
     'wss://nostr.wine',              // Premium relay with quality content
     'wss://purplepag.es',            // Good for profile/content discovery
-    'wss://relay.nostr.band',        // Search-optimized relay
     'wss://antiprimal.net',          // Broad content discovery
   ],
   

--- a/src/lib/authManager.ts
+++ b/src/lib/authManager.ts
@@ -665,7 +665,7 @@ export class AuthManager {
       relays = Array.from(this.ndk.pool.relays.keys()) as string[];
     }
     if (relays.length === 0) {
-      relays = ['wss://relay.damus.io', 'wss://relay.nostr.band', 'wss://nos.lol'];
+      relays = ['wss://relay.damus.io', 'wss://nos.lol'];
     }
 
     // Store pending pairing info including secret for validation

--- a/src/lib/countQuery.ts
+++ b/src/lib/countQuery.ts
@@ -46,9 +46,8 @@ const nip45UnsupportedRelays = new Set<string>();
 // Relays known to support NIP-45 COUNT - prioritize fastest/most reliable
 const KNOWN_NIP45_RELAYS = [
   'wss://relay.damus.io',      // 394ms - fast and reliable
-  'wss://nos.lol',              // 342ms - fastest
-  'wss://relay.nostr.band'      // 514ms - slower but reliable
-  // Note: nostr.wine (305ms) removed as it's in blocked relays list
+  'wss://nos.lol'               // 342ms - fastest
+  // Note: nostr.wine (305ms) and relay.nostr.band removed - in blocked relays list
 ];
 
 // Server API configuration

--- a/src/lib/marketplace/products.ts
+++ b/src/lib/marketplace/products.ts
@@ -25,7 +25,6 @@ import { SUPPORTED_CURRENCIES, type CurrencyCode } from '$lib/currencyStore';
 export const MARKETPLACE_RELAYS = [
 	'wss://relay.damus.io',
 	'wss://nos.lol',
-	'wss://relay.nostr.band',
 	'wss://relay.nostr.net'
 ];
 

--- a/src/lib/membershipNotificationService.ts
+++ b/src/lib/membershipNotificationService.ts
@@ -18,7 +18,6 @@ export interface ExpiringMember {
 const DM_RELAYS = [
   'wss://relay.damus.io',
   'wss://nos.lol',
-  'wss://relay.nostr.band',
   'wss://nostr.wine',
   'wss://relay.snort.social',
   'wss://purplepag.es'

--- a/src/lib/profileResolver.ts
+++ b/src/lib/profileResolver.ts
@@ -85,12 +85,11 @@ const PROFILE_FETCH_TIMEOUT = 5000; // 5 seconds
  * many users publish kind:0 there (or it's the only relay their
  * NIP-65 client targeted). Without including it, profiles that don't
  * happen to live on garden / nos.lol / damus / primal silently 404
- * and render as the anon-chef fallback. nostr.band + nostr.wine are
- * common secondary mirrors.
+ * and render as the anon-chef fallback. nostr.wine is a common
+ * secondary mirror.
  */
 const PROFILE_RELAY_URLS = [
   'wss://purplepag.es',
-  'wss://relay.nostr.band',
   'wss://nostr.wine'
 ];
 

--- a/src/lib/relays/relaySets.ts
+++ b/src/lib/relays/relaySets.ts
@@ -70,7 +70,6 @@ export const RELAY_SETS: Record<string, RelaySet> = {
       'wss://relay.damus.io',        // Large general relay
       'wss://nostr.wine',            // Quality content focus
       'wss://eden.nostr.land',       // Reliable general relay
-      'wss://relay.nostr.band',      // Search-optimized
       'wss://relay.noswhere.com'     // General relay with longform support
     ]
   }

--- a/src/routes/api/counts/[eventId]/+server.ts
+++ b/src/routes/api/counts/[eventId]/+server.ts
@@ -17,7 +17,6 @@ interface CountData {
 
 // Relays to query for counts (prioritize those known to support NIP-45)
 const COUNT_RELAYS = [
-  'wss://relay.nostr.band',
   'wss://nostr.wine',
   'wss://relay.damus.io',
   'wss://relay.primal.net'

--- a/src/routes/api/counts/batch/+server.ts
+++ b/src/routes/api/counts/batch/+server.ts
@@ -23,8 +23,7 @@ interface BatchResponse {
 
 // Relays to query for counts - prioritize fastest, most reliable
 const COUNT_RELAYS = [
-  'wss://relay.damus.io',      // 394ms - fast and reliable  
-  'wss://relay.nostr.band',    // 514ms - slower but reliable
+  'wss://relay.damus.io',      // 394ms - fast and reliable
   'wss://nos.lol'              // 342ms - fastest (if it supports NIP-45)
 ];
 


### PR DESCRIPTION
## Summary
- Removes `wss://relay.nostr.band` from active relay lists across outbox, profile, marketplace, count, article, and DM code paths — it consistently fails. Entries in `BLOCKED_RELAYS` sets are intentionally retained (they actively block the relay rather than use it).
- Removes `wss://kitchen.zap.cooking` from doc snapshots that had drifted from the live source (`consts.ts` / `nostr.ts` already didn't reference it).
- Swaps the NIP-50 search relay in `garden-relay/garden-invite.js` from `relay.nostr.band` → `wss://search.nos.today` so the Pyramid invite-form autocomplete works again.

## Files touched
- Active relay list updates: `src/lib/articleOutbox.ts`, `src/lib/membershipNotificationService.ts`, `src/lib/profileResolver.ts`, `src/lib/relays/relaySets.ts`, `src/lib/marketplace/products.ts`, `src/lib/authManager.ts`, `src/lib/countQuery.ts`, `src/routes/api/counts/batch/+server.ts`, `src/routes/api/counts/[eventId]/+server.ts`, `src/components/LongformFoodFeed.svelte`, `src/components/FoodstrFeedOptimized.svelte`
- Search relay swap: `garden-relay/garden-invite.js`
- Doc cleanup: `docs/mobile/UX_DEV_NOTES.md`, `docs/dev/FEED_INVENTORY.md`, `docs/dev/FEED_CONSISTENCY_VERIFICATION.md`, `docs/dev/RELAY_STRATEGY_MCP_REVIEW.md`

## Test plan
- [x] `pnpm run check` passes (0 errors)
- [ ] Articles, profiles, counts, marketplace, and DM flows still load events without relay.nostr.band in the pool
- [ ] Pyramid invite-form autocomplete returns results via `wss://search.nos.today`
- [ ] No regression in NIP-65 outbox publishing or NIP-46 pairing fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)