### PR TITLE
fix(profile+notifications): banner upload crop, notification bell All tab, read-state styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.524",
+  "version": "4.2.525",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.520",
+  "version": "4.2.521",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.523",
+  "version": "4.2.524",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/NotificationBell.svelte
+++ b/src/components/NotificationBell.svelte
@@ -138,10 +138,7 @@
         .filter((n) => n.type === 'comment' || n.type === 'mention')
         .map((n) => ({ kind: 'notification' as const, notification: n }));
     } else {
-      list = [
-        ...sortedNotifs.map((n) => ({ kind: 'notification' as const, notification: n })),
-        ...dmRows.map((dm) => ({ kind: 'dm' as const, ...dm }))
-      ].sort((a, b) => rowTimestamp(b) - rowTimestamp(a));
+      list = sortedNotifs.map((n) => ({ kind: 'notification' as const, notification: n }));
     }
     return list.slice(0, MAX_PREVIEW);
   })();

--- a/src/components/ParsedBio.svelte
+++ b/src/components/ParsedBio.svelte
@@ -176,7 +176,7 @@
   }
 </script>
 
-<span class={class_}>
+<span class={class_} style="white-space: pre-wrap;">
   {#if loading}
     <span class="opacity-50">{text}</span>
   {:else}

--- a/src/components/ProfileEditModal.svelte
+++ b/src/components/ProfileEditModal.svelte
@@ -584,7 +584,7 @@
        (clipped via the dialog's overflow-hidden); bottom is squared so
        the banner sits flush against the avatar / form below instead of
        carving an awkward curve into the modal content area. -->
-  <div class="relative h-40 overflow-hidden -mx-2 md:-mx-8 -mt-6" style="background-color: var(--color-input-bg);">
+  <div class="relative h-40 overflow-hidden -mx-4 md:-mx-8 -mt-6" style="background-color: var(--color-input-bg);">
     {#if formData.banner}
       <img src={formData.banner} alt="Banner" class="w-full h-full object-cover" />
     {:else}

--- a/src/components/ProfileEditModal.svelte
+++ b/src/components/ProfileEditModal.svelte
@@ -293,7 +293,15 @@
   }
 
   async function uploadImage(file: File, type: 'picture' | 'banner'): Promise<string | null> {
-    const url = 'https://nostr.build/api/v2/upload/profile';
+    // Avatars use nostr.build's profile endpoint, which crops to a square pfp.
+    // Banners must NOT be square-cropped — that endpoint squares the image
+    // regardless of the NIP-96 `media_type` hint, which is why banners came
+    // out pfp-shaped. Route banners through the general media endpoint, which
+    // preserves the uploaded aspect ratio (same endpoint the composer uses).
+    const url =
+      type === 'picture'
+        ? 'https://nostr.build/api/v2/upload/profile'
+        : 'https://nostr.build/api/v2/upload/files';
 
     // Validate file
     if (!file.type.startsWith('image/')) {

--- a/src/lib/notificationStore.ts
+++ b/src/lib/notificationStore.ts
@@ -484,9 +484,9 @@ function parseNotification(event: NDKEvent, userPubkey: string): Notification | 
     }
 
     case 1: { // Reply or mention
-      // NIP-10: Distinguish replies from mentions.
-      // A reply has e tags with 'reply'/'root' markers or uses deprecated positional e tags.
-      // A mention is a standalone post that p-tags the user but has no e tags (not in a thread).
+      // NIP-10: events with e-tags are replies in a thread; events without are standalone notes.
+      // Both types p-tag the user — "mention" here means no thread context, "comment" means
+      // there is one. The Mentions UI tab shows both types (any note that tagged you).
       const eTags = event.tags.filter((t) => t[0] === 'e');
       const isReply = eTags.length > 0;
 

--- a/src/routes/notifications/+page.svelte
+++ b/src/routes/notifications/+page.svelte
@@ -777,7 +777,7 @@
             <button
               on:click={() => item.kind === 'single' ? handleNotificationClick(item.notification) : handleGroupedClick(item)}
               class="notif-row"
-              class:notif-read={isRead}
+              class:notif-unread={!isRead}
               class:notif-zap-accent={isLargeZap(item)}
             >
               <!-- Left gutter: icon + avatar -->
@@ -902,8 +902,11 @@
   .notif-row:hover {
     background-color: var(--color-input-bg);
   }
-  .notif-read {
-    opacity: 0.55;
+  .notif-unread {
+    background-color: color-mix(in srgb, #f97316 6%, transparent);
+  }
+  .notif-unread:hover {
+    background-color: color-mix(in srgb, #f97316 10%, transparent);
   }
   .notif-zap-accent {
     border-left: 2.5px solid #f59e0b;

--- a/src/routes/notifications/+page.svelte
+++ b/src/routes/notifications/+page.svelte
@@ -157,7 +157,7 @@
     if (activeTab === 'all') return true;
     if (activeTab === 'zaps') return n.type === 'zap';
     if (activeTab === 'replies') return n.type === 'comment';
-    if (activeTab === 'mentions') return n.type === 'mention';
+    if (activeTab === 'mentions') return n.type === 'mention' || n.type === 'comment';
     return true;
   });
 


### PR DESCRIPTION
## Summary

- **Profile banners** — `ProfileEditModal` no longer forces a square crop when uploading a banner image; the full aspect ratio is preserved
- **Profile banner mobile layout** — banner negative margin corrected from `-mx-2` to `-mx-4` to match the modal's `px-4` mobile padding, so it fills edge-to-edge on small screens
- **Bio newlines** — `ParsedBio` now renders `\n` characters as actual line breaks (`white-space: pre-wrap`) instead of collapsing bios into a wall of text
- **Notification bell All tab** — previously merged Nostr notifications *and* DMs, making the full Notifications page appear blank when the user only had DM activity; All tab now shows only Nostr notifications (reactions, zaps, replies, reposts, mentions), matching what `/notifications` displays — DMs remain in the dedicated DMs tab
- **Notification read-state** — replaced the aggressive 55% opacity dim on read rows with a subtle orange tint on *unread* rows, consistent with the bell dropdown's existing treatment
- **Mentions tab** — previously only showed standalone notes with no thread context (almost always empty); now shows all notes that p-tagged you, matching how other Nostr clients define a mention

## Test plan

- [ ] Upload a wide/landscape banner image on the profile edit modal — confirm it is not cropped to a square
- [ ] On mobile, open the profile edit modal — confirm the banner fills the full width with no side gaps
- [ ] View a profile with a multi-line bio — confirm line breaks render correctly
- [ ] With only DM activity (no recent reactions/zaps/replies), open the bell: All tab should be empty; DMs tab should show conversations — `/notifications` should also be empty (no false "broken" impression)
- [ ] With Nostr notifications present, open the bell All tab — confirm reactions/zaps/replies appear; DMs do not appear in All tab
- [ ] On `/notifications`, unread rows should have a faint orange background tint; read rows should display at full opacity with no tint
- [ ] Switch to the Mentions tab — confirm it shows notes where you were p-tagged, including those inside reply threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)