### PR TITLE
fix(composer): preserve line breaks typed in the note composer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.535",
+  "version": "4.2.536",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.532",
+  "version": "4.2.535",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/PostComposer.svelte
+++ b/src/components/PostComposer.svelte
@@ -22,6 +22,7 @@
   import { MentionComposerController, type MentionState } from '$lib/mentionComposer';
   import { uploadImage, uploadVideo } from '$lib/mediaUpload';
   import { clickOutside } from '$lib/clickOutside';
+  import { showToast } from '$lib/toast';
 
   // Clear stuck posts from the publish queue
   async function clearPendingQueue() {
@@ -53,7 +54,6 @@
   let content = '';
   let posting = false;
   let success = false;
-  let successQueued = false; // True when post was queued for retry
   let error = '';
   let composerEl: HTMLDivElement;
   let lastRenderedContent = '';
@@ -200,7 +200,6 @@
     content = '';
     lastRenderedContent = '';
     error = '';
-    successQueued = false;
     showPreview = false;
     draftSaved = false;
     isMinimized = false;
@@ -422,40 +421,23 @@
       console.log('[PostComposer] Publish result:', result);
 
       if (result.success) {
-        // Published successfully on first attempt
-        success = true;
-        successQueued = false;
+        const noteLink = event.id ? `/${nip19.noteEncode(event.id)}` : null;
+        showToast('success', 'Note published', 12000, noteLink ? { label: 'View', href: noteLink } : undefined);
         resetComposerState();
-
-        const closeDelay = variant === 'modal' ? 1500 : 2500;
-        setTimeout(() => {
-          success = false;
-          if (variant === 'modal') {
-            dispatch('close');
-          } else {
-            isComposerOpen = false;
-          }
-        }, closeDelay);
+        if (variant === 'modal') {
+          dispatch('close');
+        } else {
+          isComposerOpen = false;
+        }
       } else if (result.queued) {
-        // Failed initial publish, but queued for background retry
-        // Show optimistic success - the post will be published when connection improves
-        success = true;
-        successQueued = true;
+        showToast('info', 'Note queued — will publish when connection improves', 5000);
         resetComposerState();
-
-        // Log for debugging
         console.log('[PostComposer] Post queued for background retry:', result.error);
-
-        const closeDelay = variant === 'modal' ? 2000 : 3000; // Slightly longer to read the message
-        setTimeout(() => {
-          success = false;
-          successQueued = false;
-          if (variant === 'modal') {
-            dispatch('close');
-          } else {
-            isComposerOpen = false;
-          }
-        }, closeDelay);
+        if (variant === 'modal') {
+          dispatch('close');
+        } else {
+          isComposerOpen = false;
+        }
       } else {
         error = result.error || 'Failed to publish';
       }
@@ -544,7 +526,7 @@
 
 {#if $userPublickey !== '' || variant === 'modal'}
   <div
-    class={`bg-input rounded-xl transition-all ${variant === 'inline' ? 'mb-4' : 'flex-1 flex flex-col'}`}
+    class={`bg-input rounded-xl transition-all relative ${variant === 'inline' ? 'mb-4' : 'flex-1 flex flex-col'}`}
     class:overflow-hidden={!isComposerOpen}
     class:overflow-visible={isComposerOpen}
     style="border: 1px solid var(--color-input-border)"
@@ -628,16 +610,6 @@
 
               {#if error}
                 <p class="text-red-500 text-xs mb-2">{error}</p>
-              {/if}
-
-              {#if success}
-                {#if successQueued}
-                  <p class="text-amber-600 text-xs mb-2">
-                    Post queued — will publish when connection improves
-                  </p>
-                {:else}
-                  <p class="text-green-600 text-xs mb-2">Posted!</p>
-                {/if}
               {/if}
 
               {#if !showPreview && quotedNote}
@@ -935,6 +907,10 @@
         </div>
       </div>
     {/if}
+
+    {#if posting}
+      <div class="posting-dim" aria-hidden="true"></div>
+    {/if}
   </div>
 {/if}
 
@@ -1165,5 +1141,14 @@
 
   .media-menu-item:hover {
     background: var(--color-accent-gray);
+  }
+
+  .posting-dim {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    border-radius: inherit;
+    z-index: 10;
+    pointer-events: none;
   }
 </style>

--- a/src/components/Toast.svelte
+++ b/src/components/Toast.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import XIcon from 'phosphor-svelte/lib/X';
+  import CheckCircleIcon from 'phosphor-svelte/lib/CheckCircle';
+  import WarningCircleIcon from 'phosphor-svelte/lib/WarningCircle';
+  import InfoIcon from 'phosphor-svelte/lib/Info';
   import type { ToastMessage } from '$lib/toast';
   import { dismissToast } from '$lib/toast';
 
@@ -11,14 +13,28 @@
   role={toast.variant === 'error' ? 'alert' : 'status'}
   aria-live={toast.variant === 'error' ? 'assertive' : 'polite'}
 >
+  <span class="toast-icon">
+    {#if toast.variant === 'success'}
+      <CheckCircleIcon size={20} weight="fill" />
+    {:else if toast.variant === 'error'}
+      <WarningCircleIcon size={20} weight="fill" />
+    {:else}
+      <InfoIcon size={20} weight="fill" />
+    {/if}
+  </span>
   <span class="toast-message">{toast.message}</span>
+  {#if toast.link}
+    <a href={toast.link.href} class="toast-link" on:click={() => dismissToast(toast.id)}>
+      {toast.link.label}
+    </a>
+  {/if}
   <button
     type="button"
     class="toast-dismiss"
     aria-label="Dismiss"
     on:click={() => dismissToast(toast.id)}
   >
-    <XIcon size={14} weight="bold" />
+    Dismiss
   </button>
 </div>
 
@@ -27,46 +43,70 @@
     display: flex;
     align-items: center;
     gap: 0.75rem;
-    padding: 0.75rem 1rem;
+    padding: 1rem;
     border-radius: 0.5rem;
-    background: var(--color-bg-secondary);
-    color: var(--color-text-primary);
-    border: 1px solid var(--color-input-border);
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+    background-color: var(--color-bg-primary);
+    border: 1px solid currentColor;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.35);
     font-size: 0.875rem;
     line-height: 1.4;
-    min-width: 240px;
-    max-width: 420px;
-    pointer-events: auto; /* override container's pointer-events: none */
-  }
-
-  .toast--error {
-    border-color: rgba(239, 68, 68, 0.45);
-    background: rgba(239, 68, 68, 0.1);
+    pointer-events: auto;
+    width: 100%;
   }
 
   .toast--success {
-    border-color: rgba(34, 197, 94, 0.45);
-    background: rgba(34, 197, 94, 0.1);
+    color: #22c55e;
+  }
+
+  .toast--error {
+    color: #ef4444;
+  }
+
+  .toast--info {
+    color: #3b82f6;
+  }
+
+  .toast-icon {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
   }
 
   .toast-message {
     flex: 1 1 0%;
+    color: var(--color-text-primary, #fff);
     overflow-wrap: anywhere;
     word-break: break-word;
   }
 
-  .toast-dismiss {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0.25rem;
-    border-radius: 0.25rem;
-    color: var(--color-text-secondary);
+  .toast-link {
+    flex-shrink: 0;
+    font-size: 0.8125rem;
+    font-weight: 700;
+    color: currentColor;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    white-space: nowrap;
+    opacity: 0.9;
     transition: opacity 0.15s;
   }
 
+  .toast-link:hover {
+    opacity: 1;
+  }
+
+  .toast-dismiss {
+    flex-shrink: 0;
+    font-size: 0.8125rem;
+    color: currentColor;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    opacity: 0.8;
+    transition: opacity 0.15s;
+    white-space: nowrap;
+  }
+
   .toast-dismiss:hover {
-    opacity: 0.7;
+    opacity: 1;
   }
 </style>

--- a/src/components/ToastContainer.svelte
+++ b/src/components/ToastContainer.svelte
@@ -4,10 +4,8 @@
    * (see src/routes/+layout.svelte). Subscribes to the `toasts` store in
    * $lib/toast and renders each message via the Toast component.
    *
-   * Positioning: bottom-right on desktop, above the BottomNav on mobile
-   * (where bottom-right would overlap the 64px-tall bottom navigation).
-   * z-index 9999 matches the highest convention in this codebase
-   * (MobileSearchOverlay) and sits above all modals (~50-100).
+   * Positioning: top-center, capped at the same width as the composer modal
+   * (max-w-xl / 36rem). z-index 9999 sits above all modals and the fixed header.
    */
   import { toasts } from '$lib/toast';
   import Toast from './Toast.svelte';
@@ -28,21 +26,15 @@
 <style>
   .toast-container {
     position: fixed;
-    bottom: 1rem;
-    right: 1rem;
+    top: 1rem;
+    left: 50%;
+    transform: translateX(-50%);
+    width: calc(100vw - 2rem);
+    max-width: 36rem;
     z-index: 9999;
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    pointer-events: none; /* toasts re-enable pointer-events */
-  }
-
-  @media (max-width: 640px) {
-    .toast-container {
-      left: 1rem;
-      right: 1rem;
-      /* BottomNav is ~64px tall; clear it + leave breathing room. */
-      bottom: calc(64px + 1rem);
-    }
+    pointer-events: none;
   }
 </style>

--- a/src/lib/mentionUtils.test.ts
+++ b/src/lib/mentionUtils.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { htmlToPlainText } from './mentionUtils';
+
+/**
+ * htmlToPlainText serializes the composer's contenteditable DOM back to the
+ * plain text that gets published. Browsers and embedded WebViews disagree on
+ * the markup they produce when the user presses Enter (<div> vs <p> vs bare
+ * text + <br>), so these tests pin the line-break handling across those
+ * structures using a minimal fake DOM — no jsdom required, matching this
+ * repo's pure-TS test style.
+ */
+
+const ZWSP = '​';
+
+// htmlToPlainText references the global `Node` constants; provide them for
+// the node test environment.
+if (typeof Node === 'undefined') {
+	(globalThis as any).Node = { TEXT_NODE: 3, ELEMENT_NODE: 1 };
+}
+
+function txt(value: string): any {
+	return { nodeType: 3, textContent: value, childNodes: [] };
+}
+
+function el(tagName: string, children: any[] = [], dataset: Record<string, string> = {}): any {
+	const node: any = {
+		nodeType: 1,
+		tagName,
+		nodeName: tagName,
+		dataset,
+		childNodes: children
+	};
+	Object.defineProperty(node, 'firstChild', {
+		get() {
+			return children[0] ?? null;
+		}
+	});
+	return node;
+}
+
+function br(): any {
+	return el('BR');
+}
+
+function root(children: any[]): any {
+	return { childNodes: children };
+}
+
+describe('htmlToPlainText', () => {
+	it('serializes a single bare text node unchanged', () => {
+		expect(htmlToPlainText(root([txt('hello world')]))).toBe('hello world');
+	});
+
+	it('treats <br> as a newline', () => {
+		expect(htmlToPlainText(root([txt('line 1'), br(), txt('line 2')]))).toBe('line 1\nline 2');
+	});
+
+	it('treats <div>-wrapped lines as separate lines (Chrome/Safari)', () => {
+		// Bare first line + <div> follow-ups
+		expect(
+			htmlToPlainText(root([txt('line 1'), el('DIV', [txt('line 2')]), el('DIV', [txt('line 3')])]))
+		).toBe('line 1\nline 2\nline 3');
+	});
+
+	it('preserves a blank line from an empty <div><br></div>', () => {
+		expect(
+			htmlToPlainText(
+				root([el('DIV', [txt('line 1')]), el('DIV', [br()]), el('DIV', [txt('line 3')])])
+			)
+		).toBe('line 1\n\nline 3');
+	});
+
+	// Regression: iOS/Capacitor WebViews and pasted rich text use <p> as the
+	// paragraph separator. These were previously concatenated with no break,
+	// producing strings like "🥩🍳#brunchstr".
+	it('treats <p> paragraphs as separate lines', () => {
+		expect(
+			htmlToPlainText(
+				root([
+					el('P', [txt('Champion of breakfasts. 🥩🍳')]),
+					el('P', [txt('#brunchstr #foodstr')]),
+					el('P', [txt('https://i.nostr.build/x.jpg')])
+				])
+			)
+		).toBe('Champion of breakfasts. 🥩🍳\n#brunchstr #foodstr\nhttps://i.nostr.build/x.jpg');
+	});
+
+	// Regression: a block element followed by a bare text/inline node must not
+	// merge onto the block's line (a <div> only emits a newline before itself).
+	it('breaks between a block and a following inline/text node', () => {
+		expect(htmlToPlainText(root([el('DIV', [txt('line 1')]), txt('line 2')]))).toBe(
+			'line 1\nline 2'
+		);
+		expect(
+			htmlToPlainText(root([el('DIV', [txt('line 1')]), el('SPAN', [txt('line 2')])]))
+		).toBe('line 1\nline 2');
+	});
+
+	it('does not prepend a leading newline before the first block', () => {
+		expect(htmlToPlainText(root([el('P', [txt('first')])]))).toBe('first');
+	});
+
+	it('strips zero-width spaces (mention pill caret spacers)', () => {
+		expect(htmlToPlainText(root([txt(`${ZWSP}hello${ZWSP}`)]))).toBe('hello');
+	});
+
+	it('serializes mention pills to their nostr: reference', () => {
+		const pill = el('SPAN', [txt('@alice')], { mention: 'nostr:npub1alice' });
+		expect(htmlToPlainText(root([txt('hi '), txt(ZWSP), pill, txt(ZWSP), txt(' there')]))).toBe(
+			'hi nostr:npub1alice there'
+		);
+	});
+
+	it('keeps a mention on its own line after a block', () => {
+		const pill = el('SPAN', [txt('@alice')], { mention: 'nostr:npub1alice' });
+		expect(htmlToPlainText(root([el('DIV', [txt('intro')]), pill]))).toBe('intro\nnostr:npub1alice');
+	});
+});

--- a/src/lib/mentionUtils.ts
+++ b/src/lib/mentionUtils.ts
@@ -128,26 +128,71 @@ export function replacePlainMentions(
 
 // --- DOM utilities ---
 
+// Block-level tags that introduce a line break when a contenteditable surface
+// (or pasted HTML) is serialized back to plain text. Browsers and embedded
+// WebViews disagree on the paragraph separator they emit on Enter \u2014 Chrome/
+// Safari typically wrap lines in <div>, but iOS/Capacitor WebViews and pasted
+// rich text often use <p> (and lists/headings/etc.). Treating only <div> as a
+// line boundary dropped those breaks, concatenating lines with no separator
+// (e.g. "\uD83E\uDD69\uD83C\uDF73#brunchstr"). Keep this list focused on tags that realistically
+// appear inside the composer or in pasted content.
+const BLOCK_TAGS = new Set([
+	'DIV',
+	'P',
+	'LI',
+	'UL',
+	'OL',
+	'BLOCKQUOTE',
+	'PRE',
+	'SECTION',
+	'ARTICLE',
+	'H1',
+	'H2',
+	'H3',
+	'H4',
+	'H5',
+	'H6'
+]);
+
 export function htmlToPlainText(element: Node): string {
 	let text = '';
+	// `isFirstChild` suppresses a leading newline before the first block so the
+	// output doesn't start with "\n". `prevWasBlock` records whether the last
+	// emitted node was a block element: a block only emits a newline *before*
+	// itself, so an inline/text node following a block (e.g. `<div>L1</div>L2`)
+	// would otherwise merge onto the block's line. The flag lets us insert the
+	// missing separator on that trailing edge too.
 	let isFirstChild = true;
+	let prevWasBlock = false;
+
+	const breakAfterBlock = () => {
+		if (prevWasBlock && text && !text.endsWith('\n')) {
+			text += '\n';
+		}
+	};
 
 	element.childNodes.forEach((node) => {
 		if (node.nodeType === Node.TEXT_NODE) {
 			const content = (node.textContent || '').replace(/\u200B/g, '');
-			text += content;
 			if (content) {
+				breakAfterBlock();
+				text += content;
 				isFirstChild = false;
+				prevWasBlock = false;
 			}
 		} else if (node.nodeType === Node.ELEMENT_NODE) {
 			const el = node as HTMLElement;
 
 			if (el.dataset.mention) {
+				breakAfterBlock();
 				text += el.dataset.mention;
 				isFirstChild = false;
+				prevWasBlock = false;
 			} else if (el.tagName === 'BR') {
 				text += '\n';
-			} else if (el.tagName === 'DIV') {
+				isFirstChild = false;
+				prevWasBlock = false;
+			} else if (BLOCK_TAGS.has(el.tagName)) {
 				if (!isFirstChild) {
 					text += '\n';
 				}
@@ -157,17 +202,22 @@ export function htmlToPlainText(element: Node): string {
 					text += htmlToPlainText(node);
 				}
 				isFirstChild = false;
+				prevWasBlock = true;
 			} else if (el.tagName === 'SPAN') {
 				const spanContent = htmlToPlainText(node);
-				text += spanContent;
 				if (spanContent) {
+					breakAfterBlock();
+					text += spanContent;
 					isFirstChild = false;
+					prevWasBlock = false;
 				}
 			} else {
 				const childContent = htmlToPlainText(node);
-				text += childContent;
 				if (childContent) {
+					breakAfterBlock();
+					text += childContent;
 					isFirstChild = false;
+					prevWasBlock = false;
 				}
 			}
 		}

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -14,12 +14,19 @@ import { writable } from 'svelte/store';
 
 export type ToastVariant = 'error' | 'info' | 'success';
 
+export interface ToastLink {
+  label: string;
+  href: string;
+}
+
 export interface ToastMessage {
   id: string;
   variant: ToastVariant;
   message: string;
   /** Auto-dismiss after this many ms. Pass 0 to disable auto-dismiss. */
   durationMs: number;
+  /** Optional CTA link rendered next to the message. */
+  link?: ToastLink;
 }
 
 export const toasts = writable<ToastMessage[]>([]);
@@ -30,10 +37,11 @@ export const toasts = writable<ToastMessage[]>([]);
 export function showToast(
   variant: ToastVariant,
   message: string,
-  durationMs = 4000
+  durationMs = 4000,
+  link?: ToastLink
 ): string {
   const id = `toast-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  toasts.update((list) => [...list, { id, variant, message, durationMs }]);
+  toasts.update((list) => [...list, { id, variant, message, durationMs, link }]);
   if (durationMs > 0) {
     setTimeout(() => dismissToast(id), durationMs);
   }


### PR DESCRIPTION
## Summary

- **Line-break fix**: \`htmlToPlainText\` in \`mentionUtils.ts\` only treated \`<div>\` and \`<br>\` as line boundaries. iOS/Capacitor WebViews and pasted rich text use \`<p>\` as the paragraph separator, causing lines to concatenate with no separator (e.g. \`\"🥩🍳#brunchstr\"\`). Added a \`BLOCK_TAGS\` set and a \`prevWasBlock\` flag to handle trailing inline nodes. 10 unit tests added.

- **Success toast**: After publishing, the composer showed a blank editor with a small green "Posted!" label. Replaced with an immediate composer close and a persistent success toast (12 s) that includes a "View" link to the published note. Queued posts show an info toast instead.

- **Toast redesign**: Toast style now matches the wallet panel — solid app-background card with a coloured border and icon per variant (success/error/info), a text "Dismiss" link, no transparency. Container repositioned from bottom-right to top-centre, capped at the same max-width as the composer modal (36 rem).

- **Composer dim**: While the note is publishing, a semi-transparent overlay dims the composer so the user knows the editor is no longer interactive.

## Test plan

- [ ] Type a multi-line note in the composer (press Enter between lines), publish — newlines appear in the posted event content
- [ ] Paste rich text with paragraph breaks — paragraphs become separate lines
- [ ] Verify on iOS/Capacitor — `<p>` paragraph separator preserved
- [ ] After posting: composer closes immediately and a green "Note published · View" toast appears at top-centre for 12 s
- [ ] While posting: composer dims behind the post button spinner
- [ ] Error and info toasts display with correct icon and coloured border (no transparent background)
- [ ] `pnpm vitest run src/lib/mentionUtils.test.ts` — all 10 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)