### PR TITLE
fix(wallet): validate mnemonic format before attempting Spark restore

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.514",
+  "version": "4.2.515",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/wallet/WalletPanel.svelte
+++ b/src/components/wallet/WalletPanel.svelte
@@ -2233,9 +2233,19 @@
       return;
     }
 
-    const mnemonic = restoreMnemonicInput.trim();
+    const mnemonic = restoreMnemonicInput.trim().toLowerCase().replace(/\s+/g, ' ');
     if (!mnemonic) {
       errorMessage = 'Please enter your recovery phrase';
+      return;
+    }
+
+    const words = mnemonic.split(' ');
+    if (![12, 15, 18, 21, 24].includes(words.length)) {
+      errorMessage = `Recovery phrases must be 12, 15, 18, 21, or 24 words (you entered ${words.length})`;
+      return;
+    }
+    if (!words.every((w) => /^[a-z]+$/.test(w))) {
+      errorMessage = 'Recovery phrase contains invalid characters — enter BIP-39 words only';
       return;
     }
 


### PR DESCRIPTION
## Summary

Adds early client-side validation to the recovery phrase input before calling `restoreFromMnemonic`, so users get a clear inline error immediately rather than an opaque SDK exception after the spinner appears.

**Checks added:**
- Normalizes the input (trim, lowercase, collapse whitespace) to be forgiving of copy-paste artifacts
- Word count must be 12, 15, 18, 21, or 24 — error message includes the actual count
- All words must be lowercase alphabetic (catches leading text, numbers, punctuation)

The same checks already exist inside `spark/index.ts → validateMnemonic()` as a last-resort guard; this just surfaces them earlier with friendlier messages.

## Test plan

- [ ] Enter a valid 12-word phrase → restores successfully
- [ ] Paste extra leading text with the phrase → shows word-count error immediately, spinner never appears
- [ ] Enter a phrase with numbers or punctuation → shows invalid-characters error
- [ ] Enter 11 or 13 words → shows word-count error with actual count