### PR TITLE
feat: Memories — "On this day" notes from past years

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.486",
+  "version": "4.2.487",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.485",
+  "version": "4.2.486",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.484",
+  "version": "4.2.485",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.481",
+  "version": "4.2.482",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.483",
+  "version": "4.2.484",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.482",
+  "version": "4.2.483",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.488",
+  "version": "4.2.489",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.487",
+  "version": "4.2.488",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/DesktopSideNav.svelte
+++ b/src/components/DesktopSideNav.svelte
@@ -23,6 +23,7 @@
   import HandshakeIcon from 'phosphor-svelte/lib/Handshake';
   import StorefrontIcon from 'phosphor-svelte/lib/Storefront';
   import LeafIcon from 'phosphor-svelte/lib/Leaf';
+  import ClockCounterClockwiseIcon from 'phosphor-svelte/lib/ClockCounterClockwise';
   import { totalUnreadCount } from '$lib/stores/messages';
   import { userSidePanelOpen } from '$lib/stores/userSidePanel';
 
@@ -114,6 +115,12 @@
       label: 'Nourish',
       icon: LeafIcon,
       match: (p) => p.startsWith('/nourish')
+    },
+    {
+      href: '/memories',
+      label: 'Memories',
+      icon: ClockCounterClockwiseIcon,
+      match: (p) => p.startsWith('/memories')
     },
     {
       href: '/membership',

--- a/src/components/MemoriesCard.svelte
+++ b/src/components/MemoriesCard.svelte
@@ -76,6 +76,7 @@
         on:click={() => (expanded = !expanded)}
         class="flex items-center gap-2 flex-1 min-w-0 text-left"
         aria-expanded={expanded}
+        aria-controls="memories-card-panel"
         aria-label={expanded ? 'Collapse memories' : 'Expand memories'}
       >
         <span aria-hidden="true">📅</span>
@@ -89,6 +90,7 @@
           class="ml-auto flex-shrink-0 transition-transform duration-200"
           class:rotate-180={expanded}
           style="color: var(--color-text-secondary);"
+          aria-hidden="true"
         >
           <CaretDownIcon size={16} />
         </span>
@@ -104,7 +106,7 @@
     </div>
 
     {#if expanded}
-      <div class="px-4 pb-4 flex flex-col gap-4">
+      <div id="memories-card-panel" class="px-4 pb-4 flex flex-col gap-4">
         {#each nonEmptyGroups as group (group.yearsAgo)}
           <div>
             <h3

--- a/src/components/MemoriesCard.svelte
+++ b/src/components/MemoriesCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import { browser } from '$app/environment';
+  import { goto } from '$app/navigation';
   import { ndk, userPublickey } from '$lib/nostr';
   import {
     getMemoriesCached,
@@ -9,7 +10,9 @@
     type MemoryGroup
   } from '$lib/memories';
   import MemoryNoteCard from './MemoryNoteCard.svelte';
+  import CalendarBlankIcon from 'phosphor-svelte/lib/CalendarBlank';
   import CaretDownIcon from 'phosphor-svelte/lib/CaretDown';
+  import CaretRightIcon from 'phosphor-svelte/lib/CaretRight';
   import XIcon from 'phosphor-svelte/lib/X';
 
   let groups: MemoryGroup[] = [];
@@ -18,21 +21,34 @@
   let expanded = false;
   let destroyed = false;
 
+  // Below the sm breakpoint the banner navigates to /memories instead of
+  // expanding inline. Tracked via matchMedia so click behavior and aria
+  // attributes stay in sync with the CSS caret swap (sm:hidden classes).
+  let isMobile = false;
+  let mobileQuery: MediaQueryList | null = null;
+  const handleMobileChange = (e: MediaQueryListEvent) => (isMobile = e.matches);
+
+  // Undo affordance after dismiss (no action-capable toast exists in the
+  // codebase — $lib/toast.ts is message-only — so this is an inline strip).
+  let undoVisible = false;
+  let undoTimer: ReturnType<typeof setTimeout> | null = null;
+
   // Groups ordered newest-first (1 year ago, then 2, then 3) with notes
   $: nonEmptyGroups = groups
     .filter((g) => g.events.length > 0)
     .sort((a, b) => a.yearsAgo - b.yearsAgo);
 
-  $: summary = nonEmptyGroups
-    .map((g) => {
-      const notes = g.events.length === 1 ? '1 note' : `${g.events.length} notes`;
-      const years = g.yearsAgo === 1 ? '1 year' : `${g.yearsAgo} years`;
-      return `${notes} from ${years} ago`;
-    })
-    .join(', ');
+  $: totalCount = nonEmptyGroups.reduce((n, g) => n + g.events.length, 0);
+  $: summary = `${totalCount} ${totalCount === 1 ? 'note' : 'notes'} · ${nonEmptyGroups
+    .map((g) => g.date.getFullYear())
+    .join(', ')}`;
 
   onMount(async () => {
     if (!browser) return;
+
+    mobileQuery = window.matchMedia('(max-width: 639px)');
+    isMobile = mobileQuery.matches;
+    mobileQuery.addEventListener('change', handleMobileChange);
 
     const pubkey = $userPublickey;
     if (!pubkey) return;
@@ -58,84 +74,182 @@
   // so there is nothing to register with onRelaySwitchStopSubscriptions.
   onDestroy(() => {
     destroyed = true;
+    if (undoTimer) clearTimeout(undoTimer);
+    mobileQuery?.removeEventListener('change', handleMobileChange);
   });
+
+  function handleBannerClick() {
+    if (isMobile) {
+      goto('/memories');
+    } else {
+      expanded = !expanded;
+    }
+  }
 
   function dismiss() {
     if ($userPublickey) {
       dismissMemoriesCard($userPublickey);
     }
     dismissed = true;
+    expanded = false;
+    undoVisible = true;
+    undoTimer = setTimeout(() => {
+      undoVisible = false;
+    }, 5000);
+  }
+
+  function undo() {
+    if (undoTimer) {
+      clearTimeout(undoTimer);
+      undoTimer = null;
+    }
+    // memories.ts has no undismiss export (frozen this phase); the key
+    // format mirrors dismissMemoriesCard / localDateKey in $lib/memories.
+    if (browser && $userPublickey) {
+      const d = new Date();
+      const dateKey = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(
+        d.getDate()
+      ).padStart(2, '0')}`;
+      try {
+        localStorage.removeItem(`zap_memories_dismissed_${$userPublickey}_${dateKey}`);
+      } catch {
+        // Best-effort only.
+      }
+    }
+    undoVisible = false;
+    dismissed = false;
   }
 </script>
 
-{#if loaded && !dismissed && nonEmptyGroups.length > 0}
-  <div class="memories-card rounded-xl border mb-4 overflow-hidden">
-    <!-- Banner (collapsed surface) -->
-    <div class="flex items-center gap-2 px-4 py-3">
-      <button
-        on:click={() => (expanded = !expanded)}
-        class="flex items-center gap-2 flex-1 min-w-0 text-left"
-        aria-expanded={expanded}
-        aria-controls="memories-card-panel"
-        aria-label={expanded ? 'Collapse memories' : 'Expand memories'}
-      >
-        <span aria-hidden="true">📅</span>
-        <span class="text-sm font-semibold" style="color: var(--color-text-primary);">
-          On this day
-        </span>
-        <span class="text-xs truncate" style="color: var(--color-text-secondary);">
-          {summary}
-        </span>
-        <span
-          class="ml-auto flex-shrink-0 transition-transform duration-200"
-          class:rotate-180={expanded}
-          style="color: var(--color-text-secondary);"
-          aria-hidden="true"
+{#if loaded && nonEmptyGroups.length > 0}
+  {#if !dismissed}
+    <div class="memories-card rounded-xl border mb-4 overflow-hidden">
+      <div class="flex items-stretch">
+        <!-- Banner body: whole area is the tap target -->
+        <button
+          on:click={handleBannerClick}
+          class="flex-1 min-w-0 text-left pl-4 py-3"
+          aria-expanded={isMobile ? undefined : expanded}
+          aria-controls={isMobile ? undefined : 'memories-card-panel'}
+          aria-label={isMobile
+            ? 'View memories'
+            : expanded
+              ? 'Collapse memories'
+              : 'Expand memories'}
         >
-          <CaretDownIcon size={16} />
-        </span>
-      </button>
+          <!-- Row 1: icon + title + caret -->
+          <span class="flex items-center gap-2">
+            <span class="flex-shrink-0" style="color: var(--color-primary);" aria-hidden="true">
+              <CalendarBlankIcon size={16} weight="fill" />
+            </span>
+            <span
+              class="text-sm font-semibold whitespace-nowrap"
+              style="color: var(--color-text-primary);"
+            >
+              On this day
+            </span>
+            <span
+              class="ml-auto flex-shrink-0 pr-1"
+              style="color: var(--color-text-secondary);"
+              aria-hidden="true"
+            >
+              <!-- Mobile: navigation affordance -->
+              <span class="sm:hidden">
+                <CaretRightIcon size={16} />
+              </span>
+              <!-- Desktop: inline expand affordance -->
+              <span
+                class="hidden sm:inline-block transition-transform duration-200"
+                class:rotate-180={expanded}
+              >
+                <CaretDownIcon size={16} />
+              </span>
+            </span>
+          </span>
+          <!-- Row 2: summary -->
+          <span class="block text-xs mt-0.5" style="color: var(--color-text-secondary);">
+            {summary}
+          </span>
+        </button>
+
+        <!-- Dismiss: separate target, ≥44×44px, ≥8px gap from the banner caret -->
+        <button
+          on:click={dismiss}
+          class="dismiss-btn flex-shrink-0 flex items-center justify-center self-center ml-2 mr-1 rounded-full hover:opacity-70 transition-opacity"
+          style="color: var(--color-text-secondary);"
+          aria-label="Hide memories for today"
+        >
+          <XIcon size={16} />
+        </button>
+      </div>
+
+      {#if expanded}
+        <!-- hidden below sm: mobile never expands inline (banner navigates),
+             and this guards the resize-while-expanded edge case -->
+        <div id="memories-card-panel" class="hidden sm:flex px-4 pb-4 flex-col gap-4">
+          {#each nonEmptyGroups as group (group.yearsAgo)}
+            <div>
+              <h3
+                class="text-xs font-semibold uppercase tracking-wide mb-2"
+                style="color: var(--color-text-secondary);"
+              >
+                {group.yearsAgo === 1 ? '1 year ago' : `${group.yearsAgo} years ago`}
+              </h3>
+              <div class="flex flex-col gap-2">
+                {#each group.events as event (event.id)}
+                  <MemoryNoteCard {event} yearsAgo={group.yearsAgo} />
+                {/each}
+              </div>
+            </div>
+          {/each}
+          <a
+            href="/memories"
+            class="text-sm font-medium text-orange-500 hover:text-orange-600 transition-colors"
+          >
+            See all memories →
+          </a>
+        </div>
+      {/if}
+    </div>
+  {:else if undoVisible}
+    <div
+      class="undo-strip rounded-xl border mb-4 px-4 py-2 flex items-center justify-between gap-2"
+      role="status"
+    >
+      <span class="text-xs" style="color: var(--color-text-secondary);">Memories hidden</span>
       <button
-        on:click={dismiss}
-        class="flex-shrink-0 p-1 rounded-full hover:opacity-70 transition-opacity"
-        style="color: var(--color-text-secondary);"
-        aria-label="Dismiss memories for today"
+        on:click={undo}
+        class="text-xs font-medium underline hover:opacity-80 transition-opacity"
+        style="color: var(--color-primary);"
       >
-        <XIcon size={16} />
+        Undo
       </button>
     </div>
-
-    {#if expanded}
-      <div id="memories-card-panel" class="px-4 pb-4 flex flex-col gap-4">
-        {#each nonEmptyGroups as group (group.yearsAgo)}
-          <div>
-            <h3
-              class="text-xs font-semibold uppercase tracking-wide mb-2"
-              style="color: var(--color-text-secondary);"
-            >
-              {group.yearsAgo === 1 ? '1 year ago' : `${group.yearsAgo} years ago`}
-            </h3>
-            <div class="flex flex-col gap-2">
-              {#each group.events as event (event.id)}
-                <MemoryNoteCard {event} yearsAgo={group.yearsAgo} />
-              {/each}
-            </div>
-          </div>
-        {/each}
-        <a
-          href="/memories"
-          class="text-sm font-medium text-orange-500 hover:text-orange-600 transition-colors"
-        >
-          See all memories →
-        </a>
-      </div>
-    {/if}
-  </div>
+  {/if}
 {/if}
 
 <style>
   .memories-card {
     background-color: var(--color-bg-primary);
     border-color: var(--color-input-border);
+    /* Faint accent so the banner reads as a moment, not a filter row.
+       color-mix fallback: unsupported browsers drop the gradient and keep
+       the plain background + left border. */
+    border-left: 3px solid var(--color-primary);
+    background-image: linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--color-primary) 7%, transparent),
+      transparent 55%
+    );
+  }
+
+  .undo-strip {
+    background-color: var(--color-bg-primary);
+    border-color: var(--color-input-border);
+  }
+
+  .dismiss-btn {
+    min-width: 44px;
+    min-height: 44px;
   }
 </style>

--- a/src/components/MemoriesCard.svelte
+++ b/src/components/MemoriesCard.svelte
@@ -7,6 +7,7 @@
     getMemoriesCached,
     dismissMemoriesCard,
     isMemoriesCardDismissed,
+    undismissMemoriesCard,
     type MemoryGroup
   } from '$lib/memories';
   import MemoryNoteCard from './MemoryNoteCard.svelte';
@@ -103,18 +104,8 @@
       clearTimeout(undoTimer);
       undoTimer = null;
     }
-    // memories.ts has no undismiss export (frozen this phase); the key
-    // format mirrors dismissMemoriesCard / localDateKey in $lib/memories.
-    if (browser && $userPublickey) {
-      const d = new Date();
-      const dateKey = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(
-        d.getDate()
-      ).padStart(2, '0')}`;
-      try {
-        localStorage.removeItem(`zap_memories_dismissed_${$userPublickey}_${dateKey}`);
-      } catch {
-        // Best-effort only.
-      }
+    if ($userPublickey) {
+      undismissMemoriesCard($userPublickey);
     }
     undoVisible = false;
     dismissed = false;

--- a/src/components/MemoriesCard.svelte
+++ b/src/components/MemoriesCard.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { browser } from '$app/environment';
+  import { ndk, userPublickey } from '$lib/nostr';
+  import {
+    getMemoriesCached,
+    dismissMemoriesCard,
+    isMemoriesCardDismissed,
+    type MemoryGroup
+  } from '$lib/memories';
+  import MemoryNoteCard from './MemoryNoteCard.svelte';
+  import CaretDownIcon from 'phosphor-svelte/lib/CaretDown';
+  import XIcon from 'phosphor-svelte/lib/X';
+
+  let groups: MemoryGroup[] = [];
+  let loaded = false;
+  let dismissed = false;
+  let expanded = false;
+  let destroyed = false;
+
+  // Groups ordered newest-first (1 year ago, then 2, then 3) with notes
+  $: nonEmptyGroups = groups
+    .filter((g) => g.events.length > 0)
+    .sort((a, b) => a.yearsAgo - b.yearsAgo);
+
+  $: summary = nonEmptyGroups
+    .map((g) => {
+      const notes = g.events.length === 1 ? '1 note' : `${g.events.length} notes`;
+      const years = g.yearsAgo === 1 ? '1 year' : `${g.yearsAgo} years`;
+      return `${notes} from ${years} ago`;
+    })
+    .join(', ');
+
+  onMount(async () => {
+    if (!browser) return;
+
+    const pubkey = $userPublickey;
+    if (!pubkey) return;
+
+    if (isMemoriesCardDismissed(pubkey)) {
+      dismissed = true;
+      return;
+    }
+
+    try {
+      const result = await getMemoriesCached($ndk, pubkey);
+      // In-flight work is moot if the component unmounted or the user changed
+      if (destroyed || $userPublickey !== pubkey) return;
+      groups = result;
+      loaded = true;
+    } catch (error) {
+      console.warn('[memories] Failed to load memories:', error);
+    }
+  });
+
+  // No subscription is held open: fetchMemories' subscriptions self-terminate
+  // on eose or a 10s timeout, and the destroyed flag discards late results,
+  // so there is nothing to register with onRelaySwitchStopSubscriptions.
+  onDestroy(() => {
+    destroyed = true;
+  });
+
+  function dismiss() {
+    if ($userPublickey) {
+      dismissMemoriesCard($userPublickey);
+    }
+    dismissed = true;
+  }
+</script>
+
+{#if loaded && !dismissed && nonEmptyGroups.length > 0}
+  <div class="memories-card rounded-xl border mb-4 overflow-hidden">
+    <!-- Banner (collapsed surface) -->
+    <div class="flex items-center gap-2 px-4 py-3">
+      <button
+        on:click={() => (expanded = !expanded)}
+        class="flex items-center gap-2 flex-1 min-w-0 text-left"
+        aria-expanded={expanded}
+        aria-label={expanded ? 'Collapse memories' : 'Expand memories'}
+      >
+        <span aria-hidden="true">📅</span>
+        <span class="text-sm font-semibold" style="color: var(--color-text-primary);">
+          On this day
+        </span>
+        <span class="text-xs truncate" style="color: var(--color-text-secondary);">
+          {summary}
+        </span>
+        <span
+          class="ml-auto flex-shrink-0 transition-transform duration-200"
+          class:rotate-180={expanded}
+          style="color: var(--color-text-secondary);"
+        >
+          <CaretDownIcon size={16} />
+        </span>
+      </button>
+      <button
+        on:click={dismiss}
+        class="flex-shrink-0 p-1 rounded-full hover:opacity-70 transition-opacity"
+        style="color: var(--color-text-secondary);"
+        aria-label="Dismiss memories for today"
+      >
+        <XIcon size={16} />
+      </button>
+    </div>
+
+    {#if expanded}
+      <div class="px-4 pb-4 flex flex-col gap-4">
+        {#each nonEmptyGroups as group (group.yearsAgo)}
+          <div>
+            <h3
+              class="text-xs font-semibold uppercase tracking-wide mb-2"
+              style="color: var(--color-text-secondary);"
+            >
+              {group.yearsAgo === 1 ? '1 year ago' : `${group.yearsAgo} years ago`}
+            </h3>
+            <div class="flex flex-col gap-2">
+              {#each group.events as event (event.id)}
+                <MemoryNoteCard {event} yearsAgo={group.yearsAgo} />
+              {/each}
+            </div>
+          </div>
+        {/each}
+        <a
+          href="/memories"
+          class="text-sm font-medium text-orange-500 hover:text-orange-600 transition-colors"
+        >
+          See all memories →
+        </a>
+      </div>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .memories-card {
+    background-color: var(--color-bg-primary);
+    border-color: var(--color-input-border);
+  }
+</style>

--- a/src/components/MemoryNoteCard.svelte
+++ b/src/components/MemoryNoteCard.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  import { nip19 } from 'nostr-tools';
+  import type { NDKEvent } from '@nostr-dev-kit/ndk';
+  import Avatar from './Avatar.svelte';
+  import AuthorName from './AuthorName.svelte';
+  import NoteContent from './NoteContent.svelte';
+  import { openComposerWithQuote } from '$lib/postComposerStore';
+  import { formatDate } from '$lib/utils';
+  import QuotesIcon from 'phosphor-svelte/lib/Quotes';
+
+  export let event: NDKEvent;
+  export let yearsAgo: number;
+
+  $: yearLabel = yearsAgo === 1 ? '1 year ago' : `${yearsAgo} years ago`;
+  $: dateLabel = formatDate(event.created_at || 0);
+  $: timeLabel = new Date((event.created_at || 0) * 1000).toLocaleTimeString([], {
+    hour: 'numeric',
+    minute: '2-digit'
+  });
+
+  function noteUrl(): string | null {
+    try {
+      return `/${nip19.noteEncode(event.id)}`;
+    } catch {
+      return null;
+    }
+  }
+
+  function share() {
+    try {
+      const nevent = nip19.neventEncode({ id: event.id, author: event.pubkey });
+      openComposerWithQuote(nevent, event);
+    } catch (error) {
+      console.warn('[memories] Failed to open composer with quote:', error);
+    }
+  }
+</script>
+
+<article class="memory-note-card rounded-xl border p-4">
+  <div class="flex items-center gap-2 mb-2">
+    <Avatar pubkey={event.pubkey} size={32} />
+    <div class="min-w-0 flex-1">
+      <AuthorName {event} />
+      <p class="text-xs" style="color: var(--color-text-secondary);">
+        {yearLabel} · {dateLabel}
+      </p>
+    </div>
+  </div>
+
+  <NoteContent content={event.content} className="text-sm" />
+
+  <div class="flex items-center justify-between mt-3">
+    <span class="text-xs" style="color: var(--color-text-secondary);">{timeLabel}</span>
+    <div class="flex items-center gap-3">
+      {#if noteUrl()}
+        <a
+          href={noteUrl()}
+          class="text-xs font-medium hover:opacity-80 transition-opacity"
+          style="color: var(--color-text-secondary);"
+        >
+          View
+        </a>
+      {/if}
+      <button
+        on:click={share}
+        class="flex items-center gap-1 text-xs font-medium text-orange-500 hover:text-orange-600 transition-colors"
+        aria-label="Share this memory as a quote"
+      >
+        <QuotesIcon size={14} />
+        Share
+      </button>
+    </div>
+  </div>
+</article>
+
+<style>
+  .memory-note-card {
+    background-color: var(--color-bg-primary);
+    border-color: var(--color-input-border);
+  }
+</style>

--- a/src/components/MemoryNoteCard.svelte
+++ b/src/components/MemoryNoteCard.svelte
@@ -18,13 +18,15 @@
     minute: '2-digit'
   });
 
-  function noteUrl(): string | null {
+  function noteUrl(id: string): string | null {
     try {
-      return `/${nip19.noteEncode(event.id)}`;
+      return `/${nip19.noteEncode(id)}`;
     } catch {
       return null;
     }
   }
+
+  $: viewUrl = noteUrl(event.id);
 
   function share() {
     try {
@@ -52,9 +54,9 @@
   <div class="flex items-center justify-between mt-3">
     <span class="text-xs" style="color: var(--color-text-secondary);">{timeLabel}</span>
     <div class="flex items-center gap-3">
-      {#if noteUrl()}
+      {#if viewUrl}
         <a
-          href={noteUrl()}
+          href={viewUrl}
           class="text-xs font-medium hover:opacity-80 transition-opacity"
           style="color: var(--color-text-secondary);"
         >

--- a/src/lib/memories.test.ts
+++ b/src/lib/memories.test.ts
@@ -10,8 +10,14 @@
  * exercised here.
  */
 
-import { describe, it, expect } from 'vitest';
-import { getMemoryWindows, isReplyNote, shouldCacheMemories } from './memories';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  getMemoryWindows,
+  isReplyNote,
+  shouldCacheMemories,
+  overwriteMemoriesCache,
+  type MemoryGroup
+} from './memories';
 
 /** Assert a window spans exactly the given local calendar day. */
 function expectLocalDaySpan(
@@ -177,5 +183,79 @@ describe('shouldCacheMemories', () => {
         { events: [], resolvedVia: 'timeout' }
       ])
     ).toBe(true);
+  });
+});
+
+describe('overwriteMemoriesCache (refresh gating)', () => {
+  const pubkey = 'a'.repeat(64);
+  const now = new Date(2026, 5, 10, 12, 0, 0); // Jun 10 2026 → key suffix 2026-06-10
+  const todayKey = `zap_memories_${pubkey}_2026-06-10`;
+
+  function group(resolvedVia: 'eose' | 'timeout', yearsAgo = 1): MemoryGroup {
+    return { yearsAgo, date: new Date(2025, 5, 10), events: [], resolvedVia };
+  }
+
+  // Minimal localStorage stub (vitest's node env has none)
+  let store: Map<string, string>;
+
+  beforeEach(() => {
+    store = new Map();
+    vi.stubGlobal('localStorage', {
+      get length() {
+        return store.size;
+      },
+      key: (i: number) => [...store.keys()][i] ?? null,
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        store.set(k, String(v));
+      },
+      removeItem: (k: string) => {
+        store.delete(k);
+      },
+      clear: () => store.clear()
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('does not overwrite existing cache on an all-timeout empty refresh', () => {
+    store.set(todayKey, '[{"existing":"data"}]');
+
+    const written = overwriteMemoriesCache(
+      pubkey,
+      [group('timeout', 1), group('timeout', 2), group('timeout', 3)],
+      now
+    );
+
+    expect(written).toBe(false);
+    expect(store.get(todayKey)).toBe('[{"existing":"data"}]');
+  });
+
+  it('overwrites the cache when at least one window saw EOSE', () => {
+    store.set(todayKey, '[{"existing":"data"}]');
+
+    const written = overwriteMemoriesCache(
+      pubkey,
+      [group('eose', 1), group('timeout', 2), group('timeout', 3)],
+      now
+    );
+
+    expect(written).toBe(true);
+    const stored = JSON.parse(store.get(todayKey)!);
+    expect(stored).toHaveLength(3);
+    expect(stored[0].resolvedVia).toBe('eose');
+  });
+
+  it('prunes stale prior-day keys when it writes', () => {
+    const staleKey = `zap_memories_${pubkey}_2026-06-09`;
+    store.set(staleKey, '[]');
+
+    const written = overwriteMemoriesCache(pubkey, [group('eose')], now);
+
+    expect(written).toBe(true);
+    expect(store.has(staleKey)).toBe(false);
+    expect(store.has(todayKey)).toBe(true);
   });
 });

--- a/src/lib/memories.test.ts
+++ b/src/lib/memories.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { getMemoryWindows, isReplyNote } from './memories';
+import { getMemoryWindows, isReplyNote, shouldCacheMemories } from './memories';
 
 /** Assert a window spans exactly the given local calendar day. */
 function expectLocalDaySpan(
@@ -133,5 +133,49 @@ describe('isReplyNote', () => {
 
   it('ignores e tags with no event id', () => {
     expect(isReplyNote({ tags: [['e']] })).toBe(false);
+  });
+});
+
+describe('shouldCacheMemories', () => {
+  const note = {}; // contents irrelevant; only presence is checked
+
+  it('does not cache empty results when every window timed out', () => {
+    expect(
+      shouldCacheMemories([
+        { events: [], resolvedVia: 'timeout' },
+        { events: [], resolvedVia: 'timeout' },
+        { events: [], resolvedVia: 'timeout' }
+      ])
+    ).toBe(false);
+  });
+
+  it('caches empty results when at least one window received EOSE', () => {
+    expect(
+      shouldCacheMemories([
+        { events: [], resolvedVia: 'eose' },
+        { events: [], resolvedVia: 'timeout' },
+        { events: [], resolvedVia: 'timeout' }
+      ])
+    ).toBe(true);
+  });
+
+  it('caches all-EOSE empty results (genuinely no memories today)', () => {
+    expect(
+      shouldCacheMemories([
+        { events: [], resolvedVia: 'eose' },
+        { events: [], resolvedVia: 'eose' },
+        { events: [], resolvedVia: 'eose' }
+      ])
+    ).toBe(true);
+  });
+
+  it('caches non-empty results even if every window timed out', () => {
+    expect(
+      shouldCacheMemories([
+        { events: [note], resolvedVia: 'timeout' },
+        { events: [], resolvedVia: 'timeout' },
+        { events: [], resolvedVia: 'timeout' }
+      ])
+    ).toBe(true);
   });
 });

--- a/src/lib/memories.test.ts
+++ b/src/lib/memories.test.ts
@@ -16,6 +16,9 @@ import {
   isReplyNote,
   shouldCacheMemories,
   overwriteMemoriesCache,
+  dismissMemoriesCard,
+  undismissMemoriesCard,
+  isMemoriesCardDismissed,
   type MemoryGroup
 } from './memories';
 
@@ -257,5 +260,13 @@ describe('overwriteMemoriesCache (refresh gating)', () => {
     expect(written).toBe(true);
     expect(store.has(staleKey)).toBe(false);
     expect(store.has(todayKey)).toBe(true);
+  });
+
+  it('undismiss clears the dismissal for the same day (Undo flow)', () => {
+    dismissMemoriesCard(pubkey, now);
+    expect(isMemoriesCardDismissed(pubkey, now)).toBe(true);
+
+    undismissMemoriesCard(pubkey, now);
+    expect(isMemoriesCardDismissed(pubkey, now)).toBe(false);
   });
 });

--- a/src/lib/memories.test.ts
+++ b/src/lib/memories.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for the Memories ("On this day") service's pure helpers.
+ *
+ * Window math is asserted by round-tripping the unix-second bounds back
+ * through Date rather than asserting fixed second counts, so the tests
+ * are timezone- and DST-robust (a target day straddling a DST change is
+ * 23 or 25 hours long; the contract is "00:00:00 to 23:59:59 local").
+ *
+ * No network: fetchMemories / getMemoriesCached are intentionally not
+ * exercised here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getMemoryWindows, isReplyNote } from './memories';
+
+/** Assert a window spans exactly the given local calendar day. */
+function expectLocalDaySpan(
+  window: { since: number; until: number },
+  year: number,
+  monthIndex: number,
+  day: number
+) {
+  const start = new Date(window.since * 1000);
+  expect(start.getFullYear()).toBe(year);
+  expect(start.getMonth()).toBe(monthIndex);
+  expect(start.getDate()).toBe(day);
+  expect(start.getHours()).toBe(0);
+  expect(start.getMinutes()).toBe(0);
+  expect(start.getSeconds()).toBe(0);
+
+  const end = new Date(window.until * 1000);
+  expect(end.getFullYear()).toBe(year);
+  expect(end.getMonth()).toBe(monthIndex);
+  expect(end.getDate()).toBe(day);
+  expect(end.getHours()).toBe(23);
+  expect(end.getMinutes()).toBe(59);
+  expect(end.getSeconds()).toBe(59);
+}
+
+describe('getMemoryWindows', () => {
+  it('returns windows for 1, 2, and 3 years ago in order', () => {
+    const windows = getMemoryWindows(new Date(2026, 5, 10, 14, 30, 0)); // Jun 10 2026, 2:30pm
+    expect(windows.map((w) => w.yearsAgo)).toEqual([1, 2, 3]);
+    expectLocalDaySpan(windows[0], 2025, 5, 10);
+    expectLocalDaySpan(windows[1], 2024, 5, 10);
+    expectLocalDaySpan(windows[2], 2023, 5, 10);
+  });
+
+  it('since precedes until in every window', () => {
+    for (const w of getMemoryWindows(new Date(2026, 5, 10))) {
+      expect(w.since).toBeLessThan(w.until);
+    }
+  });
+
+  it('handles Jan 1 (start-of-year boundary)', () => {
+    const windows = getMemoryWindows(new Date(2026, 0, 1, 0, 5, 0));
+    expectLocalDaySpan(windows[0], 2025, 0, 1);
+    expectLocalDaySpan(windows[1], 2024, 0, 1);
+    expectLocalDaySpan(windows[2], 2023, 0, 1);
+  });
+
+  it('handles Dec 31 (end-of-year boundary)', () => {
+    const windows = getMemoryWindows(new Date(2025, 11, 31, 23, 55, 0));
+    expectLocalDaySpan(windows[0], 2024, 11, 31);
+    expectLocalDaySpan(windows[1], 2023, 11, 31);
+    expectLocalDaySpan(windows[2], 2022, 11, 31);
+  });
+
+  it('falls back to Feb 28 when the target year has no Feb 29', () => {
+    // Feb 29 2024 (leap). 2023/2022/2021 are all non-leap.
+    const windows = getMemoryWindows(new Date(2024, 1, 29, 12, 0, 0));
+    expectLocalDaySpan(windows[0], 2023, 1, 28);
+    expectLocalDaySpan(windows[1], 2022, 1, 28);
+    expectLocalDaySpan(windows[2], 2021, 1, 28);
+  });
+
+  it('keeps Feb 28 as Feb 28 regardless of leap status', () => {
+    // Feb 28 2025 → 2024 is leap but the source day is the 28th, not the 29th.
+    const windows = getMemoryWindows(new Date(2025, 1, 28, 12, 0, 0));
+    expectLocalDaySpan(windows[0], 2024, 1, 28);
+    expectLocalDaySpan(windows[1], 2023, 1, 28);
+    expectLocalDaySpan(windows[2], 2022, 1, 28);
+  });
+});
+
+describe('isReplyNote', () => {
+  const eventId = 'e'.repeat(64);
+  const pubkey = 'a'.repeat(64);
+
+  it('keeps notes with no e tags (top-level)', () => {
+    expect(isReplyNote({ tags: [] })).toBe(false);
+    expect(isReplyNote({ tags: [['p', pubkey], ['t', 'zapcooking']] })).toBe(false);
+  });
+
+  it('drops notes with an e tag marked root', () => {
+    expect(isReplyNote({ tags: [['e', eventId, '', 'root']] })).toBe(true);
+  });
+
+  it('drops notes with an e tag marked reply', () => {
+    expect(isReplyNote({ tags: [['e', eventId, '', 'reply']] })).toBe(true);
+  });
+
+  it('drops notes with an unmarked e tag (legacy positional reply)', () => {
+    expect(isReplyNote({ tags: [['e', eventId]] })).toBe(true);
+    expect(isReplyNote({ tags: [['e', eventId, 'wss://relay.example']] })).toBe(true);
+  });
+
+  it('keeps notes whose only e tags are marked mention', () => {
+    expect(isReplyNote({ tags: [['e', eventId, '', 'mention']] })).toBe(false);
+    // Marker comparison is case-insensitive
+    expect(isReplyNote({ tags: [['e', eventId, '', 'Mention']] })).toBe(false);
+  });
+
+  it('keeps q-tag quotes (NIP-18 style quoting)', () => {
+    expect(isReplyNote({ tags: [['q', eventId]] })).toBe(false);
+    expect(isReplyNote({ tags: [['q', eventId], ['p', pubkey]] })).toBe(false);
+  });
+
+  it('drops notes mixing a mention e tag with a reply e tag', () => {
+    expect(
+      isReplyNote({
+        tags: [
+          ['e', eventId, '', 'mention'],
+          ['e', 'f'.repeat(64), '', 'reply']
+        ]
+      })
+    ).toBe(true);
+  });
+
+  it('drops e tags with unknown markers (conservative)', () => {
+    expect(isReplyNote({ tags: [['e', eventId, '', 'fork']] })).toBe(true);
+  });
+
+  it('ignores e tags with no event id', () => {
+    expect(isReplyNote({ tags: [['e']] })).toBe(false);
+  });
+});

--- a/src/lib/memories.ts
+++ b/src/lib/memories.ts
@@ -326,6 +326,15 @@ function writeCache(pubkey: string, now: Date, groups: MemoryGroup[]): void {
 }
 
 /**
+ * In-flight fetches keyed by pubkey+day. Rapid mount/unmount cycles (e.g.
+ * bouncing between /community and /memories before the first fetch
+ * finishes) share one fetch instead of opening 3 new subscriptions per
+ * mount. Entries are removed when the fetch settles, so each subscription
+ * still self-terminates on eose or its 10s timeout — nothing outlives that.
+ */
+const pendingFetches = new Map<string, Promise<MemoryGroup[]>>();
+
+/**
  * Return today's cached memories if present, otherwise fetch from relays
  * and cache the result. Empty results are cached too (so relays aren't
  * re-queried all day for users with no memories) — but only when at least
@@ -340,16 +349,29 @@ export async function getMemoriesCached(
   const cached = readCache(ndk, pubkey, now);
   if (cached) return cached;
 
-  const { getCurrentRelayGeneration } = await import('./nostr');
-  const startGeneration = getCurrentRelayGeneration();
+  const key = cacheKey(pubkey, now);
+  const pending = pendingFetches.get(key);
+  if (pending) return pending;
 
-  const groups = await fetchMemories(ndk, pubkey, now);
+  const fetchPromise = (async () => {
+    try {
+      const { getCurrentRelayGeneration } = await import('./nostr');
+      const startGeneration = getCurrentRelayGeneration();
 
-  if (getCurrentRelayGeneration() === startGeneration && shouldCacheMemories(groups)) {
-    writeCache(pubkey, now, groups);
-  }
+      const groups = await fetchMemories(ndk, pubkey, now);
 
-  return groups;
+      if (getCurrentRelayGeneration() === startGeneration && shouldCacheMemories(groups)) {
+        writeCache(pubkey, now, groups);
+      }
+
+      return groups;
+    } finally {
+      pendingFetches.delete(key);
+    }
+  })();
+
+  pendingFetches.set(key, fetchPromise);
+  return fetchPromise;
 }
 
 /**

--- a/src/lib/memories.ts
+++ b/src/lib/memories.ts
@@ -38,6 +38,12 @@ export interface MemoryGroup {
   /** Start of the target day, local time */
   date: Date;
   events: NDKEvent[];
+  /**
+   * How the window's subscription resolved. 'timeout' means relays never
+   * sent EOSE, so an empty result may just mean "relays didn't answer" —
+   * callers use this to decide whether an empty day is cacheable.
+   */
+  resolvedVia: 'eose' | 'timeout';
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -123,7 +129,8 @@ function emptyGroup(window: MemoryWindow): MemoryGroup {
   return {
     yearsAgo: window.yearsAgo,
     date: new Date(window.since * 1000),
-    events: []
+    events: [],
+    resolvedVia: 'timeout'
   };
 }
 
@@ -159,7 +166,7 @@ function fetchWindow(
     const collected = new Map<string, NDKEvent>();
     let resolved = false;
 
-    const finish = () => {
+    const finish = (resolvedVia: 'eose' | 'timeout') => {
       if (resolved) return;
       resolved = true;
       subscription.stop();
@@ -171,7 +178,8 @@ function fetchWindow(
       resolve({
         yearsAgo: window.yearsAgo,
         date: new Date(window.since * 1000),
-        events
+        events,
+        resolvedVia
       });
     };
 
@@ -181,8 +189,8 @@ function fetchWindow(
       }
     });
 
-    subscription.on('eose', finish);
-    setTimeout(finish, WINDOW_FETCH_TIMEOUT_MS);
+    subscription.on('eose', () => finish('eose'));
+    setTimeout(() => finish('timeout'), WINDOW_FETCH_TIMEOUT_MS);
   });
 }
 
@@ -225,6 +233,21 @@ interface StoredMemoryGroup {
   yearsAgo: number;
   date: string;
   events: NostrEvent[];
+  resolvedVia?: 'eose' | 'timeout';
+}
+
+/**
+ * Empty results are only cacheable when at least one window received EOSE —
+ * an all-timeout empty result means relays never answered, and caching it
+ * would suppress memories for the rest of the day. Non-empty results are
+ * always cacheable.
+ */
+export function shouldCacheMemories(
+  groups: { events: unknown[]; resolvedVia: 'eose' | 'timeout' }[]
+): boolean {
+  const hasEvents = groups.some((group) => group.events.length > 0);
+  const sawEose = groups.some((group) => group.resolvedVia === 'eose');
+  return hasEvents || sawEose;
 }
 
 function hasLocalStorage(): boolean {
@@ -273,7 +296,9 @@ function readCache(ndk: NDK, pubkey: string, now: Date): MemoryGroup[] | null {
     return stored.map((group) => ({
       yearsAgo: group.yearsAgo,
       date: new Date(group.date),
-      events: group.events.map((ev) => new NDKEvent(ndk, ev))
+      events: group.events.map((ev) => new NDKEvent(ndk, ev)),
+      // Anything that made it into the cache was deemed authoritative.
+      resolvedVia: group.resolvedVia ?? 'eose'
     }));
   } catch {
     return null;
@@ -287,7 +312,8 @@ function writeCache(pubkey: string, now: Date, groups: MemoryGroup[]): void {
   const stored: StoredMemoryGroup[] = groups.map((group) => ({
     yearsAgo: group.yearsAgo,
     date: group.date.toISOString(),
-    events: group.events.map((ev) => ev.rawEvent())
+    events: group.events.map((ev) => ev.rawEvent()),
+    resolvedVia: group.resolvedVia
   }));
 
   try {
@@ -301,9 +327,10 @@ function writeCache(pubkey: string, now: Date, groups: MemoryGroup[]): void {
 
 /**
  * Return today's cached memories if present, otherwise fetch from relays
- * and cache the result (including empty results, so relays aren't
- * re-queried all day for users with no memories). Cache writes are
- * skipped if the relay generation changed during the fetch.
+ * and cache the result. Empty results are cached too (so relays aren't
+ * re-queried all day for users with no memories) — but only when at least
+ * one window received EOSE; empty-via-timeout is never cached. Cache
+ * writes are also skipped if the relay generation changed during the fetch.
  */
 export async function getMemoriesCached(
   ndk: NDK,
@@ -318,7 +345,7 @@ export async function getMemoriesCached(
 
   const groups = await fetchMemories(ndk, pubkey, now);
 
-  if (getCurrentRelayGeneration() === startGeneration) {
+  if (getCurrentRelayGeneration() === startGeneration && shouldCacheMemories(groups)) {
     writeCache(pubkey, now, groups);
   }
 

--- a/src/lib/memories.ts
+++ b/src/lib/memories.ts
@@ -1,0 +1,346 @@
+/**
+ * Memories — "On this day" service.
+ *
+ * Finds the logged-in user's own kind 1 (text note) posts from this same
+ * calendar day 1, 2, and 3 years ago, fetched from relays, with a daily
+ * localStorage cache so relays are queried at most once per day per user.
+ *
+ * NOTE: this module deliberately avoids static imports of `$lib/nostr` and
+ * `$app/environment` so its pure helpers (`getMemoryWindows`, `isReplyNote`)
+ * stay importable under vitest's node environment (the `$app` alias is not
+ * available there). `getCurrentRelayGeneration` is loaded via dynamic import
+ * at fetch time instead, matching the dynamic-import style used elsewhere.
+ */
+
+import type NDK from '@nostr-dev-kit/ndk';
+import {
+  NDKEvent,
+  NDKRelaySet,
+  type NDKFilter,
+  type NostrEvent
+} from '@nostr-dev-kit/ndk';
+import { standardRelays } from './consts';
+
+// ═══════════════════════════════════════════════════════════════
+// TYPES
+// ═══════════════════════════════════════════════════════════════
+
+export interface MemoryWindow {
+  yearsAgo: number;
+  /** Unix seconds, 00:00:00 local time on the target day */
+  since: number;
+  /** Unix seconds, 23:59:59 local time on the target day */
+  until: number;
+}
+
+export interface MemoryGroup {
+  yearsAgo: number;
+  /** Start of the target day, local time */
+  date: Date;
+  events: NDKEvent[];
+}
+
+// ═══════════════════════════════════════════════════════════════
+// DATE WINDOWS (pure)
+// ═══════════════════════════════════════════════════════════════
+
+function isLeapYear(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+/**
+ * Local-time day windows for 1, 2, and 3 years before `now`.
+ * Feb 29 falls back to Feb 28 in non-leap target years.
+ */
+export function getMemoryWindows(now: Date): MemoryWindow[] {
+  const windows: MemoryWindow[] = [];
+  const month = now.getMonth();
+  const dayOfMonth = now.getDate();
+
+  for (const yearsAgo of [1, 2, 3]) {
+    const year = now.getFullYear() - yearsAgo;
+    let day = dayOfMonth;
+    if (month === 1 && day === 29 && !isLeapYear(year)) {
+      day = 28;
+    }
+    const start = new Date(year, month, day, 0, 0, 0, 0);
+    const end = new Date(year, month, day, 23, 59, 59, 0);
+    windows.push({
+      yearsAgo,
+      since: Math.floor(start.getTime() / 1000),
+      until: Math.floor(end.getTime() / 1000)
+    });
+  }
+
+  return windows;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// REPLY PREDICATE (pure, NIP-10 aware)
+// ═══════════════════════════════════════════════════════════════
+
+/**
+ * True if the event is a reply per NIP-10: it has an `e` tag marked
+ * `root`/`reply`, an unmarked `e` tag (legacy positional reply), or an
+ * `e` tag with an unknown marker. Mention-only `e` tags and `q`-tag
+ * quotes are NOT replies.
+ *
+ * Mirrors the semantics of the feed's reply filter
+ * (FoodstrFeedOptimized.svelte) as a pure, testable function.
+ */
+export function isReplyNote(event: { tags: string[][] }): boolean {
+  const eTags = event.tags.filter(
+    (tag) => Array.isArray(tag) && tag[0] === 'e' && tag[1]
+  );
+  if (eTags.length === 0) return false;
+
+  return eTags.some((tag) => {
+    const marker = tag[3]?.toLowerCase();
+    if (marker === 'mention') return false;
+    // 'root', 'reply', unmarked, or unknown marker → treat as reply
+    return true;
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════
+// RELAY FETCH
+// ═══════════════════════════════════════════════════════════════
+
+/** Archive-friendly relays queried in addition to the standard set. */
+const ARCHIVE_RELAYS = [
+  'wss://relay.damus.io',
+  'wss://nostr.wine',
+  'wss://relay.primal.net'
+];
+
+const WINDOW_FETCH_TIMEOUT_MS = 10000;
+
+function memoryRelayUrls(): string[] {
+  return [...new Set([...standardRelays, ...ARCHIVE_RELAYS])];
+}
+
+function emptyGroup(window: MemoryWindow): MemoryGroup {
+  return {
+    yearsAgo: window.yearsAgo,
+    date: new Date(window.since * 1000),
+    events: []
+  };
+}
+
+/**
+ * Fetch one window's events. Follows the subscribe → collect on 'event' →
+ * resolve on 'eose' with a timeout fallback pattern from the user profile
+ * page's loadMedia(). Never rejects; resolves with an empty group on error.
+ */
+function fetchWindow(
+  ndk: NDK,
+  pubkey: string,
+  window: MemoryWindow,
+  relaySet: NDKRelaySet
+): Promise<MemoryGroup> {
+  return new Promise((resolve) => {
+    const filter: NDKFilter = {
+      kinds: [1],
+      authors: [pubkey],
+      since: window.since,
+      until: window.until,
+      limit: 50
+    };
+
+    let subscription;
+    try {
+      subscription = ndk.subscribe(filter, { closeOnEose: true }, relaySet);
+    } catch (error) {
+      console.error('[memories] Failed to subscribe for window', window.yearsAgo, error);
+      resolve(emptyGroup(window));
+      return;
+    }
+
+    const collected = new Map<string, NDKEvent>();
+    let resolved = false;
+
+    const finish = () => {
+      if (resolved) return;
+      resolved = true;
+      subscription.stop();
+
+      const events = [...collected.values()]
+        .filter((ev) => !isReplyNote(ev) && (ev.content?.trim().length ?? 0) > 0)
+        .sort((a, b) => (a.created_at || 0) - (b.created_at || 0));
+
+      resolve({
+        yearsAgo: window.yearsAgo,
+        date: new Date(window.since * 1000),
+        events
+      });
+    };
+
+    subscription.on('event', (ev: NDKEvent) => {
+      if (!collected.has(ev.id)) {
+        collected.set(ev.id, ev);
+      }
+    });
+
+    subscription.on('eose', finish);
+    setTimeout(finish, WINDOW_FETCH_TIMEOUT_MS);
+  });
+}
+
+/**
+ * Fetch memories for all three windows in parallel. Empty groups are
+ * normal (relays prune old events); never throws on empty. If the relay
+ * generation changes mid-flight, results are discarded (empty groups).
+ */
+export async function fetchMemories(
+  ndk: NDK,
+  pubkey: string,
+  now: Date = new Date()
+): Promise<MemoryGroup[]> {
+  const windows = getMemoryWindows(now);
+
+  const { getCurrentRelayGeneration } = await import('./nostr');
+  const startGeneration = getCurrentRelayGeneration();
+
+  const relaySet = NDKRelaySet.fromRelayUrls(memoryRelayUrls(), ndk, false);
+  const groups = await Promise.all(
+    windows.map((window) => fetchWindow(ndk, pubkey, window, relaySet))
+  );
+
+  if (getCurrentRelayGeneration() !== startGeneration) {
+    // Relays switched mid-flight; results may mix relay sets. Discard.
+    return windows.map(emptyGroup);
+  }
+
+  return groups;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// DAILY CACHE
+// ═══════════════════════════════════════════════════════════════
+
+const CACHE_PREFIX = 'zap_memories_';
+const DISMISS_PREFIX = 'zap_memories_dismissed_';
+
+interface StoredMemoryGroup {
+  yearsAgo: number;
+  date: string;
+  events: NostrEvent[];
+}
+
+function hasLocalStorage(): boolean {
+  try {
+    return typeof localStorage !== 'undefined';
+  } catch {
+    return false;
+  }
+}
+
+/** Local-time YYYY-MM-DD */
+function localDateKey(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function cacheKey(pubkey: string, now: Date): string {
+  return `${CACHE_PREFIX}${pubkey}_${localDateKey(now)}`;
+}
+
+/** Remove keys with `prefix` except `keep`. */
+function pruneStaleKeys(prefix: string, keep: string): void {
+  const stale: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key && key.startsWith(prefix) && key !== keep) {
+      stale.push(key);
+    }
+  }
+  for (const key of stale) {
+    localStorage.removeItem(key);
+  }
+}
+
+function readCache(ndk: NDK, pubkey: string, now: Date): MemoryGroup[] | null {
+  if (!hasLocalStorage()) return null;
+
+  const raw = localStorage.getItem(cacheKey(pubkey, now));
+  if (!raw) return null;
+
+  try {
+    const stored = JSON.parse(raw) as StoredMemoryGroup[];
+    if (!Array.isArray(stored)) return null;
+    return stored.map((group) => ({
+      yearsAgo: group.yearsAgo,
+      date: new Date(group.date),
+      events: group.events.map((ev) => new NDKEvent(ndk, ev))
+    }));
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(pubkey: string, now: Date, groups: MemoryGroup[]): void {
+  if (!hasLocalStorage()) return;
+
+  const key = cacheKey(pubkey, now);
+  const stored: StoredMemoryGroup[] = groups.map((group) => ({
+    yearsAgo: group.yearsAgo,
+    date: group.date.toISOString(),
+    events: group.events.map((ev) => ev.rawEvent())
+  }));
+
+  try {
+    pruneStaleKeys(`${CACHE_PREFIX}${pubkey}_`, key);
+    localStorage.setItem(key, JSON.stringify(stored));
+  } catch (error) {
+    // Quota exceeded or storage unavailable — cache is best-effort only.
+    console.warn('[memories] Failed to write cache:', error);
+  }
+}
+
+/**
+ * Return today's cached memories if present, otherwise fetch from relays
+ * and cache the result (including empty results, so relays aren't
+ * re-queried all day for users with no memories). Cache writes are
+ * skipped if the relay generation changed during the fetch.
+ */
+export async function getMemoriesCached(
+  ndk: NDK,
+  pubkey: string,
+  now: Date = new Date()
+): Promise<MemoryGroup[]> {
+  const cached = readCache(ndk, pubkey, now);
+  if (cached) return cached;
+
+  const { getCurrentRelayGeneration } = await import('./nostr');
+  const startGeneration = getCurrentRelayGeneration();
+
+  const groups = await fetchMemories(ndk, pubkey, now);
+
+  if (getCurrentRelayGeneration() === startGeneration) {
+    writeCache(pubkey, now, groups);
+  }
+
+  return groups;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// DISMISSAL
+// ═══════════════════════════════════════════════════════════════
+
+export function dismissMemoriesCard(pubkey: string, now: Date = new Date()): void {
+  if (!hasLocalStorage()) return;
+  const key = `${DISMISS_PREFIX}${pubkey}_${localDateKey(now)}`;
+  try {
+    pruneStaleKeys(`${DISMISS_PREFIX}${pubkey}_`, key);
+    localStorage.setItem(key, '1');
+  } catch {
+    // Best-effort only.
+  }
+}
+
+export function isMemoriesCardDismissed(pubkey: string, now: Date = new Date()): boolean {
+  if (!hasLocalStorage()) return false;
+  return localStorage.getItem(`${DISMISS_PREFIX}${pubkey}_${localDateKey(now)}`) !== null;
+}

--- a/src/lib/memories.ts
+++ b/src/lib/memories.ts
@@ -432,3 +432,13 @@ export function isMemoriesCardDismissed(pubkey: string, now: Date = new Date()):
   if (!hasLocalStorage()) return false;
   return localStorage.getItem(`${DISMISS_PREFIX}${pubkey}_${localDateKey(now)}`) !== null;
 }
+
+/** Clear today's dismissal (the card's "Undo" affordance). */
+export function undismissMemoriesCard(pubkey: string, now: Date = new Date()): void {
+  if (!hasLocalStorage()) return;
+  try {
+    localStorage.removeItem(`${DISMISS_PREFIX}${pubkey}_${localDateKey(now)}`);
+  } catch {
+    // Best-effort only.
+  }
+}

--- a/src/lib/memories.ts
+++ b/src/lib/memories.ts
@@ -352,6 +352,45 @@ export async function getMemoriesCached(
   return groups;
 }
 
+/**
+ * Overwrite today's cache entry with `groups`, but only when they're
+ * authoritative per shouldCacheMemories. Returns whether the write
+ * happened. Exported separately so the gating is unit-testable.
+ */
+export function overwriteMemoriesCache(
+  pubkey: string,
+  groups: MemoryGroup[],
+  now: Date = new Date()
+): boolean {
+  if (!shouldCacheMemories(groups)) return false;
+  writeCache(pubkey, now, groups);
+  return true;
+}
+
+/**
+ * Cache-bypassing refresh for the /memories page: always hits relays,
+ * then overwrites today's cache entry only when the result is
+ * authoritative (has events or saw EOSE) and the relay generation is
+ * unchanged. `refreshed: false` means the caller should keep showing
+ * its current (cached) data.
+ */
+export async function refreshMemories(
+  ndk: NDK,
+  pubkey: string,
+  now: Date = new Date()
+): Promise<{ groups: MemoryGroup[]; refreshed: boolean }> {
+  const { getCurrentRelayGeneration } = await import('./nostr');
+  const startGeneration = getCurrentRelayGeneration();
+
+  const groups = await fetchMemories(ndk, pubkey, now);
+
+  if (getCurrentRelayGeneration() !== startGeneration) {
+    return { groups, refreshed: false };
+  }
+
+  return { groups, refreshed: overwriteMemoriesCache(pubkey, groups, now) };
+}
+
 // ═══════════════════════════════════════════════════════════════
 // DISMISSAL
 // ═══════════════════════════════════════════════════════════════

--- a/src/lib/memories.ts
+++ b/src/lib/memories.ts
@@ -206,7 +206,21 @@ export async function fetchMemories(
 ): Promise<MemoryGroup[]> {
   const windows = getMemoryWindows(now);
 
-  const { getCurrentRelayGeneration } = await import('./nostr');
+  const { getCurrentRelayGeneration, ensureNdkConnected } = await import('./nostr');
+
+  // Don't start subscriptions while NDK is still connecting — they'd all
+  // time out and read as "no memories today". Centralized here so every
+  // caller (card mount, /memories load, refresh) is gated the same way.
+  // ensureNdkConnected resolves on its own timeout, but awaiting ndkReady
+  // inside it can reject if the initial connection failed — swallow that
+  // to preserve this function's never-throw contract (windows would then
+  // resolve via timeout and correctly not be cached).
+  try {
+    await ensureNdkConnected();
+  } catch (error) {
+    console.warn('[memories] Proceeding without confirmed NDK connection:', error);
+  }
+
   const startGeneration = getCurrentRelayGeneration();
 
   const relaySet = NDKRelaySet.fromRelayUrls(memoryRelayUrls(), ndk, false);

--- a/src/lib/types/vitest.d.ts
+++ b/src/lib/types/vitest.d.ts
@@ -2,4 +2,11 @@ declare module 'vitest' {
   export const describe: (...args: any[]) => any;
   export const it: (...args: any[]) => any;
   export const expect: (...args: any[]) => any;
+  export const beforeEach: (...args: any[]) => any;
+  export const afterEach: (...args: any[]) => any;
+  export const vi: {
+    stubGlobal: (name: string, value: unknown) => void;
+    unstubAllGlobals: () => void;
+    [key: string]: any;
+  };
 }

--- a/src/routes/community/+page.svelte
+++ b/src/routes/community/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import FoodstrFeedOptimized from '../../components/FoodstrFeedOptimized.svelte';
+  import MemoriesCard from '../../components/MemoriesCard.svelte';
   import PullToRefresh from '../../components/PullToRefresh.svelte';
   import { ndk, userPublickey } from '$lib/nostr';
   import { browser } from '$app/environment';
@@ -372,6 +373,9 @@
         <CreateGroupModal bind:open={createGroupOpen} on:created={handleGroupCreated} />
       {/if}
     {:else}
+      {#if $userPublickey}
+        <MemoriesCard />
+      {/if}
       <FoodstrFeedOptimized bind:this={feedComponent} filterMode={activeTab} />
     {/if}
   </div>

--- a/src/routes/memories/+page.svelte
+++ b/src/routes/memories/+page.svelte
@@ -1,0 +1,204 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { browser } from '$app/environment';
+  import { ndk, userPublickey } from '$lib/nostr';
+  import {
+    getMemoriesCached,
+    refreshMemories,
+    type MemoryGroup
+  } from '$lib/memories';
+  import MemoryNoteCard from '../../components/MemoryNoteCard.svelte';
+  import ArrowsClockwiseIcon from 'phosphor-svelte/lib/ArrowsClockwise';
+
+  let groups: MemoryGroup[] = [];
+  let loading = false;
+  let loadedFor = ''; // pubkey the current groups belong to
+  let refreshing = false;
+  let refreshNotice = '';
+  let destroyed = false;
+
+  $: isLoggedIn = $userPublickey !== '';
+  $: sortedGroups = [...groups].sort((a, b) => a.yearsAgo - b.yearsAgo);
+  $: allEmpty = groups.length > 0 && groups.every((g) => g.events.length === 0);
+
+  const todayLabel = new Date().toLocaleDateString(undefined, {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  });
+
+  function yearLabel(yearsAgo: number): string {
+    return yearsAgo === 1 ? '1 year ago' : `${yearsAgo} years ago`;
+  }
+
+  function groupDateLabel(date: Date): string {
+    return date.toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    });
+  }
+
+  async function load() {
+    if (!browser || !$userPublickey || loading) return;
+    const pubkey = $userPublickey;
+    loading = true;
+    try {
+      const result = await getMemoriesCached($ndk, pubkey);
+      if (destroyed || $userPublickey !== pubkey) return;
+      groups = result;
+      loadedFor = pubkey;
+    } catch (error) {
+      console.warn('[memories] Failed to load memories:', error);
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function refresh() {
+    if (!browser || !$userPublickey || refreshing) return;
+    const pubkey = $userPublickey;
+    refreshing = true;
+    refreshNotice = '';
+    try {
+      // refreshMemories overwrites today's cache only when the result is
+      // authoritative (shouldCacheMemories): a timeout-empty refresh keeps
+      // the existing cache, and we keep showing the current data.
+      const { groups: fresh, refreshed } = await refreshMemories($ndk, pubkey);
+      if (destroyed || $userPublickey !== pubkey) return;
+      if (refreshed) {
+        groups = fresh;
+        loadedFor = pubkey;
+      } else {
+        refreshNotice = "Couldn't refresh — showing cached memories.";
+      }
+    } catch (error) {
+      console.warn('[memories] Refresh failed:', error);
+      refreshNotice = "Couldn't refresh — showing cached memories.";
+    } finally {
+      refreshing = false;
+    }
+  }
+
+  onMount(load);
+
+  // Load when the user logs in after landing here logged out
+  $: if (browser && isLoggedIn && loadedFor !== $userPublickey && !loading) {
+    load();
+  }
+
+  onDestroy(() => {
+    destroyed = true;
+  });
+</script>
+
+<svelte:head>
+  <title>Memories - zap.cooking</title>
+  <meta name="description" content="Your notes from this day in past years" />
+</svelte:head>
+
+<div class="px-4 max-w-2xl mx-auto w-full memories-page">
+  {#if !isLoggedIn}
+    <div class="text-center py-16">
+      <p class="text-4xl mb-3" aria-hidden="true">📅</p>
+      <h1 class="text-xl font-semibold mb-2" style="color: var(--color-text-primary);">
+        Memories
+      </h1>
+      <p class="text-sm mb-4" style="color: var(--color-text-secondary);">
+        Sign in to see what you were cooking up on this day in past years.
+      </p>
+      <a
+        href="/login?redirect=/memories"
+        class="inline-block px-4 py-2 rounded-full text-sm font-medium text-white bg-gradient-to-r from-orange-500 to-amber-500 hover:opacity-90 transition-opacity"
+      >
+        Sign in
+      </a>
+    </div>
+  {:else}
+    <div class="flex items-start justify-between gap-4 mb-6 pt-2">
+      <div>
+        <h1 class="text-2xl font-bold" style="color: var(--color-text-primary);">Memories</h1>
+        <p class="text-sm mt-1" style="color: var(--color-text-secondary);">
+          On this day · {todayLabel}
+        </p>
+      </div>
+      <button
+        on:click={refresh}
+        disabled={refreshing}
+        class="flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-sm font-medium hover:opacity-80 transition-opacity disabled:opacity-50"
+        style="color: var(--color-text-secondary); border-color: var(--color-input-border);"
+        aria-label="Refresh memories from relays"
+      >
+        <span class:animate-spin={refreshing}>
+          <ArrowsClockwiseIcon size={14} />
+        </span>
+        Refresh
+      </button>
+    </div>
+
+    {#if refreshNotice}
+      <p
+        class="text-xs rounded-lg border px-3 py-2 mb-4"
+        style="color: var(--color-text-secondary); border-color: var(--color-input-border); background-color: var(--color-input);"
+        role="status"
+      >
+        {refreshNotice}
+      </p>
+    {/if}
+
+    {#if loading && groups.length === 0}
+      <p class="text-sm py-8 text-center" style="color: var(--color-text-secondary);">
+        Looking back through your notes…
+      </p>
+    {:else if allEmpty}
+      <div class="text-center py-16">
+        <p class="text-4xl mb-3" aria-hidden="true">🍳</p>
+        <p class="text-sm" style="color: var(--color-text-secondary);">
+          No memories found for this day. Relays may not keep notes this old — or this day is
+          still waiting for its first one.
+        </p>
+      </div>
+    {:else}
+      <div class="flex flex-col gap-8">
+        {#each sortedGroups as group (group.yearsAgo)}
+          <section>
+            <h2
+              class="text-sm font-semibold mb-3"
+              style="color: var(--color-text-primary);"
+            >
+              {yearLabel(group.yearsAgo)}
+              <span class="font-normal" style="color: var(--color-text-secondary);">
+                · {groupDateLabel(group.date)}
+              </span>
+            </h2>
+            {#if group.events.length > 0}
+              <div class="flex flex-col gap-3">
+                {#each group.events as event (event.id)}
+                  <MemoryNoteCard {event} yearsAgo={group.yearsAgo} />
+                {/each}
+              </div>
+            {:else}
+              <p class="text-sm" style="color: var(--color-text-secondary);">
+                Nothing from {yearLabel(group.yearsAgo)} — relays may not keep notes this old.
+              </p>
+            {/if}
+          </section>
+        {/each}
+      </div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  /* Bottom padding so the fixed mobile nav doesn't cover content */
+  .memories-page {
+    padding-bottom: calc(80px + env(safe-area-inset-bottom, 0px));
+  }
+
+  @media (min-width: 768px) {
+    .memories-page {
+      padding-bottom: 2rem;
+    }
+  }
+</style>


### PR DESCRIPTION
## Memories — "On this day"

Shows logged-in users their own kind 1 notes from this calendar day 1/2/3 years
ago: a dismissible card atop the /community feed, and a /memories page with
year groups, share-as-quote (pre-filled composer), and a cache-bypassing
Refresh.

### Design notes
- Top-level notes only (NIP-10-aware filter: drops root/reply/unmarked e-tags,
  keeps mention-only e-tags and q-tag quotes); anonymous users never see it.
- One relay query per user per local day, cached in localStorage. Empty
  results are cached only when a window received EOSE — empty-via-timeout is
  never treated as authoritative, including on Refresh, which keeps the
  existing cache and shows a notice instead.
- Subscriptions self-terminate (eose or 10s timeout); results are discarded on
  relay-generation change; concurrent mounts share one in-flight fetch.
- Mobile-first banner: two-row layout, "9 notes · 2024, 2023, 2022" summary;
  below sm the banner navigates to /memories, at sm+ it expands inline.
  Dismiss has a 44×44px target and a 5s inline Undo strip.

### Known limitation / future work
Relay retention is the limiting factor — most relays prune old events, so
older windows will often be empty. Future option: fall back to Primal's cache
API via `src/lib/primalCache.ts` (`fetchFeed` supports authors + since/until).
Deliberately not implemented in this PR.

### Files touched outside feature scope
- `src/lib/types/vitest.d.ts` — the repo's ambient vitest stub shadows real
  vitest types for svelte-check and only declared describe/it/expect; extended
  with vi/beforeEach/afterEach used by the new tests.
- `src/components/DesktopSideNav.svelte` — one declarative NavItem (Memories)
  + icon import.
- `src/routes/community/+page.svelte` — import + 3-line gated insertion.
- `package.json` — version auto-bumps from the pre-commit hook
  (4.2.482 → 4.2.488).

### Manual QA checklist (preview deploy)
- [ ] Logged in with year-old notes: card appears at top of /community
      (Global/Following/Replies/Garden tabs; not Groups); banner shows
      "N notes · years" summary
- [ ] Mobile (<640px): tapping the banner navigates to /memories; right caret
      shown. Desktop: banner expands inline; chevron rotates
- [ ] Dismiss (X) hides the card and shows "Memories hidden — Undo" for 5s;
      Undo restores the card; without Undo it stays hidden for the day and
      across reloads; reappears next day
- [ ] Share on a memory opens the post composer pre-filled with the
      nostr:nevent1 quote; posting works
- [ ] View links to the note permalink
- [ ] /memories: groups + per-group empty states render; global empty state
      for accounts with no memories
- [ ] Refresh while online updates data; Refresh while offline (or relays
      unreachable) keeps cached data and shows "Couldn't refresh — showing
      cached" notice without clearing the page
- [ ] Logged out: no card on /community; /memories shows the sign-in prompt;
      logging in from there loads memories without a reload
- [ ] Banner layout at 360px / 433px / desktop: no truncation, summary wraps
- [ ] Light + dark mode render correctly for card, page, undo strip, notice

Made with [Cursor](https://cursor.com)