### PR TITLE
fix: SSR 500 on /notifications — guard generateAvatar against undefined pubkey

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.497",
+  "version": "4.2.498",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/CustomAvatar.svelte
+++ b/src/components/CustomAvatar.svelte
@@ -18,10 +18,13 @@
   let imageCandidates: string[] = []; // Ordered list of URLs to try
   let currentCandidateIndex = 0; // Index of current candidate being tried
   
-  // Generate a simple avatar based on pubkey
-  function generateAvatar(pubkey: string): string {
+  // Generate a simple avatar based on pubkey.
+  // Tolerates a missing pubkey: callers occasionally render before one is
+  // available, and during SSR an undefined pubkey here was crashing the
+  // whole page render with a 500 (TypeError on .split).
+  function generateAvatar(pubkey: string | null | undefined): string {
     // Create a simple colored circle based on pubkey hash
-    const hash = pubkey.split('').reduce((a, b) => {
+    const hash = String(pubkey || '').split('').reduce((a, b) => {
       a = ((a << 5) - a) + b.charCodeAt(0);
       return a & a;
     }, 0);


### PR DESCRIPTION
## Summary

Root cause of the intermittent production 500s finally captured via `wrangler pages deployment tail` while probing `https://zap.cooking/notifications` (9 hits out of 40 requests):

```
TypeError: Cannot read properties of undefined (reading 'split')
    at generateAvatar (CustomAvatar.svelte)
    at Object.$$render (...)
```

`CustomAvatar.svelte`'s `generateAvatar()` calls `pubkey.split('')` unguarded, and during SSR an avatar is sometimes rendered with an undefined pubkey — which throws and 500s the entire page render. The intermittency matches worker-isolate state: module-level caches persist across requests within an isolate, so some isolates render a code path with a missing pubkey while fresh ones don't.

**Fix:** tolerate null/undefined pubkey by hashing an empty string (falls back to a deterministic gray-ish circle). All other `pubkey` uses in the component were already guarded.

## Remaining known issue (separate PR)

The tail also caught a second, unrelated SSR error on `/wallet`:

```
TypeError: debug8.extend is not a function
    at new NDKSubscriptionManager → new NDK → createNdk → nostr.js module init
```

NDK's `debug` dependency is mis-bundled for the workerd runtime and throws during server-side module init of `nostr.js` — which poisons that isolate for all subsequent requests until it's recycled. Likely the cause of the bursty 500s on `/community`. Needs its own investigation (probably SSR-guarding the NDK construction or aliasing `debug` for the server bundle).

## Test plan

- [ ] `pnpm check` 0 errors — verified locally
- [ ] After deploy: `for i in $(seq 1 40); do curl -s -o /dev/null -w "%{http_code} " https://zap.cooking/notifications; done` — expect no 500s (previously ~25% failure rate)
- [ ] Avatars still render normally (colored fallback circle when no profile picture)

Made with [Cursor](https://cursor.com)