### PR TITLE
Revert "fix: handle deploy version skew" (#430) — reload loop in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.497",
+  "version": "4.2.495",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,8 +3,8 @@
   import '../app.css';
   import Header from '../components/Header.svelte';
   import { browser } from '$app/environment';
-  import { page, updated } from '$app/stores';
-  import { goto, beforeNavigate } from '$app/navigation';
+  import { page } from '$app/stores';
+  import { goto } from '$app/navigation';
   import { userPublickey, ndk } from '$lib/nostr';
   import BottomNav from '../components/BottomNav.svelte';
   import DesktopSideNav from '../components/DesktopSideNav.svelte';
@@ -52,33 +52,6 @@
   // Refresh engagement counts when the tab returns from background
   import { tabVisibleAfterHide } from '$lib/tabVisibility';
   import { refreshActiveEngagement } from '$lib/engagementCache';
-
-  // Version-skew guard: when a new deploy is detected (kit.version
-  // pollInterval in svelte.config.js), turn the next client-side navigation
-  // into a full-page load. Cloudflare Pages removes the previous deploy's
-  // immutable assets, so stale clients otherwise 404 on chunk imports when
-  // navigating (broken tabs until a hard refresh).
-  beforeNavigate(({ willUnload, to, cancel }) => {
-    if ($updated && !willUnload && to?.url) {
-      // Cancel the client-side navigation first so SvelteKit doesn't start
-      // resolving (stale) route chunks before the full-page load takes over.
-      cancel();
-      location.href = to.url.href;
-    }
-  });
-
-  // Safety net for the window before the first version poll: if a lazy
-  // chunk fails to load (its hashed file no longer exists on the new
-  // deploy), reload to pick up the fresh build instead of leaving the
-  // app in a broken half-navigated state.
-  onMount(() => {
-    const onPreloadError = (event: Event) => {
-      event.preventDefault();
-      location.reload();
-    };
-    window.addEventListener('vite:preloadError', onPreloadError);
-    return () => window.removeEventListener('vite:preloadError', onPreloadError);
-  });
 
   // Accept props from SvelteKit to prevent warnings
   export let data: LayoutData = {} as LayoutData;

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -35,15 +35,7 @@ const config = {
   preprocess: [vitePreprocess({})],
 
   kit: {
-    adapter: adapter,
-    version: {
-      // Poll _app/version.json so long-lived tabs detect new deploys.
-      // Cloudflare Pages drops the previous deploy's immutable assets, so
-      // without this, stale clients 404 on chunk imports during client-side
-      // navigation (and surface as broken tabs/500s until a hard refresh).
-      // Paired with the $updated guard in +layout.svelte.
-      pollInterval: 60000
-    }
+    adapter: adapter
   }
 };
 


### PR DESCRIPTION
## Summary

Reverts #430 (commit 157345b). In production it causes the site to reload every second in a loop (the `vite:preloadError` reload + version-skew guard are misfiring), which is far worse than the original stale-chunk issue.

Rolling back to restore a stable production; will investigate the loop root cause separately before re-attempting skew mitigation.

Made with [Cursor](https://cursor.com)