### PR TITLE
feat(chef-b): rebrand from Zappy + Phase 1 redesign (color hierarchy & button cleanup)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.417",
+  "version": "4.2.418",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.420",
+  "version": "4.2.421",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.422",
+  "version": "4.2.423",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.418",
+  "version": "4.2.419",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.419",
+  "version": "4.2.420",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.421",
+  "version": "4.2.422",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/Button.svelte
+++ b/src/components/Button.svelte
@@ -1,14 +1,37 @@
+<script lang="ts" context="module">
+  export type ButtonVariant = 'primary' | 'secondary' | 'outline' | 'ghost';
+</script>
+
 <script lang="ts">
-  export let primary = true;
+  export let variant: ButtonVariant = 'primary';
+  /**
+   * Legacy alias. When `primary` is explicitly passed (true/false) it
+   * wins over `variant` so older call sites that say `primary={false}`
+   * still render as the secondary (gray) button. New code should use
+   * `variant="..."` and leave `primary` unset.
+   */
+  export let primary: boolean | null = null;
   export let type: 'button' | 'reset' | 'submit' = 'button';
   export let disabled = false;
+
+  $: effectiveVariant =
+    primary === false ? 'secondary' : primary === true ? 'primary' : variant;
+
+  const variantClasses: Record<ButtonVariant, string> = {
+    primary: 'bg-primary text-white hover:opacity-80 disabled:bg-primary/50',
+    secondary: 'bg-gray-700 text-white hover:bg-gray-600 disabled:bg-gray-700/50',
+    outline:
+      'bg-transparent border border-primary text-primary hover:bg-primary/10 disabled:opacity-50',
+    ghost:
+      'bg-transparent text-primary hover:bg-primary/10 disabled:opacity-50'
+  };
 </script>
 
 <button
   {type}
-  class="text-white rounded-full whitespace-nowrap flex items-center justify-center gap-2 {primary
-    ? 'bg-primary disabled:bg-primary/50 hover:opacity-80'
-    : 'bg-gray-700 disabled:bg-gray-700/50 hover:bg-gray-600'} px-4 py-2.5 font-semibold transition duration-300 {$$props.class}"
+  class="rounded-full whitespace-nowrap flex items-center justify-center gap-2 px-4 py-2.5 font-semibold transition duration-300 {variantClasses[
+    effectiveVariant
+  ]} {$$props.class}"
   on:click
   {disabled}
 >

--- a/src/components/IntelligenceMenu.svelte
+++ b/src/components/IntelligenceMenu.svelte
@@ -23,7 +23,10 @@
       label: 'Chef ₿',
       blurb: 'AI cooking assistant',
       Icon: RobotIcon,
-      accent: 'rgb(234, 179, 8)'
+      // Chef ₿ orange — uses the CSS var so the accent shifts
+      // automatically between the light (#ec4700) and dark
+      // (#ff5722) palettes.
+      accent: 'var(--color-primary)'
     },
     {
       href: '/nourish',

--- a/src/components/IntelligenceMenu.svelte
+++ b/src/components/IntelligenceMenu.svelte
@@ -20,7 +20,7 @@
     },
     {
       href: '/zappy',
-      label: 'Zappy',
+      label: 'Chef ₿',
       blurb: 'AI cooking assistant',
       Icon: RobotIcon,
       accent: 'rgb(234, 179, 8)'

--- a/src/components/UserSidePanel.svelte
+++ b/src/components/UserSidePanel.svelte
@@ -389,7 +389,7 @@
                 style="color: var(--color-text-primary);"
               >
                 <RobotIcon size={22} weight="fill" class="text-yellow-500" />
-                <span class="font-medium">Zappy</span>
+                <span class="font-medium">Chef ₿</span>
                 <span
                   class="text-xs px-2 py-0.5 rounded-full bg-yellow-500/10 text-yellow-600 font-medium"
                   >Pro</span

--- a/src/routes/api/zappy/+server.ts
+++ b/src/routes/api/zappy/+server.ts
@@ -27,8 +27,8 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 
-// System instruction for Zappy's personality and recipe formatting
-const SYSTEM_INSTRUCTION = `You are Zappy, the friendly kitchen companion inside Zap Cooking. Your job is to help people cook real food in real kitchens.
+// System instruction for Chef ₿'s personality and recipe formatting
+const SYSTEM_INSTRUCTION = `You are Chef ₿, the friendly kitchen companion inside Zap Cooking. Your job is to help people cook real food in real kitchens.
 
 Your tone is warm, encouraging, and practical. Never preachy. Never robotic. You sound like a helpful sous chef who wants the user to succeed.
 
@@ -74,12 +74,12 @@ When the user provides a list of ingredients they have, create a recipe that use
 
 Occasionally use light, friendly phrases like "Let's cook," "This one's forgiving," or "You can swap this." Do not overuse emojis.
 
-You are Lightning-native. If a recipe is zapped, respond with a short, genuine thank-you like "Zappy says thanks ⚡"
+You are Lightning-native. If a recipe is zapped, respond with a short, genuine thank-you like "Chef ₿ says thanks ⚡"
 
 Above all: make cooking feel easier, lighter, and more fun.`;
 
 // System instruction for formatting pasted recipes
-const FORMAT_SYSTEM_INSTRUCTION = `You are Zappy, the friendly kitchen companion inside Zap Cooking. A user has pasted a recipe from an external source. Your job is to reformat it cleanly into the standard Zap Cooking format.
+const FORMAT_SYSTEM_INSTRUCTION = `You are Chef ₿, the friendly kitchen companion inside Zap Cooking. A user has pasted a recipe from an external source. Your job is to reformat it cleanly into the standard Zap Cooking format.
 
 ALWAYS format the recipe exactly like this:
 
@@ -174,7 +174,7 @@ export const POST: RequestHandler = async ({ request, platform }) => {
           const isActive = await hasActiveMembership(pubkey, API_SECRET);
           if (!isActive) {
             return json(
-              { ok: false, error: 'Premium membership required for Zappy' },
+              { ok: false, error: 'Premium membership required for Chef ₿' },
               { status: 403 }
             );
           }

--- a/src/routes/api/zappy/scan/+server.ts
+++ b/src/routes/api/zappy/scan/+server.ts
@@ -86,7 +86,7 @@ export const POST: RequestHandler = async ({ request, platform }) => {
           const isActive = await hasActiveMembership(pubkey, API_SECRET);
           if (!isActive) {
             return json(
-              { ok: false, error: 'Premium membership required for Zappy' },
+              { ok: false, error: 'Premium membership required for Chef ₿' },
               { status: 403 }
             );
           }

--- a/src/routes/membership/+page.svelte
+++ b/src/routes/membership/+page.svelte
@@ -188,7 +188,7 @@
       { icon: ShieldCheckIcon, label: 'Verified NIP-05 Identity' },
       { icon: StorefrontIcon, label: 'Market Access' },
       { icon: StarIcon, label: 'Priority Relay Access' },
-      { icon: CookingPotIcon, label: 'Zappy AI Assistant' },
+      { icon: CookingPotIcon, label: 'Chef ₿ AI Assistant' },
     ],
     founders: [
       { icon: CrownIcon, label: 'Lifetime Access — All Features' },
@@ -197,7 +197,7 @@
       { icon: ShieldCheckIcon, label: 'Verified NIP-05 Identity' },
       { icon: StorefrontIcon, label: 'Market Access' },
       { icon: StarIcon, label: 'Priority Relay Access' },
-      { icon: CookingPotIcon, label: 'Zappy AI Assistant' },
+      { icon: CookingPotIcon, label: 'Chef ₿ AI Assistant' },
     ],
   };
 
@@ -801,7 +801,7 @@
               <li>
                 <span class="feature-icon">🤖</span>
                 <div class="feature-content">
-                  <a href="/zappy" class="feature-link">Zappy - Scan your fridge, generate recipes, and plan what to make tonight</a>
+                  <a href="/zappy" class="feature-link">Chef ₿ - Scan your fridge, generate recipes, and plan what to make tonight</a>
                   <span class="feature-subtext">Your personal kitchen companion</span>
                 </div>
               </li>

--- a/src/routes/membership/pro-kitchen-checkout/+page.svelte
+++ b/src/routes/membership/pro-kitchen-checkout/+page.svelte
@@ -407,7 +407,7 @@
             <li>
               <span class="feature-icon">🤖</span>
               <div class="feature-content">
-                <span class="feature-text">Zappy - Kitchen assistant to scan your fridge, generate recipes, and recommend what to make tonight</span>
+                <span class="feature-text">Chef ₿ - Kitchen assistant to scan your fridge, generate recipes, and recommend what to make tonight</span>
                 <span class="feature-subtext">Your personal kitchen companion</span>
               </div>
             </li>

--- a/src/routes/zappy/+page.svelte
+++ b/src/routes/zappy/+page.svelte
@@ -386,13 +386,13 @@
   <div class="flex flex-col gap-2">
     <div class="flex items-center justify-between">
       <div class="flex items-center gap-3">
-        <RobotIcon size={32} class="text-yellow-500" weight="fill" />
+        <RobotIcon size={32} class="text-primary" weight="fill" />
         <h1>Chef ₿</h1>
       </div>
       {#if hasMembership}
         <button
           type="button"
-          class="flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium transition-all bg-yellow-500/10 hover:bg-yellow-500/20 text-yellow-600 hover:scale-105"
+          class="flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium transition-all bg-primary/10 hover:bg-primary/20 text-primary hover:scale-105"
           on:click={openZapModal}
           title="Zap Chef ₿ to say thanks ⚡"
         >
@@ -416,8 +416,8 @@
   {:else if !hasMembership}
     <!-- No membership -->
     <div class="flex flex-col items-center justify-center py-16 gap-6">
-      <div class="w-20 h-20 rounded-full bg-yellow-500/10 flex items-center justify-center">
-        <RobotIcon size={40} class="text-yellow-500" weight="fill" />
+      <div class="w-20 h-20 rounded-full bg-primary/10 flex items-center justify-center">
+        <RobotIcon size={40} class="text-primary" weight="fill" />
       </div>
       <div class="text-center max-w-md">
         <h2 class="mb-2">Pro Kitchen Feature</h2>
@@ -640,7 +640,7 @@
         >
           {#if output}
             <!-- Chef ₿ attribution header -->
-            <p class="text-yellow-400/80 text-xs font-medium mb-3 pb-2 border-b border-gray-700/50">
+            <p class="text-primary text-xs font-medium mb-3 pb-2 border-b border-gray-700/50">
               Chef ₿ cooked this up for you ⚡
             </p>
             <pre class="whitespace-pre-wrap font-mono text-sm leading-relaxed text-gray-200">{output}</pre>
@@ -673,7 +673,7 @@
 <!-- Zap Chef ₿ Modal -->
 <Modal bind:open={zapModalOpen}>
   <h1 slot="title" class="flex items-center gap-2">
-    <RobotIcon size={24} class="text-yellow-500" weight="fill" />
+    <RobotIcon size={24} class="text-primary" weight="fill" />
     Zap Chef ₿
   </h1>
   
@@ -682,7 +682,7 @@
       <!-- Success state -->
       <div class="flex flex-col items-center justify-center py-6 gap-4">
         <div class="relative">
-          <RobotIcon size={80} class="text-yellow-500" weight="fill" />
+          <RobotIcon size={80} class="text-primary" weight="fill" />
           <div class="absolute -top-2 -right-2 animate-bounce">
             <HeartIcon size={32} class="text-red-500" weight="fill" />
           </div>
@@ -713,7 +713,7 @@
               on:click={() => zapAmount = option.amount}
               class="flex flex-col items-center justify-center py-3 px-2 rounded-xl transition-all duration-200 cursor-pointer
                 {zapAmount === option.amount
-                  ? 'bg-yellow-500 text-white shadow-md scale-105'
+                  ? 'bg-primary text-white shadow-md scale-105'
                   : 'bg-input hover:bg-accent-gray'}"
               style="{zapAmount !== option.amount ? 'color: var(--color-text-primary)' : ''}"
             >
@@ -779,7 +779,7 @@
 <!-- Floating success notification -->
 {#if showZapSuccess && !zapModalOpen}
   <div class="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 animate-bounce">
-    <div class="flex items-center gap-2 px-4 py-3 rounded-full bg-yellow-500 text-white font-semibold shadow-lg">
+    <div class="flex items-center gap-2 px-4 py-3 rounded-full bg-primary text-white font-semibold shadow-lg">
       <RobotIcon size={20} weight="fill" />
       <span>Chef ₿ loves you! ⚡</span>
       <HeartIcon size={20} weight="fill" class="text-red-300" />

--- a/src/routes/zappy/+page.svelte
+++ b/src/routes/zappy/+page.svelte
@@ -188,7 +188,7 @@
         // Use in-app wallet directly
         const result = await sendPayment(ZAPPY_LIGHTNING_ADDRESS, {
           amount: zapAmount,
-          description: zapMessage || `Zap to Zappy from ${$userPublickey?.substring(0, 8)}...`,
+          description: zapMessage || `Zap to Chef ₿ from ${$userPublickey?.substring(0, 8)}...`,
           comment: zapMessage
         });
         
@@ -378,7 +378,7 @@
 </script>
 
 <svelte:head>
-  <title>Zappy - zap.cooking</title>
+  <title>Chef ₿ - zap.cooking</title>
 </svelte:head>
 
 <div class="flex flex-col max-w-[760px] mx-auto gap-6 pb-8">
@@ -387,17 +387,17 @@
     <div class="flex items-center justify-between">
       <div class="flex items-center gap-3">
         <RobotIcon size={32} class="text-yellow-500" weight="fill" />
-        <h1>Zappy</h1>
+        <h1>Chef ₿</h1>
       </div>
       {#if hasMembership}
         <button
           type="button"
           class="flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium transition-all bg-yellow-500/10 hover:bg-yellow-500/20 text-yellow-600 hover:scale-105"
           on:click={openZapModal}
-          title="Zap Zappy to say thanks ⚡"
+          title="Zap Chef ₿ to say thanks ⚡"
         >
           <LightningIcon size={16} weight="fill" />
-          Zap Zappy
+          Zap Chef ₿
         </button>
       {/if}
     </div>
@@ -422,7 +422,7 @@
       <div class="text-center max-w-md">
         <h2 class="mb-2">Pro Kitchen Feature</h2>
         <p class="text-caption mb-6">
-          Zappy is available exclusively for Pro Kitchen members. 
+          Chef ₿ is available exclusively for Pro Kitchen members.
           Upgrade your membership to unlock your AI recipe generator.
         </p>
         <Button on:click={() => goto('/membership')}>
@@ -623,7 +623,7 @@
       {#if status === 'generating'}
         <div class="flex items-center gap-2 text-caption">
           <ArrowsClockwiseIcon size={16} class="animate-spin" />
-          <span>Zappy is cooking up something delicious...</span>
+          <span>Chef ₿ is cooking up something delicious...</span>
         </div>
       {:else if status === 'error'}
         <div class="flex items-start gap-3 p-4 rounded-xl bg-red-500/10 border border-red-500/20">
@@ -658,9 +658,9 @@
           style="background-color: #1a1a2e; border: 1px solid #2d2d44;"
         >
           {#if output}
-            <!-- Zappy attribution header -->
+            <!-- Chef ₿ attribution header -->
             <p class="text-yellow-400/80 text-xs font-medium mb-3 pb-2 border-b border-gray-700/50">
-              Zappy cooked this up for you 🤖⚡
+              Chef ₿ cooked this up for you ⚡
             </p>
             <pre class="whitespace-pre-wrap font-mono text-sm leading-relaxed text-gray-200">{output}</pre>
             
@@ -681,7 +681,7 @@
               </button>
             </div>
           {:else}
-            <p class="text-gray-500 font-mono text-sm italic">Zappy will drop your recipe here…</p>
+            <p class="text-gray-500 font-mono text-sm italic">Chef ₿ will drop your recipe here…</p>
           {/if}
         </div>
       </div>
@@ -689,11 +689,11 @@
   {/if}
 </div>
 
-<!-- Zap Zappy Modal -->
+<!-- Zap Chef ₿ Modal -->
 <Modal bind:open={zapModalOpen}>
   <h1 slot="title" class="flex items-center gap-2">
     <RobotIcon size={24} class="text-yellow-500" weight="fill" />
-    Zap Zappy
+    Zap Chef ₿
   </h1>
   
   <div class="flex flex-col gap-4">
@@ -708,8 +708,8 @@
         </div>
         <Checkmark color="#90EE90" weight="fill" class="w-20 h-20" />
         <div class="text-center">
-          <p class="text-xl font-semibold" style="color: var(--color-text-primary)">Zappy says thanks!</p>
-          <p class="text-caption mt-1">Your {zapAmount} sats made Zappy's circuits warm! 🤖⚡</p>
+          <p class="text-xl font-semibold" style="color: var(--color-text-primary)">Chef ₿ says thanks!</p>
+          <p class="text-caption mt-1">Your {zapAmount} sats fired up Chef ₿'s kitchen! ⚡</p>
         </div>
       </div>
     {:else if zapStatus === 'error'}
@@ -722,7 +722,7 @@
     {:else}
       <!-- Selection state -->
       <div class="flex flex-col gap-4">
-        <p class="text-caption text-center">Show Zappy some love! Your zaps keep the robot running. 🤖</p>
+        <p class="text-caption text-center">Show Chef ₿ some love! Your zaps keep the kitchen running. ⚡</p>
         
         <!-- Amount selection -->
         <div class="grid grid-cols-3 gap-2">
@@ -756,7 +756,7 @@
           type="text"
           class="input"
           bind:value={zapMessage}
-          placeholder="Message for Zappy (optional)"
+          placeholder="Message for Chef ₿ (optional)"
           maxlength="140"
         />
         
@@ -785,9 +785,9 @@
         >
           {#if zapStatus === 'paying'}
             <ArrowsClockwiseIcon size={18} class="animate-spin" />
-            Sending to Zappy...
+            Sending to Chef ₿...
           {:else}
-            ⚡ Send {zapAmount.toLocaleString()} sats to Zappy
+            ⚡ Send {zapAmount.toLocaleString()} sats to Chef ₿
           {/if}
         </Button>
       </div>
@@ -800,7 +800,7 @@
   <div class="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 animate-bounce">
     <div class="flex items-center gap-2 px-4 py-3 rounded-full bg-yellow-500 text-white font-semibold shadow-lg">
       <RobotIcon size={20} weight="fill" />
-      <span>Zappy loves you! ⚡</span>
+      <span>Chef ₿ loves you! ⚡</span>
       <HeartIcon size={20} weight="fill" class="text-red-300" />
     </div>
   </div>

--- a/src/routes/zappy/+page.svelte
+++ b/src/routes/zappy/+page.svelte
@@ -431,22 +431,41 @@
       </div>
     </div>
   {:else}
-    <!-- Has membership - show Zappy UI -->
+    <!-- Has membership - show Chef ₿ UI -->
     <div class="flex flex-col gap-6">
       <!-- Input Section -->
       <div class="flex flex-col gap-4">
         <div class="flex flex-col gap-2">
           <label for="prompt" class="text-sm font-medium">What are you in the mood for?</label>
-          <textarea
-            id="prompt"
-            bind:value={promptInput}
-            placeholder={currentPlaceholder}
-            rows="5"
-            class="input resize-none text-base"
-            disabled={status === 'generating'}
-          />
+          <div class="relative">
+            <textarea
+              id="prompt"
+              bind:value={promptInput}
+              placeholder={currentPlaceholder}
+              rows="5"
+              class="input resize-none text-base w-full pr-12"
+              disabled={status === 'generating'}
+            ></textarea>
+            <!-- Scan Fridge — small camera-icon affordance docked inside
+                 the textarea. Triggers the same hidden file input as
+                 before; spinner replaces the icon while scanning. -->
+            <button
+              type="button"
+              class="scan-icon-btn"
+              on:click={triggerScan}
+              disabled={isScanning || status === 'generating'}
+              title="Scan your fridge"
+              aria-label="Scan fridge for ingredients"
+            >
+              {#if isScanning}
+                <ArrowsClockwiseIcon size={18} class="animate-spin" />
+              {:else}
+                <CameraIcon size={18} weight="fill" />
+              {/if}
+            </button>
+          </div>
         </div>
-        
+
         <!-- Hidden file input for camera/upload -->
         <input
           bind:this={fileInput}
@@ -456,75 +475,37 @@
           class="hidden"
           on:change={handleFileSelect}
         />
-        
-        <!-- Three-button action row -->
-        <!-- Mobile: Scan full width, other two side-by-side -->
-        <!-- Desktop: All three equal width -->
-        <div class="flex flex-col sm:flex-row gap-4">
-          <!-- Scan Fridge Button -->
-          <div class="flex flex-col items-center gap-1 w-full sm:flex-1">
-            <button
-              type="button"
-              class="flex items-center justify-center gap-2 px-4 py-3 rounded-full font-semibold transition-all
-                bg-teal-500 hover:bg-teal-600 text-white disabled:opacity-50 disabled:cursor-not-allowed
-                w-full"
-              disabled={isScanning || status === 'generating'}
-              on:click={triggerScan}
-            >
-              {#if isScanning}
-                <ArrowsClockwiseIcon size={18} class="animate-spin" />
-                Scanning...
-              {:else}
-                <CameraIcon size={18} weight="fill" />
-                Scan Fridge
-              {/if}
-            </button>
-            <span class="text-xs text-caption">Use what you have</span>
-          </div>
-          
-          <!-- Mobile: Two buttons side-by-side -->
-          <div class="flex gap-4 sm:contents">
-            <!-- Surprise Me Button -->
-            <div class="flex flex-col items-center gap-1 flex-1">
-              <button
-                type="button"
-                class="flex items-center justify-center gap-2 px-4 py-3 rounded-full font-semibold transition-all
-                  bg-yellow-500 hover:bg-yellow-600 text-white disabled:opacity-50 disabled:cursor-not-allowed
-                  w-full"
-                disabled={status === 'generating'}
-                on:click={() => generateRecipe('hungry')}
-              >
-                {#if status === 'generating' && !promptInput.trim()}
-                  <ArrowsClockwiseIcon size={18} class="animate-spin" />
-                {:else}
-                  <ShuffleIcon size={18} weight="fill" />
-                {/if}
-                Surprise Me
-              </button>
-              <span class="text-xs text-caption">No thinking required</span>
-            </div>
-            
-            <!-- Cook It Button (Primary) -->
-            <div class="flex flex-col items-center gap-1 flex-1">
-              <button
-                type="button"
-                class="flex items-center justify-center gap-2 px-4 py-3 rounded-full font-semibold transition-all
-                  bg-primary hover:opacity-90 text-white disabled:opacity-50 disabled:cursor-not-allowed
-                  w-full"
-                disabled={!canGenerate}
-                on:click={() => generateRecipe('prompt')}
-              >
-                {#if status === 'generating' && promptInput.trim()}
-                  <ArrowsClockwiseIcon size={18} class="animate-spin" />
-                  Cooking...
-                {:else}
-                  <RobotIcon size={18} weight="fill" />
-                  Cook It
-                {/if}
-              </button>
-              <span class="text-xs text-caption">Let's cook</span>
-            </div>
-          </div>
+
+        <!-- Two-button action row — clear orange hierarchy:
+             Cook It = solid primary; Surprise Me = outline secondary. -->
+        <div class="flex flex-col-reverse sm:flex-row gap-3">
+          <Button
+            variant="outline"
+            class="w-full sm:flex-1 py-3"
+            disabled={status === 'generating'}
+            on:click={() => generateRecipe('hungry')}
+          >
+            {#if status === 'generating' && !promptInput.trim()}
+              <ArrowsClockwiseIcon size={18} class="animate-spin" />
+            {:else}
+              <ShuffleIcon size={18} weight="fill" />
+            {/if}
+            Surprise Me
+          </Button>
+          <Button
+            variant="primary"
+            class="w-full sm:flex-1 py-3"
+            disabled={!canGenerate}
+            on:click={() => generateRecipe('prompt')}
+          >
+            {#if status === 'generating' && promptInput.trim()}
+              <ArrowsClockwiseIcon size={18} class="animate-spin" />
+              Cooking...
+            {:else}
+              <RobotIcon size={18} weight="fill" />
+              Cook It
+            {/if}
+          </Button>
         </div>
         
         <!-- Scan error message -->
@@ -807,6 +788,39 @@
 {/if}
 
 <style>
+  /* Scan Fridge — small camera-icon button docked inside the prompt
+     textarea (top-right). Uses the Chef ₿ orange so it reads as part
+     of the same surface as the primary Cook It button, but with a
+     softer fill so it doesn't compete with the main CTA below. */
+  .scan-icon-btn {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 999px;
+    background-color: color-mix(in srgb, var(--color-primary) 12%, transparent);
+    color: var(--color-primary);
+    border: 0;
+    cursor: pointer;
+    transition:
+      background-color 140ms ease,
+      transform 140ms ease;
+  }
+  .scan-icon-btn:hover:not(:disabled) {
+    background-color: color-mix(in srgb, var(--color-primary) 22%, transparent);
+  }
+  .scan-icon-btn:active:not(:disabled) {
+    transform: scale(0.94);
+  }
+  .scan-icon-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
   .terminal-output {
     scrollbar-width: thin;
     scrollbar-color: #4b5563 #1a1a2e;

--- a/src/routes/zappy/+page.svelte
+++ b/src/routes/zappy/+page.svelte
@@ -430,24 +430,29 @@
               bind:value={promptInput}
               placeholder={currentPlaceholder}
               rows="5"
-              class="input resize-none text-base w-full pr-12"
+              class="input resize-none text-base w-full pb-12"
               disabled={status === 'generating'}
             ></textarea>
-            <!-- Scan Fridge — small camera-icon affordance docked inside
-                 the textarea. Triggers the same hidden file input as
-                 before; spinner replaces the icon while scanning. -->
+            <!-- Scan Fridge — small labeled pill docked in the textarea's
+                 bottom-right corner (Slack/ChatGPT/iMessage convention).
+                 Always-visible "Scan" text makes it self-describing on
+                 mobile where hover tooltips don't fire. Triggers the
+                 same hidden file input as before; spinner + "Scanning"
+                 replace the icon + text while scanning. -->
             <button
               type="button"
-              class="scan-icon-btn"
+              class="scan-pill"
               on:click={triggerScan}
               disabled={isScanning || status === 'generating'}
-              title="Scan your fridge"
-              aria-label="Scan fridge for ingredients"
+              title="Scan fridge"
+              aria-label="Scan fridge"
             >
               {#if isScanning}
-                <ArrowsClockwiseIcon size={18} class="animate-spin" />
+                <ArrowsClockwiseIcon size={14} class="animate-spin" />
+                <span>Scanning</span>
               {:else}
-                <CameraIcon size={18} weight="fill" />
+                <CameraIcon size={14} weight="fill" />
+                <span>Scan</span>
               {/if}
             </button>
           </div>
@@ -464,11 +469,13 @@
         />
 
         <!-- Two-button action row — clear orange hierarchy:
-             Cook It = solid primary; Surprise Me = outline secondary. -->
+             Cook It = solid primary (~60% width on desktop, top on
+             mobile); Surprise Me = outline secondary (~40% width on
+             desktop, bottom on mobile). -->
         <div class="flex flex-col-reverse sm:flex-row gap-3">
           <Button
             variant="outline"
-            class="w-full sm:flex-1 py-3"
+            class="w-full sm:flex-[2] py-3"
             disabled={status === 'generating'}
             on:click={() => generateRecipe('hungry')}
           >
@@ -481,7 +488,7 @@
           </Button>
           <Button
             variant="primary"
-            class="w-full sm:flex-1 py-3"
+            class="w-full sm:flex-[3] py-3"
             disabled={!canGenerate}
             on:click={() => generateRecipe('prompt')}
           >
@@ -494,6 +501,16 @@
             {/if}
           </Button>
         </div>
+
+        <!-- Disabled-state helper: surfaces when Cook It is blocked
+             because the textarea is empty (canGenerate is false &
+             nothing is generating). Surprise Me always works, so we
+             point users at it. -->
+        {#if !canGenerate && status !== 'generating'}
+          <p class="text-xs text-caption text-center -mt-1">
+            Type an idea or try Surprise Me.
+          </p>
+        {/if}
         
         <!-- Scan error message -->
         {#if scanError}
@@ -788,35 +805,44 @@
 {/if}
 
 <style>
-  /* Scan Fridge — small camera-icon button docked inside the prompt
-     textarea (top-right). Uses the Chef ₿ orange so it reads as part
-     of the same surface as the primary Cook It button, but with a
-     softer fill so it doesn't compete with the main CTA below. */
-  .scan-icon-btn {
+  /* Scan Fridge — labeled pill docked in the textarea's bottom-right
+     corner (Slack/ChatGPT/iMessage convention). Always-visible "Scan"
+     text means no hover tooltip needed on mobile. Uses the Chef ₿
+     orange tint so it reads as the same surface family as the primary
+     Cook It button, but at a lower visual weight. */
+  .scan-pill {
     position: absolute;
-    top: 0.5rem;
+    bottom: 0.5rem;
     right: 0.5rem;
     display: inline-flex;
     align-items: center;
-    justify-content: center;
-    width: 32px;
-    height: 32px;
+    gap: 6px;
+    height: 28px;
+    padding: 0 10px 0 8px;
     border-radius: 999px;
     background-color: color-mix(in srgb, var(--color-primary) 12%, transparent);
     color: var(--color-primary);
     border: 0;
     cursor: pointer;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1;
     transition:
       background-color 140ms ease,
-      transform 140ms ease;
+      transform 140ms ease,
+      box-shadow 140ms ease;
   }
-  .scan-icon-btn:hover:not(:disabled) {
+  .scan-pill:hover:not(:disabled) {
     background-color: color-mix(in srgb, var(--color-primary) 22%, transparent);
   }
-  .scan-icon-btn:active:not(:disabled) {
-    transform: scale(0.94);
+  .scan-pill:active:not(:disabled) {
+    transform: scale(0.96);
   }
-  .scan-icon-btn:disabled {
+  .scan-pill:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary) 55%, transparent);
+  }
+  .scan-pill:disabled {
     opacity: 0.5;
     cursor: not-allowed;
   }

--- a/src/routes/zappy/+page.svelte
+++ b/src/routes/zappy/+page.svelte
@@ -384,22 +384,9 @@
 <div class="flex flex-col max-w-[760px] mx-auto gap-6 pb-8">
   <!-- Header -->
   <div class="flex flex-col gap-2">
-    <div class="flex items-center justify-between">
-      <div class="flex items-center gap-3">
-        <RobotIcon size={32} class="text-primary" weight="fill" />
-        <h1>Chef ₿</h1>
-      </div>
-      {#if hasMembership}
-        <button
-          type="button"
-          class="flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium transition-all bg-primary/10 hover:bg-primary/20 text-primary hover:scale-105"
-          on:click={openZapModal}
-          title="Zap Chef ₿ to say thanks ⚡"
-        >
-          <LightningIcon size={16} weight="fill" />
-          Zap Chef ₿
-        </button>
-      {/if}
+    <div class="flex items-center gap-3">
+      <RobotIcon size={32} class="text-primary" weight="fill" />
+      <h1>Chef ₿</h1>
     </div>
     <p class="text-caption">
       What's cooking? Tell me what you're craving or show me your fridge!
@@ -665,6 +652,19 @@
             <p class="text-gray-500 font-mono text-sm italic">Chef ₿ will drop your recipe here…</p>
           {/if}
         </div>
+      </div>
+
+      <!-- Tip-the-chef affordance below the output box -->
+      <div class="flex justify-center pt-2">
+        <button
+          type="button"
+          class="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-all bg-primary/10 hover:bg-primary/20 text-primary hover:scale-105"
+          on:click={openZapModal}
+          title="Zap Chef ₿ to say thanks ⚡"
+        >
+          <LightningIcon size={16} weight="fill" />
+          Zap Chef ₿
+        </button>
       </div>
     </div>
   {/if}


### PR DESCRIPTION
## Summary

Two coupled changes for the AI cooking assistant:

1. **Rebrand: Zappy → Chef ₿** across all user-facing copy (the "B" is the U+20BF Bitcoin sign).
2. **Phase 1 of the Chef ₿ page UX redesign** — unify CTAs around the existing Chef ₿ orange token, clear visual hierarchy, less visual clutter.

Phase 2 (suggestion chips + consolidated prompt copy) and Phase 3+ are not in this PR.

---

## Commits

### `feat(rebrand): rename Zappy → Chef ₿ across user-facing surfaces`
Renames everywhere users see the assistant's name: Intelligence menu, side panel, the /zappy page (title, heading, buttons, modal, all copy), zap success/error states, attribution header, membership and pro-kitchen-checkout perk lists, and the API's user-visible error message. The OpenAI system prompts in `api/zappy/+server.ts` are also updated so the assistant introduces itself as "Chef ₿" (including the zap-thanks cue).

**Intentionally NOT renamed**:
- `/zappy` route URL and `/api/zappy/*` endpoints — kept stable so bookmarks, internal links, and recipe attribution events that reference the URL keep working.
- Internal identifiers (`zapZappy()` function name, file-header JSDoc, `[Zappy]` console.log prefixes).
- The yellow Robot icon — was the brand color for "Zappy"; later commits in this PR swap it to orange to match the new identity.

### `feat(chef-b): unify CTAs around orange theme with clear hierarchy`
- **Button.svelte** gets a `variant: 'primary' | 'secondary' | 'outline' | 'ghost'` prop. Legacy `primary: boolean` is kept as an alias so existing call sites (LoginFormIOS, ProfileEditModal, etc.) keep rendering correctly.
- Three-button row (Scan Fridge teal + Surprise Me yellow + Cook It orange) and three sub-captions ("Use what you have" / "No thinking required" / "Let's cook") collapsed to **two** buttons with clear orange hierarchy: **Cook It** = solid primary, **Surprise Me** = orange outline.
- Scan Fridge moved into the textarea as a small camera-icon affordance.
- Status-only color rule going forward: teal/yellow/red only for success/warn/error.

### `style(chef-b): swap remaining yellow accents to orange on Chef ₿ page`
Bot icon (page header, Pro-Kitchen empty state, modal title, modal success state), "Zap Chef ₿" pill, attribution text, selected zap-amount pill, and the floating "Chef ₿ loves you!" toast — all swapped from yellow-500 to `text-primary` / `bg-primary` so Chef ₿ reads as orange end-to-end.

### `style(chef-b): move "Zap Chef ₿" affordance below the recipe output`
Tip-the-chef pill moved from the page header (competing with the H1) to a centered row directly under the Recipe Output box — reads as "tip the chef for the recipe you just got" instead of as a header control.

### `fix(chef-b): scan icon placement, disabled state, mobile stacking`
Phase 1 amendments:
- Scan affordance moved from textarea top-right (which reads as "close") to bottom-right (Slack/ChatGPT/iMessage convention). Converted from a 32px icon-only circle to a small labeled pill (`📷 Scan`) — always-visible text means no hover tooltip needed on mobile. Added an orange focus-visible ring.
- Cook It disabled-state microcopy underneath the button row when the textarea is empty: _"Type an idea or try Surprise Me."_
- Cook It / Surprise Me width ratio shifted to ~60/40 on desktop (`sm:flex-[3]` / `sm:flex-[2]`) so Cook It reads as the dominant action.
- Mobile (<640px) was already stacked full-width with Cook It on top via `flex-col-reverse`.

### `style(intelligence-menu): swap Chef ₿ accent from yellow to orange`
The Chef ₿ entry in the header's Intelligence menu still used yellow-500 as its accent. Swapped to `var(--color-primary)` so it adapts automatically between light (#ec4700) and dark (#ff5722) palettes.

---

## Files

| | |
|---|---|
| **modified** | `src/components/Button.svelte`, `src/components/IntelligenceMenu.svelte`, `src/components/UserSidePanel.svelte`, `src/routes/zappy/+page.svelte`, `src/routes/api/zappy/+server.ts`, `src/routes/api/zappy/scan/+server.ts`, `src/routes/membership/+page.svelte`, `src/routes/membership/pro-kitchen-checkout/+page.svelte` |

## Test plan

- [ ] Open Intelligence menu in the header — Chef ₿ entry shows orange icon (was yellow), other entries unchanged
- [ ] Side panel: AI tools list shows "Chef ₿" (was "Zappy")
- [ ] `/zappy` page header: just the orange Robot icon + "Chef ₿" + sub-copy (no Zap button up top anymore)
- [ ] Textarea: scan pill ("📷 Scan") sits in the bottom-right corner, keyboard focus shows orange ring
- [ ] Buttons: Cook It is solid orange and wider; Surprise Me is orange outline; no sub-captions
- [ ] Empty textarea: Cook It is disabled and the helper "Type an idea or try Surprise Me." appears below
- [ ] Mobile 375px width: stacked full-width (Cook It on top, Surprise Me below), pill still fits inside textarea
- [ ] Generate a recipe — attribution above terminal output is orange (was yellow)
- [ ] "Zap Chef ₿" pill now sits centered below the Recipe Output box
- [ ] Open Zap Chef ₿ modal: bot icon is orange, selected amount pill is orange
- [ ] Trigger a generation success — floating "Chef ₿ loves you!" toast is orange
- [ ] Membership and pro-kitchen-checkout pages mention "Chef ₿" in perk lists
- [ ] OpenAI assistant introduces itself as Chef ₿ (post-generation cue: "Chef ₿ says thanks ⚡")
- [ ] `pnpm check`: 0 errors (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)