### PR TITLE
fix(wallet): scope Spark relay backup deletion to active wallet ID + picker chain-support note

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.432",
+  "version": "4.2.433",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -26,7 +26,6 @@
     balanceVisible,
     openWallet
   } from '$lib/wallet';
-  import { displayCurrency } from '$lib/currencyStore';
   import { weblnConnected } from '$lib/wallet/webln';
   import { bitcoinConnectEnabled, bitcoinConnectWalletInfo } from '$lib/wallet/bitcoinConnect';
   import { cookingToolsStore, cookingToolsOpen } from '$lib/stores/cookingToolsWidget';
@@ -221,32 +220,26 @@
     <!-- Wallet (logged in) -->
     {#if $userPublickey && $navBalanceVisible}
       {#if hasNavWallet}
-        <!-- Mobile compact wallet pill — split into two interactive
-             zones so the user gets a one-tap currency cycle on the
-             balance text while preserving "open wallet" on the icon. -->
-        <div class="zh-wallet-mobile sm:hidden" role="group" aria-label="Wallet">
-          <button
-            type="button"
-            on:click={() => openWallet()}
-            class="zh-wallet-mobile-zone zh-wallet-mobile-icon"
-            aria-label="Open wallet"
-          >
-            <LightningIcon size={14} weight="fill" class="text-amber-400" />
-          </button>
-          <button
-            type="button"
-            on:click={() => displayCurrency.cycleSatsFiat()}
-            class="zh-wallet-mobile-zone zh-wallet-mobile-amount"
-            aria-label="Toggle currency"
-            title="Tap to toggle currency"
-          >
+        <!-- Mobile compact wallet pill — single tap target so anywhere
+             on the pill opens the wallet. Currency cycling and
+             show/hide live inside the wallet panel itself, since
+             accidental taps on a small split control were preventing
+             users from completing the "open wallet" action. -->
+        <button
+          type="button"
+          on:click={() => openWallet()}
+          class="zh-wallet-mobile sm:hidden"
+          aria-label="Open wallet"
+        >
+          <LightningIcon size={14} weight="fill" class="text-amber-400" />
+          <span class="zh-wallet-amount">
             <DenominatedBalance
               sats={$walletBalance}
               visible={$balanceVisible}
               loading={$walletLoading}
             />
-          </button>
-        </div>
+          </span>
+        </button>
         <!-- Desktop full WalletBalance widget -->
         <div class="hidden sm:block">
           <WalletBalance />
@@ -403,38 +396,6 @@
     transform: scale(0.97);
   }
 
-  /* Inner zones share styling, are full-height, and meet a 30px tap
-     target via padding. They show a subtle hover state so the user
-     sees the two are independent. */
-  .zh-wallet-mobile-zone {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    background: transparent;
-    border: 0;
-    color: inherit;
-    font: inherit;
-    cursor: pointer;
-    transition: background-color 120ms ease, color 120ms ease;
-  }
-  .zh-wallet-mobile-zone:hover {
-    background-color: rgba(0, 0, 0, 0.05);
-  }
-  :global(.dark) .zh-wallet-mobile-zone:hover {
-    background-color: rgba(255, 255, 255, 0.06);
-  }
-  :where(.zh-wallet-mobile-zone:active) {
-    transform: scale(0.96);
-  }
-  .zh-wallet-mobile-icon {
-    padding: 0 6px 0 9px;
-  }
-  .zh-wallet-mobile-amount {
-    padding: 0 10px 0 6px;
-    font-variant-numeric: tabular-nums;
-    letter-spacing: 0.01em;
-    min-width: 3.5ch;
-  }
   :global(.dark) .zh-wallet-mobile {
     background-color: rgba(255, 255, 255, 0.04);
     border-color: rgba(255, 255, 255, 0.08);

--- a/src/components/wallet/WalletModal.svelte
+++ b/src/components/wallet/WalletModal.svelte
@@ -183,14 +183,14 @@
      --connect-step which has its own (smaller) auto-sized rules. */
   @media (min-width: 768px) {
     :global(dialog:has(.wallet-scroll.picker-view:not(.picker-view--connect-step))) {
-      height: 880px !important;
-      max-height: 90vh !important;
+      height: 960px !important;
+      max-height: 92vh !important;
     }
   }
   @media (min-width: 1024px) {
     :global(dialog:has(.wallet-scroll.picker-view:not(.picker-view--connect-step))) {
-      height: 920px !important;
-      max-height: min(960px, 90vh) !important;
+      height: 1000px !important;
+      max-height: min(1040px, 92vh) !important;
     }
   }
   /* External-wallet mode (WebLN, Bitcoin Connect): elastic height —

--- a/src/components/wallet/WalletPanel.svelte
+++ b/src/components/wallet/WalletPanel.svelte
@@ -71,6 +71,7 @@
     recentSparkPayments,
     getBestEncryptionMethod,
     deleteBackupFromNostr as deleteSparkBackupFromNostr,
+    getSparkWalletId,
     getSparkWalletInfo,
     receiveOnchain,
     prepareOnchainSend,
@@ -1892,14 +1893,14 @@
     errorMessage = '';
 
     try {
-      await createSparkWallet($userPublickey, BREEZ_API_KEY);
+      const newMnemonic = await createSparkWallet($userPublickey, BREEZ_API_KEY);
       successMessage = 'Spark wallet created!';
       showBackupReminder = true;
       showAddWallet = false;
       selectedWalletType = null;
 
-      // Register in wallet store
-      await connectWallet(4, 'spark');
+      // Register in wallet store with walletId so deletion can target the right relay backup
+      await connectWallet(4, getSparkWalletId(newMnemonic));
 
       // Fetch initial balance (will be 0 for new wallet)
       await refreshBalance();
@@ -1932,8 +1933,8 @@
   async function restoreSelectedSparkBackup(backup: SparkBackupEntry) {
     const mnemonic = await restoreSparkBackup($userPublickey, BREEZ_API_KEY, backup);
     if (mnemonic) {
-      // Register in wallet store
-      await connectWallet(4, 'spark');
+      // Register in wallet store with walletId so deletion can target the right relay backup
+      await connectWallet(4, getSparkWalletId(mnemonic));
 
       // Actively fetch balance and transaction history
       await refreshBalance();
@@ -2059,8 +2060,8 @@
     try {
       const success = await restoreFromMnemonic($userPublickey, mnemonic, BREEZ_API_KEY);
       if (success) {
-        // Register in wallet store
-        await connectWallet(4, 'spark');
+        // Register in wallet store with walletId so deletion can target the right relay backup
+        await connectWallet(4, getSparkWalletId(mnemonic));
 
         // Actively fetch balance and transaction history
         await refreshBalance();
@@ -2139,8 +2140,9 @@
 
       const success = await restoreFromBackup($userPublickey, backup, BREEZ_API_KEY, decryptFn);
       if (success) {
-        // Register in wallet store
-        await connectWallet(4, 'spark');
+        // Register in wallet store with walletId so deletion can target the right relay backup
+        const restoredMnemonic = await loadMnemonic($userPublickey);
+        await connectWallet(4, restoredMnemonic ? getSparkWalletId(restoredMnemonic) : 'spark');
 
         // Actively fetch balance and transaction history
         await refreshBalance();
@@ -4474,11 +4476,19 @@
            wallet type has been selected (sub-screens have their own
            back-bar) or when the user is just adding another wallet. -->
       {#if !hasAnyWallet && !selectedWalletType}
-        <div class="explore-prompt-card">
-          <p class="explore-prompt-card__text">
+        <div
+          class="mt-6 p-3 rounded-2xl text-center"
+          style="background-color: rgba(245, 158, 11, 0.05); border: 1px solid rgba(245, 158, 11, 0.2);"
+        >
+          <p class="text-sm text-caption mb-2 leading-snug">
             Not ready for a wallet? You can explore Zap Cooking and come back anytime.
           </p>
-          <button type="button" class="explore-prompt-card__cta" on:click={dismissPicker}>
+          <button
+            type="button"
+            class="explore-prompt-cta inline-flex items-center gap-1 px-5 py-2 rounded-full text-sm font-semibold cursor-pointer transition-colors"
+            style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border); color: var(--color-text-primary);"
+            on:click={dismissPicker}
+          >
             Explore Zap Cooking →
           </button>
         </div>
@@ -4794,7 +4804,18 @@
                 if (deleteRelayBackups && $userPublickey) {
                   try {
                     if (walletToDelete.kind === 4) {
-                      await deleteSparkBackupFromNostr($userPublickey);
+                      // Legacy backups (d-tag 'spark-wallet-backup' with no
+                      // walletId suffix) predate the per-wallet d-tag scheme
+                      // and can't be targeted by our delete flow. Surface a
+                      // toast instead of silently no-op'ing.
+                      const backups = await listSparkBackups($userPublickey);
+                      if (backups.some((b) => b.isLegacy)) {
+                        errorMessage = "Legacy wallet backups can't be deleted by Zap Cooking.";
+                      } else {
+                        const sparkWalletId =
+                          walletToDelete.data !== 'spark' ? walletToDelete.data : undefined;
+                        await deleteSparkBackupFromNostr($userPublickey, sparkWalletId);
+                      }
                     } else if (walletToDelete.kind === 3) {
                       await deleteNwcBackupFromNostr($userPublickey);
                     }
@@ -6221,43 +6242,13 @@
     }
   }
 
-  /* "Explore Zap Cooking" exit card at the bottom of the welcome
-     picker. Replaces the earlier text-link "I'll do this later" — a
-     visible card with a clear CTA makes the exit obvious for users
-     who aren't ready to set up a wallet on first run. */
-  .explore-prompt-card {
-    margin-top: 2rem;
-    padding: 1rem 1.25rem;
-    border-radius: 1rem;
-    background: rgba(245, 158, 11, 0.05);
-    border: 1px solid rgba(245, 158, 11, 0.2);
-    text-align: center;
-  }
-  .explore-prompt-card__text {
-    font-size: 0.875rem;
-    color: var(--color-text-secondary);
-    margin: 0 0 0.75rem;
-    line-height: 1.5;
-  }
-  .explore-prompt-card__cta {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-    padding: 0.5rem 1.25rem;
-    border-radius: 9999px;
-    background: var(--color-input-bg);
-    border: 1px solid var(--color-input-border);
-    font-size: 0.875rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    cursor: pointer;
-    transition:
-      background-color 0.15s,
-      border-color 0.15s;
-  }
-  .explore-prompt-card__cta:hover {
-    background: rgba(255, 255, 255, 0.05);
-    border-color: rgba(245, 158, 11, 0.5);
+  /* Hover state for the "Explore Zap Cooking" exit card CTA. Layout,
+     colors, and base chrome live as inline styles on the markup to
+     stay above the wallet-modal-body :global() rules that strip
+     button backgrounds otherwise. */
+  .explore-prompt-cta:hover {
+    background-color: rgba(255, 255, 255, 0.05) !important;
+    border-color: rgba(245, 158, 11, 0.5) !important;
   }
 
   /* :global() so the rule reaches buttons rendered by child components

--- a/src/components/wallet/WalletPanel.svelte
+++ b/src/components/wallet/WalletPanel.svelte
@@ -208,6 +208,8 @@
   let expandedWalletId: number | null = null;
   let revealedMnemonic: string | null = null;
   let isBackingUp = false;
+  // Picker-home altcoin-curious prompt toggle
+  let showAltcoinReply = false;
 
   // NWC wallet info
   let nwcWalletInfo: { alias?: string; methods: string[]; relay: string; pubkey: string } | null =
@@ -4260,6 +4262,35 @@
               </button>
             {/if}
           {/if}
+
+          <!-- Picker-home prompt for users curious about non-bitcoin chains. -->
+          <div class="mt-4 text-center">
+            <button
+              type="button"
+              class="text-xs text-caption hover:text-orange-500 transition-colors cursor-pointer underline decoration-dotted underline-offset-4 bg-transparent border-0 p-0"
+              on:click={() => (showAltcoinReply = !showAltcoinReply)}
+            >
+              Looking for Ethereum, Solana, XRP, Cardano or other coins?
+            </button>
+            {#if showAltcoinReply}
+              <p
+                class="mt-3 text-sm font-medium"
+                style="color: var(--color-text-primary)"
+              >
+                Just kidding, Zap Cooking is bitcoin only!
+              </p>
+              <!-- svelte-ignore a11y-media-has-caption -->
+              <video
+                class="mt-3 mx-auto rounded-lg w-full max-w-sm"
+                src="https://video.nostr.build/ab7659486ab83bf66fe446251687ede7a3b5779cc16afbadbdb21be60bc596bb.mp4"
+                autoplay
+                loop
+                muted
+                playsinline
+                controls
+              ></video>
+            {/if}
+          </div>
         </div>
       {:else if selectedWalletType === 3}
         <!-- NWC connection -->


### PR DESCRIPTION
## Summary

Two related wallet-picker changes:

**Bug fix — Spark relay backup deletion targeted the wrong wallet.** Previously \"Delete relay backup\" derived the target d-tag from the locally stored mnemonic at deletion time, so when the user had a different active mnemonic than the wallet being removed (e.g. after restoring an older backup), it wiped the wrong relay event — typically the newest backup rather than the one the user intended to remove.

- Persist the Spark walletId in \`wallet.data\` at wallet create/restore time so deletion can target the specific per-wallet d-tag for that entry. Pre-fix wallets (\`data === 'spark'\`) fall back to the old \`loadMnemonic\` path so behavior is unchanged for them.
- Pre-flight \`listSparkBackups\` before deleting; if any entry is \`isLegacy\` (the original \`spark-wallet-backup\` d-tag with no walletId suffix, pre-dating the per-wallet scheme), show a toast instead of publishing a deletion that wouldn't match the relay event.
- Restore visible chrome on the picker home's \"Not ready for a wallet?\" exit card — the BEM-scoped rules weren't surviving the new wallet modal's \`:global()\` button reset, so the card rendered as default text on the dark background. Migrate to inline styles + utility classes matching the rest of the panel.
- Bump picker-home dialog heights (880/920 → 960/1000, 90vh → 92vh) so the now-visible exit card has room to render without clipping.

**Picker copy — clarify supported chains.** Add an expandable note under the External / Browser Wallets section of the picker that addresses users arriving from other-chain ecosystems. Resolves a recurring \"why doesn't Zap Cooking support X?\" question without cluttering the default picker.

- Collapsed state: small caption-styled link.
- Expanded state: short clarifying message + embedded clip from video.nostr.build (autoplay, loop, muted by default, controls available).

## Test plan

- [ ] Spark wallet created post-merge has its walletId persisted in \`wallet.data\` (inspect \`zapcooking_wallets\` in localStorage).
- [ ] Remove a Spark wallet with \"Also delete relay backup\" checked; verify only that wallet's backup event is overwritten on relays, not others.
- [ ] Trigger the legacy path: with a pre-existing legacy backup (\`spark-wallet-backup\` d-tag, no suffix) on relays, attempt deletion and confirm the toast appears instead of a silent miss.
- [ ] Open the picker home with no wallets — the \"Not ready for a wallet?\" exit card renders with the orange-tinted chrome, muted body text, and the pill CTA button, and the dialog is tall enough that nothing clips.
- [ ] Click the new note under External / Browser Wallets; the message and embedded clip expand inline. Click again to collapse.