### PR TITLE
fix(branta): migrate to @branta-ops/branta 3.1.x and drop the version pin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.466",
+  "version": "4.2.467",
   "private": true,
   "scripts": {
     "dev": "vite dev",
@@ -133,7 +133,6 @@
       "rollup": "^4.60.2",
       "flatted": "^3.4.2",
       "dompurify": "^3.4.2",
-      "@branta-ops/branta": "3.0.2",
       "tmp@<0.2.6": "^0.2.6",
       "qs@<6.15.2": "^6.15.2",
       "ws@>=8.0.0 <8.20.1": "^8.20.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,6 @@ overrides:
   rollup: ^4.60.2
   flatted: ^3.4.2
   dompurify: ^3.4.2
-  '@branta-ops/branta': 3.0.2
   tmp@<0.2.6: ^0.2.6
   qs@<6.15.2: ^6.15.2
   ws@>=8.0.0 <8.20.1: ^8.20.1
@@ -40,8 +39,8 @@ importers:
   .:
     dependencies:
       '@branta-ops/branta':
-        specifier: 3.0.2
-        version: 3.0.2
+        specifier: ^3.1.2
+        version: 3.1.3
       '@breeztech/breez-sdk-spark':
         specifier: 0.11.0
         version: 0.11.0
@@ -340,8 +339,8 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@branta-ops/branta@3.0.2':
-    resolution: {integrity: sha512-0ujzdfZQEEkD8PaFwCxQ/bPAOzdst/ErBRDGwhZr5Hxk9WSpUOWNdR6uWZutHgD/bb/tE8dg+UPC5uKP7/G13g==}
+  '@branta-ops/branta@3.1.3':
+    resolution: {integrity: sha512-rcyDBYnYD+cmvQWylJ+n3JdR65FiHP1tVPtWQMhKLmcXx56czL8Ez7+I9jy7pmLBIVwP6mS1EsUqSrvQi22v1w==}
 
   '@breeztech/breez-sdk-spark@0.11.0':
     resolution: {integrity: sha512-wX8ZdFfnXN9t2AuLYlZxslmdHlxqnvkU8kAmIL1GuI3LNV8F7bxMGxLV/WTaQTgd7BGW/pcejpBcNPe7jjCdfA==}
@@ -5442,7 +5441,7 @@ snapshots:
       css-tree: 3.2.1
     optional: true
 
-  '@branta-ops/branta@3.0.2': {}
+  '@branta-ops/branta@3.1.3': {}
 
   '@breeztech/breez-sdk-spark@0.11.0':
     optionalDependencies:

--- a/src/lib/brantaService.server.ts
+++ b/src/lib/brantaService.server.ts
@@ -12,21 +12,21 @@
  *
  * NOTE: This file is server-only and uses SvelteKit's $env system.
  *
- * Branta SDK v3 layout: the service class and the Payment/Destination types
- * are exported from the `/v2` entry point; only the client-options classes
- * (`BrantaClientOptions`, `BrantaServerBaseUrl`) live at the package root.
- * `BrantaServerBaseUrl` is a value (an enum-like const whose members carry the
- * resolved URL), so it's imported as a value and used to build `baseUrl`.
+ * Branta SDK 3.1 layout: the service class and the Payment/Destination types
+ * are exported from the `/v2` entry point; the client-options type,
+ * `BrantaServerBaseUrl`, and the `DestinationType` enum live at the package
+ * root. `BrantaServerBaseUrl` is a value (an enum-like const whose members
+ * carry the resolved URL), so it's imported as a value and used to build
+ * `baseUrl`.
  */
 
 import { env } from '$env/dynamic/private';
-import { BrantaServerBaseUrl, type BrantaClientOptions } from '@branta-ops/branta';
 import {
-  BrantaService,
-  type Destination,
-  type DestinationType,
-  type Payment
-} from '@branta-ops/branta/v2';
+  BrantaServerBaseUrl,
+  type BrantaClientOptions,
+  type DestinationType
+} from '@branta-ops/branta';
+import { BrantaService, type Destination, type Payment } from '@branta-ops/branta/v2';
 
 export type { Payment };
 export type PaymentWithVerifyUrl = Payment & { verifyUrl?: string };
@@ -102,7 +102,7 @@ export async function registerPayment(
     // secret/encryptedDestination to verify later.
     const destination: Destination = {
       value: paymentString.trim(),
-      zk: true
+      isZk: true
     };
 
     if (destinationType) {
@@ -118,11 +118,9 @@ export async function registerPayment(
       body.description = description;
     }
 
-    // Payment.metadata is a flat Record<string, string>; coerce values.
+    // Payment.metadata is a JSON string in SDK 3.1; serialize the object.
     if (metadata) {
-      body.metadata = Object.fromEntries(
-        Object.entries(metadata as Record<string, unknown>).map(([k, v]) => [k, String(v)])
-      );
+      body.metadata = JSON.stringify(metadata);
     }
 
     const brantaService = new BrantaService(config);
@@ -131,7 +129,7 @@ export async function registerPayment(
 
     return {
       success: true,
-      verifyUrl: result.verifyLink,
+      verifyUrl: result.verifyUrl,
       secret: result.secret,
       encryptedDestination: result.payment.destinations[0]?.value
     };
@@ -162,10 +160,12 @@ export async function getPaymentInfo(
 
   try {
     const brantaService = new BrantaService(config);
-    // getPayments resolves to a Payment[]; each Payment carries its own
-    // optional verifyUrl.
-    const payments = await brantaService.getPayments(paymentString.trim(), encryptionKey);
-    return payments[0] ?? null;
+    // getPayments resolves to a PaymentsResult { payments, verifyUrl }; the
+    // verifyUrl is shared across the result, so attach it to the payment we
+    // return.
+    const result = await brantaService.getPayments(paymentString.trim(), encryptionKey);
+    const payment = result.payments[0];
+    return payment ? { ...payment, verifyUrl: result.verifyUrl } : null;
   } catch (error) {
     console.warn('[Branta] getPaymentInfo failed:', error);
     return null;
@@ -184,8 +184,9 @@ export async function getPaymentInfoByQRCode(
 
   try {
     const brantaService = new BrantaService(config);
-    const payments = await brantaService.getPaymentsByQRCode(qrText.trim());
-    return payments[0] ?? null;
+    const result = await brantaService.getPaymentsByQrCode(qrText.trim());
+    const payment = result.payments[0];
+    return payment ? { ...payment, verifyUrl: result.verifyUrl } : null;
   } catch (error) {
     console.warn('[Branta] getPaymentInfoByQRCode failed:', error);
     return null;

--- a/src/routes/api/branta/register/+server.ts
+++ b/src/routes/api/branta/register/+server.ts
@@ -8,7 +8,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { registerPayment, isBrantaConfigured } from '$lib/brantaService.server';
-import type { DestinationType } from '@branta-ops/branta/v2';
+import type { DestinationType } from '@branta-ops/branta';
 
 const ALLOWED_DESTINATION_TYPES: ReadonlyArray<DestinationType> = [
 	'bitcoin_address',


### PR DESCRIPTION
## Summary

Resolves the `@branta-ops/branta` version mismatch on `main`: the package was **pinned to 3.0.2** via a pnpm override (added in the security PR #415 to avoid breaking the build), while `package.json` declares `^3.1.2` and the code used the 3.0.2 API. This **removes the pin** (Branta resolves to **3.1.3**) and **migrates the code** to the 3.1.x SDK.

This is **payment-verification code** (Branta guards users against address-swap attacks), so every change is grounded in the installed 3.1.x type definitions and kept behaviourally equivalent.

## API changes handled
| 3.0.2 | 3.1.x | Where |
|---|---|---|
| `DestinationType` from `…/v2` | moved to package **root** (now an enum) | `brantaService.server.ts`, `register/+server.ts` (import path) |
| `Destination.zk` | `Destination.isZk` | registration |
| `Payment.metadata: Record<string,string>` | `Payment.metadata: string` | `JSON.stringify` the object |
| `addPayment().verifyLink` | `.verifyUrl` | registration result |
| `getPayments()/getPaymentsByQRCode()` → `Payment[]` | `getPaymentsByQrCode()` → `PaymentsResult { payments, verifyUrl }` | read `result.payments[0]`, attach the shared `result.verifyUrl` |

`privacy: 'strict'` and the `BrantaServerBaseUrl` values still type-check against the new enums — unchanged.

Net behavioural effect is equivalent, with one small improvement: `getPaymentInfo`/`getPaymentInfoByQRCode` now attach the result-level `verifyUrl` to the returned payment, so **BrantaBadge's verify link is reliably populated** (previously it could be missing and fall back to a generic URL).

## Scope / safety
- Only **2 code files** changed (`brantaService.server.ts`, `register/+server.ts`); the verify route and `BrantaBadge`/`WalletPanel` consumers are untouched.
- No client reads `payment.metadata` (the object→string change is server-internal).
- Lockfile change is surgical (Branta 3.0.2 → 3.1.3; override removed).

## Verification
svelte-check **0 errors** · **161 tests pass** · `vite build` (incl. the `/api/branta/register` + `/api/branta/verify` endpoints) succeeds.

> Note: built on the current `main` (which now includes the merged Cheffy + deps PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)