### PR TITLE
fix(membership): reconcile checkout price/badge + fix mobile overflow

### DIFF
--- a/src/routes/api/membership/apply-promo/+server.ts
+++ b/src/routes/api/membership/apply-promo/+server.ts
@@ -12,17 +12,23 @@
  *   { code: string, tier: 'cook' | 'pro' | 'founders', period?: 'annual' | 'monthly' | 'lifetime' }
  *
  * Returns:
- *   200 { success: true, code, label, scope, originalUsd, finalUsd }
+ *   200 { success: true, code, label, scope, originalUsd, listUsd,
+ *         discountedUsd, amountSats, btcPrice, btcDiscountPercent,
+ *         totalDiscountPercent }
  *   200 { success: false, error: 'unknown_code' | 'expired' | 'disabled' | 'wrong_scope' | 'invalid_for_scope' }
  *
- * Promo math runs in integer USD cents (exact rounding) and is returned
- * as dollars. The 5% Bitcoin discount is NOT applied here — this previews
- * the promo-adjusted LIST price; the BTC discount + sat conversion happen
- * at invoice time.
+ * Promo math runs in integer USD cents (exact rounding). This endpoint then
+ * STACKS the 5% Bitcoin discount and converts to sats with the SAME pipeline
+ * as create-lightning-invoice, so the previewed price/sats/badge match what
+ * will actually be charged. `discountedUsd` and `amountSats` are the post-stack
+ * figures; `totalDiscountPercent` is the combined promo+BTC discount off list,
+ * for the card's badge. `listUsd` is the promo-adjusted price before the BTC
+ * discount (kept for transparency).
  */
 
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
+import { getBitcoinPrice } from '$lib/bitcoinPrice.server';
 import { applyPromo, type PromoScope } from '$lib/promoEngine.server';
 
 // Canonical membership list prices (USD). Mirrors the values in
@@ -33,6 +39,9 @@ const PRICING_USD = {
 	pro: { annual: 89, monthly: 8.99 },
 	founders: { lifetime: 210 }
 } as const;
+
+// Must match BITCOIN_DISCOUNT_PERCENT in the create-lightning-invoice endpoints.
+const BITCOIN_DISCOUNT_PERCENT = 5;
 
 export const POST: RequestHandler = async ({ request, platform }) => {
 	// Mirror the membership feature-flag guard used by the sibling endpoints.
@@ -75,12 +84,30 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 	}
 
 	const a = result.applied;
+	const originalUsd = a.originalSats / 100; // field name is unit-agnostic; values are cents
+	const listUsd = a.finalSats / 100; // promo-adjusted list price (pre-BTC-discount)
+
+	// Stack the 5% Bitcoin discount on the promo-adjusted price and convert to
+	// sats using the SAME pipeline as create-lightning-invoice, so the preview
+	// the card shows equals what will be charged.
+	const discountedUsd = listUsd * (1 - BITCOIN_DISCOUNT_PERCENT / 100);
+	const currentPrice = await getBitcoinPrice(platform);
+	const amountSats = Math.round((discountedUsd / currentPrice) * 100_000_000);
+
+	// Combined promo + BTC discount off the original list price, for the badge.
+	const totalDiscountPercent = Math.round((1 - discountedUsd / originalUsd) * 100);
+
 	return json({
 		success: true,
 		code: a.code,
 		label: a.label,
 		scope,
-		originalUsd: a.originalSats / 100, // field name is unit-agnostic; values are cents
-		finalUsd: parseFloat((a.finalSats / 100).toFixed(2))
+		originalUsd,
+		listUsd,
+		discountedUsd: parseFloat(discountedUsd.toFixed(2)),
+		amountSats,
+		btcPrice: parseFloat(currentPrice.toFixed(2)),
+		btcDiscountPercent: BITCOIN_DISCOUNT_PERCENT,
+		totalDiscountPercent
 	});
 };

--- a/src/routes/membership/cook-plus-checkout/+page.svelte
+++ b/src/routes/membership/cook-plus-checkout/+page.svelte
@@ -33,12 +33,16 @@
   let amountSats: number | null = null;
   let discountPercent = 5;
 
-  // Promo code (Lightning only). Server is the source of truth for price;
-  // this just previews the discount and forwards the code to invoice creation.
+  // Promo code (Lightning only). The apply-promo endpoint recomputes the
+  // FULL effective price (promo stacked with the 5% BTC discount) and returns
+  // amountSats + totalDiscountPercent. We bind the Lightning card's USD, sats,
+  // AND badge to those figures so the price and the badge can never disagree.
+  // discountedUsdAmount / amountSats / discountPercent are the single source of
+  // truth for what's displayed; applying/clearing a code rewrites all three.
   let promoCode = '';
   let promoApplying = false;
   let promoError: string | null = null;
-  let appliedPromo: { code: string; label: string; originalUsd: number; finalUsd: number } | null = null;
+  let appliedPromo: { code: string; label: string } | null = null;
 
   function promoErrorMessage(code: string | undefined): string {
     switch (code) {
@@ -67,12 +71,11 @@
         promoError = promoErrorMessage(data.error);
         return;
       }
-      appliedPromo = {
-        code: data.code,
-        label: data.label,
-        originalUsd: data.originalUsd,
-        finalUsd: data.finalUsd
-      };
+      appliedPromo = { code: data.code, label: data.label };
+      // Drive the card from the promo-adjusted totals so price/sats/badge agree.
+      discountedUsdAmount = data.discountedUsd;
+      amountSats = data.amountSats;
+      discountPercent = data.totalDiscountPercent;
     } catch {
       appliedPromo = null;
       promoError = 'Could not validate code. Please try again.';
@@ -85,6 +88,8 @@
     appliedPromo = null;
     promoCode = '';
     promoError = null;
+    // Restore the base (5%-only) Lightning quote.
+    fetchBitcoinPriceQuote();
   }
 
   onMount(() => {
@@ -249,6 +254,15 @@
       lightningInvoice = data.invoice;
       paymentHash = data.paymentHash;
       receiveRequestId = data.receiveRequestId;
+      // The displayed price must equal what we're actually charging. Warn if the
+      // invoice's sats differ from what the card previewed before reconciling.
+      if (typeof data.amountSats === 'number' && amountSats !== null && data.amountSats !== amountSats) {
+        console.warn('[Cook+ Checkout] Displayed sats != invoice sats', {
+          displayed: amountSats,
+          invoice: data.amountSats,
+          promo: appliedPromo?.code ?? null
+        });
+      }
       // Server is the source of truth for the charged amount — reflect any
       // promo-adjusted figures it returned.
       if (typeof data.discountedUsdAmount === 'number') discountedUsdAmount = data.discountedUsdAmount;
@@ -522,7 +536,6 @@
               <div class="payment-method-header">
                 <span class="payment-icon">⚡</span>
                 <span class="payment-name">Bitcoin Lightning</span>
-                <span class="discount-badge">{discountPercent}% OFF</span>
               </div>
               <div class="payment-provider bitcoin-pricing">
                 {#if bitcoinPriceLoading}
@@ -532,11 +545,13 @@
                   <span class="usd-pricing">
                     <span class="original-price">${COOK_PLUS_PRICE_USD}</span>
                     <span class="discounted-price">${discountedUsdAmount?.toFixed(2)}</span>
+                    <span class="discount-badge">{discountPercent}% OFF</span>
                   </span>
                 {:else}
                   <span class="usd-pricing">
                     <span class="original-price">${COOK_PLUS_PRICE_USD}</span>
                     <span class="discounted-price">${discountedUsdAmount?.toFixed(2)}</span>
+                    <span class="discount-badge">{discountPercent}% OFF</span>
                   </span>
                 {/if}
               </div>
@@ -654,7 +669,12 @@
     border-image: linear-gradient(135deg, var(--color-primary) 0%, #ff6b00 50%, #ff4500 100%) 1;
     border-radius: 16px;
     padding: 2.5rem;
-    box-shadow: 
+    /* Contain the card within the viewport: count padding+border in the width
+       and never let a flex child push it past the screen edge. */
+    box-sizing: border-box;
+    width: 100%;
+    max-width: 100%;
+    box-shadow:
       0 8px 32px rgba(236, 71, 0, 0.15),
       0 0 0 1px rgba(236, 71, 0, 0.1);
   }
@@ -868,6 +888,7 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    flex-wrap: wrap;
   }
 
   .original-price {
@@ -889,7 +910,9 @@
     border-radius: 10px;
     font-size: 0.65rem;
     font-weight: 700;
-    margin-left: auto;
+    flex-shrink: 0;
+    /* Sits inline with the price (see .usd-pricing), not floated to its own
+       line — so the badge's % always reads next to the price it describes. */
   }
 
   .loading-price {
@@ -953,6 +976,16 @@
   }
 
   @media (max-width: 480px) {
+    /* Tighten the outer chrome so the card fits narrow screens without
+       horizontal overflow. */
+    .checkout-page {
+      padding: 1rem;
+    }
+
+    .checkout-card {
+      padding: 1.5rem;
+    }
+
     .payment-method-option {
       padding: 0.75rem;
     }
@@ -969,7 +1002,8 @@
       font-size: 0.9rem;
     }
 
-    .discount-badge {
+    /* Drop the indent that pushed "57,470 sats" onto a second line. */
+    .payment-provider {
       margin-left: 0;
     }
   }
@@ -984,6 +1018,10 @@
   }
   .promo-input {
     flex: 1;
+    /* Allow the flex input to shrink below its intrinsic/placeholder width so
+       the row (input + Apply) never forces the card wider than the screen. */
+    min-width: 0;
+    box-sizing: border-box;
     padding: 0.75rem 1rem;
     background: rgba(17, 24, 39, 0.6);
     border: 2px solid rgba(236, 71, 0, 0.2);
@@ -1003,6 +1041,8 @@
     color: var(--color-primary);
     font-weight: 600;
     cursor: pointer;
+    /* Keep its size and stay on screen instead of being clipped off the right. */
+    flex-shrink: 0;
   }
   .promo-apply:disabled {
     opacity: 0.5;

--- a/src/routes/membership/genesis-checkout/+page.svelte
+++ b/src/routes/membership/genesis-checkout/+page.svelte
@@ -27,13 +27,17 @@
   let amountSats: number | null = null;
   let discountPercent = 5;
 
-  // Promo code (Lightning only). Server is the source of truth for price;
-  // this just previews the discount and forwards the code to invoice creation.
+  // Promo code (Lightning only). The apply-promo endpoint recomputes the
+  // FULL effective price (promo stacked with the 5% BTC discount) and returns
+  // amountSats + totalDiscountPercent. We bind the Lightning card's USD, sats,
+  // AND badge to those figures so the price and the badge can never disagree.
+  // discountedUsdAmount / amountSats / discountPercent are the single source of
+  // truth for what's displayed; applying/clearing a code rewrites all three.
   // Founders uses its own 'genesis' promo scope.
   let promoCode = '';
   let promoApplying = false;
   let promoError: string | null = null;
-  let appliedPromo: { code: string; label: string; originalUsd: number; finalUsd: number } | null = null;
+  let appliedPromo: { code: string; label: string } | null = null;
 
   function promoErrorMessage(code: string | undefined): string {
     switch (code) {
@@ -62,12 +66,11 @@
         promoError = promoErrorMessage(data.error);
         return;
       }
-      appliedPromo = {
-        code: data.code,
-        label: data.label,
-        originalUsd: data.originalUsd,
-        finalUsd: data.finalUsd
-      };
+      appliedPromo = { code: data.code, label: data.label };
+      // Drive the card from the promo-adjusted totals so price/sats/badge agree.
+      discountedUsdAmount = data.discountedUsd;
+      amountSats = data.amountSats;
+      discountPercent = data.totalDiscountPercent;
     } catch {
       appliedPromo = null;
       promoError = 'Could not validate code. Please try again.';
@@ -80,6 +83,8 @@
     appliedPromo = null;
     promoCode = '';
     promoError = null;
+    // Restore the base (5%-only) Lightning quote.
+    fetchBitcoinPriceQuote();
   }
 
   $: isLoggedIn = $userPublickey && $userPublickey.length > 0;
@@ -230,6 +235,15 @@
       lightningInvoice = data.invoice;
       paymentHash = data.paymentHash;
       receiveRequestId = data.receiveRequestId;
+      // The displayed price must equal what we're actually charging. Warn if the
+      // invoice's sats differ from what the card previewed before reconciling.
+      if (typeof data.amountSats === 'number' && amountSats !== null && data.amountSats !== amountSats) {
+        console.warn('[Founders Club Checkout] Displayed sats != invoice sats', {
+          displayed: amountSats,
+          invoice: data.amountSats,
+          promo: appliedPromo?.code ?? null
+        });
+      }
       // Server is the source of truth for the charged amount — reflect any
       // promo-adjusted figures it returned.
       if (typeof data.discountedUsdAmount === 'number') discountedUsdAmount = data.discountedUsdAmount;
@@ -502,7 +516,6 @@
               <div class="payment-method-header">
                 <span class="payment-icon">⚡</span>
                 <span class="payment-name">Bitcoin Lightning</span>
-                <span class="discount-badge">{discountPercent}% OFF</span>
               </div>
               <div class="payment-provider bitcoin-pricing">
                 {#if bitcoinPriceLoading}
@@ -512,11 +525,13 @@
                   <span class="usd-pricing">
                     <span class="original-price">${FOUNDERS_CLUB_PRICE_USD}</span>
                     <span class="discounted-price">${discountedUsdAmount?.toFixed(2)}</span>
+                    <span class="discount-badge">{discountPercent}% OFF</span>
                   </span>
                 {:else}
                   <span class="usd-pricing">
                     <span class="original-price">${FOUNDERS_CLUB_PRICE_USD}</span>
                     <span class="discounted-price">${discountedUsdAmount?.toFixed(2)}</span>
+                    <span class="discount-badge">{discountPercent}% OFF</span>
                   </span>
                 {/if}
               </div>
@@ -634,7 +649,12 @@
     border-image: linear-gradient(135deg, var(--color-primary) 0%, #ff6b00 50%, #ff4500 100%) 1;
     border-radius: 16px;
     padding: 2.5rem;
-    box-shadow: 
+    /* Contain the card within the viewport: count padding+border in the width
+       and never let a flex child push it past the screen edge. */
+    box-sizing: border-box;
+    width: 100%;
+    max-width: 100%;
+    box-shadow:
       0 8px 32px rgba(236, 71, 0, 0.15),
       0 0 0 1px rgba(236, 71, 0, 0.1);
   }
@@ -829,6 +849,7 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    flex-wrap: wrap;
   }
 
   .original-price {
@@ -850,7 +871,9 @@
     border-radius: 10px;
     font-size: 0.65rem;
     font-weight: 700;
-    margin-left: auto;
+    flex-shrink: 0;
+    /* Sits inline with the price (see .usd-pricing), not floated to its own
+       line — so the badge's % always reads next to the price it describes. */
   }
 
   .loading-price {
@@ -914,6 +937,16 @@
   }
 
   @media (max-width: 480px) {
+    /* Tighten the outer chrome so the card fits narrow screens without
+       horizontal overflow. */
+    .checkout-page {
+      padding: 1rem;
+    }
+
+    .checkout-card {
+      padding: 1.5rem;
+    }
+
     .payment-method-option {
       padding: 0.75rem;
     }
@@ -930,7 +963,8 @@
       font-size: 0.9rem;
     }
 
-    .discount-badge {
+    /* Drop the indent that pushed "57,470 sats" onto a second line. */
+    .payment-provider {
       margin-left: 0;
     }
   }
@@ -945,6 +979,10 @@
   }
   .promo-input {
     flex: 1;
+    /* Allow the flex input to shrink below its intrinsic/placeholder width so
+       the row (input + Apply) never forces the card wider than the screen. */
+    min-width: 0;
+    box-sizing: border-box;
     padding: 0.75rem 1rem;
     background: rgba(17, 24, 39, 0.6);
     border: 2px solid rgba(236, 71, 0, 0.2);
@@ -964,6 +1002,8 @@
     color: var(--color-primary);
     font-weight: 600;
     cursor: pointer;
+    /* Keep its size and stay on screen instead of being clipped off the right. */
+    flex-shrink: 0;
   }
   .promo-apply:disabled {
     opacity: 0.5;

--- a/src/routes/membership/pro-kitchen-checkout/+page.svelte
+++ b/src/routes/membership/pro-kitchen-checkout/+page.svelte
@@ -33,12 +33,16 @@
   let amountSats: number | null = null;
   let discountPercent = 5;
 
-  // Promo code (Lightning only). Server is the source of truth for price;
-  // this just previews the discount and forwards the code to invoice creation.
+  // Promo code (Lightning only). The apply-promo endpoint recomputes the
+  // FULL effective price (promo stacked with the 5% BTC discount) and returns
+  // amountSats + totalDiscountPercent. We bind the Lightning card's USD, sats,
+  // AND badge to those figures so the price and the badge can never disagree.
+  // discountedUsdAmount / amountSats / discountPercent are the single source of
+  // truth for what's displayed; applying/clearing a code rewrites all three.
   let promoCode = '';
   let promoApplying = false;
   let promoError: string | null = null;
-  let appliedPromo: { code: string; label: string; originalUsd: number; finalUsd: number } | null = null;
+  let appliedPromo: { code: string; label: string } | null = null;
 
   function promoErrorMessage(code: string | undefined): string {
     switch (code) {
@@ -67,12 +71,11 @@
         promoError = promoErrorMessage(data.error);
         return;
       }
-      appliedPromo = {
-        code: data.code,
-        label: data.label,
-        originalUsd: data.originalUsd,
-        finalUsd: data.finalUsd
-      };
+      appliedPromo = { code: data.code, label: data.label };
+      // Drive the card from the promo-adjusted totals so price/sats/badge agree.
+      discountedUsdAmount = data.discountedUsd;
+      amountSats = data.amountSats;
+      discountPercent = data.totalDiscountPercent;
     } catch {
       appliedPromo = null;
       promoError = 'Could not validate code. Please try again.';
@@ -85,6 +88,8 @@
     appliedPromo = null;
     promoCode = '';
     promoError = null;
+    // Restore the base (5%-only) Lightning quote.
+    fetchBitcoinPriceQuote();
   }
 
   onMount(() => {
@@ -249,6 +254,15 @@
       lightningInvoice = data.invoice;
       paymentHash = data.paymentHash;
       receiveRequestId = data.receiveRequestId;
+      // The displayed price must equal what we're actually charging. Warn if the
+      // invoice's sats differ from what the card previewed before reconciling.
+      if (typeof data.amountSats === 'number' && amountSats !== null && data.amountSats !== amountSats) {
+        console.warn('[Pro Kitchen Checkout] Displayed sats != invoice sats', {
+          displayed: amountSats,
+          invoice: data.amountSats,
+          promo: appliedPromo?.code ?? null
+        });
+      }
       // Server is the source of truth for the charged amount — reflect any
       // promo-adjusted figures it returned.
       if (typeof data.discountedUsdAmount === 'number') discountedUsdAmount = data.discountedUsdAmount;
@@ -512,7 +526,6 @@
               <div class="payment-method-header">
                 <span class="payment-icon">⚡</span>
                 <span class="payment-name">Bitcoin Lightning</span>
-                <span class="discount-badge">{discountPercent}% OFF</span>
               </div>
               <div class="payment-provider bitcoin-pricing">
                 {#if bitcoinPriceLoading}
@@ -522,11 +535,13 @@
                   <span class="usd-pricing">
                     <span class="original-price">${PRO_KITCHEN_PRICE_USD}</span>
                     <span class="discounted-price">${discountedUsdAmount?.toFixed(2)}</span>
+                    <span class="discount-badge">{discountPercent}% OFF</span>
                   </span>
                 {:else}
                   <span class="usd-pricing">
                     <span class="original-price">${PRO_KITCHEN_PRICE_USD}</span>
                     <span class="discounted-price">${discountedUsdAmount?.toFixed(2)}</span>
+                    <span class="discount-badge">{discountPercent}% OFF</span>
                   </span>
                 {/if}
               </div>
@@ -644,7 +659,12 @@
     border-image: linear-gradient(135deg, var(--color-primary) 0%, #ff6b00 50%, #ff4500 100%) 1;
     border-radius: 16px;
     padding: 2.5rem;
-    box-shadow: 
+    /* Contain the card within the viewport: count padding+border in the width
+       and never let a flex child push it past the screen edge. */
+    box-sizing: border-box;
+    width: 100%;
+    max-width: 100%;
+    box-shadow:
       0 8px 32px rgba(236, 71, 0, 0.15),
       0 0 0 1px rgba(236, 71, 0, 0.1);
   }
@@ -887,6 +907,7 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    flex-wrap: wrap;
   }
 
   .original-price {
@@ -908,7 +929,9 @@
     border-radius: 10px;
     font-size: 0.65rem;
     font-weight: 700;
-    margin-left: auto;
+    flex-shrink: 0;
+    /* Sits inline with the price (see .usd-pricing), not floated to its own
+       line — so the badge's % always reads next to the price it describes. */
   }
 
   .loading-price {
@@ -972,6 +995,16 @@
   }
 
   @media (max-width: 480px) {
+    /* Tighten the outer chrome so the card fits narrow screens without
+       horizontal overflow. */
+    .checkout-page {
+      padding: 1rem;
+    }
+
+    .checkout-card {
+      padding: 1.5rem;
+    }
+
     .payment-method-option {
       padding: 0.75rem;
     }
@@ -988,7 +1021,8 @@
       font-size: 0.9rem;
     }
 
-    .discount-badge {
+    /* Drop the indent that pushed "57,470 sats" onto a second line. */
+    .payment-provider {
       margin-left: 0;
     }
   }
@@ -1003,6 +1037,10 @@
   }
   .promo-input {
     flex: 1;
+    /* Allow the flex input to shrink below its intrinsic/placeholder width so
+       the row (input + Apply) never forces the card wider than the screen. */
+    min-width: 0;
+    box-sizing: border-box;
     padding: 0.75rem 1rem;
     background: rgba(17, 24, 39, 0.6);
     border: 2px solid rgba(236, 71, 0, 0.2);
@@ -1022,6 +1060,8 @@
     color: var(--color-primary);
     font-weight: 600;
     cursor: pointer;
+    /* Keep its size and stay on screen instead of being clipped off the right. */
+    flex-shrink: 0;
   }
   .promo-apply:disabled {
     opacity: 0.5;


### PR DESCRIPTION
## What

Lands the membership-checkout fix that was authored alongside the promo engine but **did not make it into `main`** — PR #408 merged only the engine commit (`32eeee4`), leaving the follow-up fix (`afe815b`) stranded on the old branch. This cherry-picks it cleanly onto current `main`.

So in production today, the membership Lightning checkouts still have both the mobile overflow and the price/badge mismatch. This fixes both.

## Priority 1 — price/badge correctness

- `/api/membership/apply-promo` now stacks the 5% BTC discount on the promo-adjusted price and converts to sats with the **same pipeline** as `create-lightning-invoice`, returning `discountedUsd`, `amountSats`, `btcPrice`, and `totalDiscountPercent`.
- Cook+, Pro Kitchen, and Genesis checkout cards bind USD, sats, **and** the discount badge to a single source of truth. Applying a code rewrites all three from the response; clearing re-fetches the base 5% quote. The badge can no longer say "5% OFF" while the price reflects a stacked promo.
- `proceedWithLightning()` warns if the invoice's `amountSats` differs from the previewed sats.

## Priority 2 — mobile overflow (320 / 375 / 414px)

- `.checkout-card`: `box-sizing: border-box` + `width/max-width: 100%` so padding and the border-image gradient can't bleed past the screen edge.
- `.promo-input`: `min-width: 0` so the flex input can shrink.
- `.promo-apply`: `flex-shrink: 0` so the Apply button keeps its size and stays on-screen.
- `.payment-provider`: drop the indent at ≤480px so the sats amount stays on one line.
- `.discount-badge`: moved inline with the price (inside `.usd-pricing`, `flex-wrap`), dropped `margin-left: auto`.
- Reduced `.checkout-page` / `.checkout-card` padding at ≤480px.

Stripe path and server-side promo validation untouched.

## Verification

- `pnpm test` — **151/151 pass**.
- `pnpm check` — the 4 changed files (3 checkout pages + `apply-promo`) introduce **0 errors**. There are 9 pre-existing `svelte-check` errors on `main`, all in the Branta SDK v3 files (`brantaService.server.ts` / `api/branta/register`) — unrelated to this change and fixed separately in #410.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
