### PR TITLE
fix(feed): stop sticky tab bar from clipping the top of the feed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.531",
+  "version": "4.2.532",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/app.css
+++ b/src/app.css
@@ -20,6 +20,35 @@ body {
   --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
   --safe-area-inset-left: env(safe-area-inset-left, 0px);
   --safe-area-inset-right: env(safe-area-inset-right, 0px);
+
+  /*
+   * Fixed-header geometry — single, CSS-deterministic source of truth.
+   *
+   * --header-row-h is the height of the header's content row (.zh-root). It is
+   * a fixed value the row is pinned to, so the painted header height never
+   * depends on font/image load timing (no ResizeObserver race). The two values
+   * are the measured content heights, rounded up so nothing inside clips:
+   *   - compact icon row (< 640px):                ~37.77px -> 38px
+   *   - search-bar row (>= 640px, sm: breakpoint):  ~50.36px -> 51px
+   * The content height changes at 640px (where the search bar toggles), NOT at
+   * 1023px, so that is the breakpoint used here.
+   *
+   * --header-h is the total painted height of .header-blur and is the single
+   * value consumed by BOTH #app-scroll's padding-top AND .tabs-container's top:
+   *   row height + bottom padding (0.75rem) + top padding.
+   * Top padding mirrors .header-blur exactly: max(env(safe-area-inset-top),
+   * 0.75rem) — 0.75rem on desktop/non-notched, growing with the notch inset.
+   * Because the header is pinned to these same tokens, the reserved space and
+   * the sticky tab-bar top are always equal on the first frame.
+   */
+  --header-row-h: 38px;
+  --header-h: calc(var(--header-row-h) + 0.75rem + max(env(safe-area-inset-top, 0px), 0.75rem));
+}
+
+@media (min-width: 640px) {
+  :root {
+    --header-row-h: 51px;
+  }
 }
 
 .page-loader {

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -331,6 +331,14 @@
 </div>
 
 <style>
+  /* Pin the content row to the CSS-deterministic header token so the painted
+     header height equals --header-h on the first frame, independent of font or
+     logo image load timing. The token is >= the natural content height at each
+     breakpoint, so children center within it and never clip. */
+  .zh-root {
+    height: var(--header-row-h);
+  }
+
   /* Shared icon button — minimal, balanced tap target, subtle hover.
      Wrapped in :where() so Tailwind responsive utilities (sm:hidden,
      etc.) can override individual properties without specificity

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -195,10 +195,6 @@
   let feedInitialLoadTimeout: ReturnType<typeof setTimeout> | null = null;
   let walletWelcomeSeen = false;
   let walletWelcomeForce = false;
-  // Measured height of the fixed header overlay. Drives the scroll
-  // container's top padding (so content isn't hidden behind the header)
-  // and the --header-h var that sticky sub-headers offset against.
-  let headerHeight = 64;
   let oneTapZapLoadedForPubkey = '';
   const WALLET_WELCOME_KEY = 'zapcooking_wallet_welcome_seen';
   const WALLET_WELCOME_FORCE_KEY = 'zapcooking_wallet_welcome_force';
@@ -533,22 +529,20 @@
       <!-- Header with blur. Fixed to the viewport (not sticky inside the
            scroll container) so it stays put while the page content scrolls
            and rubber-band-bounces behind it. -->
-      <div
-        class="header-blur fixed top-0 left-0 right-0 xl:left-[calc(20rem_+_5px)] z-30 py-3 px-4"
-        bind:clientHeight={headerHeight}
-      >
+      <div class="header-blur fixed top-0 left-0 right-0 xl:left-[calc(20rem_+_5px)] z-30 py-3 px-4">
         <Header />
         <!-- Decorative connector (desktop): a vertical line just left of
              the search box that curves into the header's bottom divider. -->
         <span class="header-pipe" aria-hidden="true"></span>
       </div>
       <!-- Full-page scroll container: clip horizontal overflow to prevent Safari horizontal scroll/gap.
-           Top padding clears the fixed header; --header-h lets sticky
+           Top padding clears the fixed header via the CSS-deterministic
+           --header-h (defined in app.css); the same var lets sticky
            sub-headers sit directly below it. -->
       <div
         id="app-scroll"
         class="flex-1 min-h-0 min-w-0 overflow-y-auto overflow-x-hidden xl:ml-[calc(20rem_+_5px)]"
-        style="background-color: var(--color-bg-primary); padding-top: {headerHeight}px; --header-h: {headerHeight}px;"
+        style="background-color: var(--color-bg-primary); padding-top: var(--header-h);"
       >
         <div
           class="px-4 min-w-0 max-w-full {$page.url.pathname.startsWith('/messages') ||
@@ -626,16 +620,15 @@
     background: rgba(255, 255, 255, 0.06);
   }
 
-  /* Safe area padding for header on mobile.
-     `env(safe-area-inset-top, 0px)` alone would collapse to 0 on
-     non-notched browsers (regular Chrome/Safari/Firefox on mobile
-     and desktop-narrow), making the avatar touch the viewport top.
-     `max()` keeps the baseline 0.75rem (matches the `py-3` from the
-     wrapper) and grows for devices with a real notch inset. */
-  @media (max-width: 1023px) {
-    .header-blur {
-      padding-top: max(env(safe-area-inset-top, 0px), 0.75rem);
-    }
+  /* Safe-area-aware top padding, applied at ALL widths so the painted header
+     height always equals the CSS-computed --header-h (single source of truth
+     in app.css — same max() expression). `env(safe-area-inset-top, 0px)` alone
+     would collapse to 0 on non-notched browsers (regular Chrome/Safari/Firefox
+     on mobile and desktop), making the avatar touch the viewport top; `max()`
+     keeps the baseline 0.75rem (matching the wrapper's `py-3`) and grows for
+     devices with a real notch inset. */
+  .header-blur {
+    padding-top: max(env(safe-area-inset-top, 0px), 0.75rem);
   }
 
   /* Left edge gradient for smooth transition from sidebar (desktop only) */

--- a/src/routes/community/+page.svelte
+++ b/src/routes/community/+page.svelte
@@ -364,9 +364,14 @@
   /* Keep relay tabs pinned below the glass header */
   .tabs-container {
     position: sticky;
-    /* Sit directly below the fixed header (height published as --header-h
-       by the root layout; 60px fallback). */
-    top: var(--header-h, 60px);
+    /* top:0 — NOT var(--header-h). The scroll container (#app-scroll) already
+       reserves the header height via padding-top: var(--header-h), and a
+       sticky child's offset is measured from that container's content box
+       (i.e. AFTER its padding). Setting top: var(--header-h) here would stack
+       a second header-height on top, pinning the tabs at 2x the header height
+       and leaving a header-tall gap that clips the top of the feed. top:0 pins
+       the tabs flush at the bottom of the header on every breakpoint. */
+    top: 0;
     z-index: 15; /* Below header (z-30) but above content */
     /* Frosted glass effect - matches header */
     /* Fallback for browsers that don't support color-mix */
@@ -381,13 +386,6 @@
       opacity 0.3s ease-in-out,
       transform 0.3s ease-in-out;
     will-change: opacity, transform;
-  }
-
-  /* On mobile, account for safe area inset that the header uses */
-  @media (max-width: 1023px) {
-    .tabs-container {
-      top: calc(56px + env(safe-area-inset-top, 0px));
-    }
   }
 
   /* Bottom padding to prevent fixed mobile nav from covering content */

--- a/src/routes/kitchen/+page.svelte
+++ b/src/routes/kitchen/+page.svelte
@@ -123,10 +123,14 @@
 </PullToRefresh>
 
 <style>
-  /* Keep relay tabs pinned below the fixed header; feed scrolls beneath them */
+  /* Keep relay tabs pinned below the fixed header; feed scrolls beneath them.
+     top:0 — NOT var(--header-h): #app-scroll already reserves the header height
+     via padding-top, and a sticky child's offset is measured from that
+     container's content box (after the padding), so top: var(--header-h) would
+     pin the tabs at 2x the header height. top:0 pins them flush below it. */
   .kitchen-tabs {
     position: sticky;
-    top: var(--header-h, 0px);
+    top: 0;
     z-index: 20;
     background-color: var(--color-bg-primary);
   }


### PR DESCRIPTION
## Summary

The Global/Following/Replies/Groups tab bar on the feed (and the kitchen tab bar) pinned at **twice the header height**, leaving a header-tall gap where feed content scrolled through and got clipped — on **both desktop and mobile** (reproduced in plain browsers, not PWA/Capacitor specific).

### Root cause
`#app-scroll` reserves space for the `fixed` header via `padding-top: var(--header-h)`. A `position: sticky` child's `top` offset is measured from that container's **content box** — i.e. *after* the padding. So `top: var(--header-h)` on the tab bar stacked a **second** header-height on top, pinning it at `2 × --header-h`.

The fix: the padding already accounts for the header, so the sticky offset must be `top: 0`.

### Also: `--header-h` is now a CSS-deterministic single source of truth
Previously `--header-h` came from a JS `bind:clientHeight` measurement seeded at `64px`, which lagged the real height (74px desktop / ~62px mobile) for ~3s on load (ResizeObserver race), and a hardcoded mobile override (`top: calc(56px + env(...))`) baked in a per-viewport magic number.

- `--header-row-h` / `--header-h` are defined in `app.css`, responsive at the **`sm` (640px)** breakpoint — where the search bar toggles the header content height (measured: 37.77px → 50.36px). This is the correct breakpoint; 1023px would clip the search bar between 640–1023px.
- The safe-area inset stays dynamic via `max(env(safe-area-inset-top), 0.75rem)` — no JS, works at all widths (`env` is 0 on desktop/non-notched).
- The header content row (`.zh-root`) is pinned to `--header-row-h`, so the painted header height equals `--header-h` on the **first frame**, independent of font/image load timing.
- Removed the JS `bind:clientHeight` measurement and the hardcoded mobile tab-bar `top` override.

## Before / after (pinned tab bar, measured via Playwright)

| Viewport | header bottom | tab top before | tab top after |
|---|---|---|---|
| Desktop 1440 | 75px | **150px** (2×) → 75px gap | **75px** → 0 gap |
| Mobile 390 | 62px | **124px** (2×) → 62px gap | **62px** → 0 gap |

Gap is **0 at first paint and steady state** on both breakpoints.

## Files
- `src/app.css` — define `--header-row-h` / `--header-h` (responsive at 640px)
- `src/components/Header.svelte` — pin `.zh-root` to `--header-row-h`
- `src/routes/+layout.svelte` — drop JS header measurement; `#app-scroll` uses `var(--header-h)`; `.header-blur` safe-area padding at all widths
- `src/routes/community/+page.svelte` — tab bar `top: 0`; remove mobile override
- `src/routes/kitchen/+page.svelte` — tab bar `top: 0` (same double-count bug)

## Test plan
- [ ] Desktop web: feed loads with tab bar flush under the header, no clipped first post; no reflow jump on load
- [ ] Mobile web (iOS Safari): same, with safe-area inset respected on notched devices
- [ ] Kitchen tab bar pins correctly below the header
- [ ] Scroll up/down: tab bar hide/show animation still works

Made with [Cursor](https://cursor.com)