### PR TITLE
fix: handle deploy version skew (stale-client 404 cascade / broken tabs)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.496",
+  "version": "4.2.497",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.495",
+  "version": "4.2.496",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -58,8 +58,11 @@
   // into a full-page load. Cloudflare Pages removes the previous deploy's
   // immutable assets, so stale clients otherwise 404 on chunk imports when
   // navigating (broken tabs until a hard refresh).
-  beforeNavigate(({ willUnload, to }) => {
+  beforeNavigate(({ willUnload, to, cancel }) => {
     if ($updated && !willUnload && to?.url) {
+      // Cancel the client-side navigation first so SvelteKit doesn't start
+      // resolving (stale) route chunks before the full-page load takes over.
+      cancel();
       location.href = to.url.href;
     }
   });

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,8 +3,8 @@
   import '../app.css';
   import Header from '../components/Header.svelte';
   import { browser } from '$app/environment';
-  import { page } from '$app/stores';
-  import { goto } from '$app/navigation';
+  import { page, updated } from '$app/stores';
+  import { goto, beforeNavigate } from '$app/navigation';
   import { userPublickey, ndk } from '$lib/nostr';
   import BottomNav from '../components/BottomNav.svelte';
   import DesktopSideNav from '../components/DesktopSideNav.svelte';
@@ -52,6 +52,30 @@
   // Refresh engagement counts when the tab returns from background
   import { tabVisibleAfterHide } from '$lib/tabVisibility';
   import { refreshActiveEngagement } from '$lib/engagementCache';
+
+  // Version-skew guard: when a new deploy is detected (kit.version
+  // pollInterval in svelte.config.js), turn the next client-side navigation
+  // into a full-page load. Cloudflare Pages removes the previous deploy's
+  // immutable assets, so stale clients otherwise 404 on chunk imports when
+  // navigating (broken tabs until a hard refresh).
+  beforeNavigate(({ willUnload, to }) => {
+    if ($updated && !willUnload && to?.url) {
+      location.href = to.url.href;
+    }
+  });
+
+  // Safety net for the window before the first version poll: if a lazy
+  // chunk fails to load (its hashed file no longer exists on the new
+  // deploy), reload to pick up the fresh build instead of leaving the
+  // app in a broken half-navigated state.
+  onMount(() => {
+    const onPreloadError = (event: Event) => {
+      event.preventDefault();
+      location.reload();
+    };
+    window.addEventListener('vite:preloadError', onPreloadError);
+    return () => window.removeEventListener('vite:preloadError', onPreloadError);
+  });
 
   // Accept props from SvelteKit to prevent warnings
   export let data: LayoutData = {} as LayoutData;

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -35,7 +35,15 @@ const config = {
   preprocess: [vitePreprocess({})],
 
   kit: {
-    adapter: adapter
+    adapter: adapter,
+    version: {
+      // Poll _app/version.json so long-lived tabs detect new deploys.
+      // Cloudflare Pages drops the previous deploy's immutable assets, so
+      // without this, stale clients 404 on chunk imports during client-side
+      // navigation (and surface as broken tabs/500s until a hard refresh).
+      // Paired with the $updated guard in +layout.svelte.
+      pollInterval: 60000
+    }
   }
 };
 


### PR DESCRIPTION
## Summary

Fixes the production failure where clicking feed tabs in a long-lived browser tab produces a cascade of 404s on `/_app/immutable/chunks/*.js`, CSS rejected with `text/html` MIME type, and a 500 on the fallback document request — recoverable only by hard refresh.

**Root cause:** deploy version skew. Each Cloudflare Pages deploy serves only its own hashed immutable assets; a client still running the previous build dynamic-imports chunks by their old hashed filenames during client-side navigation and gets 404s.

**Changes:**

- `svelte.config.js`: enable `kit.version.pollInterval` (60s) so clients poll `_app/version.json` and detect new deploys.
- `src/routes/+layout.svelte`:
  - `beforeNavigate` guard — once a new version is detected, the next navigation becomes a full-page load instead of a client-side one (SvelteKit's documented skew mitigation).
  - `vite:preloadError` listener — safety net for the sub-poll-interval window right after a deploy: if a chunk import still fails, reload onto the fresh build instead of leaving the app half-navigated.

Also: `package.json` version bump via pre-commit hook.

## Test plan

- [ ] `pnpm check` passes (0 errors) and production build emits `_app/version.json` — verified locally
- [ ] On preview: confirm `_app/version.json` is fetched periodically (Network tab)
- [ ] After this merges, simulate skew: keep a tab open across a subsequent deploy, click feed tabs — expect one full-page navigation onto the new build, no 404 cascade
- [ ] Confirm normal client-side navigation is unaffected when no new deploy exists

Made with [Cursor](https://cursor.com)