### PR TITLE
chore(passkey): add WebAuthn well-known files for own-RP passkey login

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,8 @@
+/.well-known/apple-app-site-association
+  Content-Type: application/json
+
+/.well-known/assetlinks.json
+  Content-Type: application/json
+
+/.well-known/webauthn
+  Content-Type: application/json

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.370",
+  "version": "4.2.371",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/static/.well-known/apple-app-site-association
+++ b/static/.well-known/apple-app-site-association
@@ -1,0 +1,5 @@
+{
+  "webcredentials": {
+    "apps": ["Z26TJQZZWC.cooking.zap.app"]
+  }
+}

--- a/static/.well-known/assetlinks.json
+++ b/static/.well-known/assetlinks.json
@@ -1,0 +1,10 @@
+[
+  {
+    "relation": ["delegate_permission/common.get_login_creds"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "cooking.zap.app",
+      "sha256_cert_fingerprints": ["C0:0C:10:DB:D5:41:0E:D5:FA:52:A6:03:5E:3A:BA:8C:EE:27:D5:21:EE:CE:F4:4E:D0:67:D4:E2:B3:A8:E8:D3"]
+    }
+  }
+]

--- a/static/.well-known/webauthn
+++ b/static/.well-known/webauthn
@@ -1,0 +1,6 @@
+{
+  "origins": [
+    "https://zap.cooking",
+    "https://www.zap.cooking"
+  ]
+}


### PR DESCRIPTION
Stages the three WebAuthn-related well-known files needed for Phase C.0 spike and beyond:

- `apple-app-site-association` — webcredentials binding for `cooking.zap.app`
- `assetlinks.json` — Android Digital Asset Links for `cooking.zap.app`
- `webauthn` — related origins for the `zap.cooking` rpID

Plus `_headers` updates so Cloudflare Pages serves all three with `Content-Type: application/json` (Apple's AASA validator is strict — wrong content type silently breaks iOS passkey login with no error).

Files are inert until Phase C ships actual passkey login UI. Safe to merge and deploy independently of any Phase C work.

Follow-up to #382.