### PR TITLE
fix(profile): upload banners without square-cropping them

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.520",
+  "version": "4.2.521",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/ProfileEditModal.svelte
+++ b/src/components/ProfileEditModal.svelte
@@ -293,7 +293,15 @@
   }
 
   async function uploadImage(file: File, type: 'picture' | 'banner'): Promise<string | null> {
-    const url = 'https://nostr.build/api/v2/upload/profile';
+    // Avatars use nostr.build's profile endpoint, which crops to a square pfp.
+    // Banners must NOT be square-cropped — that endpoint squares the image
+    // regardless of the NIP-96 `media_type` hint, which is why banners came
+    // out pfp-shaped. Route banners through the general media endpoint, which
+    // preserves the uploaded aspect ratio (same endpoint the composer uses).
+    const url =
+      type === 'picture'
+        ? 'https://nostr.build/api/v2/upload/profile'
+        : 'https://nostr.build/api/v2/upload/files';
 
     // Validate file
     if (!file.type.startsWith('image/')) {


### PR DESCRIPTION
## Summary

Profile **banner** uploads came out square (pfp-shaped) because the profile editor sent banners to nostr.build's `/api/v2/upload/profile` endpoint, which crops to a square profile picture. The NIP-96 `media_type='banner'` hint added in #423-era work isn't honored by that endpoint (its advertised `media_transformations.image` is just resize/convert/compress — no avatar/banner cropping), so banners kept getting square-cropped.

## Fix

Route **banner** uploads through the general `/api/v2/upload/files` endpoint — the same one the composer uses — which preserves the uploaded aspect ratio. **Avatars** stay on `/upload/profile`, where a square crop is the correct behavior.

```js
const url =
  type === 'picture'
    ? 'https://nostr.build/api/v2/upload/profile'  // square pfp crop
    : 'https://nostr.build/api/v2/upload/files';    // preserves aspect ratio
```

The NIP-98 auth `['u', url]` tag and the `data[0].url` response parsing already key off the same `url` variable, so both paths stay consistent. The avatar-only uploader in `src/routes/user/[slug]/+page.svelte` was checked and is unaffected.

## Test plan

1. Open the profile editor and upload a **wide** banner image → it stays wide (no longer square-cropped).
2. Upload an avatar → still correctly square-cropped.
