### PR TITLE
feat(zap): default message + zap comment in history + completion polish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.452",
+  "version": "4.2.455",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/NoteActionBar.svelte
+++ b/src/components/NoteActionBar.svelte
@@ -6,7 +6,7 @@
   import NoteTotalZaps from './NoteTotalZaps.svelte';
   import ZapModal from './ZapModal.svelte';
   import { ndk, userPublickey } from '$lib/nostr';
-  import { fetchEngagement, optimisticZapUpdate } from '$lib/engagementCache';
+  import { fetchEngagement, optimisticZapUpdate, markSelfZapCompleted } from '$lib/engagementCache';
 
   export let event: NDKEvent;
 
@@ -28,6 +28,10 @@
 
   let zapModalOpen = false;
 
+  // Called as the `onZapClick` callback from NoteTotalZaps when its
+  // internal one-tap path isn't applicable (no in-app wallet, toggle off,
+  // or signed out). NoteTotalZaps already handles the one-tap path
+  // itself, so this is purely the modal-fallback handler.
   function openZapModal() {
     if (!$userPublickey) {
       window.location.href = '/login?redirect=' + encodeURIComponent(window.location.pathname);
@@ -36,9 +40,18 @@
     zapModalOpen = true;
   }
 
-  function handleZapComplete(e: CustomEvent<{ amount: number }>) {
+  function handleZapComplete(e: CustomEvent<{ amount: number; comment?: string }>) {
     if (event) {
-      optimisticZapUpdate(event.id, (e.detail.amount || 0) * 1000, $userPublickey);
+      optimisticZapUpdate(
+        event.id,
+        (e.detail.amount || 0) * 1000,
+        $userPublickey,
+        e.detail.comment
+      );
+      // Modal zap is fully paid by the time this fires (it's dispatched
+      // from ZapModal's success branch / Bitcoin Connect onPaid). Fire
+      // the completion marker so the sparkle burst runs exactly once.
+      markSelfZapCompleted(event.id);
       fetchEngagement($ndk, event.id, $userPublickey);
     }
   }
@@ -125,4 +138,5 @@
   .full .zap-pills-row {
     padding: 0;
   }
+
 </style>

--- a/src/components/NoteTotalZaps.svelte
+++ b/src/components/NoteTotalZaps.svelte
@@ -19,6 +19,35 @@
   let showZappersModal = false;
   let isZapping = false;
 
+  // Sparkle burst on every successful self-zap. Triggered reactively
+  // off $store.zaps.lastSelfZapAt, which markSelfZapCompleted (called
+  // by the zap path on payment confirmation, NOT by the optimistic
+  // update) bumps to Date.now(). Both one-tap and ZapModal paths fire
+  // it after their respective payment success, so the burst happens at
+  // the END of the zap regardless of which path was used.
+  //
+  // Numeric counter (vs boolean) keyed in the template so each burst
+  // gets a fresh DOM tree and the CSS animation re-runs from frame 0.
+  let sparkleBurstCount = 0;
+  let prevLastSelfZapAt = $store.zaps.lastSelfZapAt;
+  let sparkleTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function triggerSparkleBurst() {
+    sparkleBurstCount += 1;
+    if (sparkleTimer) clearTimeout(sparkleTimer);
+    sparkleTimer = setTimeout(() => {
+      sparkleBurstCount = 0;
+    }, 1000);
+  }
+
+  $: {
+    const current = $store.zaps.lastSelfZapAt;
+    if (current && current !== prevLastSelfZapAt) {
+      triggerSparkleBurst();
+    }
+    prevLastSelfZapAt = current;
+  }
+
   // Long press handling
   const LONG_PRESS_DURATION = 500; // ms
   let longPressTimer: ReturnType<typeof setTimeout> | null = null;
@@ -35,6 +64,9 @@
   onDestroy(() => {
     if (longPressTimer) {
       clearTimeout(longPressTimer);
+    }
+    if (sparkleTimer) {
+      clearTimeout(sparkleTimer);
     }
   });
 
@@ -173,6 +205,10 @@
           navigator.vibrate([40, 50, 40]); // Two short pulses
         }
         console.log('[NoteTotalZaps] One-tap zap completed successfully, amount:', result.amount);
+        // Sparkle burst fires reactively via the lastSelfZapAt watcher
+        // when markSelfZapCompleted (called inside sendOneTapZap on
+        // confirmed payment) bumps the store. Single source of truth so
+        // we don't fire twice.
         // Re-fetch engagement to pick up the real zap receipt from relays
         // (the optimistic update shows instantly, but this ensures the subscription
         // is active and will reconcile with the actual zap receipt)
@@ -300,13 +336,30 @@
         ? `Zap ${getOneTapAmount()} sats (hold for custom amount)`
         : 'Send a zap'}
     >
-      <LightningIcon
-        size={18}
-        class="{totalSats > 0 ? 'text-yellow-500' : 'text-caption'} {isZapping
-          ? 'animate-pulse'
-          : ''}"
-        weight={$store.zaps.userZapped ? 'fill' : 'regular'}
-      />
+      <!-- Instant feedback on tap: the bolt turns yellow + filled the
+           moment isZapping flips (synchronous, before any await), so the
+           user sees confirmation even before createZap finishes fetching
+           the LNURL. Falls back to the persisted userZapped / totalSats
+           state afterwards. -->
+      <span class="bolt-sparkle-wrap">
+        <LightningIcon
+          size={18}
+          class="{isZapping || totalSats > 0 ? 'text-yellow-500' : 'text-caption'} {isZapping
+            ? 'animate-pulse'
+            : ''}"
+          weight={isZapping || $store.zaps.userZapped ? 'fill' : 'regular'}
+        />
+        {#if sparkleBurstCount > 0}
+          {#key sparkleBurstCount}
+            <span class="sparkle sparkle-0" aria-hidden="true"></span>
+            <span class="sparkle sparkle-1" aria-hidden="true"></span>
+            <span class="sparkle sparkle-2" aria-hidden="true"></span>
+            <span class="sparkle sparkle-3" aria-hidden="true"></span>
+            <span class="sparkle sparkle-4" aria-hidden="true"></span>
+            <span class="sparkle sparkle-5" aria-hidden="true"></span>
+          {/key}
+        {/if}
+      </span>
     </button>
 
     <!-- Zapper Pills -->
@@ -365,13 +418,26 @@
         ? `Zap ${getOneTapAmount()} sats (hold for custom amount)`
         : 'Send a zap'}
     >
-      <LightningIcon
-        size={24}
-        class="{$store.zaps.totalAmount > 0 ? 'text-yellow-500' : 'text-caption'} {isZapping
-          ? 'animate-pulse'
-          : ''}"
-        weight={$store.zaps.userZapped ? 'fill' : 'regular'}
-      />
+      <!-- Instant feedback on tap (see comment in the pill variant above). -->
+      <span class="bolt-sparkle-wrap">
+        <LightningIcon
+          size={24}
+          class="{isZapping || $store.zaps.totalAmount > 0
+            ? 'text-yellow-500'
+            : 'text-caption'} {isZapping ? 'animate-pulse' : ''}"
+          weight={isZapping || $store.zaps.userZapped ? 'fill' : 'regular'}
+        />
+        {#if sparkleBurstCount > 0}
+          {#key sparkleBurstCount}
+            <span class="sparkle sparkle-0" aria-hidden="true"></span>
+            <span class="sparkle sparkle-1" aria-hidden="true"></span>
+            <span class="sparkle sparkle-2" aria-hidden="true"></span>
+            <span class="sparkle sparkle-3" aria-hidden="true"></span>
+            <span class="sparkle sparkle-4" aria-hidden="true"></span>
+            <span class="sparkle sparkle-5" aria-hidden="true"></span>
+          {/key}
+        {/if}
+      </span>
     </button>
 
     <!-- Count Button - Opens ZappersListModal -->
@@ -406,5 +472,73 @@
   .zap-pills-row {
     overscroll-behavior-x: contain;
     -webkit-overflow-scrolling: touch;
+  }
+
+  /* Sparkle burst on zap-complete: 6 tiny dots emanate outward from the
+     bolt center on a single 700 ms keyframe, fading and shrinking as
+     they fly out. Each .sparkle-N sets its own (--tx, --ty) so the
+     particles fan out in a hex-ish pattern. The wrap stays
+     inline-flex/relative so the bolt's layout doesn't shift; pointer
+     events are off on the sparkles so they never block taps.
+     overflow: visible explicitly because the wrap's parent button is
+     often inside a row with overflow-y-hidden (.zap-pills-row), which
+     would otherwise clip particles that fly outside the row height. */
+  .bolt-sparkle-wrap {
+    position: relative;
+    display: inline-flex;
+    line-height: 0;
+    overflow: visible;
+  }
+  .sparkle {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 6px;
+    height: 6px;
+    margin: -3px 0 0 -3px;
+    background: #fbbf24;
+    border-radius: 50%;
+    pointer-events: none;
+    /* High z-index so the burst paints on top of the icon and the
+       surrounding pills row, not behind them. */
+    z-index: 10;
+    box-shadow:
+      0 0 6px 1px rgba(251, 191, 36, 0.9),
+      0 0 12px 2px rgba(249, 115, 22, 0.45);
+    animation: bolt-sparkle 950ms ease-out forwards;
+  }
+  /* Magnitudes kept small enough vertically (≤ 10 px) that the burst
+     fits inside a .zap-pills-row's overflow-y: hidden window without
+     clipping. Horizontal range is wider since the surrounding flex row
+     is overflow-x: auto and can scroll. */
+  .sparkle-0 { --tx: 18px;  --ty: 0px; }
+  .sparkle-1 { --tx: 12px;  --ty: -9px; }
+  .sparkle-2 { --tx: -3px;  --ty: -10px; }
+  .sparkle-3 { --tx: -18px; --ty: -2px; }
+  .sparkle-4 { --tx: -11px; --ty: 8px; animation-delay: 40ms; }
+  .sparkle-5 { --tx: 4px;   --ty: 10px; animation-delay: 70ms; }
+  @keyframes bolt-sparkle {
+    0% {
+      transform: translate(0, 0) scale(0.5);
+      opacity: 0;
+    }
+    8% {
+      transform: translate(calc(var(--tx) * 0.15), calc(var(--ty) * 0.15)) scale(1.3);
+      opacity: 1;
+    }
+    65% {
+      transform: translate(calc(var(--tx) * 0.85), calc(var(--ty) * 0.85)) scale(0.95);
+      opacity: 1;
+    }
+    100% {
+      transform: translate(var(--tx), var(--ty)) scale(0.2);
+      opacity: 0;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .sparkle {
+      animation: none;
+      display: none;
+    }
   }
 </style>

--- a/src/components/ZapModal.svelte
+++ b/src/components/ZapModal.svelte
@@ -5,22 +5,26 @@
   import PanLoader from './PanLoader.svelte';
   import Button from './Button.svelte';
   import Checkmark from 'phosphor-svelte/lib/CheckFat';
-  import XIcon from 'phosphor-svelte/lib/X';
+  import LightningIcon from 'phosphor-svelte/lib/LightningSlash';
 
   import CustomAvatar from './CustomAvatar.svelte';
   import CustomName from './CustomName.svelte';
   import { browser } from '$app/environment';
   import { onMount, createEventDispatcher } from 'svelte';
+  import { get } from 'svelte/store';
   import { ZapManager } from '$lib/zapManager';
   import { lightningService } from '$lib/lightningService';
   import { hapticSuccess } from '$lib/haptics';
   import { displayCurrency } from '$lib/currencyStore';
   import { convertSatsToFiat, formatFiatValue } from '$lib/currencyConversion';
 
-  const dispatch = createEventDispatcher<{ 'zap-complete': { amount: number; pollOptionId?: string } }>();
+  const dispatch = createEventDispatcher<{
+    'zap-complete': { amount: number; pollOptionId?: string; comment?: string };
+  }>();
   import { activeWallet, getWalletKindName } from '$lib/wallet';
   import { sendPayment } from '$lib/wallet/walletManager';
   import { weblnConnected } from '$lib/wallet/webln';
+  import { defaultZapMessage } from '$lib/autoZapSettings';
 
   // True when we can pay an invoice directly without launching the
   // Bitcoin Connect payment modal:
@@ -82,10 +86,68 @@
   $: if (isPollMode && pollMinSats && amount === 21) {
     amount = pollMinSats;
   }
-  let message: string = '';
+  // Pre-fill from the user's saved default zap message (set in Settings →
+  // Zap Settings → Default zap message). The user can still edit or clear
+  // this in the textarea before sending; the override doesn't affect the
+  // saved default. Each caller wraps <ZapModal/> in `{#if open}`, so the
+  // component remounts on every open and this initialiser fires fresh.
+  // Use `get()` (not `$store`) so we pull the current value without
+  // creating a subscription that re-fires on later store updates.
+  let message: string = get(defaultZapMessage);
 
   let state: 'pre' | 'pending' | 'success' | 'error' = 'pre';
   let error: Error | null = null;
+
+  // Friendly mapping for the error state. The raw error message can be
+  // alarming and technical ("Profile lud16: undefined") — translate the
+  // common cases into something a human can act on. Anything we don't
+  // recognise falls back to a soft generic message + retry; cases we
+  // know aren't retryable (e.g. recipient has no Lightning address) hide
+  // the Try Again button.
+  let errorTitle = 'Zap unavailable';
+  let errorBody = '';
+  let errorRetryable = true;
+  $: {
+    const msg = error?.message || String(error || '');
+    const lower = msg.toLowerCase();
+    if (
+      lower.includes('no lightning address') ||
+      lower.includes('lud16') ||
+      lower.includes('lud06') ||
+      lower.includes('no zap endpoint')
+    ) {
+      errorTitle = 'No Lightning address';
+      errorBody =
+        "This user hasn't set up a Lightning address yet, so zaps can't be sent to them.";
+      errorRetryable = false;
+    } else if (lower.includes('timed out') || lower.includes('timeout')) {
+      errorTitle = 'Zap timed out';
+      errorBody =
+        'The payment service took too long to respond. Check your connection and try again.';
+      errorRetryable = true;
+    } else if (lower.includes('insufficient') || lower.includes('balance')) {
+      errorTitle = 'Not enough sats';
+      errorBody = "Your wallet doesn't have enough sats for this zap. Try a smaller amount.";
+      errorRetryable = true;
+    } else if (
+      lower.includes('rejected') ||
+      lower.includes('denied') ||
+      lower.includes('cancelled') ||
+      lower.includes('canceled')
+    ) {
+      errorTitle = 'Zap cancelled';
+      errorBody = 'The payment was cancelled before it completed.';
+      errorRetryable = true;
+    } else if (lower.includes('no wallet')) {
+      errorTitle = 'No wallet connected';
+      errorBody = 'Connect a Lightning wallet to send zaps.';
+      errorRetryable = false;
+    } else {
+      errorTitle = "Couldn't send zap";
+      errorBody = msg || 'Something went wrong. Please try again.';
+      errorRetryable = true;
+    }
+  }
 
   let zapManager: ZapManager;
   let pendingTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -189,10 +251,14 @@
       );
 
       // Use the unified wallet manager to send payment (handles both Spark and NWC)
-      // Pass metadata so a pending transaction appears immediately
+      // Pass metadata so a pending transaction appears immediately. The
+      // user-typed message becomes both `comment` (rendered in italics in
+      // the wallet history row) and the source of `description` when
+      // present (rendered when the row has no associated pubkey).
       const paymentResult = await sendPayment(zapResult.invoice, {
         amount,
         description: message || `Zap to ${recipientPubkey.substring(0, 8)}...`,
+        comment: message || undefined,
         pubkey: recipientPubkey
       });
 
@@ -204,8 +270,9 @@
       state = 'success';
       hapticSuccess();
 
-      // Notify parent that zap completed so it can refresh zap totals
-      dispatch('zap-complete', { amount, pollOptionId });
+      // Notify parent that zap completed so it can refresh zap totals.
+      // Include the user-typed message so the optimistic pill shows it.
+      dispatch('zap-complete', { amount, pollOptionId, comment: message || undefined });
 
       // Auto-close modal after 2.5s; user can also tap anywhere to dismiss
       successTimeout = setTimeout(() => {
@@ -272,7 +339,7 @@
         invoice: zapResult.invoice,
         verify: zapResult.verify,
         onPaid: () => {
-          dispatch('zap-complete', { amount, pollOptionId });
+          dispatch('zap-complete', { amount, pollOptionId, comment: message || undefined });
         },
         onCancelled: () => {
           // User cancelled - reopen our modal
@@ -433,20 +500,31 @@
         </Button>
       </div>
     {:else if state == 'error'}
-      <div class="flex flex-col items-center justify-center">
-        <XIcon color="red" weight="bold" class="w-36 h-36" />
-        <span class="text-2xl ml-4 text-center" style="color: var(--color-text-primary)"
-          >An Error Occurred.</span
+      <div class="flex flex-col items-center justify-center py-2">
+        <div
+          class="w-16 h-16 rounded-full flex items-center justify-center mb-3"
+          style="background-color: rgba(245, 158, 11, 0.12); color: #f59e0b;"
         >
-        <span class="text-base text-caption text-center mt-2">{error && error.toString()}</span>
-        <div class="flex gap-2 mt-4">
+          <LightningIcon weight="fill" size={32} />
+        </div>
+        <span
+          class="text-lg font-semibold text-center"
+          style="color: var(--color-text-primary)">{errorTitle}</span
+        >
+        <span
+          class="text-sm text-center mt-1.5 max-w-xs"
+          style="color: var(--color-text-secondary)">{errorBody}</span
+        >
+        <div class="flex gap-2 mt-5">
           <Button on:click={() => (open = false)}>Close</Button>
-          <Button
-            on:click={() => {
-              state = 'pre';
-              error = null;
-            }}>Try Again</Button
-          >
+          {#if errorRetryable}
+            <Button
+              on:click={() => {
+                state = 'pre';
+                error = null;
+              }}>Try Again</Button
+            >
+          {/if}
         </div>
       </div>
     {:else if state == 'success'}
@@ -514,6 +592,14 @@
           </span>
           {#if successFiatStr}
             <span class="text-sm text-caption">{successFiatStr}</span>
+          {/if}
+          {#if message.trim()}
+            <p
+              class="text-sm italic text-center max-w-xs mt-1 break-words"
+              style="color: var(--color-text-secondary)"
+            >
+              "{message}"
+            </p>
           {/if}
         </div>
       </button>

--- a/src/components/ZappersListModal.svelte
+++ b/src/components/ZappersListModal.svelte
@@ -197,8 +197,17 @@
               <div class="font-semibold truncate" style="color: var(--color-text-primary)">
                 {zapper.displayName}
               </div>
+              {#if zapper.comment}
+                <div
+                  class="text-sm italic mt-0.5 line-clamp-2 whitespace-pre-wrap break-words"
+                  style="color: var(--color-text-secondary)"
+                  title={zapper.comment}
+                >
+                  "{zapper.comment}"
+                </div>
+              {/if}
               {#if formatTimestamp(zapper.timestamp)}
-                <div class="text-xs text-caption">
+                <div class="text-xs text-caption mt-0.5">
                   {formatTimestamp(zapper.timestamp)}
                 </div>
               {/if}

--- a/src/components/wallet/WalletPanel.svelte
+++ b/src/components/wallet/WalletPanel.svelte
@@ -1060,13 +1060,21 @@
       const pending = $pendingTransactions;
       const now = Math.floor(Date.now() / 1000);
 
+      // Match window for migrating pending tx metadata onto the SDK
+      // history row. Has to be wide enough that an SDK timestamp that
+      // drifts a bit from when we sent still matches. Orphan cleanup
+      // uses the same window so a completed pending tx that never gets
+      // an SDK counterpart eventually drops out instead of lingering
+      // forever. Kept in sync with PENDING_TX_TTL_SECS in walletManager.
+      const PENDING_MIGRATION_WINDOW_SECS = 30 * 60;
+
       for (const pendingTx of pending) {
         if (pendingTx.status === 'completed') {
           const matchingRealIndex = transactions.findIndex(
             (tx) =>
               tx.amount === pendingTx.amount &&
               tx.type === 'outgoing' &&
-              Math.abs(tx.timestamp - pendingTx.timestamp) < 600
+              Math.abs(tx.timestamp - pendingTx.timestamp) < PENDING_MIGRATION_WINDOW_SECS
           );
 
           if (matchingRealIndex >= 0) {
@@ -1085,7 +1093,7 @@
               comment: pendingTx.comment
             });
             removePendingTransaction(pendingTx.id);
-          } else if (now - pendingTx.timestamp > 600) {
+          } else if (now - pendingTx.timestamp > PENDING_MIGRATION_WINDOW_SECS) {
             removePendingTransaction(pendingTx.id);
           }
         } else if (pendingTx.status === 'pending' && now - pendingTx.timestamp > 1800) {

--- a/src/lib/autoZapSettings.ts
+++ b/src/lib/autoZapSettings.ts
@@ -19,12 +19,18 @@ import { CLIENT_TAG_IDENTIFIER } from '$lib/consts';
 // Storage keys
 const ONE_TAP_ZAP_ENABLED_KEY = 'zapcooking_one_tap_zap_enabled';
 const ONE_TAP_ZAP_AMOUNT_KEY = 'zapcooking_one_tap_zap_amount';
+const DEFAULT_ZAP_MESSAGE_KEY = 'zapcooking_default_zap_message';
 
 // Default amount in sats (user's preferred zap amount)
 const DEFAULT_AMOUNT = 21;
 
 // Maximum allowed amount (safety limit)
 export const MAX_ONE_TAP_ZAP_AMOUNT = 10000;
+
+// Length cap for the default zap message — prevents accidental novel-length
+// blobs in the zap comment field. Matches the practical limit most LNURL
+// servers accept for `comment` parameters.
+export const MAX_ZAP_MESSAGE_LENGTH = 280;
 
 // Nostr settings
 const SETTINGS_KIND = 30078;
@@ -33,6 +39,10 @@ const SETTINGS_D_TAG = 'one-tap-zap-settings';
 export interface OneTapZapSettings {
   enabled: boolean;
   amount: number;
+  /** Default zap comment, pre-filled into ZapModal and used for one-tap
+   * zaps. Empty string means "no default" (preserves current behaviour
+   * for users who never set one). */
+  defaultMessage: string;
 }
 
 let isLoadingFromRelay = false;
@@ -60,15 +70,21 @@ function normalizeSettings(settings: Partial<OneTapZapSettings>): OneTapZapSetti
     amount:
       typeof settings.amount === 'number'
         ? Math.min(Math.max(1, settings.amount), MAX_ONE_TAP_ZAP_AMOUNT)
-        : DEFAULT_AMOUNT
+        : DEFAULT_AMOUNT,
+    defaultMessage:
+      typeof settings.defaultMessage === 'string'
+        ? settings.defaultMessage.slice(0, MAX_ZAP_MESSAGE_LENGTH)
+        : ''
   };
 }
 
 function applySettings(settings: OneTapZapSettings): void {
   oneTapZapEnabled.set(settings.enabled);
   oneTapZapAmount.set(settings.amount);
+  defaultZapMessage.set(settings.defaultMessage);
   saveEnabled(settings.enabled);
   saveAmount(settings.amount);
+  saveDefaultMessage(settings.defaultMessage);
 }
 
 /**
@@ -121,6 +137,36 @@ function saveAmount(amount: number): void {
   }
 }
 
+/**
+ * Load default zap message from localStorage
+ */
+function loadDefaultMessage(): string {
+  if (!browser) return '';
+  try {
+    const stored = localStorage.getItem(DEFAULT_ZAP_MESSAGE_KEY);
+    return typeof stored === 'string' ? stored.slice(0, MAX_ZAP_MESSAGE_LENGTH) : '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Save default zap message to localStorage
+ */
+function saveDefaultMessage(message: string): void {
+  if (!browser) return;
+  try {
+    if (message) {
+      localStorage.setItem(DEFAULT_ZAP_MESSAGE_KEY, message);
+    } else {
+      // Empty string means "no default" — drop the key entirely.
+      localStorage.removeItem(DEFAULT_ZAP_MESSAGE_KEY);
+    }
+  } catch {
+    // Ignore storage errors
+  }
+}
+
 // --- Stores ---
 
 /** Whether one-tap zap is enabled */
@@ -128,6 +174,11 @@ export const oneTapZapEnabled = writable<boolean>(false);
 
 /** One-tap zap amount in sats - user's preferred default zap amount */
 export const oneTapZapAmount = writable<number>(DEFAULT_AMOUNT);
+
+/** Default zap comment, pre-filled into ZapModal and used as the message
+ * for one-tap zaps. Empty string means "no default" — preserves the
+ * pre-feature behaviour where ZapModal opened with an empty message. */
+export const defaultZapMessage = writable<string>('');
 
 // Legacy exports for compatibility during transition
 export const autoZapEnabled = oneTapZapEnabled;
@@ -143,6 +194,7 @@ if (browser) {
     hasLoaded = true;
     oneTapZapEnabled.set(loadEnabled());
     oneTapZapAmount.set(loadAmount());
+    defaultZapMessage.set(loadDefaultMessage());
   }, 0);
 }
 
@@ -159,12 +211,19 @@ oneTapZapAmount.subscribe((amount) => {
   }
 });
 
+defaultZapMessage.subscribe((message) => {
+  if (browser && hasLoaded) {
+    saveDefaultMessage(message);
+  }
+});
+
 // --- Nostr Sync ---
 
 export async function loadOneTapZapSettings(): Promise<OneTapZapSettings> {
   const localSettings = normalizeSettings({
     enabled: loadEnabled(),
-    amount: loadAmount()
+    amount: loadAmount(),
+    defaultMessage: loadDefaultMessage()
   });
   applySettings(localSettings);
 
@@ -259,7 +318,8 @@ export function setOneTapZapEnabled(enabled: boolean): void {
   oneTapZapEnabled.set(enabled);
   const settings = normalizeSettings({
     enabled,
-    amount: get(oneTapZapAmount)
+    amount: get(oneTapZapAmount),
+    defaultMessage: get(defaultZapMessage)
   });
   void publishOneTapZapSettings(settings);
 }
@@ -272,9 +332,32 @@ export function setOneTapZapAmount(sats: number): void {
   oneTapZapAmount.set(capped);
   const settings = normalizeSettings({
     enabled: get(oneTapZapEnabled),
-    amount: capped
+    amount: capped,
+    defaultMessage: get(defaultZapMessage)
   });
   void publishOneTapZapSettings(settings);
+}
+
+/**
+ * Set the default zap message (capped at MAX_ZAP_MESSAGE_LENGTH).
+ * Pass an empty string to clear the default.
+ */
+export function setDefaultZapMessage(message: string): void {
+  const trimmed = (message || '').slice(0, MAX_ZAP_MESSAGE_LENGTH);
+  defaultZapMessage.set(trimmed);
+  const settings = normalizeSettings({
+    enabled: get(oneTapZapEnabled),
+    amount: get(oneTapZapAmount),
+    defaultMessage: trimmed
+  });
+  void publishOneTapZapSettings(settings);
+}
+
+/**
+ * Get the current default zap message
+ */
+export function getDefaultZapMessage(): string {
+  return get(defaultZapMessage);
 }
 
 /**

--- a/src/lib/engagementCache.ts
+++ b/src/lib/engagementCache.ts
@@ -18,6 +18,10 @@ export interface Zapper {
   pubkey: string;
   amount: number; // in sats
   timestamp: number;
+  /** Zap message (content of the kind-9734 zap request inside the
+   * receipt's description tag). Undefined when the zap had no comment
+   * or we couldn't parse the request. */
+  comment?: string;
 }
 
 // Types for engagement data
@@ -40,6 +44,12 @@ export interface EngagementData {
     count: number;
     userZapped: boolean;
     topZappers: Zapper[]; // Top zappers sorted by amount (descending)
+    /** Bumps to Date.now() each time the local user successfully sends a
+     * zap on this event (via optimistic update). UI watches this to
+     * trigger a sparkle/celebration animation on every zap — including
+     * repeat zaps where `userZapped` is already true and wouldn't show
+     * a transition. Undefined / 0 means "never zapped in this session". */
+    lastSelfZapAt?: number;
   };
   loading: boolean;
   lastFetched: number;
@@ -652,8 +662,12 @@ function processZap(data: EngagementData, event: NDKEvent, userPublickey: string
   // ThreadCommentActions, shareNoteImage, FoodstrFeedOptimized glow tier).
   const amountMillisats = amountSats * 1000;
 
-  // Extract zapper info from the zap request in the description tag
+  // Extract zapper info from the zap request in the description tag.
+  // The kind-9734 zap request lives JSON-encoded in the receipt's
+  // `description` tag — its `pubkey` is the actual zapper and its
+  // `content` is the user-typed zap message.
   let zapperPubkey = event.pubkey; // fallback to zapper service pubkey
+  let zapComment: string | undefined;
   try {
     const descTag = event.tags.find(t => t[0] === 'description')?.[1];
     if (descTag) {
@@ -661,9 +675,12 @@ function processZap(data: EngagementData, event: NDKEvent, userPublickey: string
       if (zapRequest.pubkey) {
         zapperPubkey = zapRequest.pubkey;
       }
+      if (typeof zapRequest.content === 'string' && zapRequest.content.length > 0) {
+        zapComment = zapRequest.content;
+      }
     }
   } catch {
-    // Failed to parse description, use event pubkey
+    // Failed to parse description, use event pubkey and no comment
   }
 
   // Check if this matches an optimistic zap we already added
@@ -710,11 +727,17 @@ function processZap(data: EngagementData, event: NDKEvent, userPublickey: string
       existingZapper.amount += amountSats;
     }
     existingZapper.timestamp = Math.max(existingZapper.timestamp, zapTimestamp);
+    // Keep the most recent non-empty comment so the pill detail surfaces
+    // the message the user just sent rather than an older blank zap.
+    if (zapComment) {
+      existingZapper.comment = zapComment;
+    }
   } else {
     data.zaps.topZappers.push({
       pubkey: zapperPubkey,
       amount: amountSats,
-      timestamp: zapTimestamp
+      timestamp: zapTimestamp,
+      comment: zapComment
     });
   }
 
@@ -839,11 +862,16 @@ export function cleanupEngagement(eventId: string): void {
 // Optimistically update zap count when zap is initiated
 // This provides immediate feedback while the zap is processing
 // The subscription will correct the count when the real zap receipt arrives
-export function optimisticZapUpdate(eventId: string, amountMillisats: number, userPublickey: string): void {
+export function optimisticZapUpdate(
+  eventId: string,
+  amountMillisats: number,
+  userPublickey: string,
+  comment?: string
+): void {
   const store = getEngagementStore(eventId);
   const amountSats = Math.floor(amountMillisats / 1000);
   const now = Date.now();
-  
+
   // Track this optimistic zap (keyed by eventId + userPubkey + timestamp for uniqueness)
   const optimisticKey = `${eventId}:${userPublickey}:${now}`;
   optimisticZaps.set(optimisticKey, {
@@ -851,7 +879,7 @@ export function optimisticZapUpdate(eventId: string, amountMillisats: number, us
     timestamp: now,
     userPubkey: userPublickey
   });
-  
+
   // Clean up old optimistic zaps (older than 5 minutes)
   const fiveMinutesAgo = now - 5 * 60 * 1000;
   for (const [key, zap] of optimisticZaps.entries()) {
@@ -859,7 +887,7 @@ export function optimisticZapUpdate(eventId: string, amountMillisats: number, us
       optimisticZaps.delete(key);
     }
   }
-  
+
   store.update(s => {
     const updated = { ...s };
 
@@ -868,29 +896,118 @@ export function optimisticZapUpdate(eventId: string, amountMillisats: number, us
     updated.zaps.totalAmount += amountMillisats;
     updated.zaps.count += 1;
     updated.zaps.userZapped = true;
-    
+    // Intentionally NOT bumping lastSelfZapAt here. The optimistic update
+    // runs after LNURL succeeds but before the actual payment confirms —
+    // a celebration animation hooked to that moment would fire before
+    // the payment is done, then again at completion. UI animations
+    // (sparkle burst) watch lastSelfZapAt which is set by
+    // markSelfZapCompleted() only after the payment is fully through.
+
     // Add or update zapper in the list optimistically
     const existingZapper = updated.zaps.topZappers.find(z => z.pubkey === userPublickey);
     if (existingZapper) {
       existingZapper.amount += amountSats;
       existingZapper.timestamp = Math.floor(Date.now() / 1000);
+      if (comment) existingZapper.comment = comment;
     } else {
       updated.zaps.topZappers.push({
         pubkey: userPublickey,
         amount: amountSats,
-        timestamp: Math.floor(Date.now() / 1000)
+        timestamp: Math.floor(Date.now() / 1000),
+        comment: comment || undefined
       });
     }
-    
+
     // Sort by amount descending, keep top 10
     updated.zaps.topZappers.sort((a, b) => b.amount - a.amount);
     if (updated.zaps.topZappers.length > 10) {
       updated.zaps.topZappers = updated.zaps.topZappers.slice(0, 10);
     }
-    
+
     // Save to cache with optimistic update
     saveToCache(eventId, updated);
-    
+
+    return updated;
+  });
+}
+
+/**
+ * Mark a self-zap as fully completed (payment confirmed). Bumps
+ * lastSelfZapAt so UI animations keyed off it (sparkle burst) fire
+ * exactly once per zap — at completion, not during the in-flight
+ * optimistic window. Call this from the zap path right after the
+ * payment provider returns success.
+ */
+export function markSelfZapCompleted(eventId: string): void {
+  const store = getEngagementStore(eventId);
+  store.update(s => {
+    const updated = { ...s };
+    updated.zaps.lastSelfZapAt = Date.now();
+    saveToCache(eventId, updated);
+    return updated;
+  });
+}
+
+/**
+ * Roll back a previously-applied optimistic zap update. Call this when a
+ * zap fails to complete (LNURL has no callback, payment errored, etc.) so
+ * the phantom count doesn't linger on the note until a real receipt
+ * arrives (which it won't, because no zap was made).
+ *
+ * Pass the EXACT amount you originally passed to optimisticZapUpdate so
+ * we subtract the right value. If multiple optimistic entries exist for
+ * the same user+event we revert the most recent one.
+ */
+export function revertOptimisticZap(
+  eventId: string,
+  amountMillisats: number,
+  userPublickey: string
+): void {
+  const store = getEngagementStore(eventId);
+  const amountSats = Math.floor(amountMillisats / 1000);
+
+  // Remove the most recent matching tracking entry so a later real
+  // receipt isn't accidentally matched to this reverted optimistic.
+  let mostRecentKey: string | null = null;
+  let mostRecentTs = 0;
+  for (const [key, opt] of optimisticZaps.entries()) {
+    if (
+      key.startsWith(`${eventId}:${userPublickey}:`) &&
+      opt.amountMillisats === amountMillisats &&
+      opt.timestamp > mostRecentTs
+    ) {
+      mostRecentKey = key;
+      mostRecentTs = opt.timestamp;
+    }
+  }
+  if (mostRecentKey) {
+    optimisticZaps.delete(mostRecentKey);
+  }
+
+  store.update(s => {
+    const updated = { ...s };
+    updated.zaps.totalAmount = Math.max(0, updated.zaps.totalAmount - amountMillisats);
+    updated.zaps.count = Math.max(0, updated.zaps.count - 1);
+
+    // Subtract from the user's entry; remove if it drops to 0.
+    const idx = updated.zaps.topZappers.findIndex(z => z.pubkey === userPublickey);
+    if (idx !== -1) {
+      const zapper = updated.zaps.topZappers[idx];
+      const newAmount = zapper.amount - amountSats;
+      if (newAmount <= 0) {
+        updated.zaps.topZappers.splice(idx, 1);
+        // Only flip userZapped off if there are no other zaps from this user.
+        const stillHasZap = updated.zaps.topZappers.some(z => z.pubkey === userPublickey);
+        if (!stillHasZap) {
+          updated.zaps.userZapped = false;
+        }
+      } else {
+        zapper.amount = newAmount;
+      }
+      updated.zaps.topZappers.sort((a, b) => b.amount - a.amount);
+    }
+
+    saveToCache(eventId, updated);
     return updated;
   });
 }

--- a/src/lib/oneTapZap.ts
+++ b/src/lib/oneTapZap.ts
@@ -12,8 +12,12 @@ import { ndk, userPublickey } from '$lib/nostr';
 import { ZapManager } from '$lib/zapManager';
 import { activeWallet } from '$lib/wallet';
 import { sendPayment } from '$lib/wallet/walletManager';
-import { oneTapZapEnabled, oneTapZapAmount } from '$lib/autoZapSettings';
-import { optimisticZapUpdate } from '$lib/engagementCache';
+import { oneTapZapEnabled, oneTapZapAmount, defaultZapMessage } from '$lib/autoZapSettings';
+import {
+  optimisticZapUpdate,
+  revertOptimisticZap,
+  markSelfZapCompleted
+} from '$lib/engagementCache';
 
 /**
  * Check if one-tap zap is available (enabled + has in-app wallet)
@@ -73,6 +77,7 @@ export async function sendOneTapZap(target: NDKEvent | NDKUser): Promise<OneTapZ
   }
 
     const amount = get(oneTapZapAmount);
+    const message = get(defaultZapMessage);
     const currentUserPubkey = get(userPublickey);
     console.log('[OneTapZap] Amount:', amount, 'sats, Wallet kind:', wallet.kind);
 
@@ -93,41 +98,71 @@ export async function sendOneTapZap(target: NDKEvent | NDKUser): Promise<OneTapZ
       return { success: false, error: 'Invalid target for zap' };
     }
 
-    // Optimistically update the zap count immediately (before payment starts)
-    // This provides instant visual feedback while payment processes in background
-    if (eventId && currentUserPubkey) {
-      optimisticZapUpdate(eventId, amount * 1000, currentUserPubkey);
-      console.log('[OneTapZap] Optimistic update applied for event:', eventId, 'amount:', amount, 'sats');
-    }
+    // Track whether we've applied the optimistic update so the catch
+    // block knows whether to revert. We defer the optimistic update until
+    // AFTER createZap succeeds — that call is what fetches the
+    // recipient's LNURL endpoint and gets back an invoice. If the
+    // recipient has no lud16 / lud06, or the LNURL provider errors,
+    // createZap throws BEFORE any optimistic count would be applied, so
+    // the note never shows a phantom zap that never actually happened.
+    let optimisticApplied = false;
+    const amountMillisats = amount * 1000;
 
     try {
       const zapManager = new ZapManager(ndkInstance);
 
-    // Create the zap invoice
+    // Create the zap invoice. Throws if the recipient isn't zappable
+    // (no lud16 / lud06, LNURL endpoint unreachable, etc.).
     console.log('[OneTapZap] Creating zap invoice...');
     const zapResult = await zapManager.createZap(
       recipientPubkey,
-      amount * 1000, // Convert to millisats
-      '', // No message for one-tap zaps
+      amountMillisats, // Convert to millisats
+      message, // User-configurable default zap message (empty string by default)
       eventId
     );
     console.log('[OneTapZap] Zap invoice created:', zapResult.invoice?.substring(0, 50) + '...');
+
+    // LNURL succeeded → recipient is zappable → apply the optimistic
+    // update so the UI shows immediate feedback while payment processes.
+    if (eventId && currentUserPubkey) {
+      optimisticZapUpdate(eventId, amountMillisats, currentUserPubkey, message || undefined);
+      optimisticApplied = true;
+      console.log('[OneTapZap] Optimistic update applied for event:', eventId, 'amount:', amount, 'sats');
+    }
 
     // Send the payment
     console.log('[OneTapZap] Sending payment...');
     const paymentResult = await sendPayment(zapResult.invoice, {
       amount,
-      description: `Zap to ${recipientPubkey.substring(0, 8)}...`,
+      description: message || `Zap to ${recipientPubkey.substring(0, 8)}...`,
+      comment: message || undefined,
       pubkey: recipientPubkey
     });
     console.log('[OneTapZap] Payment result:', paymentResult);
 
     if (!paymentResult.success) {
+      // Payment failed after the optimistic update — revert it so the
+      // note doesn't show a phantom zap that never actually arrived.
+      if (optimisticApplied && eventId && currentUserPubkey) {
+        revertOptimisticZap(eventId, amountMillisats, currentUserPubkey);
+      }
       return { success: false, error: paymentResult.error || 'Payment failed' };
+    }
+
+    // Payment fully completed — mark the self-zap for any UI animation
+    // that wants a one-shot "celebration" trigger (e.g. sparkle burst).
+    if (eventId) {
+      markSelfZapCompleted(eventId);
     }
 
     return { success: true, amount };
   } catch (e) {
+    // createZap threw (no lud16, LNURL down, etc.) OR something else
+    // failed mid-flow. If we'd already applied the optimistic update,
+    // revert it; if we hadn't, there's nothing to revert.
+    if (optimisticApplied && eventId && currentUserPubkey) {
+      revertOptimisticZap(eventId, amountMillisats, currentUserPubkey);
+    }
     const errorMessage = e instanceof Error ? e.message : 'Unknown error';
     console.error('[OneTapZap] Failed:', errorMessage, e);
     return { success: false, error: errorMessage };

--- a/src/lib/wallet/walletManager.ts
+++ b/src/lib/wallet/walletManager.ts
@@ -319,13 +319,17 @@ export async function sendPayment(
   // Generate a temporary ID for the pending transaction
   const pendingId = `pending-${Date.now()}-${Math.random().toString(36).substring(7)}`;
 
-  // Add pending transaction if we have metadata
+  // Add pending transaction if we have metadata. The `comment` field is the
+  // user-typed zap message — distinct from `description`, which is a generic
+  // display string. WalletPanel renders comment in italics on the row when
+  // present, so callers should pass the message through here.
   if (metadata?.amount) {
     addPendingTransaction({
       id: pendingId,
       type: 'outgoing',
       amount: metadata.amount,
       description: metadata.description || 'Sending payment...',
+      comment: metadata.comment,
       timestamp: Math.floor(Date.now() / 1000),
       pubkey: metadata.pubkey,
       walletId: wallet.id
@@ -572,14 +576,27 @@ export interface Transaction {
  */
 const PENDING_TX_KEY = 'zapcooking_pending_transactions';
 
+// How long completed pending transactions live in localStorage before we
+// drop them on initial load. They serve as the bridge that carries the
+// recipient pubkey + zap comment onto the SDK history row (via the
+// matching pass in WalletPanel.loadTransactionHistory). 5 minutes was
+// too short — if the SDK history hadn't picked up the payment yet, or
+// the user closed the wallet panel right after sending and came back
+// later, the pending tx was dropped before its metadata was migrated
+// onto the real SDK row. The row then renders as a generic "Sent" with
+// no recipient. 30 minutes gives the migration plenty of time to run on
+// the next wallet-panel open. Once migrated, metadata is persisted under
+// the SDK txid (zapcooking_tx_metadata) and survives indefinitely.
+const PENDING_TX_TTL_SECS = 30 * 60;
+
 function loadPendingFromStorage(): Transaction[] {
   if (typeof window === 'undefined' || typeof localStorage === 'undefined') return [];
   try {
     const stored = localStorage.getItem(PENDING_TX_KEY);
     if (stored) {
       const txs = JSON.parse(stored) as Transaction[];
-      const fiveMinutesAgo = Math.floor(Date.now() / 1000) - 300;
-      return txs.filter((tx) => tx.timestamp > fiveMinutesAgo);
+      const cutoff = Math.floor(Date.now() / 1000) - PENDING_TX_TTL_SECS;
+      return txs.filter((tx) => tx.timestamp > cutoff);
     }
   } catch (e) {
     console.error('[WalletManager] Failed to load pending transactions:', e);

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -12,6 +12,7 @@
   import SignOutIcon from 'phosphor-svelte/lib/SignOut';
   import ShieldCheckIcon from 'phosphor-svelte/lib/ShieldCheck';
   import WarningIcon from 'phosphor-svelte/lib/Warning';
+  import ChatIcon from 'phosphor-svelte/lib/ChatCircle';
   import Button from '../../components/Button.svelte';
   import Modal from '../../components/Modal.svelte';
   import Accordion from '../../components/Accordion.svelte';
@@ -36,9 +37,12 @@
   import {
     oneTapZapEnabled,
     oneTapZapAmount,
+    defaultZapMessage,
     setOneTapZapEnabled,
     setOneTapZapAmount,
-    MAX_ONE_TAP_ZAP_AMOUNT
+    setDefaultZapMessage,
+    MAX_ONE_TAP_ZAP_AMOUNT,
+    MAX_ZAP_MESSAGE_LENGTH
   } from '$lib/autoZapSettings';
   import { hellthreadThreshold } from '$lib/hellthreadFilterSettings';
   import {
@@ -1029,6 +1033,40 @@
               Connect a Spark or NWC wallet to enable one-tap zaps.
             </p>
           {/if}
+        </div>
+
+        <!-- Default Zap Message — applies to ALL zaps (both ZapModal and
+             one-tap), not just one-tap, so it sits outside the one-tap
+             wallet-gating block. Pre-fills the ZapModal message textarea
+             on open; users can override per-zap. -->
+        <div class="p-4 rounded-xl" style="border: 1px solid var(--color-input-border);">
+          <label for="default-zap-message" class="block">
+            <div class="flex items-center gap-2 mb-1">
+              <ChatIcon size={18} weight="fill" class="text-amber-500" />
+              <span class="font-medium" style="color: var(--color-text-primary)"
+                >Default zap message</span
+              >
+            </div>
+            <p class="text-sm text-caption mb-3">
+              Pre-fills the zap message field. You can edit or clear it before each zap.
+            </p>
+          </label>
+          <!-- bind:value keeps the store + localStorage in sync on every
+               keystroke (the autoZapSettings subscriber persists). on:change
+               (which fires on blur) handles the NIP-78 relay publish so we
+               don't spam relays during typing. -->
+          <textarea
+            id="default-zap-message"
+            rows="2"
+            maxlength={MAX_ZAP_MESSAGE_LENGTH}
+            bind:value={$defaultZapMessage}
+            on:change={() => setDefaultZapMessage($defaultZapMessage)}
+            placeholder="e.g. Thanks for the great recipe!"
+            class="input w-full resize-none"
+          ></textarea>
+          <p class="text-xs text-caption mt-2 text-right">
+            {$defaultZapMessage.length}/{MAX_ZAP_MESSAGE_LENGTH}
+          </p>
         </div>
       </div>
     </Accordion>


### PR DESCRIPTION
## Summary

Adds a user-configurable default zap message that pre-fills the ZapModal textarea on every open and ships with one-tap zaps. The message is then plumbed end-to-end so it surfaces wherever the zap is visible — wallet history rows, ZappersListModal entries, and the ZapModal success state. Plus a handful of related polish around the zap flow that fell out of testing on a Vercel preview:

- Settings → Zap Settings → **Default zap message** textarea (live `bind:value`, NIP-78 relay publish on blur). 280-char cap with counter.
- `Zapper.comment` plumbed through the engagement-cache. `processZap` parses the kind-9734 zap request from the receipt's `description` tag, so the message shows for everyone's zaps, not just your own optimistic ones.
- `walletManager.sendPayment` forwards `metadata.comment` into the pending transaction. WalletPanel already rendered `tx.comment` in italics on outgoing rows.
- ZapModal success state and ZappersListModal entries render the comment in italics.
- One-tap zaps use the default message for both the zap request content and the wallet-history metadata.

### Reliability fixes

- **No more phantom zap counts.** Optimistic update is now applied *after* `createZap()` succeeds (so a recipient with no `lud16` / a failing LNURL endpoint never produces a count that won't reconcile). New `revertOptimisticZap()` undoes the update if `sendPayment` errors.
- **Friendlier ZapModal error UI.** Replaced the giant red X with an amber `LightningSlash` in a tinted circle, mapped raw errors to human messages (`"This user hasn't set up a Lightning address yet, so zaps can't be sent to them."` instead of `"Profile lud16: undefined"`), and made Try Again context-aware — hidden for unrecoverable cases.
- **Pending tx TTL bumped 5 min → 30 min.** Was causing wallet history rows to lose their recipient name + comment if the user closed and reopened the wallet panel before the SDK history sync. The pending tx is the bridge that carries recipient pubkey + zap comment onto the SDK row; if it ages out before that migration runs, the row renders as a generic "Sent". Matching window in `WalletPanel.loadTransactionHistory` bumped to match.

### Completion polish on the bolt

- Bolt turns yellow + filled the moment `isZapping` flips (synchronous on tap, before any await). Instant tap confirmation — no waiting on LNURL.
- One-shot sparkle burst when the zap is fully paid. Six amber particles fan out with a brief "pop" overshoot then fade. Fires via a dedicated `markSelfZapCompleted(eventId)` called *only* after `sendPayment` returns success (one-tap path) or after the modal's `zap-complete` event (modal path). Decoupled from `optimisticZapUpdate` so it fires exactly once at the end of the flow, not at the LNURL step *and* again at payment.
- Respects `prefers-reduced-motion`.

## Test plan

- [ ] Settings → Zap Settings → Default zap message: type, blur, refresh page → message persists; check NIP-78 event published with content
- [ ] Open ZapModal on any note → textarea pre-fills with your default; edit/clear works; sending uses the edited value
- [ ] One-tap zap → wallet history row shows ⚡ to {recipient} with the message in italics
- [ ] ZapModal success state → shows the message in italics under the amount badge
- [ ] Click a zapper pill on a note → ZappersListModal opens with the message under each zapper that had one
- [ ] Zap a note whose author has no `lud16` → friendly "No Lightning address" error, no phantom zap count gets added (refresh and confirm)
- [ ] Zap a note → bolt instantly turns gold on tap; sparkle burst fires once when payment confirms; second tap on same note also bursts
- [ ] Close wallet, wait > 5 min, reopen → previously-sent zap row still shows ⚡ to {recipient} with the message (was the 5-min TTL bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)