### PR TITLE
fix(ux): fixed-overlay header + pipe connector, profile banner/avatar, sidemenu name truncation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.525",
+  "version": "4.2.526",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.526",
+  "version": "4.2.527",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -154,9 +154,12 @@
     />
   </button>
 
-  <!-- Center: search bar (desktop) -->
+  <!-- Center: search bar (desktop). Left padding at xl sets the gap from
+       the pipe's vertical line to 12px (10px here + the input's 2px margin),
+       matching the header's 12px top/bottom padding so the search box has
+       equal visual padding on all three framed sides. -->
   <div
-    class="hidden sm:flex flex-1 self-center print:hidden max-w-2xl min-w-[280px] lg:min-w-[500px]"
+    class="hidden sm:flex flex-1 self-center print:hidden max-w-2xl min-w-[280px] lg:min-w-[500px] xl:pl-2.5"
   >
     <TagsSearchAutocomplete
       placeholderString={'Search recipes, tags, or users...'}

--- a/src/components/UserSidePanel.svelte
+++ b/src/components/UserSidePanel.svelte
@@ -246,19 +246,19 @@
   >
     <!-- Header section with user info -->
     <div class="flex-shrink-0 p-6 border-b" style="border-color: var(--color-input-border);">
-      <div class="flex items-start justify-between">
+      <div class="flex items-center justify-between gap-2">
         <button
           on:click={() => navigate(`/user/${nip19.npubEncode($userPublickey)}`)}
-          class="profile-header-btn flex items-center gap-4 cursor-pointer bg-transparent border-0 p-0"
+          class="profile-header-btn flex items-center gap-4 cursor-pointer bg-transparent border-0 p-0 min-w-0 flex-1"
         >
-          <CustomAvatar pubkey={$userPublickey} size={48} imageUrl={$userProfilePictureOverride} />
-          <span class="font-semibold text-base" style="color: var(--color-text-primary);">
+          <CustomAvatar pubkey={$userPublickey} size={48} imageUrl={$userProfilePictureOverride} className="flex-shrink-0" />
+          <span class="font-semibold text-base truncate min-w-0" style="color: var(--color-text-primary);">
             {displayName}
           </span>
         </button>
         <button
           on:click={close}
-          class="p-2 rounded-full hover:bg-opacity-10 hover:bg-gray-500 transition-colors cursor-pointer"
+          class="flex-shrink-0 p-2 rounded-full hover:bg-opacity-10 hover:bg-gray-500 transition-colors cursor-pointer"
           style="color: var(--color-text-primary);"
           aria-label="Close menu"
         >

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -195,6 +195,10 @@
   let feedInitialLoadTimeout: ReturnType<typeof setTimeout> | null = null;
   let walletWelcomeSeen = false;
   let walletWelcomeForce = false;
+  // Measured height of the fixed header overlay. Drives the scroll
+  // container's top padding (so content isn't hidden behind the header)
+  // and the --header-h var that sticky sub-headers offset against.
+  let headerHeight = 64;
   let oneTapZapLoadedForPubkey = '';
   const WALLET_WELCOME_KEY = 'zapcooking_wallet_welcome_seen';
   const WALLET_WELCOME_FORCE_KEY = 'zapcooking_wallet_welcome_force';
@@ -526,16 +530,26 @@
       {/if}
       <!-- Fixed sidebar -->
       <DesktopSideNav />
-      <!-- Full-page scroll container: clip horizontal overflow to prevent Safari horizontal scroll/gap -->
+      <!-- Header with blur. Fixed to the viewport (not sticky inside the
+           scroll container) so it stays put while the page content scrolls
+           and rubber-band-bounces behind it. -->
+      <div
+        class="header-blur fixed top-0 left-0 right-0 xl:left-[calc(20rem_+_5px)] z-30 py-3 px-4"
+        bind:clientHeight={headerHeight}
+      >
+        <Header />
+        <!-- Decorative connector (desktop): a vertical line just left of
+             the search box that curves into the header's bottom divider. -->
+        <span class="header-pipe" aria-hidden="true"></span>
+      </div>
+      <!-- Full-page scroll container: clip horizontal overflow to prevent Safari horizontal scroll/gap.
+           Top padding clears the fixed header; --header-h lets sticky
+           sub-headers sit directly below it. -->
       <div
         id="app-scroll"
-        class="flex-1 min-h-0 min-w-0 overflow-y-auto overflow-x-hidden xl:ml-80"
-        style="background-color: var(--color-bg-primary);"
+        class="flex-1 min-h-0 min-w-0 overflow-y-auto overflow-x-hidden xl:ml-[calc(20rem_+_5px)]"
+        style="background-color: var(--color-bg-primary); padding-top: {headerHeight}px; --header-h: {headerHeight}px;"
       >
-        <!-- Sticky header with blur -->
-        <div class="header-blur sticky top-0 z-20 py-3 px-4">
-          <Header />
-        </div>
         <div
           class="px-4 min-w-0 max-w-full {$page.url.pathname.startsWith('/messages') ||
           $page.url.pathname.startsWith('/groups')
@@ -581,24 +595,35 @@
     }
   }
 
-  /* Header with frosted glass effect */
+  /* Header with frosted glass effect. The bottom divider is drawn by
+     ::after (not border-bottom) so it can be cleanly swapped for the pipe
+     connector at xl without leaving a leftover full-width line behind. */
   .header-blur {
     /* Fallback for browsers that don't support color-mix */
     background-color: var(--color-bg-primary);
     background-color: color-mix(in srgb, var(--color-bg-primary) 70%, transparent);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
-    border-bottom: 1px solid color-mix(in srgb, var(--color-input-border) 60%, transparent);
+  }
+  .header-blur::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 1px;
+    background: color-mix(in srgb, var(--color-input-border) 60%, transparent);
+    pointer-events: none;
   }
 
-  /* Dark-mode header gets a subtle navy lean + thin glow band so the
-     header reads as its own surface, not just a tinted body. Light
-     mode is left clean. */
+  /* Dark-mode header gets a subtle navy lean; the divider uses a faint
+     white line. */
   :global(.dark) .header-blur {
     background-color: rgba(14, 21, 41, 0.78);
     background-image: linear-gradient(to bottom, rgba(33, 39, 73, 0.45), rgba(14, 21, 41, 0.65));
-    border-bottom-color: rgba(255, 255, 255, 0.06);
-    box-shadow: 0 1px 0 rgba(168, 85, 247, 0.04);
+  }
+  :global(.dark) .header-blur::after {
+    background: rgba(255, 255, 255, 0.06);
   }
 
   /* Safe area padding for header on mobile.
@@ -624,6 +649,41 @@
       width: 10%;
       background: linear-gradient(to right, var(--color-bg-primary) 0%, transparent 100%);
       pointer-events: none;
+    }
+  }
+
+  /* Decorative pipe connector — only on xl, where the logo lives in the
+     sidebar and the search box sits at the content's left edge. ONE element
+     draws the vertical line (from the very top of the header), the rounded
+     elbow, and the full-width horizontal divider, so all three share the
+     same color/weight and meet by construction. The header's own
+     border-bottom (and dark-mode glow) are removed at xl so there's no
+     second, misaligned line. */
+  .header-pipe {
+    display: none;
+  }
+  @media (min-width: 1280px) {
+    /* Swap the full-width divider for the pipe: one element draws the
+       vertical line (from the top), the rounded elbow, and the horizontal
+       divider running right from the elbow — nothing to the left of it. */
+    .header-blur::after {
+      display: none;
+    }
+    .header-pipe {
+      display: block;
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 16px;
+      right: 0;
+      border-left: 1px solid color-mix(in srgb, var(--color-input-border) 60%, transparent);
+      border-bottom: 1px solid color-mix(in srgb, var(--color-input-border) 60%, transparent);
+      border-bottom-left-radius: 16px;
+      pointer-events: none;
+    }
+    :global(.dark) .header-pipe {
+      border-left-color: rgba(255, 255, 255, 0.06);
+      border-bottom-color: rgba(255, 255, 255, 0.06);
     }
   }
 </style>

--- a/src/routes/community/+page.svelte
+++ b/src/routes/community/+page.svelte
@@ -364,9 +364,10 @@
   /* Keep relay tabs pinned below the glass header */
   .tabs-container {
     position: sticky;
-    /* Position below the glass header (~60px on desktop) */
-    top: 60px;
-    z-index: 15; /* Below header (z-20) but above content */
+    /* Sit directly below the fixed header (height published as --header-h
+       by the root layout; 60px fallback). */
+    top: var(--header-h, 60px);
+    z-index: 15; /* Below header (z-30) but above content */
     /* Frosted glass effect - matches header */
     /* Fallback for browsers that don't support color-mix */
     background-color: var(--color-bg-primary);

--- a/src/routes/kitchen/+page.svelte
+++ b/src/routes/kitchen/+page.svelte
@@ -123,10 +123,10 @@
 </PullToRefresh>
 
 <style>
-  /* Keep relay tabs pinned; feed scrolls beneath them */
+  /* Keep relay tabs pinned below the fixed header; feed scrolls beneath them */
   .kitchen-tabs {
     position: sticky;
-    top: 0;
+    top: var(--header-h, 0px);
     z-index: 20;
     background-color: var(--color-bg-primary);
   }

--- a/src/routes/user/[slug]/+page.svelte
+++ b/src/routes/user/[slug]/+page.svelte
@@ -1833,10 +1833,15 @@
 </Modal>
 
 <div class="max-w-4xl mx-auto w-full">
-  <!-- Profile Banner -->
-  <div class="relative -mx-4 sm:-mx-6 lg:-mx-8 mb-4">
+  <!-- Profile Banner. Below xl (no sidebar) it's full-bleed and flush under
+       the top bar with square corners. At xl it's a contained, fixed-size
+       rounded card constrained to the content column — never wider than the
+       top bar — with a gap below the header. The outer wrapper stays the
+       container width so the overlapping avatar aligns with the name/content
+       below it (left edge), regardless of the banner's bleed. -->
+  <div class="relative mb-4 xl:mt-4">
     <div
-      class="h-32 sm:h-40 overflow-hidden rounded-2xl"
+      class="banner-fullbleed h-32 sm:h-40 overflow-hidden rounded-none xl:rounded-2xl"
       style="background: {profile?.banner
         ? 'transparent'
         : 'linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-hover) 100%)'}"
@@ -1846,8 +1851,8 @@
       {/if}
     </div>
 
-    <!-- Avatar overlapping banner -->
-    <div class="absolute -bottom-10 left-4 sm:left-6 lg:left-8">
+    <!-- Avatar overlapping banner; left edge aligns with the name/content. -->
+    <div class="absolute -bottom-10 left-4">
       <button
         class="hover:opacity-90 transition-opacity flex-shrink-0 rounded-full ring-4 ring-[var(--color-bg-primary)]"
         on:click={() => (qrModal = true)}
@@ -1865,12 +1870,11 @@
     </div>
   </div>
 
-  <!-- Profile Header -->
-  <div class="flex items-start gap-5 pb-5 pt-8">
-    <!-- Spacer for avatar (hidden on mobile where avatar overlaps banner) -->
-    <div class="hidden sm:block w-20 flex-shrink-0"></div>
-
-    <!-- Profile Info (right side) -->
+  <!-- Profile Header. Name/bio align to the container's left edge (under
+       the avatar) so they share the same margin as the stats, tabs and
+       note body text below. pt-12 clears the avatar's overhang. -->
+  <div class="flex items-start pb-5 pt-12">
+    <!-- Profile Info -->
     <div class="flex-1 min-w-0 flex flex-col gap-2">
       <!-- Name Row with Action Buttons on Right -->
       <div class="flex items-start justify-between gap-3">
@@ -2392,6 +2396,22 @@
 {/if}
 
 <style>
+  /* Below xl (no sidebar) the banner is full-bleed: symmetric
+     viewport-relative margins stretch it to the viewport width (= the top
+     bar), clipped by #app-scroll's overflow-x-hidden. At xl it's contained to
+     the content container (margins reset to 0) so it's a fixed-size card that
+     is never wider than the top bar. */
+  .banner-fullbleed {
+    margin-left: calc(50% - 50vw);
+    margin-right: calc(50% - 50vw);
+  }
+  @media (min-width: 1280px) {
+    .banner-fullbleed {
+      margin-left: 0;
+      margin-right: 0;
+    }
+  }
+
   /* Ensure line-clamp works for bio text */
   :global(.line-clamp-2) {
     display: -webkit-box;


### PR DESCRIPTION
## Summary

UX polish for the desktop header, profile page, and the user side menu. Three related fixes that ride together.

### Header → fixed overlay
- Convert the desktop header from sticky-in-scroll to a **fixed overlay** so the bar no longer rubber-band bounces on overscroll (the page still scrolls behind it).
- Publish the header height as a `--header-h` CSS variable so the **kitchen** and **community** sub-tabs pin directly beneath it (no overlap, no gap).
- Add the desktop **pipe connector** to the left of the search bar, and move the header divider to an `::after` pseudo-element (hidden at `xl` so the pipe takes over without a double line).

### Profile page
- Banner is **full-bleed below `xl`** (square top; square bottom on mobile where there's no column edge) and a **contained rounded card at `xl`** — never wider than the top bar.
- Indent the avatar so the banner's left edge/rounded corner stays visible.
- Align the name/bio to the content column (same left margin as stats, tabs, and note body).

### Side menu
- Truncate long display names instead of letting them break the side-menu header layout.

## Notes
- Independent of the NIP-46 remote-signer fix (#452); no overlapping files.
- `svelte-check` passes (0 errors).
