### PR TITLE
Rename Echoes to Memories

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.507",
+  "version": "4.2.508",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/DesktopSideNav.svelte
+++ b/src/components/DesktopSideNav.svelte
@@ -111,7 +111,7 @@
     },
     {
       href: '/memories',
-      label: 'Echoes',
+      label: 'Memories',
       icon: ClockCounterClockwiseIcon,
       match: (p) => p.startsWith('/memories')
     },

--- a/src/components/MemoriesCard.svelte
+++ b/src/components/MemoriesCard.svelte
@@ -123,10 +123,10 @@
           aria-expanded={isMobile ? undefined : expanded}
           aria-controls={isMobile ? undefined : 'memories-card-panel'}
           aria-label={isMobile
-            ? 'View echoes'
+            ? 'View memories'
             : expanded
-              ? 'Collapse echoes'
-              : 'Expand echoes'}
+              ? 'Collapse memories'
+              : 'Expand memories'}
         >
           <!-- Row 1: icon + title + caret -->
           <span class="flex items-center gap-2">
@@ -137,7 +137,7 @@
               class="text-sm font-semibold whitespace-nowrap"
               style="color: var(--color-text-primary);"
             >
-              Echoes
+              Memories
             </span>
             <span
               class="ml-auto flex-shrink-0 pr-1"
@@ -171,7 +171,7 @@
           on:click={dismiss}
           class="dismiss-btn flex-shrink-0 flex items-center justify-center self-center ml-2 mr-1 rounded-full hover:opacity-70 transition-opacity"
           style="color: var(--color-text-secondary);"
-          aria-label="Hide echoes for today"
+          aria-label="Hide memories for today"
         >
           <XIcon size={16} />
         </button>
@@ -200,7 +200,7 @@
             href="/memories"
             class="text-sm font-medium text-orange-500 hover:text-orange-600 transition-colors"
           >
-            See all echoes →
+            See all memories →
           </a>
         </div>
       {/if}
@@ -210,7 +210,7 @@
       class="undo-strip rounded-xl border mb-4 px-4 py-2 flex items-center justify-between gap-2"
       role="status"
     >
-      <span class="text-xs" style="color: var(--color-text-secondary);">Echoes hidden</span>
+      <span class="text-xs" style="color: var(--color-text-secondary);">Memories hidden</span>
       <button
         on:click={undo}
         class="text-xs font-medium underline hover:opacity-80 transition-opacity"

--- a/src/routes/memories/+page.svelte
+++ b/src/routes/memories/+page.svelte
@@ -94,8 +94,8 @@
 </script>
 
 <svelte:head>
-  <title>Echoes - zap.cooking</title>
-  <meta name="description" content="Echoes — a look back at notes from this day" />
+  <title>Memories - zap.cooking</title>
+  <meta name="description" content="Memories — a look back at notes from this day" />
 </svelte:head>
 
 <div class="px-4 max-w-2xl mx-auto w-full memories-page">
@@ -103,7 +103,7 @@
     <div class="text-center py-16">
       <p class="text-4xl mb-3" aria-hidden="true">📅</p>
       <h1 class="text-xl font-semibold mb-2" style="color: var(--color-text-primary);">
-        Echoes
+        Memories
       </h1>
       <p class="text-sm mb-4" style="color: var(--color-text-secondary);">
         A look back at notes from this day. Sign in to see yours.
@@ -118,7 +118,7 @@
   {:else}
     <div class="flex items-start justify-between gap-4 mb-6 pt-2">
       <div>
-        <h1 class="text-2xl font-bold" style="color: var(--color-text-primary);">Echoes</h1>
+        <h1 class="text-2xl font-bold" style="color: var(--color-text-primary);">Memories</h1>
         <p class="text-sm mt-1" style="color: var(--color-text-secondary);">
           A look back at notes from this day · {todayLabel}
         </p>
@@ -128,7 +128,7 @@
         disabled={refreshing}
         class="flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-sm font-medium hover:opacity-80 transition-opacity disabled:opacity-50"
         style="color: var(--color-text-secondary); border-color: var(--color-input-border);"
-        aria-label="Refresh echoes from relays"
+        aria-label="Refresh memories from relays"
       >
         <span class:animate-spin={refreshing}>
           <ArrowsClockwiseIcon size={14} />
@@ -155,7 +155,7 @@
       <div class="text-center py-16">
         <p class="text-4xl mb-3" aria-hidden="true">🍳</p>
         <p class="text-sm" style="color: var(--color-text-secondary);">
-          No echoes found for this day. Relays may not keep notes this old — or this day is
+          No memories found for this day. Relays may not keep notes this old — or this day is
           still waiting for its first one.
         </p>
       </div>


### PR DESCRIPTION
## Summary

Renames the on-this-day feature from **Echoes** to **Memories** in all user-facing copy. The feature was already `/memories` internally (route, `lib/memories.ts`, cache keys, component filenames), so this is purely a brand-string change — no logic, routes, or storage touched.

## Changes

- **DesktopSideNav**: nav label `Echoes` → `Memories`
- **MemoriesCard** (feed banner): title, "Memories hidden" undo strip, "See all memories →" link, and the view/collapse/expand/hide aria-labels
- **/memories page**: `<title>`, meta description, both headers, the refresh aria-label, and the empty state

Left alone on purpose: "relay echoes back" comment phrasing in engagement/repost code — that's the verb, not the brand.

## Verification

- `pnpm check`: 0 errors
- `pnpm test`: 197/197
- Repo-wide sweep confirms zero remaining `Echo`/`Echoes` brand strings

Note: the "Workers Builds" checks always fail on this repo and are ignorable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)