### PR TITLE
fix(ssr): prevent NDK server initialization crash causing intermittent 500s

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.545",
+  "version": "4.2.546",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/nostr.ts
+++ b/src/lib/nostr.ts
@@ -187,6 +187,28 @@ function createNdk(mode: RelayMode, relayUrls: string[]): NDK {
   });
 }
 
+/**
+ * Server-side NDK stub.
+ *
+ * In SSR we never want to open relays or instantiate full NDK internals.
+ * Some route/layout code still imports the `ndk` store during SSR, so provide
+ * a minimal no-op shape that is safe to call and returns empty results.
+ */
+function createServerNdkStub(): NDK {
+  const noopSubscription = {
+    on: () => noopSubscription,
+    stop: () => {}
+  };
+
+  return {
+    fetchEvent: async () => null,
+    fetchEvents: async () => new Set(),
+    subscribe: () => noopSubscription,
+    connect: async () => {},
+    getUser: ({ pubkey }: { pubkey: string }) => ({ pubkey })
+  } as unknown as NDK;
+}
+
 // ═══════════════════════════════════════════════════════════════
 // STATE
 // ═══════════════════════════════════════════════════════════════
@@ -225,8 +247,9 @@ const initialRelays = getCurrentRelays();
 // Note: This is now a snapshot; for dynamic relays use getCurrentRelays()
 export const relays = initialRelays;
 
-// Create initial NDK instance (default mode)
-let currentNdk: NDK = createNdk('default', initialRelays);
+// Create initial NDK instance (default mode).
+// IMPORTANT: never construct real NDK on the server; use a no-op stub for SSR.
+let currentNdk: NDK = browser ? createNdk('default', initialRelays) : createServerNdkStub();
 let currentRelayMode: RelayMode = 'default';
 
 // NDK ready state - resolves when NDK is connected


### PR DESCRIPTION
## Summary

Fixes intermittent **document 500s** on SSR routes (e.g. `/recipes`, `/user/<npub>`) caused by server-side NDK construction.

From live Pages runtime logs, failing requests show:

`TypeError: debug8.extend is not a function`

with stack through:
- `new NDKSubscriptionManager`
- `new NDK`
- `createNdk` in `src/lib/nostr.ts`
- layout import path during SSR render

## Root cause

`src/lib/nostr.ts` always created a real NDK instance at module load:

```ts
let currentNdk: NDK = createNdk('default', initialRelays);
```

That executes during SSR too, which intermittently crashes in the Pages runtime before route-level loaders run.

## Fix

Make SSR initialization safe by never constructing real NDK on the server:
- add a minimal server-side no-op NDK stub (`createServerNdkStub()`)
- initialize `currentNdk` as:

```ts
let currentNdk: NDK = browser ? createNdk('default', initialRelays) : createServerNdkStub();
```

Client behavior is unchanged: real NDK is still created in browser and connected as before.

## Verification

Local (`pnpm build` + `wrangler pages dev`):
- `/recipes` x30: all `200`
- `/user/npub1zsyt...` x20: all `200`
- worker log signatures:
  - `[handleError]`: `0`
  - `debug8.extend is not a function`: `0`

## Notes

- This complements PR #461 (route-level `ssr=false` hotfix for `/user/[slug]` and `/[nip19]`).
- `package.json` version bump is the repo's standard pre-commit hook behavior.

Made with [Cursor](https://cursor.com)