### PR TITLE
Update branta sdk to v3 and use bolt11 zk (supersedes #385)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.384",
+  "version": "4.2.385",
   "private": true,
   "scripts": {
     "dev": "vite dev",
@@ -28,7 +28,7 @@
     "node": "22.x"
   },
   "dependencies": {
-    "@branta-ops/branta": "^1.0.0",
+    "@branta-ops/branta": "^3.0.2",
     "@breeztech/breez-sdk-spark": "0.11.0",
     "@capacitor/android": "^8.0.0",
     "@capacitor/app": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.385",
+  "version": "4.2.386",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
   .:
     dependencies:
       '@branta-ops/branta':
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: ^3.0.2
+        version: 3.0.2
       '@breeztech/breez-sdk-spark':
         specifier: 0.11.0
         version: 0.11.0
@@ -324,8 +324,8 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@branta-ops/branta@1.0.0':
-    resolution: {integrity: sha512-X11TSAk4lSGdk8nCjBgtfKWRuo5wKkX8Q5g4V/pJPPc3HEEZ+DB79JsNmQcRLutf+N6KOxgVW0x4rKg6zwZCUw==}
+  '@branta-ops/branta@3.0.2':
+    resolution: {integrity: sha512-0ujzdfZQEEkD8PaFwCxQ/bPAOzdst/ErBRDGwhZr5Hxk9WSpUOWNdR6uWZutHgD/bb/tE8dg+UPC5uKP7/G13g==}
 
   '@breeztech/breez-sdk-spark@0.11.0':
     resolution: {integrity: sha512-wX8ZdFfnXN9t2AuLYlZxslmdHlxqnvkU8kAmIL1GuI3LNV8F7bxMGxLV/WTaQTgd7BGW/pcejpBcNPe7jjCdfA==}
@@ -5519,7 +5519,7 @@ snapshots:
       css-tree: 3.2.1
     optional: true
 
-  '@branta-ops/branta@1.0.0': {}
+  '@branta-ops/branta@3.0.2': {}
 
   '@breeztech/breez-sdk-spark@0.11.0':
     optionalDependencies:

--- a/src/components/BrantaBadge.svelte
+++ b/src/components/BrantaBadge.svelte
@@ -38,10 +38,16 @@
 
     try {
       const address = encryptedDestination || paymentString;
-      const param = rawQrText
-        ? `qr=${encodeURIComponent(rawQrText)}`
-        : `payment=${encodeURIComponent(address)}${secret ? `&secret=${encodeURIComponent(secret)}` : ''}`;
-      const res = await fetch(`/api/branta/verify?${param}`);
+      // Secret is sent in a POST body (not as a query param) so it isn't
+      // captured by logs, proxies, or referrers.
+      const requestBody = rawQrText
+        ? { qr: rawQrText }
+        : { payment: address, ...(secret ? { secret } : {}) };
+      const res = await fetch('/api/branta/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(requestBody)
+      });
       const data = await res.json();
 
       if (res.status === 503) {

--- a/src/components/BrantaBadge.svelte
+++ b/src/components/BrantaBadge.svelte
@@ -21,6 +21,8 @@
 
   export let paymentString: string = '';
   export let rawQrText: string = '';
+  export let secret: string | undefined = undefined;
+  export let encryptedDestination: string | undefined = undefined;
   export let autoVerify: boolean = true;
   export let showUnverified: boolean = false;
 
@@ -35,9 +37,10 @@
     loading = true;
 
     try {
+      const address = encryptedDestination || paymentString;
       const param = rawQrText
         ? `qr=${encodeURIComponent(rawQrText)}`
-        : `payment=${encodeURIComponent(paymentString)}`;
+        : `payment=${encodeURIComponent(address)}${secret ? `&secret=${encodeURIComponent(secret)}` : ''}`;
       const res = await fetch(`/api/branta/verify?${param}`);
       const data = await res.json();
 

--- a/src/lib/brantaService.server.ts
+++ b/src/lib/brantaService.server.ts
@@ -75,15 +75,16 @@ export async function registerPayment(
   }
 
   try {
-    // Build destination object with optional zk flag
+    // Always register with zk encryption enabled so the destination value
+    // is encrypted at rest in Branta. Callers must persist the returned
+    // secret/encryptedDestination to verify later.
     const destination: Destination = {
-      value: paymentString.trim()
+      value: paymentString.trim(),
+      zk: true
     };
 
-    destination.zk = true;
-
     if (destinationType) {
-        destination.type = destinationType;
+      destination.type = destinationType;
     }
 
     const body: Payment = {

--- a/src/lib/brantaService.server.ts
+++ b/src/lib/brantaService.server.ts
@@ -13,7 +13,8 @@
  */
 
 import { env } from '$env/dynamic/private';
-import { V2BrantaClient, type BrantaClientOptions, type Destination, type Payment } from '@branta-ops/branta';
+import { type BrantaClientOptions } from '@branta-ops/branta';
+import { BrantaService, type Destination, type DestinationType, type Payment } from '@branta-ops/branta/v2';
 
 export type { Payment };
 
@@ -21,6 +22,7 @@ export interface RegisterPaymentResult {
   success: boolean;
   verifyLink?: string;
   secret?: string;
+  encryptedDestination?: string;
   error?: string;
 }
 
@@ -40,7 +42,7 @@ export function getBrantaConfig(platform?: any): BrantaClientOptions | null {
     env.BRANTA_API_BASE_URL ||
     'https://guardrail.branta.pro';
 
-  return { defaultApiKey: apiKey, baseUrl };
+  return { defaultApiKey: apiKey, baseUrl, privacy: 'strict' };
 }
 
 /**
@@ -63,7 +65,7 @@ export async function registerPayment(
   ttl: number | undefined,
   description: string | undefined,
   metadata: object | undefined,
-  zk: boolean | undefined,
+  destinationType: DestinationType | undefined,
   platform?: any
 ): Promise<RegisterPaymentResult> {
   const config = getBrantaConfig(platform);
@@ -78,9 +80,10 @@ export async function registerPayment(
       value: paymentString.trim()
     };
 
-    // Use zk (zero-knowledge) for on-chain addresses, plaintext for lightning
-    if (zk !== undefined) {
-      destination.zk = zk;
+    destination.zk = true;
+
+    if (destinationType) {
+        destination.type = destinationType;
     }
 
     const body: Payment = {
@@ -97,16 +100,16 @@ export async function registerPayment(
       body.metadata = metadata as Record<string, string>;
     }
 
-    const brantaClient = new V2BrantaClient(config);
+    const brantaService = new BrantaService(config);
 
-    // Use ZK encryption for on-chain addresses, plaintext for Lightning
-    if (zk) {
-      const result = await brantaClient.addZKPayment(body);
-      return { success: true, verifyLink: result.verifyLink, secret: result.secret };
-    } else {
-      const result = await brantaClient.addPayment(body);
-      return { success: true, verifyLink: result.verifyLink };
-    }
+    const result = await brantaService.addPayment(body);
+
+    return {
+      success: true,
+      verifyLink: result.verifyLink,
+      secret: result.secret,
+      encryptedDestination: result.payment.destinations[0]?.value
+    };
   } catch (error) {
     if (error instanceof Error && error.name === 'AbortError') {
       console.warn('[Branta] Registration request timed out');
@@ -126,14 +129,15 @@ export async function registerPayment(
  */
 export async function getPaymentInfo(
   paymentString: string,
+  encryptionKey?: string,
   platform?: any
 ): Promise<Payment | null> {
   const config = getBrantaConfig(platform);
   if (!config || !paymentString?.trim()) return null;
 
   try {
-    const brantaClient = new V2BrantaClient(config);
-    const response = await brantaClient.getPayments(paymentString.trim());
+    const brantaService = new BrantaService(config);
+    const response = await brantaService.getPayments(paymentString.trim(), encryptionKey);
     return response[0] ?? null;
   } catch (error) {
     console.warn('[Branta] getPaymentInfo failed:', error);
@@ -152,8 +156,8 @@ export async function getPaymentInfoByQRCode(
   if (!config || !qrText?.trim()) return null;
 
   try {
-    const brantaClient = new V2BrantaClient(config);
-    const response = await brantaClient.getPaymentsByQRCode(qrText.trim());
+    const brantaService = new BrantaService(config);
+    const response = await brantaService.getPaymentsByQRCode(qrText.trim());
 
     return response[0] ?? null;
   } catch (error) {

--- a/src/routes/api/branta/register/+server.ts
+++ b/src/routes/api/branta/register/+server.ts
@@ -8,6 +8,15 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { registerPayment, isBrantaConfigured } from '$lib/brantaService.server';
+import type { DestinationType } from '@branta-ops/branta/v2';
+
+const ALLOWED_DESTINATION_TYPES: ReadonlyArray<DestinationType> = [
+	'bitcoin_address',
+	'bolt11',
+	'bolt12',
+	'ln_url',
+	'tether_address'
+];
 
 export const POST: RequestHandler = async ({ request, platform }) => {
 	// Check if Branta is configured
@@ -23,12 +32,26 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 			return json({ success: false, error: 'paymentString is required' }, { status: 400 });
 		}
 
+		let validatedDestinationType: DestinationType | undefined;
+		if (destinationType !== undefined && destinationType !== null) {
+			if (
+				typeof destinationType !== 'string' ||
+				!ALLOWED_DESTINATION_TYPES.includes(destinationType as DestinationType)
+			) {
+				return json(
+					{ success: false, error: 'invalid destinationType' },
+					{ status: 400 }
+				);
+			}
+			validatedDestinationType = destinationType as DestinationType;
+		}
+
 		const result = await registerPayment(
 			paymentString,
 			typeof ttl === 'number' ? ttl : undefined,
 			typeof description === 'string' ? description : undefined,
 			typeof metadata === 'object' ? metadata : undefined,
-			destinationType ? destinationType : undefined,
+			validatedDestinationType,
 			platform
 		);
 

--- a/src/routes/api/branta/register/+server.ts
+++ b/src/routes/api/branta/register/+server.ts
@@ -17,7 +17,7 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 
 	try {
 		const body = await request.json();
-		const { paymentString, ttl, description, metadata, zk } = body;
+		const { paymentString, ttl, description, metadata, destinationType } = body;
 
 		if (!paymentString || typeof paymentString !== 'string' || paymentString.trim().length === 0) {
 			return json({ success: false, error: 'paymentString is required' }, { status: 400 });
@@ -28,11 +28,12 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 			typeof ttl === 'number' ? ttl : undefined,
 			typeof description === 'string' ? description : undefined,
 			typeof metadata === 'object' ? metadata : undefined,
-			typeof zk === 'boolean' ? zk : undefined, platform
+			destinationType ? destinationType : undefined,
+			platform
 		);
 
 		if (result.success) {
-			return json({ success: true, verifyLink: result.verifyLink });
+			return json({ success: true, verifyLink: result.verifyLink, secret: result.secret, encryptedDestination: result.encryptedDestination });
 		}
 
 		return json({ success: false, error: result.error }, { status: 500 });

--- a/src/routes/api/branta/verify/+server.ts
+++ b/src/routes/api/branta/verify/+server.ts
@@ -23,10 +23,11 @@ export const GET: RequestHandler = async ({ url, platform }) => {
 		return json({ verified: false, error: 'payment or qr query parameter is required' }, { status: 400 });
 	}
 
+	const encryptionKey = url.searchParams.get('secret') ?? undefined;
 	try {
 		const payment = qrText
 			? await getPaymentInfoByQRCode(qrText, platform)
-			: await getPaymentInfo(paymentString!, platform);
+			: await getPaymentInfo(paymentString!, encryptionKey, platform);
 
 		return json({ verified: payment !== null, payment: payment ?? undefined });
 	} catch (error) {

--- a/src/routes/api/branta/verify/+server.ts
+++ b/src/routes/api/branta/verify/+server.ts
@@ -1,29 +1,44 @@
 /**
  * Branta Payment Verification Endpoint
  *
- * GET /api/branta/verify?payment=<paymentString>
- * GET /api/branta/verify?qr=<rawQrText>
- * Checks if a payment address/invoice is registered with Branta Guardrail
+ * POST /api/branta/verify
+ *   body: { payment?: string, qr?: string, secret?: string }
+ *
+ * Checks if a payment address/invoice is registered with Branta Guardrail.
+ * Uses POST so the (sensitive) Branta secret is not placed in URL query
+ * params, where it can leak via logs, proxies, and referrers.
  */
 
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getPaymentInfo, getPaymentInfoByQRCode, isBrantaConfigured } from '$lib/brantaService.server';
 
-export const GET: RequestHandler = async ({ url, platform }) => {
-	// Check if Branta is configured
+export const POST: RequestHandler = async ({ request, platform }) => {
 	if (!isBrantaConfigured(platform)) {
 		return json({ verified: false, error: 'Branta not configured' }, { status: 503 });
 	}
 
-	const qrText = url.searchParams.get('qr');
-	const paymentString = url.searchParams.get('payment');
-
-	if (!qrText && !paymentString) {
-		return json({ verified: false, error: 'payment or qr query parameter is required' }, { status: 400 });
+	let body: { payment?: unknown; qr?: unknown; secret?: unknown };
+	try {
+		body = await request.json();
+	} catch {
+		return json({ verified: false, error: 'invalid JSON body' }, { status: 400 });
 	}
 
-	const encryptionKey = url.searchParams.get('secret') ?? undefined;
+	const qrText = typeof body.qr === 'string' && body.qr.trim() ? body.qr : undefined;
+	const paymentString =
+		typeof body.payment === 'string' && body.payment.trim() ? body.payment : undefined;
+
+	if (!qrText && !paymentString) {
+		return json(
+			{ verified: false, error: 'payment or qr field is required' },
+			{ status: 400 }
+		);
+	}
+
+	const rawSecret = typeof body.secret === 'string' ? body.secret : undefined;
+	const encryptionKey = rawSecret?.trim() ? rawSecret : undefined;
+
 	try {
 		const payment = qrText
 			? await getPaymentInfoByQRCode(qrText, platform)

--- a/src/routes/wallet/+page.svelte
+++ b/src/routes/wallet/+page.svelte
@@ -1110,8 +1110,10 @@
     return segments;
   }
 
-  // Register a payment address/invoice with Branta Guardrail
-  // zk: true enables zero-knowledge encryption (on-chain addresses), false for plaintext (Lightning)
+  // Register a payment address/invoice with Branta Guardrail.
+  // Registration is always zk-encrypted server-side; the returned `secret`
+  // and `encryptedDestination` are required to verify on-chain destinations
+  // later. Returns {} on any failure so callers can fall back gracefully.
   async function registerWithBranta(paymentString: string, description?: string, destinationType?: string): Promise<{ secret?: string; encryptedDestination?: string }> {
     try {
       const res = await fetch('/api/branta/register', {
@@ -1124,7 +1126,15 @@
           ttl: 86400 // 24 hours
         })
       });
+      if (!res.ok) {
+        console.warn('[Branta] Registration returned non-OK status:', res.status);
+        return {};
+      }
       const data = await res.json().catch(() => ({}));
+      if (data?.success !== true) {
+        console.warn('[Branta] Registration unsuccessful:', data?.error);
+        return {};
+      }
       return { secret: data.secret, encryptedDestination: data.encryptedDestination };
     } catch (e) {
       // Silent fail - Branta registration is optional
@@ -1148,6 +1158,8 @@
     // Reset on-chain state
     receiveMode = 'lightning';
     onchainAddress = null;
+    onchainBrantaSecret = undefined;
+    onchainBrantaEncryptedDestination = undefined;
   }
 
   // Generate on-chain Bitcoin address for receiving
@@ -1477,8 +1489,9 @@
         throw new Error('Failed to generate invoice - no invoice returned');
       }
       generatedPaymentHash = result.paymentHash || '';
-      // Register with Branta for verification (zk: false for Lightning)
-      // Await to ensure badge can verify after registration completes
+      // Register Lightning invoice with Branta as a `bolt11` destination so
+      // the badge can verify it. Await to ensure the badge can verify after
+      // registration completes.
       await registerWithBranta(
         result.invoice,
         `zap.cooking invoice for ${amountToUse} sats`,
@@ -5288,6 +5301,8 @@
                     class="w-full py-3 px-4 rounded-xl border border-input hover:bg-input text-primary-color font-medium transition-colors"
                     on:click={() => {
                       onchainAddress = null;
+                      onchainBrantaSecret = undefined;
+                      onchainBrantaEncryptedDestination = undefined;
                       receiveMode = 'lightning';
                     }}
                   >
@@ -5367,7 +5382,7 @@
                             on:click={async () => {
                               const wasHidden = showLightningAddressQr !== nwcLud16;
                               if (wasHidden && nwcLud16) {
-                                await registerWithBranta(nwcLud16, 'NWC Lightning Address', false);
+                                await registerWithBranta(nwcLud16, 'NWC Lightning Address');
                                 showLightningAddressQr = nwcLud16;
                               } else {
                                 showLightningAddressQr = null;
@@ -5454,8 +5469,7 @@
                               if (wasHidden && $sparkLightningAddressStore) {
                                 await registerWithBranta(
                                   $sparkLightningAddressStore,
-                                  'Spark Lightning Address',
-                                  false
+                                  'Spark Lightning Address'
                                 );
                                 showLightningAddressQr = $sparkLightningAddressStore;
                               } else {

--- a/src/routes/wallet/+page.svelte
+++ b/src/routes/wallet/+page.svelte
@@ -391,6 +391,8 @@
   // On-chain Bitcoin state
   let receiveMode: 'lightning' | 'onchain' = 'lightning';
   let onchainAddress: string | null = null;
+  let onchainBrantaSecret: string | undefined;
+  let onchainBrantaEncryptedDestination: string | undefined;
   let isGeneratingOnchainAddress = false;
   let unclaimedDeposits: UnclaimedDeposit[] = [];
   let isLoadingDeposits = false;
@@ -1110,21 +1112,24 @@
 
   // Register a payment address/invoice with Branta Guardrail
   // zk: true enables zero-knowledge encryption (on-chain addresses), false for plaintext (Lightning)
-  async function registerWithBranta(paymentString: string, description?: string, zk?: boolean) {
+  async function registerWithBranta(paymentString: string, description?: string, destinationType?: string): Promise<{ secret?: string; encryptedDestination?: string }> {
     try {
-      await fetch('/api/branta/register', {
+      const res = await fetch('/api/branta/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           paymentString,
           description,
-          ttl: 86400, // 24 hours
-          zk
+          destinationType,
+          ttl: 86400 // 24 hours
         })
       });
+      const data = await res.json().catch(() => ({}));
+      return { secret: data.secret, encryptedDestination: data.encryptedDestination };
     } catch (e) {
       // Silent fail - Branta registration is optional
       console.warn('[Branta] Registration failed:', e);
+      return {};
     }
   }
 
@@ -1154,9 +1159,10 @@
 
     try {
       const result = await receiveOnchain();
-      // Register with Branta for verification (plaintext for now, ZK in follow-up PR)
       // Await to ensure badge can verify after registration completes
-      await registerWithBranta(result.address, 'zap.cooking Bitcoin deposit address', false);
+      const brantaResult = await registerWithBranta(result.address, 'zap.cooking Bitcoin deposit address', 'bitcoin_address');
+      onchainBrantaSecret = brantaResult.secret;
+      onchainBrantaEncryptedDestination = brantaResult.encryptedDestination;
       onchainAddress = result.address;
       // Also load any pending deposits
       await loadUnclaimedDeposits();
@@ -1476,7 +1482,7 @@
       await registerWithBranta(
         result.invoice,
         `zap.cooking invoice for ${amountToUse} sats`,
-        false
+        'bolt11'
       );
       generatedInvoice = result.invoice;
 
@@ -5184,7 +5190,7 @@
 
                   <!-- Branta Verification Badge -->
                   <div class="flex justify-center">
-                    <BrantaBadge paymentString={onchainAddress} />
+                    <BrantaBadge paymentString={onchainAddress} secret={onchainBrantaSecret} encryptedDestination={onchainBrantaEncryptedDestination} />
                   </div>
 
                   <!-- Address (segmented for easier verification) -->


### PR DESCRIPTION
Supersedes #385 by @kylemccullen — same Branta SDK v3 migration, plus the Copilot review fixes applied on top so we can merge today.

Authorship of the SDK migration commit is preserved (@kylemccullen). Closing #385 because the source branch lives on a fork without "Allow edits by maintainers" enabled, so the Copilot fixes couldn't be pushed there.

## Summary

- Bump `@branta-ops/branta` to `^3.0.2`, migrate to `BrantaService`, support `destinationType` (`bitcoin_address` / `bolt11`).
- Pass Branta's `secret` + `encryptedDestination` from on-chain address registration through to `BrantaBadge` for verification.
- Address all 8 Copilot review comments from #385 (see commit `fix(branta): address Copilot review feedback on PR #385`):
  1. Guard `registerWithBranta` against non-2xx / `success:false` responses
  2. Clear `onchainBrantaSecret` / `onchainBrantaEncryptedDestination` on receive-modal reset
  3. Update outdated "zk: false for Lightning" comment
  4. Validate `destinationType` against the SDK whitelist (400 on invalid)
  5. Make always-zk behavior explicit in `brantaService` comment
  6. Fix indentation in `if (destinationType)` block
  7. Move Branta `secret` out of URL query string — verify endpoint is now POST with JSON body
  8. Treat empty-string `secret` as undefined
- Also drop two leftover `false` boolean args to `registerWithBranta` that broke type-check after the signature changed from `zk?: boolean` to `destinationType?: string`.

## Test plan

- [ ] `pnpm check` passes (verified locally: 0 errors)
- [ ] Generate on-chain address in wallet — Branta badge verifies after registration
- [ ] Generate Lightning invoice — Branta badge verifies
- [ ] Show NWC / Spark Lightning Address QR — badge appears
- [ ] Open and close the receive modal a few times — confirm no stale secret leaks into a fresh address

🤖 Generated with [Claude Code](https://claude.com/claude-code)