### PR TITLE
fix: deploy version skew v2 — loop-proof recovery (re-attempt of #430)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.496",
+  "version": "4.2.497",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.495",
+  "version": "4.2.496",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,8 +3,8 @@
   import '../app.css';
   import Header from '../components/Header.svelte';
   import { browser } from '$app/environment';
-  import { page } from '$app/stores';
-  import { goto } from '$app/navigation';
+  import { page, updated } from '$app/stores';
+  import { goto, beforeNavigate } from '$app/navigation';
   import { userPublickey, ndk } from '$lib/nostr';
   import BottomNav from '../components/BottomNav.svelte';
   import DesktopSideNav from '../components/DesktopSideNav.svelte';
@@ -52,6 +52,60 @@
   // Refresh engagement counts when the tab returns from background
   import { tabVisibleAfterHide } from '$lib/tabVisibility';
   import { refreshActiveEngagement } from '$lib/engagementCache';
+
+  // Version-skew guard: when a new deploy is detected (kit.version
+  // pollInterval in svelte.config.js), turn the next client-side navigation
+  // into a full-page load. Cloudflare Pages removes the previous deploy's
+  // immutable assets, so stale clients otherwise 404 on chunk imports when
+  // navigating (broken tabs until a hard refresh).
+  beforeNavigate(({ willUnload, to, cancel }) => {
+    if ($updated && !willUnload && to?.url) {
+      // Cancel the client-side navigation first so SvelteKit doesn't start
+      // resolving (stale) route chunks before the full-page load takes over.
+      cancel();
+      location.href = to.url.href;
+    }
+  });
+
+  // Recovery for chunk-load failures in the window before the first version
+  // poll. Unlike the reverted #430, the reload is loop-proof: a sessionStorage
+  // flag permits AT MOST ONE automatic reload until the page subsequently
+  // stays healthy (no preload error for 10s). A persistent failure that a
+  // reload can't fix (ad-blocker, broken cache) therefore reloads once and
+  // then gives up instead of refreshing forever.
+  const SKEW_RELOAD_FLAG = 'zap_skew_reload_attempted';
+  onMount(() => {
+    const onPreloadError = (event: Event) => {
+      let alreadyTried = true;
+      try {
+        alreadyTried = sessionStorage.getItem(SKEW_RELOAD_FLAG) === '1';
+        if (!alreadyTried) sessionStorage.setItem(SKEW_RELOAD_FLAG, '1');
+      } catch {
+        // No storage means no loop protection — never reload in that case.
+        return;
+      }
+      if (alreadyTried) return;
+      event.preventDefault();
+      location.reload();
+    };
+    window.addEventListener('vite:preloadError', onPreloadError);
+
+    // Page survived 10s without a preload error: consider it healthy and
+    // re-arm the one-shot so a future deploy can still trigger a recovery
+    // reload later in this session.
+    const rearmTimer = setTimeout(() => {
+      try {
+        sessionStorage.removeItem(SKEW_RELOAD_FLAG);
+      } catch {
+        // ignore storage errors
+      }
+    }, 10_000);
+
+    return () => {
+      clearTimeout(rearmTimer);
+      window.removeEventListener('vite:preloadError', onPreloadError);
+    };
+  });
 
   // Accept props from SvelteKit to prevent warnings
   export let data: LayoutData = {} as LayoutData;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -75,7 +75,24 @@
   // then gives up instead of refreshing forever.
   const SKEW_RELOAD_FLAG = 'zap_skew_reload_attempted';
   onMount(() => {
+    const rearmFlag = () => {
+      try {
+        sessionStorage.removeItem(SKEW_RELOAD_FLAG);
+      } catch {
+        // ignore storage errors
+      }
+    };
+    // Page stayed healthy (no preload error) for 10s: re-arm the one-shot
+    // so a future deploy can still trigger a recovery reload later in this
+    // session. The timer restarts on every preload error, so the flag can
+    // never clear while errors are still occurring — a persistent failure
+    // reloads once and then stays inert.
+    let rearmTimer = setTimeout(rearmFlag, 10_000);
+
     const onPreloadError = (event: Event) => {
+      clearTimeout(rearmTimer);
+      rearmTimer = setTimeout(rearmFlag, 10_000);
+
       let alreadyTried = true;
       try {
         alreadyTried = sessionStorage.getItem(SKEW_RELOAD_FLAG) === '1';
@@ -89,17 +106,6 @@
       location.reload();
     };
     window.addEventListener('vite:preloadError', onPreloadError);
-
-    // Page survived 10s without a preload error: consider it healthy and
-    // re-arm the one-shot so a future deploy can still trigger a recovery
-    // reload later in this session.
-    const rearmTimer = setTimeout(() => {
-      try {
-        sessionStorage.removeItem(SKEW_RELOAD_FLAG);
-      } catch {
-        // ignore storage errors
-      }
-    }, 10_000);
 
     return () => {
       clearTimeout(rearmTimer);

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -35,7 +35,15 @@ const config = {
   preprocess: [vitePreprocess({})],
 
   kit: {
-    adapter: adapter
+    adapter: adapter,
+    version: {
+      // Poll _app/version.json so long-lived tabs detect new deploys.
+      // Cloudflare Pages drops the previous deploy's immutable assets, so
+      // without this, stale clients 404 on chunk imports during client-side
+      // navigation (broken tabs/500s until a hard refresh).
+      // Paired with the $updated guard in +layout.svelte.
+      pollInterval: 60000
+    }
   }
 };
 


### PR DESCRIPTION
## Summary

Re-attempt of #430 (reverted in #431 after it caused a reload loop in production).

**What went wrong in #430:** the `vite:preloadError` handler called `location.reload()` unconditionally. When a module preload fails in a way a reload cannot fix (ad-blocker blocking a chunk, broken cached HTML/asset pairing), every page load re-fired the error and the site refreshed once per second, forever.

**What's kept (unchanged from #430):**
- `kit.version.pollInterval: 60000` — clients poll `_app/version.json` to detect new deploys.
- `beforeNavigate` guard — when a new version is detected, `cancel()` the client-side navigation and do a full-page load instead (SvelteKit's documented skew mitigation). This part navigates rather than reloads, and cannot loop.

**What's different (the fix):** the recovery reload is now **one-shot**:
- A `sessionStorage` flag (`zap_skew_reload_attempted`) is set before reloading; if a preload error fires while the flag is set, we do **nothing** — max one automatic reload per failure episode.
- The flag re-arms only after the page stays healthy (no preload error) for 10 seconds, so a genuine future deploy later in the session can still trigger one recovery reload.
- If `sessionStorage` is unavailable, we never reload (no loop protection → no reload).

## Test plan

- [ ] `pnpm check` 0 errors; production build passes — verified locally
- [ ] On preview: site loads normally, no spontaneous reloads, `_app/version.json` polled in Network tab
- [ ] Loop-proofing: in DevTools, block a `/_app/immutable/chunks/*.js` URL pattern and navigate — expect at most ONE automatic reload, then normal failure behavior (no refresh loop)
- [ ] After merge + a subsequent deploy: leave a tab open across the deploy, click feed tabs — expect a single full-page navigation onto the new build
- [ ] Recommend merging during a low-traffic window and watching production for a few minutes given #430's history

Made with [Cursor](https://cursor.com)