### PR TITLE
feat(header): sleek mobile redesign + unified Intelligence + denominated balance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.412",
+  "version": "4.2.413",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.415",
+  "version": "4.2.416",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.414",
+  "version": "4.2.415",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.416",
+  "version": "4.2.417",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.410",
+  "version": "4.2.411",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.411",
+  "version": "4.2.412",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.413",
+  "version": "4.2.414",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/DenominatedBalance.svelte
+++ b/src/components/DenominatedBalance.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { displayCurrency } from '$lib/currencyStore';
+  import { displayCurrency, type CurrencyCode } from '$lib/currencyStore';
   import { convertSatsToFiat, formatFiatValue } from '$lib/currencyConversion';
 
   export let sats: number | null;
@@ -10,12 +10,14 @@
 
   let fiatValue: number | null = null;
   let lastFetchedSats: number | null = null;
-  let lastFetchedCurrency: string = '';
+  let lastFetchedCurrency: CurrencyCode | '' = '';
+  // Monotonic request id — every fetch increments. Only the most
+  // recent request is allowed to write `fiatValue` / `fiatLoading`,
+  // so an older promise that resolves after the user switched
+  // currency or amount can't clobber the latest state.
+  let requestSeq = 0;
   let fiatLoading = false;
 
-  // Re-fetch fiat only when sats, currency, or visibility actually change to
-  // an active fiat view. Compares against last-fetched to avoid request
-  // storms from unrelated parent reactivity.
   $: if (
     visible &&
     sats !== null &&
@@ -24,10 +26,15 @@
   ) {
     lastFetchedSats = sats;
     lastFetchedCurrency = $displayCurrency;
+    const mySeq = ++requestSeq;
+    const requestedCurrency = $displayCurrency;
+    const requestedSats = sats;
     fiatLoading = true;
-    convertSatsToFiat(sats).then((v) => {
-      // Drop stale results if currency switched mid-flight.
-      if ($displayCurrency === lastFetchedCurrency) {
+    // Pass the requested currency explicitly so the conversion uses
+    // it (not whatever the store now points to), and compare against
+    // the monotonic seq to discard stale results.
+    convertSatsToFiat(requestedSats, requestedCurrency).then((v) => {
+      if (mySeq === requestSeq) {
         fiatValue = v;
         fiatLoading = false;
       }
@@ -35,6 +42,8 @@
   }
 
   $: if ($displayCurrency === 'SATS') {
+    // Invalidate any in-flight fetch so it can't write back later.
+    requestSeq++;
     fiatValue = null;
     fiatLoading = false;
   }

--- a/src/components/DenominatedBalance.svelte
+++ b/src/components/DenominatedBalance.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import { displayCurrency } from '$lib/currencyStore';
+  import { convertSatsToFiat, formatFiatValue } from '$lib/currencyConversion';
+
+  export let sats: number | null;
+  export let visible: boolean = true;
+  export let loading: boolean = false;
+  /** When true, large sats values are abbreviated (1.2k / 3.4M). */
+  export let compact: boolean = true;
+
+  let fiatValue: number | null = null;
+  let lastFetchedSats: number | null = null;
+  let lastFetchedCurrency: string = '';
+  let fiatLoading = false;
+
+  // Re-fetch fiat only when sats, currency, or visibility actually change to
+  // an active fiat view. Compares against last-fetched to avoid request
+  // storms from unrelated parent reactivity.
+  $: if (
+    visible &&
+    sats !== null &&
+    $displayCurrency !== 'SATS' &&
+    (sats !== lastFetchedSats || $displayCurrency !== lastFetchedCurrency)
+  ) {
+    lastFetchedSats = sats;
+    lastFetchedCurrency = $displayCurrency;
+    fiatLoading = true;
+    convertSatsToFiat(sats).then((v) => {
+      // Drop stale results if currency switched mid-flight.
+      if ($displayCurrency === lastFetchedCurrency) {
+        fiatValue = v;
+        fiatLoading = false;
+      }
+    });
+  }
+
+  $: if ($displayCurrency === 'SATS') {
+    fiatValue = null;
+    fiatLoading = false;
+  }
+
+  function formatSatsValue(n: number): string {
+    if (!compact) return n.toLocaleString();
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+    return n.toLocaleString();
+  }
+</script>
+
+{#if !visible}
+  ***
+{:else if loading || sats === null}
+  ...
+{:else if $displayCurrency === 'SATS'}
+  {formatSatsValue(sats)}
+{:else if fiatValue !== null}
+  {formatFiatValue(fiatValue)}
+{:else if fiatLoading}
+  ...
+{:else}
+  --
+{/if}

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -37,7 +37,6 @@
     type MembershipTier
   } from '$lib/stores/membershipStatus';
 
-  let isLoading = true;
   let intelligenceMenuOpen = false;
 
   // Count active timers (running or paused + done)
@@ -57,10 +56,6 @@
     } else {
       goto(`/tag/${query}`);
     }
-  }
-
-  $: if ($userPublickey !== undefined) {
-    isLoading = false;
   }
 
   $: resolvedTheme = $theme === 'system' ? theme.getResolvedTheme() : $theme;
@@ -187,7 +182,7 @@
       <div class="relative">
         <button
           type="button"
-          on:click={() => (intelligenceMenuOpen = !intelligenceMenuOpen)}
+          on:click|stopPropagation={() => (intelligenceMenuOpen = !intelligenceMenuOpen)}
           class="zh-iconbtn zh-intelligence-btn {onIntelligenceSurface || intelligenceMenuOpen
             ? 'is-active'
             : ''}"

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -10,6 +10,7 @@
   import CustomAvatar from './CustomAvatar.svelte';
   import IntelligenceIcon from './icons/IntelligenceIcon.svelte';
   import IntelligenceMenu from './IntelligenceMenu.svelte';
+  import DenominatedBalance from './DenominatedBalance.svelte';
   import { theme } from '$lib/themeStore';
   import WalletBalance from './WalletBalance.svelte';
   import LightningIcon from 'phosphor-svelte/lib/Lightning';
@@ -134,12 +135,6 @@
     }
   }
 
-  function formatBalance(balance: number | null): string {
-    if (balance === null) return '---';
-    if (balance >= 1000000) return `${(balance / 1000000).toFixed(2)}M`;
-    if (balance >= 1000) return `${(balance / 1000).toFixed(1)}k`;
-    return balance.toLocaleString();
-  }
 </script>
 
 <!-- Mobile-first sleek header -->
@@ -239,13 +234,11 @@
         >
           <LightningIcon size={14} weight="fill" class="text-amber-400" />
           <span class="zh-wallet-amount">
-            {#if $walletLoading || $walletBalance === null}
-              ---
-            {:else if $balanceVisible}
-              {formatBalance($walletBalance)}
-            {:else}
-              ***
-            {/if}
+            <DenominatedBalance
+              sats={$walletBalance}
+              visible={$balanceVisible}
+              loading={$walletLoading}
+            />
           </span>
         </button>
         <!-- Desktop full WalletBalance widget -->

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -326,8 +326,11 @@
 </div>
 
 <style>
-  /* Shared icon button — minimal, balanced tap target, subtle hover */
-  .zh-iconbtn {
+  /* Shared icon button — minimal, balanced tap target, subtle hover.
+     Wrapped in :where() so Tailwind responsive utilities (sm:hidden,
+     etc.) can override individual properties without specificity
+     fights. */
+  :where(.zh-iconbtn) {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -363,7 +366,10 @@
   }
 
   /* Mobile wallet pill — compact { icon + balance } that opens the wallet
-     modal directly. Keeps the header dense without losing live balance. */
+     modal directly. Mobile only; the desktop uses the existing
+     WalletBalance widget. The media query is co-located with the
+     component CSS so it beats the Tailwind `sm:hidden` utility (which
+     would otherwise lose to this rule's specificity). */
   .zh-wallet-mobile {
     display: inline-flex;
     align-items: center;
@@ -385,6 +391,11 @@
   }
   .zh-wallet-mobile:active {
     transform: scale(0.97);
+  }
+  @media (min-width: 640px) {
+    .zh-wallet-mobile {
+      display: none;
+    }
   }
   :global(.dark) .zh-wallet-mobile {
     background-color: rgba(255, 255, 255, 0.04);

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -26,6 +26,7 @@
     balanceVisible,
     openWallet
   } from '$lib/wallet';
+  import { displayCurrency } from '$lib/currencyStore';
   import { weblnConnected } from '$lib/wallet/webln';
   import { bitcoinConnectEnabled, bitcoinConnectWalletInfo } from '$lib/wallet/bitcoinConnect';
   import { cookingToolsStore, cookingToolsOpen } from '$lib/stores/cookingToolsWidget';
@@ -225,22 +226,32 @@
     <!-- Wallet (logged in) -->
     {#if $userPublickey && $navBalanceVisible}
       {#if hasNavWallet}
-        <!-- Mobile compact wallet pill -->
-        <button
-          type="button"
-          on:click={() => openWallet()}
-          class="zh-wallet-mobile sm:hidden"
-          aria-label="Open wallet"
-        >
-          <LightningIcon size={14} weight="fill" class="text-amber-400" />
-          <span class="zh-wallet-amount">
+        <!-- Mobile compact wallet pill — split into two interactive
+             zones so the user gets a one-tap currency cycle on the
+             balance text while preserving "open wallet" on the icon. -->
+        <div class="zh-wallet-mobile sm:hidden" role="group" aria-label="Wallet">
+          <button
+            type="button"
+            on:click={() => openWallet()}
+            class="zh-wallet-mobile-zone zh-wallet-mobile-icon"
+            aria-label="Open wallet"
+          >
+            <LightningIcon size={14} weight="fill" class="text-amber-400" />
+          </button>
+          <button
+            type="button"
+            on:click={() => displayCurrency.cycleSatsFiat()}
+            class="zh-wallet-mobile-zone zh-wallet-mobile-amount"
+            aria-label="Toggle currency"
+            title="Tap to toggle currency"
+          >
             <DenominatedBalance
               sats={$walletBalance}
               visible={$balanceVisible}
               loading={$walletLoading}
             />
-          </span>
-        </button>
+          </button>
+        </div>
         <!-- Desktop full WalletBalance widget -->
         <div class="hidden sm:block">
           <WalletBalance />
@@ -358,37 +369,76 @@
     color: rgb(233, 213, 255);
   }
 
-  /* Mobile wallet pill — compact { icon + balance } that opens the wallet
-     modal directly. Mobile only; the desktop uses the existing
-     WalletBalance widget. The media query is co-located with the
-     component CSS so it beats the Tailwind `sm:hidden` utility (which
-     would otherwise lose to this rule's specificity). */
+  /* Mobile wallet pill — compact container split into two interactive
+     zones: a lightning icon (opens the wallet modal) and a balance
+     text (one-tap cycles SATS ↔ preferred fiat). Mobile only; desktop
+     uses the existing WalletBalance widget. The media query is
+     co-located with the component CSS so it beats the Tailwind
+     `sm:hidden` utility (which would otherwise lose to this rule's
+     specificity). */
   .zh-wallet-mobile {
     display: inline-flex;
-    align-items: center;
-    gap: 6px;
+    align-items: stretch;
     height: 30px;
-    padding: 0 10px 0 8px;
     border-radius: 999px;
     background-color: var(--color-input-bg);
     border: 1px solid var(--color-input-border, transparent);
     color: var(--color-text-primary);
-    cursor: pointer;
     font-size: 12px;
     font-weight: 600;
     line-height: 1;
-    transition:
-      background-color 140ms ease,
-      border-color 140ms ease,
-      box-shadow 140ms ease;
-  }
-  .zh-wallet-mobile:active {
-    transform: scale(0.97);
+    overflow: hidden;
+    transition: background-color 140ms ease, border-color 140ms ease;
   }
   @media (min-width: 640px) {
     .zh-wallet-mobile {
       display: none;
     }
+  }
+
+  /* When `.zh-wallet-mobile` is used as a single button (the "Set up"
+     branch), fall back to old behavior. */
+  button.zh-wallet-mobile {
+    cursor: pointer;
+    padding: 0 10px 0 8px;
+    gap: 6px;
+    align-items: center;
+  }
+  button.zh-wallet-mobile:active {
+    transform: scale(0.97);
+  }
+
+  /* Inner zones share styling, are full-height, and meet a 30px tap
+     target via padding. They show a subtle hover state so the user
+     sees the two are independent. */
+  .zh-wallet-mobile-zone {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: 0;
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+    transition: background-color 120ms ease, color 120ms ease;
+  }
+  .zh-wallet-mobile-zone:hover {
+    background-color: rgba(0, 0, 0, 0.05);
+  }
+  :global(.dark) .zh-wallet-mobile-zone:hover {
+    background-color: rgba(255, 255, 255, 0.06);
+  }
+  :where(.zh-wallet-mobile-zone:active) {
+    transform: scale(0.96);
+  }
+  .zh-wallet-mobile-icon {
+    padding: 0 6px 0 9px;
+  }
+  .zh-wallet-mobile-amount {
+    padding: 0 10px 0 6px;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.01em;
+    min-width: 3.5ch;
   }
   :global(.dark) .zh-wallet-mobile {
     background-color: rgba(255, 255, 255, 0.04);

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -6,11 +6,10 @@
   import SVGNostrCookingWithText from '../assets/nostr.cooking-withtext.svg';
   import SearchIcon from 'phosphor-svelte/lib/MagnifyingGlass';
   import CookingPotIcon from 'phosphor-svelte/lib/CookingPot';
-  import SparkleIcon from 'phosphor-svelte/lib/Sparkle';
-  import RobotIcon from 'phosphor-svelte/lib/Robot';
-  import LeafIcon from 'phosphor-svelte/lib/Leaf';
   import TagsSearchAutocomplete from './TagsSearchAutocomplete.svelte';
   import CustomAvatar from './CustomAvatar.svelte';
+  import IntelligenceIcon from './icons/IntelligenceIcon.svelte';
+  import IntelligenceMenu from './IntelligenceMenu.svelte';
   import { theme } from '$lib/themeStore';
   import WalletBalance from './WalletBalance.svelte';
   import LightningIcon from 'phosphor-svelte/lib/Lightning';
@@ -18,7 +17,14 @@
   import { userSidePanelOpen } from '$lib/stores/userSidePanel';
   import { mobileSearchOpen } from '$lib/stores/mobileSearch';
   import { timerStore } from '$lib/timerStore';
-  import { navBalanceVisible, walletConnected, openWallet } from '$lib/wallet';
+  import {
+    navBalanceVisible,
+    walletConnected,
+    walletBalance,
+    walletLoading,
+    balanceVisible,
+    openWallet
+  } from '$lib/wallet';
   import { weblnConnected } from '$lib/wallet/webln';
   import { bitcoinConnectEnabled, bitcoinConnectWalletInfo } from '$lib/wallet/bitcoinConnect';
   import { cookingToolsStore, cookingToolsOpen } from '$lib/stores/cookingToolsWidget';
@@ -30,17 +36,13 @@
   } from '$lib/stores/membershipStatus';
 
   let isLoading = true;
+  let intelligenceMenuOpen = false;
 
   // Count active timers (running or paused + done)
   $: activeTimers = $timerStore.timers.filter(
     (t) => t.status === 'running' || t.status === 'paused' || t.status === 'done'
   );
   $: hasActiveTimers = activeTimers.length > 0;
-
-  // Debug: log when profile picture override changes
-  $: if ($userProfilePictureOverride) {
-    console.log('[Header] userProfilePictureOverride changed:', $userProfilePictureOverride);
-  }
 
   function openTag(query: string) {
     mobileSearchOpen.set(false);
@@ -55,12 +57,10 @@
     }
   }
 
-  // Simple loading state management
   $: if ($userPublickey !== undefined) {
     isLoading = false;
   }
 
-  // Reactive resolved theme for logo switching
   $: resolvedTheme = $theme === 'system' ? theme.getResolvedTheme() : $theme;
   $: isDarkMode = resolvedTheme === 'dark';
   $: hasNavWallet =
@@ -68,7 +68,14 @@
     $weblnConnected ||
     ($bitcoinConnectEnabled && $bitcoinConnectWalletInfo.connected);
 
-  // Membership status for header tier badge
+  // Active state highlights the Intelligence icon when the user is
+  // currently on one of the AI surfaces.
+  $: onIntelligenceSurface =
+    $page.url.pathname.startsWith('/souschef') ||
+    $page.url.pathname.startsWith('/zappy') ||
+    $page.url.pathname.startsWith('/nourish');
+
+  // Membership
   let membershipMap: Record<string, MembershipStatus> = {};
   const unsubMembership = membershipStatusMap.subscribe((value) => {
     membershipMap = value;
@@ -126,26 +133,36 @@
       goto('/explore');
     }
   }
+
+  function formatBalance(balance: number | null): string {
+    if (balance === null) return '---';
+    if (balance >= 1000000) return `${(balance / 1000000).toFixed(2)}M`;
+    if (balance >= 1000) return `${(balance / 1000).toFixed(1)}k`;
+    return balance.toLocaleString();
+  }
 </script>
 
-<!-- Mobile-first layout -->
-<div class="relative flex gap-2 sm:gap-9 lg:gap-12 justify-between overflow-visible">
+<!-- Mobile-first sleek header -->
+<div class="zh-root relative flex items-center gap-3 sm:gap-6 lg:gap-10 justify-between overflow-visible">
+  <!-- Left: compact logo -->
   <button
     on:click={handleLogoClick}
-    class="flex-none xl:hidden cursor-pointer transition-transform duration-150 active:scale-95 active:opacity-80"
+    class="zh-logo flex-none xl:hidden cursor-pointer transition-transform duration-150 active:scale-95"
+    aria-label="zap.cooking home"
   >
     <img
       src={SVGNostrCookingWithText}
-      class="logo-light w-28 sm:w-40 my-2 sm:my-3 dark:hidden"
-      alt="zap.cooking Logo With Text"
+      class="w-24 sm:w-32 my-1.5 sm:my-2 dark:hidden"
+      alt="zap.cooking"
     />
     <img
       src="/zap_cooking_logo_white.svg"
-      class="logo-dark w-28 sm:w-40 my-2 sm:my-3 hidden dark:block"
-      alt="zap.cooking Logo With Text"
+      class="w-24 sm:w-32 my-1.5 sm:my-2 hidden dark:block"
+      alt="zap.cooking"
     />
   </button>
 
+  <!-- Center: search bar (desktop) -->
   <div
     class="hidden sm:flex flex-1 self-center print:hidden max-w-2xl min-w-[280px] lg:min-w-[500px]"
   >
@@ -155,88 +172,96 @@
     />
   </div>
   <span class="hidden lg:max-xl:flex lg:max-xl:grow"></span>
-  <div class="flex items-center gap-1 sm:gap-3 self-center flex-none print:hidden">
-    <!-- Search icon (mobile/tablet only when search bar hidden) -->
+
+  <!-- Right: action cluster -->
+  <div class="flex items-center gap-1.5 sm:gap-2.5 self-center flex-none print:hidden">
+    <!-- Search icon (mobile only) -->
     <div class="block sm:hidden">
       <button
         on:click={() => mobileSearchOpen.set(true)}
-        class="w-8 h-8 sm:w-9 sm:h-9 flex items-center justify-center hover:opacity-80 hover:bg-accent-gray rounded-full transition-colors cursor-pointer"
-        style="color: var(--color-text-primary)"
+        class="zh-iconbtn"
         aria-label="Search"
       >
-        <SearchIcon size={18} weight="bold" class="sm:w-5 sm:h-5" />
+        <SearchIcon size={18} weight="bold" />
       </button>
     </div>
 
-    <!-- Sous Chef, Zappy & Nourish icons (logged in) -->
+    <!-- Unified Intelligence icon (logged in) -->
     {#if $userPublickey}
-      <a
-        href="/souschef"
-        class="w-8 h-8 sm:w-9 sm:h-9 flex items-center justify-center rounded-full transition-colors cursor-pointer hover:bg-accent-gray"
-        aria-label="Sous Chef"
-      >
-        <SparkleIcon size={18} weight="fill" class="text-primary sm:w-5 sm:h-5" />
-      </a>
-      <a
-        href="/zappy"
-        class="w-8 h-8 sm:w-9 sm:h-9 flex items-center justify-center rounded-full transition-colors cursor-pointer hover:bg-accent-gray"
-        aria-label="Zappy"
-      >
-        <RobotIcon size={18} weight="regular" class="text-yellow-500/70 sm:w-5 sm:h-5" />
-      </a>
-      <a
-        href="/nourish"
-        class="w-8 h-8 sm:w-9 sm:h-9 flex items-center justify-center rounded-full transition-colors cursor-pointer hover:bg-accent-gray"
-        aria-label="Nourish"
-      >
-        <LeafIcon size={18} weight="fill" class="text-green-500/70 sm:w-5 sm:h-5" />
-      </a>
+      <div class="relative">
+        <button
+          type="button"
+          on:click={() => (intelligenceMenuOpen = !intelligenceMenuOpen)}
+          class="zh-iconbtn zh-intelligence-btn {onIntelligenceSurface || intelligenceMenuOpen
+            ? 'is-active'
+            : ''}"
+          aria-label="Intelligence tools"
+          aria-haspopup="menu"
+          aria-expanded={intelligenceMenuOpen}
+        >
+          <IntelligenceIcon size={20} active={onIntelligenceSurface || intelligenceMenuOpen} />
+        </button>
+        <IntelligenceMenu
+          open={intelligenceMenuOpen}
+          on:close={() => (intelligenceMenuOpen = false)}
+        />
+      </div>
     {/if}
 
-    <!-- Cooking Tools toggle (timer + converter) -->
+    <!-- Cooking Tools toggle (timer + converter) — kept but lighter -->
     <button
       on:click={toggleCookingTools}
       data-cooking-tools-button
-      class="w-8 h-8 sm:w-9 sm:h-9 flex items-center justify-center rounded-full transition-colors cursor-pointer relative {$cookingToolsOpen
+      class="zh-iconbtn relative {$cookingToolsOpen
         ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-600 dark:text-amber-400'
-        : 'hover:opacity-80 hover:bg-accent-gray'}"
-      style={$cookingToolsOpen ? '' : 'color: var(--color-text-primary)'}
+        : ''}"
       aria-label={$cookingToolsOpen ? 'Hide cooking tools' : 'Show cooking tools'}
     >
-      <CookingPotIcon
-        size={18}
-        weight={$cookingToolsOpen || hasActiveTimers ? 'fill' : 'bold'}
-        class="sm:w-5 sm:h-5"
-      />
+      <CookingPotIcon size={18} weight={$cookingToolsOpen || hasActiveTimers ? 'fill' : 'bold'} />
       {#if hasActiveTimers}
         <span
-          class="absolute -top-0.5 -right-0.5 w-3.5 h-3.5 sm:w-4 sm:h-4 bg-amber-500 text-white text-[10px] sm:text-xs font-bold rounded-full flex items-center justify-center"
+          class="absolute -top-0.5 -right-0.5 w-3.5 h-3.5 bg-amber-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center"
         >
           {activeTimers.length}
         </span>
       {/if}
     </button>
 
-    <!-- Wallet button (mobile only) - opens wallet modal -->
-    {#if $userPublickey}
-      <button
-        type="button"
-        on:click={() => openWallet()}
-        class="sm:hidden w-8 h-8 flex items-center justify-center rounded-full transition-colors cursor-pointer hover:opacity-80 hover:bg-accent-gray"
-        style="color: var(--color-text-primary)"
-        aria-label="Open wallet"
-      >
-        <WalletIcon size={18} weight="bold" />
-      </button>
-    {/if}
-
-    <!-- Wallet Balance - only show when logged in -->
+    <!-- Wallet (logged in) -->
     {#if $userPublickey && $navBalanceVisible}
       {#if hasNavWallet}
+        <!-- Mobile compact wallet pill -->
+        <button
+          type="button"
+          on:click={() => openWallet()}
+          class="zh-wallet-mobile sm:hidden"
+          aria-label="Open wallet"
+        >
+          <LightningIcon size={14} weight="fill" class="text-amber-400" />
+          <span class="zh-wallet-amount">
+            {#if $walletLoading || $walletBalance === null}
+              ---
+            {:else if $balanceVisible}
+              {formatBalance($walletBalance)}
+            {:else}
+              ***
+            {/if}
+          </span>
+        </button>
+        <!-- Desktop full WalletBalance widget -->
         <div class="hidden sm:block">
           <WalletBalance />
         </div>
       {:else}
+        <button
+          type="button"
+          on:click={() => openWallet('setup')}
+          class="zh-wallet-mobile sm:hidden"
+          aria-label="Set up a wallet"
+        >
+          <LightningIcon size={14} weight="fill" class="text-amber-400" />
+          <span class="zh-wallet-amount">Set up</span>
+        </button>
         <button
           type="button"
           on:click={() => openWallet('setup')}
@@ -247,6 +272,17 @@
           <span>Set up a Wallet</span>
         </button>
       {/if}
+    {:else if $userPublickey && hasNavWallet}
+      <!-- Wallet exists but balance is hidden via $navBalanceVisible: still
+           expose a compact tap-to-open affordance on mobile. -->
+      <button
+        type="button"
+        on:click={() => openWallet()}
+        class="zh-iconbtn sm:hidden"
+        aria-label="Open wallet"
+      >
+        <WalletIcon size={18} weight="bold" />
+      </button>
     {/if}
 
     <!-- Tier badge for active members -->
@@ -265,11 +301,17 @@
     <div class="print:hidden flex-shrink-0">
       {#if $userPublickey !== ''}
         <button
-          class="flex cursor-pointer rounded-full transition-transform duration-200 hover:scale-105 active:scale-95"
+          class="zh-avatar-btn"
           on:click={() => userSidePanelOpen.set(true)}
           aria-label="Open user menu"
         >
-          <CustomAvatar pubkey={$userPublickey} size={32} imageUrl={$userProfilePictureOverride} />
+          <span class="zh-avatar-ring">
+            <CustomAvatar
+              pubkey={$userPublickey}
+              size={32}
+              imageUrl={$userProfilePictureOverride}
+            />
+          </span>
         </button>
       {:else}
         <a
@@ -284,6 +326,122 @@
 </div>
 
 <style>
+  /* Shared icon button — minimal, balanced tap target, subtle hover */
+  .zh-iconbtn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 999px;
+    color: var(--color-text-primary);
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+    transition:
+      background-color 140ms ease,
+      color 140ms ease,
+      box-shadow 140ms ease;
+  }
+  .zh-iconbtn:hover {
+    background-color: var(--color-input-bg);
+  }
+  .zh-iconbtn:active {
+    transform: scale(0.96);
+  }
+
+  /* Intelligence button — when active, soft purple ring + glow */
+  .zh-intelligence-btn.is-active {
+    background-color: rgba(168, 85, 247, 0.1);
+    box-shadow:
+      inset 0 0 0 1px rgba(168, 85, 247, 0.35),
+      0 0 12px rgba(168, 85, 247, 0.18);
+    color: rgb(216, 180, 254);
+  }
+  :global(.dark) .zh-intelligence-btn.is-active {
+    color: rgb(233, 213, 255);
+  }
+
+  /* Mobile wallet pill — compact { icon + balance } that opens the wallet
+     modal directly. Keeps the header dense without losing live balance. */
+  .zh-wallet-mobile {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    height: 30px;
+    padding: 0 10px 0 8px;
+    border-radius: 999px;
+    background-color: var(--color-input-bg);
+    border: 1px solid var(--color-input-border, transparent);
+    color: var(--color-text-primary);
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1;
+    transition:
+      background-color 140ms ease,
+      border-color 140ms ease,
+      box-shadow 140ms ease;
+  }
+  .zh-wallet-mobile:active {
+    transform: scale(0.97);
+  }
+  :global(.dark) .zh-wallet-mobile {
+    background-color: rgba(255, 255, 255, 0.04);
+    border-color: rgba(255, 255, 255, 0.08);
+    box-shadow: inset 0 0 0 1px rgba(251, 191, 36, 0.06);
+  }
+  .zh-wallet-amount {
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.01em;
+    min-width: 2.5ch;
+    text-align: right;
+  }
+
+  /* Avatar — soft purple glow ring, scales softly on hover/tap */
+  .zh-avatar-btn {
+    display: inline-flex;
+    padding: 0;
+    background: transparent;
+    border: 0;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: transform 200ms ease;
+  }
+  .zh-avatar-btn:hover {
+    transform: scale(1.04);
+  }
+  .zh-avatar-btn:active {
+    transform: scale(0.96);
+  }
+  .zh-avatar-ring {
+    display: inline-flex;
+    padding: 2px;
+    border-radius: 999px;
+    background:
+      radial-gradient(
+        circle at 30% 30%,
+        rgba(168, 85, 247, 0.55),
+        rgba(168, 85, 247, 0.18) 60%,
+        transparent 80%
+      );
+    box-shadow:
+      0 0 0 1px rgba(168, 85, 247, 0.35),
+      0 0 10px rgba(168, 85, 247, 0.25);
+  }
+  :global(.dark) .zh-avatar-ring {
+    background:
+      radial-gradient(
+        circle at 30% 30%,
+        rgba(192, 132, 252, 0.6),
+        rgba(168, 85, 247, 0.2) 60%,
+        transparent 80%
+      );
+    box-shadow:
+      0 0 0 1px rgba(192, 132, 252, 0.4),
+      0 0 12px rgba(168, 85, 247, 0.3);
+  }
+
   .signin-button:hover {
     border-color: var(--color-accent-gray);
     background-color: var(--color-input-bg);

--- a/src/components/IntelligenceMenu.svelte
+++ b/src/components/IntelligenceMenu.svelte
@@ -79,7 +79,6 @@
         role="menuitem"
         on:click={() => go(item.href)}
       >
-        <span class="dot" style:background-color={item.accent}></span>
         <span class="icon" style:color={item.accent}>
           <svelte:component this={item.Icon} size={16} weight="fill" />
         </span>
@@ -130,7 +129,7 @@
 
   .item {
     display: grid;
-    grid-template-columns: auto auto 1fr;
+    grid-template-columns: auto 1fr;
     align-items: center;
     gap: 10px;
     width: 100%;
@@ -146,13 +145,6 @@
 
   .item:hover {
     background-color: var(--color-input-bg);
-  }
-
-  .dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 999px;
-    box-shadow: 0 0 6px currentColor;
   }
 
   .icon {

--- a/src/components/IntelligenceMenu.svelte
+++ b/src/components/IntelligenceMenu.svelte
@@ -53,10 +53,14 @@
   }
 
   onMount(() => {
-    document.addEventListener('mousedown', onDocClick);
+    // Use `click` rather than `mousedown` so the opener's own click
+    // handler runs first. Otherwise mousedown closes the menu, then
+    // the opener's click immediately re-toggles it back open — and
+    // tapping the icon while the menu is open feels broken.
+    document.addEventListener('click', onDocClick);
     document.addEventListener('keydown', onKey);
     return () => {
-      document.removeEventListener('mousedown', onDocClick);
+      document.removeEventListener('click', onDocClick);
       document.removeEventListener('keydown', onKey);
     };
   });

--- a/src/components/IntelligenceMenu.svelte
+++ b/src/components/IntelligenceMenu.svelte
@@ -1,0 +1,193 @@
+<script lang="ts">
+  import { onMount, createEventDispatcher } from 'svelte';
+  import { goto } from '$app/navigation';
+  import SparkleIcon from 'phosphor-svelte/lib/Sparkle';
+  import RobotIcon from 'phosphor-svelte/lib/Robot';
+  import LeafIcon from 'phosphor-svelte/lib/Leaf';
+
+  export let open: boolean = false;
+
+  const dispatch = createEventDispatcher();
+  let panelEl: HTMLDivElement;
+
+  const items = [
+    {
+      href: '/souschef',
+      label: 'Sous Chef',
+      blurb: 'Recipe guidance & ideas',
+      Icon: SparkleIcon,
+      accent: 'rgb(168, 85, 247)'
+    },
+    {
+      href: '/zappy',
+      label: 'Zappy',
+      blurb: 'AI cooking assistant',
+      Icon: RobotIcon,
+      accent: 'rgb(234, 179, 8)'
+    },
+    {
+      href: '/nourish',
+      label: 'Nourish',
+      blurb: 'Smart nutrition scoring',
+      Icon: LeafIcon,
+      accent: 'rgb(34, 197, 94)'
+    }
+  ];
+
+  function close() {
+    dispatch('close');
+  }
+
+  function go(href: string) {
+    close();
+    goto(href);
+  }
+
+  function onDocClick(e: MouseEvent) {
+    if (!open || !panelEl) return;
+    if (!panelEl.contains(e.target as Node)) close();
+  }
+
+  function onKey(e: KeyboardEvent) {
+    if (e.key === 'Escape') close();
+  }
+
+  onMount(() => {
+    document.addEventListener('mousedown', onDocClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDocClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  });
+</script>
+
+{#if open}
+  <div
+    bind:this={panelEl}
+    class="intelligence-menu"
+    role="menu"
+    aria-label="Intelligence tools"
+  >
+    <div class="header-row">
+      <span class="eyebrow">Intelligence</span>
+    </div>
+    {#each items as item}
+      <button
+        type="button"
+        class="item"
+        role="menuitem"
+        on:click={() => go(item.href)}
+      >
+        <span class="dot" style:background-color={item.accent}></span>
+        <span class="icon" style:color={item.accent}>
+          <svelte:component this={item.Icon} size={16} weight="fill" />
+        </span>
+        <span class="text">
+          <span class="label">{item.label}</span>
+          <span class="blurb">{item.blurb}</span>
+        </span>
+      </button>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .intelligence-menu {
+    position: absolute;
+    top: calc(100% + 8px);
+    right: 0;
+    min-width: 232px;
+    padding: 6px;
+    border-radius: 14px;
+    background-color: var(--color-bg-secondary);
+    border: 1px solid var(--color-input-border, var(--color-accent-gray));
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 0.04) inset,
+      0 8px 24px rgba(0, 0, 0, 0.35),
+      0 2px 6px rgba(0, 0, 0, 0.25);
+    backdrop-filter: blur(12px);
+    z-index: 60;
+    animation: menu-in 140ms ease-out;
+  }
+
+  :global(.dark) .intelligence-menu {
+    background-color: rgba(17, 24, 39, 0.92);
+  }
+
+  .header-row {
+    padding: 8px 10px 4px;
+  }
+
+  .eyebrow {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-text-caption, #9ca3af);
+    opacity: 0.7;
+  }
+
+  .item {
+    display: grid;
+    grid-template-columns: auto auto 1fr;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 9px 10px;
+    border-radius: 10px;
+    background: transparent;
+    border: 0;
+    color: var(--color-text-primary);
+    cursor: pointer;
+    text-align: left;
+    transition: background-color 120ms ease;
+  }
+
+  .item:hover {
+    background-color: var(--color-input-bg);
+  }
+
+  .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 999px;
+    box-shadow: 0 0 6px currentColor;
+  }
+
+  .icon {
+    display: inline-flex;
+    width: 16px;
+    height: 16px;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .text {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.2;
+    min-width: 0;
+  }
+
+  .label {
+    font-size: 13px;
+    font-weight: 600;
+  }
+
+  .blurb {
+    font-size: 11px;
+    opacity: 0.62;
+  }
+
+  @keyframes menu-in {
+    from {
+      opacity: 0;
+      transform: translateY(-4px) scale(0.98);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+</style>

--- a/src/components/WalletBalance.svelte
+++ b/src/components/WalletBalance.svelte
@@ -48,6 +48,12 @@
   import { displayCurrency } from '$lib/currencyStore';
 
   function onPillKeydown(e: KeyboardEvent) {
+    // Only the outer pill itself should toggle the dropdown — without
+    // the currentTarget===target check, Enter/Space while focused on
+    // the inner currency-cycle button would bubble up and re-toggle
+    // the dropdown right after the inner button already handled the
+    // key natively.
+    if (e.currentTarget !== e.target) return;
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
       toggleDropdown();

--- a/src/components/WalletBalance.svelte
+++ b/src/components/WalletBalance.svelte
@@ -45,6 +45,14 @@
   import NwcLogo from './icons/NwcLogo.svelte';
   import BitcoinConnectLogo from './icons/BitcoinConnectLogo.svelte';
   import DenominatedBalance from './DenominatedBalance.svelte';
+  import { displayCurrency } from '$lib/currencyStore';
+
+  function onPillKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      toggleDropdown();
+    }
+  }
 
   let dropdownActive = false;
   let showRemoveBitcoinConnectModal = false;
@@ -117,27 +125,39 @@
 {#if $weblnConnected}
   <!-- WebLN Wallet Widget -->
   <div class="relative" use:clickOutside on:click_outside={() => (dropdownActive = false)}>
-    <!-- Balance button -->
-    <button
-      class="flex items-center gap-1.5 px-3 py-1.5 rounded-full transition-colors cursor-pointer text-sm font-medium"
+    <!-- Balance pill — outer is a div (so the inner balance can be a
+         real <button> for currency cycling without nested buttons).
+         Clicking the icon or caret toggles the dropdown; clicking the
+         balance text cycles SATS ↔ last fiat. -->
+    <div
+      class="balance-pill flex items-center gap-1.5 px-3 py-1.5 rounded-full transition-colors cursor-pointer text-sm font-medium"
       style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+      role="button"
+      tabindex="0"
       on:click={toggleDropdown}
+      on:keydown={onPillKeydown}
     >
       <div
         class="w-4 h-4 rounded-full bg-gradient-to-br from-orange-500 to-amber-500 flex items-center justify-center flex-shrink-0"
       >
         <LightningIcon size={10} weight="fill" class="text-white" />
       </div>
-      <span class="min-w-[3.5rem] text-right">
+      <button
+        type="button"
+        class="balance-cycle min-w-[3.5rem] text-right"
+        on:click|stopPropagation={() => displayCurrency.cycleSatsFiat()}
+        aria-label="Toggle currency"
+        title="Tap to toggle currency"
+      >
         <DenominatedBalance
           sats={weblnBalance}
           visible={$balanceVisible}
           loading={weblnBalanceLoading}
         />
-      </span>
+      </button>
 
       <CaretDownIcon size={12} class="text-caption ml-0.5" />
-    </button>
+    </div>
 
     <!-- Dropdown menu -->
     {#if dropdownActive}
@@ -210,27 +230,36 @@
 {:else if $bitcoinConnectEnabled && $bitcoinConnectWalletInfo.connected}
   <!-- Bitcoin Connect Wallet Widget -->
   <div class="relative" use:clickOutside on:click_outside={() => (dropdownActive = false)}>
-    <!-- Balance button -->
-    <button
-      class="flex items-center gap-1.5 px-3 py-1.5 rounded-full transition-colors cursor-pointer text-sm font-medium"
+    <!-- Balance pill (see WebLN variant above for split rationale) -->
+    <div
+      class="balance-pill flex items-center gap-1.5 px-3 py-1.5 rounded-full transition-colors cursor-pointer text-sm font-medium"
       style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+      role="button"
+      tabindex="0"
       on:click={toggleDropdown}
+      on:keydown={onPillKeydown}
     >
       <div
         class="w-4 h-4 rounded-full bg-gradient-to-br from-yellow-500 to-orange-500 flex items-center justify-center flex-shrink-0"
       >
         <BitcoinConnectLogo size={10} className="text-white" />
       </div>
-      <span class="min-w-[3.5rem] text-right">
+      <button
+        type="button"
+        class="balance-cycle min-w-[3.5rem] text-right"
+        on:click|stopPropagation={() => displayCurrency.cycleSatsFiat()}
+        aria-label="Toggle currency"
+        title="Tap to toggle currency"
+      >
         <DenominatedBalance
           sats={$bitcoinConnectBalance}
           visible={$balanceVisible}
           loading={$bitcoinConnectBalanceLoading}
         />
-      </span>
+      </button>
 
       <CaretDownIcon size={12} class="text-caption ml-0.5" />
-    </button>
+    </div>
 
     <!-- Dropdown menu -->
     {#if dropdownActive}
@@ -301,23 +330,32 @@
 {:else if $walletConnected && $activeWallet}
   <!-- Embedded Wallet Widget -->
   <div class="relative" use:clickOutside on:click_outside={() => (dropdownActive = false)}>
-    <!-- Balance button -->
-    <button
-      class="flex items-center gap-1.5 px-3 py-1.5 rounded-full transition-colors cursor-pointer text-sm font-medium"
+    <!-- Balance pill (see WebLN variant above for split rationale) -->
+    <div
+      class="balance-pill flex items-center gap-1.5 px-3 py-1.5 rounded-full transition-colors cursor-pointer text-sm font-medium"
       style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+      role="button"
+      tabindex="0"
       on:click={toggleDropdown}
+      on:keydown={onPillKeydown}
     >
       <LightningIcon size={16} weight="fill" class="text-amber-500" />
-      <span class="min-w-[3.5rem] text-right">
+      <button
+        type="button"
+        class="balance-cycle min-w-[3.5rem] text-right"
+        on:click|stopPropagation={() => displayCurrency.cycleSatsFiat()}
+        aria-label="Toggle currency"
+        title="Tap to toggle currency"
+      >
         <DenominatedBalance
           sats={$walletBalance}
           visible={$balanceVisible}
           loading={$walletLoading}
         />
-      </span>
+      </button>
 
       <CaretDownIcon size={12} class="text-caption ml-0.5" />
-    </button>
+    </div>
 
     <!-- Dropdown menu -->
     {#if dropdownActive}
@@ -462,5 +500,42 @@
   }
   .wallet-name-pill:active {
     transform: translateY(1px);
+  }
+
+  /* Outer pill is a role=button div; remove the default focus ring
+     style and add our own to match the rest of the header chrome. */
+  .balance-pill {
+    outline: none;
+  }
+  .balance-pill:focus-visible {
+    box-shadow: 0 0 0 2px rgba(251, 191, 36, 0.35);
+  }
+
+  /* Inner balance — real button so currency cycling is keyboard-
+     accessible and screen-reader-labeled. Visually transparent so it
+     blends into the pill, with a subtle hover background to hint that
+     it's an independent affordance. */
+  .balance-cycle {
+    background: transparent;
+    border: 0;
+    padding: 0 4px;
+    margin: 0 -2px;
+    color: inherit;
+    font: inherit;
+    line-height: 1;
+    cursor: pointer;
+    border-radius: 6px;
+    font-variant-numeric: tabular-nums;
+    transition: background-color 120ms ease;
+  }
+  .balance-cycle:hover {
+    background-color: rgba(0, 0, 0, 0.06);
+  }
+  :global(.dark) .balance-cycle:hover {
+    background-color: rgba(255, 255, 255, 0.08);
+  }
+  .balance-cycle:focus-visible {
+    outline: none;
+    background-color: rgba(251, 191, 36, 0.12);
   }
 </style>

--- a/src/components/WalletBalance.svelte
+++ b/src/components/WalletBalance.svelte
@@ -44,6 +44,7 @@
   import SparkLogo from './icons/SparkLogo.svelte';
   import NwcLogo from './icons/NwcLogo.svelte';
   import BitcoinConnectLogo from './icons/BitcoinConnectLogo.svelte';
+  import DenominatedBalance from './DenominatedBalance.svelte';
 
   let dropdownActive = false;
   let showRemoveBitcoinConnectModal = false;
@@ -71,17 +72,6 @@
   // Fetch WebLN balance when connected
   $: if ($weblnConnected && weblnBalance === null && !weblnBalanceLoading) {
     refreshWeblnBalance();
-  }
-
-  function formatBalance(balance: number | null): string {
-    if (balance === null) return '---';
-    if (balance >= 1000000) {
-      return `${(balance / 1000000).toFixed(2)}M`;
-    }
-    if (balance >= 1000) {
-      return `${(balance / 1000).toFixed(1)}k`;
-    }
-    return balance.toLocaleString();
   }
 
   async function handleRefresh() {
@@ -138,15 +128,13 @@
       >
         <LightningIcon size={10} weight="fill" class="text-white" />
       </div>
-      {#if weblnBalanceLoading}
-        <span class="animate-pulse min-w-[3.5rem] text-right">...</span>
-      {:else if weblnBalance === null}
-        <span class="min-w-[3.5rem] text-right">---</span>
-      {:else if $balanceVisible}
-        <span class="min-w-[3.5rem] text-right">{formatBalance(weblnBalance)}</span>
-      {:else}
-        <span class="min-w-[3.5rem] text-right">***</span>
-      {/if}
+      <span class="min-w-[3.5rem] text-right">
+        <DenominatedBalance
+          sats={weblnBalance}
+          visible={$balanceVisible}
+          loading={weblnBalanceLoading}
+        />
+      </span>
 
       <CaretDownIcon size={12} class="text-caption ml-0.5" />
     </button>
@@ -233,15 +221,13 @@
       >
         <BitcoinConnectLogo size={10} className="text-white" />
       </div>
-      {#if $bitcoinConnectBalanceLoading}
-        <span class="animate-pulse min-w-[3.5rem] text-right">...</span>
-      {:else if $bitcoinConnectBalance === null}
-        <span class="min-w-[3.5rem] text-right">---</span>
-      {:else if $balanceVisible}
-        <span class="min-w-[3.5rem] text-right">{formatBalance($bitcoinConnectBalance)}</span>
-      {:else}
-        <span class="min-w-[3.5rem] text-right">***</span>
-      {/if}
+      <span class="min-w-[3.5rem] text-right">
+        <DenominatedBalance
+          sats={$bitcoinConnectBalance}
+          visible={$balanceVisible}
+          loading={$bitcoinConnectBalanceLoading}
+        />
+      </span>
 
       <CaretDownIcon size={12} class="text-caption ml-0.5" />
     </button>
@@ -322,13 +308,13 @@
       on:click={toggleDropdown}
     >
       <LightningIcon size={16} weight="fill" class="text-amber-500" />
-      {#if $walletLoading || $walletBalance === null}
-        <span class="animate-pulse min-w-[3.5rem] text-right">...</span>
-      {:else if $balanceVisible}
-        <span class="min-w-[3.5rem] text-right">{formatBalance($walletBalance)}</span>
-      {:else}
-        <span class="min-w-[3.5rem] text-right">***</span>
-      {/if}
+      <span class="min-w-[3.5rem] text-right">
+        <DenominatedBalance
+          sats={$walletBalance}
+          visible={$balanceVisible}
+          loading={$walletLoading}
+        />
+      </span>
 
       <CaretDownIcon size={12} class="text-caption ml-0.5" />
     </button>

--- a/src/components/icons/IntelligenceIcon.svelte
+++ b/src/components/icons/IntelligenceIcon.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+  export let size: number = 20;
+  export let active: boolean = false;
+  let className = '';
+  export { className as class };
+</script>
+
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+  class={`intelligence-icon ${active ? 'is-active' : ''} ${className}`}
+  aria-hidden="true"
+>
+  <g class="orbit-group">
+    <ellipse
+      cx="12"
+      cy="12"
+      rx="10"
+      ry="3.5"
+      stroke="currentColor"
+      stroke-width="1.25"
+      stroke-linecap="round"
+      opacity="0.85"
+    />
+    <circle cx="2" cy="12" r="1.25" fill="currentColor" />
+    <circle cx="22" cy="12" r="1.25" fill="currentColor" />
+  </g>
+
+  <path
+    class="spark"
+    d="M12 7.5 L12.9 11.1 L16.5 12 L12.9 12.9 L12 16.5 L11.1 12.9 L7.5 12 L11.1 11.1 Z"
+    fill="currentColor"
+  />
+</svg>
+
+<style>
+  .intelligence-icon {
+    display: block;
+    color: currentColor;
+    transition: filter 200ms ease;
+  }
+
+  .orbit-group {
+    transform-origin: 12px 12px;
+    transform-box: fill-box;
+  }
+
+  .spark {
+    transform-origin: 12px 12px;
+    transform-box: fill-box;
+  }
+
+  .is-active {
+    filter:
+      drop-shadow(0 0 3px rgba(168, 85, 247, 0.7))
+      drop-shadow(0 0 7px rgba(168, 85, 247, 0.4));
+  }
+
+  .is-active .orbit-group {
+    animation: orbit-rotate 6s linear infinite;
+  }
+
+  .is-active .spark {
+    animation: spark-pulse 2.4s ease-in-out infinite;
+  }
+
+  @keyframes orbit-rotate {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+  }
+
+  @keyframes spark-pulse {
+    0%, 100% { transform: scale(1); opacity: 1; }
+    50% { transform: scale(1.12); opacity: 0.92; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .is-active .orbit-group,
+    .is-active .spark {
+      animation: none;
+    }
+  }
+</style>

--- a/src/components/icons/IntelligenceIcon.svelte
+++ b/src/components/icons/IntelligenceIcon.svelte
@@ -1,85 +1,45 @@
 <script lang="ts">
+  import AtomIcon from 'phosphor-svelte/lib/Atom';
+
   export let size: number = 20;
   export let active: boolean = false;
   let className = '';
   export { className as class };
 </script>
 
-<svg
-  width={size}
-  height={size}
-  viewBox="0 0 24 24"
-  fill="none"
-  xmlns="http://www.w3.org/2000/svg"
+<span
   class={`intelligence-icon ${active ? 'is-active' : ''} ${className}`}
   aria-hidden="true"
 >
-  <g class="orbit-group">
-    <ellipse
-      cx="12"
-      cy="12"
-      rx="10"
-      ry="3.5"
-      stroke="currentColor"
-      stroke-width="1.25"
-      stroke-linecap="round"
-      opacity="0.85"
-    />
-    <circle cx="2" cy="12" r="1.25" fill="currentColor" />
-    <circle cx="22" cy="12" r="1.25" fill="currentColor" />
-  </g>
-
-  <path
-    class="spark"
-    d="M12 7.5 L12.9 11.1 L16.5 12 L12.9 12.9 L12 16.5 L11.1 12.9 L7.5 12 L11.1 11.1 Z"
-    fill="currentColor"
-  />
-</svg>
+  <AtomIcon {size} weight="bold" />
+</span>
 
 <style>
   .intelligence-icon {
-    display: block;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     color: currentColor;
-    transition: filter 200ms ease;
-  }
-
-  .orbit-group {
-    transform-origin: 12px 12px;
-    transform-box: fill-box;
-  }
-
-  .spark {
-    transform-origin: 12px 12px;
-    transform-box: fill-box;
+    transition: filter 220ms ease, transform 220ms ease;
   }
 
   .is-active {
     filter:
       drop-shadow(0 0 3px rgba(168, 85, 247, 0.7))
-      drop-shadow(0 0 7px rgba(168, 85, 247, 0.4));
+      drop-shadow(0 0 8px rgba(168, 85, 247, 0.35));
   }
 
-  .is-active .orbit-group {
-    animation: orbit-rotate 6s linear infinite;
+  .is-active :global(svg) {
+    animation: orbit-spin 9s linear infinite;
   }
 
-  .is-active .spark {
-    animation: spark-pulse 2.4s ease-in-out infinite;
-  }
-
-  @keyframes orbit-rotate {
+  @keyframes orbit-spin {
     from { transform: rotate(0deg); }
     to { transform: rotate(360deg); }
   }
 
-  @keyframes spark-pulse {
-    0%, 100% { transform: scale(1); opacity: 1; }
-    50% { transform: scale(1.12); opacity: 0.92; }
-  }
-
   @media (prefers-reduced-motion: reduce) {
-    .is-active .orbit-group,
-    .is-active .spark {
+    .is-active :global(svg) {
       animation: none;
     }
   }

--- a/src/lib/currencyStore.ts
+++ b/src/lib/currencyStore.ts
@@ -34,11 +34,25 @@ export const SUPPORTED_CURRENCIES: Currency[] = [
 ];
 
 const STORAGE_KEY = 'zapcooking_display_currency';
+const PREFERRED_FIAT_KEY = 'zapcooking_preferred_fiat';
 
 function getInitialCurrency(): CurrencyCode {
   if (!browser) return 'USD';
   const stored = localStorage.getItem(STORAGE_KEY);
   if (stored && SUPPORTED_CURRENCIES.some((c) => c.code === stored)) {
+    return stored as CurrencyCode;
+  }
+  return 'USD';
+}
+
+function getPreferredFiat(): CurrencyCode {
+  if (!browser) return 'USD';
+  const stored = localStorage.getItem(PREFERRED_FIAT_KEY);
+  if (
+    stored &&
+    stored !== 'SATS' &&
+    SUPPORTED_CURRENCIES.some((c) => c.code === stored)
+  ) {
     return stored as CurrencyCode;
   }
   return 'USD';
@@ -53,6 +67,15 @@ interface CurrencyStore {
   initialize: () => void;
   setCurrency: (currency: CurrencyCode) => void;
   getCurrency: () => Currency;
+  /**
+   * One-tap cycle between SATS and the user's last-selected fiat.
+   * - From a fiat → SATS (remembering which fiat to come back to).
+   * - From SATS → the remembered fiat (defaults to USD on first use).
+   * The remembered "preferred fiat" is also updated whenever the user
+   * picks a fiat via setCurrency, so the cycle target tracks the
+   * full picker.
+   */
+  cycleSatsFiat: () => void;
 }
 
 function createCurrencyStore(): CurrencyStore {
@@ -73,11 +96,25 @@ function createCurrencyStore(): CurrencyStore {
       if (!browser) return;
       currentCurrency = currency;
       localStorage.setItem(STORAGE_KEY, currency);
+      // Track the most recent fiat selection so the SATS↔fiat cycle
+      // returns to whatever the user last explicitly picked.
+      if (currency !== 'SATS') {
+        localStorage.setItem(PREFERRED_FIAT_KEY, currency);
+      }
       set(currency);
     },
 
     getCurrency(): Currency {
       return getCurrencyByCode(currentCurrency);
+    },
+
+    cycleSatsFiat() {
+      if (!browser) return;
+      const target: CurrencyCode =
+        currentCurrency === 'SATS' ? getPreferredFiat() : 'SATS';
+      currentCurrency = target;
+      localStorage.setItem(STORAGE_KEY, target);
+      set(target);
     }
   };
 }

--- a/src/lib/currencyStore.ts
+++ b/src/lib/currencyStore.ts
@@ -110,8 +110,17 @@ function createCurrencyStore(): CurrencyStore {
 
     cycleSatsFiat() {
       if (!browser) return;
-      const target: CurrencyCode =
-        currentCurrency === 'SATS' ? getPreferredFiat() : 'SATS';
+      let target: CurrencyCode;
+      if (currentCurrency === 'SATS') {
+        target = getPreferredFiat();
+      } else {
+        // Remember the fiat we're leaving so the next cycle returns
+        // to it. Without this, existing users whose display currency
+        // was persisted before PREFERRED_FIAT_KEY existed (e.g. EUR)
+        // would always cycle SATS → USD instead of SATS → EUR.
+        localStorage.setItem(PREFERRED_FIAT_KEY, currentCurrency);
+        target = 'SATS';
+      }
       currentCurrency = target;
       localStorage.setItem(STORAGE_KEY, target);
       set(target);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -484,10 +484,15 @@
     box-shadow: 0 1px 0 rgba(168, 85, 247, 0.04);
   }
 
-  /* Safe area padding for header on mobile */
+  /* Safe area padding for header on mobile.
+     `env(safe-area-inset-top, 0px)` alone would collapse to 0 on
+     non-notched browsers (regular Chrome/Safari/Firefox on mobile
+     and desktop-narrow), making the avatar touch the viewport top.
+     `max()` keeps the baseline 0.75rem (matches the `py-3` from the
+     wrapper) and grows for devices with a real notch inset. */
   @media (max-width: 1023px) {
     .header-blur {
-      padding-top: env(safe-area-inset-top, 0px);
+      padding-top: max(env(safe-area-inset-top, 0px), 0.75rem);
     }
   }
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -467,6 +467,21 @@
     background-color: color-mix(in srgb, var(--color-bg-primary) 70%, transparent);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid color-mix(in srgb, var(--color-input-border) 60%, transparent);
+  }
+
+  /* Dark-mode header gets a subtle navy lean + thin glow band so the
+     header reads as its own surface, not just a tinted body. Light
+     mode is left clean. */
+  :global(.dark) .header-blur {
+    background-color: rgba(14, 21, 41, 0.78);
+    background-image: linear-gradient(
+      to bottom,
+      rgba(33, 39, 73, 0.45),
+      rgba(14, 21, 41, 0.65)
+    );
+    border-bottom-color: rgba(255, 255, 255, 0.06);
+    box-shadow: 0 1px 0 rgba(168, 85, 247, 0.04);
   }
 
   /* Safe area padding for header on mobile */


### PR DESCRIPTION
## Summary

Mobile-first header redesign per design brief — premium fintech/social aesthetic, less clutter, better visual hierarchy. Builds on top of the in-modal wallet from #387.

### What changed

**Right cluster consolidation**
- Sous Chef ✨ + Zappy 🤖 + Nourish 🌿 trio collapsed behind a single **Intelligence** icon (phosphor `Atom`, monochrome white, slow-rotating with soft purple glow when active).
- Tapping it opens a small dropdown listing all three surfaces with their existing accent colors and one-line blurbs.
- Active state highlights the icon whenever the user is on `/souschef`, `/zappy`, or `/nourish`.

**Live wallet balance with currency toggle**
- Header pill (mobile) and desktop `WalletBalance` widget both now read `$displayCurrency` and render either compact sats (`1.2k`, `3.4M`) or formatted fiat (`$75.20`, `€68,40`, `¥10,500`) via the existing `currencyConversion` lib.
- **One-tap cycle** on the balance text: SATS ↔ user's last-selected fiat (defaults to USD, persisted in localStorage). Mobile pill is split into two zones — lightning icon (opens wallet modal) and balance text (cycles currency).
- The full multi-currency picker already lives inside the wallet modal; the cycle is the quick affordance.
- New small `<DenominatedBalance>` helper centralizes the sats-vs-fiat rendering with proper loading/visibility states and avoids request storms by tracking last-fetched sats+currency.

**Avatar**
- Soft purple radial-gradient ring + outer glow so user identity reads as the right-side anchor.

**Layout chrome**
- Logo shrunk on mobile (`w-24 sm:w-32`) for visual balance against the denser right cluster.
- Unified 36px icon buttons with consistent hover/active states.
- `.header-blur` gains a thin border-bottom and, in dark mode, a subtle navy gradient (`#0e1529 → #212749`) with a faint purple-tinged shadow. Light mode left clean.
- `padding-top` uses `max(env(safe-area-inset-top), 0.75rem)` so the header keeps a baseline buffer even on non-notched browsers (previously the env() fallback collapsed to 0 and the avatar touched the viewport top).

**Preserved**
- Cooking-pot timer (active-count badge stays surfaced)
- Mobile search trigger, tier badge, WalletBalance dropdown (wallet switch / refresh / show-hide-balance)
- All existing routing and wallet states

### Files

| | |
|---|---|
| **new** | `src/components/icons/IntelligenceIcon.svelte`, `src/components/IntelligenceMenu.svelte`, `src/components/DenominatedBalance.svelte` |
| **modified** | `src/components/Header.svelte`, `src/components/WalletBalance.svelte`, `src/lib/currencyStore.ts`, `src/routes/+layout.svelte` |

### Test plan

- [ ] Mobile (< 640px): logo, search icon, Intelligence icon, cooking pot, compact wallet pill (icon zone + balance zone), avatar all render with breathing room
- [ ] Desktop (≥ 640px): full search bar shown; Intelligence dropdown opens below icon; existing `WalletBalance` widget shown (and only that, no duplicate mobile pill)
- [ ] Intelligence menu: clicking each item navigates to its surface and closes the menu; outside-click and Escape close
- [ ] Active state: visiting `/souschef`, `/zappy`, or `/nourish` highlights the Intelligence icon with purple ring + glow + slow rotation
- [ ] Currency cycle: tap the balance value on mobile pill → flips between SATS and last fiat; tap inside desktop pill on the balance only → same; tapping the icon (mobile) or anywhere else on the pill (desktop) still opens wallet modal / dropdown
- [ ] Currency persistence: pick EUR in the wallet modal picker → close and reload → header shows EUR; tap cycle → SATS; tap again → returns to EUR
- [ ] Dark and light modes both render cleanly
- [ ] `pnpm check`: 0 errors (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)