### PR TITLE
feat(souschef): consolidate to single smart input + purple theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.442",
+  "version": "4.2.443",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.444",
+  "version": "4.2.445",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.443",
+  "version": "4.2.444",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/parseRecipe.server.ts
+++ b/src/lib/parseRecipe.server.ts
@@ -208,8 +208,22 @@ async function fetchUrlContent(
     if (!parsed.ok) throw new Error(parsed.reason);
 
     const fetchTarget = parsed.url.toString();
+    // Browser-shaped User-Agent. The prior `ZapCooking/1.0 bot` UA was
+    // 403'd on sight by Cloudflare/Akamai-fronted recipe sites
+    // (AllRecipes, Bon Appétit, NYT Cooking, etc.), which made the
+    // URL-import feature unusable for most mainstream sources. These
+    // are user-initiated, one-at-a-time imports — not crawling — so a
+    // generic browser UA reflects the actual traffic shape. Sites
+    // with TLS fingerprinting or JS challenges will still block; this
+    // only fixes naive UA-based bot detection.
     const response = await fetch(fetchTarget, {
-      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; ZapCooking/1.0; +https://zap.cooking)' },
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Accept':
+          'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.9'
+      },
       redirect: 'manual'
     });
 

--- a/src/lib/souschefDetect.test.ts
+++ b/src/lib/souschefDetect.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for the unified Sous Chef input auto-detection.
+ *
+ * The contract is narrow on purpose — we want false-positive URL
+ * detection to be impossible (a recipe pasted with a source link at
+ * the top must NOT be routed to the rate-limited URL path), and we
+ * want short partial input to stay in `null` state so the submit
+ * button doesn't enable while the user is mid-keystroke.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { detectMode } from './souschefDetect';
+
+const SAMPLE_URL = 'https://example.com/recipes/sheet-pan-chicken';
+// A 30+ char string is the threshold for text mode. This sample is
+// well above to make tests resilient to small phrasing tweaks.
+const SAMPLE_RECIPE_TEXT =
+  'Heat 2 tbsp olive oil in a large skillet over medium heat until shimmering.';
+
+describe('detectMode', () => {
+  describe('empty / whitespace input', () => {
+    it('returns null for an empty string', () => {
+      expect(detectMode('', false)).toBe(null);
+    });
+
+    it('returns null for whitespace-only input', () => {
+      expect(detectMode('   ', false)).toBe(null);
+      expect(detectMode('\n\n\t  ', false)).toBe(null);
+    });
+  });
+
+  describe('URL detection', () => {
+    it("returns 'url' for a single trimmed URL", () => {
+      expect(detectMode(SAMPLE_URL, false)).toBe('url');
+    });
+
+    it("returns 'url' for a URL with leading/trailing whitespace", () => {
+      expect(detectMode(`  ${SAMPLE_URL}  `, false)).toBe('url');
+      expect(detectMode(`\n${SAMPLE_URL}\n`, false)).toBe('url');
+    });
+
+    it("accepts http:// in addition to https://", () => {
+      expect(detectMode('http://example.com/recipe', false)).toBe('url');
+    });
+
+    it("is case-insensitive on the scheme", () => {
+      expect(detectMode('HTTPS://Example.com/Recipe', false)).toBe('url');
+    });
+  });
+
+  describe('text-mode false-positive guards', () => {
+    it("routes a URL on line 1 with recipe text below to 'text'", () => {
+      const input = `${SAMPLE_URL}\n\nIngredients:\n- 2 tbsp olive oil\n- 1 chicken breast`;
+      expect(detectMode(input, false)).toBe('text');
+    });
+
+    it("routes a URL with trailing text on the same line to 'text'", () => {
+      const input = `${SAMPLE_URL} this looks great`;
+      expect(detectMode(input, false)).toBe('text');
+    });
+
+    it("routes 'see <url>' style citations to 'text'", () => {
+      const input = `Sheet pan chicken — see ${SAMPLE_URL} for the original`;
+      expect(detectMode(input, false)).toBe('text');
+    });
+  });
+
+  describe('text detection', () => {
+    it("returns 'text' for multi-line recipe text with no URL", () => {
+      const input = 'Ingredients:\n- 2 cups flour\n- 1 tsp salt\n- 1 egg\n\nDirections:\n1. Mix dry ingredients.';
+      expect(detectMode(input, false)).toBe('text');
+    });
+
+    it("returns 'text' for the sample recipe sentence (well over 30 chars)", () => {
+      expect(detectMode(SAMPLE_RECIPE_TEXT, false)).toBe('text');
+    });
+  });
+
+  describe('short-input threshold', () => {
+    it('returns null for text under 30 chars with no URL', () => {
+      expect(detectMode('chicken with rice', false)).toBe(null);
+      expect(detectMode('quick recipe', false)).toBe(null);
+    });
+
+    it('returns null for text exactly at 29 chars', () => {
+      const twentyNine = 'a'.repeat(29);
+      expect(twentyNine.length).toBe(29); // sanity check
+      expect(detectMode(twentyNine, false)).toBe(null);
+    });
+
+    it("returns 'text' for text exactly at the 30-char threshold", () => {
+      const thirty = 'a'.repeat(30);
+      expect(thirty.length).toBe(30); // sanity check
+      expect(detectMode(thirty, false)).toBe('text');
+    });
+  });
+
+  describe('image precedence', () => {
+    it("returns 'image' when hasImage is true regardless of text", () => {
+      expect(detectMode('', true)).toBe('image');
+      expect(detectMode('   ', true)).toBe('image');
+      expect(detectMode(SAMPLE_URL, true)).toBe('image');
+      expect(detectMode(SAMPLE_RECIPE_TEXT, true)).toBe('image');
+    });
+
+    it("returns 'image' even when text would otherwise be a clean URL", () => {
+      // Image always wins — we don't support multi-modal input in
+      // Phase 1, so this is the intentional contract: a staged image
+      // ignores any URL the user may have started pasting.
+      expect(detectMode(SAMPLE_URL, true)).toBe('image');
+    });
+  });
+});

--- a/src/lib/souschefDetect.ts
+++ b/src/lib/souschefDetect.ts
@@ -24,9 +24,11 @@ export function detectMode(text: string, hasImage: boolean): SousChefMode | null
   if (hasImage) return 'image';
   const trimmed = text.trim();
   if (trimmed.length === 0) return null;
-  // URL only if the entire trimmed input is a single URL token —
-  // no internal whitespace, no trailing content.
-  if (/^https?:\/\/\S+$/i.test(trimmed) && !/\s/.test(trimmed)) return 'url';
+  // URL only if the entire trimmed input is a single URL token.
+  // The anchored `^...$` plus `\S+` guarantees no whitespace
+  // anywhere in the string — a recipe pasted with a source link at
+  // the top falls through to the text branch below.
+  if (/^https?:\/\/\S+$/i.test(trimmed)) return 'url';
   if (trimmed.length >= 30) return 'text';
   return null;
 }

--- a/src/lib/souschefDetect.ts
+++ b/src/lib/souschefDetect.ts
@@ -1,0 +1,32 @@
+/**
+ * Auto-detection for the unified Sous Chef input. Consumed by
+ * `src/routes/souschef/+page.svelte` to derive the active import mode
+ * from a single textarea + optional staged image, replacing the prior
+ * three-tab UI.
+ *
+ * Rules (kept narrow on purpose):
+ *   - `hasImage` wins. If an image is staged, mode is always `'image'`
+ *     regardless of any text in the textarea (we don't support
+ *     multi-modal input — see the consolidation prompt's "out of
+ *     scope" list).
+ *   - URL only if the entire trimmed input is a single URL token. A
+ *     URL on line 1 with recipe text below routes to `'text'` so we
+ *     don't accidentally throw the user into the rate-limited URL
+ *     path when they pasted a recipe with a source link.
+ *   - Text mode requires ≥30 trimmed characters. Below that we return
+ *     `null` so the submit button stays disabled while the user is
+ *     still typing the first word.
+ */
+
+export type SousChefMode = 'image' | 'url' | 'text';
+
+export function detectMode(text: string, hasImage: boolean): SousChefMode | null {
+  if (hasImage) return 'image';
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return null;
+  // URL only if the entire trimmed input is a single URL token —
+  // no internal whitespace, no trailing content.
+  if (/^https?:\/\/\S+$/i.test(trimmed) && !/\s/.test(trimmed)) return 'url';
+  if (trimmed.length >= 30) return 'text';
+  return null;
+}

--- a/src/routes/souschef/+page.svelte
+++ b/src/routes/souschef/+page.svelte
@@ -198,7 +198,7 @@
     await processImageFile(files[0]);
   }
 
-  async function processImageFile(file: File) {
+  async function processImageFile(file: File): Promise<void> {
     if (!file.type.startsWith('image/')) {
       extractionError = 'Please upload an image file (JPG, PNG, WEBP, or GIF)';
       return;
@@ -210,17 +210,24 @@
       return;
     }
 
-    // Read as base64
-    const reader = new FileReader();
-    reader.onload = () => {
-      uploadedImageData = reader.result as string;
-      uploadedImagePreview = uploadedImageData;
-      extractionError = '';
-    };
-    reader.onerror = () => {
-      extractionError = 'Failed to read image file';
-    };
-    reader.readAsDataURL(file);
+    // Read as base64. Wrap FileReader's callback API in a Promise so
+    // `await processImageFile(...)` actually waits for the read to
+    // finish — otherwise the await resolves the instant we call
+    // `readAsDataURL`, before `uploadedImageData` is populated.
+    await new Promise<void>((resolve) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        uploadedImageData = reader.result as string;
+        uploadedImagePreview = uploadedImageData;
+        extractionError = '';
+        resolve();
+      };
+      reader.onerror = () => {
+        extractionError = 'Failed to read image file';
+        resolve();
+      };
+      reader.readAsDataURL(file);
+    });
   }
 
   // Paste handler — the hint promises ⌘V works for images, so we
@@ -244,6 +251,10 @@
   function removeImage() {
     uploadedImageData = null;
     uploadedImagePreview = null;
+    // Clear the file input value so picking the same file again
+    // re-fires `change`. Browsers don't fire `change` when the new
+    // FileList matches the prior one.
+    if (fileInput) fileInput.value = '';
   }
   
   // Detection runs live on input/drop/paste. Text mode requires ≥30
@@ -700,6 +711,7 @@
           >
             <textarea
               id="souschef-input"
+              aria-label="Recipe input. Paste a URL, paste recipe text, or drop a photo."
               bind:value={textInput}
               on:paste={handlePaste}
               placeholder="Paste a recipe URL, paste recipe text, or drop a photo…"

--- a/src/routes/souschef/+page.svelte
+++ b/src/routes/souschef/+page.svelte
@@ -17,14 +17,13 @@
     ANON_IMPORT_MAX_AGE_MS,
     type AnonImportHandoff
   } from '$lib/anonImport';
+  import { detectMode } from '$lib/souschefDetect';
   import Button from '../../components/Button.svelte';
-  import Tabs from '../../components/Tabs.svelte';
   import TagsComboBox from '../../components/TagsComboBox.svelte';
   import StringComboBox from '../../components/StringComboBox.svelte';
   import MediaUploader from '../../components/MediaUploader.svelte';
   import MarkdownEditor from '../../components/MarkdownEditor.svelte';
   import UploadIcon from 'phosphor-svelte/lib/UploadSimple';
-  import LinkIcon from 'phosphor-svelte/lib/Link';
   import SparkleIcon from 'phosphor-svelte/lib/Sparkle';
   import ArrowsClockwiseIcon from 'phosphor-svelte/lib/ArrowsClockwise';
   import WarningIcon from 'phosphor-svelte/lib/Warning';
@@ -52,36 +51,22 @@
   let isAnonPreview = false;
   let anonPreviewSourceUrl = '';
   
-  // Input mode
-  type InputMode = 'image' | 'url' | 'text';
-  let inputMode: InputMode = 'url';
-  const ALL_TABS = [
-    { id: 'image', label: 'Upload Image' },
-    { id: 'url', label: 'Paste URL' },
-    { id: 'text', label: 'Paste Text' }
-  ];
-  // URL import is free for everyone; image/text stay behind the member
-  // gate. Non-members see a URL-only tab set so the premium surfaces
-  // aren't advertised to them inline. Initialize optimistically to the
-  // URL-only set — the reactive statement below widens to ALL_TABS
-  // once `hasMembership` resolves.
-  let tabs: { id: string; label: string }[] = ALL_TABS.filter((t) => t.id === 'url');
-  $: tabs = hasMembership ? ALL_TABS : ALL_TABS.filter((t) => t.id === 'url');
-  $: if (!hasMembership && inputMode !== 'url') inputMode = 'url';
+  // Input mode — derived from the unified input via `detectMode`
+  // (extracted to `$lib/souschefDetect` so it can be unit-tested).
+  // The page used to split image / URL / text behind explicit tabs;
+  // now a single textarea + drop zone auto-detects from the content.
+  // Downstream code (extractRecipe, image rehost) still branches on
+  // the mode, so the discriminator survives — it just isn't
+  // user-selectable.
 
-  // Text input state
+  // Unified input state. `textInput` holds either a URL or pasted
+  // recipe text; `uploadedImageData` is set on drop/paste/upload.
   let textInput = '';
-
-  // Image upload state
   let fileInput: HTMLInputElement;
   let isDragging = false;
   let uploadedImageData: string | null = null;
   let uploadedImagePreview: string | null = null;
-  
-  // URL input state
-  let urlInput = '';
-  let urlError = '';
-  
+
   // Publishing state
   let isPublishing = false;
   let publishError = '';
@@ -183,23 +168,6 @@
     // { sourceUrl: anonPreviewSourceUrl }.
   }
   
-  // Handle tab change
-  function handleTabChange(event: CustomEvent<string>) {
-    inputMode = event.detail as InputMode;
-    clearInputs();
-  }
-  
-  // Clear all inputs
-  function clearInputs() {
-    uploadedImageData = null;
-    uploadedImagePreview = null;
-    urlInput = '';
-    urlError = '';
-    textInput = '';
-    extractionError = '';
-    extractionSuccess = false;
-  }
-  
   // Image handling
   function handleDrop(e: DragEvent) {
     e.preventDefault();
@@ -227,19 +195,21 @@
   
   async function handleFiles(files: FileList) {
     if (files.length === 0) return;
-    
-    const file = files[0];
+    await processImageFile(files[0]);
+  }
+
+  async function processImageFile(file: File) {
     if (!file.type.startsWith('image/')) {
       extractionError = 'Please upload an image file (JPG, PNG, WEBP, or GIF)';
       return;
     }
-    
+
     // Check file size (max 20MB for OpenAI)
     if (file.size > 20 * 1024 * 1024) {
       extractionError = 'Image file is too large. Please use an image under 20MB.';
       return;
     }
-    
+
     // Read as base64
     const reader = new FileReader();
     reader.onload = () => {
@@ -252,33 +222,38 @@
     };
     reader.readAsDataURL(file);
   }
-  
+
+  // Paste handler — the hint promises ⌘V works for images, so we
+  // intercept image clipboard items and route them through the same
+  // upload path. Plain text/URL paste falls through to the textarea.
+  function handlePaste(e: ClipboardEvent) {
+    const items = e.clipboardData?.items;
+    if (!items) return;
+    for (const item of items) {
+      if (item.type.startsWith('image/')) {
+        const file = item.getAsFile();
+        if (file) {
+          e.preventDefault();
+          void processImageFile(file);
+          return;
+        }
+      }
+    }
+  }
+
   function removeImage() {
     uploadedImageData = null;
     uploadedImagePreview = null;
   }
   
-  // URL validation
-  function validateUrl(url: string): boolean {
-    try {
-      new URL(url);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-  
-  $: if (urlInput) {
-    urlError = validateUrl(urlInput) ? '' : 'Please enter a valid URL';
-  }
-  
-  // Check if we can extract
-  $: canExtract = inputMode === 'image'
-    ? !!uploadedImageData
-    : inputMode === 'url'
-      ? (!!urlInput && !urlError)
-      : !!textInput.trim();
-  
+  // Detection runs live on input/drop/paste. Text mode requires ≥30
+  // chars to avoid flickering between `null` and `text` on every
+  // keystroke; the threshold is enforced inside detectMode().
+  // TODO(analytics): emit `sous_chef_mode_detected({mode})` when
+  // detectedMode flips from null → a real mode.
+  $: detectedMode = detectMode(textInput, !!uploadedImageData);
+  $: canExtract = detectedMode !== null;
+
   // Upload image to nostr.build
   async function uploadToNostrBuild(file: File): Promise<string | null> {
     const body = new FormData();
@@ -358,41 +333,55 @@
       goto('/login?redirect=/souschef');
       return;
     }
-    if (!canExtract || isExtracting) return;
-    
+    // Snapshot the detected mode so async awaits below see a stable
+    // discriminator even if textInput were to change mid-flight. (The
+    // textarea is disabled during isExtracting, so this is belt+
+    // suspenders — but cheap belt+suspenders.)
+    const mode = detectedMode;
+    if (!mode || isExtracting) return;
+
+    // Non-member upsell: image/text are gated. The button stays
+    // visually enabled and the click itself is the conversion event
+    // — we redirect to /membership without calling the import API.
+    if (!hasMembership && (mode === 'text' || mode === 'image')) {
+      // TODO(analytics): emit `sous_chef_upsell_triggered` with { mode }
+      goto('/membership');
+      return;
+    }
+
     isExtracting = true;
     extractionError = '';
     extractionProgress = 'Analyzing content...';
-    
+
     try {
       const requestBody: any = {
-        type: inputMode,
+        type: mode,
         pubkey: $userPublickey
       };
-      
-      if (inputMode === 'image') {
+
+      if (mode === 'image') {
         requestBody.imageData = uploadedImageData;
         extractionProgress = 'Extracting recipe from image...';
-      } else if (inputMode === 'text') {
+      } else if (mode === 'text') {
         requestBody.textData = textInput.trim();
         extractionProgress = 'Formatting your recipe...';
       } else {
-        requestBody.url = urlInput;
+        requestBody.url = textInput.trim();
         extractionProgress = 'Fetching and extracting recipe from URL...';
       }
-      
+
       const response = await fetch('/api/extract-recipe', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(requestBody)
       });
-      
+
       const data = await response.json();
-      
+
       if (!response.ok || !data.success) {
         throw new Error(data.error || 'Failed to extract recipe');
       }
-      
+
       // Populate the form with extracted data
       const recipe = data.recipe;
       title = recipe.title || '';
@@ -403,12 +392,12 @@
       servings = recipe.servings || '';
       ingredientsArray.set(recipe.ingredients || []);
       directionsArray.set(recipe.directions || []);
-      
+
       // Match tags to existing tags
       const matchedTags: recipeTagSimple[] = [];
       for (const tagName of recipe.tags || []) {
         const normalizedTag = tagName.toLowerCase().trim();
-        const existingTag = recipeTags.find(t => 
+        const existingTag = recipeTags.find(t =>
           t.title.toLowerCase() === normalizedTag
         );
         if (existingTag) {
@@ -418,11 +407,11 @@
         }
       }
       selectedTags.set(matchedTags);
-      
+
       // Handle image upload/rehosting
       const uploadedUrls: string[] = [];
-      
-      if (inputMode === 'image' && uploadedImageData) {
+
+      if (mode === 'image' && uploadedImageData) {
         // Upload the user's image to nostr.build
         extractionProgress = 'Uploading image to nostr.build...';
         const file = base64ToFile(uploadedImageData, 'recipe-image.jpg');
@@ -430,7 +419,7 @@
         if (uploadedUrl) {
           uploadedUrls.push(uploadedUrl);
         }
-      } else if (inputMode === 'url' && recipe.imageUrls && recipe.imageUrls.length > 0) {
+      } else if (mode === 'url' && recipe.imageUrls && recipe.imageUrls.length > 0) {
         // Rehost the first image from the URL to nostr.build
         extractionProgress = 'Downloading and uploading recipe image...';
         const firstImageUrl = recipe.imageUrls[0];
@@ -599,7 +588,21 @@
   <title>Sous Chef - zap.cooking</title>
 </svelte:head>
 
-<div class="flex flex-col max-w-[760px] mx-auto gap-6 pb-8">
+<!--
+  Scoped purple theme — see IntelligenceMenu.svelte's Sous Chef entry
+  (`accent: 'rgb(168, 85, 247)'`) for the source of truth. We override
+  --color-primary on this wrapper only, so every `text-primary` /
+  `bg-primary` / `border-primary` utility class descending from here
+  (including those inside <Button>) resolves to purple. Outside this
+  subtree the global orange palette is untouched.
+
+  Tailwind v4's compiled utilities use `var(--color-primary)`
+  (verified against dist/_app CSS), so the cascade override propagates
+  correctly. The remaining hard-coded orange literals on inline
+  `style=` attributes are replaced with purple equivalents in the same
+  pass — those don't pick up the variable.
+-->
+<div class="flex flex-col max-w-[760px] mx-auto gap-6 pb-8" style="--color-primary: #a855f7;">
   <!-- Header -->
   <div class="flex flex-col gap-2">
     <div class="flex items-center gap-3">
@@ -612,9 +615,6 @@
     <p class="text-caption">
       A little extra help in the kitchen.
     </p>
-    <p class="text-caption text-sm">
-      URL imports are free. Image and text imports are a Pro Kitchen feature.
-    </p>
   </div>
 
   {#if isLoading}
@@ -624,17 +624,24 @@
       <p class="text-caption">Checking membership status...</p>
     </div>
   {:else}
-    {#if $userPublickey && !hasMembership && !isAnonPreview && !extractionSuccess}
-      <!-- Non-member upgrade nudge — inline banner rather than a blocking
-           gate. URL import is free for all; this banner surfaces the
-           image/text benefit without hiding the whole feature. -->
-      <div class="flex items-start gap-3 p-4 rounded-xl" style="background-color: rgba(249, 115, 22, 0.08); border: 1px solid rgba(249, 115, 22, 0.25);">
+    {#if $userPublickey && !hasMembership && !isAnonPreview && !extractionSuccess
+         && (detectedMode === 'text' || detectedMode === 'image')}
+      <!-- Contextual upgrade nudge — only renders when the unified
+           input has detected a gated mode (image or text). URL is free
+           for everyone, so the banner stays hidden in that case and
+           when the input is empty. The CTA copy says "Cook+ and above"
+           because the server gate is `hasActiveMembership` (any tier),
+           not specifically Pro Kitchen.
+           TODO(tier-consolidation): when Cook+ is removed in the
+           planned single-tier consolidation, rewrite this copy to
+           "members" and revisit whether the gate should narrow then. -->
+      <div class="flex items-start gap-3 p-4 rounded-xl" style="background-color: rgba(168, 85, 247, 0.08); border: 1px solid rgba(168, 85, 247, 0.25);">
         <SparkleIcon size={22} class="text-primary flex-shrink-0 mt-0.5" weight="fill" />
         <div class="flex-1">
           <p class="text-sm">
             <span class="font-semibold" style="color: var(--color-primary);">URL imports are on us.</span>
-            Unlock image + text imports and more with
-            <button type="button" class="underline" on:click={() => goto('/membership')}>Pro Kitchen</button>.
+            Image and text imports are a Cook+ and above feature.
+            <button type="button" class="underline" on:click={() => goto('/membership')}>View membership</button>.
           </p>
         </div>
       </div>
@@ -642,100 +649,79 @@
     <!-- Has membership - show extraction UI -->
     
     {#if !extractionSuccess}
-      <!-- Input Section -->
+      <!-- Unified input — auto-detects URL / image / text. Mode is
+           derived from the textarea + uploadedImageData; explicit tabs
+           were removed in the souschef/consolidate refactor. -->
       <div class="flex flex-col gap-4">
-        <Tabs {tabs} activeTab={inputMode} on:change={handleTabChange} />
-        
-        {#if inputMode === 'image'}
-          <!-- Image Upload -->
-          <div class="flex flex-col gap-4">
-            {#if !uploadedImagePreview}
-              <div
-                class="relative flex flex-col items-center justify-center rounded-xl border-2 border-dashed px-6 py-12 transition-all duration-200 cursor-pointer"
-                class:border-primary={isDragging}
-                style="border-color: {isDragging ? 'var(--color-primary)' : 'var(--color-input-border)'}; background-color: var(--color-input-bg)"
-                on:drop={handleDrop}
-                on:dragover={handleDragOver}
-                on:dragleave={handleDragLeave}
-                on:click={() => fileInput.click()}
-                role="button"
-                tabindex="0"
-                on:keypress={(e) => e.key === 'Enter' && fileInput.click()}
-              >
-                <input
-                  bind:this={fileInput}
-                  type="file"
-                  accept="image/jpeg,image/png,image/webp,image/gif"
-                  class="hidden"
-                  on:change={handleFileSelect}
-                />
-                
-                <UploadIcon size={48} class="text-caption mb-4" />
-                <div class="text-center">
-                  <p class="font-semibold text-primary mb-1">Upload a recipe image</p>
-                  <p class="text-caption text-sm">or drag and drop</p>
-                  <p class="text-caption text-xs mt-2">JPG, PNG, WEBP, GIF (max 20MB)</p>
-                </div>
-              </div>
-            {:else}
-              <!-- Image Preview -->
-              <div class="relative rounded-xl overflow-hidden">
-                <img
-                  src={uploadedImagePreview}
-                  alt="Recipe to extract"
-                  class="w-full max-h-[400px] object-contain bg-input"
-                />
-                <button
-                  type="button"
-                  class="absolute top-3 right-3 bg-black/60 hover:bg-red-500 text-white rounded-full p-2 transition-all cursor-pointer"
-                  on:click={removeImage}
-                >
-                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <line x1="18" y1="6" x2="6" y2="18"></line>
-                    <line x1="6" y1="6" x2="18" y2="18"></line>
-                  </svg>
-                </button>
-              </div>
-            {/if}
-          </div>
-        {:else if inputMode === 'url'}
-          <!-- URL Input -->
-          <div class="flex flex-col gap-2">
-            <div class="flex items-center gap-2">
-              <LinkIcon size={20} class="text-caption" />
-              <span class="text-sm text-caption">Recipe URL</span>
-            </div>
-            <input
-              type="url"
-              placeholder="https://example.com/recipe..."
-              bind:value={urlInput}
-              class="input"
+        <!-- Hidden file input — triggered by the toolbar "Upload image"
+             button or programmatically on keyboard fallback. -->
+        <input
+          bind:this={fileInput}
+          type="file"
+          accept="image/jpeg,image/png,image/webp,image/gif"
+          class="hidden"
+          on:change={handleFileSelect}
+        />
+
+        {#if uploadedImagePreview}
+          <!-- Image-mode preview. The textarea is intentionally hidden
+               while an image is staged — one mode at a time. -->
+          <div class="relative rounded-xl overflow-hidden">
+            <img
+              src={uploadedImagePreview}
+              alt="Recipe to extract"
+              class="w-full max-h-[400px] object-contain bg-input"
             />
-            {#if urlError}
-              <p class="text-sm text-danger">{urlError}</p>
-            {/if}
-            <p class="text-xs text-caption">
-              Paste a URL from any recipe website. The AI will extract the recipe details.
-            </p>
+            <button
+              type="button"
+              aria-label="Remove image"
+              class="absolute top-3 right-3 bg-black/60 hover:bg-red-500 text-white rounded-full p-2 transition-all cursor-pointer"
+              on:click={removeImage}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <line x1="18" y1="6" x2="6" y2="18"></line>
+                <line x1="6" y1="6" x2="18" y2="18"></line>
+              </svg>
+            </button>
           </div>
         {:else}
-          <!-- Text Input -->
-          <div class="flex flex-col gap-2">
-            <label for="text-input" class="text-sm text-caption">Drop a recipe in here</label>
+          <!-- Unified textarea + drop zone. The whole container is the
+               drop target so users can drop anywhere; paste of an image
+               from the clipboard is intercepted in handlePaste. -->
+          <div
+            class="relative flex flex-col rounded-xl border-2 border-dashed transition-all duration-200"
+            class:border-primary={isDragging}
+            style="border-color: {isDragging ? 'var(--color-primary)' : 'var(--color-input-border)'}; background-color: var(--color-input-bg)"
+            role="group"
+            aria-label="Recipe input. Paste a URL, paste recipe text, or drop a photo."
+            on:drop={handleDrop}
+            on:dragover={handleDragOver}
+            on:dragleave={handleDragLeave}
+          >
             <textarea
-              id="text-input"
+              id="souschef-input"
               bind:value={textInput}
-              placeholder="Paste a URL, copy from a website, type it out, screenshot text — whatever you've got, Sous Chef will handle it."
-              rows="10"
-              class="input resize-none text-base"
+              on:paste={handlePaste}
+              placeholder="Paste a recipe URL, paste recipe text, or drop a photo…"
+              rows="8"
+              class="w-full bg-transparent border-0 p-4 resize-none focus:outline-none focus:ring-0 text-base"
               disabled={isExtracting}
             />
-            <p class="text-xs text-caption">
-              Paste any recipe text and Sous Chef will format it for zap.cooking.
-            </p>
+            <div class="flex items-center justify-between gap-3 px-4 py-2 border-t" style="border-color: var(--color-input-border)">
+              <span class="text-xs text-caption">⌘V works for URLs, text, and images.</span>
+              <button
+                type="button"
+                class="inline-flex items-center gap-1.5 text-sm font-medium text-caption hover:text-primary transition-colors"
+                on:click={() => fileInput.click()}
+                disabled={isExtracting}
+              >
+                <UploadIcon size={16} />
+                Upload image
+              </button>
+            </div>
           </div>
         {/if}
-        
+
         <!-- Error message -->
         {#if extractionError}
           <div class="flex items-start gap-3 p-4 rounded-xl bg-red-500/10 border border-red-500/20">
@@ -767,7 +753,7 @@
       <div class="flex flex-col gap-6">
         {#if isAnonPreview}
           <!-- Anon-preview banner (via landing hero handoff) -->
-          <div class="flex items-start gap-3 p-4 rounded-xl" style="background-color: rgba(249, 115, 22, 0.08); border: 1px solid rgba(249, 115, 22, 0.25);">
+          <div class="flex items-start gap-3 p-4 rounded-xl" style="background-color: rgba(168, 85, 247, 0.08); border: 1px solid rgba(168, 85, 247, 0.25);">
             <SparkleIcon size={24} class="text-primary flex-shrink-0 mt-0.5" weight="fill" />
             <div class="flex-1">
               <p class="font-semibold" style="color: var(--color-primary);">Recipe imported — sign in to save or publish</p>
@@ -898,7 +884,7 @@
               type="button"
               on:click={() => goto('/login?redirect=/souschef')}
               class="w-full flex items-center justify-center gap-2 px-6 py-3 rounded-full font-semibold transition-all"
-              style="background: linear-gradient(135deg, #f97316 0%, #fb923c 100%); color: white; box-shadow: 0 2px 8px rgba(249, 115, 22, 0.3);"
+              style="background: linear-gradient(135deg, #a855f7 0%, #c084fc 100%); color: white; box-shadow: 0 2px 8px rgba(168, 85, 247, 0.3);"
             >
               <SparkleIcon size={18} weight="fill" />
               Sign in to publish
@@ -913,7 +899,7 @@
             on:click={publishRecipe}
             disabled={isPublishing || !title || $images.length === 0 || $selectedTags.length === 0 || $ingredientsArray.length === 0 || $directionsArray.length === 0}
             class="w-full flex items-center justify-center gap-2 px-6 py-3 rounded-full font-semibold transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-            style="background: linear-gradient(135deg, #f97316 0%, #fb923c 100%); color: white; box-shadow: 0 2px 8px rgba(249, 115, 22, 0.3);"
+            style="background: linear-gradient(135deg, #a855f7 0%, #c084fc 100%); color: white; box-shadow: 0 2px 8px rgba(168, 85, 247, 0.3);"
             class:hover:shadow-lg={!isPublishing && title && $images.length > 0 && $selectedTags.length > 0 && $ingredientsArray.length > 0 && $directionsArray.length > 0}
           >
             {#if isPublishing}


### PR DESCRIPTION
## Summary

Collapses the Sous Chef page's three-tab UI (Upload Image / Paste URL / Paste Text) into a single auto-detecting input. The member gate surfaces contextually only when a non-member enters a gated mode (image or text), and the page is themed purple to match its row in [`IntelligenceMenu`](src/components/IntelligenceMenu.svelte). URL imports remain free for everyone; image/text remain gated.

**Bundled fix (commit `5ee03be`):** swapped the URL-fetch `User-Agent` from a transparent bot identifier to a Chrome-shaped UA. This helps sites that block on UA-string heuristics. **It does NOT affect Cloudflare-protected sites** (AllRecipes, NYT Cooking, Bon Appétit etc.) — those use TLS-fingerprint / interactive bot detection that's orthogonal to the UA. Those sites continue to work in production (the Cloudflare Workers runtime is accepted by them) and continue to fail in local dev with `npm run dev` (Node's undici fetch is fingerprinted as bot-like, regardless of the UA we send). The local-dev limitation is pre-existing — confirmed identical on `main` — not introduced by this PR.

## Phases

### Phase 1 — Unified input (`src/routes/souschef/+page.svelte`)
- Removed the `<Tabs>` switcher and the `ALL_TABS` / `tabs` / `inputMode` state. Mode is derived from a new `detectMode(text, hasImage)` helper invoked reactively via `$: detectedMode = ...`.
- `extractRecipe()` snapshots `const mode = detectedMode` at entry and uses `mode` throughout (6 sites) so async awaits see a stable discriminator.
- One container: a borderless `<textarea>` inside a drop-zone wrapper with a toolbar (`"⌘V works for URLs, text, and images."` + "Upload image" button). The image preview replaces the textarea while staged — one mode at a time.
- Added `handlePaste()` so the ⌘V hint is truthful for images. Shared the image-handling path with drag and the file-input via a new `processImageFile(file)` helper (wrapped in a Promise per Copilot review).
- Removed `urlInput` / `urlError` state, `validateUrl()`, `handleTabChange()`, `clearInputs()`, and the `Tabs` / `LinkIcon` imports.
- Preserved: anon-import handoff (`onMount` + `hydrateFromHandoff` + `isAnonPreview`), `MediaUploader` binding to `images: Writable<string[]>`, sign-in flow, all four `redirect=/souschef` literals.

### Phase 2 — Conditional gating
- Banner at `+page.svelte:619-639` now guards on `(detectedMode === 'text' \|\| detectedMode === 'image')` so it only appears when the user has triggered a gated mode. URL and empty input keep it hidden.
- Banner copy: *"Image and text imports are a Cook+ and above feature. View membership."* — honest to the actual server gate (`hasActiveMembership(pubkey)`, which accepts any active tier).
- `extractRecipe()` adds an upsell branch right after the mode snapshot: if `!hasMembership && (mode === 'text' \|\| 'image')`, redirect to `/membership` and return without calling `/api/extract-recipe`. The click itself is the conversion event.

### Phase 3 — Purple theme (scoped)
- Wrapper override on the outermost `<div>`: `style="--color-primary: #a855f7;"`. Sourced from `src/components/IntelligenceMenu.svelte:19` (`accent: 'rgb(168, 85, 247)'`).
- Tailwind v4's compiled `.bg-primary` / `.text-primary` / `.border-primary` utilities resolve `var(--color-primary)` at render time (verified against `dist/_app` CSS), so the cascade propagates through `<Button>` and every utility inside the page.
- Replaced four inline orange `style=` literals with purple equivalents: `#f97316` / `#fb923c` → `#a855f7` / `#c084fc`; `rgba(249, 115, 22, …)` → `rgba(168, 85, 247, …)` in the non-member banner, the anon-preview banner, and both gradient publish buttons.
- `src/app.css` was not touched. The global `--color-primary` (orange) is unchanged everywhere outside `/souschef`.

### Phase 4 — Tests
- Extracted `detectMode` to `src/lib/souschefDetect.ts` (pure module, no Svelte/DOM deps) so it can be unit-tested.
- Added `src/lib/souschefDetect.test.ts` with 16 tests covering the eight mandatory cases plus scheme-case-insensitivity, `http://`, `"see <url>"` citations, and exact 29/30-char boundary checks.
- `+page.svelte` now imports `detectMode` from the new module.

### Bundled fix — URL fetch User-Agent (`src/lib/parseRecipe.server.ts:208-227`)
- Was: `Mozilla/5.0 (compatible; ZapCooking/1.0; +https://zap.cooking)` — transparent bot identifier. Some sites with naive UA-based bot detection 403 it on sight.
- Now: a Chrome-shaped UA plus matching `Accept` and `Accept-Language` headers that real browsers always send.
- **What this fixes:** sites that check UA strings (a long tail of smaller sites that block obvious bot identifiers).
- **What this does NOT fix:** Cloudflare/Akamai-fronted sites with TLS-fingerprint or interactive bot detection (AllRecipes, NYT Cooking, Bon Appétit, etc.). These were verified to 403 from local Node fetch regardless of UA, on both `main` and this branch. They work in production because Cloudflare Workers' fetch has a different TLS fingerprint that those sites accept. Production behavior is unchanged by this commit.

## Decisions

- **Keep the `/souschef` URL** — rename would ripple to 5+ inbound link sites and four `redirect=/souschef` literals for no UX gain.
- **Banner copy: "Cook+ and above"** — matches the actual server gate (`active` membership of any tier), not the prior "Pro Kitchen" wording. A `TODO(tier-consolidation)` notes that this copy will become "members" when Cook+ is removed in the planned single-tier consolidation.
- **Non-member flow: expose and upsell** — submit on a gated mode redirects to `/membership` rather than disabling. The click is the conversion signal; non-members learn about the gated feature by trying it.
- **Purple via scoped CSS-variable override on a page wrapper** — not a third "Tailwind purple utilities" pattern, not a global token change. Verified Tailwind v4 cascades `var(--color-primary)` correctly before applying.
- **Bundle the UA fix despite it not unblocking Cloudflare-protected sites** — it's a net improvement for the long tail of sites that *do* check UA strings, costs nothing in prod, and adds standard browser headers. The motivating example (AllRecipes) turned out to be a deeper Node-vs-Workers TLS-runtime issue that's out of scope for any URL-fetch tweak.

## Visual states

(Screenshots need eyes — describing states from the markup.)

1. **Empty input** — Header `SparkleIcon` purple via `text-primary`. Drop-zone idle border in neutral `--color-input-border`. Disabled "Get Recipe" button shows the purple `<Button>` `bg-primary` at reduced opacity.
2. **URL detected** — Same as 1; Extract button enables to full-opacity purple. No mode chip; URL detection is implicit. Banner hidden (URL is free for everyone).
3. **Text detected** — Same surfaces as 1; Extract button enables. For non-members, the purple-tinted banner appears above.
4. **Image detected** — Drop zone collapses into the image preview block. Outside the preview, Extract button remains purple.
5. **Non-member + banner** — Purple-tinted banner (`rgba(168, 85, 247, 0.08)` bg, `rgba(168, 85, 247, 0.25)` border, `text-primary` accent on the highlighted phrase). "View membership" CTA inherits theme. Visible only when `detectedMode === 'text' \|\| 'image'`.

## Manual verification checklist

Reviewer note: **test URL extraction on a bot-friendly site** (e.g. `https://www.budgetbytes.com/baked-chicken-drumsticks/`) — Cloudflare-protected sites like AllRecipes will 403 in local dev regardless of this PR (limitation of Node's undici TLS fingerprint, identical on `main`). The Cloudflare Pages preview deployment of this PR currently needs `OPENAI_API_KEY` configured for preview env to test end-to-end on CF runtime.

- [ ] Member: URL extracts on a bot-friendly site (e.g. Budget Bytes). Verified locally via curl: `200 OK` with parsed recipe data.
- [ ] Member: text extracts (submit hits API)
- [ ] Member: image extracts (drop, paste, or "Upload image" all route to the same handler)
- [ ] Non-member: URL extracts (URL is free for everyone)
- [ ] Non-member: text/image shows banner, submit redirects to `/membership`, **no API call fires**
- [ ] Anon-import handoff from landing hero still works (`/` → paste URL in `LandingImportHero` → arrive at `/souschef` with the parsed recipe and the view-only "Sign in to publish" CTA)
- [ ] `/`, `/membership`, `/feed-post` still render in orange (cross-route theme-leak check — only `/souschef` should look purple)

## Tests

- **101 / 101 passing** (was 85; +16 new in `src/lib/souschefDetect.test.ts`).
- `pnpm check` → 0 errors, 128 warnings (baseline unchanged).

## Follow-up TODOs added in this PR

- `TODO(analytics): sous_chef_mode_detected({mode})` — emit when detection flips from `null` → a real mode.
- `TODO(analytics): sous_chef_upsell_triggered({mode})` — emit on the non-member upsell branch in `extractRecipe()`.
- `TODO(tier-consolidation)` — revisit the "Cook+ and above" banner copy if Cook+ is retired in the planned single-tier consolidation.

## Out of scope

- `/api/extract-recipe`, `/api/extract-recipe/public`, the rest of `parseRecipe.server.ts` beyond the UA swap.
- The `/membership` upsell page.
- The anon-import handoff structure — preserved, not refactored.
- Server-side image MIME / size validation — separate hardening PR.
- Real analytics wiring — markers only, no events emitted yet.
- Renaming `/souschef` ↔ `/extract` — kept `/souschef`.
- **Local-dev URL extraction on Cloudflare-protected sites (AllRecipes-class).** These return 403 to Node's undici fetch regardless of UA. Works in production via Cloudflare Workers' runtime. A future PR could route the URL fetch through a TLS-spoofing client (`cycletls`, `node-tls-client`) or a headless browser service to bring local-dev parity, but that's a separate, larger investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)