### PR TITLE
feat(chef-b): Phase 2 — consolidated prompt, auto-expand textarea, one-tap suggestion chips

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.426",
+  "version": "4.2.427",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.424",
+  "version": "4.2.425",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.427",
+  "version": "4.2.428",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.425",
+  "version": "4.2.426",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.423",
+  "version": "4.2.424",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/routes/api/zappy/+server.ts
+++ b/src/routes/api/zappy/+server.ts
@@ -34,6 +34,8 @@ Your tone is warm, encouraging, and practical. Never preachy. Never robotic. You
 
 You generate clear, achievable recipes using common ingredients unless the user specifies otherwise. Recipes are guides, not rules. Encourage substitutions and experimentation when helpful.
 
+Always commit to a recipe. Even when the user's prompt is short, vague, or a theme (e.g. "Real food", "Gut health", "30-min dinner", "Cozy vegetarian", "Kid-friendly", "High protein", "Mediterranean dinner", "Pantry only"), treat it as a creative direction. Make sensible assumptions about cuisine, ingredients, and constraints, then go straight to the recipe. Do not ask the user clarifying questions, do not offer to suggest options, do not stall — pick something good and cook.
+
 Keep things focused and human. No long backstories. No unnecessary fluff.
 
 ALWAYS format your recipes exactly like this:

--- a/src/routes/zappy/+page.svelte
+++ b/src/routes/zappy/+page.svelte
@@ -11,6 +11,7 @@
   import Modal from '../../components/Modal.svelte';
   import LightningIcon from 'phosphor-svelte/lib/Lightning';
   import RobotIcon from 'phosphor-svelte/lib/Robot';
+  import LeafIcon from 'phosphor-svelte/lib/Leaf';
   import CookingPotIcon from 'phosphor-svelte/lib/CookingPot';
   import CopyIcon from 'phosphor-svelte/lib/Copy';
   import CheckIcon from 'phosphor-svelte/lib/Check';
@@ -68,11 +69,20 @@
   const suggestionChips = [
     'Cozy vegetarian',
     '30-min dinner',
-    "Use what's in my fridge",
-    'High-protein lunch',
+    'Mediterranean dinner',
+    'One-pot meal',
+    'Sheet pan dinner',
+    'Hearty salad',
     'Kid-friendly',
     'Pantry only'
   ];
+
+  // Nourish program presets — same fireChip behavior, just visually
+  // tagged with a green leaf to indicate they're aligned with the
+  // Nourish nutrition surface. The chips still POST to /api/zappy
+  // like the regular ones; the leaf is a visual program tag, not a
+  // separate code path.
+  const nourishChips = ['High protein', 'Gut health', 'Real food'];
 
   // Tracks which chip (if any) is currently driving the generation.
   // Used to show a per-chip spinner while leaving the rest dimmed.
@@ -541,6 +551,36 @@
                 {chipText}
               </button>
             {/each}
+          </div>
+
+          <!-- Nourish program presets — same chip behavior, tagged
+               with a green leaf so users can see at a glance which
+               prompts align with the Nourish nutrition surface. -->
+          <div class="flex flex-col gap-1.5 mt-1" aria-label="Nourish program prompts">
+            <span class="text-xs font-medium text-caption flex items-center gap-1.5">
+              <LeafIcon size={12} weight="fill" class="text-green-500" />
+              Nourish program
+            </span>
+            <div class="flex flex-wrap gap-2">
+              {#each nourishChips as chipText}
+                {@const isFiring = tappedChip === chipText}
+                <button
+                  type="button"
+                  class="suggestion-chip"
+                  class:is-loading={isFiring}
+                  on:click={() => fireChip(chipText)}
+                  disabled={status === 'generating'}
+                  aria-busy={isFiring}
+                >
+                  {#if isFiring}
+                    <ArrowsClockwiseIcon size={12} class="animate-spin" />
+                  {:else}
+                    <LeafIcon size={12} weight="fill" class="text-green-500" />
+                  {/if}
+                  {chipText}
+                </button>
+              {/each}
+            </div>
           </div>
         </div>
 

--- a/src/routes/zappy/+page.svelte
+++ b/src/routes/zappy/+page.svelte
@@ -66,23 +66,27 @@
   // immediately using the chip's label as the prompt — the textarea
   // is left alone so chips and the custom input stay separate
   // affordances (one-tap presets vs. write-your-own).
-  const suggestionChips = [
-    'Cozy vegetarian',
-    '30-min dinner',
-    'Mediterranean dinner',
-    'One-pot meal',
-    'Sheet pan dinner',
-    'Hearty salad',
-    'Kid-friendly',
-    'Pantry only'
+  //
+  // The three Nourish-tagged chips carry a green leaf glyph so users
+  // can see at a glance which prompts align with the Nourish
+  // nutrition surface. They share the same fireChip behavior and
+  // POST to /api/zappy like every other chip; the leaf is a visual
+  // tag only. Order is intentionally interspersed (not grouped) so
+  // the row reads as a mixed bag of presets rather than a taxonomy.
+  type Chip = { label: string; nourish?: boolean };
+  const suggestionChips: Chip[] = [
+    { label: 'Cozy vegetarian' },
+    { label: 'High protein', nourish: true },
+    { label: '30-min dinner' },
+    { label: 'Mediterranean dinner' },
+    { label: 'Gut health', nourish: true },
+    { label: 'One-pot meal' },
+    { label: 'Sheet pan dinner' },
+    { label: 'Real food', nourish: true },
+    { label: 'Hearty salad' },
+    { label: 'Kid-friendly' },
+    { label: 'Pantry only' }
   ];
-
-  // Nourish program presets — same fireChip behavior, just visually
-  // tagged with a green leaf to indicate they're aligned with the
-  // Nourish nutrition surface. The chips still POST to /api/zappy
-  // like the regular ones; the leaf is a visual program tag, not a
-  // separate code path.
-  const nourishChips = ['High protein', 'Gut health', 'Real food'];
 
   // Tracks which chip (if any) is currently driving the generation.
   // Used to show a per-chip spinner while leaving the rest dimmed.
@@ -530,57 +534,31 @@
 
           <!-- Suggestion chips — one-tap presets. The chip's label IS
                the prompt; tapping fires a generation immediately
-               (textarea is left alone). The tapped chip shows a
-               spinner inline; all chips + Cook It + Surprise Me
-               disable for the duration. Built as a local pattern;
-               not extracted to a shared Chip component yet. -->
+               (textarea is left alone). Nourish-tagged chips carry
+               a small green leaf next to the label; they're
+               interspersed (not grouped) so the row reads as a
+               mixed bag rather than a taxonomy. Built as a local
+               pattern; not extracted to a shared Chip component
+               yet. -->
           <div class="flex flex-wrap gap-2" aria-label="Prompt suggestions">
-            {#each suggestionChips as chipText}
-              {@const isFiring = tappedChip === chipText}
+            {#each suggestionChips as chip}
+              {@const isFiring = tappedChip === chip.label}
               <button
                 type="button"
                 class="suggestion-chip"
                 class:is-loading={isFiring}
-                on:click={() => fireChip(chipText)}
+                on:click={() => fireChip(chip.label)}
                 disabled={status === 'generating'}
                 aria-busy={isFiring}
               >
                 {#if isFiring}
                   <ArrowsClockwiseIcon size={12} class="animate-spin" />
+                {:else if chip.nourish}
+                  <LeafIcon size={12} weight="fill" class="text-green-500" />
                 {/if}
-                {chipText}
+                {chip.label}
               </button>
             {/each}
-          </div>
-
-          <!-- Nourish program presets — same chip behavior, tagged
-               with a green leaf so users can see at a glance which
-               prompts align with the Nourish nutrition surface. -->
-          <div class="flex flex-col gap-1.5 mt-1" aria-label="Nourish program prompts">
-            <span class="text-xs font-medium text-caption flex items-center gap-1.5">
-              <LeafIcon size={12} weight="fill" class="text-green-500" />
-              Nourish program
-            </span>
-            <div class="flex flex-wrap gap-2">
-              {#each nourishChips as chipText}
-                {@const isFiring = tappedChip === chipText}
-                <button
-                  type="button"
-                  class="suggestion-chip"
-                  class:is-loading={isFiring}
-                  on:click={() => fireChip(chipText)}
-                  disabled={status === 'generating'}
-                  aria-busy={isFiring}
-                >
-                  {#if isFiring}
-                    <ArrowsClockwiseIcon size={12} class="animate-spin" />
-                  {:else}
-                    <LeafIcon size={12} weight="fill" class="text-green-500" />
-                  {/if}
-                  {chipText}
-                </button>
-              {/each}
-            </div>
           </div>
         </div>
 

--- a/src/routes/zappy/+page.svelte
+++ b/src/routes/zappy/+page.svelte
@@ -61,9 +61,10 @@
     autoSizePrompt();
   }
 
-  // One-tap prompt seeds. Tapping any of these replaces the
-  // textarea contents, focuses it, and parks the cursor at the
-  // end so the user can keep typing to refine.
+  // One-tap prompt seeds. Tapping a chip fires a generation
+  // immediately using the chip's label as the prompt — the textarea
+  // is left alone so chips and the custom input stay separate
+  // affordances (one-tap presets vs. write-your-own).
   const suggestionChips = [
     'Cozy vegetarian',
     '30-min dinner',
@@ -73,15 +74,20 @@
     'Pantry only'
   ];
 
-  async function applyChip(text: string) {
-    promptInput = text;
-    await tick();
-    if (promptEl) {
-      promptEl.focus();
-      const end = promptEl.value.length;
-      promptEl.setSelectionRange(end, end);
+  // Tracks which chip (if any) is currently driving the generation.
+  // Used to show a per-chip spinner while leaving the rest dimmed.
+  let tappedChip: string | null = null;
+
+  async function fireChip(text: string) {
+    if (status === 'generating') return;
+    tappedChip = text;
+    try {
+      await generateRecipe('prompt', text);
+    } finally {
+      // Reset on both success and error so the chip returns to idle
+      // even when generateRecipe surfaces an error via errorMessage.
+      tappedChip = null;
     }
-    // height is handled by the reactive `$: promptInput, autoSizePrompt()`
   }
   
   // Rotating placeholder examples
@@ -160,21 +166,27 @@
     if (zapSuccessTimeout) clearTimeout(zapSuccessTimeout);
   });
   
-  // Generate recipe from prompt
-  async function generateRecipe(mode: 'prompt' | 'hungry' = 'prompt') {
+  // Generate recipe from prompt. `promptOverride` lets one-tap chips
+  // supply their label as the prompt without writing into the
+  // textarea — keeps presets and custom input as separate paths.
+  async function generateRecipe(
+    mode: 'prompt' | 'hungry' = 'prompt',
+    promptOverride?: string
+  ) {
     if (status === 'generating') return;
-    if (mode === 'prompt' && !promptInput.trim()) return;
-    
+    const effectivePrompt = (promptOverride ?? promptInput).trim();
+    if (mode === 'prompt' && !effectivePrompt) return;
+
     status = 'generating';
     errorMessage = '';
     output = '';
-    
+
     try {
       const response = await fetch('/api/zappy', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          prompt: promptInput.trim(),
+          prompt: effectivePrompt,
           mode,
           pubkey: $userPublickey
         })
@@ -506,19 +518,26 @@
             </button>
           </div>
 
-          <!-- Suggestion chips — one-tap prompt seeds. Each chip
-               replaces the textarea contents, focuses, and parks the
-               cursor at the end so the user can refine. Built as a
-               local pattern; not extracted to a shared Chip
-               component yet (per design brief). -->
+          <!-- Suggestion chips — one-tap presets. The chip's label IS
+               the prompt; tapping fires a generation immediately
+               (textarea is left alone). The tapped chip shows a
+               spinner inline; all chips + Cook It + Surprise Me
+               disable for the duration. Built as a local pattern;
+               not extracted to a shared Chip component yet. -->
           <div class="flex flex-wrap gap-2" aria-label="Prompt suggestions">
             {#each suggestionChips as chipText}
+              {@const isFiring = tappedChip === chipText}
               <button
                 type="button"
                 class="suggestion-chip"
-                on:click={() => applyChip(chipText)}
+                class:is-loading={isFiring}
+                on:click={() => fireChip(chipText)}
                 disabled={status === 'generating'}
+                aria-busy={isFiring}
               >
+                {#if isFiring}
+                  <ArrowsClockwiseIcon size={12} class="animate-spin" />
+                {/if}
                 {chipText}
               </button>
             {/each}
@@ -890,6 +909,7 @@
   .suggestion-chip {
     display: inline-flex;
     align-items: center;
+    gap: 6px;
     height: 30px;
     padding: 0 12px;
     border-radius: 999px;
@@ -903,7 +923,8 @@
     transition:
       background-color 140ms ease,
       transform 140ms ease,
-      box-shadow 140ms ease;
+      box-shadow 140ms ease,
+      opacity 140ms ease;
   }
   .suggestion-chip:hover:not(:disabled) {
     background-color: color-mix(in srgb, var(--color-primary) 18%, transparent);
@@ -918,6 +939,13 @@
   .suggestion-chip:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+  }
+  /* The chip currently driving a generation keeps its readability
+     above the other disabled chips so the user can see WHICH one
+     fired. Pairs with the inline spinner in the template. */
+  .suggestion-chip.is-loading:disabled {
+    opacity: 0.9;
+    background-color: color-mix(in srgb, var(--color-primary) 16%, transparent);
   }
 
   /* Scan Fridge — labeled pill docked in the textarea's bottom-right

--- a/src/routes/zappy/+page.svelte
+++ b/src/routes/zappy/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte';
+  import { onMount, onDestroy, tick } from 'svelte';
   import { browser } from '$app/environment';
   import { goto } from '$app/navigation';
   import { userPublickey } from '$lib/nostr';
@@ -38,6 +38,51 @@
   
   // Form state
   let promptInput = '';
+  let promptEl: HTMLTextAreaElement;
+
+  // Auto-grow the prompt textarea between min (~2 rows) and max
+  // (~6 rows). CSS sets the bounds via min-height / max-height +
+  // overflow-y:auto; this keeps the rendered height in sync with
+  // content. Wrapped in tick() so we read scrollHeight *after* the
+  // new value is in the DOM (covers chip taps, scan auto-fill,
+  // ingredient add/remove — all of which assign promptInput
+  // programmatically).
+  async function autoSizePrompt() {
+    await tick();
+    if (!promptEl) return;
+    promptEl.style.height = 'auto';
+    promptEl.style.height = `${promptEl.scrollHeight}px`;
+  }
+
+  // Run autoSize whenever the prompt value changes from any path —
+  // user typing (via bind:value), chip apply, scan auto-fill, etc.
+  $: if (browser) {
+    promptInput;
+    autoSizePrompt();
+  }
+
+  // One-tap prompt seeds. Tapping any of these replaces the
+  // textarea contents, focuses it, and parks the cursor at the
+  // end so the user can keep typing to refine.
+  const suggestionChips = [
+    'Cozy vegetarian',
+    '30-min dinner',
+    "Use what's in my fridge",
+    'High-protein lunch',
+    'Kid-friendly',
+    'Pantry only'
+  ];
+
+  async function applyChip(text: string) {
+    promptInput = text;
+    await tick();
+    if (promptEl) {
+      promptEl.focus();
+      const end = promptEl.value.length;
+      promptEl.setSelectionRange(end, end);
+    }
+    // height is handled by the reactive `$: promptInput, autoSizePrompt()`
+  }
   
   // Rotating placeholder examples
   const placeholderExamples = [
@@ -383,15 +428,18 @@
 
 <div class="flex flex-col max-w-[760px] mx-auto gap-6 pb-8">
   <!-- Header -->
-  <div class="flex flex-col gap-2">
-    <div class="flex items-center gap-3">
-      <RobotIcon size={32} class="text-primary" weight="fill" />
-      <h1>Chef ₿</h1>
-    </div>
-    <p class="text-caption">
-      What's cooking? Tell me what you're craving or show me your fridge!
-    </p>
-    <p class="text-caption text-sm">Pro Kitchen feature.</p>
+  <div class="flex items-center gap-3 flex-wrap">
+    <RobotIcon size={32} class="text-primary" weight="fill" />
+    <h1>Chef ₿</h1>
+    <!-- Pro Kitchen badge — replaces the standalone
+         "Pro Kitchen feature." line that used to sit below the
+         H1. Folded in here since it's the same copy-consolidation
+         pass (Phase 5 work, cheap to do now). -->
+    <span
+      class="inline-flex px-2 py-0.5 rounded-full text-[10px] font-bold tracking-wide border bg-primary/10 text-primary border-primary/30"
+    >
+      PRO KITCHEN
+    </span>
   </div>
   
   {#if isLoading}
@@ -427,10 +475,11 @@
           <div class="relative">
             <textarea
               id="prompt"
+              bind:this={promptEl}
               bind:value={promptInput}
               placeholder={currentPlaceholder}
-              rows="5"
-              class="input resize-none text-base w-full pb-12"
+              rows="2"
+              class="input auto-grow resize-none text-base w-full pb-12"
               disabled={status === 'generating'}
             ></textarea>
             <!-- Scan Fridge — small labeled pill docked in the textarea's
@@ -455,6 +504,24 @@
                 <span>Scan</span>
               {/if}
             </button>
+          </div>
+
+          <!-- Suggestion chips — one-tap prompt seeds. Each chip
+               replaces the textarea contents, focuses, and parks the
+               cursor at the end so the user can refine. Built as a
+               local pattern; not extracted to a shared Chip
+               component yet (per design brief). -->
+          <div class="flex flex-wrap gap-2" aria-label="Prompt suggestions">
+            {#each suggestionChips as chipText}
+              <button
+                type="button"
+                class="suggestion-chip"
+                on:click={() => applyChip(chipText)}
+                disabled={status === 'generating'}
+              >
+                {chipText}
+              </button>
+            {/each}
           </div>
         </div>
 
@@ -805,6 +872,54 @@
 {/if}
 
 <style>
+  /* Prompt textarea — starts compact (~2 rows of usable text plus the
+     scan-pill gutter at the bottom) and grows up to ~6 rows. The JS
+     `autoSizePrompt` keeps `style.height` in sync with scrollHeight;
+     max-height + overflow-y here cap the growth and switch to scroll. */
+  .input.auto-grow {
+    min-height: 6.5rem;
+    max-height: 14rem;
+    overflow-y: auto;
+  }
+
+  /* Suggestion chip — orange-tint button at secondary visual weight,
+     clearly tappable, focus-visible ring for keyboard users. Pattern
+     kept local on this page; we'll extract a shared Chip component
+     later if the detected-ingredients chips end up close enough to
+     consolidate. */
+  .suggestion-chip {
+    display: inline-flex;
+    align-items: center;
+    height: 30px;
+    padding: 0 12px;
+    border-radius: 999px;
+    border: 0;
+    background-color: color-mix(in srgb, var(--color-primary) 10%, transparent);
+    color: var(--color-primary);
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 1;
+    cursor: pointer;
+    transition:
+      background-color 140ms ease,
+      transform 140ms ease,
+      box-shadow 140ms ease;
+  }
+  .suggestion-chip:hover:not(:disabled) {
+    background-color: color-mix(in srgb, var(--color-primary) 18%, transparent);
+  }
+  .suggestion-chip:active:not(:disabled) {
+    transform: scale(0.96);
+  }
+  .suggestion-chip:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary) 55%, transparent);
+  }
+  .suggestion-chip:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
   /* Scan Fridge — labeled pill docked in the textarea's bottom-right
      corner (Slack/ChatGPT/iMessage convention). Always-visible "Scan"
      text means no hover tooltip needed on mobile. Uses the Chef ₿


### PR DESCRIPTION
## Summary

Phase 2 of the Chef ₿ UX redesign — input area cleanup and one-tap presets. Builds on the Phase 1 / rebrand work merged in #390.

Phase 3+ (streaming, recipe card with Save/Zap/Share, recents) is **not** in this PR.

---

## Commits

### `feat(chef-b): consolidate prompt copy, auto-expand textarea, suggestion chips`

Prompt copy collapsed from three stacked lines to one:
- Dropped "What's cooking? Tell me what you're craving…" and "Pro Kitchen feature."
- Kept only the textarea label "What are you in the mood for?"
- Folded in the Phase 5 **PRO KITCHEN** badge next to the H1 since it was a 1-line change tied to the same copy pass.

Textarea behavior:
- `rows="2"` baseline; new `.auto-grow` class adds `min-height: 6.5rem` (≈ 2 rows + scan-pill gutter) and `max-height: 14rem` (≈ 6 rows) with `overflow-y: auto` past the cap.
- `autoSizePrompt()` reads `scrollHeight` after a `tick()` and sets `style.height` to match.
- Single reactive statement `$: promptInput, autoSizePrompt()` is the only autosize entry point — handles user typing, chip taps, scan auto-fill, and ingredient add/remove uniformly.
- Scan pill stays docked bottom-right inside the textarea (Phase 1 amendment).

Suggestion chips (initial set, refined below):
- 6 chips below the textarea: Cozy vegetarian / 30-min dinner / Use what's in my fridge / High-protein lunch / Kid-friendly / Pantry only.
- Real `<button>` elements with orange-tinted background, `gap-2 flex-wrap`, orange focus-visible ring, disabled while generating.
- Local `.suggestion-chip` pattern — not extracted to a shared component yet per brief.

### `fix(chef-b): chips fire generation directly (one-tap presets)`

Chips no longer fill the textarea and wait for a Cook It tap. Tapping a chip fires `/api/zappy` immediately with the chip's label as the prompt:
- `generateRecipe(mode, promptOverride?)` accepts an optional second arg; chip flow passes the chip text.
- New `fireChip(text)` wraps the call in a `try/finally` that toggles a `tappedChip` marker so the firing chip can render an inline spinner.
- All chips + Cook It + Surprise Me disable for the duration. The tapped chip keeps `opacity: 0.9` (vs. `0.5` for the others) so it's clearly the one in flight.
- Errors surface via the existing `errorMessage` path; the marker resets either way.
- Old `applyChip` (textarea fill + focus) removed.

### `style(chef-b): expand chip presets + add Nourish program group`

- Dropped "Use what's in my fridge" — redundant with the Scan pill in the textarea.
- Moved "High-protein lunch" into a Nourish-tagged section as "High protein".
- Added four popular + healthy presets: Mediterranean dinner / One-pot meal / Sheet pan dinner / Hearty salad.
- Added a "Nourish program" section below the regular chips with three Nourish-tagged chips (High protein / Gut health / Real food), each carrying a small green leaf glyph (using the existing Nourish brand color from `IntelligenceMenu`, not a new token).

### `style(chef-b): intersperse Nourish chips into the main suggestion row`

Per design feedback: dropped the dedicated "Nourish program" section header. The three Nourish chips now sit in the single flex-wrap row alongside the regular presets at positions 2, 5, and 8 (Cozy vegetarian → **High protein** → 30-min dinner → Mediterranean dinner → **Gut health** → One-pot meal → Sheet pan dinner → **Real food** → Hearty salad → Kid-friendly → Pantry only). Each Nourish chip still carries its green leaf. Data model collapsed to a single `Chip = { label, nourish? }` array.

### `fix(chef-b): never ask clarifying questions on short prompts`

Bug surfaced during testing: tapping "Real food" sometimes returned "Got it! Let's make something real and satisfying. What ingredients do you have on hand? Or do you want me to suggest a comforting, straightforward recipe?" — the endpoint is single-turn so the user can't reply.

Tightened `SYSTEM_INSTRUCTION` in `src/routes/api/zappy/+server.ts` with an explicit rule: always commit to a recipe, treat short theme prompts (the chip labels listed as examples) as creative direction, make sensible assumptions, no clarifying questions, no offers to suggest options, no stalling. Pick something good and cook.

---

## Files
| | |
|---|---|
| **modified** | `src/routes/zappy/+page.svelte`, `src/routes/api/zappy/+server.ts` |

## Test plan

- [ ] Header shows orange Robot icon + "Chef ₿" + PRO KITCHEN pill (Pro Kitchen sub-line is gone)
- [ ] Single label above textarea: "What are you in the mood for?"
- [ ] Textarea starts at ~2 rows, grows as you type up to ~6 rows then scrolls; Scan pill stays bottom-right
- [ ] Chip row below textarea contains 11 chips in one flex-wrap row, Nourish chips with green leaf at positions 2 / 5 / 8 (interspersed, not grouped)
- [ ] Tap any chip → recipe generates immediately, no textarea fill, no second tap required
- [ ] Tapped chip shows inline spinner + label, stays brighter than the other dimmed chips
- [ ] Cook It + Surprise Me + other chips disable while a chip generation is in flight
- [ ] Tap "Real food" (and other one-word/theme chips) → returns a recipe, NOT a clarifying question
- [ ] Custom textarea typing → Cook It still works the same; chips and textarea are independent
- [ ] Keyboard: Tab through chips, Enter fires the same handler
- [ ] Mobile 375px: chips wrap cleanly, spinner doesn't shift layout
- [ ] `pnpm check`: 0 errors (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)