### PR TITLE
fix(cheffy): dress the character illustration + de-duplicate the mobile homepage entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.465",
+  "version": "4.2.466",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.464",
+  "version": "4.2.465",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/CheffyHomeCard.svelte
+++ b/src/components/CheffyHomeCard.svelte
@@ -1,74 +1,55 @@
 <script lang="ts">
   /**
-   * Compact inline Cheffy launcher for the Explore (home) page. Replaces
-   * the older large card so the homepage stays focused on browsing
-   * recipes and there's no large Cheffy surface competing with the
-   * persistent floating launcher. Tapping it opens the Cheffy messenger.
+   * Lightweight, borderless Cheffy mention for the Explore (home) page.
+   *
+   * On mobile the persistent floating launcher is the primary way in, so
+   * the homepage must NOT also carry a large bordered Cheffy card — that
+   * would be a duplicate entry point. This is a single, low-noise inline
+   * row that stays subordinate to browsing recipes and opens the same
+   * messenger.
    */
   import { openCheffy } from '$lib/stores/cheffyChat';
-  import CheffyAvatar from './CheffyAvatar.svelte';
   import CaretRightIcon from 'phosphor-svelte/lib/CaretRight';
 </script>
 
-<button type="button" class="cheffy-inline" on:click={() => openCheffy()}>
-  <CheffyAvatar size={32} expression="happy" />
-  <span class="cheffy-inline-text">
-    <span class="lead">Not sure what to make?</span>
-    <span class="cta">Ask Cheffy</span>
-  </span>
-  <CaretRightIcon size={18} weight="bold" class="cheffy-inline-caret" />
+<button type="button" class="cheffy-row" on:click={() => openCheffy()}>
+  <span class="muted">Need help deciding?</span>
+  <span class="cta">Ask Cheffy</span>
+  <CaretRightIcon size={15} weight="bold" class="cheffy-row-caret" />
 </button>
 
 <style>
-  .cheffy-inline {
-    display: flex;
+  .cheffy-row {
+    display: inline-flex;
     align-items: center;
-    gap: 12px;
-    width: 100%;
-    padding: 12px 14px;
-    border-radius: 14px;
-    background-color: var(--color-bg-secondary);
-    border: 1px solid color-mix(in srgb, var(--color-primary) 20%, var(--color-input-border));
-    color: var(--color-text-primary);
+    gap: 6px;
+    padding: 6px 2px;
+    background: transparent;
+    border: 0;
+    color: var(--color-text-secondary);
+    font-size: 0.9rem;
+    line-height: 1.2;
     cursor: pointer;
     text-align: left;
-    transition:
-      background-color 140ms ease,
-      transform 140ms ease;
   }
-  .cheffy-inline:hover {
-    background-color: color-mix(in srgb, var(--color-primary) 6%, var(--color-bg-secondary));
-  }
-  .cheffy-inline:active {
-    transform: scale(0.995);
-  }
-  .cheffy-inline:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary) 45%, transparent);
-  }
-  .cheffy-inline-text {
-    display: flex;
-    flex-direction: column;
-    line-height: 1.25;
-    min-width: 0;
-    flex: 1;
-  }
-  .lead {
-    font-size: 0.9rem;
+  .muted {
     color: var(--color-text-secondary);
   }
   .cta {
-    font-size: 0.95rem;
-    font-weight: 700;
+    font-weight: 600;
     color: var(--color-primary);
   }
-  .cheffy-inline :global(.cheffy-inline-caret) {
-    color: var(--color-text-secondary);
+  .cheffy-row:hover .cta {
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  .cheffy-row :global(.cheffy-row-caret) {
+    color: var(--color-primary);
     flex-shrink: 0;
   }
-  @media (prefers-reduced-motion: reduce) {
-    .cheffy-inline {
-      transition: none;
-    }
+  .cheffy-row:focus-visible {
+    outline: none;
+    border-radius: 6px;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary) 45%, transparent);
   }
 </style>

--- a/src/components/CheffyHomeCard.svelte
+++ b/src/components/CheffyHomeCard.svelte
@@ -20,10 +20,14 @@
 
 <style>
   .cheffy-row {
-    display: inline-flex;
+    /* Full-width in-flow row with a comfortable 44px touch target,
+       while staying borderless and visually secondary to browsing. */
+    display: flex;
     align-items: center;
     gap: 6px;
-    padding: 6px 2px;
+    width: 100%;
+    min-height: 44px;
+    padding: 0 2px;
     background: transparent;
     border: 0;
     color: var(--color-text-secondary);

--- a/src/components/icons/CheffyIcon.svelte
+++ b/src/components/icons/CheffyIcon.svelte
@@ -153,29 +153,54 @@
       <path d={mouthPath} fill={mouthFilled ? 'currentColor' : 'none'} />
     </g>
   {:else}
-    <!-- ── Character-only torso + arms (drawn first so the head overlaps
-         the shoulders). Arms attach at shoulder level, never the head. -->
+    <!-- ── Character-only body: a dressed chef torso (shirt + apron bib)
+         so he never reads as a bare blob. Drawn first so the head
+         overlaps the shoulders; arms attach at shoulder level. -->
     {#if variant === 'character'}
       <g>
-        <!-- Short arms from the shoulders -->
+        <!-- Short sleeved arms from the shoulders, with small hands -->
         <path
-          d="M25.5 47 Q20.5 48.5 20 52.5"
+          d="M25 47 Q19.5 48.5 19 53"
           fill="none"
-          stroke="var(--cheffy-body-shade, #E6B765)"
-          stroke-width="3.8"
+          stroke="var(--cheffy-shirt, var(--color-primary, #ec4700))"
+          stroke-width="4.2"
           stroke-linecap="round"
         />
         <path
-          d="M38.5 47 Q43.5 48.5 44 52.5"
+          d="M39 47 Q44.5 48.5 45 53"
           fill="none"
-          stroke="var(--cheffy-body-shade, #E6B765)"
-          stroke-width="3.8"
+          stroke="var(--cheffy-shirt, var(--color-primary, #ec4700))"
+          stroke-width="4.2"
           stroke-linecap="round"
         />
-        <!-- Small rounded torso -->
+        <circle cx="19" cy="53" r="2.4" fill="var(--cheffy-body, #F6DCA6)" />
+        <circle cx="45" cy="53" r="2.4" fill="var(--cheffy-body, #F6DCA6)" />
+
+        <!-- Shirt / torso -->
         <path
-          d="M25 45.5 Q25 43.8 32 43.8 Q39 43.8 39 45.5 L40.5 55 Q40.5 59.5 32 59.5 Q23.5 59.5 23.5 55 Z"
-          fill="var(--cheffy-body, #F6DCA6)"
+          d="M24 46 Q24 44 32 44 Q40 44 40 46 L41 56 Q41 60.5 32 60.5 Q23 60.5 23 56 Z"
+          fill="var(--cheffy-shirt, var(--color-primary, #ec4700))"
+        />
+        <!-- Apron bib (cream) with straps and a pocket line — minimal,
+             but enough to read as "dressed" rather than bare. -->
+        <path
+          d="M27.5 46.5 L29.5 45 M36.5 46.5 L34.5 45"
+          fill="none"
+          stroke="var(--cheffy-apron, #FBEAC6)"
+          stroke-width="1.3"
+          stroke-linecap="round"
+        />
+        <path
+          d="M28 47 Q28 45.9 32 45.9 Q36 45.9 36 47 L36.8 57 Q36.8 59.6 32 59.6 Q27.2 59.6 27.2 57 Z"
+          fill="var(--cheffy-apron, #FBEAC6)"
+        />
+        <path
+          d="M28.4 53 L35.6 53"
+          fill="none"
+          stroke="var(--cheffy-shirt-shade, #C23A00)"
+          stroke-width="0.8"
+          opacity="0.35"
+          stroke-linecap="round"
         />
       </g>
     {/if}

--- a/src/components/icons/CheffyIcon.svelte
+++ b/src/components/icons/CheffyIcon.svelte
@@ -194,12 +194,14 @@
           d="M28 47 Q28 45.9 32 45.9 Q36 45.9 36 47 L36.8 57 Q36.8 59.6 32 59.6 Q27.2 59.6 27.2 57 Z"
           fill="var(--cheffy-apron, #FBEAC6)"
         />
+        <!-- Pocket line keyed to its own apron shade (not the shirt
+             colour) so the apron can be re-tinted independently. -->
         <path
           d="M28.4 53 L35.6 53"
           fill="none"
-          stroke="var(--cheffy-shirt-shade, #C23A00)"
+          stroke="var(--cheffy-apron-shade, #D9B98A)"
           stroke-width="0.8"
-          opacity="0.35"
+          opacity="0.55"
           stroke-linecap="round"
         />
       </g>


### PR DESCRIPTION
## Summary

Two clarity/polish fixes for the Cheffy mobile UX, per the latest design feedback.

### 1. Character no longer looks "shirtless"
The larger `character` illustration (messenger welcome, gates, `/cheffy` feature page) was a bare beige torso that read as a shirtless blob. It's now **dressed**: an orange chef shirt with a **cream apron bib** (straps + a pocket line), short **sleeved** arms, and small hands. Polished, friendly, intentional.

The **`compact`** variant is unchanged and stays **face-first with no body** (launcher, nav, small placements). All large placements already use `variant="character"`, so they pick up the dressed version automatically — no call-site changes.

| | before | after |
|---|---|---|
| character | bare beige torso ("shirtless") | orange shirt + cream apron, sleeved arms, hands |
| compact | face + hat, no body | unchanged |

*(Verified visually by rasterizing both variants at 64/110px on light + dark before/after.)*

### 2. No duplicate Cheffy surface on mobile
The Explore homepage entry was still a **bordered card**, duplicating the persistent floating launcher on mobile. It's now a **lightweight, borderless, single-line row**:

> Need help deciding? **Ask Cheffy** →

It's visually secondary to browsing recipes and opens the same messenger. Mobile users now have **one clear way in** (the floating launcher), with the homepage row as a quiet, low-noise mention rather than a competing card. Works the same, subtly, on desktop.

## UX hierarchy (mobile)
browse recipes → tap floating Cheffy launcher → messenger sheet → chat. No "card vs button" duplicate-entry-point decision.

## Acceptance criteria
- ✅ Mobile homepage no longer has a large duplicate Cheffy card
- ✅ Cheffy is primarily accessed via the floating launcher on mobile
- ✅ Remaining homepage mention is compact and low-noise (borderless single-line row)
- ✅ Larger illustration no longer appears shirtless/unfinished (shirt + apron)
- ✅ Compact icon is face-first with no body
- ✅ Cleaner, more intentional, more polished on mobile

## Verification
svelte-check **0 errors** · eslint clean · **161 tests pass** · `vite build` (client + server) succeeds.

> Note: built on top of the merged Cheffy work in `main`. Independent of the open deps-security PR #415.

🤖 Generated with [Claude Code](https://claude.com/claude-code)