### PR TITLE
fix(wallet): stop modal body padding from painting over scroll content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.441",
+  "version": "4.2.442",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/wallet/WalletModal.svelte
+++ b/src/components/wallet/WalletModal.svelte
@@ -57,8 +57,14 @@
     flex-direction: column;
     overflow: hidden;
     background-color: var(--color-bg-secondary);
-    padding-top: 2rem;
-    padding-bottom: 2rem;
+    /* No vertical padding on the flex container: flex column + body
+       padding + a flex:1 overflow-auto child cause the child to
+       extend through the padding region, painting the body's
+       bg-secondary over the top and bottom of the scrollable content.
+       The vertical visual buffer lives inside the inner .wallet-scroll
+       instead. */
+    padding-top: 0;
+    padding-bottom: 0;
   }
   /* Floating logo (left) + close button (right) — both sit on top of
      content in the top corners of the modal. No opaque banner — the

--- a/src/components/wallet/WalletPanel.svelte
+++ b/src/components/wallet/WalletPanel.svelte
@@ -2652,7 +2652,7 @@
          inset as the non-WebLN balance frame and the inner wallet-scroll
          content below, so widths line up consistently. -->
     {#if $weblnConnected}
-      <div class="mb-8 mx-4 p-6 rounded-2xl bg-input border border-input">
+      <div class="mt-8 mb-8 mx-4 p-6 rounded-2xl bg-input border border-input">
         <div class="flex items-start justify-between gap-3 mb-2 balance-row">
           <div class="flex-1 min-w-0">
             <div
@@ -2731,7 +2731,7 @@
          while the connection / disconnect card below it scrolls.
          Mirrors the WebLN sticky-balance pattern above. -->
     {#if $bitcoinConnectEnabled && $wallets.length === 0 && !$weblnConnected}
-      <div class="mb-8 mx-4 p-6 rounded-2xl bg-input border border-input">
+      <div class="mt-8 mb-8 mx-4 p-6 rounded-2xl bg-input border border-input">
         <div class="flex items-start justify-between gap-3 mb-2 balance-row">
           <div class="flex-1 min-w-0">
             <div
@@ -6202,8 +6202,11 @@
     background-color: var(--color-bg-secondary);
     /* 1rem horizontal padding gives a visible bg-secondary "border"
        around the balance card on both sides, matching the inner
-       scroll container's padding so balance and history align. */
-    padding: 0 1rem;
+       scroll container's padding so balance and history align. The
+       2rem top padding replaces the buffer we used to get from
+       wallet-modal-body's padding-top (now zeroed to avoid the
+       flex + padding overlap bug on the scroll child below). */
+    padding: 2rem 1rem 0;
     transition: padding-bottom 0.18s ease-out;
     /* Keep the frame above the scrolling content so its solid bg masks
        transactions briefly visible at the card's rounded corners. */
@@ -6229,7 +6232,10 @@
   .wallet-scroll.picker-view,
   .wallet-scroll.wallet-info-view,
   .wallet-scroll.remove-wallet-view {
-    padding-top: 0.5rem;
+    /* Top buffer lives here (not on wallet-modal-body) because the
+       flex container's padding bleeds bg-secondary over the top of
+       the scrollable content. */
+    padding-top: 2rem;
     padding-bottom: 1.5rem;
   }
   @media (min-width: 768px) {
@@ -6240,7 +6246,7 @@
     .wallet-scroll.remove-wallet-view {
       padding-left: 1.5rem;
       padding-right: 1.5rem;
-      padding-top: 0.75rem;
+      padding-top: 2rem;
       padding-bottom: 2rem;
     }
   }


### PR DESCRIPTION
## Summary

Small layout fix for the wallet modal. The outer \`wallet-modal-body\` carried \`padding-top: 2rem\` and \`padding-bottom: 2rem\` to inset its content from the dialog edge. Combined with a flex column layout and a \`flex: 1; overflow-y: auto\` child (\`.wallet-scroll\`), the scroll child extended *through* the parent's padding region; the parent's \`bg-secondary\` then painted over the top and bottom of the scrollable content.

The symptom was subtle: \`scrollHeight === clientHeight\` (the content technically fit the scroll viewport) but the picker's bolt icon was half-clipped at the top and the \"Explore Zap Cooking\" exit button half-clipped at the bottom, because the parent's padding band visually overlapped them.

The fix moves the vertical buffer off the flex container and onto the elements inside it:

- \`wallet-modal-body\`: \`padding-top\` / \`padding-bottom\` → \`0\`.
- \`.wallet-scroll.{picker,send,receive,wallet-info,remove-wallet}-view\`: \`padding-top\` bumped from \`0.5rem\` / \`0.75rem\` → \`2rem\` so the top-of-view content (icons, sub-screen headers) keeps its ~32px buffer from the dialog edge.
- \`.balance-frame\` (connected-wallet view, sits above the scroll rather than inside it): \`padding: 0 1rem\` → \`padding: 2rem 1rem 0\` so the balance card keeps its top buffer.
- The two inline WebLN / Bitcoin Connect balance cards: \`mt-8\` added for the same top buffer.

## Test plan

- [ ] Open the wallet picker with no wallets connected — confirm the bolt icon at the top and the \"Explore Zap Cooking\" button at the bottom are both fully visible, with ~32px breathing room above the icon and below the button before the dialog edge.
- [ ] Open the connected-wallet view (Spark / NWC) — confirm the balance card sits ~32px below the dialog edge, not flush against it.
- [ ] Connect a WebLN wallet — confirm the WebLN balance card has the same top buffer.
- [ ] Connect a Bitcoin Connect wallet — same check for the Bitcoin Connect balance card.
- [ ] Open the Send and Receive sub-screens — the back-bar header should sit ~32px below the dialog edge.