### PR TITLE
feat(reads): inline YouTube embeds, hashtag links, and richer actions menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.369",
+  "version": "4.2.370",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.368",
+  "version": "4.2.369",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/PostActionsMenu.svelte
+++ b/src/components/PostActionsMenu.svelte
@@ -8,6 +8,7 @@
   import LinkIcon from 'phosphor-svelte/lib/Link';
   import UserIcon from 'phosphor-svelte/lib/User';
   import TextAlignLeftIcon from 'phosphor-svelte/lib/TextAlignLeft';
+  import BracketsCurlyIcon from 'phosphor-svelte/lib/BracketsCurly';
   import DownloadIcon from 'phosphor-svelte/lib/DownloadSimple';
   import DotsThree from 'phosphor-svelte/lib/DotsThree';
   import { clickOutside } from '$lib/clickOutside';
@@ -99,6 +100,33 @@
   let textCopied = false;
   let textCopyTimeout: ReturnType<typeof setTimeout> | null = null;
 
+  let jsonCopied = false;
+  let jsonCopyTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  async function handleCopyJson() {
+    if (!browser) return;
+    try {
+      const raw = (event as unknown as { rawEvent?: () => unknown }).rawEvent?.() ?? {
+        id: event.id,
+        pubkey: event.pubkey,
+        created_at: event.created_at,
+        kind: event.kind,
+        tags: event.tags,
+        content: event.content,
+        sig: event.sig
+      };
+      await navigator.clipboard.writeText(JSON.stringify(raw, null, 2));
+      jsonCopied = true;
+      if (jsonCopyTimeout) clearTimeout(jsonCopyTimeout);
+      jsonCopyTimeout = setTimeout(() => {
+        jsonCopied = false;
+        closeMenu();
+      }, 800);
+    } catch (error) {
+      console.error('Failed to copy JSON:', error);
+    }
+  }
+
   async function handleCopyText() {
     if (!browser) return;
 
@@ -189,6 +217,19 @@
         {:else}
           <TextAlignLeftIcon size={16} class="text-caption" />
           <span>Copy Text</span>
+        {/if}
+      </button>
+      <button
+        on:click={handleCopyJson}
+        class="w-full px-4 py-2 text-left text-sm hover:bg-accent-gray flex items-center gap-2"
+        style="color: var(--color-text-primary);"
+      >
+        {#if jsonCopied}
+          <CheckIcon size={16} class="text-green-500" weight="bold" />
+          <span>Copied!</span>
+        {:else}
+          <BracketsCurlyIcon size={16} class="text-caption" />
+          <span>Copy JSON</span>
         {/if}
       </button>
       {#if engagementData}

--- a/src/components/Recipe/Recipe.svelte
+++ b/src/components/Recipe/Recipe.svelte
@@ -11,6 +11,12 @@
   import PencilSimpleIcon from 'phosphor-svelte/lib/PencilSimple';
   import TrashIcon from 'phosphor-svelte/lib/Trash';
   import ShoppingCartIcon from 'phosphor-svelte/lib/ShoppingCart';
+  import CopyIcon from 'phosphor-svelte/lib/Copy';
+  import CheckIcon from 'phosphor-svelte/lib/Check';
+  import LinkIcon from 'phosphor-svelte/lib/Link';
+  import UserIcon from 'phosphor-svelte/lib/User';
+  import TextAlignLeftIcon from 'phosphor-svelte/lib/TextAlignLeft';
+  import BracketsCurlyIcon from 'phosphor-svelte/lib/BracketsCurly';
   import Button from '../Button.svelte';
   import ShareModal from '../ShareModal.svelte';
   import SaveButton from '../SaveButton.svelte';
@@ -86,6 +92,11 @@
   let groceryModal = false;
   let printModalOpen = false;
   let menuOpen = false;
+  let copiedId = false;
+  let copiedLink = false;
+  let copiedNpub = false;
+  let copiedText = false;
+  let copiedJson = false;
   let deleteConfirmOpen = false;
   let isDeleting = false;
   let isEditingRecipe = false;
@@ -331,6 +342,58 @@
     } else {
       zapModal = true;
     }
+  }
+
+  async function copyToClipboard(text: string, flag: 'id' | 'link' | 'npub' | 'text' | 'json') {
+    if (!browser) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      if (flag === 'id') copiedId = true;
+      else if (flag === 'link') copiedLink = true;
+      else if (flag === 'npub') copiedNpub = true;
+      else if (flag === 'text') copiedText = true;
+      else if (flag === 'json') copiedJson = true;
+      setTimeout(() => {
+        copiedId = false;
+        copiedLink = false;
+        copiedNpub = false;
+        copiedText = false;
+        copiedJson = false;
+        menuOpen = false;
+      }, 800);
+    } catch (error) {
+      console.error('Failed to copy:', error);
+    }
+  }
+
+  async function handleCopyId() {
+    await copyToClipboard(computedNaddr, 'id');
+  }
+
+  async function handleCopyLink() {
+    await copyToClipboard(shareUrl, 'link');
+  }
+
+  async function handleCopyNpub() {
+    const authorPubkey = event.author?.hexpubkey || event.pubkey;
+    await copyToClipboard(nip19.npubEncode(authorPubkey), 'npub');
+  }
+
+  async function handleCopyText() {
+    await copyToClipboard(event.content || '', 'text');
+  }
+
+  async function handleCopyJson() {
+    const raw = (event as unknown as { rawEvent?: () => unknown }).rawEvent?.() ?? {
+      id: event.id,
+      pubkey: event.pubkey,
+      created_at: event.created_at,
+      kind: event.kind,
+      tags: event.tags,
+      content: event.content,
+      sig: event.sig
+    };
+    await copyToClipboard(JSON.stringify(raw, null, 2), 'json');
   }
 
   async function handleEdit() {
@@ -693,7 +756,7 @@
 <article class="max-w-[760px] mx-auto">
   {#if checkingGated}
     <div class="flex items-center justify-center p-8">
-      <div class="text-caption">Loading recipe...</div>
+      <div class="text-caption">Loading {isActualRecipe ? 'recipe' : 'article'}...</div>
     </div>
   {:else if gatedMetadata && !unlockedRecipe}
     <!-- Show gated payment UI -->
@@ -885,7 +948,7 @@
                 class="absolute right-0 top-full mt-2 z-20 rounded-xl shadow-lg py-2 min-w-[200px]"
                 style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
               >
-                {#if isOwner}
+                {#if isOwner && isActualRecipe}
                   <button
                     class="w-full flex items-center gap-3 px-4 py-2.5 text-left text-sm hover:bg-accent-gray transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                     style="color: var(--color-text-primary);"
@@ -927,27 +990,97 @@
                     Add to Grocery List
                   </button>
                 {/if}
+                {#if isActualRecipe}
+                  <button
+                    class="w-full flex items-center gap-3 px-4 py-2.5 text-left text-sm hover:bg-accent-gray transition-colors"
+                    style="color: var(--color-text-primary);"
+                    on:click={() => {
+                      printModalOpen = true;
+                      menuOpen = false;
+                    }}
+                  >
+                    <PrinterIcon size={18} />
+                    Print
+                  </button>
+                {/if}
+                {#if isActualRecipe}
+                  <button
+                    class="w-full flex items-center gap-3 px-4 py-2.5 text-left text-sm hover:bg-accent-gray transition-colors"
+                    style="color: var(--color-text-primary);"
+                    on:click={() => {
+                      menuOpen = false;
+                      goto(`/boost?recipe=${computedNaddr}`);
+                    }}
+                  >
+                    <LightningIcon size={18} />
+                    Boost this recipe
+                  </button>
+                {/if}
+                <hr class="my-1 border-t" style="border-color: var(--color-input-border);" />
                 <button
                   class="w-full flex items-center gap-3 px-4 py-2.5 text-left text-sm hover:bg-accent-gray transition-colors"
                   style="color: var(--color-text-primary);"
-                  on:click={() => {
-                    printModalOpen = true;
-                    menuOpen = false;
-                  }}
+                  on:click={handleCopyId}
                 >
-                  <PrinterIcon size={18} />
-                  Print
+                  {#if copiedId}
+                    <CheckIcon size={18} class="text-green-500" weight="bold" />
+                    Copied!
+                  {:else}
+                    <CopyIcon size={18} />
+                    Copy {isActualRecipe ? 'Recipe' : 'Article'} ID
+                  {/if}
                 </button>
                 <button
                   class="w-full flex items-center gap-3 px-4 py-2.5 text-left text-sm hover:bg-accent-gray transition-colors"
                   style="color: var(--color-text-primary);"
-                  on:click={() => {
-                    menuOpen = false;
-                    goto(`/boost?recipe=${computedNaddr}`);
-                  }}
+                  on:click={handleCopyLink}
                 >
-                  <LightningIcon size={18} />
-                  Boost this recipe
+                  {#if copiedLink}
+                    <CheckIcon size={18} class="text-green-500" weight="bold" />
+                    Link Copied!
+                  {:else}
+                    <LinkIcon size={18} />
+                    Copy Link
+                  {/if}
+                </button>
+                <button
+                  class="w-full flex items-center gap-3 px-4 py-2.5 text-left text-sm hover:bg-accent-gray transition-colors"
+                  style="color: var(--color-text-primary);"
+                  on:click={handleCopyNpub}
+                >
+                  {#if copiedNpub}
+                    <CheckIcon size={18} class="text-green-500" weight="bold" />
+                    Copied!
+                  {:else}
+                    <UserIcon size={18} />
+                    Copy npub
+                  {/if}
+                </button>
+                <button
+                  class="w-full flex items-center gap-3 px-4 py-2.5 text-left text-sm hover:bg-accent-gray transition-colors"
+                  style="color: var(--color-text-primary);"
+                  on:click={handleCopyText}
+                >
+                  {#if copiedText}
+                    <CheckIcon size={18} class="text-green-500" weight="bold" />
+                    Copied!
+                  {:else}
+                    <TextAlignLeftIcon size={18} />
+                    Copy Text
+                  {/if}
+                </button>
+                <button
+                  class="w-full flex items-center gap-3 px-4 py-2.5 text-left text-sm hover:bg-accent-gray transition-colors"
+                  style="color: var(--color-text-primary);"
+                  on:click={handleCopyJson}
+                >
+                  {#if copiedJson}
+                    <CheckIcon size={18} class="text-green-500" weight="bold" />
+                    Copied!
+                  {:else}
+                    <BracketsCurlyIcon size={18} />
+                    Copy JSON
+                  {/if}
                 </button>
                 {#if isOwner}
                   <hr class="my-1 border-t" style="border-color: var(--color-input-border);" />
@@ -959,7 +1092,7 @@
                     }}
                   >
                     <TrashIcon size={18} />
-                    Delete Recipe
+                    Delete {isActualRecipe ? 'Recipe' : 'Article'}
                   </button>
                 {/if}
               </div>
@@ -1296,6 +1429,35 @@
 
   :global(.prose tbody tr) {
     border-bottom-color: var(--color-input-border);
+  }
+
+  /* Inline YouTube embeds inside rendered markdown */
+  :global(.prose .youtube-embed) {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    margin: 1.25rem 0;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    background: #000;
+  }
+
+  :global(.prose .youtube-embed iframe) {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+  }
+
+  /* Hashtag pills inside rendered markdown */
+  :global(.prose a.hashtag-link) {
+    color: var(--color-primary);
+    text-decoration: none;
+  }
+
+  :global(.prose a.hashtag-link:hover) {
+    text-decoration: underline;
   }
 
   /* Recipe image carousel: horizontal scroll, one image at a time */

--- a/src/components/Recipe/Recipe.svelte
+++ b/src/components/Recipe/Recipe.svelte
@@ -97,6 +97,7 @@
   let copiedNpub = false;
   let copiedText = false;
   let copiedJson = false;
+  let copyTimeout: ReturnType<typeof setTimeout> | null = null;
   let deleteConfirmOpen = false;
   let isDeleting = false;
   let isEditingRecipe = false;
@@ -168,7 +169,10 @@
     event &&
     event.tags.some((tag) => tag[0] === 't' && RECIPE_TAGS.includes(tag[1]?.toLowerCase() || ''));
 
-  onDestroy(() => { unsubMembership(); });
+  onDestroy(() => {
+    unsubMembership();
+    if (copyTimeout) clearTimeout(copyTimeout);
+  });
 
   // Gated recipe state
   let gatedMetadata: GatedRecipeMetadata | null = null;
@@ -348,17 +352,24 @@
     if (!browser) return;
     try {
       await navigator.clipboard.writeText(text);
+      copiedId = false;
+      copiedLink = false;
+      copiedNpub = false;
+      copiedText = false;
+      copiedJson = false;
       if (flag === 'id') copiedId = true;
       else if (flag === 'link') copiedLink = true;
       else if (flag === 'npub') copiedNpub = true;
       else if (flag === 'text') copiedText = true;
       else if (flag === 'json') copiedJson = true;
-      setTimeout(() => {
+      if (copyTimeout) clearTimeout(copyTimeout);
+      copyTimeout = setTimeout(() => {
         copiedId = false;
         copiedLink = false;
         copiedNpub = false;
         copiedText = false;
         copiedJson = false;
+        copyTimeout = null;
         menuOpen = false;
       }, 800);
     } catch (error) {

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -104,15 +104,12 @@ function embedYoutubeInElement(root: Element, doc: Document): void {
 
     const wrapper = buildYoutubeEmbed(id, doc);
 
-    // Strip any leading decorative chars (emoji, whitespace, punctuation) before the link
-    // and check whether the link is effectively the entire paragraph.
-    const paraText = (p.textContent || '').trim();
+    // Replace the paragraph only if the link is a bare URL (link text === href),
+    // meaning the author didn't write custom label text. For labeled links like
+    // [Watch the pitch](https://youtu.be/...) the original text is preserved and
+    // the embed is inserted after the paragraph.
     const linkText = (link.textContent || '').trim();
-    const decorationStripped = paraText
-      .replace(/^[\s\p{P}\p{S}]+/u, '')
-      .replace(/[\s\p{P}\p{S}]+$/u, '');
-
-    if (decorationStripped === linkText) {
+    if (linkText === href) {
       p.replaceWith(wrapper);
     } else {
       p.parentNode?.insertBefore(wrapper, p.nextSibling);

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -1,7 +1,7 @@
 import MarkdownIt from 'markdown-it';
 import { sanitizeHTML } from '$lib/sanitize';
 
-const md = new MarkdownIt();
+const md = new MarkdownIt({ linkify: true });
 
 // Override link renderer to open links in new tab
 const defaultRender = md.renderer.rules.link_open || function(tokens, idx, options, env, self) {
@@ -14,9 +14,126 @@ md.renderer.rules.link_open = function(tokens, idx, options, env, self) {
   return defaultRender(tokens, idx, options, env, self);
 };
 
+const YOUTUBE_PATTERNS = [
+  /^(?:https?:\/\/)?(?:www\.|m\.)?youtube\.com\/watch\?(?:[^#]*&)?v=([a-zA-Z0-9_-]{11})(?:[&#].*)?$/,
+  /^(?:https?:\/\/)?(?:www\.|m\.)?youtu\.be\/([a-zA-Z0-9_-]{11})(?:[?#].*)?$/,
+  /^(?:https?:\/\/)?(?:www\.|m\.)?youtube\.com\/shorts\/([a-zA-Z0-9_-]{11})(?:[?#].*)?$/,
+  /^(?:https?:\/\/)?(?:www\.|m\.)?youtube\.com\/embed\/([a-zA-Z0-9_-]{11})(?:[?#].*)?$/
+];
+
+function extractYoutubeId(url: string): string | null {
+  const trimmed = url.trim();
+  for (const re of YOUTUBE_PATTERNS) {
+    const m = trimmed.match(re);
+    if (m) return m[1];
+  }
+  return null;
+}
+
+const HASHTAG_RE = /#([\p{L}\p{N}_]+)/gu;
+const HASHTAG_SKIP_TAGS = new Set(['A', 'CODE', 'PRE', 'SCRIPT', 'STYLE', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6']);
+
+function collectTextNodes(el: Element, out: Text[]): void {
+  if (HASHTAG_SKIP_TAGS.has(el.nodeName)) return;
+  for (const child of Array.from(el.childNodes)) {
+    if (child.nodeType === 3) {
+      out.push(child as Text);
+    } else if (child.nodeType === 1) {
+      collectTextNodes(child as Element, out);
+    }
+  }
+}
+
+function linkHashtagsInElement(root: Element, doc: Document): void {
+  const textNodes: Text[] = [];
+  collectTextNodes(root, textNodes);
+  for (const node of textNodes) {
+    const text = node.textContent || '';
+    HASHTAG_RE.lastIndex = 0;
+    if (!HASHTAG_RE.test(text)) continue;
+    HASHTAG_RE.lastIndex = 0;
+
+    const fragment = doc.createDocumentFragment();
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = HASHTAG_RE.exec(text)) !== null) {
+      if (match.index > lastIndex) {
+        fragment.appendChild(doc.createTextNode(text.slice(lastIndex, match.index)));
+      }
+      const a = doc.createElement('a');
+      a.setAttribute('href', `/tag/${match[1].toLowerCase()}`);
+      a.className = 'hashtag-link';
+      a.textContent = match[0];
+      fragment.appendChild(a);
+      lastIndex = match.index + match[0].length;
+    }
+    if (lastIndex < text.length) {
+      fragment.appendChild(doc.createTextNode(text.slice(lastIndex)));
+    }
+    node.parentNode?.replaceChild(fragment, node);
+  }
+}
+
+function buildYoutubeEmbed(id: string, doc: Document): HTMLElement {
+  const wrapper = doc.createElement('div');
+  wrapper.className = 'youtube-embed';
+  const iframe = doc.createElement('iframe');
+  iframe.setAttribute('src', `https://www.youtube-nocookie.com/embed/${id}`);
+  iframe.setAttribute('title', 'YouTube video player');
+  iframe.setAttribute('frameborder', '0');
+  iframe.setAttribute(
+    'allow',
+    'accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share'
+  );
+  iframe.setAttribute('referrerpolicy', 'strict-origin-when-cross-origin');
+  iframe.setAttribute('allowfullscreen', '');
+  iframe.setAttribute('loading', 'lazy');
+  wrapper.appendChild(iframe);
+  return wrapper;
+}
+
+function embedYoutubeInElement(root: Element, doc: Document): void {
+  const paragraphs = Array.from(root.querySelectorAll('p'));
+  for (const p of paragraphs) {
+    const links = p.querySelectorAll('a');
+    if (links.length !== 1) continue;
+    const link = links[0];
+    const href = link.getAttribute('href') || '';
+    const id = extractYoutubeId(href);
+    if (!id) continue;
+
+    const wrapper = buildYoutubeEmbed(id, doc);
+
+    // Strip any leading decorative chars (emoji, whitespace, punctuation) before the link
+    // and check whether the link is effectively the entire paragraph.
+    const paraText = (p.textContent || '').trim();
+    const linkText = (link.textContent || '').trim();
+    const decorationStripped = paraText
+      .replace(/^[\s\p{P}\p{S}]+/u, '')
+      .replace(/[\s\p{P}\p{S}]+$/u, '');
+
+    if (decorationStripped === linkText) {
+      p.replaceWith(wrapper);
+    } else {
+      p.parentNode?.insertBefore(wrapper, p.nextSibling);
+    }
+  }
+}
+
+function enhanceContent(html: string): string {
+  if (!html || typeof DOMParser === 'undefined') return html;
+  const doc = new DOMParser().parseFromString(`<div>${html}</div>`, 'text/html');
+  const root = doc.body.firstElementChild as HTMLElement | null;
+  if (!root) return html;
+  embedYoutubeInElement(root, doc);
+  linkHashtagsInElement(root, doc);
+  return root.innerHTML;
+}
+
 export function parseMarkdown(markdown: string) {
   const parsedMarkdown = md.render(markdown);
-  return sanitizeHTML(parsedMarkdown);
+  const sanitized = sanitizeHTML(parsedMarkdown);
+  return enhanceContent(sanitized);
 }
 
 interface MarkdownInformation {


### PR DESCRIPTION
## Summary

Improves the rendering and action menu for longform articles (and, where it makes sense, recipes too).

### Markdown rendering (`src/lib/parser.ts`)
- **Inline YouTube embeds.** Standalone YouTube links inside paragraphs become responsive 16:9 `youtube-nocookie.com` iframes (lazy-loaded). Strict regex extracts the 11-char video ID; the iframe is constructed via `setAttribute` after sanitization so user input never reaches the embed URL.
  - Decorative leading/trailing whitespace, punctuation, and symbols (e.g. `🎥 `) are stripped before deciding whether the link is "the whole paragraph" — if so, the paragraph is replaced; otherwise the embed is inserted *after* the paragraph and original text is preserved.
- **Hashtag autolinking.** `#tag` in rendered prose becomes `<a href="/tag/<lower>">`. DOM-walks text nodes only and skips `<a>`, `<code>`, `<pre>`, and headings (so `## Heading` stays a heading).
- **Linkify enabled** on markdown-it so bare URLs in article markdown become clickable.

### Action menu (`src/components/Recipe/Recipe.svelte`)
- **New items** in the 3-dot menu, matching the note-card menu's pattern: **Copy ID**, **Copy Link**, **Copy npub**, **Copy Text**, **Copy JSON** (with the standard 800ms "Copied!" feedback).
  - "Copy ID" copies the canonical naddr; label switches between "Copy Recipe ID" / "Copy Article ID" based on whether the event is recipe-shaped.
  - "Copy JSON" uses NDK's `rawEvent()` if available, otherwise reconstructs a Nostr event object from `id`/`pubkey`/`created_at`/`kind`/`tags`/`content`/`sig`, and pretty-prints it.
- **Context-aware for articles.** When the event isn't an actual recipe (no recipe tags), the menu hides Print, Boost, and Edit (all of which are recipe-only flows), and the Delete button reads "Delete Article" instead of "Delete Recipe".
- The gated-content "Loading recipe…" placeholder now reads "Loading article…" for non-recipe events.

### Note menu (`src/components/PostActionsMenu.svelte`)
- Adds **Copy JSON** alongside the existing Copy items so the option is available everywhere.

## Test plan
- [ ] Visit a longform article that includes a YouTube link prefixed with text/emoji and verify the iframe embeds inline.
- [ ] Verify standalone YouTube links replace their paragraph; YouTube links in mid-sentence appear as an embed *after* the paragraph with the original text preserved.
- [ ] Verify hashtags in rendered article prose link to `/tag/<name>`; verify hashtags inside `<a>`, `<code>`, and headings are NOT linked.
- [ ] On a recipe page, confirm Print/Boost/Edit/Delete-Recipe are present.
- [ ] On an article page, confirm Print/Boost/Edit are hidden and Delete reads "Delete Article".
- [ ] Test all five Copy actions (ID, Link, npub, Text, JSON) on both a recipe and an article — verify clipboard contents match expectations.
- [ ] Test Copy JSON in the note action menu (PostActionsMenu) on a regular note in the feed.