### PR TITLE
fix(wallet,notifications): cap QR size + batch EOSE notification inserts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.513",
+  "version": "4.2.514",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.514",
+  "version": "4.2.515",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/wallet/WalletPanel.svelte
+++ b/src/components/wallet/WalletPanel.svelte
@@ -5782,7 +5782,7 @@
             <div class="text-sm text-caption mb-2">Send only Bitcoin to this address:</div>
 
             <!-- QR Code -->
-            <div class="qr-wrapper self-center p-4 rounded-xl bg-white" style="width: 100%;">
+            <div class="qr-wrapper mx-auto p-4 rounded-xl bg-white max-w-xs w-full">
               <svg
                 class="w-full"
                 use:qr={{
@@ -6162,7 +6162,7 @@
 
             <!-- QR Code -->
             {#if generatedInvoice && generatedInvoice.length > 0}
-              <div class="qr-wrapper self-center p-4 rounded-xl bg-white" style="width: 100%;">
+              <div class="qr-wrapper mx-auto p-4 rounded-xl bg-white max-w-xs w-full">
                 <svg
                   class="w-full"
                   use:qr={{

--- a/src/lib/notificationStore.ts
+++ b/src/lib/notificationStore.ts
@@ -228,36 +228,63 @@ export function subscribeToNotifications(ndk: NDK, userPubkey: string, forceFull
     { closeOnEose: false }
   );
 
-  activeSubscription.on('event', async (event: NDKEvent) => {
+  // Buffer events received before EOSE so we can insert them in one
+  // addBulk() call (one sort + one localStorage write) instead of doing
+  // a full sort + localStorage write for every individual event.
+  let eoseReceived = false;
+  const preEoseBuffer: NDKEvent[] = [];
+
+  function handleEvent(event: NDKEvent, isRealtime: boolean) {
     // For zap receipts (9735), the pubkey is the zapper service, not the sender.
     // Self-zap filtering happens in parseNotification after extracting the real sender.
-    if (event.kind !== 9735 && event.pubkey === userPubkey) {
-      return;
-    }
-
-    // Filter out hellthreads (events with excessive p tags)
-    if (isHellthread(event)) {
-      return;
-    }
+    if (event.kind !== 9735 && event.pubkey === userPubkey) return;
+    if (isHellthread(event)) return;
 
     const notification = parseNotification(event, userPubkey);
-    if (notification) {
-      // Add to store
-      notifications.add(notification);
+    if (!notification) return;
 
-      // Record NIP-57 zap data to Spark SDK for received zaps
-      if (event.kind === 9735) {
-        recordZapToSparkSdk(event);
-      }
+    if (!isRealtime) {
+      // Pre-EOSE: buffer for bulk insert
+      preEoseBuffer.push(event);
+      return;
+    }
 
-      // Send local notification if app is backgrounded and permissions are granted
-      if (browser) {
-        try {
-          await sendLocalNotificationForNostrEvent(notification);
-        } catch (error) {
-          console.error('[Notifications] Error sending local notification:', error);
-        }
+    // Post-EOSE realtime event: add individually (rare, no perf issue)
+    notifications.add(notification);
+
+    if (event.kind === 9735) recordZapToSparkSdk(event);
+
+    if (browser) {
+      sendLocalNotificationForNostrEvent(notification).catch((error) => {
+        console.error('[Notifications] Error sending local notification:', error);
+      });
+    }
+  }
+
+  activeSubscription.on('event', (event: NDKEvent) => {
+    handleEvent(event, eoseReceived);
+  });
+
+  activeSubscription.on('eose', () => {
+    eoseReceived = true;
+    if (preEoseBuffer.length === 0) return;
+
+    // Parse + dedup the buffer, then bulk-insert (one sort + one localStorage write)
+    const parsed: Notification[] = [];
+    const seenIds = new Set<string>();
+    for (const event of preEoseBuffer) {
+      if (seenIds.has(event.id)) continue;
+      seenIds.add(event.id);
+      const notification = parseNotification(event, userPubkey);
+      if (notification) {
+        parsed.push(notification);
+        if (event.kind === 9735) recordZapToSparkSdk(event);
       }
+    }
+    preEoseBuffer.length = 0;
+
+    if (parsed.length > 0) {
+      notifications.addBulk(parsed);
     }
   });
 

--- a/src/routes/explore/+page.svelte
+++ b/src/routes/explore/+page.svelte
@@ -46,6 +46,7 @@
   let cookingToolsTipEl: HTMLDivElement | null = null;
   let tipPointerX = '2.5rem';
   let tipTop = '0.5rem';
+  let tipLeft = '0.75rem';
   let tipPointerScheduled = false;
   $: showCookingToolsTip = $cookingToolsTipVisible;
   function dismissCookingToolsTip() {
@@ -88,12 +89,28 @@
     const anchorRect = anchor.getBoundingClientRect();
     const anchorCenter = anchorRect.left + anchorRect.width / 2;
     const arrowOffset = 16;
-    const rawPointerX = anchorCenter - tipRect.left;
+
+    // Preferred arrow inset from the tip's left edge
+    const arrowInset = 28;
+    const leftMargin = 8;
+    const rightMargin = 12;
+    const viewportWidth = window.innerWidth;
+
+    // Position the balloon so the arrow lands on the anchor center
+    const idealLeft = anchorCenter - arrowInset;
+    const clampedLeft = Math.min(
+      Math.max(idealLeft, leftMargin),
+      viewportWidth - tipRect.width - rightMargin
+    );
+
+    // Recalculate the arrow's actual offset within the (possibly clamped) balloon
+    const actualPointerX = anchorCenter - clampedLeft;
     const minPointerX = 18;
     const maxPointerX = Math.max(minPointerX, tipRect.width - 18);
 
     tipTop = `${Math.max(anchorRect.bottom + arrowOffset, 8)}px`;
-    tipPointerX = `${Math.min(Math.max(rawPointerX, minPointerX), maxPointerX)}px`;
+    tipLeft = `${clampedLeft}px`;
+    tipPointerX = `${Math.min(Math.max(actualPointerX, minPointerX), maxPointerX)}px`;
   }
 
   $: if (showCookingToolsTip) {
@@ -587,7 +604,7 @@
       <div
         bind:this={cookingToolsTipEl}
         class="flex items-start gap-3 p-4 cooking-tools-tip"
-        style={`--tip-pointer-x: ${tipPointerX}; --tip-top: ${tipTop};`}
+        style={`--tip-pointer-x: ${tipPointerX}; --tip-top: ${tipTop}; --tip-left: ${tipLeft};`}
       >
         <span class="text-2xl flex-shrink-0" aria-hidden="true">🍳</span>
         <div class="flex-1 min-w-0">
@@ -658,7 +675,7 @@
   .cooking-tools-tip {
     position: absolute;
     top: var(--tip-top, 0.5rem);
-    right: 0.75rem;
+    left: var(--tip-left, 0.75rem);
     max-width: min(260px, 78vw);
     border-radius: 18px;
     border: 2px solid var(--tip-border);


### PR DESCRIPTION
## Summary

- **Wallet QR codes**: Added `max-w-xs` to both the on-chain address and Lightning invoice QR wrappers so they don't stretch to the full modal width on larger screens
- **Notification freeze on /explore**: Fixed an O(n²) performance spike that froze the page on load for users with many historical notifications
- **Kitchen tip balloon**: Fixed arrow pointer not aligning with the pot icon — balloon is now positioned dynamically so the arrow lands on the anchor instead of being clamped to the balloon's far-left edge

## Notification fix detail

`subscribeToNotifications` previously called `notifications.add()` for every incoming event during initial EOSE, which triggered a full sort + `JSON.stringify` + `localStorage.setItem` per event. For an active user with hundreds of reactions/zaps/replies from the past 7 days, this meant hundreds of synchronous writes on the main thread — enough to freeze the UI for several seconds.

The fix buffers all pre-EOSE events and calls `addBulk()` once after EOSE fires (one sort, one localStorage write). Post-EOSE realtime events still use individual `add()` calls, which is fine since they arrive one at a time.

## Test plan

- [ ] Open wallet modal → verify on-chain QR and Lightning QR are reasonably sized (not full-width)
- [ ] Navigate to `/explore` as a logged-in user with notifications — page should load without freezing
- [ ] Verify notifications still populate correctly in the bell dropdown after load
- [ ] Open `/explore` and confirm the kitchen tip balloon arrow points at the pot icon