### PR TITLE
fix(note-header): compact timestamp + truncate name to stop mobile wrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.452",
+  "version": "4.2.454",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -33,7 +33,6 @@
     hasMutedTag,
     isThreadMuted
   } from '$lib/mutableIntegration';
-  import { formatDistanceToNow } from 'date-fns';
   import Avatar from './Avatar.svelte';
   import type { NDKSubscription } from '@nostr-dev-kit/ndk';
   import { NDKEvent, NDKSubscriptionCacheUsage } from '@nostr-dev-kit/ndk';
@@ -792,8 +791,20 @@
     }
   }
 
+  // Compact "X-unit-ago" formatter for note headers (e.g. "10m", "3h",
+  // "2d", "1y"). Replaces date-fns' formatDistanceToNow which produced
+  // verbose phrases like "about 3 hours ago" that wrapped mid-phrase on
+  // mobile and pushed the post-actions menu around.
   function formatTimeAgo(timestamp: number): string {
-    return formatDistanceToNow(new Date(timestamp * 1000), { addSuffix: true });
+    const seconds = Math.floor(Date.now() / 1000) - timestamp;
+    if (seconds < 60) return 'now';
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes}m`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h`;
+    const days = Math.floor(hours / 24);
+    if (days < 365) return `${days}d`;
+    return `${Math.floor(days / 365)}y`;
   }
 
   function isImageUrl(url: string): boolean {
@@ -5199,10 +5210,13 @@
 
                 <div class="flex items-center space-x-2 flex-wrap min-w-0">
                   {#if !hideAuthorName}
-                    <AuthorName {event} />
-                    <span class="text-sm" style="color: var(--color-caption)">·</span>
+                    <!-- truncate + min-w-0 lets a long display name shrink with an
+                         ellipsis instead of pushing the timestamp onto a new line
+                         (or worse, splitting "about 3 hours ago" mid-phrase). -->
+                    <AuthorName {event} className="font-semibold text-sm truncate min-w-0" />
+                    <span class="text-sm flex-shrink-0" style="color: var(--color-caption)">·</span>
                   {/if}
-                  <span class="text-sm" style="color: var(--color-caption)">
+                  <span class="text-sm whitespace-nowrap flex-shrink-0" style="color: var(--color-caption)">
                     {event.created_at ? formatTimeAgo(event.created_at) : 'Unknown time'}
                   </span>
                   <ClientAttribution tags={event.tags} enableEnrichment={false} />

--- a/src/routes/[nip19]/+page.svelte
+++ b/src/routes/[nip19]/+page.svelte
@@ -7,7 +7,6 @@
   import { onMount } from 'svelte';
   import Avatar from '../../components/Avatar.svelte';
   import CustomName from '../../components/CustomName.svelte';
-  import { formatDistanceToNow } from 'date-fns';
   import NoteContent from '../../components/NoteContent.svelte';
   import PollDisplay from '../../components/PollDisplay.svelte';
   import NoteActionBar from '../../components/NoteActionBar.svelte';
@@ -216,8 +215,19 @@
     }
   }
 
+  // Compact "X-unit-ago" formatter for note headers (e.g. "10m", "3h",
+  // "2d", "1y"). Mirrors the helper in FoodstrFeedOptimized — short
+  // form avoids mid-phrase wrap on mobile.
   function formatTimeAgo(timestamp: number): string {
-    return formatDistanceToNow(new Date(timestamp * 1000), { addSuffix: true });
+    const seconds = Math.floor(Date.now() / 1000) - timestamp;
+    if (seconds < 60) return 'now';
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes}m`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h`;
+    const days = Math.floor(hours / 24);
+    if (days < 365) return `${days}d`;
+    return `${Math.floor(days / 365)}y`;
   }
 
 
@@ -487,18 +497,18 @@
                 </div>
                 <div class="flex-1 min-w-0">
                   <div class="flex items-center justify-between mb-1">
-                    <div class="flex items-center space-x-2">
+                    <div class="flex items-center space-x-2 min-w-0">
                       <a
                         href="/user/{nip19.npubEncode(
                           parentNote.author?.hexpubkey || parentNote.pubkey
                         )}"
-                        class="font-semibold text-sm transition-colors username-link"
+                        class="font-semibold text-sm transition-colors username-link truncate min-w-0"
                         style="color: var(--color-text-primary)"
                       >
                         <CustomName pubkey={parentNote.author?.hexpubkey || parentNote.pubkey} />
                       </a>
-                      <span class="text-sm" style="color: var(--color-caption)">·</span>
-                      <span class="text-sm" style="color: var(--color-caption)">
+                      <span class="text-sm flex-shrink-0" style="color: var(--color-caption)">·</span>
+                      <span class="text-sm whitespace-nowrap flex-shrink-0" style="color: var(--color-caption)">
                         {parentNote.created_at ? formatTimeAgo(parentNote.created_at) : ''}
                       </span>
                     </div>
@@ -546,13 +556,13 @@
               <div class="flex items-center space-x-2 mb-2 flex-wrap">
                 <a
                   href="/user/{nip19.npubEncode(event.author?.hexpubkey || event.pubkey)}"
-                  class="font-semibold text-sm transition-colors username-link"
+                  class="font-semibold text-sm transition-colors username-link truncate min-w-0"
                   style="color: var(--color-text-primary)"
                 >
                   <CustomName pubkey={event.author?.hexpubkey || event.pubkey} />
                 </a>
-                <span class="text-sm" style="color: var(--color-caption)">·</span>
-                <span class="text-sm" style="color: var(--color-caption)">
+                <span class="text-sm flex-shrink-0" style="color: var(--color-caption)">·</span>
+                <span class="text-sm whitespace-nowrap flex-shrink-0" style="color: var(--color-caption)">
                   {event.created_at ? formatTimeAgo(event.created_at) : 'Unknown time'}
                 </span>
                 <ClientAttribution tags={event.tags} enableEnrichment={true} />
@@ -624,16 +634,16 @@
                     </a>
                     <div class="flex-1 min-w-0">
                       <div class="flex items-center justify-between mb-1">
-                        <div class="flex items-center space-x-2">
+                        <div class="flex items-center space-x-2 min-w-0">
                           <a
                             href="/user/{nip19.npubEncode(reply.author?.hexpubkey || reply.pubkey)}"
-                            class="font-medium text-sm transition-colors username-link"
+                            class="font-medium text-sm transition-colors username-link truncate min-w-0"
                             style="color: var(--color-text-primary)"
                           >
                             <CustomName pubkey={reply.author?.hexpubkey || reply.pubkey} />
                           </a>
-                          <span class="text-xs" style="color: var(--color-caption)">·</span>
-                          <span class="text-xs" style="color: var(--color-caption)">
+                          <span class="text-xs flex-shrink-0" style="color: var(--color-caption)">·</span>
+                          <span class="text-xs whitespace-nowrap flex-shrink-0" style="color: var(--color-caption)">
                             {reply.created_at ? formatTimeAgo(reply.created_at) : ''}
                           </span>
                         </div>
@@ -676,20 +686,20 @@
                           </a>
                           <div class="flex-1 min-w-0">
                             <div class="flex items-center justify-between mb-0.5">
-                              <div class="flex items-center space-x-2">
+                              <div class="flex items-center space-x-2 min-w-0">
                                 <a
                                   href="/user/{nip19.npubEncode(
                                     nestedReply.author?.hexpubkey || nestedReply.pubkey
                                   )}"
-                                  class="font-medium text-xs transition-colors username-link"
+                                  class="font-medium text-xs transition-colors username-link truncate min-w-0"
                                   style="color: var(--color-text-primary)"
                                 >
                                   <CustomName
                                     pubkey={nestedReply.author?.hexpubkey || nestedReply.pubkey}
                                   />
                                 </a>
-                                <span class="text-xs" style="color: var(--color-caption)">·</span>
-                                <span class="text-xs" style="color: var(--color-caption)">
+                                <span class="text-xs flex-shrink-0" style="color: var(--color-caption)">·</span>
+                                <span class="text-xs whitespace-nowrap flex-shrink-0" style="color: var(--color-caption)">
                                   {nestedReply.created_at
                                     ? formatTimeAgo(nestedReply.created_at)
                                     : ''}


### PR DESCRIPTION
## Summary

The note header timestamp was wrapping mid-phrase on mobile — *"about 3 hours"* on line 1, *"ago"* orphaned on line 2 — pushing the post-actions menu around the layout. Two changes:

1. **Compact timestamps.** Replaced date-fns' `formatDistanceToNow` (which produces verbose phrases) with a unit formatter that returns `now` / `Nm` / `Nh` / `Nd` / `Ny` — e.g. `3h` instead of `about 3 hours ago`. Applied in `FoodstrFeedOptimized` (feed) and the thread route (parent note, focused event, reply, nested reply). Other places that still want the verbose form (polls, articles, etc.) are untouched.

2. **Robust row layout.** Author name link gets `truncate min-w-0` so long names ellipse instead of pushing the timestamp anywhere. The dot separator and timestamp span get `flex-shrink-0` so they stay full-size, and the timestamp keeps `whitespace-nowrap` defensively. The post-actions menu (`⋯`) stays pinned to the right via the existing `justify-between` on the outer container.

Removed the now-unused `formatDistanceToNow` import from both files.

## Test plan

- [ ] Feed at mobile widths: timestamp shows like `3h`, fits next to name on one line
- [ ] Long display name (e.g. emoji + long handle): name ellipses with `…`, timestamp still visible
- [ ] Thread view: parent note, focused note, replies, nested replies — all show compact timestamps with no wrap
- [ ] Desktop layout unchanged structurally; `⋯` still pinned right
- [ ] Spot-check polls / articles / other places using `formatDistanceToNow` elsewhere — verbose phrasing preserved there

🤖 Generated with [Claude Code](https://claude.com/claude-code)