### PR TITLE
fix(feed): stop profile view thrashing on author replies + rename client tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.499",
+  "version": "4.2.500",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.498",
+  "version": "4.2.499",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -2927,6 +2927,12 @@
         return;
       }
 
+      // Profile view: respect authorScope (matches initial load filter)
+      if (authorPubkey) {
+        if (authorScope === 'top-level' && isReply(event)) return;
+        if (authorScope === 'replies' && !isReply(event)) return;
+      }
+
       // For Global feed, exclude posts from followed users
       if (!authorPubkey && followedPubkeysForRealtime.length > 0) {
         const authorKey = event.author?.hexpubkey || event.pubkey;
@@ -3023,8 +3029,9 @@
       // Garden/Following/Replies: respect foodFilterEnabled toggle
       if (foodFilterEnabled && !shouldIncludeEvent(event)) return;
     } else if (filterMode !== 'members') {
-      // Global mode (and profile view): always apply food filter
-      if (!shouldIncludeEvent(event)) return;
+      // Global feed: always apply food filter
+      // Profile view: respect the foodFilterEnabled toggle (matches initial load)
+      if (authorPubkey ? (foodFilterEnabled && !shouldIncludeEvent(event)) : !shouldIncludeEvent(event)) return;
     }
     // Members mode: no food filter
 
@@ -4651,6 +4658,7 @@
       loading = true;
       try {
         await loadFoodstrFeed(false);
+        if (authorPubkey) preseedRenderedNotes(20);
         console.log(
           `[Feed] Profile/special mode: Loaded ${events.length} events for ${authorPubkey || filterMode}`
         );

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -24,7 +24,7 @@ export type recipeTagSimple = {
 export const DEFAULT_PROFILE_IMAGE = 'https://zap.cooking/default-pfp.jpg';
 
 // NIP-89 Client identification
-export const CLIENT_TAG_IDENTIFIER = 'zap.cooking';
+export const CLIENT_TAG_IDENTIFIER = 'Zap Cooking';
 export const CLIENT_DISPLAY_NAME = 'Zap Cooking';
 
 // Recipe tag prefixes

--- a/src/lib/timerSettings.ts
+++ b/src/lib/timerSettings.ts
@@ -7,7 +7,7 @@
  * Event Structure:
  * - kind: 30078 (NIP-78 Application-specific Data)
  * - d tag: "timer-settings" (addressable/replaceable)
- * - client tag: "zap.cooking"
+ * - client tag: "Zap Cooking"
  * - content: JSON payload with settings
  */
 


### PR DESCRIPTION
## Summary

- **Profile feed refresh bug**: The realtime subscription had no `authorScope` awareness — author replies always flowed into `handleRealtimeEvent` regardless of the `authorScope="top-level"` prop. On an active account this caused continuous `events`-array reassignments → Svelte DOM reconciliation → IntersectionObserver callbacks firing as nodes shifted → open `CommentThread` components collapsing. Also fixes two related inconsistencies: `handleRealtimeEvent` now respects `foodFilterEnabled` for profile views (matching initial load behaviour), and `preseedRenderedNotes(20)` is called after load to prevent an immediate burst of render-zone changes.
- **Client tag rename**: `CLIENT_TAG_IDENTIFIER` changed from `"zap.cooking"` to `"Zap Cooking"` — the proper display name, consistent with the `CLIENT_DISPLAY_NAME` constant that already existed alongside it.

## Test plan

- [ ] Open a profile with many posts and replies (e.g. an active food poster)
- [ ] Expand a comment thread on a post in the Posts tab — verify it stays open and doesn't collapse as new events arrive
- [ ] Confirm the Posts tab only shows top-level posts (no replies leaking in)
- [ ] Publish a note via PostComposer and inspect the raw event — client tag should read `["client", "Zap Cooking"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)