### PR TITLE
fix(home): server-redirect / to /explore + unmask SSR errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.458",
+  "version": "4.2.459",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,27 @@
-import type { Handle } from '@sveltejs/kit';
+import type { Handle, HandleServerError } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
+
+/**
+ * Log the real server-side error (with stack) instead of letting SvelteKit
+ * silently mask it as the generic { message: "Internal Error" } sent to the
+ * client. Without this, a render/load throw on any route is invisible in the
+ * Cloudflare/Vercel function logs beyond a bare 500. The returned object is
+ * what the client receives, so keep it generic — the detail stays server-side.
+ */
+export const handleError: HandleServerError = ({ error, event, status, message }) => {
+  const err = error as Error | undefined;
+  console.error('[handleError]', {
+    method: event.request.method,
+    path: event.url.pathname,
+    status,
+    message,
+    name: err?.name,
+    error: err?.message ?? String(error),
+    stack: err?.stack
+  });
+
+  return { message: 'Internal Error' };
+};
 
 const ENABLE_CORS_ALL = env.ENABLE_CORS_ALL?.toLowerCase() === 'true';
 const ALLOW_METHODS = 'GET, POST, PATCH, OPTIONS';

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,0 +1,13 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+/**
+ * The homepage is just a doorway to /explore. Redirect on the server so the
+ * Worker responds before any page-component SSR render runs — the previous
+ * approach SSR-rendered the whole app shell only to client-redirect in
+ * onMount, and a render-time throw on this node surfaced as a masked 500.
+ * A 307 keeps the method and is non-permanent (so the root can change later).
+ */
+export const load: PageServerLoad = () => {
+  throw redirect(307, '/explore');
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
+  // `/` redirects to /explore server-side (see +page.server.ts), so this
+  // component normally never renders. The onMount fallback only fires if a
+  // client-side navigation ever lands here without hitting the server load.
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
-  import type { PageData } from './$types';
 
-  export const data: PageData = {} as PageData;
-
-  onMount(async () => {
-    goto(`/explore`);
+  onMount(() => {
+    goto('/explore');
   });
 </script>


### PR DESCRIPTION
## What

Production returns **HTTP 500 on the homepage** (`https://zap.cooking/`). This fixes the symptom and ensures any future SSR failure is no longer masked.

## Investigation (verified, not assumed)

- **Deploy target is Cloudflare Pages**, not Vercel (`deploy` = `wrangler pages deploy .svelte-kit/cloudflare`; prod headers `server: cloudflare`). Repro was done on the real **workerd** runtime via `wrangler pages dev`.
- **Scope is isolated to `/`.** Prod: `/` = 500, but `/explore` = 200, `/recipes` = 200, **`/membership` = 200**. `/membership` is also SSR'd through the Worker, so the Worker, `hooks.server.ts`, and the layout are all fine. The 500 shell shows `node_ids:[0,1]` with `membershipEnabled` resolved — i.e. the layout loaded and the **`/` page node** is what throws.
- The real error is masked as the generic `{ message: "Internal Error" }` because there was no `handleError`.

## Changes

**(b) `src/routes/+page.server.ts` (new)** — `throw redirect(307, '/explore')`. The homepage is just a doorway to `/explore`; redirecting in the server `load` short-circuits the response **before** any homepage page-component SSR render, so whatever was throwing in that render path is off the critical path. Also strictly better than SSR-rendering the whole app shell just to client-redirect in `onMount`.

`+page.svelte` — drops the invalid `export const data: PageData = {} as PageData` (page `data` must be a settable `export let` prop, not a read-only `const` — the one objectively-wrong line on the failing route). Keeps an `onMount` `goto('/explore')` fallback for in-app navigations to `/`.

**(a) `src/hooks.server.ts`** — adds `handleError` that logs the real error + stack (method, path, status, name, message, stack) while still returning a generic message to the client. Guarantees the next 500 is diagnosable.

## Verification

- `pnpm check` — **0 errors**.
- Cloudflare **workerd** repro (`wrangler pages dev` on the adapter-cloudflare build): `/` → **307 → /explore → 200**; `/explore` 200; no throw in worker stderr.

## Honest caveat

The prod 500 **could not be reproduced locally** — the exact deployed commit returns 200 on a faithful workerd build (with and without env vars), so the fault appears prod-environment/artifact specific and I could not capture the real stack (wrangler/Vercel auth unavailable). This is therefore a **validated mitigation with ~80% confidence it resolves the symptom**, not a confirmed-root-cause fix. Change (a) closes the gap: if anything still 500s after deploy, the stack will be in the function logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
