### PR TITLE
fix(api): two-tier disclosure for membership check-status; dev-gate the batch mock

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.472",
+  "version": "4.2.473",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.471",
+  "version": "4.2.472",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/routes/api/membership/+server.ts
+++ b/src/routes/api/membership/+server.ts
@@ -1,4 +1,5 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
+import { dev } from '$app/environment';
 import { env } from '$env/dynamic/private';
 import { lookupMember } from '$lib/membershipApi.server';
 
@@ -30,7 +31,9 @@ function parsePubkeys(url: URL): string[] {
 }
 
 function mockMembership(pubkey: string): ApiMembershipStatus {
-  // Deterministic mock for local/dev environments without membership backend configured.
+  // Deterministic mock for local dev without the membership backend
+  // configured. Only reachable when `dev` is true — production and
+  // preview builds fail loudly instead (see below).
   const bucket = parseInt(pubkey.slice(-2), 16) % 5;
   if (bucket === 0) return { active: true, tier: 'cook_plus' };
   if (bucket === 1) return { active: true, tier: 'pro_kitchen' };
@@ -52,14 +55,20 @@ export const GET: RequestHandler = async ({ url, platform }) => {
   ).toLowerCase();
   const apiSecret = platform?.env?.RELAY_API_SECRET || env.RELAY_API_SECRET;
 
-  // TODO: wire this endpoint to the canonical membership source for all environments.
-  const shouldUseLiveLookup = membershipEnabled === 'true' && Boolean(apiSecret);
-
-  if (!shouldUseLiveLookup) {
-    for (const pubkey of limitedPubkeys) {
-      results[pubkey] = mockMembership(pubkey);
+  if (membershipEnabled !== 'true' || !apiSecret) {
+    // Local dev keeps the deterministic mock; everywhere else fails
+    // loudly — this fallback once served mock data unconditionally,
+    // masking misconfiguration in production.
+    if (dev) {
+      for (const pubkey of limitedPubkeys) {
+        results[pubkey] = mockMembership(pubkey);
+      }
+      return json(results);
     }
-    return json(results);
+    console.error(
+      '[api/membership] MEMBERSHIP_ENABLED/RELAY_API_SECRET not configured — refusing to serve membership data'
+    );
+    return json({ error: 'membership lookup unavailable' }, { status: 503 });
   }
 
   await Promise.all(

--- a/src/routes/api/membership/check-status/+server.ts
+++ b/src/routes/api/membership/check-status/+server.ts
@@ -11,23 +11,27 @@
  *   pubkey: string
  * }
  *
- * Returns:
- * {
- *   found: boolean,
- *   member?: {
- *     pubkey: string,
- *     tier: string,
- *     status: string,
- *     subscription_end: string,
- *     payment_id: string,
- *     ...
- *   }
- * }
+ * Two disclosure tiers:
+ *
+ * PUBLIC (no auth) — badge surface only. `found` is always true; a
+ * pubkey that was never a member is indistinguishable from a lapsed
+ * one (both report isActive: false, tier 'member'):
+ *   { found: true, isActive: boolean, member: { tier: string } }
+ *
+ * OWNER (NIP-98 `Authorization` header signed by the queried pubkey
+ * itself — pair with signNip98AuthHeader in $lib/nip98) — the full
+ * record:
+ *   { found: true, isActive, isExpired, owner: true,
+ *     member: { pubkey, tier, status, subscription_end,
+ *               subscription_start, payment_method } }
+ * An absent, invalid, or mismatched signature degrades to the public
+ * shape rather than erroring.
  */
 
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { lookupMember } from '$lib/membershipApi.server';
+import { verifyNip98 } from '$lib/nip98.server';
 
 /**
  * Normalize relay tier values to the canonical app tiers.
@@ -51,50 +55,77 @@ export const POST: RequestHandler = async ({ request, platform }) => {
     return json({ error: 'Forbidden' }, { status: 403 });
   }
 
+  // Read the body bytes ONCE — NIP-98 payload verification and JSON
+  // parsing must see the same bytes (see verifyNip98's doc comment on
+  // body-consumption semantics on Cloudflare Workers).
+  let pubkey: unknown;
+  let bodyBytes: Uint8Array;
   try {
-    const body = await request.json();
-    const { pubkey } = body;
+    bodyBytes = new Uint8Array(await request.arrayBuffer());
+    ({ pubkey } = JSON.parse(new TextDecoder().decode(bodyBytes)));
+  } catch {
+    return json({ error: 'pubkey is required' }, { status: 400 });
+  }
 
-    if (!pubkey) {
-      return json(
-        { error: 'pubkey is required' },
-        { status: 400 }
-      );
+  if (!pubkey || typeof pubkey !== 'string') {
+    return json({ error: 'pubkey is required' }, { status: 400 });
+  }
+
+  // Validate pubkey format
+  if (!/^[0-9a-fA-F]{64}$/.test(pubkey)) {
+    return json({ error: 'Invalid pubkey format' }, { status: 400 });
+  }
+
+  // Owner check: a NIP-98 header signed by the queried pubkey itself
+  // unlocks the full record. Any failure degrades to the public shape
+  // — callers that only need badge data never send a header.
+  let isOwner = false;
+  if (request.headers.get('Authorization')) {
+    const verification = await verifyNip98(request, {
+      expectedPubkey: pubkey.toLowerCase(),
+      bodyBytes
+    });
+    if (verification.ok) {
+      isOwner = true;
+    } else {
+      console.warn('[check-status] NIP-98 rejected:', verification.reason);
     }
+  }
 
-    // Validate pubkey format
-    if (!/^[0-9a-fA-F]{64}$/.test(pubkey)) {
-      return json(
-        { error: 'Invalid pubkey format' },
-        { status: 400 }
-      );
-    }
+  const API_SECRET = platform?.env?.RELAY_API_SECRET || env.RELAY_API_SECRET;
+  if (!API_SECRET) {
+    console.error('[Membership Status] RELAY_API_SECRET not configured');
+    return json({ error: 'membership lookup unavailable' }, { status: 503 });
+  }
 
-    // Get API secret
-    const API_SECRET = platform?.env?.RELAY_API_SECRET || env.RELAY_API_SECRET;
-    if (!API_SECRET) {
-      return json(
-        { error: 'RELAY_API_SECRET not configured' },
-        { status: 500 }
-      );
-    }
-
+  try {
     const result = await lookupMember(pubkey, API_SECRET);
 
     if (!result.found) {
-      return json({ found: false });
+      return isOwner
+        ? json({ found: false, owner: true })
+        : json({ found: true, isActive: false, member: { tier: 'member' } });
     }
 
     const tier = normalizeRelayTier(result.member.tier, result.member.payment_id);
-    const member = { ...result.member, tier };
+
+    if (!isOwner) {
+      // Public shape: tier is disclosed only while the membership is
+      // active, so lapsed and never-a-member are indistinguishable.
+      return json({
+        found: true,
+        isActive: result.isActive,
+        member: { tier: result.isActive ? tier : 'member' }
+      });
+    }
 
     // Founders get lifetime access — ensure expiry is at least 10 years out
-    if (tier === 'founders' && member.subscription_end) {
+    let subscriptionEnd = result.member.subscription_end;
+    if (tier === 'founders' && subscriptionEnd) {
       const tenYearsFromNow = new Date();
       tenYearsFromNow.setFullYear(tenYearsFromNow.getFullYear() + 10);
-      const currentExpiry = new Date(member.subscription_end);
-      if (currentExpiry < tenYearsFromNow) {
-        member.subscription_end = tenYearsFromNow.toISOString();
+      if (new Date(subscriptionEnd) < tenYearsFromNow) {
+        subscriptionEnd = tenYearsFromNow.toISOString();
       }
     }
 
@@ -102,19 +133,18 @@ export const POST: RequestHandler = async ({ request, platform }) => {
       found: true,
       isActive: result.isActive,
       isExpired: result.isExpired,
-      member
+      owner: true,
+      member: {
+        pubkey: result.member.pubkey,
+        tier,
+        status: result.member.status,
+        subscription_end: subscriptionEnd,
+        subscription_start: result.member.subscription_start,
+        payment_method: result.member.payment_method
+      }
     });
-
-  } catch (error: any) {
+  } catch (error) {
     console.error('[Membership Status] Error checking status:', error);
-
-    return json(
-      {
-        error: error.message || 'Failed to check membership status',
-        found: false
-      },
-      { status: 500 }
-    );
+    return json({ error: 'membership lookup unavailable' }, { status: 503 });
   }
 };
-

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -21,6 +21,7 @@
   import { theme, type Theme } from '$lib/themeStore';
   import { displayCurrency, SUPPORTED_CURRENCIES, type CurrencyCode } from '$lib/currencyStore';
   import { getAuthManager, type NIP46ConnectionInfo } from '$lib/authManager';
+  import { signNip98AuthHeader } from '$lib/nip98';
   import {
     userPublickey,
     ndk,
@@ -373,10 +374,24 @@
     if (!pk) return;
     membershipLoading = true;
     try {
+      // NIP-98 auth proves we own this pubkey, unlocking the full
+      // record (expiry, payment method). Without a signer we fall back
+      // to the public shape — tier badge only.
+      const bodyString = JSON.stringify({ pubkey: pk });
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      try {
+        headers.Authorization = await signNip98AuthHeader($ndk, {
+          method: 'POST',
+          url: `${location.origin}/api/membership/check-status`,
+          bodyString
+        });
+      } catch {
+        // No signer available — public shape is fine.
+      }
       const res = await fetch('/api/membership/check-status', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ pubkey: pk })
+        headers,
+        body: bodyString
       });
       if (res.ok) {
         membershipData = await res.json();
@@ -578,16 +593,19 @@
           </div>
 
           <div class="flex flex-col gap-2 text-sm">
-            <div class="flex justify-between">
-              <span class="text-caption">{membershipData.isExpired ? 'Expired' : 'Expires'}</span>
-              <span style="color: var(--color-text-primary)">
-                {expiryDate.toLocaleDateString('en-US', {
-                  year: 'numeric',
-                  month: 'long',
-                  day: 'numeric'
-                })}
-              </span>
-            </div>
+            <!-- Only present on the NIP-98 owner-tier response; the public shape carries no expiry -->
+            {#if member.subscription_end}
+              <div class="flex justify-between">
+                <span class="text-caption">{membershipData.isExpired ? 'Expired' : 'Expires'}</span>
+                <span style="color: var(--color-text-primary)">
+                  {expiryDate.toLocaleDateString('en-US', {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric'
+                  })}
+                </span>
+              </div>
+            {/if}
             <div class="flex justify-between">
               <span class="text-caption">Payment</span>
               <span style="color: var(--color-text-primary)">


### PR DESCRIPTION
## Summary

Closes an unauthenticated data exposure on `/api/membership/check-status` and stops the batch membership endpoint from masking misconfiguration with mock data.

### Commit 1 — restrict check-status full member record to NIP-98-verified owner

`POST /api/membership/check-status` previously returned the full member record (`payment_id`, `status`, `subscription_end`, `payment_method`, …) for **any** pubkey anyone posted. It now has two disclosure tiers:

- **Public (no auth):** `{ found: true, isActive, member: { tier } }` — badge surface only. Tier is disclosed only while the membership is active, so a lapsed member is indistinguishable from a never-member.
- **Owner (NIP-98 `Authorization` header signed by the queried pubkey itself):** the full record, minus `payment_id`/`created_at`/`updated_at` (no caller consumes them), plus `owner: true`. An absent/invalid/mismatched signature **degrades to the public shape** rather than erroring, so existing unauthenticated callers keep working with zero changes.

The settings page (the only client needing full detail) now signs the request with the existing `signNip98AuthHeader` helper and gracefully falls back to the public shape when no signer is available. Error branches no longer echo `error.message` or config detail to clients — generic 503 with server-side logging.

### Commit 2 — restrict membership mock fallback to dev builds

`GET /api/membership` (batch badge lookup) served deterministic **mock** member data whenever `MEMBERSHIP_ENABLED`/`RELAY_API_SECRET` were missing — ~60% of pubkeys appeared as active members, so a dropped env var in prod would silently fabricate badges. The mock is now gated on `dev` from `$app/environment` (build-time constant, unreachable in production/preview builds); non-dev builds log an error and return 503, which the `membershipStatus` store already handles gracefully (`active: false, tier: 'unknown'`, no crash).

## Test plan

- `pnpm check`: 0 errors
- `pnpm test`: 161/161 pass
- Caller audit: all 8 check-status call sites query the logged-in user's own pubkey and consume only `isActive`/`member.tier`, both preserved in the public shape

Known/deferred (queued for separate cleanup): `membership/test-relay-access` diagnostic page stays degraded (pre-existing field-path bugs), and the settings `validTier` fallback defaulting unknown tiers to `cook_plus` is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)