### PR TITLE
fix: counts API 500, recovery-reload loop, and mid-scroll feed jumps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.499",
+  "version": "4.2.500",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.498",
+  "version": "4.2.499",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.500",
+  "version": "4.2.501",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -3071,9 +3071,19 @@
         // Sort by repost time when present (so reposted notes surface alongside the repost),
         // otherwise by the event's own created_at.
         const sortedBatch = batch.sort((a, b) => getEventSortTime(b) - getEventSortTime(a));
-        events = [...sortedBatch, ...events].sort(
-          (a, b) => getEventSortTime(b) - getEventSortTime(a)
-        );
+
+        // Same gate as fetchFreshAndMerge / runContentRefresh: only mutate the
+        // rendered list while the user is at the top. Prepending mid-scroll
+        // shifts content under the user's finger on iOS Safari (no scroll
+        // anchoring support) — divert to the "N new posts" pill instead.
+        if (isScrolledToTop) {
+          events = [...sortedBatch, ...events].sort(
+            (a, b) => getEventSortTime(b) - getEventSortTime(a)
+          );
+        } else {
+          pendingNewEvents = [...pendingNewEvents, ...sortedBatch];
+          showNewPostsButton = true;
+        }
 
         // Update last event time
         const maxTime = Math.max(...batch.map(getEventSortTime));
@@ -3299,8 +3309,12 @@
           // User is at top - auto-prepend smoothly
           events = dedupeAndSort([...newEvents, ...events]);
         } else {
-          // User is scrolled down - show "new posts" button
-          pendingNewEvents = newEvents;
+          // User is scrolled down - show "new posts" button. Append (don't
+          // replace): realtime processBatch also diverts events here, and a
+          // replacement would silently drop them (they're already marked
+          // seen, so they would never render). loadPendingPosts dedupes the
+          // combined list by id.
+          pendingNewEvents = [...pendingNewEvents, ...newEvents];
           showNewPostsButton = true;
         }
 

--- a/src/lib/utils/eventId.ts
+++ b/src/lib/utils/eventId.ts
@@ -1,0 +1,19 @@
+/**
+ * Pure event-id validation with ZERO imports.
+ *
+ * This module must stay dependency-free: it is imported by server API
+ * endpoints (e.g. /api/counts/*) whose worker bundles must not pull in
+ * the NDK module graph. $lib/nostr constructs NDK at module scope, which
+ * crashes during module init in the Cloudflare worker runtime
+ * ("debug.extend is not a function") and 500s every request to any
+ * endpoint that transitively imports it.
+ */
+
+/**
+ * Validate that eventId is exactly 64 hex characters (Nostr event ID format)
+ */
+const EVENT_ID_PATTERN = /^[a-f0-9]{64}$/i;
+
+export function isValidEventId(id: unknown): id is string {
+  return typeof id === 'string' && EVENT_ID_PATTERN.test(id);
+}

--- a/src/lib/utils/nostrRefs.ts
+++ b/src/lib/utils/nostrRefs.ts
@@ -19,13 +19,10 @@ const recipeCache = new Map<string, RecipeMetadata>();
 const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
 const FETCH_TIMEOUT = 5000; // 5 seconds timeout for fetches
 
-/**
- * Validate that eventId is exactly 64 hex characters (Nostr event ID format)
- */
-const EVENT_ID_PATTERN = /^[a-f0-9]{64}$/i;
-export function isValidEventId(id: unknown): id is string {
-  return typeof id === 'string' && EVENT_ID_PATTERN.test(id);
-}
+// Moved to $lib/utils/eventId (dependency-free) so server endpoints can
+// validate ids without pulling this module's NDK import chain into their
+// worker bundle. Re-exported here for backwards compatibility.
+export { isValidEventId } from './eventId';
 
 /**
  * Resolve a profile by pubkey or npub string

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -67,50 +67,82 @@
     }
   });
 
-  // Recovery for chunk-load failures in the window before the first version
-  // poll. Unlike the reverted #430, the reload is loop-proof: a sessionStorage
-  // flag permits AT MOST ONE automatic reload until the page subsequently
-  // stays healthy (no preload error for 10s). A persistent failure that a
-  // reload can't fix (ad-blocker, broken cache) therefore reloads once and
-  // then gives up instead of refreshing forever.
-  const SKEW_RELOAD_FLAG = 'zap_skew_reload_attempted';
+  // Recovery for chunk-load failures (stale deploy assets): reload AT MOST
+  // ONCE per browser session. The previous design re-armed after 10s of
+  // health, which produced a reload roughly every 10s on clients where the
+  // failure recurs indefinitely (e.g. iOS Safari with a content blocker or
+  // poisoned HTML cache). sessionStorage survives reloads in the same tab,
+  // so a recovery reload that didn't fix the problem can never repeat —
+  // further failures are only counted and logged.
+  const RECOVERY_RELOAD_KEY = 'zc:recovery-reload';
+
+  interface RecoveryReloadRecord {
+    /** Set when the one recovery reload of this session was triggered. */
+    reloadedAt?: number;
+    /** Total vite:preloadError events this session, including suppressed ones. */
+    errors: number;
+    /** Message of the most recent preload error (failing chunk URL when available). */
+    lastError?: string;
+    lastErrorAt?: number;
+  }
+
   onMount(() => {
-    const rearmFlag = () => {
+    const readRecord = (): RecoveryReloadRecord => {
       try {
-        sessionStorage.removeItem(SKEW_RELOAD_FLAG);
+        const parsed = JSON.parse(sessionStorage.getItem(RECOVERY_RELOAD_KEY) ?? '');
+        if (parsed && typeof parsed === 'object') {
+          const rec = parsed as Partial<RecoveryReloadRecord>;
+          return { ...rec, errors: typeof rec.errors === 'number' ? rec.errors : 0 };
+        }
       } catch {
-        // ignore storage errors
+        // Missing or corrupt record — start fresh.
       }
+      return { errors: 0 };
     };
-    // Page stayed healthy (no preload error) for 10s: re-arm the one-shot
-    // so a future deploy can still trigger a recovery reload later in this
-    // session. The timer restarts on every preload error, so the flag can
-    // never clear while errors are still occurring — a persistent failure
-    // reloads once and then stays inert.
-    let rearmTimer = setTimeout(rearmFlag, 10_000);
 
     const onPreloadError = (event: Event) => {
-      clearTimeout(rearmTimer);
-      rearmTimer = setTimeout(rearmFlag, 10_000);
+      // Vite attaches the underlying error as `payload` on the event.
+      const payload = (event as Event & { payload?: unknown }).payload;
+      const message =
+        payload instanceof Error ? payload.message : String(payload ?? 'unknown preload error');
 
-      let alreadyTried = true;
+      const record = readRecord();
+      record.errors += 1;
+      record.lastError = message;
+      record.lastErrorAt = Date.now();
+
+      if (record.reloadedAt) {
+        // Already used this session's one recovery reload — never reload
+        // again. Persist the counter for diagnostics and let the failure
+        // surface normally (SvelteKit error handling / console).
+        try {
+          sessionStorage.setItem(RECOVERY_RELOAD_KEY, JSON.stringify(record));
+        } catch {
+          // ignore storage errors
+        }
+        console.warn(
+          `[recovery] Chunk preload failed again after recovery reload (error #${record.errors}); suppressing further reloads.`,
+          message
+        );
+        return;
+      }
+
+      record.reloadedAt = Date.now();
       try {
-        alreadyTried = sessionStorage.getItem(SKEW_RELOAD_FLAG) === '1';
-        if (!alreadyTried) sessionStorage.setItem(SKEW_RELOAD_FLAG, '1');
+        // sessionStorage writes are synchronous — the record is durably in
+        // place before reload() below, so the post-reload page always sees
+        // reloadedAt and cannot reload a second time.
+        sessionStorage.setItem(RECOVERY_RELOAD_KEY, JSON.stringify(record));
       } catch {
         // No storage means no loop protection — never reload in that case.
         return;
       }
-      if (alreadyTried) return;
       event.preventDefault();
       location.reload();
     };
     window.addEventListener('vite:preloadError', onPreloadError);
 
-    return () => {
-      clearTimeout(rearmTimer);
-      window.removeEventListener('vite:preloadError', onPreloadError);
-    };
+    return () => window.removeEventListener('vite:preloadError', onPreloadError);
   });
 
   // Accept props from SvelteKit to prevent warnings

--- a/src/routes/api/counts/[eventId]/+server.ts
+++ b/src/routes/api/counts/[eventId]/+server.ts
@@ -1,5 +1,6 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
+import { isValidEventId } from '$lib/utils/eventId';
 
 // In-memory cache with TTL (for edge/serverless)
 // In production, consider using Cloudflare KV or Redis
@@ -228,8 +229,7 @@ async function fetchEngagementCounts(eventId: string): Promise<CountData> {
 export const GET: RequestHandler = async ({ params, url, platform }) => {
   const { eventId } = params;
 
-  const isValidNostrEventId = typeof eventId === 'string' && /^[a-f0-9]{64}$/i.test(eventId);
-  if (!isValidNostrEventId) {
+  if (!isValidEventId(eventId)) {
     return json({ error: 'Invalid event ID' }, { status: 400 });
   }
 

--- a/src/routes/api/counts/batch/+server.ts
+++ b/src/routes/api/counts/batch/+server.ts
@@ -1,6 +1,9 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { isValidEventId } from '$lib/utils/nostrRefs';
+// Import from the dependency-free module — NOT $lib/utils/nostrRefs, whose
+// import chain reaches $lib/nostr's module-scope NDK construction and
+// crashes worker module init (500 on every request to this endpoint).
+import { isValidEventId } from '$lib/utils/eventId';
 
 // In-memory cache with TTL
 const countCache = new Map<string, { data: CountData; timestamp: number }>();


### PR DESCRIPTION
## Summary

Three production fixes from the Track A/B investigation (captured stacks via `wrangler pages deployment tail`), one commit per concern.

### Commit 1 — `217a3cf`: decouple `/api/counts` endpoints from the NDK module graph

`POST /api/counts/batch` returned 500 on **every** request. Captured stack:

```
TypeError: debug8.extend is not a function
    at new NDKSubscriptionManager → new NDK → createNdk
    at chunks/nostr.js (module init)
    at chunks/nostrRefs.js (module init)
    at endpoints/api/counts/batch/_server.ts.js
```

The endpoint imported `isValidEventId` from `$lib/utils/nostrRefs`, whose import chain reaches `$lib/nostr`'s **module-scope** `createNdk()` — which throws in the worker runtime during module init, before the handler runs. Fix: `isValidEventId` now lives in a zero-import module (`$lib/utils/eventId`); both counts endpoints import it from there; `nostrRefs` re-exports for compatibility. A scan of all other `+server.ts` import graphs (2 levels) confirms no other endpoint reaches the module-scope NDK init.

### Commit 2 — `f02d3a8`: recovery reload at most once per session

The #432 `vite:preloadError` handler re-armed after 10s of health — on clients where the chunk failure recurs forever (iOS Safari + content blocker / poisoned cache), that produced a reload roughly every 10 seconds. Now:

- at most ONE recovery reload per browser session, guarded by a namespaced sessionStorage record (`zc:recovery-reload`) written **synchronously before** `location.reload()`
- the record carries `reloadedAt`, the failing chunk message (`lastError`/`lastErrorAt`), and an `errors` counter that keeps incrementing across suppressed events — diagnostic evidence of recurrence frequency
- suppressed failures only `console.warn`; without sessionStorage access it never reloads

### Commit 3 — `0288e40`: gate realtime feed inserts behind the "N new posts" pill

`processBatch` (live relay subscription path) prepended events into the rendered list unconditionally, even mid-scroll. The other two refresh paths (`fetchFreshAndMerge`, `runContentRefresh`) already gate on `isScrolledToTop` and divert to `pendingNewEvents` + the pill. iOS Safari has no scroll anchoring, so every live batch visibly shifted the feed. The realtime write site now uses the identical gate; debounce (300ms) and keyed `{#each}` untouched.

**Adjacent change required for correctness:** `fetchFreshAndMerge`'s scrolled-down branch previously did `pendingNewEvents = newEvents` (replace). With realtime events now also landing in `pendingNewEvents`, a replacement would silently drop them — they're already in `seenEventIds`, so they would never render at all. Switched to append (the pattern `runContentRefresh` already uses); `loadPendingPosts` dedupes the combined list by id.

## Known properties / accepted trade-offs

- **Once-per-session reload policy:** a user who consumes their one recovery reload early and hits a *legitimate* deploy-skew failure later in the same session sees a failed navigation instead of auto-recovery (the `beforeNavigate` + version-poll path still covers most of those). Possible follow-up: key the guard on app version so a real new deploy resets the budget.
- **Unbounded `pendingNewEvents`:** during a very long scrolled session on a busy feed, the pending buffer grows without a cap. Capping is deferred — dropping buffered events is not trivial because they are already marked in `seenEventIds` and would need un-marking to ever render again.

## Deferred — PR 2 scope (root-cause fix for the worker NDK crash)

- Browser-guard or lazy-init the module-scope `createNdk()` in `$lib/nostr.ts` so server bundles never construct NDK at module init (fixes the remaining intermittent page-level 500s: `/wallet`, `/recipes`, `/community`).
- `debug` interop in the worker bundle: Vite `ssr.noExternal`/alias for `debug`, verify Pages `nodejs_compat` flag and compatibility date.
- `membershipNotificationService`: the `/api/cron/*` endpoints construct `new NDK(...)` at request time — same `debug.extend` TypeError exposure when they execute.

## Test plan

- [x] `pnpm check` 0 errors; full vitest suite 197/197 after each commit
- [ ] Preview: POST `/api/counts/batch` returns 200 (definitive check is post-merge against production, where the 500 reproduces)
- [ ] Preview, iPhone Safari: scroll deep in Global feed, idle 2 min — no shifts; pill appears on live posts; tap pill → top + merged, no duplicates; scroll back up → auto-merge
- [ ] Preview: at top of feed, live posts still prepend smoothly without the pill
- [ ] DevTools: block `*/_app/immutable/chunks/*`, navigate — exactly one reload, then suppression; `zc:recovery-reload` record populated
- [ ] Post-merge: `for i in $(seq 1 20); do curl -s -o /dev/null -w "%{http_code} " -X POST https://zap.cooking/api/counts/batch -H 'Content-Type: application/json' -d '{"eventIds":["<64-hex>"]}'; done` — expect no 500s

Note: the "Workers Builds" CI checks (`zapcooking-frontend` / `frontend`) have failed on unrelated PRs (e.g. #430/#432/#433) while the Cloudflare Pages deploy succeeds — pre-existing flakiness, same as #375. The Pages preview is the meaningful check.

Made with [Cursor](https://cursor.com)