### PR TITLE
hotfix: disable SSR on /user/[slug] and /[nip19] to stop intermittent 500s

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.544",
+  "version": "4.2.545",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/routes/[nip19]/+page.ts
+++ b/src/routes/[nip19]/+page.ts
@@ -1,0 +1,3 @@
+// Hotfix: disable SSR for client-data-only nip19 route to bypass
+// intermittent server-side NDK construction failures in the Pages runtime.
+export const ssr = false;

--- a/src/routes/user/[slug]/+page.ts
+++ b/src/routes/user/[slug]/+page.ts
@@ -1,0 +1,3 @@
+// Hotfix: disable SSR for client-data-only user profile route to bypass
+// intermittent server-side NDK construction failures in the Pages runtime.
+export const ssr = false;


### PR DESCRIPTION
## Summary

Emergency stabilization for intermittent document 500s on:
- `/user/<npub>`
- `/<nip19>`

Observed in prod as fresh origin failures (`cf-cache-status: DYNAMIC`) and confirmed in Pages runtime logs:

`TypeError: debug8.extend is not a function`

stacking through NDK construction during SSR from the layout import path (`nostr.ts`), before route-level client loaders are relevant.

## Fix

Disable SSR on the two affected client-data-only routes by adding:

- `src/routes/user/[slug]/+page.ts`
- `src/routes/[nip19]/+page.ts`

```ts
export const ssr = false;
```

This removes the failing SSR execution path for those document requests and serves a stable shell that hydrates client-side.

## Verification

Local (`pnpm build` + `wrangler pages dev`) status loops:

- `/user/npub1zsyt...` x20 → all `200`
- `/npub1zsyt...` x20 → all `200`

## Follow-up (separate)

A broader hardening PR should make `nostr.ts` browser-only/lazy so NDK is never constructed in SSR code paths globally.

---

Note: `package.json` version bump in this commit is from the repo's standard pre-commit hook.

Made with [Cursor](https://cursor.com)