### PR TITLE
fix(wallet): add bottom inset on WebLN/BC external modal mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.448",
+  "version": "4.2.449",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/wallet/WalletModal.svelte
+++ b/src/components/wallet/WalletModal.svelte
@@ -233,6 +233,19 @@
   :global(.wallet-modal-body--external .wallet-scroll .mb-3) {
     margin-bottom: 0 !important;
   }
+  /* External mode disables the inner scroll, so the last card would
+     otherwise sit flush against the dialog's bottom edge. Add an
+     explicit bottom inset on desktop. padding-top stays 0 to match the
+     regular scrolling wallet view — the floating X close button overlays
+     the balance card's top-right corner just like the Spark/NWC view.
+     Mobile already gets its insets from env(safe-area-inset-*) in the
+     bottom @media block. */
+  @media (min-width: 768px) {
+    :global(.wallet-modal-body--external) {
+      padding-top: 0 !important;
+      padding-bottom: 2rem !important;
+    }
+  }
   /* External (BC/WebLN) and connect-step modes have short, fixed
      content — there's nothing tall enough to scroll. Suppress the
      wallet-scroll's overflow so neither a scrollbar nor accidental


### PR DESCRIPTION
## Summary

External-wallet mode (WebLN, Bitcoin Connect) uses `height: auto` so the dialog hugs its content, and zeros the trailing `mb-8` / `mb-3` margins of the connection card to avoid lopsided bottom whitespace. With the base `wallet-modal-body` padding also at 0 (a deliberate fix for a flex+padding bg overlap in the regular scrolling view), the connection card's Disconnect button sat flush against the dialog's bottom edge.

Adds desktop-only `padding-bottom: 2rem` to `.wallet-modal-body--external` so the card has a symmetric inset. `padding-top` stays 0 to match the regular view — the floating X close button overlays the balance card's top-right corner the same way as the Spark/NWC view. Mobile already gets its insets from `env(safe-area-inset-*)` in the bottom @media block.

## Test plan

- [ ] Connect WebLN (e.g. Alby), open the wallet modal on desktop — Disconnect button sits with breathing room above the modal's bottom edge
- [ ] X close button overlays the balance card's top-right corner (matches Spark/NWC view)
- [ ] Same check with Bitcoin Connect connected
- [ ] Mobile (<768 px) layout unchanged — safe-area insets still apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)