### PR TITLE
feat(cheffy): first-use experience invite on /explore

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.522",
+  "version": "4.2.523",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.521",
+  "version": "4.2.522",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.520",
+  "version": "4.2.521",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/CheffyExploreInvite.svelte
+++ b/src/components/CheffyExploreInvite.svelte
@@ -30,16 +30,15 @@
   const DISMISS_KEY = 'zapcooking:cheffy-experience-dismissed:v1';
   const REVEAL_DELAY_MS = 6500;
 
-  // Quick chips — each opens Cheffy and sends one discovery prompt.
+  // Quick chips — each opens Cheffy and sends one actionable prompt that
+  // returns something useful (a real recipe), not just a conversation.
   const CHIPS: { label: string; prompt: string; mode: 'chat' | 'hungry' }[] = [
-    { label: 'Quick dinner', prompt: 'I need a quick dinner idea.', mode: 'chat' },
+    { label: 'Recipe for chicken', prompt: 'Give me a recipe for chicken.', mode: 'chat' },
     {
-      label: 'Use what I have',
-      prompt: 'Help me make something with what I already have at home.',
+      label: 'Quick weeknight dinner',
+      prompt: 'Give me a quick weeknight dinner recipe I can make in about 30 minutes.',
       mode: 'chat'
     },
-    { label: 'Healthy', prompt: 'I want something healthy for dinner.', mode: 'chat' },
-    { label: 'Comfort food', prompt: "I'm in the mood for comfort food.", mode: 'chat' },
     { label: 'Surprise me', prompt: '', mode: 'hungry' }
   ];
 

--- a/src/components/CheffyExploreInvite.svelte
+++ b/src/components/CheffyExploreInvite.svelte
@@ -1,0 +1,378 @@
+<script lang="ts">
+  /**
+   * First-use Cheffy experience invite — Explore page only.
+   *
+   * Product principle: do NOT sell Cheffy before the visitor experiences
+   * Cheffy. This is a gentle, dismissible nudge that lets a logged-out
+   * visitor or a logged-in non-member feel one helpful Cheffy interaction
+   * first; the membership pitch only appears AFTER Cheffy responds (the
+   * conversion card lives in the messenger). It deliberately never says
+   * "free question", "trial", or "limited access".
+   *
+   *  - Desktop (≥1024px): small floating card, bottom-right.
+   *  - Mobile/tablet: bottom sheet.
+   * Non-blocking, keyboard accessible, respects reduced motion. Shown
+   * after a short delay or when the visitor scrolls near the
+   * "What are you cooking?" area, and never again once dismissed/used.
+   */
+  import { onMount, onDestroy, tick } from 'svelte';
+  import { browser } from '$app/environment';
+  import { userPublickey } from '$lib/nostr';
+  import {
+    membershipStatusMap,
+    queueMembershipLookup,
+    type MembershipStatus
+  } from '$lib/stores/membershipStatus';
+  import { startCheffyExperience, cheffyExperienceUsed } from '$lib/stores/cheffyChat';
+  import CheffyAvatar from './CheffyAvatar.svelte';
+  import XIcon from 'phosphor-svelte/lib/X';
+
+  const DISMISS_KEY = 'zapcooking:cheffy-experience-dismissed:v1';
+  const REVEAL_DELAY_MS = 6500;
+
+  // Quick chips — each opens Cheffy and sends one discovery prompt.
+  const CHIPS: { label: string; prompt: string; mode: 'chat' | 'hungry' }[] = [
+    { label: 'Quick dinner', prompt: 'I need a quick dinner idea.', mode: 'chat' },
+    {
+      label: 'Use what I have',
+      prompt: 'Help me make something with what I already have at home.',
+      mode: 'chat'
+    },
+    { label: 'Healthy', prompt: 'I want something healthy for dinner.', mode: 'chat' },
+    { label: 'Comfort food', prompt: "I'm in the mood for comfort food.", mode: 'chat' },
+    { label: 'Surprise me', prompt: '', mode: 'hungry' }
+  ];
+
+  let dismissed = browser ? localStorage.getItem(DISMISS_KEY) === '1' : true;
+  let engaged = false; // started the experience this session → hide
+  let revealed = false; // delay/scroll trigger has fired
+  let draft = '';
+  let inputEl: HTMLInputElement;
+
+  // ── Membership: only non-members are eligible ───────────────────
+  let membershipMap: Record<string, MembershipStatus> = {};
+  const unsub = membershipStatusMap.subscribe((v) => (membershipMap = v));
+  $: if ($userPublickey) queueMembershipLookup($userPublickey);
+  $: normalizedPk = String($userPublickey || '')
+    .trim()
+    .toLowerCase();
+  $: isMember = Boolean($userPublickey && membershipMap[normalizedPk]?.active);
+
+  // Logged-out OR logged-in non-member, not dismissed, not already used.
+  $: eligible = !isMember && !dismissed && !engaged && !$cheffyExperienceUsed;
+  $: visible = revealed && eligible;
+
+  let revealTimer: ReturnType<typeof setTimeout>;
+  let io: IntersectionObserver | undefined;
+
+  function reveal() {
+    revealed = true;
+  }
+
+  function persistDismiss() {
+    if (!browser) return;
+    try {
+      localStorage.setItem(DISMISS_KEY, '1');
+    } catch {
+      // storage blocked — invite simply reappears next session
+    }
+  }
+
+  function dismiss() {
+    dismissed = true;
+    persistDismiss();
+  }
+
+  async function start(prompt: string, mode: 'chat' | 'hungry') {
+    engaged = true; // hide the invite; the messenger takes over
+    persistDismiss(); // don't re-nudge after they've engaged
+    await tick();
+    startCheffyExperience(prompt, mode);
+  }
+
+  function helpMeCook() {
+    const text = draft.trim();
+    // Empty input → a "surprise me" recipe still gives a useful answer.
+    if (text) start(text, 'chat');
+    else start('', 'hungry');
+  }
+
+  function onInputKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      helpMeCook();
+    }
+  }
+
+  function onCardKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      dismiss();
+    }
+  }
+
+  onMount(() => {
+    if (!browser) return;
+    revealTimer = setTimeout(reveal, REVEAL_DELAY_MS);
+
+    // Reveal early if the visitor scrolls near the "What are you cooking?"
+    // area (anchored on the Explore page).
+    const anchor = document.querySelector('[data-cheffy-invite-anchor]');
+    if (anchor && 'IntersectionObserver' in window) {
+      io = new IntersectionObserver(
+        (entries) => {
+          if (entries.some((e) => e.isIntersecting)) reveal();
+        },
+        { root: document.getElementById('app-scroll'), threshold: 0.15 }
+      );
+      io.observe(anchor);
+    }
+  });
+
+  onDestroy(() => {
+    unsub();
+    if (revealTimer) clearTimeout(revealTimer);
+    io?.disconnect();
+  });
+</script>
+
+{#if visible}
+  <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+  <aside class="invite" aria-labelledby="cheffy-invite-title" on:keydown={onCardKeydown}>
+    <button type="button" class="invite-close" aria-label="Dismiss" on:click={dismiss}>
+      <XIcon size={16} weight="bold" />
+    </button>
+
+    <div class="invite-head">
+      <CheffyAvatar size={30} expression="happy" />
+      <h2 id="cheffy-invite-title" class="invite-title">Need dinner ideas?</h2>
+    </div>
+    <p class="invite-body">Cheffy can help you find something worth cooking.</p>
+
+    <div class="invite-input-row">
+      <label class="sr-only" for="cheffy-invite-input">What are you hungry for?</label>
+      <input
+        id="cheffy-invite-input"
+        bind:this={inputEl}
+        bind:value={draft}
+        type="text"
+        class="invite-input"
+        placeholder="What are you hungry for?"
+        on:keydown={onInputKeydown}
+        maxlength="200"
+      />
+    </div>
+
+    <div class="invite-chips" role="group" aria-label="Quick ideas">
+      {#each CHIPS as chip}
+        <button type="button" class="invite-chip" on:click={() => start(chip.prompt, chip.mode)}>
+          {chip.label}
+        </button>
+      {/each}
+    </div>
+
+    <div class="invite-actions">
+      <button type="button" class="invite-primary" on:click={helpMeCook}>Help me cook</button>
+      <button type="button" class="invite-ghost" on:click={dismiss}>Keep exploring</button>
+    </div>
+  </aside>
+{/if}
+
+<style>
+  .invite {
+    position: fixed;
+    z-index: 50;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    background-color: var(--color-bg-secondary);
+    color: var(--color-text-primary);
+    border: 1px solid var(--color-input-border);
+
+    /* Mobile/tablet: bottom sheet. */
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 18px 18px calc(18px + env(safe-area-inset-bottom, 0px));
+    border-radius: 18px 18px 0 0;
+    box-shadow: 0 -10px 32px rgba(0, 0, 0, 0.22);
+    animation: invite-slide-up 240ms ease-out;
+  }
+
+  /* Desktop: compact floating card, bottom-right. */
+  @media (min-width: 1024px) {
+    .invite {
+      left: auto;
+      right: 1.5rem;
+      bottom: 1.5rem;
+      width: 340px;
+      padding: 18px;
+      border-radius: 18px;
+      box-shadow:
+        0 18px 48px rgba(0, 0, 0, 0.28),
+        0 4px 12px rgba(0, 0, 0, 0.16);
+      animation: invite-pop 180ms ease-out;
+    }
+  }
+
+  .invite-close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 999px;
+    border: 0;
+    background: transparent;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    transition: background-color 140ms ease;
+  }
+  .invite-close:hover {
+    background-color: var(--color-input-bg);
+  }
+
+  .invite-head {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    padding-right: 32px;
+  }
+  .invite-title {
+    font-size: 1.05rem;
+    font-weight: 700;
+    margin: 0;
+  }
+  .invite-body {
+    font-size: 0.9rem;
+    line-height: 1.4;
+    color: var(--color-text-secondary);
+    margin: 0;
+  }
+
+  .invite-input {
+    width: 100%;
+    min-height: 44px;
+    padding: 11px 14px;
+    border-radius: 12px;
+    border: 1px solid var(--color-input-border);
+    background-color: var(--color-input-bg);
+    color: var(--color-text-primary);
+    font-size: 16px; /* ≥16px avoids iOS zoom-on-focus */
+    line-height: 1.35;
+  }
+  .invite-input:focus {
+    outline: none;
+    border-color: var(--color-primary);
+  }
+
+  .invite-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 7px;
+  }
+  .invite-chip {
+    min-height: 36px;
+    padding: 0 13px;
+    border-radius: 999px;
+    border: 1px solid var(--color-input-border);
+    background-color: var(--color-bg-primary);
+    color: var(--color-text-primary);
+    font-size: 0.84rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition:
+      border-color 140ms ease,
+      background-color 140ms ease;
+  }
+  .invite-chip:hover {
+    border-color: var(--color-primary);
+    background-color: color-mix(in srgb, var(--color-primary) 8%, transparent);
+  }
+
+  .invite-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 2px;
+  }
+  .invite-primary {
+    flex: 1;
+    min-height: 44px;
+    padding: 0 18px;
+    border-radius: 999px;
+    border: 0;
+    background-color: var(--color-primary);
+    color: #fff;
+    font-weight: 600;
+    font-size: 0.92rem;
+    cursor: pointer;
+    transition: filter 140ms ease;
+  }
+  .invite-primary:hover {
+    filter: brightness(1.06);
+  }
+  .invite-ghost {
+    min-height: 44px;
+    padding: 0 14px;
+    border-radius: 999px;
+    border: 0;
+    background: transparent;
+    color: var(--color-text-secondary);
+    font-weight: 600;
+    font-size: 0.9rem;
+    cursor: pointer;
+  }
+  .invite-ghost:hover {
+    color: var(--color-text-primary);
+  }
+
+  .invite-close:focus-visible,
+  .invite-chip:focus-visible,
+  .invite-primary:focus-visible,
+  .invite-ghost:focus-visible,
+  .invite-input:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary) 45%, transparent);
+  }
+
+  @keyframes invite-slide-up {
+    from {
+      transform: translateY(100%);
+    }
+    to {
+      transform: translateY(0);
+    }
+  }
+  @keyframes invite-pop {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .invite {
+      animation: none;
+    }
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+</style>

--- a/src/components/CheffyMessenger.svelte
+++ b/src/components/CheffyMessenger.svelte
@@ -79,6 +79,14 @@
   // Re-assert preview mode so follow-up sends stay tagged as experience
   // requests (e.g. after a mid-chat reload, where the flag would reset).
   $: if (inExperience && !$cheffyExperienceMode) cheffyExperienceMode.set(true);
+  // If membership resolves true mid-session, drop the preview flags so a
+  // new member never lands on a blank surface (conversion card hidden by
+  // `inExperience`, composer hidden by `$cheffyConversion`) and their
+  // sends are no longer tagged as a preview.
+  $: if (hasMembership && ($cheffyConversion !== null || $cheffyExperienceMode)) {
+    cheffyConversion.set(null);
+    cheffyExperienceMode.set(false);
+  }
   // Opening Cheffy again after the experience was spent (e.g. via the
   // launcher) lands on the friendly card, never a technical wall.
   $: if (
@@ -537,7 +545,8 @@
 
                   <!-- Context-aware follow-ups: only under the latest
                        response, never while a turn is in flight, and not
-                       during the single-shot preview. -->
+                       during the non-member preview (the composer carries
+                       the preview turns). -->
                   {#if m.id === lastMsgId && !$cheffyLoading && !inExperience && (m.kind === 'text' || m.kind === 'recipe')}
                     <div class="context-row">
                       <CheffySuggestionChips
@@ -555,9 +564,10 @@
         {/if}
 
         {#if inExperience && $cheffyConversion}
-          <!-- Soft conversion card — invites the visitor to create a free
-               kitchen or unlock Kitchen+ after one helpful Cheffy answer.
-               Never a paywall: this is the gentle next step. -->
+          <!-- Soft conversion card — shown once the preview turns are
+               spent (or when the experience was already used): invites the
+               visitor to create a free kitchen or unlock Kitchen+. Never a
+               paywall — this is the gentle next step. -->
           <div class="conversion" role="group" aria-label="Keep cooking with Cheffy">
             <CheffyAvatar size={44} expression="happy" variant="character" />
             {#if $cheffyConversion === 'used'}

--- a/src/components/CheffyMessenger.svelte
+++ b/src/components/CheffyMessenger.svelte
@@ -30,6 +30,7 @@
     cheffyAnnounce,
     cheffyExperienceMode,
     cheffyExperienceUsed,
+    cheffyExperienceCount,
     cheffyConversion,
     sendCheffy,
     retryCheffy,
@@ -68,12 +69,16 @@
 
   // ── First-use experience (non-member preview) ───────────────────
   // A non-member (logged out OR logged-in without a membership) who
-  // entered via the /explore invite, or who has already spent their
-  // experience, sees the preview flow + a soft conversion card instead
+  // entered via the /explore invite, or who has any preview turns spent
+  // (so a mid-chat reload keeps them in the preview rather than dropping
+  // to the gate), sees the preview flow + a soft conversion card instead
   // of the hard sign-in / membership gate. Members are never affected.
   $: inExperience =
     !hasMembership &&
-    ($cheffyExperienceMode || $cheffyExperienceUsed || $cheffyConversion !== null);
+    ($cheffyExperienceMode || $cheffyExperienceCount > 0 || $cheffyConversion !== null);
+  // Re-assert preview mode so follow-up sends stay tagged as experience
+  // requests (e.g. after a mid-chat reload, where the flag would reset).
+  $: if (inExperience && !$cheffyExperienceMode) cheffyExperienceMode.set(true);
   // Opening Cheffy again after the experience was spent (e.g. via the
   // launcher) lands on the friendly card, never a technical wall.
   $: if (
@@ -482,7 +487,7 @@
     {:else}
       <!-- Conversation -->
       <div class="cheffy-list" bind:this={listEl}>
-        {#if $cheffyThread.length === 0 && !inExperience}
+        {#if $cheffyThread.length === 0 && !$cheffyConversion}
           <!-- Minimal welcome — the starter chips live above the
                composer, not here, so users can also just start typing. -->
           <div class="welcome">
@@ -596,9 +601,9 @@
       </div>
 
       <!-- Starter suggestions — a single scrollable row directly above
-           the composer; removed once the conversation begins. Hidden in
-           the single-shot preview. -->
-      {#if $cheffyThread.length === 0 && !inExperience}
+           the composer; removed once the conversation begins or the
+           conversion card takes over. -->
+      {#if $cheffyThread.length === 0 && !$cheffyConversion}
         <div class="starter-row">
           <CheffySuggestionChips
             suggestions={STARTER_SUGGESTIONS}
@@ -608,28 +613,33 @@
         </div>
       {/if}
 
-      {#if !inExperience}
+      <!-- Composer — usable during a member chat and during the preview
+           turns; replaced by the conversion card once they're spent. -->
+      {#if !$cheffyConversion}
       <!-- Fixed composer -->
       <div class="cheffy-composer">
         {#if scanError}
           <p class="scan-error" role="alert">{scanError}</p>
         {/if}
         <div class="composer-row">
-          <button
-            type="button"
-            class="composer-icon"
-            aria-label="Add ingredients, photo, or recipe"
-            aria-haspopup="menu"
-            aria-expanded={attachOpen}
-            on:click|stopPropagation={() => (attachOpen = !attachOpen)}
-            disabled={isScanning}
-          >
-            {#if isScanning}
-              <ArrowsClockwiseIcon size={20} class="animate-spin" />
-            {:else}
-              <PaperclipIcon size={20} />
-            {/if}
-          </button>
+          {#if !inExperience}
+            <!-- Attach (scan / photo / paste) is a member-only tool. -->
+            <button
+              type="button"
+              class="composer-icon"
+              aria-label="Add ingredients, photo, or recipe"
+              aria-haspopup="menu"
+              aria-expanded={attachOpen}
+              on:click|stopPropagation={() => (attachOpen = !attachOpen)}
+              disabled={isScanning}
+            >
+              {#if isScanning}
+                <ArrowsClockwiseIcon size={20} class="animate-spin" />
+              {:else}
+                <PaperclipIcon size={20} />
+              {/if}
+            </button>
+          {/if}
           <label class="sr-only" for="cheffy-composer-input">Message Cheffy</label>
           <textarea
             id="cheffy-composer-input"
@@ -657,6 +667,7 @@
         </div>
       </div>
 
+      {#if !inExperience}
       <!-- Hidden file inputs for scan/photo/upload -->
       <input
         bind:this={cameraInput}
@@ -698,6 +709,7 @@
             <LinkIcon size={20} /> Import a link
           </button>
         </div>
+      {/if}
       {/if}
       {/if}
     {/if}

--- a/src/components/CheffyMessenger.svelte
+++ b/src/components/CheffyMessenger.svelte
@@ -28,6 +28,9 @@
     cheffyLoading,
     cheffyDraft,
     cheffyAnnounce,
+    cheffyExperienceMode,
+    cheffyExperienceUsed,
+    cheffyConversion,
     sendCheffy,
     retryCheffy,
     startOverCheffy,
@@ -62,6 +65,41 @@
     .toLowerCase();
   $: signedIn = $userPublickey !== '';
   $: hasMembership = Boolean(membershipMap[normalizedPk]?.active);
+
+  // ── First-use experience (non-member preview) ───────────────────
+  // A non-member (logged out OR logged-in without a membership) who
+  // entered via the /explore invite, or who has already spent their
+  // experience, sees the preview flow + a soft conversion card instead
+  // of the hard sign-in / membership gate. Members are never affected.
+  $: inExperience =
+    !hasMembership &&
+    ($cheffyExperienceMode || $cheffyExperienceUsed || $cheffyConversion !== null);
+  // Opening Cheffy again after the experience was spent (e.g. via the
+  // launcher) lands on the friendly card, never a technical wall.
+  $: if (
+    $cheffyOpen &&
+    inExperience &&
+    $cheffyExperienceUsed &&
+    $cheffyThread.length === 0 &&
+    $cheffyConversion === null
+  ) {
+    cheffyConversion.set('used');
+  }
+  // Gates apply only outside the experience flow.
+  $: showSignInGate = !inExperience && !signedIn;
+  $: showMembershipGate = !inExperience && signedIn && !hasMembership;
+
+  function convCreateKitchen() {
+    closeCheffy();
+    goto('/login?redirect=/explore');
+  }
+  function convUnlockKitchenPlus() {
+    closeCheffy();
+    goto('/membership');
+  }
+  function convKeepExploring() {
+    closeCheffy();
+  }
 
   // ── Layout mode ────────────────────────────────────────────────
   let isDesktop = false; // ≥1024px → non-modal floating panel
@@ -407,7 +445,7 @@
       </div>
     </header>
 
-    {#if !signedIn}
+    {#if showSignInGate}
       <!-- Sign-in gate -->
       <div class="cheffy-gate">
         <CheffyAvatar size={72} expression="neutral" variant="character" />
@@ -424,7 +462,7 @@
           Sign in
         </button>
       </div>
-    {:else if !hasMembership}
+    {:else if showMembershipGate}
       <!-- Membership gate -->
       <div class="cheffy-gate">
         <CheffyAvatar size={72} expression="neutral" variant="character" />
@@ -444,7 +482,7 @@
     {:else}
       <!-- Conversation -->
       <div class="cheffy-list" bind:this={listEl}>
-        {#if $cheffyThread.length === 0}
+        {#if $cheffyThread.length === 0 && !inExperience}
           <!-- Minimal welcome — the starter chips live above the
                composer, not here, so users can also just start typing. -->
           <div class="welcome">
@@ -493,8 +531,9 @@
                   {/if}
 
                   <!-- Context-aware follow-ups: only under the latest
-                       response, never while a turn is in flight. -->
-                  {#if m.id === lastMsgId && !$cheffyLoading && (m.kind === 'text' || m.kind === 'recipe')}
+                       response, never while a turn is in flight, and not
+                       during the single-shot preview. -->
+                  {#if m.id === lastMsgId && !$cheffyLoading && !inExperience && (m.kind === 'text' || m.kind === 'recipe')}
                     <div class="context-row">
                       <CheffySuggestionChips
                         compact
@@ -509,11 +548,57 @@
             {/if}
           {/each}
         {/if}
+
+        {#if inExperience && $cheffyConversion}
+          <!-- Soft conversion card — invites the visitor to create a free
+               kitchen or unlock Kitchen+ after one helpful Cheffy answer.
+               Never a paywall: this is the gentle next step. -->
+          <div class="conversion" role="group" aria-label="Keep cooking with Cheffy">
+            <CheffyAvatar size={44} expression="happy" variant="character" />
+            {#if $cheffyConversion === 'used'}
+              <h3 class="conv-title">Cheffy already helped you get started</h3>
+              <p class="conv-body">
+                Create your free kitchen to save ideas, or unlock Kitchen+ to keep cooking with
+                Cheffy.
+              </p>
+            {:else if signedIn}
+              <h3 class="conv-title">Keep cooking with Cheffy</h3>
+              <p class="conv-body">
+                Kitchen+ gives you Cheffy, Nourish, saved drafts, recipe tools, and more ways to
+                build your kitchen.
+              </p>
+            {:else}
+              <h3 class="conv-title">Save this to your kitchen</h3>
+              <p class="conv-body">
+                Create a free Zap Cooking account to save meals, follow cooks, and come back to what
+                Cheffy helped you make.
+              </p>
+            {/if}
+            <div class="conv-actions">
+              {#if !signedIn}
+                <button type="button" class="conv-primary" on:click={convCreateKitchen}>
+                  Create your free kitchen
+                </button>
+                <button type="button" class="conv-secondary" on:click={convUnlockKitchenPlus}>
+                  Unlock Kitchen+
+                </button>
+              {:else}
+                <button type="button" class="conv-primary" on:click={convUnlockKitchenPlus}>
+                  Unlock Kitchen+
+                </button>
+              {/if}
+              <button type="button" class="conv-ghost" on:click={convKeepExploring}>
+                Keep exploring
+              </button>
+            </div>
+          </div>
+        {/if}
       </div>
 
       <!-- Starter suggestions — a single scrollable row directly above
-           the composer; removed once the conversation begins. -->
-      {#if $cheffyThread.length === 0}
+           the composer; removed once the conversation begins. Hidden in
+           the single-shot preview. -->
+      {#if $cheffyThread.length === 0 && !inExperience}
         <div class="starter-row">
           <CheffySuggestionChips
             suggestions={STARTER_SUGGESTIONS}
@@ -523,6 +608,7 @@
         </div>
       {/if}
 
+      {#if !inExperience}
       <!-- Fixed composer -->
       <div class="cheffy-composer">
         {#if scanError}
@@ -612,6 +698,7 @@
             <LinkIcon size={20} /> Import a link
           </button>
         </div>
+      {/if}
       {/if}
     {/if}
   </div>
@@ -1116,6 +1203,77 @@
     font-weight: 600;
     font-size: 0.95rem;
     cursor: pointer;
+  }
+
+  /* ── Soft conversion card (post-experience) ────────────────── */
+  .conversion {
+    margin: 6px auto 4px;
+    width: 100%;
+    max-width: 30ch;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    text-align: center;
+    padding: 18px 16px;
+    border-radius: 16px;
+    background-color: var(--color-bg-secondary);
+    border: 1px solid var(--color-input-border);
+  }
+  .conv-title {
+    font-size: 1.05rem;
+    font-weight: 700;
+    margin: 0;
+    color: var(--color-text-primary);
+  }
+  .conv-body {
+    font-size: 0.88rem;
+    line-height: 1.45;
+    color: var(--color-text-secondary);
+    margin: 0;
+  }
+  .conv-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: 100%;
+    margin-top: 4px;
+  }
+  .conv-primary,
+  .conv-secondary,
+  .conv-ghost {
+    min-height: 44px;
+    padding: 0 18px;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 0.9rem;
+    cursor: pointer;
+  }
+  .conv-primary {
+    border: 0;
+    background-color: var(--color-primary);
+    color: #fff;
+    transition: filter 140ms ease;
+  }
+  .conv-primary:hover {
+    filter: brightness(1.06);
+  }
+  .conv-secondary {
+    background: transparent;
+    border: 1px solid var(--color-primary);
+    color: var(--color-primary);
+    transition: background-color 140ms ease;
+  }
+  .conv-secondary:hover {
+    background-color: color-mix(in srgb, var(--color-primary) 10%, transparent);
+  }
+  .conv-ghost {
+    background: transparent;
+    border: 0;
+    color: var(--color-text-secondary);
+  }
+  .conv-ghost:hover {
+    color: var(--color-text-primary);
   }
 
   @keyframes cheffy-fade {

--- a/src/lib/stores/cheffyChat.ts
+++ b/src/lib/stores/cheffyChat.ts
@@ -324,6 +324,10 @@ export function startOverCheffy() {
   cheffyDraft.set('');
   cheffyStarted.set(false);
   cheffyConversion.set(null);
+  // Drop preview tagging on reset; the messenger re-asserts it for a
+  // non-member still in the preview, but a member who started one and
+  // then upgraded gets clean multi-turn history again.
+  cheffyExperienceMode.set(false);
   lastTurn = null;
   cheffyAnnounce.set('Conversation cleared.');
 }

--- a/src/lib/stores/cheffyChat.ts
+++ b/src/lib/stores/cheffyChat.ts
@@ -9,7 +9,7 @@
  * Multi-turn is session-only: the live thread is re-sent on each request
  * and never persisted to disk or Nostr.
  */
-import { writable, get } from 'svelte/store';
+import { writable, derived, get } from 'svelte/store';
 import { browser } from '$app/environment';
 import { userPublickey } from '$lib/nostr';
 import {
@@ -62,35 +62,60 @@ export function dismissCheffyHint() {
 }
 
 // ── First-use experience ("experience", never "free question") ──
-// A non-member (logged out OR logged in without an active membership)
-// may use Cheffy ONCE from the /explore invite as a controlled preview.
-// The server is the real gate (HttpOnly cookie); these stores drive the
-// in-messenger preview UI and the soft conversion card that follows.
-const EXPERIENCE_USED_KEY = 'zapcooking:cheffy-experience-used:v1';
+// A non-member (logged out OR logged in without an active membership) may
+// chat with Cheffy a few times from the /explore invite as a controlled
+// preview, so they get a real back-and-forth before any membership pitch.
+// The server is the real gate (HttpOnly cookie counter); these stores
+// mirror it to drive the preview UI and the soft conversion card.
+export const EXPERIENCE_MAX_TURNS = 3;
+const EXPERIENCE_COUNT_KEY = 'zapcooking:cheffy-experience-used:v1';
 
-/** True once this device has consumed its Cheffy experience. Persisted. */
-export const cheffyExperienceUsed = writable<boolean>(
-  browser ? localStorage.getItem(EXPERIENCE_USED_KEY) === '1' : false
+function readExperienceCount(): number {
+  if (!browser) return 0;
+  const n = parseInt(localStorage.getItem(EXPERIENCE_COUNT_KEY) || '0', 10);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+/** Preview answers this device has spent. Persisted; mirrors the cookie. */
+export const cheffyExperienceCount = writable<number>(readExperienceCount());
+
+/** True once every preview turn is spent. */
+export const cheffyExperienceUsed = derived(
+  cheffyExperienceCount,
+  ($count) => $count >= EXPERIENCE_MAX_TURNS
 );
 
 /** True while the current messenger session is a non-member preview. */
 export const cheffyExperienceMode = writable(false);
 
 /** Which soft conversion card to show inside the messenger, or null.
- *  'response' = after the first helpful preview answer;
- *  'used'     = the experience was already spent. */
+ *  'response' = after the preview turns are spent;
+ *  'used'     = the experience was already spent before this session. */
 export type CheffyConversion = null | 'response' | 'used';
 export const cheffyConversion = writable<CheffyConversion>(null);
 
-function markExperienceUsed() {
-  cheffyExperienceUsed.set(true);
-  if (browser) {
-    try {
-      localStorage.setItem(EXPERIENCE_USED_KEY, '1');
-    } catch {
-      // storage blocked — the server cookie still enforces one use
-    }
+function persistExperienceCount(count: number) {
+  if (!browser) return;
+  try {
+    localStorage.setItem(EXPERIENCE_COUNT_KEY, String(count));
+  } catch {
+    // storage blocked — the server cookie still enforces the cap
   }
+}
+
+/** Record one spent preview answer. */
+function recordExperienceTurn() {
+  cheffyExperienceCount.update((c) => {
+    const next = c + 1;
+    persistExperienceCount(next);
+    return next;
+  });
+}
+
+/** Force the spent state when the server says the preview is used up. */
+function markExperienceExhausted() {
+  cheffyExperienceCount.set(EXPERIENCE_MAX_TURNS);
+  persistExperienceCount(EXPERIENCE_MAX_TURNS);
 }
 
 // ── Conversation state ──────────────────────────────────────────
@@ -177,8 +202,7 @@ async function dispatchTurn(
         prompt: promptForApi,
         mode,
         pubkey: get(userPublickey),
-        // Previews are single-shot — never send prior turns.
-        messages: isExperience ? [] : apiHistory,
+        messages: apiHistory,
         ...(isExperience ? { experience: true } : {})
       })
     });
@@ -187,7 +211,7 @@ async function dispatchTurn(
     // Experience already spent — swap the pending bubble for the friendly
     // conversion card rather than surfacing a technical error.
     if (data?.code === 'CHEFFY_EXPERIENCE_USED') {
-      markExperienceUsed();
+      markExperienceExhausted();
       cheffyThread.update((t) => t.filter((m) => m.id !== pendingId));
       cheffyConversion.set('used');
       cheffyAnnounce.set('Cheffy already helped you get started.');
@@ -212,11 +236,14 @@ async function dispatchTurn(
     );
     cheffyAnnounce.set(isRecipe ? 'Cheffy shared a recipe.' : 'Cheffy replied.');
 
-    // First helpful preview answer → spend the experience and invite the
-    // visitor to create a free kitchen or unlock Kitchen+.
+    // Spend one preview turn. Only invite the visitor to create a free
+    // kitchen or unlock Kitchen+ once all preview turns are used up — let
+    // them actually chat with Cheffy first.
     if (isExperience) {
-      markExperienceUsed();
-      cheffyConversion.set('response');
+      recordExperienceTurn();
+      if (get(cheffyExperienceCount) >= EXPERIENCE_MAX_TURNS) {
+        cheffyConversion.set('response');
+      }
     }
   } catch (err) {
     const detail = err instanceof Error ? err.message : 'Cheffy could not respond.';

--- a/src/lib/stores/cheffyChat.ts
+++ b/src/lib/stores/cheffyChat.ts
@@ -61,6 +61,38 @@ export function dismissCheffyHint() {
   }
 }
 
+// ── First-use experience ("experience", never "free question") ──
+// A non-member (logged out OR logged in without an active membership)
+// may use Cheffy ONCE from the /explore invite as a controlled preview.
+// The server is the real gate (HttpOnly cookie); these stores drive the
+// in-messenger preview UI and the soft conversion card that follows.
+const EXPERIENCE_USED_KEY = 'zapcooking:cheffy-experience-used:v1';
+
+/** True once this device has consumed its Cheffy experience. Persisted. */
+export const cheffyExperienceUsed = writable<boolean>(
+  browser ? localStorage.getItem(EXPERIENCE_USED_KEY) === '1' : false
+);
+
+/** True while the current messenger session is a non-member preview. */
+export const cheffyExperienceMode = writable(false);
+
+/** Which soft conversion card to show inside the messenger, or null.
+ *  'response' = after the first helpful preview answer;
+ *  'used'     = the experience was already spent. */
+export type CheffyConversion = null | 'response' | 'used';
+export const cheffyConversion = writable<CheffyConversion>(null);
+
+function markExperienceUsed() {
+  cheffyExperienceUsed.set(true);
+  if (browser) {
+    try {
+      localStorage.setItem(EXPERIENCE_USED_KEY, '1');
+    } catch {
+      // storage blocked — the server cookie still enforces one use
+    }
+  }
+}
+
 // ── Conversation state ──────────────────────────────────────────
 export const cheffyThread = writable<ChatMessage[]>([]);
 export const cheffyLoading = writable(false);
@@ -119,6 +151,9 @@ async function dispatchTurn(
   expectRecipe: boolean
 ) {
   cheffyLoading.set(true);
+  // Captured per-turn: a preview request never leaks prior turns and is
+  // tagged so the server can apply the controlled experience path.
+  const isExperience = get(cheffyExperienceMode);
   const statusLine = pickLine(expectRecipe ? COOKING_LINES : THINKING_LINES, lastStatusLine);
   lastStatusLine = statusLine;
   const pendingId = nextId();
@@ -142,10 +177,23 @@ async function dispatchTurn(
         prompt: promptForApi,
         mode,
         pubkey: get(userPublickey),
-        messages: apiHistory
+        // Previews are single-shot — never send prior turns.
+        messages: isExperience ? [] : apiHistory,
+        ...(isExperience ? { experience: true } : {})
       })
     });
     const data = await resp.json();
+
+    // Experience already spent — swap the pending bubble for the friendly
+    // conversion card rather than surfacing a technical error.
+    if (data?.code === 'CHEFFY_EXPERIENCE_USED') {
+      markExperienceUsed();
+      cheffyThread.update((t) => t.filter((m) => m.id !== pendingId));
+      cheffyConversion.set('used');
+      cheffyAnnounce.set('Cheffy already helped you get started.');
+      return;
+    }
+
     if (!resp.ok || !data.ok) {
       throw new Error(data.error || 'Cheffy could not respond.');
     }
@@ -163,6 +211,13 @@ async function dispatchTurn(
       )
     );
     cheffyAnnounce.set(isRecipe ? 'Cheffy shared a recipe.' : 'Cheffy replied.');
+
+    // First helpful preview answer → spend the experience and invite the
+    // visitor to create a free kitchen or unlock Kitchen+.
+    if (isExperience) {
+      markExperienceUsed();
+      cheffyConversion.set('response');
+    }
   } catch (err) {
     const detail = err instanceof Error ? err.message : 'Cheffy could not respond.';
     cheffyThread.update((t) =>
@@ -207,6 +262,23 @@ export async function sendCheffy(content: string, mode: 'chat' | 'hungry' = 'cha
   );
 }
 
+/**
+ * Enter the first-use experience from the /explore invite. Opens the
+ * messenger as a non-member preview and sends the one prompt. If this
+ * device already spent its experience, skips the API and shows the soft
+ * conversion card instead of a paywall.
+ */
+export function startCheffyExperience(content: string, mode: 'chat' | 'hungry' = 'chat') {
+  cheffyExperienceMode.set(true);
+  cheffyConversion.set(null);
+  openCheffy();
+  if (get(cheffyExperienceUsed)) {
+    cheffyConversion.set('used');
+    return;
+  }
+  void sendCheffy(content, mode);
+}
+
 export async function retryCheffy() {
   if (get(cheffyLoading) || !lastTurn) return;
   cheffyThread.update((t) => t.filter((m) => m.kind !== 'error'));
@@ -224,6 +296,7 @@ export function startOverCheffy() {
   cheffyThread.set([]);
   cheffyDraft.set('');
   cheffyStarted.set(false);
+  cheffyConversion.set(null);
   lastTurn = null;
   cheffyAnnounce.set('Conversation cleared.');
 }

--- a/src/routes/api/zappy/+server.ts
+++ b/src/routes/api/zappy/+server.ts
@@ -133,13 +133,16 @@ const HUNGRY_PROMPT = `Surprise me with a complete recipe! It could be any cuisi
 const MAX_HISTORY_TURNS = 12;
 const MAX_HISTORY_MESSAGE_CHARS = 4000;
 
-// First-use "experience" — a single controlled preview for non-members,
-// initiated from the /explore invite. Deliberately NOT a "free question"
-// or "trial": it is a smaller, single-shot discovery answer. One use per
-// device is enforced with an HttpOnly cookie (localStorage alone is not
-// trusted). The endpoint fails CLOSED — non-members get nothing unless
-// the request is an explicit, allowed experience request.
+// First-use "experience" — a short controlled preview chat for
+// non-members, initiated from the /explore invite. Deliberately NOT a
+// "free question" or "trial": it is a handful of smaller discovery
+// answers so the visitor gets a real back-and-forth. The turn count is
+// enforced with an HttpOnly cookie (localStorage alone is not trusted).
+// The endpoint fails CLOSED — non-members get nothing unless the request
+// is an explicit, allowed experience request.
 const EXPERIENCE_COOKIE = 'zapcooking_cheffy_experience_used';
+const EXPERIENCE_MAX_TURNS = 3;
+const EXPERIENCE_MAX_HISTORY = 6; // ~3 prior exchanges of context
 const EXPERIENCE_MAX_PROMPT_CHARS = 750;
 const EXPERIENCE_MAX_TOKENS = 700;
 const EXPERIENCE_COOKIE_MAX_AGE = 60 * 60 * 24 * 180; // ~180 days
@@ -180,6 +183,7 @@ export const POST: RequestHandler = async ({ request, platform, cookies }) => {
     // reach Cheffy — and only once per device. `experienceGranted` stays
     // false for members, so their answers keep full depth.
     let experienceGranted = false;
+    let experienceCount = 0; // preview turns already spent on this device
     const MEMBERSHIP_ENABLED = platform?.env?.MEMBERSHIP_ENABLED || env.MEMBERSHIP_ENABLED;
     if (MEMBERSHIP_ENABLED?.toLowerCase() === 'true') {
       // Best-effort membership determination. Fail OPEN only for a
@@ -212,8 +216,11 @@ export const POST: RequestHandler = async ({ request, platform, cookies }) => {
             { status: 403 }
           );
         }
-        // One preview per device (HttpOnly cookie — not client-trusted).
-        if (cookies.get(EXPERIENCE_COOKIE) === '1') {
+        // A few preview turns per device (HttpOnly cookie counter — not
+        // client-trusted). Once spent, invite them to convert.
+        const prior = parseInt(cookies.get(EXPERIENCE_COOKIE) || '0', 10);
+        experienceCount = Number.isFinite(prior) && prior > 0 ? prior : 0;
+        if (experienceCount >= EXPERIENCE_MAX_TURNS) {
           return json(
             {
               ok: false,
@@ -241,10 +248,11 @@ export const POST: RequestHandler = async ({ request, platform, cookies }) => {
       );
     }
 
-    // Sanitize optional conversation history (ignored for format mode and
-    // for the single-shot experience preview).
+    // Sanitize optional conversation history (ignored for format mode).
+    // The preview keeps a short window so Cheffy can follow the chat.
     let history: { role: 'user' | 'assistant'; content: string }[] = [];
-    if (!isFormatMode && !experienceGranted && Array.isArray(body.messages)) {
+    if (!isFormatMode && Array.isArray(body.messages)) {
+      const turnLimit = experienceGranted ? EXPERIENCE_MAX_HISTORY : MAX_HISTORY_TURNS;
       history = body.messages
         .filter(
           (m: any) =>
@@ -253,7 +261,7 @@ export const POST: RequestHandler = async ({ request, platform, cookies }) => {
             typeof m.content === 'string' &&
             m.content.trim().length > 0
         )
-        .slice(-MAX_HISTORY_TURNS)
+        .slice(-turnLimit)
         .map((m: any) => ({
           role: m.role,
           content: String(m.content).slice(0, MAX_HISTORY_MESSAGE_CHARS)
@@ -310,10 +318,10 @@ export const POST: RequestHandler = async ({ request, platform, cookies }) => {
       );
     }
 
-    // Spend the one-use preview only on a successful answer, so a failed
+    // Count a preview turn only on a successful answer, so a failed
     // attempt never burns the visitor's experience.
     if (experienceGranted) {
-      cookies.set(EXPERIENCE_COOKIE, '1', {
+      cookies.set(EXPERIENCE_COOKIE, String(experienceCount + 1), {
         path: '/',
         httpOnly: true,
         sameSite: 'lax',

--- a/src/routes/api/zappy/+server.ts
+++ b/src/routes/api/zappy/+server.ts
@@ -133,7 +133,18 @@ const HUNGRY_PROMPT = `Surprise me with a complete recipe! It could be any cuisi
 const MAX_HISTORY_TURNS = 12;
 const MAX_HISTORY_MESSAGE_CHARS = 4000;
 
-export const POST: RequestHandler = async ({ request, platform }) => {
+// First-use "experience" — a single controlled preview for non-members,
+// initiated from the /explore invite. Deliberately NOT a "free question"
+// or "trial": it is a smaller, single-shot discovery answer. One use per
+// device is enforced with an HttpOnly cookie (localStorage alone is not
+// trusted). The endpoint fails CLOSED — non-members get nothing unless
+// the request is an explicit, allowed experience request.
+const EXPERIENCE_COOKIE = 'zapcooking_cheffy_experience_used';
+const EXPERIENCE_MAX_PROMPT_CHARS = 750;
+const EXPERIENCE_MAX_TOKENS = 700;
+const EXPERIENCE_COOKIE_MAX_AGE = 60 * 60 * 24 * 180; // ~180 days
+
+export const POST: RequestHandler = async ({ request, platform, cookies }) => {
   try {
     // Check for OpenAI API key
     const OPENAI_API_KEY = (platform?.env as any)?.OPENAI_API_KEY || env.OPENAI_API_KEY;
@@ -143,6 +154,7 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 
     const body = await request.json();
     const { prompt, mode = 'prompt', pubkey } = body;
+    const isExperience = body.experience === true;
 
     // Validate mode. "chat" and "prompt" are aliases for the
     // conversational path; "prompt" is kept for any older callers.
@@ -162,8 +174,66 @@ export const POST: RequestHandler = async ({ request, platform }) => {
       );
     }
 
-    // Limit prompt length (format mode allows longer input for pasted recipes)
-    const maxPromptLength = isFormatMode ? 10000 : 2000;
+    // Membership gate (Cheffy is a Pro Kitchen feature) with a single
+    // controlled "experience" preview for non-members. Members are
+    // unaffected. The experience path is the ONLY way a non-member can
+    // reach Cheffy — and only once per device. `experienceGranted` stays
+    // false for members, so their answers keep full depth.
+    let experienceGranted = false;
+    const MEMBERSHIP_ENABLED = platform?.env?.MEMBERSHIP_ENABLED || env.MEMBERSHIP_ENABLED;
+    if (MEMBERSHIP_ENABLED?.toLowerCase() === 'true') {
+      // Best-effort membership determination. Fail OPEN only for a
+      // verifiable, pubkey-bearing caller during a membership-service
+      // outage (preserves prior behavior); never for a missing pubkey.
+      let isMember = false;
+      if (pubkey && typeof pubkey === 'string' && pubkey.trim()) {
+        const API_SECRET = platform?.env?.RELAY_API_SECRET || env.RELAY_API_SECRET;
+        if (!API_SECRET) {
+          // No secret configured — preserve prior fall-through (allow).
+          isMember = true;
+        } else {
+          try {
+            const { hasActiveMembership } = await import('$lib/membershipApi.server');
+            isMember = await hasActiveMembership(pubkey, API_SECRET);
+          } catch (err) {
+            console.error('[Cheffy] Error checking membership:', err);
+            isMember = true; // outage: fail open for a pubkey-bearing caller
+          }
+        }
+      }
+
+      if (!isMember) {
+        // Non-members get the controlled discovery preview only — never
+        // recipe formatting, image scanning, or other advanced tools.
+        const experienceModeAllowed = mode === 'chat' || mode === 'prompt' || mode === 'hungry';
+        if (!isExperience || !experienceModeAllowed) {
+          return json(
+            { ok: false, error: 'Cheffy is available to Pro Kitchen members.' },
+            { status: 403 }
+          );
+        }
+        // One preview per device (HttpOnly cookie — not client-trusted).
+        if (cookies.get(EXPERIENCE_COOKIE) === '1') {
+          return json(
+            {
+              ok: false,
+              code: 'CHEFFY_EXPERIENCE_USED',
+              error: 'Create your free kitchen or unlock Kitchen+ to keep cooking with Cheffy.'
+            },
+            { status: 200 }
+          );
+        }
+        experienceGranted = true;
+      }
+    }
+
+    // Limit prompt length. Experience previews are capped tighter; format
+    // mode allows longer input for pasted recipes.
+    const maxPromptLength = experienceGranted
+      ? EXPERIENCE_MAX_PROMPT_CHARS
+      : isFormatMode
+        ? 10000
+        : 2000;
     if (prompt && prompt.length > maxPromptLength) {
       return json(
         { ok: false, error: `Input is too long (max ${maxPromptLength} characters)` },
@@ -171,9 +241,10 @@ export const POST: RequestHandler = async ({ request, platform }) => {
       );
     }
 
-    // Sanitize optional conversation history (ignored for format mode).
+    // Sanitize optional conversation history (ignored for format mode and
+    // for the single-shot experience preview).
     let history: { role: 'user' | 'assistant'; content: string }[] = [];
-    if (!isFormatMode && Array.isArray(body.messages)) {
+    if (!isFormatMode && !experienceGranted && Array.isArray(body.messages)) {
       history = body.messages
         .filter(
           (m: any) =>
@@ -187,36 +258,6 @@ export const POST: RequestHandler = async ({ request, platform }) => {
           role: m.role,
           content: String(m.content).slice(0, MAX_HISTORY_MESSAGE_CHARS)
         }));
-    }
-
-    // Check membership status (Pro Kitchen feature). Fail CLOSED when
-    // gating is enabled but the caller sent no pubkey — otherwise a
-    // non-member could reach this paid endpoint just by omitting it.
-    const MEMBERSHIP_ENABLED = platform?.env?.MEMBERSHIP_ENABLED || env.MEMBERSHIP_ENABLED;
-    if (MEMBERSHIP_ENABLED?.toLowerCase() === 'true') {
-      if (!pubkey || typeof pubkey !== 'string' || !pubkey.trim()) {
-        return json(
-          { ok: false, error: 'Cheffy is available to Pro Kitchen members.' },
-          { status: 403 }
-        );
-      }
-      const API_SECRET = platform?.env?.RELAY_API_SECRET || env.RELAY_API_SECRET;
-      if (API_SECRET) {
-        try {
-          const { hasActiveMembership } = await import('$lib/membershipApi.server');
-          const isActive = await hasActiveMembership(pubkey, API_SECRET);
-          if (!isActive) {
-            return json(
-              { ok: false, error: 'Cheffy is available to Pro Kitchen members.' },
-              { status: 403 }
-            );
-          }
-        } catch (err) {
-          console.error('[Cheffy] Error checking membership:', err);
-          // Fail open ONLY for membership-service outages, not for a
-          // missing pubkey (handled above).
-        }
-      }
     }
 
     // Determine the user prompt and system instruction based on mode
@@ -244,7 +285,8 @@ export const POST: RequestHandler = async ({ request, platform }) => {
       body: JSON.stringify({
         model: 'gpt-4.1-mini',
         messages,
-        max_tokens: 2048,
+        // Previews stay useful but intentionally lighter than full depth.
+        max_tokens: experienceGranted ? EXPERIENCE_MAX_TOKENS : 2048,
         temperature: isFormatMode ? 0.3 : 0.8
       })
     });
@@ -266,6 +308,18 @@ export const POST: RequestHandler = async ({ request, platform }) => {
         { ok: false, error: 'Cheffy went quiet for a second. Please try again.' },
         { status: 500 }
       );
+    }
+
+    // Spend the one-use preview only on a successful answer, so a failed
+    // attempt never burns the visitor's experience.
+    if (experienceGranted) {
+      cookies.set(EXPERIENCE_COOKIE, '1', {
+        path: '/',
+        httpOnly: true,
+        sameSite: 'lax',
+        secure: true,
+        maxAge: EXPERIENCE_COOKIE_MAX_AGE
+      });
     }
 
     return json({

--- a/src/routes/api/zappy/+server.ts
+++ b/src/routes/api/zappy/+server.ts
@@ -147,7 +147,7 @@ const EXPERIENCE_MAX_PROMPT_CHARS = 750;
 const EXPERIENCE_MAX_TOKENS = 700;
 const EXPERIENCE_COOKIE_MAX_AGE = 60 * 60 * 24 * 180; // ~180 days
 
-export const POST: RequestHandler = async ({ request, platform, cookies }) => {
+export const POST: RequestHandler = async ({ request, platform, cookies, url }) => {
   try {
     // Check for OpenAI API key
     const OPENAI_API_KEY = (platform?.env as any)?.OPENAI_API_KEY || env.OPENAI_API_KEY;
@@ -227,7 +227,7 @@ export const POST: RequestHandler = async ({ request, platform, cookies }) => {
               code: 'CHEFFY_EXPERIENCE_USED',
               error: 'Create your free kitchen or unlock Kitchen+ to keep cooking with Cheffy.'
             },
-            { status: 200 }
+            { status: 429 }
           );
         }
         experienceGranted = true;
@@ -319,13 +319,17 @@ export const POST: RequestHandler = async ({ request, platform, cookies }) => {
     }
 
     // Count a preview turn only on a successful answer, so a failed
-    // attempt never burns the visitor's experience.
+    // attempt never burns the visitor's experience. Derive `secure` from
+    // the request protocol so the turn cap also holds over plain HTTP
+    // (local dev / staging) while staying Secure in production.
     if (experienceGranted) {
+      const isHttps =
+        url.protocol === 'https:' || request.headers.get('x-forwarded-proto') === 'https';
       cookies.set(EXPERIENCE_COOKIE, String(experienceCount + 1), {
         path: '/',
         httpOnly: true,
         sameSite: 'lax',
-        secure: true,
+        secure: isHttps,
         maxAge: EXPERIENCE_COOKIE_MAX_AGE
       });
     }

--- a/src/routes/explore/+page.svelte
+++ b/src/routes/explore/+page.svelte
@@ -19,6 +19,7 @@
   import LongformFoodFeed from '../../components/LongformFoodFeed.svelte';
   import LandingImportHero from '../../components/LandingImportHero.svelte';
   import CheffyHomeCard from '../../components/CheffyHomeCard.svelte';
+  import CheffyExploreInvite from '../../components/CheffyExploreInvite.svelte';
   import type { NDKEvent } from '@nostr-dev-kit/ndk';
   import { nip19 } from 'nostr-tools';
   import { init, markOnce } from '$lib/perf/explorePerf';
@@ -532,7 +533,7 @@
       </section>
 
       <!-- What are you cooking? — Intent Cards -->
-      <section class="flex flex-col gap-3">
+      <section class="flex flex-col gap-3" data-cheffy-invite-anchor>
         <h2 class="text-lg font-semibold" style="color: var(--color-text-primary);">
           What are you cooking?
         </h2>
@@ -596,6 +597,9 @@
     </div>
   </div>
 </PullToRefresh>
+
+<!-- First-use Cheffy experience invite (non-members only; self-gating) -->
+<CheffyExploreInvite />
 
 <!-- One-time Cooking Tools tip (4.2 first-60-seconds) -->
 {#if showCookingToolsTip}


### PR DESCRIPTION
## What

A light **first-time Cheffy experience gate** on `/explore`. The principle: don't sell Cheffy before the visitor experiences Cheffy. A logged-out visitor or logged-in non-member gets a short **multi-turn preview chat** with Cheffy, then a soft invitation to create a free kitchen or unlock Kitchen+.

It's an *experience* gate, not a question gate — no "free question", "trial", or "limited access" copy appears before Cheffy responds.

## How it works

- **`CheffyExploreInvite.svelte`** (new) — dismissible floating card (desktop, bottom-right) / bottom sheet (mobile). Shown **only to non-members**, after ~6.5s or when the visitor scrolls near "What are you cooking?". Keyboard accessible, respects reduced motion, uses design tokens. Dismissal/use persisted in `localStorage`. Chips are 3 actionable, recipe-yielding prompts:
  - "Recipe for chicken" → *Give me a recipe for chicken.*
  - "Quick weeknight dinner" → *Give me a quick weeknight dinner recipe I can make in about 30 minutes.*
  - "Surprise me" → existing hungry/recipe mode.
- **`cheffyChat.ts`** — experience-mode + conversion-card state and a **preview turn counter** (mirrored to `localStorage`). `startCheffyExperience()` opens the messenger and sends the first prompt; the visitor can keep chatting until the turns are spent, then the conversion card appears. A server `CHEFFY_EXPERIENCE_USED` reply becomes a friendly card, not an error.
- **`/api/zappy`** — non-members are still blocked **unless `experience: true`**. Experience requests allow only `chat`/`hungry` (no formatting, scanning, or advanced tools), cap the prompt + token budget, and keep a short history window so Cheffy follows the chat. The turn cap (**3 per device**) is enforced server-side via an **HttpOnly cookie counter**, incremented only on a successful answer (a failed attempt never burns a turn). Member behavior is unchanged; the membership check still fails closed.
- **`CheffyMessenger.svelte`** — in preview mode it bypasses the sign-in/membership gates and keeps the composer usable for the allowed turns (attach/scan stays member-only), then shows a soft conversion card whose copy varies by signed-in state (logged-out → "Create your free kitchen" + "Unlock Kitchen+"; logged-in non-member → "Unlock Kitchen+"; already-used → friendly Cheffy message). A mid-chat reload keeps the visitor in the preview (based on the persisted turn count) rather than dropping them to the hard gate.

## Gating preserved

- `/cheffy` full page remains gated for non-members.
- Active Kitchen+ / Pro / Founder members never see the invite or the experience restrictions.
- No existing membership check weakened except the clearly-defined `experience: true` path.

## Verification

- `pnpm check` → **0 errors** (122 pre-existing warnings, none in changed files).
- Existing Cheffy unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)