### PR TITLE
fix(souschef): actually remove ⌘V hint from input toolbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.446",
+  "version": "4.2.447",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/routes/souschef/+page.svelte
+++ b/src/routes/souschef/+page.svelte
@@ -719,8 +719,7 @@
               class="w-full bg-transparent border-0 p-4 resize-none focus:outline-none focus:ring-0 text-base"
               disabled={isExtracting}
             />
-            <div class="flex items-center justify-between gap-3 px-4 py-2 border-t" style="border-color: var(--color-input-border)">
-              <span class="text-xs text-caption">⌘V works for URLs, text, and images.</span>
+            <div class="flex items-center justify-end gap-3 px-4 py-2 border-t" style="border-color: var(--color-input-border)">
               <button
                 type="button"
                 class="inline-flex items-center gap-1.5 text-sm font-medium text-caption hover:text-primary transition-colors"


### PR DESCRIPTION
## Summary

#399 was supposed to remove the `⌘V works for URLs, text, and images.` hint from the bottom-left of the Sous Chef input toolbar. The squash-merge applied half the diff — the `handlePaste` comment update landed on main (commit `806043d`), but the actual toolbar change (the `<span>` removal + `justify-between` → `justify-end` swap) was silently dropped.

Likely cause: GitHub's merge algorithm got confused after #397's earlier squash made the file's lineage ambiguous between `souschef/consolidate` and main. When it computed the diff for #399, it decided the toolbar hunk was already applied and skipped it. The comment hunk applied cleanly because that section was untouched by #397's squash.

This branches fresh from current main and applies only the toolbar change — no shared history with the prior squashed branches, so there's no merge-base ambiguity to trip over.

## After this PR

The toolbar contains only the right-aligned "Upload image" button. The `⌘V` text is gone. Paste detection still works (handler unchanged; only the visible hint is removed).

## Diff

`src/routes/souschef/+page.svelte` — 2 lines changed:
- Removed `<span class="text-xs text-caption">⌘V works for URLs, text, and images.</span>` (the hint).
- Changed the toolbar wrapper's `justify-between` → `justify-end` so the Upload image button right-aligns.

Plus `package.json` version bump from the pre-commit hook.

## Verify

- `pnpm check` → 0 errors, 128 warnings.
- `pnpm test` → 132 / 132 passing.

## Merge note

To avoid a third round of this, consider **merge commit** instead of squash for this PR — there's only one commit anyway, so squash gains nothing, and merge-commit preserves clear history that the squash algorithm doesn't have to guess at. Either way the diff is two lines and trivially verifiable in the Files Changed tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)