### PR TITLE
fix: stop per-avatar /api/membership request flood

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.496",
+  "version": "4.2.497",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.495",
+  "version": "4.2.496",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/Avatar.svelte
+++ b/src/components/Avatar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { browser } from '$app/environment';
-  import { createEventDispatcher, onDestroy, onMount } from 'svelte';
+  import { createEventDispatcher, onDestroy } from 'svelte';
   import CustomAvatar from './CustomAvatar.svelte';
   import {
     getMembershipLabel,

--- a/src/components/Avatar.svelte
+++ b/src/components/Avatar.svelte
@@ -3,7 +3,6 @@
   import { createEventDispatcher, onDestroy, onMount } from 'svelte';
   import CustomAvatar from './CustomAvatar.svelte';
   import {
-    getMembership,
     getMembershipLabel,
     membershipStatusMap,
     queueMembershipLookup,
@@ -49,15 +48,13 @@
     }
   })();
 
+  // Membership lookup goes through the debounced queue ONLY. Calling
+  // getMembership() here as well (as this used to) bypassed the 75ms batch
+  // window and fired one HTTP request per mounted avatar — hundreds of
+  // single-pubkey /api/membership invocations per feed page.
   $: if (normalizedPubkey) {
     queueMembershipLookup(normalizedPubkey);
   }
-
-  onMount(() => {
-    if (normalizedPubkey) {
-      void getMembership([normalizedPubkey]);
-    }
-  });
 
   function handleClick(event: MouseEvent): void {
     if (isActiveMember) {

--- a/src/components/MembershipBeltBadge.svelte
+++ b/src/components/MembershipBeltBadge.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-  import { onDestroy, onMount } from 'svelte';
+  import { onDestroy } from 'svelte';
   import {
-    getMembership,
     getMembershipLabel,
     membershipStatusMap,
     queueMembershipLookup,
@@ -34,15 +33,12 @@
     }
   })();
 
+  // Membership lookup goes through the debounced queue ONLY — see
+  // Avatar.svelte for why the extra onMount getMembership() call was removed
+  // (it bypassed batching and fired one request per mounted badge).
   $: if (normalizedPubkey) {
     queueMembershipLookup(normalizedPubkey);
   }
-
-  onMount(() => {
-    if (normalizedPubkey) {
-      void getMembership([normalizedPubkey]);
-    }
-  });
 
   onDestroy(() => {
     unsubscribe();


### PR DESCRIPTION
## Summary

Cloudflare function logs show hundreds of single-pubkey `GET /api/membership?pubkeys=<pk>` invocations within a 1–2s window on feed/notifications page views.

**Root cause:** `Avatar.svelte` and `MembershipBeltBadge.svelte` requested membership twice:
- reactively via `queueMembershipLookup()` (correct — 75ms debounce, batches up to 200 pubkeys per request), and
- in `onMount` via `getMembership([pubkey])`, which bypasses the debounce queue and fetches immediately. Since queued keys aren't marked in-flight until the debounce flushes, the dedupe check missed and every mounted avatar fired its own one-pubkey request — then the batch fetched the same keys again 75ms later.

**Fix:** remove the redundant `onMount` call in both components; the reactive `queueMembershipLookup` already runs on init and covers first render. Array-based callers (market, kitchens) are unaffected — they were already batched.

**Impact:** a page with N avatars goes from ~N+1 membership invocations to ~1–2. Cuts billable function invocations dramatically and removes a significant source of worker pressure (potentially related to the intermittent SSR 500s under investigation).

## Test plan

- [ ] `pnpm check` 0 errors — verified locally
- [ ] On preview: load /notifications and /community with DevTools Network filtered to `api/membership` — expect a few batched multi-pubkey requests instead of dozens of single-pubkey ones
- [ ] Membership rings/badges still appear on avatars of active members after load

Made with [Cursor](https://cursor.com)