### PR TITLE
fix(cheffy): dim launcher on scroll + step under the create menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.472",
+  "version": "4.2.473",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.471",
+  "version": "4.2.472",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/CheffyLauncher.svelte
+++ b/src/components/CheffyLauncher.svelte
@@ -22,6 +22,21 @@
   // Show the expanded hint only for first-timers, and only this session.
   let showHint = false;
 
+  // Scroll-dim — mirrors the behaviour on CreateMenuButton (the orange
+  // create FAB that sits directly below us). Both launchers dim to
+  // 0.45 opacity while the page is actively scrolling so they don't
+  // distract from the content, and snap back ~160ms after scroll ends.
+  let isScrolling = false;
+  let scrollTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  function handleScroll() {
+    isScrolling = true;
+    if (scrollTimeout) clearTimeout(scrollTimeout);
+    scrollTimeout = setTimeout(() => {
+      isScrolling = false;
+    }, 160);
+  }
+
   onMount(() => {
     if (!$cheffyHintSeen) {
       showHint = true;
@@ -31,10 +46,23 @@
         dismissCheffyHint();
       }, 6000);
     }
+
+    if (typeof window === 'undefined') return;
+    // Scrolling happens on the #app-scroll container, not the window.
+    // Window listener is a defensive fallback for routes that scroll the
+    // window directly.
+    const scrollContainer = document.getElementById('app-scroll');
+    scrollContainer?.addEventListener('scroll', handleScroll, { passive: true });
+    window.addEventListener('scroll', handleScroll, { passive: true });
   });
 
   onDestroy(() => {
     if (hintTimer) clearTimeout(hintTimer);
+    if (scrollTimeout) clearTimeout(scrollTimeout);
+    if (typeof window === 'undefined') return;
+    const scrollContainer = document.getElementById('app-scroll');
+    scrollContainer?.removeEventListener('scroll', handleScroll);
+    window.removeEventListener('scroll', handleScroll);
   });
 
   function launch() {
@@ -50,6 +78,7 @@
     type="button"
     class="cheffy-launcher"
     class:has-hint={showHint}
+    class:is-scrolling={isScrolling}
     on:click={launch}
     aria-label="Open Cheffy"
   >
@@ -112,6 +141,15 @@
   .cheffy-launcher:focus-visible {
     outline: none;
     box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 45%, transparent);
+  }
+
+  /* Dim while the page is actively scrolling — matches CreateMenuButton.
+     pointer-events:none so a tap landing mid-scroll doesn't accidentally
+     pop the chat panel; restores ~160 ms after scroll ends. */
+  .cheffy-launcher.is-scrolling {
+    opacity: 0.45;
+    pointer-events: none;
+    transition: opacity 160ms ease;
   }
 
   .launcher-icon {

--- a/src/components/CheffyLauncher.svelte
+++ b/src/components/CheffyLauncher.svelte
@@ -101,7 +101,16 @@
       40px + env(safe-area-inset-bottom, 0px) + 1rem + var(--timer-widget-offset, 0px) + 56px +
         0.75rem
     );
-    z-index: 40;
+    /* One below the create FAB / its expanded menu (both at z-index 40,
+       with the menu's inner panel at z-index 45 within that stacking
+       context). The create menu opens upward from the FAB into the same
+       screen region as this launcher; keeping Cheffy at z-index 40
+       (same as the menu container) painted Cheffy on top of the menu
+       because it's mounted later in document order. Dropping to 39 lets
+       the menu paint over Cheffy whenever they overlap, without
+       affecting any other floating UI (timer / cooking-tools widgets
+       sit at z-index 50). */
+    z-index: 39;
 
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
## Summary

Two small visual fixes to the floating Cheffy launcher so it stops fighting the orange create FAB it sits above:

1. **Dim on scroll.** `CreateMenuButton` (the FAB) drops to `opacity: 0.45` and disables pointer events while the page is actively scrolling, then snaps back ~160 ms after the scroll ends. Cheffy stayed at full opacity and looked out of place mid-scroll. Mirror the same scroll-fade pattern verbatim — listen to the `#app-scroll` container (window fallback), set `isScrolling` with a 160 ms debounce, apply `.is-scrolling { opacity: 0.45; pointer-events: none; }`. The two floating affordances now read as a unit during scroll.

2. **Step under the create menu.** Cheffy and `CreateMenuButton` were both at `z-index: 40`. The menu panel inside the FAB is at `z-index: 45`, but that's relative to the FAB's stacking context — which itself is at 40 at the document level. With both Cheffy and the create-menu container at document z-level 40, document order decided the painter, and Cheffy (mounted later in `+layout.svelte`) painted over the menu. When the menu opens upward into Cheffy's vertical column the "New read" item was visibly clipped.

   Drop Cheffy to `z-index: 39` so it yields to the create-menu container whenever they overlap. Nothing else floats at 40 in Cheffy's screen position, and the timer / cooking-tools widgets sit at 50 and remain above Cheffy as before. Cheffy and the FAB don't visually overlap each other (Cheffy is stacked one button up via fixed bottom offsets), so this is purely a "who paints on top when the menu opens" change.

## Test plan

- [ ] `pnpm check` — 0 errors. `pnpm build` — clean.
- [ ] Scroll the feed: Cheffy dims to ~0.45 alongside the FAB, both snap back ~160 ms after scroll ends.
- [ ] Tap the orange `+` FAB to open the create menu: the menu items (`New recipe`, `New post`, `New read`) render fully, no overlap from Cheffy.
- [ ] Cheffy still receives clicks when no scroll is in flight.
- [ ] Timer widget / cooking-tools widget when active: still float above Cheffy (unchanged behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)