### PR TITLE
feat(feed): Phase 0 — foundations (types, NIP-92 imeta parser, blurhash decoder)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.442",
+  "version": "4.2.443",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/feed/blurhash.test.ts
+++ b/src/lib/feed/blurhash.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for the hand-ported blurhash decoder.
+ *
+ * Note: `blurhashToDataUrl` depends on a canvas implementation that
+ * doesn't exist in the vitest jsdom environment, so it is tested
+ * indirectly via `decodeBlurhash` (the pixel-buffer step) and through
+ * `isValidBlurhash` (validation). The data-URL wrapping is exercised
+ * by manual QA against the dev demo route in Phase 1.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { decodeBlurhash, isValidBlurhash, blurhashToDataUrl } from './blurhash';
+
+// A canonical reference hash from the woltapp/blurhash README. Encodes
+// a 1920x1080 photo with 4x3 components.
+const REFERENCE_HASH = 'LEHV6nWB2yk8pyo0adR*.7kCMdnj';
+
+describe('isValidBlurhash', () => {
+  it('accepts the canonical reference hash', () => {
+    expect(isValidBlurhash(REFERENCE_HASH)).toBe(true);
+  });
+  it('rejects hashes that are too short', () => {
+    expect(isValidBlurhash('L')).toBe(false);
+    expect(isValidBlurhash('')).toBe(false);
+    expect(isValidBlurhash(undefined)).toBe(false);
+    expect(isValidBlurhash(null)).toBe(false);
+  });
+  it('rejects hashes whose declared component count mismatches the body length', () => {
+    // Truncate one trailing char off a known-good hash.
+    expect(isValidBlurhash(REFERENCE_HASH.slice(0, -1))).toBe(false);
+  });
+  it('rejects non-string inputs', () => {
+    // @ts-expect-error testing runtime guard against wrong type
+    expect(isValidBlurhash(42)).toBe(false);
+  });
+});
+
+describe('decodeBlurhash', () => {
+  it('returns an RGBA buffer of the requested size', () => {
+    const pixels = decodeBlurhash(REFERENCE_HASH, 4, 3);
+    expect(pixels).toBeInstanceOf(Uint8ClampedArray);
+    expect(pixels.length).toBe(4 * 3 * 4); // RGBA, 4 bytes per pixel
+  });
+
+  it('fills the alpha channel with 255', () => {
+    const pixels = decodeBlurhash(REFERENCE_HASH, 8, 8);
+    for (let i = 3; i < pixels.length; i += 4) {
+      expect(pixels[i]).toBe(255);
+    }
+  });
+
+  it('produces pixel values within the 0-255 range', () => {
+    const pixels = decodeBlurhash(REFERENCE_HASH, 16, 16);
+    for (let i = 0; i < pixels.length; i++) {
+      expect(pixels[i]).toBeGreaterThanOrEqual(0);
+      expect(pixels[i]).toBeLessThanOrEqual(255);
+    }
+  });
+
+  it('produces a non-uniform image (real DC + AC components decoded)', () => {
+    const pixels = decodeBlurhash(REFERENCE_HASH, 16, 16);
+    const first = [pixels[0], pixels[1], pixels[2]];
+    // The reference encodes a photo, not a flat color — at least one
+    // pixel somewhere in the buffer must differ from the top-left.
+    let differ = false;
+    for (let i = 4; i < pixels.length; i += 4) {
+      if (
+        pixels[i] !== first[0] ||
+        pixels[i + 1] !== first[1] ||
+        pixels[i + 2] !== first[2]
+      ) {
+        differ = true;
+        break;
+      }
+    }
+    expect(differ).toBe(true);
+  });
+
+  it('throws on malformed input', () => {
+    expect(() => decodeBlurhash('!!!', 4, 4)).toThrow();
+    expect(() => decodeBlurhash('', 4, 4)).toThrow();
+  });
+});
+
+describe('blurhashToDataUrl', () => {
+  it('returns null for invalid input', () => {
+    expect(blurhashToDataUrl(undefined)).toBeNull();
+    expect(blurhashToDataUrl('')).toBeNull();
+    expect(blurhashToDataUrl('!!!')).toBeNull();
+  });
+
+  it('returns null when no canvas implementation is available (SSR / jsdom)', () => {
+    // jsdom's HTMLCanvasElement.getContext returns null without the
+    // node-canvas peer dep, so this path exercises the safe-fail
+    // contract: callers receive null and paint the bg-secondary
+    // fallback tile.
+    const out = blurhashToDataUrl(REFERENCE_HASH);
+    // Accept either null (no canvas) or a data: URL (if a future env
+    // provides one) — the contract is "never throws".
+    expect(out === null || (typeof out === 'string' && out.startsWith('data:image/'))).toBe(true);
+  });
+});

--- a/src/lib/feed/blurhash.ts
+++ b/src/lib/feed/blurhash.ts
@@ -1,0 +1,216 @@
+/**
+ * Blurhash decoder — hand-ported to avoid pulling the `blurhash` npm
+ * dep (~3 kb on its own, plus base83/sRGB constants), and to keep
+ * decode/encode logic in one auditable place.
+ *
+ * Algorithm follows the canonical blurhash spec (woltapp/blurhash):
+ *   1. The hash starts with a base83-encoded "size flag" byte that
+ *      packs `numX = (flag % 9) + 1` and `numY = floor(flag / 9) + 1`.
+ *   2. The next 1 char is `quantisedMaxValue`, which sets the AC
+ *      component scale: `maximumValue = (q + 1) / 166`.
+ *   3. Next 4 chars are the DC component (the average sRGB color),
+ *      base83-decoded to 24 bits and unpacked as RGB.
+ *   4. Remaining chars: 2 chars per AC component (numX * numY - 1
+ *      components total), each a 14-bit base83 number that decodes to
+ *      three signed normalized floats (R, G, B).
+ *   5. To render a pixel at (x, y) we cosine-blend the components
+ *      across the image.
+ *
+ * Output is a tiny rasterized image (default 32x32) returned as a
+ * `data:image/png;base64,…` URL ready to drop into a `<img src>` or a
+ * `background-image: url(…)`. We rasterize via OffscreenCanvas where
+ * available (workers, modern browsers) and fall back to a regular
+ * `<canvas>` otherwise. SSR (no canvas) returns `null` — callers paint
+ * a solid bg-secondary tile in that case.
+ */
+
+const BASE83 =
+  '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz#$%*+,-.:;=?@[]^_{|}~';
+
+function base83Decode(str: string): number {
+  let value = 0;
+  for (let i = 0; i < str.length; i++) {
+    const digit = BASE83.indexOf(str[i]);
+    if (digit === -1) {
+      throw new Error('blurhash: invalid base83 character');
+    }
+    value = value * 83 + digit;
+  }
+  return value;
+}
+
+function sRGBToLinear(value: number): number {
+  const v = value / 255;
+  return v <= 0.04045 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+}
+
+function linearTosRGB(value: number): number {
+  const v = Math.max(0, Math.min(1, value));
+  return v <= 0.0031308
+    ? Math.round(v * 12.92 * 255 + 0.5)
+    : Math.round((1.055 * Math.pow(v, 1 / 2.4) - 0.055) * 255 + 0.5);
+}
+
+function signPow(v: number, exp: number): number {
+  return Math.sign(v) * Math.pow(Math.abs(v), exp);
+}
+
+function decodeDC(value: number): [number, number, number] {
+  const r = value >> 16;
+  const g = (value >> 8) & 255;
+  const b = value & 255;
+  return [sRGBToLinear(r), sRGBToLinear(g), sRGBToLinear(b)];
+}
+
+function decodeAC(value: number, maximumValue: number): [number, number, number] {
+  const quantR = Math.floor(value / (19 * 19));
+  const quantG = Math.floor(value / 19) % 19;
+  const quantB = value % 19;
+  return [
+    signPow((quantR - 9) / 9, 2) * maximumValue,
+    signPow((quantG - 9) / 9, 2) * maximumValue,
+    signPow((quantB - 9) / 9, 2) * maximumValue
+  ];
+}
+
+/** Validate that a string is a usable blurhash. Cheap pre-check. */
+export function isValidBlurhash(hash: string | undefined | null): hash is string {
+  if (typeof hash !== 'string' || hash.length < 6) return false;
+  try {
+    const sizeFlag = base83Decode(hash[0]);
+    const numY = Math.floor(sizeFlag / 9) + 1;
+    const numX = (sizeFlag % 9) + 1;
+    return hash.length === 4 + 2 * numX * numY;
+  } catch {
+    return false;
+  }
+}
+
+/** Decode a blurhash to a flat `Uint8ClampedArray` of RGBA pixels.
+ * Exposed so callers that already own a canvas can blit directly. */
+export function decodeBlurhash(
+  hash: string,
+  width: number,
+  height: number,
+  punch = 1
+): Uint8ClampedArray {
+  if (!isValidBlurhash(hash)) {
+    throw new Error('blurhash: malformed hash');
+  }
+  const sizeFlag = base83Decode(hash[0]);
+  const numY = Math.floor(sizeFlag / 9) + 1;
+  const numX = (sizeFlag % 9) + 1;
+  const quantisedMaxValue = base83Decode(hash[1]);
+  const maximumValue = ((quantisedMaxValue + 1) / 166) * punch;
+
+  const colors: [number, number, number][] = new Array(numX * numY);
+  for (let i = 0; i < colors.length; i++) {
+    if (i === 0) {
+      const value = base83Decode(hash.substring(2, 6));
+      colors[i] = decodeDC(value);
+    } else {
+      const value = base83Decode(hash.substring(4 + i * 2, 6 + i * 2));
+      colors[i] = decodeAC(value, maximumValue);
+    }
+  }
+
+  const bytesPerRow = width * 4;
+  const pixels = new Uint8ClampedArray(bytesPerRow * height);
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      let r = 0;
+      let g = 0;
+      let b = 0;
+      for (let j = 0; j < numY; j++) {
+        const basisY = Math.cos((Math.PI * y * j) / height);
+        for (let i = 0; i < numX; i++) {
+          const basis = Math.cos((Math.PI * x * i) / width) * basisY;
+          const color = colors[i + j * numX];
+          r += color[0] * basis;
+          g += color[1] * basis;
+          b += color[2] * basis;
+        }
+      }
+      const o = 4 * x + y * bytesPerRow;
+      pixels[o] = linearTosRGB(r);
+      pixels[o + 1] = linearTosRGB(g);
+      pixels[o + 2] = linearTosRGB(b);
+      pixels[o + 3] = 255;
+    }
+  }
+  return pixels;
+}
+
+/**
+ * Decode a blurhash to a tiny PNG data-URL suitable for use as a CSS
+ * `background-image` or `<img src>` placeholder.
+ *
+ * - SSR-safe: returns `null` when no canvas is available.
+ * - All exceptions (invalid hash, OOM on huge sizes) are swallowed
+ *   into `null` so callers don't need try/catch — the convention is
+ *   "show the bg-secondary fallback tile when this returns null".
+ *
+ * Output size defaults to 32x32, which is plenty for a CSS placeholder
+ * that the browser will upscale + blur via `filter: blur(20px)`.
+ */
+export function blurhashToDataUrl(
+  hash: string | undefined | null,
+  width = 32,
+  height = 32
+): string | null {
+  if (!isValidBlurhash(hash)) return null;
+  try {
+    const pixels = decodeBlurhash(hash, width, height);
+    const canvas = createCanvas(width, height);
+    if (!canvas) return null;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return null;
+    const imageData = ctx.createImageData(width, height);
+    imageData.data.set(pixels);
+    ctx.putImageData(imageData, 0, 0);
+    return canvasToDataUrl(canvas);
+  } catch {
+    return null;
+  }
+}
+
+type AnyCanvas = HTMLCanvasElement | OffscreenCanvas;
+
+function createCanvas(width: number, height: number): AnyCanvas | null {
+  if (typeof OffscreenCanvas !== 'undefined') {
+    try {
+      return new OffscreenCanvas(width, height);
+    } catch {
+      /* fall through */
+    }
+  }
+  if (typeof document !== 'undefined') {
+    const c = document.createElement('canvas');
+    c.width = width;
+    c.height = height;
+    return c;
+  }
+  return null;
+}
+
+function canvasToDataUrl(canvas: AnyCanvas): string | null {
+  // HTMLCanvasElement path — synchronous data URL.
+  if (typeof HTMLCanvasElement !== 'undefined' && canvas instanceof HTMLCanvasElement) {
+    return canvas.toDataURL('image/png');
+  }
+  // OffscreenCanvas has no synchronous `toDataURL`. We render to a
+  // temporary HTMLCanvasElement when one is available, otherwise we
+  // give up rather than block on the async `convertToBlob` path —
+  // callers can re-try on a frame where DOM is available.
+  if (typeof document !== 'undefined') {
+    const fallback = document.createElement('canvas');
+    fallback.width = canvas.width;
+    fallback.height = canvas.height;
+    const fctx = fallback.getContext('2d');
+    if (!fctx) return null;
+    fctx.drawImage(canvas as unknown as CanvasImageSource, 0, 0);
+    return fallback.toDataURL('image/png');
+  }
+  return null;
+}

--- a/src/lib/feed/imeta.test.ts
+++ b/src/lib/feed/imeta.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Tests for the NIP-92 imeta parser and the URL-fallback path.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseImeta, isImageUrl, isVideoUrl } from './imeta';
+
+describe('parseImeta', () => {
+  it('returns empty for events with no media', () => {
+    expect(parseImeta({ content: 'just text', tags: [] })).toEqual([]);
+    expect(parseImeta({ content: '', tags: [] })).toEqual([]);
+    expect(parseImeta({})).toEqual([]);
+  });
+
+  it('parses a single imeta tag with url + mime + dim + blurhash + alt', () => {
+    const event = {
+      content: '',
+      tags: [
+        [
+          'imeta',
+          'url https://nostr.build/i/x.jpg',
+          'm image/jpeg',
+          'dim 1920x1080',
+          'blurhash LkO~xqj[ofa#fkj[ayj[~qfQayj[',
+          'alt A bowl of soup'
+        ]
+      ]
+    };
+    const items = parseImeta(event);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      url: 'https://nostr.build/i/x.jpg',
+      mime: 'image/jpeg',
+      dim: { w: 1920, h: 1080 },
+      blurhash: 'LkO~xqj[ofa#fkj[ayj[~qfQayj[',
+      alt: 'A bowl of soup'
+    });
+  });
+
+  it('parses multiple imeta tags in order', () => {
+    const event = {
+      content: '',
+      tags: [
+        ['imeta', 'url https://nostr.build/i/a.jpg', 'm image/jpeg'],
+        ['imeta', 'url https://nostr.build/i/b.png', 'm image/png'],
+        ['imeta', 'url https://nostr.build/i/c.gif', 'm image/gif']
+      ]
+    };
+    const items = parseImeta(event);
+    expect(items.map((i) => i.url)).toEqual([
+      'https://nostr.build/i/a.jpg',
+      'https://nostr.build/i/b.png',
+      'https://nostr.build/i/c.gif'
+    ]);
+  });
+
+  it('infers mime from extension when imeta omits `m`', () => {
+    const event = {
+      content: '',
+      tags: [['imeta', 'url https://example.com/x.webp']]
+    };
+    expect(parseImeta(event)[0].mime).toBe('image/webp');
+  });
+
+  it('collects multiple `fallback` slots on a single tag', () => {
+    const event = {
+      content: '',
+      tags: [
+        [
+          'imeta',
+          'url https://primary/x.jpg',
+          'fallback https://mirror1/x.jpg',
+          'fallback https://mirror2/x.jpg'
+        ]
+      ]
+    };
+    const item = parseImeta(event)[0];
+    expect(item.fallback).toEqual(['https://mirror1/x.jpg', 'https://mirror2/x.jpg']);
+  });
+
+  it('rejects imeta tags with no `url` slot', () => {
+    const event = {
+      content: '',
+      tags: [
+        ['imeta', 'm image/jpeg', 'dim 100x100'],
+        ['imeta', 'url https://ok.example/x.jpg']
+      ]
+    };
+    const items = parseImeta(event);
+    expect(items).toHaveLength(1);
+    expect(items[0].url).toBe('https://ok.example/x.jpg');
+  });
+
+  it('ignores malformed `dim` values', () => {
+    const event = {
+      content: '',
+      tags: [
+        ['imeta', 'url https://example.com/x.jpg', 'dim not-a-dimension'],
+        ['imeta', 'url https://example.com/y.jpg', 'dim 0x0'],
+        ['imeta', 'url https://example.com/z.jpg', 'dim 800x600']
+      ]
+    };
+    const items = parseImeta(event);
+    expect(items[0].dim).toBeUndefined();
+    expect(items[1].dim).toBeUndefined();
+    expect(items[2].dim).toEqual({ w: 800, h: 600 });
+  });
+
+  it('preserves spaces inside the alt value', () => {
+    const event = {
+      content: '',
+      tags: [['imeta', 'url https://x/a.jpg', 'alt A long alt with multiple words']]
+    };
+    expect(parseImeta(event)[0].alt).toBe('A long alt with multiple words');
+  });
+
+  it('captures the sha256 hash from `x`', () => {
+    const event = {
+      content: '',
+      tags: [['imeta', 'url https://x/a.jpg', 'x abc123def456']]
+    };
+    expect(parseImeta(event)[0].hash).toBe('abc123def456');
+  });
+
+  it('falls back to URL extraction when no imeta tags are present', () => {
+    const event = {
+      content: 'check out https://nostr.build/i/photo.jpg and https://example.com/movie.mp4',
+      tags: []
+    };
+    const items = parseImeta(event);
+    expect(items.map((i) => i.url)).toEqual([
+      'https://nostr.build/i/photo.jpg',
+      'https://example.com/movie.mp4'
+    ]);
+    expect(items[0].mime).toBe('image/jpeg');
+    expect(items[1].mime).toBe('video/mp4');
+  });
+
+  it('dedupes repeated URLs in the fallback path', () => {
+    const event = {
+      content: 'a https://x.com/a.png b https://x.com/a.png c',
+      tags: []
+    };
+    expect(parseImeta(event)).toHaveLength(1);
+  });
+
+  it('does NOT merge imeta with content URLs when imeta is present', () => {
+    // Damus/Amethyst/Jumble all behave this way — an event that
+    // provides imeta is trusted to declare its full media set.
+    const event = {
+      content: 'https://content/in-body.jpg',
+      tags: [['imeta', 'url https://imeta-only.jpg']]
+    };
+    const items = parseImeta(event);
+    expect(items).toHaveLength(1);
+    expect(items[0].url).toBe('https://imeta-only.jpg');
+  });
+
+  it('strips trailing punctuation from content URLs', () => {
+    const event = {
+      content: 'See https://x.com/a.jpg, also https://y.com/b.png.',
+      tags: []
+    };
+    const urls = parseImeta(event).map((i) => i.url);
+    expect(urls).toContain('https://x.com/a.jpg');
+    expect(urls).toContain('https://y.com/b.png');
+  });
+
+  it('skips non-image, non-video URLs in fallback extraction', () => {
+    const event = {
+      content: 'https://example.com/article and https://example.com/photo.jpg',
+      tags: []
+    };
+    const items = parseImeta(event);
+    expect(items).toHaveLength(1);
+    expect(items[0].url).toBe('https://example.com/photo.jpg');
+  });
+
+  it('classifies known image hosts without an extension', () => {
+    const event = {
+      content: 'https://image.nostr.build/abc123',
+      tags: []
+    };
+    expect(parseImeta(event)).toHaveLength(1);
+  });
+});
+
+describe('isImageUrl', () => {
+  it('accepts common image extensions', () => {
+    expect(isImageUrl('https://x.com/a.jpg')).toBe(true);
+    expect(isImageUrl('https://x.com/a.JPEG')).toBe(true);
+    expect(isImageUrl('https://x.com/a.png?cache=1')).toBe(true);
+    expect(isImageUrl('https://x.com/a.webp')).toBe(true);
+    expect(isImageUrl('https://x.com/a.avif')).toBe(true);
+  });
+  it('accepts known image hosts', () => {
+    expect(isImageUrl('https://image.nostr.build/abc')).toBe(true);
+    expect(isImageUrl('https://primal.b-cdn.net/foo')).toBe(true);
+    expect(isImageUrl('https://i.ibb.co/bar')).toBe(true);
+  });
+  it('rejects malformed URLs and non-images', () => {
+    expect(isImageUrl('not a url')).toBe(false);
+    expect(isImageUrl('https://example.com/page')).toBe(false);
+  });
+});
+
+describe('isVideoUrl', () => {
+  it('accepts common video extensions', () => {
+    expect(isVideoUrl('https://x.com/a.mp4')).toBe(true);
+    expect(isVideoUrl('https://x.com/a.webm')).toBe(true);
+    expect(isVideoUrl('https://x.com/a.MOV')).toBe(true);
+  });
+  it('rejects non-video URLs', () => {
+    expect(isVideoUrl('https://x.com/a.jpg')).toBe(false);
+    expect(isVideoUrl('not a url')).toBe(false);
+  });
+});

--- a/src/lib/feed/imeta.ts
+++ b/src/lib/feed/imeta.ts
@@ -1,0 +1,208 @@
+/**
+ * NIP-92 `imeta` tag parser.
+ *
+ * NIP-92 attaches inline-media metadata to a note via repeated `imeta`
+ * tags whose remaining slots are space-separated `key value` pairs:
+ *
+ *   ["imeta",
+ *     "url https://nostr.build/i/x.jpg",
+ *     "m image/jpeg",
+ *     "dim 1920x1080",
+ *     "blurhash LkO~xq...",
+ *     "alt A bowl of soup",
+ *     "x <sha256>",
+ *     "fallback https://other.host/x.jpg"]
+ *
+ * Each tag describes ONE media URL. The `url` field is mandatory; the
+ * rest are best-effort.
+ *
+ * When a note has no `imeta` tags we fall back to extracting raw URLs
+ * from `event.content` and classifying them with the same heuristics
+ * `NoteContent.svelte` uses today (extension + known-host list). The
+ * fallback never produces `dim`, `blurhash`, or `alt` — those only come
+ * from `imeta` tags or, in future phases, from a side-channel HEAD
+ * probe (out of scope here).
+ *
+ * This module is framework-free and synchronous; safe to import in any
+ * context (SSR or client).
+ */
+
+import type { MediaItem } from './types';
+
+interface RawEventLike {
+  content?: string;
+  tags?: string[][];
+}
+
+// Extension regexes — mirror NoteContent.svelte so behavior matches the
+// pre-overhaul feed exactly.
+const IMAGE_EXT = /\.(jpg|jpeg|png|gif|webp|svg|bmp|avif)(\?.*)?$/i;
+const VIDEO_EXT = /\.(mp4|webm|mov|avi|mkv|m4v)(\?.*)?$/i;
+
+// URL extraction regex. Matches http/https URLs anywhere in plain text;
+// trailing punctuation (period, comma, paren, etc.) is trimmed below.
+const URL_RE = /\bhttps?:\/\/[^\s<>"']+/gi;
+
+// Trailing punctuation chars commonly attached to URLs in note text.
+const TRAILING_PUNCT = /[.,;:!?)\]}>"'`]+$/;
+
+/** Best-effort image-URL classifier. Mirrors `NoteContent.svelte`'s
+ * `isImageUrl` so the fallback path produces the same media list the
+ * old feed did. */
+export function isImageUrl(url: string): boolean {
+  try {
+    const u = new URL(url);
+    if (IMAGE_EXT.test(u.pathname)) return true;
+    const host = u.hostname.toLowerCase();
+    if (host.includes('image.nostr.build')) return true;
+    if (host.includes('nostr.build') && u.pathname.includes('/i/')) return true;
+    if (host.includes('imgur.com')) return true;
+    if (host.includes('imgproxy')) return true;
+    if (host.includes('primal.b-cdn.net')) return true;
+    if (host.includes('media.tenor.com')) return true;
+    if (host.includes('i.ibb.co')) return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/** Best-effort video-URL classifier. */
+export function isVideoUrl(url: string): boolean {
+  try {
+    const u = new URL(url);
+    return VIDEO_EXT.test(u.pathname);
+  } catch {
+    return false;
+  }
+}
+
+/** Parse the `dim` value from an imeta entry. Returns `undefined` for
+ * malformed input rather than throwing. */
+function parseDim(raw: string | undefined): { w: number; h: number } | undefined {
+  if (!raw) return undefined;
+  const m = raw.match(/^(\d+)\s*x\s*(\d+)$/i);
+  if (!m) return undefined;
+  const w = Number(m[1]);
+  const h = Number(m[2]);
+  if (!Number.isFinite(w) || !Number.isFinite(h) || w <= 0 || h <= 0) return undefined;
+  return { w, h };
+}
+
+/** Coarse MIME inference from URL extension when imeta `m` is absent. */
+function inferMime(url: string): string {
+  try {
+    const path = new URL(url).pathname.toLowerCase();
+    if (path.endsWith('.jpg') || path.endsWith('.jpeg')) return 'image/jpeg';
+    if (path.endsWith('.png')) return 'image/png';
+    if (path.endsWith('.gif')) return 'image/gif';
+    if (path.endsWith('.webp')) return 'image/webp';
+    if (path.endsWith('.avif')) return 'image/avif';
+    if (path.endsWith('.svg')) return 'image/svg+xml';
+    if (path.endsWith('.bmp')) return 'image/bmp';
+    if (path.endsWith('.mp4') || path.endsWith('.m4v')) return 'video/mp4';
+    if (path.endsWith('.webm')) return 'video/webm';
+    if (path.endsWith('.mov')) return 'video/quicktime';
+    if (path.endsWith('.mkv')) return 'video/x-matroska';
+  } catch {
+    /* fall through */
+  }
+  // Coarse fallback: classify, but mark as wildcard so downstream code
+  // knows the exact type is unknown.
+  if (isVideoUrl(url)) return 'video/*';
+  return 'image/*';
+}
+
+/** Walk an imeta tag's remaining slots and collect `key value` pairs
+ * into a map. Per NIP-92 each slot has a single space separating the
+ * key from the (possibly space-containing) value. */
+function parseImetaSlots(tag: string[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  // Slot 0 is the literal "imeta"; skip.
+  for (let i = 1; i < tag.length; i++) {
+    const slot = tag[i];
+    if (typeof slot !== 'string') continue;
+    const sep = slot.indexOf(' ');
+    if (sep === -1) continue;
+    const key = slot.slice(0, sep).toLowerCase();
+    const value = slot.slice(sep + 1).trim();
+    if (!key || !value) continue;
+    // `fallback` may appear multiple times within a single imeta tag —
+    // collect them into a comma-separated holding string and split out
+    // below. Other keys are last-write-wins, matching common practice.
+    if (key === 'fallback' && out.fallback) {
+      out.fallback = `${out.fallback}\n${value}`;
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+/** Build a `MediaItem` from one imeta tag. Returns `null` if the tag
+ * lacks a usable URL. */
+function imetaToMediaItem(tag: string[]): MediaItem | null {
+  const slots = parseImetaSlots(tag);
+  const url = slots.url;
+  if (!url) return null;
+  const item: MediaItem = {
+    url,
+    mime: slots.m || inferMime(url)
+  };
+  const dim = parseDim(slots.dim);
+  if (dim) item.dim = dim;
+  if (slots.blurhash) item.blurhash = slots.blurhash;
+  if (slots.alt) item.alt = slots.alt;
+  if (slots.x) item.hash = slots.x;
+  if (slots.fallback) {
+    item.fallback = slots.fallback
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  return item;
+}
+
+/** Extract bare image/video URLs from note content. Used as the fallback
+ * when no `imeta` tags are present. Preserves source order and dedupes
+ * — if the same URL appears twice in the body we only render once. */
+function extractMediaUrls(content: string): MediaItem[] {
+  if (!content) return [];
+  const out: MediaItem[] = [];
+  const seen = new Set<string>();
+  const matches = content.match(URL_RE) || [];
+  for (const raw of matches) {
+    const cleaned = raw.replace(TRAILING_PUNCT, '');
+    if (!cleaned || seen.has(cleaned)) continue;
+    if (!isImageUrl(cleaned) && !isVideoUrl(cleaned)) continue;
+    seen.add(cleaned);
+    out.push({ url: cleaned, mime: inferMime(cleaned) });
+  }
+  return out;
+}
+
+/**
+ * Parse media items from a Nostr event.
+ *
+ * Strategy:
+ *   1. Collect all `imeta` tags. Each yields one MediaItem with the
+ *      richest metadata available.
+ *   2. If the event has zero usable imeta tags, fall back to scanning
+ *      the content for bare URLs.
+ *   3. The two paths are intentionally exclusive: an event that
+ *      provides imeta is trusted to declare its full media set, so we
+ *      do NOT merge imeta with content-extracted URLs (matches the
+ *      behavior of Damus, Amethyst, and Jumble — and prevents
+ *      double-rendering when a note links to its own imeta'd image).
+ */
+export function parseImeta(event: RawEventLike): MediaItem[] {
+  const tags = event.tags || [];
+  const imeta: MediaItem[] = [];
+  for (const t of tags) {
+    if (!Array.isArray(t) || t.length < 2 || t[0] !== 'imeta') continue;
+    const item = imetaToMediaItem(t);
+    if (item) imeta.push(item);
+  }
+  if (imeta.length > 0) return imeta;
+  return extractMediaUrls(event.content || '');
+}

--- a/src/lib/feed/types.ts
+++ b/src/lib/feed/types.ts
@@ -1,0 +1,127 @@
+/**
+ * Shared types for the feed overhaul (Phase 0 — Foundations).
+ *
+ * These are framework-free view-model types — derived from raw NDK events
+ * by `normalize.ts` in Phase 2 and consumed by the new `FeedNote.*`
+ * component tree in Phase 4. They are NOT persisted anywhere; they are
+ * always recomputed from the underlying NDKEvent on read, so changing
+ * shapes here never invalidates the IndexedDB caches.
+ */
+
+/** Image / video item parsed from a note. Dimensions, blurhash, and alt
+ * come from NIP-92 `imeta` tags when present; otherwise only `url` and a
+ * best-guess `mime` are populated. */
+export interface MediaItem {
+  url: string;
+  /** Best-effort MIME type — derived from imeta `m`, from the URL
+   * extension as a fallback, or `'image/*'` / `'video/*'` when only the
+   * coarse kind is known. */
+  mime: string;
+  /** Pixel dimensions from imeta `dim` (e.g. `"1920x1080"`). Used by
+   * MediaTile to reserve aspect-ratio and kill CLS. */
+  dim?: { w: number; h: number };
+  /** Blurhash placeholder per NIP-92 `blurhash`. Decoded to a data URL
+   * lazily by `blurhash.ts`. */
+  blurhash?: string;
+  /** Alt text per NIP-92 `alt`. */
+  alt?: string;
+  /** Additional URLs (per NIP-92 `fallback`) tried if the primary URL
+   * errors. */
+  fallback?: string[];
+  /** Optional `x` (sha256) from imeta — for content addressing /
+   * deduplication. Not used today but cheap to carry. */
+  hash?: string;
+}
+
+/** A repost wrapper (kind 6 / kind 16). The repost's body is the inner
+ * event; the outer `vm` is rendered as a "X reposted" shell by
+ * `FeedNoteRepost.svelte` (Phase 4). */
+export interface RepostVM {
+  /** Pubkey of the user who reposted. */
+  reposterPubkey: string;
+  /** Timestamp of the repost action. */
+  repostedAt: number;
+  /** Inner event's id, so the FeedNoteRepost can resolve it from
+   * `eventStore` / NDK cache. */
+  innerEventId: string;
+  /** Inner event's pubkey when available from the kind-6 `p` tag. */
+  innerPubkey?: string;
+  /** The inner event's view-model once resolved. Null while loading. */
+  inner: FeedNoteVM | null;
+}
+
+/** A quoted / embedded event (`nostr:nevent1…` inside the body or a `q`
+ * tag). Rendered inline by `FeedNoteBody`. */
+export interface EmbedVM {
+  /** Bech32 reference (nevent / note / naddr) as it appears in source. */
+  ref: string;
+  /** Resolved event id, when decoded. */
+  eventId?: string;
+  /** Resolved view-model once fetched. Null while loading. */
+  inner: FeedNoteVM | null;
+}
+
+/** Feed view model — what `FeedNote.svelte` consumes. Built once per
+ * event by `normalize.ts` (Phase 2) and memoized by event id so passing
+ * the same event through multiple sources reuses the same instance. */
+export interface FeedNoteVM {
+  /** Stable identity — the underlying event id, hex. */
+  id: string;
+  /** Author pubkey, hex. */
+  pubkey: string;
+  /** Event kind. 1 / 6 / 16 are the common feed kinds; 30023 / 30024
+   * (long-form / draft) fall back to the legacy path in Phase 6. */
+  kind: number;
+  /** created_at, seconds. */
+  createdAt: number;
+  /** Raw note content. Rendered by `FeedNoteBody` after parsing. */
+  content: string;
+  /** Parallel arrays of tags as they appear on the event — kept so
+   * downstream code can read e.g. `client`, `subject`, `t` hashtags
+   * without going back to NDK. */
+  tags: string[][];
+  /** Parsed media (images + videos), in source order. Empty if the note
+   * has none. */
+  media: MediaItem[];
+  /** Quoted events found in the body or via `q` tags. */
+  embeds: EmbedVM[];
+  /** Populated when `kind === 6 || kind === 16` (NIP-18 repost). */
+  repost?: RepostVM;
+  /** Pubkeys mentioned via `p` tags or `nostr:nprofile1…` — used to
+   * pre-warm `profileCache` for the visible window. */
+  mentionedPubkeys: string[];
+  /** Hashtags from `t` tags, lower-cased. */
+  hashtags: string[];
+  /** Client attribution from the `client` tag, if present. */
+  client?: string;
+  /** Set when the note is a reply (has a non-mention `e` tag). */
+  replyTo?: { rootId?: string; parentId?: string };
+}
+
+/** The feed tab the user is viewing. URL-bookmarkable via the
+ * `?tab=` searchParam on `/community`. */
+export type FeedTab = 'global' | 'following' | 'replies' | 'members' | 'garden';
+
+/** Pagination cursor passed to `FeedSource.loadMore()`. Matches the
+ * `since` / `until` convention used by the existing monolith so cursor
+ * semantics port verbatim in Phase 2. */
+export interface FeedCursor {
+  until?: number;
+  since?: number;
+}
+
+/** Reactive state surface a `FeedSource` exposes. Consumed by
+ * `FeedContainer` / `VirtualFeedList` (Phase 5). */
+export interface FeedSourceState {
+  /** Events in display order (newest first). */
+  events: FeedNoteVM[];
+  /** True while the initial fetch is in flight. */
+  loading: boolean;
+  /** True while a `loadMore` is in flight. */
+  loadingMore: boolean;
+  /** False when the source has reached its tail (or determined there's
+   * nothing further to fetch in this session). */
+  hasMore: boolean;
+  /** Non-null when the last fetch errored. */
+  error: string | null;
+}


### PR DESCRIPTION
## Summary

Phase 0 of the planned feed overhaul. Lays down the type and parsing primitives that subsequent phases depend on, with no production wiring and no runtime side-effects. Nothing is visible to users in this PR.

See \`/Users/daniel/.claude/plans/cached-waddling-treasure.md\` for the full overhaul plan (8 phases). This is the smallest, safest first slice.

### What's new

- \`src/lib/feed/types.ts\` — view-model types (\`FeedNoteVM\`, \`MediaItem\`, \`RepostVM\`, \`EmbedVM\`, \`FeedTab\`, \`FeedCursor\`, \`FeedSourceState\`). Framework-free. Always recomputed from cached \`NDKEvent\`s on read — **no IndexedDB schema changes**, so warm caches in production aren't invalidated.
- \`src/lib/feed/imeta.ts\` — NIP-92 \`imeta\` tag parser (\`parseImeta\`, \`isImageUrl\`, \`isVideoUrl\`). Reads \`url\`, \`m\`, \`dim\`, \`blurhash\`, \`alt\`, \`x\`, \`fallback\` slots. When no \`imeta\` tags are present, falls back to scanning \`event.content\` for raw image/video URLs using the same hostname + extension heuristics \`NoteContent.svelte\` uses today — so fallback-path media lists exactly match the current feed.
- \`src/lib/feed/blurhash.ts\` — hand-ported canonical blurhash decoder (~200 LOC) instead of the \`blurhash\` npm dep. Exports \`isValidBlurhash\`, \`decodeBlurhash\` (pixel buffer), and \`blurhashToDataUrl\` (PNG data URL via canvas). SSR-safe: returns \`null\` when no canvas is available, so callers paint a solid \`--color-bg-secondary\` tile.
- \`src/lib/feed/imeta.test.ts\` (20 tests) + \`src/lib/feed/blurhash.test.ts\` (11 tests).

### Test plan

- [x] \`pnpm test src/lib/feed/\` — 31/31 tests pass.
- [x] \`pnpm check\` / \`tsc --noEmit\` — clean.
- [ ] \`pnpm build\` on Vercel preview — should succeed identically to main (no production paths touched).

### What's NOT in this PR

- No component changes.
- No \`/community\` or \`/[nip19]\` route changes.
- No new IndexedDB tables or schema bumps.
- No new bundle-size contribution to production routes (the new module is unimported by anything user-facing yet).

The Phase 1 PR (\`feat/feed-media-gallery\`) will be the first user-visible step — adding the gallery grid + Lightbox components behind a dev-only demo route.