### PR TITLE
ci: enforce typecheck, tests, and build; add soft-fail lint

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -5,9 +5,18 @@ on:
     branches: ['main']
   pull_request:
     branches: ['main']
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  npm-install:
+  lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Soft-fail: repo-wide formatting/eslint debt (563 prettier files, ~17k eslint errors).
+    # Tracked for cleanup — flip to enforcing once formatting debt is paid.
+    continue-on-error: true
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
@@ -37,3 +46,113 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
 
+      - name: Lint 🧹
+        run: pnpm lint
+
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: Enable Corepack (pnpm) 🎯
+        run: |
+          corepack enable
+          pnpm --version
+
+      - name: Use cache for pnpm 🎁
+        id: cache-pnpm
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
+      - name: Setup Node.js 🟢
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install pnpm packages 📦
+        run: |
+          pnpm install --frozen-lockfile
+
+      - name: Typecheck (svelte-check) 🔍
+        run: pnpm check
+
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: Enable Corepack (pnpm) 🎯
+        run: |
+          corepack enable
+          pnpm --version
+
+      - name: Use cache for pnpm 🎁
+        id: cache-pnpm
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
+      - name: Setup Node.js 🟢
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install pnpm packages 📦
+        run: |
+          pnpm install --frozen-lockfile
+
+      - name: Test (vitest) 🧪
+        run: pnpm test
+
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      # Client bundling OOMs V8's default heap; build needs ~8GB (runners have 16GB).
+      NODE_OPTIONS: --max-old-space-size=8192
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: Enable Corepack (pnpm) 🎯
+        run: |
+          corepack enable
+          pnpm --version
+
+      - name: Use cache for pnpm 🎁
+        id: cache-pnpm
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
+      - name: Setup Node.js 🟢
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install pnpm packages 📦
+        run: |
+          pnpm install --frozen-lockfile
+
+      - name: Build (Cloudflare adapter, smoke test only) 🏗️
+        run: pnpm build

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -116,6 +116,11 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
 
+      # tsconfig.json extends ./.svelte-kit/tsconfig.json, which only exists after sync
+      # (the check and build jobs run sync implicitly; bare vitest does not)
+      - name: Generate .svelte-kit (svelte-kit sync) 🔄
+        run: pnpm exec svelte-kit sync
+
       - name: Test (vitest) 🧪
         run: pnpm test
 

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -14,39 +14,39 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Soft-fail: repo-wide formatting/eslint debt (563 prettier files, ~17k eslint errors).
-    # Tracked for cleanup — flip to enforcing once formatting debt is paid.
-    continue-on-error: true
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
+
+      - name: Setup Node.js 🟢
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
 
       - name: Enable Corepack (pnpm) 🎯
         run: |
           corepack enable
           pnpm --version
 
+      - name: Get pnpm store directory 📂
+        run: echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+
       - name: Use cache for pnpm 🎁
-        id: cache-pnpm
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.pnpm-store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          path: ${{ env.PNPM_STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-
-
-      - name: Setup Node.js 🟢
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'pnpm'
+            ${{ runner.os }}-pnpm-store-
 
       - name: Install pnpm packages 📦
         run: |
           pnpm install --frozen-lockfile
 
+      # Soft-fail: repo-wide formatting/eslint debt (563 prettier files, ~17k eslint errors).
+      # Tracked for cleanup — flip to enforcing once formatting debt is paid.
       - name: Lint 🧹
+        continue-on-error: true
         run: pnpm lint
 
   check:
@@ -56,26 +56,26 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
 
+      - name: Setup Node.js 🟢
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Enable Corepack (pnpm) 🎯
         run: |
           corepack enable
           pnpm --version
 
+      - name: Get pnpm store directory 📂
+        run: echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+
       - name: Use cache for pnpm 🎁
-        id: cache-pnpm
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.pnpm-store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          path: ${{ env.PNPM_STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-
-
-      - name: Setup Node.js 🟢
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'pnpm'
+            ${{ runner.os }}-pnpm-store-
 
       - name: Install pnpm packages 📦
         run: |
@@ -91,26 +91,26 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
 
+      - name: Setup Node.js 🟢
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Enable Corepack (pnpm) 🎯
         run: |
           corepack enable
           pnpm --version
 
+      - name: Get pnpm store directory 📂
+        run: echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+
       - name: Use cache for pnpm 🎁
-        id: cache-pnpm
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.pnpm-store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          path: ${{ env.PNPM_STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-
-
-      - name: Setup Node.js 🟢
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'pnpm'
+            ${{ runner.os }}-pnpm-store-
 
       - name: Install pnpm packages 📦
         run: |
@@ -134,26 +134,26 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
 
+      - name: Setup Node.js 🟢
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Enable Corepack (pnpm) 🎯
         run: |
           corepack enable
           pnpm --version
 
+      - name: Get pnpm store directory 📂
+        run: echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+
       - name: Use cache for pnpm 🎁
-        id: cache-pnpm
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.pnpm-store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          path: ${{ env.PNPM_STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-
-
-      - name: Setup Node.js 🟢
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'pnpm'
+            ${{ runner.os }}-pnpm-store-
 
       - name: Install pnpm packages 📦
         run: |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.469",
+  "version": "4.2.470",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.470",
+  "version": "4.2.471",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.467",
+  "version": "4.2.469",
   "private": true,
   "scripts": {
     "dev": "vite dev",


### PR DESCRIPTION
## Summary
Upgrades the checks workflow from install-only to a full quality gate. Previously CI only ran `pnpm install --frozen-lockfile` — a PR could break types, tests, or the build and still go green.

- **4 parallel jobs** (`lint`, `check`, `test`, `build`), each reusing the existing checkout → corepack → pnpm-cache → setup-node → install preamble (shared cache key, so installs stay fast)
- **`check`** (svelte-check) — enforced; currently 0 errors / 126 warnings
- **`test`** (vitest) — enforced; 161 tests, ~2s, no network use
- **`build`** — enforced smoke test on the default Cloudflare adapter path (no secrets/bindings needed). Job-level `NODE_OPTIONS: --max-old-space-size=8192` because client bundling OOMs V8's default heap
- **`lint`** — soft-fail (`continue-on-error: true`) due to repo-wide debt: 563 prettier-unformatted files and ~17k eslint errors. Comment in the workflow tracks flipping it to enforcing once the debt is paid. Note: the job shows green even when lint fails; failures are visible in job logs only
- **`concurrency`** keyed on workflow+ref with `cancel-in-progress: true` so stacked pushes don't queue
- **`timeout-minutes: 10`** on all jobs as a hang-catcher

The `package.json` change is just the pre-commit hook's automatic version bump.

This is CI-only — no deploy config, wrangler files, or source files touched. (The "Workers Builds" check failing is pre-existing and unrelated.)

## Test plan
- [x] All four commands run locally against this tree: check ✅, test ✅, build ✅ (with heap bump), lint ❌ (expected — soft-failed in CI)
- [ ] Verify the four jobs run green on this PR (lint green via soft-fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)