### PR TITLE
fix(nav): keep desktop side nav visible under the user panel backdrop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.491",
+  "version": "4.2.492",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/DesktopSideNav.svelte
+++ b/src/components/DesktopSideNav.svelte
@@ -25,7 +25,6 @@
   import LeafIcon from 'phosphor-svelte/lib/Leaf';
   import ClockCounterClockwiseIcon from 'phosphor-svelte/lib/ClockCounterClockwise';
   import { totalUnreadCount } from '$lib/stores/messages';
-  import { userSidePanelOpen } from '$lib/stores/userSidePanel';
 
   $: pathname = $page.url.pathname;
   $: resolvedTheme = $theme === 'system' ? theme.getResolvedTheme() : $theme;
@@ -168,11 +167,11 @@
   }
 </script>
 
-<aside
-  class="hidden xl:block xl:w-80 fixed top-0 left-0 h-screen z-10 transition-opacity duration-300"
-  class:opacity-0={$userSidePanelOpen}
-  class:pointer-events-none={$userSidePanelOpen}
->
+<!-- Stays visible (dimmed and blurred like the rest of the page)
+     under the user side panel's backdrop — it must NOT fade itself
+     out when the panel opens, or the backdrop completely obscures the
+     menu and logo (issue #426). -->
+<aside class="hidden xl:block xl:w-80 fixed top-0 left-0 h-screen z-10">
   <div
     class="h-full overflow-y-auto scrollbar-hide p-3"
     style="background-color: var(--color-bg-primary);"

--- a/src/components/UserSidePanel.svelte
+++ b/src/components/UserSidePanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { fly, slide } from 'svelte/transition';
-  import { goto } from '$app/navigation';
+  import { goto, afterNavigate } from '$app/navigation';
   import { nip19 } from 'nostr-tools';
   import { onMount, onDestroy } from 'svelte';
   import { browser } from '$app/environment';
@@ -108,6 +108,13 @@
   function close() {
     userSidePanelOpen.set(false);
   }
+
+  // The desktop side nav stays visible and clickable above the
+  // backdrop while this panel is open — close the panel whenever a
+  // navigation happens so it doesn't linger over the new page.
+  afterNavigate(() => {
+    if ($userSidePanelOpen) close();
+  });
 
   function handleBackdropClick(e: MouseEvent) {
     if (e.target === e.currentTarget) {


### PR DESCRIPTION
Fixes #426.

## Problem

On desktop, opening the right-side user menu made the left side nav and logo vanish completely — the backdrop's dim/blur read as a solid wall over the left column.

## Root cause

`DesktopSideNav` faded itself to `opacity-0` + `pointer-events-none` whenever `userSidePanelOpen` was set (introduced in f7b488c6, the unified-messaging commit). So the nav wasn't merely dimmed by the backdrop — it was removed outright, and the blur showed the feed content behind where it used to be.

## Fix

- Remove the self-fade. The nav stays in place at its normal z-index and gets dimmed + blurred by the panel's backdrop **uniformly with the rest of the page** — the menu and logo remain discernible through the frost, with no hard edges or special-cased regions.
- `UserSidePanel` now also closes itself on `afterNavigate` as a safeguard, so the panel can never linger over a new page after navigation.

## Test plan
- [x] Desktop (≥1280px): open the avatar menu — left nav + logo visible through the uniform dim/blur (matching the rest of the page) instead of disappearing
- [x] Click the dimmed area — panel closes (click-outside unchanged)
- [x] Mobile width: behavior unchanged (side nav is hidden below xl anyway)
- [x] Regular modals unaffected (nav z-index untouched at z-10)