### PR TITLE
feat(header): visible wallet pill in dark mode across breakpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.442",
+  "version": "4.2.443",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -397,9 +397,13 @@
   }
 
   :global(.dark) .zh-wallet-mobile {
-    background-color: rgba(255, 255, 255, 0.04);
-    border-color: rgba(255, 255, 255, 0.08);
-    box-shadow: inset 0 0 0 1px rgba(251, 191, 36, 0.06);
+    /* Visible translucent fill (~2x previous) so the pill reads as a
+       distinct chip against the dark page bg. */
+    background-color: rgba(255, 255, 255, 0.08);
+    /* Amber-tinted border so the pill picks up the brand colour from
+       the lightning bolt and the wallet modal's amber gradient. */
+    border-color: rgba(251, 191, 36, 0.35);
+    box-shadow: inset 0 0 0 1px rgba(251, 191, 36, 0.08);
   }
   .zh-wallet-amount {
     font-variant-numeric: tabular-nums;

--- a/src/components/WalletBalance.svelte
+++ b/src/components/WalletBalance.svelte
@@ -522,6 +522,24 @@
     box-shadow: 0 0 0 2px rgba(251, 191, 36, 0.35);
   }
 
+  /* Dark mode — desktop pill matches the mobile pill (`.zh-wallet-mobile`
+     in Header.svelte) so the header's wallet pill looks identical at
+     every breakpoint. Translucent off-white fill + amber-tinted border
+     picks up the brand colour. `!important` is necessary because the
+     pill's <div> carries inline `style=` for background-color / border
+     (set via CSS variables) — inline styles win class-selector
+     specificity otherwise. */
+  :global(.dark) .balance-pill {
+    background-color: rgba(255, 255, 255, 0.08) !important;
+    border-color: rgba(251, 191, 36, 0.35) !important;
+    box-shadow: inset 0 0 0 1px rgba(251, 191, 36, 0.08);
+  }
+  :global(.dark) .balance-pill:focus-visible {
+    box-shadow:
+      inset 0 0 0 1px rgba(251, 191, 36, 0.08),
+      0 0 0 2px rgba(251, 191, 36, 0.35);
+  }
+
   /* Inner balance text — display-only. Currency switching moved into
      the dropdown so an accidental tap on the balance can't change
      what's displayed; the outer pill handles the open-dropdown


### PR DESCRIPTION
## Summary

The wallet pill in the header used a near-invisible dark-mode treatment — \`rgba(255, 255, 255, 0.04)\` fill and \`rgba(255, 255, 255, 0.08)\` border. Against the dark page background the pill chrome essentially disappeared, leaving the lightning bolt and balance text reading as free-floating elements with no container.

Bump the dark-mode treatment so the pill reads as a distinct chip and picks up the brand amber from the lightning bolt and the wallet-modal accents:

- **Fill** \`rgba(255, 255, 255, 0.08)\` — doubled, visible translucent off-white.
- **Border** \`rgba(251, 191, 36, 0.35)\` — amber, clearly outlined.
- **Inset glow** \`rgba(251, 191, 36, 0.08)\` — subtle warm halo.

Applied to both pill instances so they match across breakpoints:

- \`src/components/Header.svelte\` — \`.zh-wallet-mobile\` (mobile, <640px).
- \`src/components/WalletBalance.svelte\` — \`.balance-pill\` (desktop, ≥640px).

\`WalletBalance\`'s rule needs \`!important\` because the pill \`<div>\` carries inline \`style=\` for \`background-color\` / \`border\` via CSS variables, which would otherwise outrank the class-selector specificity.

Light-mode treatment is unchanged.

## Test plan

- [ ] Local dark mode: mobile header (<640px viewport) — wallet pill is visibly outlined with amber.
- [ ] Local dark mode: desktop header (≥640px viewport) — wallet pill matches the mobile look.
- [ ] Local light mode: both pills render with their original light-mode chrome (no regression).
- [ ] Vercel preview: same checks against the staging deployment.