### PR TITLE
feat(memories): rebrand to Echoes with subheading

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.489",
+  "version": "4.2.490",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.490",
+  "version": "4.2.491",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/DesktopSideNav.svelte
+++ b/src/components/DesktopSideNav.svelte
@@ -118,7 +118,7 @@
     },
     {
       href: '/memories',
-      label: 'Memories',
+      label: 'Echoes',
       icon: ClockCounterClockwiseIcon,
       match: (p) => p.startsWith('/memories')
     },

--- a/src/components/MemoriesCard.svelte
+++ b/src/components/MemoriesCard.svelte
@@ -159,7 +159,7 @@
           </span>
           <!-- Row 2: subheading + summary -->
           <span class="block text-xs mt-0.5" style="color: var(--color-text-secondary);">
-            Notes from this day in years past.
+            A look back at notes from this day
           </span>
           <span class="block text-xs mt-0.5" style="color: var(--color-text-secondary);">
             {summary}

--- a/src/components/MemoriesCard.svelte
+++ b/src/components/MemoriesCard.svelte
@@ -123,10 +123,10 @@
           aria-expanded={isMobile ? undefined : expanded}
           aria-controls={isMobile ? undefined : 'memories-card-panel'}
           aria-label={isMobile
-            ? 'View memories'
+            ? 'View echoes'
             : expanded
-              ? 'Collapse memories'
-              : 'Expand memories'}
+              ? 'Collapse echoes'
+              : 'Expand echoes'}
         >
           <!-- Row 1: icon + title + caret -->
           <span class="flex items-center gap-2">
@@ -137,7 +137,7 @@
               class="text-sm font-semibold whitespace-nowrap"
               style="color: var(--color-text-primary);"
             >
-              On this day
+              Echoes
             </span>
             <span
               class="ml-auto flex-shrink-0 pr-1"
@@ -157,7 +157,10 @@
               </span>
             </span>
           </span>
-          <!-- Row 2: summary -->
+          <!-- Row 2: subheading + summary -->
+          <span class="block text-xs mt-0.5" style="color: var(--color-text-secondary);">
+            Notes from this day in years past.
+          </span>
           <span class="block text-xs mt-0.5" style="color: var(--color-text-secondary);">
             {summary}
           </span>
@@ -168,7 +171,7 @@
           on:click={dismiss}
           class="dismiss-btn flex-shrink-0 flex items-center justify-center self-center ml-2 mr-1 rounded-full hover:opacity-70 transition-opacity"
           style="color: var(--color-text-secondary);"
-          aria-label="Hide memories for today"
+          aria-label="Hide echoes for today"
         >
           <XIcon size={16} />
         </button>
@@ -197,7 +200,7 @@
             href="/memories"
             class="text-sm font-medium text-orange-500 hover:text-orange-600 transition-colors"
           >
-            See all memories →
+            See all echoes →
           </a>
         </div>
       {/if}
@@ -207,7 +210,7 @@
       class="undo-strip rounded-xl border mb-4 px-4 py-2 flex items-center justify-between gap-2"
       role="status"
     >
-      <span class="text-xs" style="color: var(--color-text-secondary);">Memories hidden</span>
+      <span class="text-xs" style="color: var(--color-text-secondary);">Echoes hidden</span>
       <button
         on:click={undo}
         class="text-xs font-medium underline hover:opacity-80 transition-opacity"

--- a/src/routes/memories/+page.svelte
+++ b/src/routes/memories/+page.svelte
@@ -94,8 +94,8 @@
 </script>
 
 <svelte:head>
-  <title>Memories - zap.cooking</title>
-  <meta name="description" content="Your notes from this day in past years" />
+  <title>Echoes - zap.cooking</title>
+  <meta name="description" content="Echoes — notes from this day in years past" />
 </svelte:head>
 
 <div class="px-4 max-w-2xl mx-auto w-full memories-page">
@@ -103,10 +103,10 @@
     <div class="text-center py-16">
       <p class="text-4xl mb-3" aria-hidden="true">📅</p>
       <h1 class="text-xl font-semibold mb-2" style="color: var(--color-text-primary);">
-        Memories
+        Echoes
       </h1>
       <p class="text-sm mb-4" style="color: var(--color-text-secondary);">
-        Sign in to see what you were cooking up on this day in past years.
+        Notes from this day in years past. Sign in to see yours.
       </p>
       <a
         href="/login?redirect=/memories"
@@ -118,9 +118,9 @@
   {:else}
     <div class="flex items-start justify-between gap-4 mb-6 pt-2">
       <div>
-        <h1 class="text-2xl font-bold" style="color: var(--color-text-primary);">Memories</h1>
+        <h1 class="text-2xl font-bold" style="color: var(--color-text-primary);">Echoes</h1>
         <p class="text-sm mt-1" style="color: var(--color-text-secondary);">
-          On this day · {todayLabel}
+          Notes from this day in years past. · {todayLabel}
         </p>
       </div>
       <button
@@ -128,7 +128,7 @@
         disabled={refreshing}
         class="flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-sm font-medium hover:opacity-80 transition-opacity disabled:opacity-50"
         style="color: var(--color-text-secondary); border-color: var(--color-input-border);"
-        aria-label="Refresh memories from relays"
+        aria-label="Refresh echoes from relays"
       >
         <span class:animate-spin={refreshing}>
           <ArrowsClockwiseIcon size={14} />
@@ -155,7 +155,7 @@
       <div class="text-center py-16">
         <p class="text-4xl mb-3" aria-hidden="true">🍳</p>
         <p class="text-sm" style="color: var(--color-text-secondary);">
-          No memories found for this day. Relays may not keep notes this old — or this day is
+          No echoes found for this day. Relays may not keep notes this old — or this day is
           still waiting for its first one.
         </p>
       </div>

--- a/src/routes/memories/+page.svelte
+++ b/src/routes/memories/+page.svelte
@@ -95,7 +95,7 @@
 
 <svelte:head>
   <title>Echoes - zap.cooking</title>
-  <meta name="description" content="Echoes — notes from this day in years past" />
+  <meta name="description" content="Echoes — a look back at notes from this day" />
 </svelte:head>
 
 <div class="px-4 max-w-2xl mx-auto w-full memories-page">
@@ -106,7 +106,7 @@
         Echoes
       </h1>
       <p class="text-sm mb-4" style="color: var(--color-text-secondary);">
-        Notes from this day in years past. Sign in to see yours.
+        A look back at notes from this day. Sign in to see yours.
       </p>
       <a
         href="/login?redirect=/memories"
@@ -120,7 +120,7 @@
       <div>
         <h1 class="text-2xl font-bold" style="color: var(--color-text-primary);">Echoes</h1>
         <p class="text-sm mt-1" style="color: var(--color-text-secondary);">
-          Notes from this day in years past. · {todayLabel}
+          A look back at notes from this day · {todayLabel}
         </p>
       </div>
       <button


### PR DESCRIPTION
## Summary

Follow-up to #424 — these two commits landed on `feat/memories` minutes after the squash-merge, so they're re-raised here on a fresh branch off `main`.

- Renames the user-facing "On this day" feature to **Echoes**: banner card title, /memories page headers (logged-in + logged-out), browser tab title, meta description, desktop nav label, and all related strings (See all echoes, Echoes hidden — Undo, empty state, aria-labels).
- Adds the subheading **"A look back at notes from this day"** to the banner card and page headers.
- Unchanged on purpose: `/memories` route path, component/file names, `memories.ts` API, and localStorage keys (renaming keys would drop users' existing cache/dismiss state).

## Test plan

- [ ] Banner card on /community shows "Echoes" / "A look back at notes from this day" / count summary
- [ ] /memories shows "Echoes" header with subheading + today's date (logged in) and the sign-in prompt (logged out)
- [ ] Desktop nav shows "Echoes"; dismiss/undo strip reads "Echoes hidden — Undo"

Made with [Cursor](https://cursor.com)