### PR TITLE
fix(nwc): reject malformed connection strings and normalize npub pubkeys

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.513",
+  "version": "4.2.514",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/wallet/nwc.ts
+++ b/src/lib/wallet/nwc.ts
@@ -35,14 +35,22 @@ export function parseNwcUrl(url: string): { pubkey: string; relay: string; secre
 	try {
 		// CRITICAL: Trim whitespace, newlines, and any invisible characters
 		// Without this, pasted URLs with trailing newlines cause relay connection timeouts
-		let cleaned = url.trim().replace(/[\r\n\t]/g, '')
+		const cleaned_input = url.trim().replace(/[\r\n\t]/g, '')
 
-		// Handle both formats: with and without //
-		cleaned = cleaned
-			.replace('nostr+walletconnect://', '')
-			.replace('nostrwalletconnect://', '')
-			.replace('nostr+walletconnect:', '')
-			.replace('nostrwalletconnect:', '')
+		// Reject anything that doesn't begin with a recognised NWC scheme.
+		// A non-anchored replace would silently swallow leading garbage text
+		// and produce a corrupted pubkey, so we gate hard here first.
+		if (!/^nostr(?:\+walletconnect)?:\/\//i.test(cleaned_input) &&
+		    !/^nostrwalletconnect:/i.test(cleaned_input)) {
+			return null
+		}
+
+		// Strip the scheme to get pubkey?params
+		let cleaned = cleaned_input
+			.replace(/^nostr\+walletconnect:\/\//i, '')
+			.replace(/^nostrwalletconnect:\/\//i, '')
+			.replace(/^nostr\+walletconnect:/i, '')
+			.replace(/^nostrwalletconnect:/i, '')
 
 		const [pubkey, queryString] = cleaned.split('?')
 
@@ -59,7 +67,14 @@ export function parseNwcUrl(url: string): { pubkey: string; relay: string; secre
 			return null
 		}
 
-		return { pubkey: pubkey.trim(), relay, secret, lud16 }
+		// Normalize pubkey: accept npub1… bech32 or raw 64-char hex
+		const normalizedPubkey = normalizePubkey(pubkey.trim())
+		if (!/^[0-9a-fA-F]{64}$/.test(normalizedPubkey)) {
+			console.error('[NWC] Invalid pubkey in connection string:', pubkey.trim())
+			return null
+		}
+
+		return { pubkey: normalizedPubkey, relay, secret, lud16 }
 	} catch (e) {
 		console.error('[NWC] Failed to parse connection URL:', e)
 		return null
@@ -71,6 +86,23 @@ export function parseNwcUrl(url: string): { pubkey: string; relay: string; secre
  */
 export function isValidNwcUrl(url: string): boolean {
 	return parseNwcUrl(url) !== null
+}
+
+/**
+ * Normalize public key to hex format
+ * Handles both raw 64-char hex and npub1 bech32 format
+ */
+function normalizePubkey(pubkey: string): string {
+	const cleaned = pubkey.trim()
+	if (cleaned.startsWith('npub1')) {
+		try {
+			const decoded = nip19.decode(cleaned)
+			if (decoded.type === 'npub') return decoded.data as string
+		} catch (e) {
+			console.error('[NWC] Failed to decode npub:', e)
+		}
+	}
+	return cleaned
 }
 
 /**


### PR DESCRIPTION
## Summary

Two hardening fixes for NWC connection string parsing:

- **Leading-text rejection**: `parseNwcUrl` now gates on an anchored scheme check (`^nostr+walletconnect://`) before stripping the prefix. Previously a non-anchored `.replace()` would find the protocol mid-string and silently discard everything before it, producing a corrupted pubkey that caused a `"second arg must be public key"` crypto error at wallet info / balance fetch time.

- **npub pubkey normalization**: Added `normalizePubkey()` (mirrors the existing `normalizeSecretKey()` for `nsec`) to decode `npub1…` bech32 pubkeys to raw 32-byte hex. Some wallet providers (e.g. Yakihonne) embed the pubkey in bech32 format in the connection string.

Both are caught in `parseNwcUrl` before the parsed result is returned, so `isValidNwcUrl()` now correctly rejects bad input with the existing UI error message rather than letting a broken wallet get added.

## Test plan

- [ ] Paste a valid `nostr+walletconnect://…` string → connects successfully
- [ ] Paste a string with leading text (e.g. `"Here is your string: nostr+walletconnect://…"`) → shows "Invalid NWC connection string" error
- [ ] Paste a connection string where the pubkey is `npub1…` format → parses and connects correctly
- [ ] Wallet info / balance fetch works after connecting with a Yakihonne-issued string