### PR TITLE
feat(clink): support paying CLINK static offers (noffer1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.473",
+  "version": "4.2.474",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.475",
+  "version": "4.2.476",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.474",
+  "version": "4.2.475",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/NoteContent.svelte
+++ b/src/components/NoteContent.svelte
@@ -4,6 +4,7 @@
   import type { NDKEvent } from '@nostr-dev-kit/ndk';
   import ProfileLink from './ProfileLink.svelte';
   import NoteEmbed from './NoteEmbed.svelte';
+  import NofferButton from './clink/NofferButton.svelte';
   import LinkPreview from './LinkPreview.svelte';
   import VideoPreview from './VideoPreview.svelte';
   import { processContentWithProfiles } from '$lib/contentProcessor';
@@ -119,9 +120,12 @@
 
   // Parse content and create clickable links for URLs, hashtags, and nostr references
   function parseContent(text: string) {
-    // Include naddr1 for addressable events (recipes, long-form content)
+    // Include naddr1 for addressable events (recipes, long-form content).
+    // noffer1 (CLINK static offers) is detected both as a bare token and with
+    // the optional `nostr:` prefix — when present we render an inline "⚡ Pay"
+    // pill (NofferButton) instead of treating it as plain text.
     const urlRegex =
-      /(https?:\/\/[^\s]+)|nostr:(nevent1|note1|npub1|nprofile1|naddr1)([023456789acdefghjklmnpqrstuvwxyz]+)/g;
+      /(https?:\/\/[^\s]+)|nostr:(nevent1|note1|npub1|nprofile1|naddr1|noffer1)([023456789acdefghjklmnpqrstuvwxyz]+)|\b(noffer1)([023456789acdefghjklmnpqrstuvwxyz]{6,})/g;
     const hashtagRegex = /#[\w]+/g;
 
     const parts = [];
@@ -140,7 +144,7 @@
     }> = [];
     urlRegex.lastIndex = 0;
     while ((match = urlRegex.exec(text)) !== null) {
-      const [fullMatch, url, nostrPrefix, nostrData] = match;
+      const [fullMatch, url, nostrPrefix, nostrData, bareNofferPrefix, bareNofferData] = match;
       if (url) {
         urlMatches.push({
           index: match.index,
@@ -155,6 +159,17 @@
           type: 'nostr',
           prefix: nostrPrefix,
           data: nostrData
+        });
+      } else if (bareNofferPrefix && bareNofferData) {
+        // Bare `noffer1…` (no `nostr:` prefix) — treat the same as a
+        // nostr:noffer1 reference so the downstream renderer surfaces a
+        // Pay button.
+        urlMatches.push({
+          index: match.index,
+          content: fullMatch,
+          type: 'nostr',
+          prefix: bareNofferPrefix,
+          data: bareNofferData
         });
       }
     }
@@ -325,6 +340,10 @@
       {:else if part.prefix === 'naddr1'}
         <!-- Addressable event (recipe, article, etc.) - render as embedded content -->
         <NoteEmbed nostrString={part.content} depth={embedDepth} />
+      {:else if part.prefix === 'noffer1'}
+        <!-- CLINK static offer — render an inline "⚡ Pay" pill that opens
+             NofferPayModal. Matches the bxrd.app affordance. -->
+        <NofferButton noffer={part.content} />
       {:else}
         <button
           class="text-blue-500 hover:text-blue-700 hover:underline cursor-pointer"

--- a/src/components/ParsedBio.svelte
+++ b/src/components/ParsedBio.svelte
@@ -33,8 +33,14 @@
     // Order matters: noffer goes first so a bare `noffer1…` token isn't
     // accidentally swallowed by the URL pattern (it wouldn't be, since
     // bech32 has no `://`, but precedence keeps intent clear).
+    //
+    // IMPORTANT: do NOT wrap each `.source` in extra parens here — the
+    // base regexes already each contain one capturing group, and wrapping
+    // them doubles the groups (outer + inner) which shifts the indices.
+    // The code below expects match[1]=noffer, [2]=url, [3]=nostr — that
+    // only holds when each alternative contributes exactly one group.
     const combinedRegex = new RegExp(
-      `(${NOFFER_REGEX.source})|(${URL_REGEX.source})|(${NOSTR_REGEX.source})`,
+      `${NOFFER_REGEX.source}|${URL_REGEX.source}|${NOSTR_REGEX.source}`,
       'g'
     );
 

--- a/src/components/ParsedBio.svelte
+++ b/src/components/ParsedBio.svelte
@@ -2,12 +2,13 @@
   import { ndk } from '$lib/nostr';
   import { nip19 } from 'nostr-tools';
   import { onMount } from 'svelte';
+  import NofferButton from './clink/NofferButton.svelte';
 
   export let text: string = '';
   export let class_: string = '';
 
   interface BioSegment {
-    type: 'text' | 'url' | 'nostr';
+    type: 'text' | 'url' | 'nostr' | 'noffer';
     content: string;
     href?: string;
     pubkey?: string;
@@ -20,12 +21,22 @@
   // Regex patterns
   const URL_REGEX = /(https?:\/\/[^\s<>"\)]+)/g;
   const NOSTR_REGEX = /(nostr:n(?:pub|profile)1[023456789acdefghjklmnpqrstuvwxyz]+)/g;
+  // CLINK noffer — both `nostr:noffer1…` and bare `noffer1…`. Word boundary
+  // before the bare form so we don't match in the middle of an identifier.
+  const NOFFER_REGEX =
+    /((?:nostr:)?noffer1[023456789acdefghjklmnpqrstuvwxyz]{6,})/g;
 
   function parseText(input: string): BioSegment[] {
     const result: BioSegment[] = [];
 
-    // Combined regex to match both URLs and nostr links
-    const combinedRegex = new RegExp(`(${URL_REGEX.source})|(${NOSTR_REGEX.source})`, 'g');
+    // Combined regex to match URLs, nostr profile links, and CLINK noffers.
+    // Order matters: noffer goes first so a bare `noffer1…` token isn't
+    // accidentally swallowed by the URL pattern (it wouldn't be, since
+    // bech32 has no `://`, but precedence keeps intent clear).
+    const combinedRegex = new RegExp(
+      `(${NOFFER_REGEX.source})|(${URL_REGEX.source})|(${NOSTR_REGEX.source})`,
+      'g'
+    );
 
     let lastIndex = 0;
     let match;
@@ -40,17 +51,23 @@
       }
 
       if (match[1]) {
+        // Noffer match
+        result.push({
+          type: 'noffer',
+          content: match[1]
+        });
+      } else if (match[2]) {
         // URL match
         result.push({
           type: 'url',
-          content: match[1],
-          href: match[1]
+          content: match[2],
+          href: match[2]
         });
-      } else if (match[2]) {
+      } else if (match[3]) {
         // Nostr match
         result.push({
           type: 'nostr',
-          content: match[2]
+          content: match[3]
         });
       }
 
@@ -172,6 +189,8 @@
           href={segment.href}
           class="text-primary hover:underline"
         >@{segment.displayName || segment.content}</a>
+      {:else if segment.type === 'noffer'}
+        <NofferButton noffer={segment.content} />
       {/if}
     {/each}
   {/if}

--- a/src/components/clink/NofferButton.svelte
+++ b/src/components/clink/NofferButton.svelte
@@ -1,25 +1,41 @@
 <!--
-  Small "⚡ Pay" pill rendered inline anywhere we surface a CLINK noffer
-  (note content, profile page, bio). Click opens NofferPayModal which
-  does the actual RPC / wallet hand-off.
+  CLINK noffer "Pay" affordance.
+
+  Two variants, sharing one click target → NofferPayModal:
+
+    `pill` (default) — small inline pill for note content / bios / list
+      rows. Filled zap-orange → amber gradient, white icon + label,
+      subtle brand-orange glow. Flows with surrounding text but reads
+      as a real CTA, not a label.
+
+    `cta` — full-width prominent button for the profile page or any
+      other place we want noffer payments front and center. Matches the
+      visual weight of the Send Zap button (large tap target, bold
+      label) but uses the gradient to distinguish.
 -->
 <script lang="ts">
   import LightningIcon from 'phosphor-svelte/lib/Lightning';
   import NofferPayModal from './NofferPayModal.svelte';
 
   export let noffer: string;
+  /** Visual size — 'pill' is the inline default, 'cta' is full-width prominent. */
+  export let variant: 'pill' | 'cta' = 'pill';
+  /** Label override; defaults differ per variant. */
+  export let label: string = '';
 
   let open = false;
+
+  $: resolvedLabel = label || (variant === 'cta' ? 'Pay CLINK offer' : 'Pay');
 </script>
 
 <button
   type="button"
-  class="noffer-pay-btn"
+  class="noffer-pay-btn noffer-pay-btn--{variant}"
   on:click|stopPropagation|preventDefault={() => (open = true)}
   title="Pay this CLINK offer"
 >
-  <LightningIcon weight="fill" size={14} />
-  <span>Pay</span>
+  <LightningIcon weight="fill" size={variant === 'cta' ? 20 : 14} />
+  <span>{resolvedLabel}</span>
 </button>
 
 {#if open}
@@ -30,28 +46,56 @@
   .noffer-pay-btn {
     display: inline-flex;
     align-items: center;
-    gap: 0.25rem;
-    padding: 0.2rem 0.6rem;
-    border-radius: 9999px;
-    font-size: 0.75rem;
-    font-weight: 600;
-    color: #f59e0b;
-    background-color: rgba(245, 158, 11, 0.12);
-    border: 1px solid rgba(245, 158, 11, 0.4);
+    justify-content: center;
+    gap: 0.4rem;
+    color: #fff;
+    font-weight: 700;
+    /* Zap-orange → amber gradient. The diagonal gradient picks up the
+       brand orange (#ec4700, also `--zap-orange` in app.css) on the
+       leading edge and warms into amber-500 on the trailing edge —
+       mirrors the orange/amber sweep used elsewhere for zap pills. */
+    background: linear-gradient(135deg, #ec4700 0%, #f59e0b 100%);
+    border: none;
     cursor: pointer;
     transition:
-      background-color 0.15s ease-out,
-      transform 0.05s ease-out;
+      transform 0.08s ease-out,
+      box-shadow 0.15s ease-out,
+      filter 0.15s ease-out;
     vertical-align: middle;
+    text-decoration: none;
+    line-height: 1;
   }
   .noffer-pay-btn:hover {
-    background-color: rgba(245, 158, 11, 0.22);
+    filter: brightness(1.05);
+    box-shadow: 0 0 18px rgba(236, 71, 0, 0.45);
   }
   .noffer-pay-btn:active {
     transform: scale(0.97);
   }
   .noffer-pay-btn:focus-visible {
-    outline: 2px solid #f59e0b;
+    outline: 2px solid #ec4700;
     outline-offset: 2px;
+  }
+
+  /* Inline pill — used in note content and bios. Small enough to flow
+     between words; soft glow so it pulls the eye without screaming. */
+  .noffer-pay-btn--pill {
+    padding: 0.3rem 0.7rem;
+    border-radius: 9999px;
+    font-size: 0.8125rem;
+    box-shadow: 0 0 0 1px rgba(236, 71, 0, 0.5), 0 2px 8px rgba(236, 71, 0, 0.25);
+  }
+
+  /* Full-width CTA — used on the profile page. Stronger glow to match
+     the visual weight of the Send Zap button it sits next to. */
+  .noffer-pay-btn--cta {
+    width: 100%;
+    padding: 0.85rem 1rem;
+    border-radius: 0.5rem;
+    font-size: 1rem;
+    box-shadow: 0 4px 14px rgba(236, 71, 0, 0.32);
+  }
+  .noffer-pay-btn--cta:hover {
+    box-shadow: 0 6px 22px rgba(236, 71, 0, 0.5);
   }
 </style>

--- a/src/components/clink/NofferButton.svelte
+++ b/src/components/clink/NofferButton.svelte
@@ -1,0 +1,57 @@
+<!--
+  Small "⚡ Pay" pill rendered inline anywhere we surface a CLINK noffer
+  (note content, profile page, bio). Click opens NofferPayModal which
+  does the actual RPC / wallet hand-off.
+-->
+<script lang="ts">
+  import LightningIcon from 'phosphor-svelte/lib/Lightning';
+  import NofferPayModal from './NofferPayModal.svelte';
+
+  export let noffer: string;
+
+  let open = false;
+</script>
+
+<button
+  type="button"
+  class="noffer-pay-btn"
+  on:click|stopPropagation|preventDefault={() => (open = true)}
+  title="Pay this CLINK offer"
+>
+  <LightningIcon weight="fill" size={14} />
+  <span>Pay</span>
+</button>
+
+{#if open}
+  <NofferPayModal bind:open {noffer} />
+{/if}
+
+<style>
+  .noffer-pay-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.2rem 0.6rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #f59e0b;
+    background-color: rgba(245, 158, 11, 0.12);
+    border: 1px solid rgba(245, 158, 11, 0.4);
+    cursor: pointer;
+    transition:
+      background-color 0.15s ease-out,
+      transform 0.05s ease-out;
+    vertical-align: middle;
+  }
+  .noffer-pay-btn:hover {
+    background-color: rgba(245, 158, 11, 0.22);
+  }
+  .noffer-pay-btn:active {
+    transform: scale(0.97);
+  }
+  .noffer-pay-btn:focus-visible {
+    outline: 2px solid #f59e0b;
+    outline-offset: 2px;
+  }
+</style>

--- a/src/components/clink/NofferPayModal.svelte
+++ b/src/components/clink/NofferPayModal.svelte
@@ -1,0 +1,319 @@
+<!--
+  Modal that handles a CLINK noffer payment.
+
+  Two paths in one modal, mirroring bxrd.app's note view:
+    • In-app: when the viewer has Spark / NWC / WebLN connected, runs the
+      kind-21001 RPC against the offer's relay and pays the returned
+      bolt11 via `walletManager.sendPayment`.
+    • External: a `lightning:noffer1…` QR + copy button for CLINK-aware
+      wallets (Zeus, ShockWallet) to scan and handle the RPC themselves.
+
+  Friendly error mapping mirrors ZapModal's pattern — most NofferError
+  codes get a specific human-readable title + body.
+-->
+<script lang="ts">
+  import Modal from '../Modal.svelte';
+  import Button from '../Button.svelte';
+  import LightningIcon from 'phosphor-svelte/lib/Lightning';
+  import LightningSlashIcon from 'phosphor-svelte/lib/LightningSlash';
+  import CopyIcon from 'phosphor-svelte/lib/Copy';
+  import CheckIcon from 'phosphor-svelte/lib/Check';
+  import Checkmark from 'phosphor-svelte/lib/CheckFat';
+  import { qr } from '@svelte-put/qr/svg';
+  import { decodeNoffer, stripNostrPrefix } from '$lib/clink/noffer';
+  import { NofferError, type NofferData } from '$lib/clink/types';
+  import { requestInvoice } from '$lib/clink/nofferClient';
+  import { sendPayment } from '$lib/wallet/walletManager';
+  import { activeWallet } from '$lib/wallet';
+  import { weblnConnected } from '$lib/wallet/webln';
+  import CustomName from '../CustomName.svelte';
+  import CustomAvatar from '../CustomAvatar.svelte';
+
+  export let open = false;
+  export let noffer: string;
+
+  let data: NofferData | null = null;
+  let decodeError: string | null = null;
+  let state: 'idle' | 'requesting' | 'paying' | 'success' | 'error' = 'idle';
+  let error: Error | null = null;
+  let amountInput = '';
+  let copied = false;
+
+  $: hasInAppWallet =
+    $weblnConnected ||
+    ($activeWallet && ($activeWallet.kind === 3 || $activeWallet.kind === 4));
+
+  $: lightningUri = `lightning:${stripNostrPrefix(noffer)}`;
+
+  // Decode whenever the noffer prop changes. We pre-populate the amount
+  // input with the offer's TLV-4 price (when present) so a Fixed offer
+  // shows the right number and a Variable offer has a starting hint.
+  $: {
+    try {
+      data = decodeNoffer(noffer);
+      decodeError = null;
+      if (data.price != null && !amountInput) {
+        amountInput = String(data.price);
+      }
+    } catch (e) {
+      decodeError = e instanceof Error ? e.message : String(e);
+      data = null;
+    }
+  }
+
+  $: needsAmountInput = data ? data.pricingType !== 'fixed' : false;
+  $: amountSats = (() => {
+    const n = Number(amountInput);
+    return Number.isFinite(n) && n > 0 ? Math.floor(n) : 0;
+  })();
+  $: payDisabled =
+    !data ||
+    state === 'requesting' ||
+    state === 'paying' ||
+    (needsAmountInput && amountSats <= 0);
+
+  // Friendly error mapping — mirrors ZapModal's title/body/retryable shape.
+  let errorTitle = "Couldn't pay this offer";
+  let errorBody = '';
+  let errorRetryable = true;
+  $: {
+    const msg = (error?.message || '').toLowerCase();
+    if (error instanceof NofferError) {
+      switch (error.code) {
+        case 1:
+          errorTitle = 'Offer no longer valid';
+          errorBody = 'The service rejected this offer as invalid.';
+          errorRetryable = false;
+          break;
+        case 2:
+          errorTitle = 'Temporary failure';
+          errorBody =
+            "The service couldn't complete the request right now. Try again in a moment.";
+          errorRetryable = true;
+          break;
+        case 3:
+          errorTitle = 'Offer moved';
+          errorBody = error.latest
+            ? 'This offer has a newer version. Ask the recipient for the updated noffer.'
+            : 'This offer has been retired by the recipient.';
+          errorRetryable = false;
+          break;
+        case 4:
+          errorTitle = 'Unsupported feature';
+          errorBody = "The service doesn't support this kind of payment request.";
+          errorRetryable = false;
+          break;
+        case 5:
+          errorTitle = 'Amount out of range';
+          errorBody = error.range
+            ? `Pick an amount between ${error.range.min.toLocaleString()} and ${error.range.max.toLocaleString()} sats.`
+            : "The amount you entered is outside the offer's allowed range.";
+          errorRetryable = true;
+          break;
+        default:
+          errorTitle = 'Offer error';
+          errorBody = error.message;
+          errorRetryable = true;
+      }
+    } else if (msg.includes('timed out') || msg.includes('timeout')) {
+      errorTitle = 'Offer timed out';
+      errorBody =
+        "The service didn't respond in time. Check your connection and try again.";
+      errorRetryable = true;
+    } else if (msg.includes('sign in')) {
+      errorTitle = 'Sign in to pay';
+      errorBody = 'You need to be signed in to pay an offer.';
+      errorRetryable = false;
+    } else if (msg.includes('no wallet') || msg.includes('not connected')) {
+      errorTitle = 'No wallet connected';
+      errorBody = 'Connect a Lightning wallet first, or scan the QR with a CLINK-aware wallet.';
+      errorRetryable = false;
+    } else {
+      errorTitle = "Couldn't pay this offer";
+      errorBody = error?.message || 'Something went wrong. Please try again.';
+      errorRetryable = true;
+    }
+  }
+
+  async function payWithInAppWallet() {
+    if (!data) return;
+    state = 'requesting';
+    error = null;
+    try {
+      const { bolt11 } = await requestInvoice(data, {
+        amountSats: amountSats > 0 ? amountSats : undefined,
+        description: `Offer: ${data.offerId}`
+      });
+      state = 'paying';
+      const effectiveAmount = amountSats > 0 ? amountSats : data.price;
+      const result = await sendPayment(bolt11, {
+        amount: effectiveAmount,
+        description: `CLINK offer: ${data.offerId}`,
+        pubkey: data.pubkey
+      });
+      if (!result.success) {
+        throw new Error(result.error || 'Payment failed');
+      }
+      state = 'success';
+    } catch (e) {
+      error = e as Error;
+      state = 'error';
+    }
+  }
+
+  async function copyNoffer() {
+    try {
+      await navigator.clipboard.writeText(stripNostrPrefix(noffer));
+      copied = true;
+      setTimeout(() => (copied = false), 1500);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  function tryAgain() {
+    state = 'idle';
+    error = null;
+  }
+</script>
+
+<Modal bind:open>
+  <h1 slot="title" class="flex items-center gap-2">
+    <LightningIcon weight="fill" class="text-amber-500" />
+    Pay offer
+  </h1>
+
+  {#if decodeError}
+    <div class="text-center py-6">
+      <p class="text-sm" style="color: var(--color-text-primary)">
+        Couldn't read this offer.
+      </p>
+      <p class="text-xs text-caption mt-2 font-mono break-all">{decodeError}</p>
+    </div>
+  {:else if data}
+    {#if state === 'success'}
+      <div class="flex flex-col items-center py-6">
+        <div
+          class="w-16 h-16 rounded-full flex items-center justify-center mb-3"
+          style="background-color: rgba(16, 185, 129, 0.15); color: #10b981;"
+        >
+          <Checkmark weight="fill" size={32} />
+        </div>
+        <p class="text-lg font-semibold" style="color: var(--color-text-primary)">Paid!</p>
+        <p class="text-sm mt-1" style="color: var(--color-text-secondary)">
+          {(amountSats > 0 ? amountSats : (data.price ?? 0)).toLocaleString()} sats sent.
+        </p>
+      </div>
+    {:else if state === 'error'}
+      <div class="flex flex-col items-center py-2">
+        <div
+          class="w-16 h-16 rounded-full flex items-center justify-center mb-3"
+          style="background-color: rgba(245, 158, 11, 0.12); color: #f59e0b;"
+        >
+          <LightningSlashIcon weight="fill" size={32} />
+        </div>
+        <span class="text-lg font-semibold text-center" style="color: var(--color-text-primary)">
+          {errorTitle}
+        </span>
+        <span class="text-sm text-center mt-1.5 max-w-xs" style="color: var(--color-text-secondary)">
+          {errorBody}
+        </span>
+        <div class="flex gap-2 mt-5">
+          <Button on:click={() => (open = false)}>Close</Button>
+          {#if errorRetryable}
+            <Button on:click={tryAgain}>Try Again</Button>
+          {/if}
+        </div>
+      </div>
+    {:else}
+      <div class="flex flex-col gap-4">
+        <!-- Recipient -->
+        <div class="flex items-center gap-3">
+          <CustomAvatar pubkey={data.pubkey} size={40} />
+          <div class="flex-1 min-w-0">
+            <div class="font-semibold truncate" style="color: var(--color-text-primary)">
+              <CustomName pubkey={data.pubkey} />
+            </div>
+            <div class="text-xs text-caption truncate font-mono">
+              {data.offerId}
+            </div>
+          </div>
+        </div>
+
+        <!-- Amount -->
+        {#if needsAmountInput}
+          <label class="block">
+            <span class="text-sm font-medium" style="color: var(--color-text-primary)">
+              Amount (sats)
+            </span>
+            <input
+              type="number"
+              min="1"
+              bind:value={amountInput}
+              placeholder={data.price ? String(data.price) : 'e.g. 1000'}
+              class="input mt-1 w-full"
+              disabled={state === 'requesting' || state === 'paying'}
+            />
+            {#if data.currency}
+              <span class="text-xs text-caption mt-1 block">
+                Recipient prices in {data.currency}; you pay in sats.
+              </span>
+            {/if}
+          </label>
+        {:else}
+          <div
+            class="flex items-center justify-between p-3 rounded-lg"
+            style="background: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+          >
+            <span class="text-sm text-caption">Amount</span>
+            <span class="font-semibold" style="color: var(--color-text-primary)">
+              {(data.price ?? 0).toLocaleString()} sats
+            </span>
+          </div>
+        {/if}
+
+        <!-- Primary action: in-app pay -->
+        {#if hasInAppWallet}
+          <Button on:click={payWithInAppWallet} disabled={payDisabled}>
+            {#if state === 'requesting'}
+              Requesting invoice…
+            {:else if state === 'paying'}
+              Paying…
+            {:else}
+              ⚡ Pay with my wallet
+            {/if}
+          </Button>
+        {/if}
+
+        <!-- Secondary: scan-with-external-wallet -->
+        <div
+          class="border-t pt-4"
+          style="border-color: var(--color-input-border)"
+        >
+          <p class="text-sm text-center mb-2" style="color: var(--color-text-secondary)">
+            …or scan with a CLINK-aware wallet (Zeus, ShockWallet, …)
+          </p>
+          <div class="flex justify-center bg-white p-4 rounded-lg">
+            <svg
+              use:qr={{ data: lightningUri, shape: 'square' }}
+              class="w-48 h-48"
+              aria-label="QR code for {lightningUri}"
+            />
+          </div>
+          <button
+            type="button"
+            class="w-full mt-2 inline-flex items-center justify-center gap-2 text-sm py-2 rounded-full hover:bg-input transition-colors"
+            style="color: var(--color-text-secondary)"
+            on:click={copyNoffer}
+          >
+            {#if copied}
+              <CheckIcon size={16} /> Copied
+            {:else}
+              <CopyIcon size={16} /> Copy offer
+            {/if}
+          </button>
+        </div>
+      </div>
+    {/if}
+  {/if}
+</Modal>

--- a/src/components/clink/NofferPayModal.svelte
+++ b/src/components/clink/NofferPayModal.svelte
@@ -291,7 +291,7 @@
           style="border-color: var(--color-input-border)"
         >
           <p class="text-sm text-center mb-2" style="color: var(--color-text-secondary)">
-            …or scan with a CLINK-aware wallet (Zeus, ShockWallet, …)
+            or scan with a CLINK-aware wallet (Zeus or ShockWallet)
           </p>
           <div class="flex justify-center bg-white p-4 rounded-lg">
             <svg

--- a/src/components/clink/NofferPayModal.svelte
+++ b/src/components/clink/NofferPayModal.svelte
@@ -140,12 +140,18 @@
     state = 'requesting';
     error = null;
     try {
+      // For Fixed offers the amount input is hidden in the UI — never
+      // forward `amountInput` to the service or the wallet history, since
+      // it could be a stale value left over from a prior Variable /
+      // Spontaneous offer in the same session. The service knows the
+      // canonical price from the offer id; we honour `data.price` for
+      // display + wallet metadata.
+      const effectiveAmount = needsAmountInput ? amountSats : (data.price ?? 0);
       const { bolt11 } = await requestInvoice(data, {
-        amountSats: amountSats > 0 ? amountSats : undefined,
+        amountSats: needsAmountInput && amountSats > 0 ? amountSats : undefined,
         description: `Offer: ${data.offerId}`
       });
       state = 'paying';
-      const effectiveAmount = amountSats > 0 ? amountSats : data.price;
       const result = await sendPayment(bolt11, {
         amount: effectiveAmount,
         description: `CLINK offer: ${data.offerId}`,
@@ -201,7 +207,7 @@
         </div>
         <p class="text-lg font-semibold" style="color: var(--color-text-primary)">Paid!</p>
         <p class="text-sm mt-1" style="color: var(--color-text-secondary)">
-          {(amountSats > 0 ? amountSats : (data.price ?? 0)).toLocaleString()} sats sent.
+          {(needsAmountInput ? amountSats : (data.price ?? 0)).toLocaleString()} sats sent.
         </p>
       </div>
     {:else if state === 'error'}

--- a/src/lib/clink/noffer.test.ts
+++ b/src/lib/clink/noffer.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for the CLINK noffer1… bech32 decoder.
+ *
+ * We don't have a publicly-shared production noffer to use as a fixture
+ * (the user's profile noffer in the screenshot is truncated in the UI),
+ * so the tests encode synthetic noffers via the same `bech32` library
+ * and round-trip them through the decoder. Each test pins the TLV byte
+ * layout described in the CLINK spec.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { bech32 } from 'bech32';
+import { decodeNoffer, isNofferString, stripNostrPrefix } from './noffer';
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    out[i / 2] = parseInt(hex.substring(i, i + 2), 16);
+  }
+  return out;
+}
+
+function utf8(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+function encodeTestNoffer(tlvs: Array<{ type: number; value: Uint8Array }>): string {
+  const parts: number[] = [];
+  for (const { type, value } of tlvs) {
+    parts.push(type, value.length, ...value);
+  }
+  const words = bech32.toWords(new Uint8Array(parts));
+  return bech32.encode('noffer', words, 5000);
+}
+
+// A 32-byte hex string (the user's pubkey from the conversation — used
+// because it's a known-real pubkey, makes the test fixture meaningful).
+const PUBKEY = 'ee6ea13ab9fe5c4a68eaf9b1a34fe014a66b40117c50ee2a614f4cda959b6e74';
+const RELAY = 'wss://relay.example.com';
+const OFFER_ID = 'tip-jar';
+
+describe('decodeNoffer', () => {
+  it('decodes the minimum-required TLVs (0/1/2) and defaults pricingType to spontaneous', () => {
+    const noffer = encodeTestNoffer([
+      { type: 0, value: hexToBytes(PUBKEY) },
+      { type: 1, value: utf8(RELAY) },
+      { type: 2, value: utf8(OFFER_ID) }
+    ]);
+    const decoded = decodeNoffer(noffer);
+    expect(decoded.pubkey).toBe(PUBKEY);
+    expect(decoded.relay).toBe(RELAY);
+    expect(decoded.offerId).toBe(OFFER_ID);
+    expect(decoded.pricingType).toBe('spontaneous');
+    expect(decoded.price).toBeUndefined();
+    expect(decoded.currency).toBeUndefined();
+  });
+
+  it('decodes Fixed pricing with a price in sats (TLVs 3 + 4)', () => {
+    const noffer = encodeTestNoffer([
+      { type: 0, value: hexToBytes(PUBKEY) },
+      { type: 1, value: utf8(RELAY) },
+      { type: 2, value: utf8(OFFER_ID) },
+      { type: 3, value: new Uint8Array([0]) }, // Fixed
+      { type: 4, value: new Uint8Array([0x27, 0x10]) } // 10000 big-endian
+    ]);
+    const decoded = decodeNoffer(noffer);
+    expect(decoded.pricingType).toBe('fixed');
+    expect(decoded.price).toBe(10000);
+  });
+
+  it('decodes Variable pricing with a currency code (TLVs 3 + 5)', () => {
+    const noffer = encodeTestNoffer([
+      { type: 0, value: hexToBytes(PUBKEY) },
+      { type: 1, value: utf8(RELAY) },
+      { type: 2, value: utf8(OFFER_ID) },
+      { type: 3, value: new Uint8Array([1]) }, // Variable
+      { type: 5, value: utf8('USD') }
+    ]);
+    const decoded = decodeNoffer(noffer);
+    expect(decoded.pricingType).toBe('variable');
+    expect(decoded.currency).toBe('USD');
+  });
+
+  it('accepts the nostr: URI prefix', () => {
+    const noffer = encodeTestNoffer([
+      { type: 0, value: hexToBytes(PUBKEY) },
+      { type: 1, value: utf8(RELAY) },
+      { type: 2, value: utf8(OFFER_ID) }
+    ]);
+    expect(decodeNoffer('nostr:' + noffer).pubkey).toBe(PUBKEY);
+    expect(decodeNoffer('NOSTR:' + noffer).pubkey).toBe(PUBKEY);
+  });
+
+  it('throws on non-noffer hrp', () => {
+    expect(() => decodeNoffer('npub1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')).toThrow();
+  });
+
+  it('throws on missing required TLVs', () => {
+    const noffer = encodeTestNoffer([
+      { type: 0, value: hexToBytes(PUBKEY) }
+      // missing relay + offer id
+    ]);
+    expect(() => decodeNoffer(noffer)).toThrow(/relay/i);
+  });
+
+  it('throws on pubkey TLV with wrong length', () => {
+    const noffer = encodeTestNoffer([
+      { type: 0, value: new Uint8Array(16) }, // 16-byte pubkey is invalid
+      { type: 1, value: utf8(RELAY) },
+      { type: 2, value: utf8(OFFER_ID) }
+    ]);
+    expect(() => decodeNoffer(noffer)).toThrow(/pubkey/i);
+  });
+});
+
+describe('isNofferString', () => {
+  it('matches bare noffer1', () => {
+    const noffer = encodeTestNoffer([
+      { type: 0, value: hexToBytes(PUBKEY) },
+      { type: 1, value: utf8(RELAY) },
+      { type: 2, value: utf8(OFFER_ID) }
+    ]);
+    expect(isNofferString(noffer)).toBe(true);
+  });
+  it('matches nostr:noffer1', () => {
+    const noffer = encodeTestNoffer([
+      { type: 0, value: hexToBytes(PUBKEY) },
+      { type: 1, value: utf8(RELAY) },
+      { type: 2, value: utf8(OFFER_ID) }
+    ]);
+    expect(isNofferString('nostr:' + noffer)).toBe(true);
+  });
+  it('does not match npub', () => {
+    expect(isNofferString('npub1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')).toBe(false);
+  });
+  it('does not match empty / null / undefined', () => {
+    expect(isNofferString('')).toBe(false);
+    expect(isNofferString(null)).toBe(false);
+    expect(isNofferString(undefined)).toBe(false);
+  });
+});
+
+describe('stripNostrPrefix', () => {
+  it('strips nostr: when present', () => {
+    expect(stripNostrPrefix('nostr:noffer1abc')).toBe('noffer1abc');
+    expect(stripNostrPrefix('NOSTR:noffer1abc')).toBe('noffer1abc');
+  });
+  it('is a no-op when absent', () => {
+    expect(stripNostrPrefix('noffer1abc')).toBe('noffer1abc');
+  });
+});

--- a/src/lib/clink/noffer.test.ts
+++ b/src/lib/clink/noffer.test.ts
@@ -33,8 +33,9 @@ function encodeTestNoffer(tlvs: Array<{ type: number; value: Uint8Array }>): str
   return bech32.encode('noffer', words, 5000);
 }
 
-// A 32-byte hex string (the user's pubkey from the conversation — used
-// because it's a known-real pubkey, makes the test fixture meaningful).
+// Fixed example pubkey used across the fixtures below — a real-looking
+// 32-byte hex string so the encoded TLV-0 round-trips through the
+// decoder under realistic conditions.
 const PUBKEY = 'ee6ea13ab9fe5c4a68eaf9b1a34fe014a66b40117c50ee2a614f4cda959b6e74';
 const RELAY = 'wss://relay.example.com';
 const OFFER_ID = 'tip-jar';

--- a/src/lib/clink/noffer.ts
+++ b/src/lib/clink/noffer.ts
@@ -1,0 +1,153 @@
+/**
+ * CLINK noffer1… bech32 decoder.
+ *
+ * Spec: https://github.com/shocknet/CLINK/blob/main/specs/clink-offers.md
+ *
+ *   TLV 0 — 32-byte service pubkey
+ *   TLV 1 — recommended relay URL (utf-8)
+ *   TLV 2 — opaque offer identifier (utf-8)
+ *   TLV 3 — (opt) pricing type: 0=Fixed, 1=Variable, 2=Spontaneous (default)
+ *   TLV 4 — (opt) price in sats (big-endian)
+ *   TLV 5 — (opt) currency code (utf-8; only meaningful with type 1)
+ *
+ * nostr-tools 2.13 does not include `noffer` in `nip19`, so this module
+ * hand-rolls the TLV decode against the existing `bech32` package
+ * (already used in `src/lib/zapManager.ts`).
+ */
+
+import { bech32 } from 'bech32';
+import type { NofferData, PricingType } from './types';
+
+const NOFFER_HRP = 'noffer';
+
+// noffer payloads can comfortably exceed bech32's default 90-char limit
+// (the user's profile noffer in the screenshot is ~85+ chars and that's a
+// short offer id). nostr-tools sets this to 5000 for nip19 — match it.
+const BECH32_LIMIT = 5000;
+
+const TLV_PUBKEY = 0;
+const TLV_RELAY = 1;
+const TLV_OFFER_ID = 2;
+const TLV_PRICING_TYPE = 3;
+const TLV_PRICE = 4;
+const TLV_CURRENCY = 5;
+
+interface TlvEntry {
+  type: number;
+  value: Uint8Array;
+}
+
+function parseTlvs(bytes: Uint8Array): TlvEntry[] {
+  const tlvs: TlvEntry[] = [];
+  let offset = 0;
+  while (offset < bytes.length) {
+    if (offset + 2 > bytes.length) {
+      throw new Error('Malformed noffer: TLV header truncated');
+    }
+    const type = bytes[offset];
+    const length = bytes[offset + 1];
+    if (offset + 2 + length > bytes.length) {
+      throw new Error(`Malformed noffer: TLV ${type} body truncated`);
+    }
+    tlvs.push({ type, value: bytes.slice(offset + 2, offset + 2 + length) });
+    offset += 2 + length;
+  }
+  return tlvs;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let hex = '';
+  for (let i = 0; i < bytes.length; i++) {
+    hex += bytes[i].toString(16).padStart(2, '0');
+  }
+  return hex;
+}
+
+function bytesToUtf8(bytes: Uint8Array): string {
+  return new TextDecoder('utf-8').decode(bytes);
+}
+
+function bytesToBigEndianInt(bytes: Uint8Array): number {
+  let n = 0;
+  for (let i = 0; i < bytes.length; i++) {
+    n = n * 256 + bytes[i];
+  }
+  return n;
+}
+
+function pricingTypeFromByte(byte: number): PricingType {
+  if (byte === 0) return 'fixed';
+  if (byte === 1) return 'variable';
+  return 'spontaneous';
+}
+
+/**
+ * Decode a `noffer1…` (or `nostr:noffer1…`) string into its TLV fields.
+ *
+ * Throws on:
+ * - wrong HRP / non-bech32 input,
+ * - missing required TLVs 0/1/2,
+ * - truncated TLV bytes,
+ * - pubkey TLV not exactly 32 bytes.
+ */
+export function decodeNoffer(input: string): NofferData {
+  const cleaned = input.trim().replace(/^nostr:/i, '');
+  if (!cleaned.toLowerCase().startsWith(NOFFER_HRP + '1')) {
+    throw new Error("Not a noffer string (expected 'noffer1…')");
+  }
+
+  const decoded = bech32.decode(cleaned.toLowerCase(), BECH32_LIMIT);
+  if (decoded.prefix !== NOFFER_HRP) {
+    throw new Error(`Expected hrp 'noffer', got '${decoded.prefix}'`);
+  }
+
+  const bytes = new Uint8Array(bech32.fromWords(decoded.words));
+  const tlvs = parseTlvs(bytes);
+
+  const pubkeyTlv = tlvs.find((t) => t.type === TLV_PUBKEY);
+  if (!pubkeyTlv || pubkeyTlv.value.length !== 32) {
+    throw new Error('Malformed noffer: missing or wrong-length pubkey (TLV 0)');
+  }
+  const relayTlv = tlvs.find((t) => t.type === TLV_RELAY);
+  if (!relayTlv) throw new Error('Malformed noffer: missing relay (TLV 1)');
+  const offerIdTlv = tlvs.find((t) => t.type === TLV_OFFER_ID);
+  if (!offerIdTlv) throw new Error('Malformed noffer: missing offer id (TLV 2)');
+
+  const pricingTypeTlv = tlvs.find((t) => t.type === TLV_PRICING_TYPE);
+  const priceTlv = tlvs.find((t) => t.type === TLV_PRICE);
+  const currencyTlv = tlvs.find((t) => t.type === TLV_CURRENCY);
+
+  const data: NofferData = {
+    pubkey: bytesToHex(pubkeyTlv.value),
+    relay: bytesToUtf8(relayTlv.value),
+    offerId: bytesToUtf8(offerIdTlv.value),
+    pricingType: pricingTypeTlv ? pricingTypeFromByte(pricingTypeTlv.value[0]) : 'spontaneous'
+  };
+  if (priceTlv && priceTlv.value.length > 0) {
+    data.price = bytesToBigEndianInt(priceTlv.value);
+  }
+  if (currencyTlv && currencyTlv.value.length > 0) {
+    data.currency = bytesToUtf8(currencyTlv.value);
+  }
+  return data;
+}
+
+/**
+ * Lightweight detector — checks shape only, does NOT decode TLVs.
+ * Use this in regex/segment parsers where you just need to know "is this
+ * a noffer-shaped token". For real use, call `decodeNoffer()` and let it
+ * throw if malformed.
+ */
+export function isNofferString(s: string | undefined | null): s is string {
+  if (typeof s !== 'string') return false;
+  return /^(nostr:)?noffer1[023456789acdefghjklmnpqrstuvwxyz]{6,}$/i.test(s.trim());
+}
+
+/**
+ * Strip a leading `nostr:` prefix if present and return the bare
+ * `noffer1…` token. Useful for building `lightning:` URIs and copy-to-
+ * clipboard affordances.
+ */
+export function stripNostrPrefix(noffer: string): string {
+  return noffer.replace(/^nostr:/i, '');
+}

--- a/src/lib/clink/noffer.ts
+++ b/src/lib/clink/noffer.ts
@@ -147,7 +147,13 @@ export function isNofferString(s: string | undefined | null): s is string {
  * Strip a leading `nostr:` prefix if present and return the bare
  * `noffer1…` token. Useful for building `lightning:` URIs and copy-to-
  * clipboard affordances.
+ *
+ * Trims surrounding whitespace before the prefix check so a stored
+ * profile field like `"  nostr:noffer1…"` doesn't leak its leading
+ * spaces into the `lightning:` URI or the clipboard. `isNofferString`
+ * already trims on its own match, so callers that validated with it
+ * could otherwise produce an invalid `lightning: nostr:…` URI here.
  */
 export function stripNostrPrefix(noffer: string): string {
-  return noffer.replace(/^nostr:/i, '');
+  return noffer.trim().replace(/^nostr:/i, '');
 }

--- a/src/lib/clink/nofferClient.ts
+++ b/src/lib/clink/nofferClient.ts
@@ -1,0 +1,166 @@
+/**
+ * CLINK noffer kind-21001 RPC client.
+ *
+ * Spec: https://github.com/shocknet/CLINK/blob/main/specs/clink-offers.md
+ *
+ * Flow (payer side):
+ *   1. Build a JSON request payload with the offer id and (when needed)
+ *      the amount in sats.
+ *   2. NIP-44 encrypt the payload to the offer's service pubkey.
+ *   3. Sign and publish a kind-21001 ephemeral event tagged
+ *      `["p", servicePubkey]` and `["clink_version","1"]` on the relay
+ *      carried in the noffer's TLV 1.
+ *   4. Subscribe to kind-21001 on the same relay, filtered to events
+ *      tagged for us (`["p", myPubkey]`). Decrypt the first response and
+ *      parse it as either `{bolt11}` (success) or `{error,code,...}`
+ *      (typed failure surfaced as `NofferError`).
+ *
+ * The caller is responsible for actually paying the returned bolt11 via
+ * `walletManager.sendPayment()` or the external BC modal.
+ */
+
+import { get } from 'svelte/store';
+import { ndk } from '$lib/nostr';
+import { NDKEvent, NDKRelaySet, type NDKKind } from '@nostr-dev-kit/ndk';
+import { encrypt, decrypt } from '$lib/encryptionService';
+import { NofferError, type NofferData, type NofferRequest, type NofferResponse } from './types';
+
+// NDKKind's enum doesn't have 21001 yet — cast explicitly.
+const KIND_CLINK = 21001 as NDKKind;
+const DEFAULT_TIMEOUT_MS = 30000;
+
+export interface RequestInvoiceOptions {
+  /** Amount in sats. Required for Spontaneous offers; optional override
+   * for Fixed/Variable. Services may ignore for Fixed offers. */
+  amountSats?: number;
+  /** Free-text description for the payment (the service may include it
+   * in the invoice description). */
+  description?: string;
+  /** NIP-XX payer_data passthrough (rarely used). */
+  payerData?: Record<string, unknown>;
+  /** How long the invoice should be valid for, in seconds (hint to the
+   * service — not all services honor it). */
+  expiresInSeconds?: number;
+  /** How long to wait for a response before giving up. Default 30s. */
+  timeoutMs?: number;
+}
+
+/**
+ * Send a CLINK offer request and await the service's invoice response.
+ *
+ * @returns `{ bolt11 }` on success.
+ * @throws `NofferError` when the service returns a typed error payload.
+ * @throws plain `Error` on timeout / signer-missing / network failure.
+ */
+export async function requestInvoice(
+  noffer: NofferData,
+  options: RequestInvoiceOptions = {}
+): Promise<{ bolt11: string }> {
+  const ndkInstance = get(ndk);
+  if (!ndkInstance) throw new Error('NDK not initialised');
+  if (!ndkInstance.signer) {
+    throw new Error('Sign in to pay an offer');
+  }
+
+  const me = await ndkInstance.signer.user();
+  const myPubkey = me.pubkey;
+  if (!myPubkey) throw new Error('Could not resolve signer pubkey');
+
+  // Build the request payload. Pricing rules:
+  // - Fixed: amount baked into the offer; we still pass amountSats when
+  //   present in case the service double-checks.
+  // - Variable / Spontaneous: amountSats is required.
+  const requestPayload: NofferRequest = { offer: noffer.offerId };
+  if (options.amountSats != null && options.amountSats > 0) {
+    requestPayload.amount_sats = Math.floor(options.amountSats);
+  }
+  if (options.description) requestPayload.description = options.description;
+  if (options.payerData) requestPayload.payer_data = options.payerData;
+  if (options.expiresInSeconds) requestPayload.expires_in_seconds = options.expiresInSeconds;
+
+  const plaintext = JSON.stringify(requestPayload);
+  const { ciphertext } = await encrypt(noffer.pubkey, plaintext, 'nip44');
+
+  // Make sure the relay is in NDK's pool so the subscription + publish
+  // both target it. NDKRelaySet.fromRelayUrls with `true` autoconnects.
+  try {
+    ndkInstance.addExplicitRelay(noffer.relay);
+  } catch (e) {
+    console.warn('[noffer] Could not add relay to NDK pool:', noffer.relay, e);
+  }
+  const relaySet = NDKRelaySet.fromRelayUrls([noffer.relay], ndkInstance, true);
+
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  // Subscribe BEFORE publishing so we don't race a fast response.
+  const responsePromise = new Promise<{ bolt11: string }>((resolve, reject) => {
+    const sub = ndkInstance.subscribe(
+      {
+        kinds: [KIND_CLINK],
+        '#p': [myPubkey],
+        authors: [noffer.pubkey],
+        // 5s grace for slight clock skew between us and the service.
+        since: Math.floor(Date.now() / 1000) - 5
+      },
+      { closeOnEose: false },
+      relaySet
+    );
+
+    let settled = false;
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      sub.stop();
+      fn();
+    };
+
+    const timer = setTimeout(() => {
+      finish(() => reject(new Error('Offer request timed out')));
+    }, timeoutMs);
+
+    sub.on('event', async (responseEvent: NDKEvent) => {
+      if (settled) return;
+      // The `authors` filter already guards this server-side, but defend
+      // against relays that ignore filters.
+      if (responseEvent.pubkey !== noffer.pubkey) return;
+      try {
+        const decryptedJson = await decrypt(noffer.pubkey, responseEvent.content, 'nip44');
+        const parsed = JSON.parse(decryptedJson) as NofferResponse;
+        if (parsed.bolt11) {
+          finish(() => resolve({ bolt11: parsed.bolt11 as string }));
+          return;
+        }
+        if (parsed.code != null || parsed.error) {
+          finish(() =>
+            reject(
+              new NofferError(
+                parsed.code ?? 0,
+                parsed.error ?? 'Unknown error',
+                parsed.range,
+                parsed.latest
+              )
+            )
+          );
+          return;
+        }
+        // Unrecognised payload — keep listening; maybe a stale event.
+      } catch (e) {
+        console.warn('[noffer] Failed to parse response event, ignoring:', e);
+      }
+    });
+  });
+
+  // Build, sign, publish.
+  const evt = new NDKEvent(ndkInstance);
+  evt.kind = KIND_CLINK;
+  evt.content = ciphertext;
+  evt.tags = [
+    ['p', noffer.pubkey],
+    ['clink_version', '1']
+  ];
+  await evt.sign();
+  await evt.publish(relaySet);
+
+  return responsePromise;
+}

--- a/src/lib/clink/nofferClient.ts
+++ b/src/lib/clink/nofferClient.ts
@@ -20,7 +20,7 @@
  */
 
 import { get } from 'svelte/store';
-import { ndk } from '$lib/nostr';
+import { ndk, userPublickey } from '$lib/nostr';
 import { NDKEvent, NDKRelaySet, type NDKKind } from '@nostr-dev-kit/ndk';
 import { encrypt, decrypt } from '$lib/encryptionService';
 import { NofferError, type NofferData, type NofferRequest, type NofferResponse } from './types';
@@ -62,9 +62,15 @@ export async function requestInvoice(
     throw new Error('Sign in to pay an offer');
   }
 
-  const me = await ndkInstance.signer.user();
-  const myPubkey = me.pubkey;
-  if (!myPubkey) throw new Error('Could not resolve signer pubkey');
+  // Use the app's canonical user-pubkey store. `ndkInstance.signer.user()`
+  // is the wrong source for NIP-46 sessions — NDKNip46Signer.user() returns
+  // the SIGNER service pubkey, not the user's pubkey (see src/lib/nip46Rpc.ts
+  // for the fetchNip46UserPubkey workaround used elsewhere). The
+  // `userPublickey` store is the unified "who am I" surface that authManager
+  // populates correctly for every signer type — using it here ensures the
+  // `#p` filter below subscribes to the right pubkey.
+  const myPubkey = get(userPublickey);
+  if (!myPubkey) throw new Error('Sign in to pay an offer');
 
   // Build the request payload. Pricing rules:
   // - Fixed: amount baked into the offer; we still pass amountSats when

--- a/src/lib/clink/types.ts
+++ b/src/lib/clink/types.ts
@@ -1,0 +1,73 @@
+/**
+ * Types for CLINK (Nostr-native LN protocol) noffer support.
+ *
+ * Spec: https://github.com/shocknet/CLINK/blob/main/specs/clink-offers.md
+ *
+ * The `noffer1…` bech32 string carries TLVs describing a static payment
+ * offer. The payer encrypts a kind-21001 request to the service pubkey,
+ * the service responds with an encrypted kind-21001 carrying a bolt11
+ * invoice.
+ */
+
+export type PricingType = 'fixed' | 'variable' | 'spontaneous';
+
+export interface NofferData {
+  /** 32-byte service pubkey, hex-encoded lowercase. (TLV 0) */
+  pubkey: string;
+  /** Recommended relay URL where the service listens. (TLV 1) */
+  relay: string;
+  /** Opaque offer identifier the service uses to look up the offer. (TLV 2) */
+  offerId: string;
+  /** Pricing type — defaults to 'spontaneous' when TLV 3 is absent. */
+  pricingType: PricingType;
+  /** Price in sats. (TLV 4) Present for Fixed offers and as a hint for Variable. */
+  price?: number;
+  /** Currency code (TLV 5) — only meaningful when `pricingType === 'variable'`. */
+  currency?: string;
+}
+
+/** Payload of the kind-21001 request event (NIP-44 encrypted before sending). */
+export interface NofferRequest {
+  offer: string;
+  amount_sats?: number;
+  payer_data?: Record<string, unknown>;
+  zap?: string;
+  expires_in_seconds?: number;
+  description?: string;
+}
+
+/** Payload of the kind-21001 response event (NIP-44 encrypted on the wire). */
+export interface NofferResponse {
+  bolt11?: string;
+  error?: string;
+  code?: number;
+  range?: { min: number; max: number };
+  /** Present on error code 3 (Expired/Moved) — the noffer to use instead. */
+  latest?: string;
+}
+
+export const NOFFER_ERROR_CODE = {
+  INVALID_OFFER: 1,
+  TEMPORARY_FAILURE: 2,
+  EXPIRED_OR_MOVED: 3,
+  UNSUPPORTED_FEATURE: 4,
+  INVALID_AMOUNT: 5
+} as const;
+
+export class NofferError extends Error {
+  code: number;
+  range?: { min: number; max: number };
+  latest?: string;
+  constructor(
+    code: number,
+    message: string,
+    range?: { min: number; max: number },
+    latest?: string
+  ) {
+    super(message);
+    this.name = 'NofferError';
+    this.code = code;
+    this.range = range;
+    this.latest = latest;
+  }
+}

--- a/src/lib/profileResolver.ts
+++ b/src/lib/profileResolver.ts
@@ -13,6 +13,10 @@ export interface ProfileData {
   about?: string;
   nip05?: string;
   lud16?: string;
+  /** CLINK static offer bech32 string (noffer1…). Written by bxrd.app's
+   * profile editor; we surface a Pay affordance when present.
+   * See https://github.com/shocknet/CLINK/blob/main/specs/clink-offers.md */
+  noffer?: string;
   lastFetched: number;
 }
 
@@ -164,6 +168,19 @@ async function fetchProfileFromRelays(pubkey: string, ndkInstance: NDK): Promise
         ? (parsed.displayName as string)
         : undefined;
 
+    // CLINK noffer: the field key isn't formally standardised yet — bxrd.app's
+    // profile editor labels it "CLINK offer (noffer)" and most likely writes it
+    // as `noffer`, but accept `offer` and `clink_offer` as fallbacks so we
+    // don't lose data if the key name diverges. The value must start with
+    // `noffer1` to be considered valid (so we don't pick up unrelated fields).
+    const rawNoffer =
+      (typeof parsed.noffer === 'string' && parsed.noffer) ||
+      (typeof parsed.offer === 'string' && parsed.offer) ||
+      (typeof parsed.clink_offer === 'string' && parsed.clink_offer) ||
+      undefined;
+    const noffer =
+      rawNoffer && /^(nostr:)?noffer1/i.test(rawNoffer.trim()) ? rawNoffer.trim() : undefined;
+
     const profileData: ProfileData = {
       pubkey,
       name,
@@ -172,6 +189,7 @@ async function fetchProfileFromRelays(pubkey: string, ndkInstance: NDK): Promise
       about: typeof parsed.about === 'string' ? parsed.about : undefined,
       nip05: typeof parsed.nip05 === 'string' ? parsed.nip05 : undefined,
       lud16: typeof parsed.lud16 === 'string' ? parsed.lud16 : undefined,
+      noffer,
       lastFetched: Date.now()
     };
 

--- a/src/routes/user/[slug]/+page.svelte
+++ b/src/routes/user/[slug]/+page.svelte
@@ -1724,20 +1724,6 @@
         </div>
       {/if}
 
-      <!-- CLINK offer (noffer) — set on the user's kind:0 by bxrd.app's
-           profile editor. NDK preserves custom kind:0 fields on
-           NDKUserProfile (it Object.assigns the parsed JSON), so we read
-           via a typed cast and validate the shape before exposing the
-           Pay pill. -->
-      {#if profileNoffer}
-        <div class="flex items-center gap-2 text-sm">
-          <LightningIcon size={18} weight="fill" class="text-amber-500 flex-shrink-0" />
-          <span class="text-caption">CLINK offer</span>
-          <div class="flex-1 flex justify-end">
-            <NofferButton noffer={profileNoffer} />
-          </div>
-        </div>
-      {/if}
 
       <!-- Action buttons for other users -->
       {#if hexpubkey !== $userPublickey}
@@ -1754,6 +1740,13 @@
             <LightningIcon size={22} weight="fill" />
             <span>{isZapping ? 'Zapping...' : 'Send Zap'}</span>
           </button>
+        {/if}
+
+        <!-- CLINK offer — full-width CTA, gradient brand orange. Sits
+             alongside Send Zap so the two payment paths read as peers
+             rather than the noffer feeling buried. -->
+        {#if profileNoffer && hexpubkey && !$mutedPubkeys.has(hexpubkey)}
+          <NofferButton noffer={profileNoffer} variant="cta" />
         {/if}
 
         <!-- DM Button -->

--- a/src/routes/user/[slug]/+page.svelte
+++ b/src/routes/user/[slug]/+page.svelte
@@ -4,6 +4,8 @@
   import type { NDKFilter, NDKUser, NDKUserProfile } from '@nostr-dev-kit/ndk';
   import { nip19 } from 'nostr-tools';
   import ZapModal from '../../../components/ZapModal.svelte';
+  import NofferButton from '../../../components/clink/NofferButton.svelte';
+  import { isNofferString } from '$lib/clink/noffer';
   import Feed from '../../../components/Feed.svelte';
   import { validateMarkdownTemplate } from '$lib/parser';
   import { goto } from '$app/navigation';
@@ -53,6 +55,21 @@
   let loaded = false;
   let zapModal = false;
   let isZapping = false;
+
+  // CLINK noffer pulled from the user's kind:0 custom field. NDK
+  // Object.assigns the parsed JSON onto NDKUserProfile, so custom
+  // fields like `noffer` ride along — they're just not typed. Validate
+  // the shape (must start with `noffer1` after stripping optional
+  // `nostr:` prefix) before exposing as a Pay pill. Tolerant of the
+  // field key — `noffer` is the most likely name (bxrd.app's profile
+  // editor labels it "CLINK offer (noffer)"); fall back to `offer` /
+  // `clink_offer` if it lands under a slightly different key.
+  $: profileNoffer = (() => {
+    if (!profile) return undefined;
+    const p = profile as unknown as Record<string, unknown>;
+    const raw = (p.noffer || p.offer || p.clink_offer) as unknown;
+    return typeof raw === 'string' && isNofferString(raw) ? raw : undefined;
+  })();
 
   // Tab state: 'recipes' | 'posts' | 'media' | 'reads' | 'following' | 'drafts'
   // Default to 'posts' tab for a more social-first experience
@@ -1704,6 +1721,21 @@
               <CopyIcon size={16} />
             {/if}
           </button>
+        </div>
+      {/if}
+
+      <!-- CLINK offer (noffer) — set on the user's kind:0 by bxrd.app's
+           profile editor. NDK preserves custom kind:0 fields on
+           NDKUserProfile (it Object.assigns the parsed JSON), so we read
+           via a typed cast and validate the shape before exposing the
+           Pay pill. -->
+      {#if profileNoffer}
+        <div class="flex items-center gap-2 text-sm">
+          <LightningIcon size={18} weight="fill" class="text-amber-500 flex-shrink-0" />
+          <span class="text-caption">CLINK offer</span>
+          <div class="flex-1 flex justify-end">
+            <NofferButton noffer={profileNoffer} />
+          </div>
         </div>
       {/if}
 


### PR DESCRIPTION
## Summary

Adds CLINK static-offer support — detect `noffer1…` (and `nostr:noffer1…`) in note content, bios, and the kind-0 `noffer` profile field that bxrd.app's profile editor writes, and render an inline "⚡ Pay" pill. Tapping it opens `NofferPayModal`, which does the kind-21001 NIP-44-encrypted RPC against the relay carried in the noffer's TLV-1 and pays the returned bolt11 via `walletManager.sendPayment` — OR shows a `lightning:noffer1…` QR for an external CLINK-aware wallet (Zeus, ShockWallet) to scan.

Spec: https://github.com/shocknet/CLINK/blob/main/specs/clink-offers.md

## How it works

- **Decoder** — `src/lib/clink/noffer.ts` parses the `noffer1` bech32 + TLVs (pubkey, relay, offerId, pricingType, optional price + currency). Uses the `bech32` dep already in the project (same one `zapManager.ts` uses); no new dependencies.
- **RPC client** — `src/lib/clink/nofferClient.ts` mirrors the single-shot send-and-await pattern from `nip46Rpc.ts`. NIP-44 encrypts the request payload via the unified `encryptionService`, publishes the kind-21001 event to a relay-set scoped to TLV-1, and subscribes for the response on the same relay. 30 s timeout. Maps the 5 CLINK error codes onto a typed `NofferError` that the modal surfaces with friendly titles.
- **UI** — `NofferButton.svelte` (small amber pill) + `NofferPayModal.svelte` (recipient header, amount input for Variable/Spontaneous, "Pay with my wallet" primary action, `@svelte-put/qr` fallback for external wallets, copy button).
- **Wired in** — `NoteContent.svelte` and `ParsedBio.svelte` segment parsers learned the new prefix; `profileResolver.ts` gained a `noffer` field on `ProfileData`; the profile page (`user/[slug]/+page.svelte`) renders the pill next to the Lightning address when present.

## Tests

`src/lib/clink/noffer.test.ts` — 13 round-trip tests covering Fixed / Variable / Spontaneous pricing, optional price + currency, `nostr:` URI prefix tolerance, and rejection of malformed input (wrong HRP, missing required TLVs, wrong pubkey length).

```
Test Files  9 passed (9)
     Tests  164 passed (164)
```

## Test plan

- [ ] `pnpm check` — 0 errors. `pnpm build` — clean.
- [ ] Profile page renders the Pay pill on a profile whose kind-0 carries a noffer (the user's own profile at `npub1…ee6ea13a…` is a known reference). Pill is absent when the field is missing.
- [ ] Post (locally) a note containing a bare `noffer1…` token — inline Pay pill renders in the feed and in the thread view.
- [ ] Paste a noffer into a profile bio — `ParsedBio` surfaces the Pay pill.
- [ ] Pay flow — external: tap Pay → modal opens → QR renders → scan from Zeus → invoice paid (verified by recipient).
- [ ] Pay flow — in-app (Spark or WebLN connected): tap "Pay with my wallet" → spinner cycles `Requesting invoice…` → `Paying…` → success state, wallet history row shows the recipient pubkey.
- [ ] Error UX — point at a stale/unreachable relay (timeout maps to "Offer timed out", retryable) and at a fabricated offer id (NofferError code 1, "Offer no longer valid", non-retryable).

## Out of scope (deliberate)

- Adding the noffer field to *our* profile editor — write path is a follow-up; v1 just reads.
- Following the `latest` redirect on NofferError code 3 (we show a clear "ask the recipient for the updated noffer" message).
- TLV-5 currency conversion display (we surface the code as a hint; user still enters sats).

🤖 Generated with [Claude Code](https://claude.com/claude-code)