### PR TITLE
fix(nip46): remote signers (Primal) stamp events with signer pubkey, breaking uploads/zaps/auth

### DIFF
--- a/docs/troubleshooting/NIP46_REMOTE_SIGNER_SIGNING.md
+++ b/docs/troubleshooting/NIP46_REMOTE_SIGNER_SIGNING.md
@@ -1,0 +1,106 @@
+# NIP-46 Remote Signer — Events Signed With the Wrong Pubkey
+
+**Status:** Fixed
+**Affected:** Users logged in via a NIP-46 remote signer whose **signer pubkey differs from their user pubkey** — most notably **Primal** remote signing. Local keys (nsec), NIP-07 extensions, and Amber are **not** affected.
+**Core fix:** `src/lib/authManager.ts` (`bindUserToSigner`)
+**Related hardening:** `src/lib/mediaUpload.ts` + `MediaUploader.svelte`, `ImageUploader.svelte`, `ProfileEditModal.svelte`
+
+---
+
+## Symptoms
+
+For users on an affected remote signer, anything that produced a **signed Nostr event** failed, usually silently:
+
+- **Image uploads** to nostr.build returned `401 Unauthorized, please provide a valid nip-98 token`.
+- **Zaps** failed (the zap request, kind `9734`, is a signed event rejected by the LNURL callback / relays).
+- **Relay NIP-42 auth** failed: `error: failed to authenticate`.
+- Notes (kind `1`), reactions, and other publishes would be rejected by relays for an invalid signature.
+
+The console showed an upload like this (diagnostics, since removed):
+
+```
+[NIP98-DEBUG] {"pubkey":"fe3faf63…c2cb43d", … ,"idMatches":true,"sigValid":false}
+nostr.build/api/v2/upload/files:1  Failed to load resource: 401
+```
+
+`idMatches: true` (the event id is consistent with its fields) but `sigValid: false` (the signature does not verify), and the `pubkey` is the **signer/bunker** key — not the user's.
+
+## Root cause
+
+The bug lives in how NDK's `NDKNip46Signer` reports the signing user, combined with how `NDKEvent` stamps an event's author.
+
+1. **`NDKNip46Signer` initializes `remoteUser` to the signer (bunker) pubkey** in its constructor and **never updates it** — not even after a successful `connect`/`blockUntilReady`:
+
+   ```js
+   // node_modules/@nostr-dev-kit/ndk — NDKNip46Signer
+   this.remoteUser = new NDKUser({ pubkey: remotePubkey }); // remotePubkey = SIGNER pubkey
+   …
+   async user() { return this.remoteUser; }
+   ```
+
+2. **`NDKEvent.toNostrEvent()` derives the author from `signer.user()`** when the event has no pubkey set:
+
+   ```js
+   if (!pubkey && this.pubkey === "") {
+     const user = await this.ndk?.signer?.user();
+     this.pubkey = user?.pubkey || "";
+   }
+   ```
+
+3. So every event we sign is **stamped with the signer's pubkey**, while the bunker actually signs with the **user's** key. The resulting event claims `pubkey = <signer>` but carries a signature valid for `<user>`. Any verifier (nostr.build, relays, LNURL callbacks) recomputes the id, checks the signature against the stated pubkey, and rejects it.
+
+### Why only Primal / why it was invisible elsewhere
+
+NIP-46 explicitly allows the **signer pubkey to differ from the user pubkey**. Primal's remote signer uses this: the bunker key (`fe3faf…`) is not the user key (`ee6ea1…`). For signers where the two are equal (local nsec, NIP-07, Amber), stamping the "signer" pubkey coincidentally produces the correct value, so the bug never manifested.
+
+The app compounds it: Primal's `connect` handshake is rejected (`We don't accept connect requests with new secret`), so `blockUntilReady()` times out. The app recovers by calling `get_public_key` to learn the real user pubkey and logs the user in — but that pubkey was **never propagated onto the signer object**, so `signer.user()` kept returning the bunker pubkey.
+
+## The fix
+
+After the real user pubkey is known (via `get_public_key`), bind it onto the signer and NDK so all downstream signing uses it. `remotePubkey` (the RPC routing target sent to the bunker) is deliberately left untouched.
+
+```ts
+// src/lib/authManager.ts
+private bindUserToSigner(user: NDKUser): void {
+  if (this.nip46Signer) {
+    (this.nip46Signer as unknown as { remoteUser: NDKUser }).remoteUser = user;
+  }
+  this.ndk.activeUser = user;
+}
+```
+
+`bindUserToSigner(user)` is called at **all three** NIP-46 entry points so every way of establishing a session is covered:
+
+1. Fresh `bunker://` connect
+2. Reconnect / restore from `localStorage`
+3. `nostrconnect://` pairing
+
+Because `toNostrEvent()` only resolves the pubkey when it is empty, fixing `signer.user()` fixes **all** signed events at once — uploads, zaps, relay auth, notes, reactions.
+
+> Note: the pre-existing workaround that set `_remoteUser` / `_userPubkey` had no effect — those are not real `NDKNip46Signer` fields. The real field is `remoteUser`.
+
+## Related upload hardening
+
+While diagnosing, the four duplicated nostr.build upload implementations were consolidated into `src/lib/mediaUpload.ts` (`uploadToNostrBuild`) and made more robust for remote signers:
+
+- **Warm the signer** (`blockUntilReady`) *before* stamping the NIP-98 `created_at`, so a slow bunker connect/approval does not consume the token's freshness window.
+- **Retry once** on an auth failure with a freshly-signed, freshly-stamped token.
+- Add a NIP-98 `expiration` tag.
+- Fix `ImageUploader`'s signing hint, which only mentioned browser extensions (now mentions extension / Amber / Primal).
+
+These are defense-in-depth; the signature mismatch above was the actual blocker.
+
+## How to verify
+
+1. Log in with a **Primal remote signer** (signer pubkey ≠ user pubkey).
+2. Post an image in the composer → upload succeeds (first attempt may pause on the Primal approval prompt).
+3. Send a zap → succeeds.
+4. (Optional) Confirm a signed event verifies and carries the **user** pubkey:
+   ```js
+   import { verifyEvent, getEventHash } from 'nostr-tools';
+   // event.pubkey === <user pubkey>, getEventHash(event) === event.id, verifyEvent(event) === true
+   ```
+
+## Takeaway
+
+For NIP-46 remote signers, **do not assume `signer.user()` returns the logged-in user.** NDK reports the signer pubkey unless `remoteUser` is explicitly bound to the user pubkey learned via `get_public_key`. Any future feature that constructs and signs events through a remote signer depends on this binding; if the signer is ever re-created, re-bind.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.525",
+  "version": "4.2.526",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.528",
+  "version": "4.2.529",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.527",
+  "version": "4.2.528",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.526",
+  "version": "4.2.527",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/ImageUploader.svelte
+++ b/src/components/ImageUploader.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { ndk } from '$lib/nostr';
-  import { NDKEvent } from '@nostr-dev-kit/ndk';
-  import { Fetch } from 'hurdak';
+  import { uploadToNostrBuild as nostrBuildUpload } from '$lib/mediaUpload';
 
   export let setUrl: (url: string) => void;
   export let name = 'file';
@@ -39,41 +38,10 @@
     input?.click();
   }
 
-  export async function uploadToNostrBuild(body: any) {
-    const uploadUrl = 'https://nostr.build/api/v2/upload/files';
-    const template = new NDKEvent($ndk);
-    template.kind = 27235;
-    template.created_at = Math.floor(Date.now() / 1000);
-    template.content = '';
-    template.tags = [
-      ['u', uploadUrl],
-      ['method', 'POST']
-    ];
-
-    // Sign with a timeout — extension popups can get blocked in overlays
-    const signResult = await Promise.race([
-      template.sign().then(() => true).catch(() => { throw new Error('Signing failed — are you signed in?'); }),
-      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('Signing timed out — check your Nostr extension popup.')), 30000))
-    ]);
-
-    // Ensure all fields are properly formatted according to NIP-98
-    const authEvent = {
-      id: template.id,
-      pubkey: template.pubkey,
-      created_at: template.created_at,
-      kind: template.kind,
-      tags: template.tags,
-      content: template.content,
-      sig: template.sig
-    };
-
-    return Fetch.fetchJson(uploadUrl, {
-      body,
-      method: 'POST',
-      headers: {
-        Authorization: `Nostr ${btoa(JSON.stringify(authEvent))}`
-      }
-    });
+  export async function uploadToNostrBuild(body: FormData) {
+    // Shared helper warms the signer and retries once on a stale NIP-98 token
+    // (remote signers like Primal add latency that can expire the first one).
+    return nostrBuildUpload($ndk, body);
   }
 </script>
 
@@ -93,7 +61,7 @@
       <div class="flex flex-col items-center gap-2 py-2">
         <div class="upload-spinner"></div>
         <p class="text-sm text-caption">Uploading...</p>
-        <p class="text-xs text-caption" style="opacity: 0.6;">Check for a signing popup from your Nostr extension</p>
+        <p class="text-xs text-caption" style="opacity: 0.6;">Approve the signing request in your signer (extension, Amber, or Primal)</p>
       </div>
     {:else}
       <div class="flex gap-0.5 text-sm leading-6 items-center">

--- a/src/components/MediaUploader.svelte
+++ b/src/components/MediaUploader.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import type { Writable } from 'svelte/store';
   import { ndk } from '$lib/nostr';
-  import { NDKEvent } from '@nostr-dev-kit/ndk';
-  import { Fetch } from 'hurdak';
+  import { uploadToNostrBuild } from '$lib/mediaUpload';
   import XIcon from 'phosphor-svelte/lib/X';
   import PlayIcon from 'phosphor-svelte/lib/Play';
   import ImageIcon from 'phosphor-svelte/lib/Image';
@@ -66,43 +65,14 @@
     return /\.(mp4|webm|mov|avi)$/i.test(url);
   }
 
-  // Upload to nostr.build
-  async function uploadToNostrBuild(file: File): Promise<string | null> {
-    const body = new FormData();
-    body.append('file[]', file);
-    
-    const url = 'https://nostr.build/api/v2/upload/files';
-    const template = new NDKEvent($ndk);
-    template.kind = 27235;
-    template.created_at = Math.floor(Date.now() / 1000);
-    template.content = '';
-    template.tags = [
-      ['u', url],
-      ['method', 'POST']
-    ];
-
-    await template.sign();
-    
-    const authEvent = {
-      id: template.id,
-      pubkey: template.pubkey,
-      created_at: template.created_at,
-      kind: template.kind,
-      tags: template.tags,
-      content: template.content,
-      sig: template.sig
-    };
-
+  // Upload a single file to nostr.build (shared NIP-98 helper handles auth +
+  // remote-signer retry). Returns the URL, or null on failure.
+  async function uploadFile(file: File): Promise<string | null> {
     try {
-      const result = await Fetch.fetchJson(url, {
-        body,
-        method: 'POST',
-        headers: {
-          Authorization: `Nostr ${btoa(JSON.stringify(authEvent))}`
-        }
-      });
-      
-      if (result && result.data && result.data[0]?.url) {
+      const body = new FormData();
+      body.append('file[]', file);
+      const result = await uploadToNostrBuild($ndk, body);
+      if (result?.data?.[0]?.url) {
         return result.data[0].url;
       }
     } catch (error) {
@@ -113,31 +83,31 @@
 
   async function handleFiles(files: FileList) {
     if (files.length === 0) return;
-    
+
     isUploading = true;
     const totalFiles = files.length;
     let uploaded = 0;
-    
+
     for (const file of Array.from(files)) {
       // Check file type
       if (!file.type.startsWith('image/') && !file.type.startsWith('video/')) {
         continue;
       }
-      
+
       // Check limit
       if (limit > 0 && $uploadedImages.length >= limit) {
         break;
       }
-      
+
       uploadProgress = `Uploading ${uploaded + 1} of ${totalFiles}...`;
-      const url = await uploadToNostrBuild(file);
-      
+      const url = await uploadFile(file);
+
       if (url) {
         uploadedImages.update(imgs => [...imgs, url]);
         uploaded++;
       }
     }
-    
+
     isUploading = false;
     uploadProgress = '';
   }

--- a/src/components/ProfileEditModal.svelte
+++ b/src/components/ProfileEditModal.svelte
@@ -11,7 +11,7 @@
   import Button from './Button.svelte';
   import { ndk, userPublickey } from '$lib/nostr';
   import { NDKEvent } from '@nostr-dev-kit/ndk';
-  import { Fetch } from 'hurdak';
+  import { uploadToNostrBuild } from '$lib/mediaUpload';
   import { profileCacheManager } from '$lib/profileCache';
   import {
     backupProfile,
@@ -311,38 +311,13 @@
       throw new Error('Image must be less than 10MB');
     }
 
-    // Create NIP-98 auth event
-    const template = new NDKEvent($ndk);
-    template.kind = 27235;
-    template.created_at = Math.floor(Date.now() / 1000);
-    template.content = '';
-    template.tags = [
-      ['u', url],
-      ['method', 'POST']
-    ];
-    await template.sign();
-
-    const authEvent = {
-      id: template.id,
-      pubkey: template.pubkey,
-      created_at: template.created_at,
-      kind: template.kind,
-      tags: template.tags,
-      content: template.content,
-      sig: template.sig
-    };
-
     const body = new FormData();
     body.append('file[]', file);
     body.append('media_type', type === 'picture' ? 'avatar' : 'banner');
 
-    const result = await Fetch.fetchJson(url, {
-      body,
-      method: 'POST',
-      headers: {
-        Authorization: `Nostr ${btoa(JSON.stringify(authEvent))}`
-      }
-    });
+    // Shared helper handles NIP-98 auth, warms the signer, and retries once on
+    // a stale token (remote signers like Primal add latency that can expire it).
+    const result = await uploadToNostrBuild($ndk, body, { url });
 
     if (result?.data?.[0]?.url) {
       return result.data[0].url;

--- a/src/lib/authManager.ts
+++ b/src/lib/authManager.ts
@@ -420,6 +420,7 @@ export class AuthManager {
       // rather than log the session in as the signer service.
       const userPubkey = await this.fetchNip46UserPubkey();
       const user = this.ndk.getUser({ pubkey: userPubkey });
+      this.bindUserToSigner(user);
 
       console.log('[NIP-46] Signer pubkey:', signerPubkey);
       console.log('[NIP-46] User pubkey (from get_public_key):', userPubkey);
@@ -570,6 +571,7 @@ export class AuthManager {
       }
 
       const user = this.ndk.getUser({ pubkey: userPubkey });
+      this.bindUserToSigner(user);
 
       console.log('[NIP-46] Reconnected as user:', userPubkey);
 
@@ -1010,6 +1012,7 @@ export class AuthManager {
       }
 
       const user = this.ndk.getUser({ pubkey: userPubkey });
+      this.bindUserToSigner(user);
 
       const nip46Info: NIP46ConnectionInfo = {
         signerPubkey,
@@ -1078,6 +1081,28 @@ export class AuthManager {
     this.startNip46ResponseListener(pendingInfo.localPubkey);
 
     console.log('[NIP-46] Listener restarted, waiting for signer response...');
+  }
+
+  /**
+   * Bind the authenticated user onto the NIP-46 signer and NDK.
+   *
+   * NDKNip46Signer.user() returns its `remoteUser`, which it initializes to the
+   * SIGNER pubkey in the constructor and never updates — not even after a
+   * successful connect. For bunkers whose signer pubkey differs from the user
+   * pubkey (e.g. Primal remote signing), every event we sign would otherwise be
+   * stamped (via NDKEvent.toNostrEvent → signer.user()) with the signer's
+   * pubkey while the bunker signs with the user's key — producing an event
+   * whose signature fails verification. That silently breaks relay NIP-42 auth,
+   * NIP-98 uploads (nostr.build 401), notes, reactions — everything.
+   *
+   * Point the signer's reported user at the real user. `remotePubkey` (used to
+   * route the signing RPC to the bunker) is intentionally left untouched.
+   */
+  private bindUserToSigner(user: NDKUser): void {
+    if (this.nip46Signer) {
+      (this.nip46Signer as unknown as { remoteUser: NDKUser }).remoteUser = user;
+    }
+    this.ndk.activeUser = user;
   }
 
   // Ensure NIP-46 signer is ready (call before signing operations)

--- a/src/lib/mediaUpload.ts
+++ b/src/lib/mediaUpload.ts
@@ -16,26 +16,47 @@ const MAX_VIDEO_DURATION = 60; // seconds
  * the subsequent sign attempt surfaces any real error.
  */
 async function warmSigner(ndk: NDK): Promise<void> {
-	const signer = ndk.signer as { blockUntilReady?: () => Promise<unknown> } | undefined;
-	if (!signer?.blockUntilReady) return;
-	try {
-		await Promise.race([
-			signer.blockUntilReady(),
-			new Promise((_, reject) =>
-				setTimeout(() => reject(new Error('signer warm timeout')), 30000)
-			)
-		]);
-	} catch {
-		// Ignore — proceed and let the sign attempt report the real problem.
-	}
+  const signer = ndk.signer as { blockUntilReady?: () => Promise<unknown> } | undefined;
+  if (!signer?.blockUntilReady) return;
+  try {
+    await Promise.race([
+      signer.blockUntilReady(),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('signer warm timeout')), 30000))
+    ]);
+  } catch {
+    // Ignore — proceed and let the sign attempt report the real problem.
+  }
+}
+
+/**
+ * Sign the event with a timeout so a blocked extension popup or an unanswered
+ * remote-signer approval surfaces an error instead of hanging the upload
+ * forever. Generous (60s) because remote signers (Amber/Primal) require manual
+ * approval; warmSigner has already absorbed the connection latency by now.
+ */
+async function signWithTimeout(template: NDKEvent, ms = 60000): Promise<void> {
+  await Promise.race([
+    template.sign(),
+    new Promise<never>((_, reject) =>
+      setTimeout(
+        () =>
+          reject(
+            new Error(
+              'Signing timed out — approve the request in your signer (extension, Amber, or Primal).'
+            )
+          ),
+        ms
+      )
+    )
+  ]);
 }
 
 /** True if a failed upload response looks like a rejected/expired NIP-98 token. */
 function isAuthFailure(status: number, bodyText: string): boolean {
-	if (status === 401 || status === 403) return true;
-	// nostr.build sometimes returns 400 for a stale/invalid auth event.
-	const t = bodyText.toLowerCase();
-	return /nip[\s-]?98|unauthor|expired|timestamp|created_at|invalid auth/.test(t);
+  if (status === 401 || status === 403) return true;
+  // nostr.build sometimes returns 400 for a stale/invalid auth event.
+  const t = bodyText.toLowerCase();
+  return /nip[\s-]?98|unauthor|expired|timestamp|created_at|invalid auth/.test(t);
 }
 
 /**
@@ -43,39 +64,39 @@ function isAuthFailure(status: number, bodyText: string): boolean {
  * `created_at` at call time, so re-invoking on a retry yields a fresh token.
  */
 async function buildAuthHeader(ndk: NDK, url: string): Promise<string> {
-	const template = new NDKEvent(ndk);
-	template.kind = 27235;
-	const now = Math.floor(Date.now() / 1000);
-	template.created_at = now;
-	template.content = '';
-	template.tags = [
-		['u', url],
-		['method', 'POST'],
-		['expiration', String(now + 60)]
-	];
+  const template = new NDKEvent(ndk);
+  template.kind = 27235;
+  const now = Math.floor(Date.now() / 1000);
+  template.created_at = now;
+  template.content = '';
+  template.tags = [
+    ['u', url],
+    ['method', 'POST'],
+    ['expiration', String(now + 60)]
+  ];
 
-	await template.sign();
+  await signWithTimeout(template);
 
-	const authEvent = {
-		id: template.id,
-		pubkey: template.pubkey,
-		created_at: template.created_at,
-		kind: template.kind,
-		tags: template.tags,
-		content: template.content,
-		sig: template.sig
-	};
+  const authEvent = {
+    id: template.id,
+    pubkey: template.pubkey,
+    created_at: template.created_at,
+    kind: template.kind,
+    tags: template.tags,
+    content: template.content,
+    sig: template.sig
+  };
 
-	return `Nostr ${btoa(JSON.stringify(authEvent))}`;
+  return `Nostr ${btoa(JSON.stringify(authEvent))}`;
 }
 
 function parseUploadError(bodyText: string, status: number, statusText: string): string {
-	try {
-		const data = JSON.parse(bodyText);
-		return data.message || data.error || `Upload failed with status ${status}`;
-	} catch {
-		return bodyText || `HTTP ${status}: ${statusText}`;
-	}
+  try {
+    const data = JSON.parse(bodyText);
+    return data.message || data.error || `Upload failed with status ${status}`;
+  } catch {
+    return bodyText || `HTTP ${status}: ${statusText}`;
+  }
 }
 
 /**
@@ -92,42 +113,38 @@ function parseUploadError(bodyText: string, status: number, statusText: string):
  * @param opts.url override endpoint (defaults to the general files endpoint;
  *   ProfileEditModal uses the profile endpoint for square-cropped avatars).
  */
-export async function uploadToNostrBuild(
-	ndk: NDK,
-	body: FormData,
-	opts: { url?: string } = {}
-) {
-	if (!ndk.signer) {
-		throw new Error('You must be signed in to upload.');
-	}
+export async function uploadToNostrBuild(ndk: NDK, body: FormData, opts: { url?: string } = {}) {
+  if (!ndk.signer) {
+    throw new Error('You must be signed in to upload.');
+  }
 
-	const url = opts.url ?? NOSTR_BUILD_URL;
+  const url = opts.url ?? NOSTR_BUILD_URL;
 
-	await warmSigner(ndk);
+  await warmSigner(ndk);
 
-	const attempt = async () => {
-		const authorization = await buildAuthHeader(ndk, url);
-		return fetch(url, { method: 'POST', body, headers: { Authorization: authorization } });
-	};
+  const attempt = async () => {
+    const authorization = await buildAuthHeader(ndk, url);
+    return fetch(url, { method: 'POST', body, headers: { Authorization: authorization } });
+  };
 
-	let response = await attempt();
+  let response = await attempt();
 
-	if (!response.ok) {
-		const firstText = await response.text();
-		if (isAuthFailure(response.status, firstText)) {
-			// Token likely arrived stale (slow remote sign). Retry once with a
-			// fresh timestamp — the signer is warm and approval is now granted.
-			response = await attempt();
-			if (!response.ok) {
-				const text = await response.text();
-				throw new Error(parseUploadError(text, response.status, response.statusText));
-			}
-		} else {
-			throw new Error(parseUploadError(firstText, response.status, response.statusText));
-		}
-	}
+  if (!response.ok) {
+    const firstText = await response.text();
+    if (isAuthFailure(response.status, firstText)) {
+      // Token likely arrived stale (slow remote sign). Retry once with a
+      // fresh timestamp — the signer is warm and approval is now granted.
+      response = await attempt();
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(parseUploadError(text, response.status, response.statusText));
+      }
+    } else {
+      throw new Error(parseUploadError(firstText, response.status, response.statusText));
+    }
+  }
 
-	return await response.json();
+  return await response.json();
 }
 
 /**
@@ -135,18 +152,18 @@ export async function uploadToNostrBuild(
  * Throws on validation failure or upload error.
  */
 export async function uploadImage(ndk: NDK, file: File): Promise<string> {
-	if (file.size > MAX_IMAGE_SIZE) {
-		throw new Error('Image must be less than 5MB');
-	}
+  if (file.size > MAX_IMAGE_SIZE) {
+    throw new Error('Image must be less than 5MB');
+  }
 
-	const body = new FormData();
-	body.append('file[]', file);
-	const result = await uploadToNostrBuild(ndk, body);
+  const body = new FormData();
+  body.append('file[]', file);
+  const result = await uploadToNostrBuild(ndk, body);
 
-	if (result?.data?.[0]?.url) {
-		return result.data[0].url;
-	}
-	throw new Error(result?.message || result?.error || 'Failed to upload image');
+  if (result?.data?.[0]?.url) {
+    return result.data[0].url;
+  }
+  throw new Error(result?.message || result?.error || 'Failed to upload image');
 }
 
 /**
@@ -154,43 +171,43 @@ export async function uploadImage(ndk: NDK, file: File): Promise<string> {
  * Validates size and duration. Throws on failure.
  */
 export async function uploadVideo(ndk: NDK, file: File): Promise<string> {
-	if (file.size > MAX_VIDEO_SIZE) {
-		throw new Error('Video must be less than 50MB');
-	}
+  if (file.size > MAX_VIDEO_SIZE) {
+    throw new Error('Video must be less than 50MB');
+  }
 
-	// Validate video duration
-	try {
-		const video = document.createElement('video');
-		video.preload = 'metadata';
-		const objectUrl = URL.createObjectURL(file);
+  // Validate video duration
+  try {
+    const video = document.createElement('video');
+    video.preload = 'metadata';
+    const objectUrl = URL.createObjectURL(file);
 
-		try {
-			const duration = await new Promise<number>((resolve, reject) => {
-				video.onloadedmetadata = () => resolve(video.duration);
-				video.onerror = () => reject(new Error('Failed to load video metadata'));
-				video.src = objectUrl;
-			});
+    try {
+      const duration = await new Promise<number>((resolve, reject) => {
+        video.onloadedmetadata = () => resolve(video.duration);
+        video.onerror = () => reject(new Error('Failed to load video metadata'));
+        video.src = objectUrl;
+      });
 
-			if (duration > 0 && duration > MAX_VIDEO_DURATION) {
-				throw new Error('Video must be less than 60 seconds');
-			}
-		} finally {
-			URL.revokeObjectURL(objectUrl);
-		}
-	} catch (metaError) {
-		// Re-throw validation errors, but ignore metadata read failures
-		if (metaError instanceof Error && metaError.message.includes('less than')) {
-			throw metaError;
-		}
-		console.warn('Could not read video metadata:', metaError);
-	}
+      if (duration > 0 && duration > MAX_VIDEO_DURATION) {
+        throw new Error('Video must be less than 60 seconds');
+      }
+    } finally {
+      URL.revokeObjectURL(objectUrl);
+    }
+  } catch (metaError) {
+    // Re-throw validation errors, but ignore metadata read failures
+    if (metaError instanceof Error && metaError.message.includes('less than')) {
+      throw metaError;
+    }
+    console.warn('Could not read video metadata:', metaError);
+  }
 
-	const body = new FormData();
-	body.append('file[]', file);
-	const result = await uploadToNostrBuild(ndk, body);
+  const body = new FormData();
+  body.append('file[]', file);
+  const result = await uploadToNostrBuild(ndk, body);
 
-	if (result?.data?.[0]?.url) {
-		return result.data[0].url;
-	}
-	throw new Error(result?.message || result?.error || 'Failed to upload video');
+  if (result?.data?.[0]?.url) {
+    return result.data[0].url;
+  }
+  throw new Error(result?.message || result?.error || 'Failed to upload video');
 }

--- a/src/lib/mediaUpload.ts
+++ b/src/lib/mediaUpload.ts
@@ -7,16 +7,51 @@ const MAX_VIDEO_SIZE = 50 * 1024 * 1024; // 50MB
 const MAX_VIDEO_DURATION = 60; // seconds
 
 /**
- * Upload files to nostr.build with NIP-98 authentication.
+ * Bring the (possibly remote) signer to a ready state. NIP-46 bunkers such
+ * as Primal need a relay round-trip — and, the first time the app asks them
+ * to sign a kind:27235 event, a one-time user-approval prompt. We block on
+ * that here, BEFORE stamping the NIP-98 timestamp, so the slow connect/
+ * approval doesn't eat into the auth token's freshness window. Local-key and
+ * extension signers resolve effectively instantly. Non-fatal on timeout —
+ * the subsequent sign attempt surfaces any real error.
  */
-export async function uploadToNostrBuild(ndk: NDK, body: FormData) {
+async function warmSigner(ndk: NDK): Promise<void> {
+	const signer = ndk.signer as { blockUntilReady?: () => Promise<unknown> } | undefined;
+	if (!signer?.blockUntilReady) return;
+	try {
+		await Promise.race([
+			signer.blockUntilReady(),
+			new Promise((_, reject) =>
+				setTimeout(() => reject(new Error('signer warm timeout')), 30000)
+			)
+		]);
+	} catch {
+		// Ignore — proceed and let the sign attempt report the real problem.
+	}
+}
+
+/** True if a failed upload response looks like a rejected/expired NIP-98 token. */
+function isAuthFailure(status: number, bodyText: string): boolean {
+	if (status === 401 || status === 403) return true;
+	// nostr.build sometimes returns 400 for a stale/invalid auth event.
+	const t = bodyText.toLowerCase();
+	return /nip[\s-]?98|unauthor|expired|timestamp|created_at|invalid auth/.test(t);
+}
+
+/**
+ * Build + sign a fresh NIP-98 Authorization header for the given URL. Stamps
+ * `created_at` at call time, so re-invoking on a retry yields a fresh token.
+ */
+async function buildAuthHeader(ndk: NDK, url: string): Promise<string> {
 	const template = new NDKEvent(ndk);
 	template.kind = 27235;
-	template.created_at = Math.floor(Date.now() / 1000);
+	const now = Math.floor(Date.now() / 1000);
+	template.created_at = now;
 	template.content = '';
 	template.tags = [
-		['u', NOSTR_BUILD_URL],
-		['method', 'POST']
+		['u', url],
+		['method', 'POST'],
+		['expiration', String(now + 60)]
 	];
 
 	await template.sign();
@@ -31,25 +66,65 @@ export async function uploadToNostrBuild(ndk: NDK, body: FormData) {
 		sig: template.sig
 	};
 
-	const response = await fetch(NOSTR_BUILD_URL, {
-		body,
-		method: 'POST',
-		headers: {
-			Authorization: `Nostr ${btoa(JSON.stringify(authEvent))}`
-		}
-	});
+	return `Nostr ${btoa(JSON.stringify(authEvent))}`;
+}
+
+function parseUploadError(bodyText: string, status: number, statusText: string): string {
+	try {
+		const data = JSON.parse(bodyText);
+		return data.message || data.error || `Upload failed with status ${status}`;
+	} catch {
+		return bodyText || `HTTP ${status}: ${statusText}`;
+	}
+}
+
+/**
+ * Upload files to nostr.build with NIP-98 authentication.
+ *
+ * nostr.build verifies that the NIP-98 event's `created_at` is recent
+ * (~60s). Remote signers (NIP-46, e.g. Primal) add round-trip + first-time
+ * approval latency, so a token signed up front can arrive already expired.
+ * To handle that we warm the signer first, then build a freshly-signed,
+ * freshly-stamped header on each attempt and retry once on an auth failure —
+ * by the retry the signer auto-approves kind:27235, so the new timestamp
+ * lands well inside the window.
+ *
+ * @param opts.url override endpoint (defaults to the general files endpoint;
+ *   ProfileEditModal uses the profile endpoint for square-cropped avatars).
+ */
+export async function uploadToNostrBuild(
+	ndk: NDK,
+	body: FormData,
+	opts: { url?: string } = {}
+) {
+	if (!ndk.signer) {
+		throw new Error('You must be signed in to upload.');
+	}
+
+	const url = opts.url ?? NOSTR_BUILD_URL;
+
+	await warmSigner(ndk);
+
+	const attempt = async () => {
+		const authorization = await buildAuthHeader(ndk, url);
+		return fetch(url, { method: 'POST', body, headers: { Authorization: authorization } });
+	};
+
+	let response = await attempt();
 
 	if (!response.ok) {
-		const errorText = await response.text();
-		let errorData;
-		try {
-			errorData = JSON.parse(errorText);
-		} catch {
-			errorData = { message: errorText || `HTTP ${response.status}: ${response.statusText}` };
+		const firstText = await response.text();
+		if (isAuthFailure(response.status, firstText)) {
+			// Token likely arrived stale (slow remote sign). Retry once with a
+			// fresh timestamp — the signer is warm and approval is now granted.
+			response = await attempt();
+			if (!response.ok) {
+				const text = await response.text();
+				throw new Error(parseUploadError(text, response.status, response.statusText));
+			}
+		} else {
+			throw new Error(parseUploadError(firstText, response.status, response.statusText));
 		}
-		throw new Error(
-			errorData.message || errorData.error || `Upload failed with status ${response.status}`
-		);
 	}
 
 	return await response.json();


### PR DESCRIPTION
## Problem

Users logged in via a **NIP-46 remote signer whose signer pubkey differs from their user pubkey** — most notably **Primal** remote signing — had every signed action fail, usually silently:

- **Image uploads** to nostr.build → `401 Unauthorized, please provide a valid nip-98 token`
- **Zaps** → the zap request (kind `9734`) is rejected (invalid signature)
- **Relay NIP-42 auth** → `error: failed to authenticate`
- Notes / reactions would be rejected by relays

Local keys (nsec), NIP-07 extensions, and Amber are **not** affected.

## Root cause

NDK's `NDKNip46Signer` initializes `remoteUser` to the **signer (bunker)** pubkey and never updates it — even after a successful connect. `user()` returns `remoteUser`, and `NDKEvent.toNostrEvent()` stamps an event's author from `signer.user()`. So every signed event is stamped with the **signer** pubkey, while the bunker actually signs with the **user** key → the event claims one pubkey but carries a signature valid for another → every verifier (nostr.build, relays, LNURL callbacks) rejects it.

NIP-46 explicitly allows signer pubkey ≠ user pubkey, which Primal uses. For signers where they're equal, stamping the "signer" pubkey happens to be correct, so the bug was invisible. Primal compounds it: its `connect` handshake is rejected (`We don't accept connect requests with new secret`) so `blockUntilReady()` times out; the app recovers via `get_public_key` to log the user in, but that pubkey was never propagated onto the signer object.

## Fix

After learning the real user pubkey, bind it onto the signer and NDK (`bindUserToSigner` in `authManager.ts`), at all three NIP-46 entry points (fresh `bunker://` connect, reconnect/restore, `nostrconnect://` pairing). `remotePubkey` (the RPC routing target) is intentionally left untouched. Because `toNostrEvent()` resolves the author from `signer.user()`, this one fix repairs uploads, zaps, relay auth, notes, and reactions together.

## Also included (upload hardening)

The four duplicated nostr.build upload implementations are consolidated into `mediaUpload.ts` and made more robust for remote signers: warm the signer before stamping the NIP-98 `created_at`, retry once on an auth failure with a fresh token, add an `expiration` tag, and fix `ImageUploader`'s extension-only signing hint. This is defense-in-depth; the signature mismatch above was the actual blocker.

## Verification

Verified live with a Primal remote signer: image uploads and zaps both succeed. A signed event now carries the **user** pubkey and `verifyEvent()` passes.

## Docs

Full writeup: `docs/troubleshooting/NIP46_REMOTE_SIGNER_SIGNING.md`
