### PR TITLE
feat(thread): clickable reply cards, connected thread lines, nevent relay hints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.548",
+  "version": "4.2.549",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/NoteContent.svelte
+++ b/src/components/NoteContent.svelte
@@ -14,6 +14,7 @@
   export let content: string;
   export let className: string = '';
   export let showLinkPreviews: boolean = true;
+  export let showNostrEmbeds: boolean = true;
   export let embedDepth: number = 0; // Track nesting depth to prevent infinite recursion
   export let collapsible: boolean = true; // Enable collapsible long content
   export let maxLength: number = 500; // Character limit before collapse
@@ -389,10 +390,14 @@
           colorClass="text-orange-500 hover:text-orange-600"
         />
       {:else if part.prefix === 'nevent1' || part.prefix === 'note1'}
-        <NoteEmbed nostrString={part.content} depth={embedDepth} />
+        {#if showNostrEmbeds}
+          <NoteEmbed nostrString={part.content} depth={embedDepth} />
+        {/if}
       {:else if part.prefix === 'naddr1'}
         <!-- Addressable event (recipe, article, etc.) - render as embedded content -->
-        <NoteEmbed nostrString={part.content} depth={embedDepth} />
+        {#if showNostrEmbeds}
+          <NoteEmbed nostrString={part.content} depth={embedDepth} />
+        {/if}
       {:else if part.prefix === 'noffer1'}
         <!-- CLINK static offer — render an inline "⚡ Pay" pill that opens
              NofferPayModal. Matches the bxrd.app affordance. -->

--- a/src/components/NoteEmbed.svelte
+++ b/src/components/NoteEmbed.svelte
@@ -433,10 +433,10 @@
 {:else if event}
   <div
     class="parent-quote-embed my-2 cursor-pointer hover:opacity-90 transition-opacity"
-    on:click|stopPropagation={handleCardClick}
+    on:click|stopPropagation={(e) => { if ((e.target as HTMLElement).closest('a, button')) return; handleCardClick(); }}
     role="link"
     tabindex="0"
-    on:keydown={(e) => e.key === 'Enter' && handleCardClick()}
+    on:keydown|self={(e) => e.key === 'Enter' && handleCardClick()}
   >
     <div class="parent-quote-header">
       <CustomAvatar pubkey={event.author.hexpubkey} size={16} />

--- a/src/components/NoteEmbed.svelte
+++ b/src/components/NoteEmbed.svelte
@@ -431,10 +431,12 @@
     </div>
   </div>
 {:else if event}
-  <a
-    href={getNoteUrl()}
-    class="parent-quote-embed my-2 block hover:opacity-90 transition-opacity"
-    on:click|stopPropagation
+  <div
+    class="parent-quote-embed my-2 cursor-pointer hover:opacity-90 transition-opacity"
+    on:click|stopPropagation={handleCardClick}
+    role="link"
+    tabindex="0"
+    on:keydown={(e) => e.key === 'Enter' && handleCardClick()}
   >
     <div class="parent-quote-header">
       <CustomAvatar pubkey={event.author.hexpubkey} size={16} />
@@ -451,19 +453,13 @@
       </div>
     {/if}
 
-    <!-- Content preview -->
-    {#if getContentWithoutMedia(event.content).trim()}
-      <p class="parent-quote-content">
-        {getContentWithoutMedia(event.content).trim().slice(0, 200)}{getContentWithoutMedia(
-          event.content
-        ).trim().length > 200
-          ? '...'
-          : ''}
-      </p>
+    <!-- Full note content with truncation for long posts -->
+    {#if event.content.trim()}
+      <div class="parent-quote-content" on:click|stopPropagation>
+        <NoteContent content={event.content} collapsible={true} embedDepth={depth + 1} showLinkPreviews={false} />
+      </div>
     {/if}
-
-    <span class="parent-quote-link">View quoted note →</span>
-  </a>
+  </div>
 {:else}
   <div class="parent-quote-embed my-2">
     <div class="parent-quote-header">
@@ -503,23 +499,8 @@
   }
 
   .parent-quote-content {
-    font-size: 0.75rem;
-    color: var(--color-text-secondary);
-    line-height: 1.4;
-    margin-top: 0.25rem;
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    line-clamp: 3;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-  }
-
-  .parent-quote-link {
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: #f97316;
-    margin-top: 0.25rem;
-    display: inline-block;
+    font-size: 0.875rem;
+    margin-top: 0.375rem;
   }
 
   .parent-quote-loading {

--- a/src/components/NoteTotalComments.svelte
+++ b/src/components/NoteTotalComments.svelte
@@ -5,6 +5,8 @@
   import type { NDKEvent } from '@nostr-dev-kit/ndk';
   import CommentIcon from 'phosphor-svelte/lib/ChatTeardropText';
   import { getEngagementStore, fetchEngagement } from '$lib/engagementCache';
+  import { goto } from '$app/navigation';
+  import { nip19 } from 'nostr-tools';
 
   export let event: NDKEvent;
 
@@ -15,22 +17,31 @@
     // Batch fetch may be in progress, but individual fetch ensures counts load
     fetchEngagement($ndk, event.id, $userPublickey);
   });
-</script>
 
-<button
-  class="flex items-center gap-1.5 hover:bg-input rounded px-0.5 transition duration-300 cursor-pointer"
-  style="color: var(--color-text-primary)"
-  on:click={() => {
-    // Find the FeedComments container for this event and trigger its toggle.
-    // FeedComments.svelte roots render with class="inline-comments" + data-event-id;
-    // it listens for a 'toggleComments' CustomEvent in its onMount.
+  function handleCommentClick() {
+    // In the feed, FeedComments.svelte renders with class="inline-comments" +
+    // data-event-id and listens for 'toggleComments' — use that when available.
     const feedCommentsEl = document
       .querySelector(`[data-event-id="${event.id}"]`)
       ?.closest('.inline-comments');
     if (feedCommentsEl) {
       feedCommentsEl.dispatchEvent(new CustomEvent('toggleComments'));
+      return;
     }
-  }}
+    // Anywhere else (thread page, profile page), navigate to the note thread.
+    const relayUrl = (event as any).relay?.url ?? (event as any).onRelays?.[0]?.url;
+    try {
+      goto('/' + nip19.neventEncode({ id: event.id, relays: relayUrl ? [relayUrl] : [], kind: event.kind ?? 1 }));
+    } catch {
+      goto('/' + nip19.noteEncode(event.id));
+    }
+  }
+</script>
+
+<button
+  class="flex items-center gap-1.5 hover:bg-input rounded px-0.5 transition duration-300 cursor-pointer"
+  style="color: var(--color-text-primary)"
+  on:click={handleCommentClick}
   title="View comments"
 >
   <CommentIcon size={24} class="text-caption" />

--- a/src/components/comments/CommentCard.svelte
+++ b/src/components/comments/CommentCard.svelte
@@ -22,18 +22,15 @@
   import { format as formatDate } from 'timeago.js';
   import Avatar from '../Avatar.svelte';
   import CustomAvatar from '../CustomAvatar.svelte';
+  import ClientAttribution from '../ClientAttribution.svelte';
   import NoteContent from '../NoteContent.svelte';
-  import ZapModal from '../ZapModal.svelte';
   import ReplyComposer from './ReplyComposer.svelte';
+  import ThreadCommentActions from '../ThreadCommentActions.svelte';
+  import ChatCircleIcon from 'phosphor-svelte/lib/ChatCircle';
   import { resolveProfileByPubkey, formatDisplayName } from '$lib/profileResolver';
   import { getAnonChefName } from '$lib/anonName';
-  import { formatAmount } from '$lib/utils';
-  import { addClientTagToEvent } from '$lib/nip89';
-  import HeartIcon from 'phosphor-svelte/lib/Heart';
-  import LightningIcon from 'phosphor-svelte/lib/Lightning';
   import { onMount, onDestroy, createEventDispatcher } from 'svelte';
   const dispatch = createEventDispatcher();
-  import { extractZapAmountSats } from '$lib/zapAmount';
 
   /** The comment event rendered by this card. */
   export let event: NDKEvent;
@@ -63,12 +60,18 @@
    */
   export let allComments: NDKEvent[] = [];
 
-  // Variant-indexed scalar props (passed as JS numbers, not CSS).
+  // Variant-indexed avatar sizes (CSS font sizes are now unified across variants).
   const sizes = {
-    recipe: { avatar: 40, parentQuoteAvatar: 16, actionIcon: 16 },
-    feed: { avatar: 32, parentQuoteAvatar: 16, actionIcon: 14 }
+    recipe: { avatar: 40 },
+    feed: { avatar: 32 }
   } as const;
   const s = sizes[variant];
+
+  // True when any sibling comment is a direct reply to this one — drives
+  // the vertical thread line below this card's avatar.
+  $: hasReplies = allComments.some(
+    (c) => c.id !== event.id && c.getMatchingTags('e').some((t) => t[1] === event.id)
+  );
 
   // Avatar / CustomAvatar both accept the pubkey/size/className subset
   // we need, so we swap the component rather than branch with {#if}.
@@ -86,19 +89,6 @@
   // Reply box state — the composer itself owns everything inside the form.
   let showReplyBox = false;
 
-  // Like state
-  let liked = false;
-  let likeCount = 0;
-  let likesLoading = true;
-  let processedLikes = new Set();
-  let likeSubscription: any = null;
-
-  // Zap state
-  let zapModalOpen = false;
-  let totalZapAmount = 0;
-  let hasUserZapped = false;
-  let processedZaps = new Set<string>();
-  let zapSubscription: any = null;
 
   /**
    * Unified parent-comment detection. Merges the pre-Stage-4 strategies:
@@ -124,33 +114,6 @@
     if (matchInVisible) return matchInVisible[1];
 
     return candidates[candidates.length - 1][1];
-  }
-
-  function loadZaps() {
-    if (!event?.id || !$ndk) return;
-
-    totalZapAmount = 0;
-    processedZaps.clear();
-    hasUserZapped = false;
-
-    zapSubscription = $ndk.subscribe({
-      kinds: [9735],
-      '#e': [event.id]
-    });
-
-    zapSubscription.on('event', (zapEvent: NDKEvent) => {
-      if (!zapEvent.sig || processedZaps.has(zapEvent.sig)) return;
-
-      const { sats } = extractZapAmountSats(zapEvent);
-      if (sats <= 0) return;
-
-      totalZapAmount += sats;
-      processedZaps.add(zapEvent.sig);
-
-      if (zapEvent.tags.some((tag) => tag[0] === 'P' && tag[1] === $userPublickey)) {
-        hasUserZapped = true;
-      }
-    });
   }
 
   onMount(async () => {
@@ -207,75 +170,9 @@
       parentLoading = false;
     }
 
-    // Likes subscription — default closeOnEose per pre-Stage-4 behaviour.
-    // (Live-count staleness is tracked as a FOLLOWUPS item.)
-    likeSubscription = $ndk.subscribe({
-      kinds: [7],
-      '#e': [event.id]
-    });
-
-    likeSubscription.on('event', (e: NDKEvent) => {
-      if (processedLikes.has(e.id)) return;
-      processedLikes.add(e.id);
-      if (e.pubkey === $userPublickey) liked = true;
-      likeCount++;
-      likesLoading = false;
-    });
-
-    likeSubscription.on('eose', () => {
-      likesLoading = false;
-    });
-
-    loadZaps();
   });
 
-  onDestroy(() => {
-    if (likeSubscription) likeSubscription.stop();
-    if (zapSubscription) zapSubscription.stop();
-  });
-
-  async function toggleLike() {
-    if (liked || !$userPublickey) return;
-
-    const reactionEvent = new NDKEvent($ndk);
-    reactionEvent.kind = 7;
-    reactionEvent.content = '+';
-    reactionEvent.tags = [
-      ['e', event.id, '', 'reply'],
-      ['p', event.pubkey]
-    ];
-    addClientTagToEvent(reactionEvent);
-
-    // Sign first so we have the event id, then register it in the
-    // component's `processedLikes` Set BEFORE the publish await. The
-    // subscription echo of our own reaction can arrive synchronously
-    // once the relay receives it; without the pre-registration, the
-    // echo passes the `processedLikes.has(e.id)` guard on line 206,
-    // runs its own `likeCount++` on line 209, and the post-publish
-    // `likeCount++` below brings the total to +2.
-    try {
-      await reactionEvent.sign();
-    } catch {
-      return;
-    }
-    if (!reactionEvent.id) return;
-    processedLikes.add(reactionEvent.id);
-
-    // Optimistic UI — bump before publish resolves so the click
-    // feels instant. Revert in the catch if publish fails.
-    likeCount++;
-    liked = true;
-
-    try {
-      await reactionEvent.publish();
-    } catch {
-      // Rollback both the optimistic count AND the dedup sentinel so a
-      // retry can register cleanly under the same event id.
-      processedLikes.delete(reactionEvent.id);
-      likeCount--;
-      liked = false;
-    }
-  }
+  onDestroy(() => {});
 
   function setReplyBox(open: boolean) {
     showReplyBox = open;
@@ -291,10 +188,6 @@
   let loginRedirectHref = '';
   $: loginRedirectHref = `/login?redirect=${encodeURIComponent($page.url.pathname)}`;
 
-  function openZapModal() {
-    zapModalOpen = true;
-  }
-
   function truncateContent(content: string, maxLength: number = 100): string {
     const cleaned = content
       .replace(/https?:\/\/[^\s]+/g, '[link]')
@@ -307,33 +200,34 @@
 </script>
 
 {#if variant !== 'feed' || !$mutedPubkeys.has(event.pubkey)}
-  <div class="comment-card comment-card--{variant}">
-    <!-- Embedded parent quote (if replying to another comment) -->
+  <div class="comment-card comment-card--{variant}" class:nested={!parentLoading && parentComment !== null}>
+    <!-- Replying-to indicator + indent for nested replies -->
     {#if !parentLoading && parentComment}
-      <div class="parent-quote">
-        <div class="parent-quote-header">
-          <svelte:component
-            this={AvatarComp}
-            pubkey={parentComment.pubkey}
-            size={s.parentQuoteAvatar}
-          />
-          <span class="parent-quote-author">{parentDisplayName || 'Loading...'}</span>
-        </div>
-        <p class="parent-quote-content">{truncateContent(parentComment.content)}</p>
+      <div class="reply-to-indicator">
+        Replying to <a
+          href="/user/{nip19.npubEncode(parentComment.pubkey)}"
+          class="reply-to-name"
+          on:click|stopPropagation
+        >{parentDisplayName || '...'}</a>
       </div>
     {/if}
 
     <!-- Main comment row -->
     <div class="comment-row">
-      <!-- Avatar -->
-      <a href="/user/{nip19.npubEncode(event.pubkey)}" class="comment-avatar">
-        <svelte:component
-          this={AvatarComp}
-          className="rounded-full"
-          pubkey={event.pubkey}
-          size={s.avatar}
-        />
-      </a>
+      <!-- Avatar column: avatar + optional thread line to children -->
+      <div class="avatar-col">
+        <a href="/user/{nip19.npubEncode(event.pubkey)}" class="comment-avatar">
+          <svelte:component
+            this={AvatarComp}
+            className="rounded-full"
+            pubkey={event.pubkey}
+            size={s.avatar}
+          />
+        </a>
+        {#if hasReplies}
+          <div class="thread-line"></div>
+        {/if}
+      </div>
 
       <!-- Content -->
       <div class="comment-content">
@@ -349,6 +243,7 @@
           <span class="comment-time">
             {formatDate(new Date((event.created_at || 0) * 1000))}
           </span>
+          <ClientAttribution tags={event.tags} enableEnrichment={false} />
         </div>
 
         <!-- Comment Text -->
@@ -358,55 +253,23 @@
 
         <!-- Actions -->
         <div class="comment-actions">
-          <!-- Like Button -->
-          <button
-            on:click={toggleLike}
-            class="action-btn"
-            class:text-red-500={liked}
-            disabled={!$userPublickey}
-            aria-label={liked ? 'Liked' : 'Like comment'}
-          >
-            <HeartIcon size={s.actionIcon} weight={liked ? 'fill' : 'regular'} />
-            {#if !likesLoading && likeCount > 0}
-              <span>{likeCount}</span>
-            {/if}
-          </button>
-
-          <!-- Zap Button -->
-          {#if $userPublickey}
-            <button
-              on:click={openZapModal}
-              class="action-btn zap-btn"
-              class:text-yellow-500={hasUserZapped}
-              aria-label="Zap comment"
-            >
-              <LightningIcon size={s.actionIcon} weight={hasUserZapped ? 'fill' : 'regular'} />
-              {#if totalZapAmount > 0}
-                <span>{formatAmount(totalZapAmount)}</span>
-              {/if}
-            </button>
-          {:else}
-            <span class="action-btn zap-display">
-              <LightningIcon
-                size={s.actionIcon}
-                class={totalZapAmount > 0 ? 'text-yellow-500' : ''}
-              />
-              {#if totalZapAmount > 0}
-                <span>{formatAmount(totalZapAmount)}</span>
-              {/if}
-            </span>
-          {/if}
+          <ThreadCommentActions {event} compact={variant === 'feed'} showReplyButton={false} />
 
           <!-- Reply button (signed in) or sign-in link (anon) — both variants. -->
           {#if $userPublickey}
             <button
+              type="button"
               on:click={() => setReplyBox(!showReplyBox)}
-              class="action-btn action-btn-text"
+              class="reply-btn"
             >
-              {showReplyBox ? 'Cancel' : 'Reply'}
+              <ChatCircleIcon size={variant === 'feed' ? 16 : 18} weight="regular" />
+              <span>{showReplyBox ? 'Cancel' : 'Reply'}</span>
             </button>
           {:else}
-            <a href={loginRedirectHref} class="action-btn action-btn-text">Sign in to reply</a>
+            <a href={loginRedirectHref} class="reply-btn">
+              <ChatCircleIcon size={variant === 'feed' ? 16 : 18} weight="regular" />
+              <span>Sign in to reply</span>
+            </a>
           {/if}
         </div>
 
@@ -436,9 +299,6 @@
     </div>
   </div>
 
-  {#if zapModalOpen}
-    <ZapModal bind:open={zapModalOpen} {event} />
-  {/if}
 {/if}
 
 <style>
@@ -446,6 +306,7 @@
 
   .comment-card {
     width: 100%;
+    padding: 0.5rem 0;
   }
 
   .comment-row {
@@ -459,8 +320,27 @@
     }
   }
 
+  /* Avatar column: stacks avatar above the optional thread line */
+  .avatar-col {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex: 0 0 auto;
+  }
+
   .comment-avatar {
     flex: 0 0 auto;
+  }
+
+  /* Vertical thread line that runs from the parent avatar down to the
+     bottom of its card, meeting the border-left of the first nested reply */
+  .thread-line {
+    flex: 1;
+    width: 2px;
+    background-color: var(--color-input-border);
+    margin-top: 4px;
+    border-radius: 1px;
+    min-height: 0.5rem;
   }
 
   .comment-content {
@@ -479,6 +359,7 @@
   }
 
   .comment-author {
+    font-size: 0.875rem;
     font-weight: 600;
     color: var(--color-text-primary);
     overflow-wrap: anywhere;
@@ -490,11 +371,14 @@
   }
 
   .comment-time {
+    font-size: 0.75rem;
     color: var(--color-text-secondary);
     white-space: nowrap;
   }
 
   .comment-body {
+    font-size: 1rem;
+    line-height: 1.6;
     margin-bottom: 0.5rem;
     color: var(--color-text-primary);
     overflow-wrap: anywhere;
@@ -504,68 +388,60 @@
   .comment-actions {
     display: flex;
     align-items: center;
+    gap: 0.25rem;
   }
 
-  .action-btn {
+  .reply-btn {
     display: flex;
     align-items: center;
     gap: 0.25rem;
+    padding: 0.25rem 0.375rem;
+    border-radius: 0.25rem;
+    font-size: 0.75rem;
+    color: var(--color-caption);
+    transition: background-color 0.15s, color 0.15s;
+    cursor: pointer;
+  }
+
+  .reply-btn:hover {
+    background-color: var(--color-input);
     color: var(--color-text-primary);
-    transition: color 0.15s;
   }
 
-  .action-btn:hover {
-    color: var(--color-primary);
+  /* ── Nested reply indentation ───────────────────────────────────── */
+  /* margin-left = avatar-center so border-left aligns with the thread */
+  /* line drawn below the parent avatar, creating one continuous line. */
+  /* padding-left bridges from the border to the content start.        */
+
+  .comment-card--feed.nested {
+    margin-left: 1rem;     /* 16px = center of 32px avatar */
+    border-left: 2px solid var(--color-input-border);
+    padding-left: 1.375rem; /* 22px → content at 16+2+22 = 40px = parent content start */
   }
 
-  .action-btn-text {
-    font-weight: 500;
+  .comment-card--recipe.nested {
+    margin-left: 1.25rem;   /* 20px = center of 40px avatar */
+    border-left: 2px solid var(--color-input-border);
+    padding-left: 1.875rem; /* 30px → content at 20+2+30 = 52px = parent content start */
   }
 
-  .zap-btn:hover {
-    color: #eab308; /* yellow-500 */
-  }
+  /* ── Replying-to indicator ──────────────────────────────────────── */
 
-  .zap-display {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
-    color: var(--color-text-secondary);
-  }
-
-  /* ── Parent-quote embed (shared sizing across variants) ─────────── */
-
-  .parent-quote {
-    margin-bottom: 0.5rem;
-    padding: 0.5rem 0.75rem;
-    background: var(--color-input);
-    border-left: 3px solid var(--color-primary, #f97316);
-    border-radius: 0.375rem;
-  }
-
-  .parent-quote-header {
-    display: flex;
-    align-items: center;
-    gap: 0.375rem;
+  .reply-to-indicator {
+    font-size: 0.75rem;
+    color: var(--color-caption);
     margin-bottom: 0.25rem;
   }
 
-  .parent-quote-author {
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: var(--color-text-secondary);
+  .reply-to-name {
+    color: var(--color-primary, #f97316);
   }
 
-  .parent-quote-content {
-    font-size: 0.75rem;
-    color: var(--color-text-secondary);
-    line-height: 1.4;
-    margin: 0;
-    overflow-wrap: anywhere;
-    word-break: break-word;
+  .reply-to-name:hover {
+    text-decoration: underline;
   }
 
-  /* ── Variant modifiers — sizing & typography ─────────────────────── */
+  /* ── Variant modifiers — avatar width only (typography is now unified) */
 
   .comment-card--recipe .comment-avatar {
     width: 40px;
@@ -574,33 +450,4 @@
     width: 32px;
   }
 
-  .comment-card--recipe .comment-author {
-    font-size: 1rem;
-  }
-  .comment-card--feed .comment-author {
-    font-size: 0.875rem;
-  }
-
-  .comment-card--recipe .comment-time {
-    font-size: 0.875rem;
-  }
-  .comment-card--feed .comment-time {
-    font-size: 0.75rem;
-  }
-
-  .comment-card--recipe .comment-body {
-    font-size: 1rem;
-  }
-  .comment-card--feed .comment-body {
-    font-size: 0.875rem;
-  }
-
-  .comment-card--recipe .comment-actions {
-    gap: 1rem;
-    font-size: 0.875rem;
-  }
-  .comment-card--feed .comment-actions {
-    gap: 0.75rem;
-    font-size: 0.75rem;
-  }
 </style>

--- a/src/components/comments/CommentCard.svelte
+++ b/src/components/comments/CommentCard.svelte
@@ -29,7 +29,7 @@
   import ChatCircleIcon from 'phosphor-svelte/lib/ChatCircle';
   import { resolveProfileByPubkey, formatDisplayName } from '$lib/profileResolver';
   import { getAnonChefName } from '$lib/anonName';
-  import { onMount, onDestroy, createEventDispatcher } from 'svelte';
+  import { onMount, createEventDispatcher } from 'svelte';
   const dispatch = createEventDispatcher();
 
   /** The comment event rendered by this card. */
@@ -172,7 +172,6 @@
 
   });
 
-  onDestroy(() => {});
 
   function setReplyBox(open: boolean) {
     showReplyBox = open;

--- a/src/components/comments/CommentThread.svelte
+++ b/src/components/comments/CommentThread.svelte
@@ -210,6 +210,6 @@
   .comments-list {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 0;
   }
 </style>

--- a/src/lib/mentionComposer.ts
+++ b/src/lib/mentionComposer.ts
@@ -25,6 +25,7 @@ import {
 	parseMentions as parseMentionsUtil,
 	escapeRegex
 } from '$lib/mentionUtils';
+import { seedProfileCache } from '$lib/profileResolver';
 
 export type { CachedProfile } from '$lib/followListCache';
 
@@ -421,6 +422,7 @@ export class MentionComposerController {
 		this.insertMentionNode(mention, user.name, true);
 
 		addToCache(user);
+		seedProfileCache(user.pubkey, { name: user.name, picture: user.picture });
 		this.updateContentFromComposer();
 		this.showMentionSuggestions = false;
 		this.mentionSuggestions = [];

--- a/src/lib/notificationStore.ts
+++ b/src/lib/notificationStore.ts
@@ -1,6 +1,7 @@
 import { writable, derived, get } from 'svelte/store';
 import { browser } from '$app/environment';
 import type NDK from '@nostr-dev-kit/ndk';
+import { NDKKind } from '@nostr-dev-kit/ndk';
 import type { NDKEvent, NDKSubscription } from '@nostr-dev-kit/ndk';
 import { mutedPubkeys } from '$lib/muteListStore';
 import { isHellthread } from '$lib/notificationUtils';
@@ -223,7 +224,11 @@ export function subscribeToNotifications(ndk: NDK, userPubkey: string, forceFull
       // Reposts of kind 1 notes (NIP-18)
       { kinds: [6], '#p': [userPubkey], since },
       // Generic reposts — recipes, etc. (NIP-18 kind 16)
-      { kinds: [16], '#p': [userPubkey], since }
+      { kinds: [16], '#p': [userPubkey], since },
+      // NIP-22 comments on my recipes (uppercase P = root event author)
+      { kinds: [1111 as NDKKind], '#P': [userPubkey], since },
+      // NIP-22 replies to my comments (lowercase p = parent comment author)
+      { kinds: [1111 as NDKKind], '#p': [userPubkey], since }
     ],
     { closeOnEose: false }
   );
@@ -331,7 +336,9 @@ export async function fetchOlderNotifications(
         { kinds: [9735], '#p': [userPubkey], since, until },
         { kinds: [1], '#p': [userPubkey], since, until },
         { kinds: [6], '#p': [userPubkey], since, until },
-        { kinds: [16], '#p': [userPubkey], since, until }
+        { kinds: [16], '#p': [userPubkey], since, until },
+        { kinds: [1111 as NDKKind], '#P': [userPubkey], since, until },
+        { kinds: [1111 as NDKKind], '#p': [userPubkey], since, until }
       ],
       { closeOnEose: true }
     );
@@ -508,6 +515,18 @@ function parseNotification(event: NDKEvent, userPubkey: string): Notification | 
         type: isReply ? 'comment' : 'mention',
         eventId: event.id,
         targetEventId: replyToEvent,
+        content: cleanContentForPreview(event.content || '')
+      };
+    }
+
+    case 1111: { // NIP-22 comment on a recipe or reply to a comment
+      // lowercase 'e' tag = parent comment id (present when replying to a comment)
+      const parentETag = event.tags.find((t) => t[0] === 'e');
+      return {
+        ...baseNotification,
+        type: 'comment',
+        eventId: event.id,
+        targetEventId: parentETag?.[1],
         content: cleanContentForPreview(event.content || '')
       };
     }

--- a/src/lib/profileResolver.ts
+++ b/src/lib/profileResolver.ts
@@ -350,6 +350,15 @@ export async function resolveProfiles(nostrStrings: string[], ndkInstance: NDK):
   return results;
 }
 
+// Pre-populate the cache with a known profile (e.g. from mention autocomplete)
+// so ProfileLink can resolve it immediately without a relay fetch.
+export function seedProfileCache(pubkey: string, data: { name?: string; display_name?: string; picture?: string; nip05?: string }): void {
+  if (!pubkey) return;
+  const existing = profileCache[pubkey];
+  if (existing && isCacheValid(existing)) return;
+  profileCache[pubkey] = { pubkey, ...data, lastFetched: Date.now() };
+}
+
 // Clear cache (useful for testing or manual refresh)
 export function clearProfileCache(): void {
   profileCache = {};

--- a/src/routes/[nip19]/+page.svelte
+++ b/src/routes/[nip19]/+page.svelte
@@ -12,6 +12,7 @@
   import PollDisplay from '../../components/PollDisplay.svelte';
   import NoteActionBar from '../../components/NoteActionBar.svelte';
   import ClientAttribution from '../../components/ClientAttribution.svelte';
+  import { NDKRelaySet } from '@nostr-dev-kit/ndk';
   import type { NDKEvent } from '@nostr-dev-kit/ndk';
   import { createCommentFilter } from '$lib/commentFilters';
   import { stripTrackingParams } from '$lib/utils/stripTrackingParams';
@@ -156,6 +157,20 @@
     loadingParents = false;
   }
 
+  // Encode a note/reply event as nevent1 with relay hints for better discoverability.
+  function noteUrl(evt: NDKEvent): string {
+    const relayUrl = evt.relay?.url ?? (evt as any).onRelays?.[0]?.url;
+    try {
+      return '/' + nip19.neventEncode({
+        id: evt.id,
+        relays: relayUrl ? [relayUrl] : [],
+        kind: evt.kind ?? 1
+      });
+    } catch {
+      return '/' + nip19.noteEncode(evt.id);
+    }
+  }
+
   // Fetch replies to this note
   function fetchReplies(eventId: string) {
     loadingReplies = true;
@@ -165,7 +180,29 @@
     if (!event) return;
 
     const filter = createCommentFilter(event);
-    const sub = $ndk.subscribe(filter, { closeOnEose: false });
+
+    // Build a wider relay set: NDK's default pool + the relay that served the
+    // main event + any relay hints embedded in the event's e/p tags.
+    // This handles the common case where replies live on the author's write
+    // relay but not on all of NDK's default pool relays.
+    let relaySet: NDKRelaySet | undefined;
+    try {
+      const extraUrls = new Set<string>();
+      // Relay that served the main event
+      const sourceRelay = event.relay?.url || event.onRelays?.[0]?.url;
+      if (sourceRelay) extraUrls.add(sourceRelay);
+      // Relay hints in event e/p tags (NIP-10 clients often include them)
+      for (const tag of event.tags) {
+        if ((tag[0] === 'e' || tag[0] === 'p') && tag[2]?.startsWith('wss://')) {
+          extraUrls.add(tag[2]);
+        }
+      }
+      if (extraUrls.size > 0 && $ndk) {
+        relaySet = NDKRelaySet.fromRelayUrls([...extraUrls], $ndk, true);
+      }
+    } catch { /* non-fatal */ }
+
+    const sub = $ndk.subscribe(filter, { closeOnEose: false }, relaySet);
 
     sub.on('event', (e: NDKEvent) => {
       if (processedReplies.has(e.id)) return;
@@ -236,9 +273,11 @@
       if (decoded.type === 'nevent' || decoded.type === 'note') {
         // Fetch the referenced event
         let eventId = '';
+        let neventRelays: string[] = [];
         switch (decoded.type) {
           case 'nevent':
             eventId = (decoded as nip19.DecodedNevent).data.id;
+            neventRelays = (decoded as nip19.DecodedNevent).data.relays ?? [];
             break;
           case 'note':
             eventId = (decoded as nip19.DecodedNote).data;
@@ -248,7 +287,15 @@
           ids: [eventId]
         };
 
-        const subscription = $ndk.subscribe(filter, { closeOnEose: false });
+        // Include relay hints from nevent1 when fetching the main event
+        let eventRelaySet: NDKRelaySet | undefined;
+        if (neventRelays.length > 0 && $ndk) {
+          try {
+            eventRelaySet = NDKRelaySet.fromRelayUrls(neventRelays, $ndk, true);
+          } catch { /* non-fatal */ }
+        }
+
+        const subscription = $ndk.subscribe(filter, { closeOnEose: false }, eventRelaySet);
         let resolved = false;
 
         subscription.on('event', async (receivedEvent: NDKEvent) => {
@@ -557,16 +604,10 @@
     {:else if parentThread.length > 0}
       <div class="space-y-0">
         {#each parentThread as parentNote, index}
-          <div class="relative">
-            <!-- Thread line connecting to next note -->
-            <div
-              class="absolute left-5 top-12 bottom-0 w-0.5"
-              style="background-color: var(--color-input-border)"
-            ></div>
-
+          <div>
             <article class="py-3">
               <div class="flex space-x-3 -mx-2 px-2 py-2 rounded-lg">
-                <div class="flex-shrink-0 z-10">
+                <div class="flex-shrink-0">
                   <a
                     href="/user/{nip19.npubEncode(
                       parentNote.author?.hexpubkey || parentNote.pubkey
@@ -601,11 +642,11 @@
                     <PollDisplay event={parentNote} />
                   {:else}
                     <a
-                      href="/{nip19.noteEncode(parentNote.id)}"
-                      class="block text-sm leading-relaxed hover:opacity-80"
+                      href="{noteUrl(parentNote)}"
+                      class="block text-base leading-relaxed hover:opacity-80"
                       style="color: var(--color-text-secondary)"
                     >
-                      <NoteContent content={parentNote.content} />
+                      <NoteContent content={parentNote.content} showNostrEmbeds={false} />
                     </a>
                   {/if}
                   <!-- Parent note actions -->
@@ -621,7 +662,7 @@
     {/if}
 
     <!-- Main Note -->
-    <article class="py-4 border-b" style="border-color: var(--color-input-border)">
+    <article class="py-6">
       <div class="flex space-x-3">
         <a
           href="/user/{nip19.npubEncode(event.author?.hexpubkey || event.pubkey)}"
@@ -650,7 +691,7 @@
                 </span>
                 <ClientAttribution tags={event.tags} enableEnrichment={true} />
               </div>
-              <div class="text-sm leading-relaxed mb-3" style="color: var(--color-text-primary)">
+              <div class="text-base leading-relaxed mb-3" style="color: var(--color-text-primary)">
                 {#if event.kind === 1068}
                   <PollDisplay {event} />
                 {:else}
@@ -666,21 +707,8 @@
     </article>
 
     <!-- Replies Section -->
-    <div class="mt-4">
-      <div
-        class="flex items-center gap-2 text-sm font-medium mb-3"
-        style="color: var(--color-text-secondary)"
-      >
-        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
-          />
-        </svg>
-        <span>Replies ({directReplies.length})</span>
-      </div>
+    <div class="border-t mt-2" style="border-color: var(--color-input-border)">
+
 
       <!-- Replies List -->
       {#if loadingReplies}
@@ -705,13 +733,18 @@
             {#if !$mutedPubkeys.has(reply.author?.hexpubkey || reply.pubkey)}
               <div>
                 <article
-                  class="py-3 border-b last:border-0"
+                  class="py-8 border-b last:border-0 cursor-pointer hover:bg-[var(--color-bg-hover,rgba(255,255,255,0.03))]"
                   style="border-color: var(--color-input-border)"
+                  on:click={() => goto(noteUrl(reply))}
+                  role="link"
+                  tabindex="0"
+                  on:keydown={(e) => e.key === 'Enter' && goto(noteUrl(reply))}
                 >
                   <div class="flex space-x-3">
                     <a
                       href="/user/{nip19.npubEncode(reply.author?.hexpubkey || reply.pubkey)}"
                       class="flex-shrink-0"
+                      on:click|stopPropagation
                     >
                       <Avatar pubkey={reply.author?.hexpubkey || reply.pubkey} size={32} />
                     </a>
@@ -722,6 +755,7 @@
                             href="/user/{nip19.npubEncode(reply.author?.hexpubkey || reply.pubkey)}"
                             class="font-medium text-sm transition-colors username-link truncate min-w-0"
                             style="color: var(--color-text-primary)"
+                            on:click|stopPropagation
                           >
                             <CustomName pubkey={reply.author?.hexpubkey || reply.pubkey} />
                           </a>
@@ -730,20 +764,22 @@
                             {reply.created_at ? formatTimeAgo(reply.created_at) : ''}
                           </span>
                         </div>
-                        <PostActionsMenu event={reply} />
+                        <span on:click|stopPropagation>
+                          <PostActionsMenu event={reply} />
+                        </span>
                       </div>
                       <div
-                        class="text-sm leading-relaxed"
-                        style="color: var(--color-text-secondary)"
+                        class="text-base leading-relaxed"
+                        style="color: var(--color-text-primary)"
                       >
                         {#if reply.kind === 1068}
                           <PollDisplay event={reply} />
                         {:else}
-                          <NoteContent content={reply.content} />
+                          <NoteContent content={reply.content} showNostrEmbeds={false} />
                         {/if}
                       </div>
                       <!-- Reply actions -->
-                      <div class="mt-2">
+                      <div class="mt-2" on:click|stopPropagation>
                         <NoteActionBar event={reply} />
                       </div>
                     </div>
@@ -754,13 +790,20 @@
                 {#each getNestedReplies(reply.id).slice(0, 2) as nestedReply (nestedReply.id)}
                   {#if !$mutedPubkeys.has(nestedReply.author?.hexpubkey || nestedReply.pubkey)}
                     <div class="ml-8 pl-3">
-                      <article class="py-2">
+                      <article
+                        class="py-2 cursor-pointer hover:bg-[var(--color-bg-hover,rgba(255,255,255,0.03))] rounded"
+                        on:click={() => goto(noteUrl(nestedReply))}
+                        role="link"
+                        tabindex="0"
+                        on:keydown={(e) => e.key === 'Enter' && goto(noteUrl(nestedReply))}
+                      >
                         <div class="flex space-x-2">
                           <a
                             href="/user/{nip19.npubEncode(
                               nestedReply.author?.hexpubkey || nestedReply.pubkey
                             )}"
                             class="flex-shrink-0"
+                            on:click|stopPropagation
                           >
                             <Avatar
                               pubkey={nestedReply.author?.hexpubkey || nestedReply.pubkey}
@@ -774,8 +817,9 @@
                                   href="/user/{nip19.npubEncode(
                                     nestedReply.author?.hexpubkey || nestedReply.pubkey
                                   )}"
-                                  class="font-medium text-xs transition-colors username-link truncate min-w-0"
+                                  class="font-medium text-sm transition-colors username-link truncate min-w-0"
                                   style="color: var(--color-text-primary)"
+                                  on:click|stopPropagation
                                 >
                                   <CustomName
                                     pubkey={nestedReply.author?.hexpubkey || nestedReply.pubkey}
@@ -788,20 +832,22 @@
                                     : ''}
                                 </span>
                               </div>
-                              <PostActionsMenu event={nestedReply} />
+                              <span on:click|stopPropagation>
+                                <PostActionsMenu event={nestedReply} />
+                              </span>
                             </div>
                             <div
-                              class="text-xs leading-relaxed"
-                              style="color: var(--color-text-secondary)"
+                              class="text-sm leading-relaxed"
+                              style="color: var(--color-text-primary)"
                             >
                               {#if nestedReply.kind === 1068}
                                 <PollDisplay event={nestedReply} />
                               {:else}
-                                <NoteContent content={nestedReply.content} />
+                                <NoteContent content={nestedReply.content} showNostrEmbeds={false} />
                               {/if}
                             </div>
                             <!-- Nested reply actions -->
-                            <div class="mt-1.5">
+                            <div class="mt-1.5" on:click|stopPropagation>
                               <NoteActionBar event={nestedReply} variant="compact" />
                             </div>
                           </div>
@@ -814,7 +860,7 @@
                 <!-- Show more nested replies link -->
                 {#if getNestedReplies(reply.id).length > 2}
                   <a
-                    href="/{nip19.noteEncode(reply.id)}"
+                    href="{noteUrl(reply)}"
                     class="ml-8 pl-3 py-2 block text-xs text-primary hover:opacity-80"
                   >
                     Show {getNestedReplies(reply.id).length - 2} more {getNestedReplies(reply.id)

--- a/src/routes/[nip19]/+page.svelte
+++ b/src/routes/[nip19]/+page.svelte
@@ -198,7 +198,7 @@
         }
       }
       if (extraUrls.size > 0 && $ndk) {
-        relaySet = NDKRelaySet.fromRelayUrls([...extraUrls], $ndk, true);
+        relaySet = NDKRelaySet.fromRelayUrls([...extraUrls].slice(0, 3), $ndk, true);
       }
     } catch { /* non-fatal */ }
 
@@ -277,7 +277,9 @@
         switch (decoded.type) {
           case 'nevent':
             eventId = (decoded as nip19.DecodedNevent).data.id;
-            neventRelays = (decoded as nip19.DecodedNevent).data.relays ?? [];
+            neventRelays = ((decoded as nip19.DecodedNevent).data.relays ?? [])
+              .filter((r) => r.startsWith('wss://'))
+              .slice(0, 3);
             break;
           case 'note':
             eventId = (decoded as nip19.DecodedNote).data;
@@ -735,10 +737,10 @@
                 <article
                   class="py-8 border-b last:border-0 cursor-pointer hover:bg-[var(--color-bg-hover,rgba(255,255,255,0.03))]"
                   style="border-color: var(--color-input-border)"
-                  on:click={() => goto(noteUrl(reply))}
+                  on:click={(e) => { if ((e.target as HTMLElement).closest('a, button')) return; goto(noteUrl(reply)); }}
                   role="link"
                   tabindex="0"
-                  on:keydown={(e) => e.key === 'Enter' && goto(noteUrl(reply))}
+                  on:keydown|self={(e) => e.key === 'Enter' && goto(noteUrl(reply))}
                 >
                   <div class="flex space-x-3">
                     <a
@@ -792,10 +794,10 @@
                     <div class="ml-8 pl-3">
                       <article
                         class="py-2 cursor-pointer hover:bg-[var(--color-bg-hover,rgba(255,255,255,0.03))] rounded"
-                        on:click={() => goto(noteUrl(nestedReply))}
+                        on:click={(e) => { if ((e.target as HTMLElement).closest('a, button')) return; goto(noteUrl(nestedReply)); }}
                         role="link"
                         tabindex="0"
-                        on:keydown={(e) => e.key === 'Enter' && goto(noteUrl(nestedReply))}
+                        on:keydown|self={(e) => e.key === 'Enter' && goto(noteUrl(nestedReply))}
                       >
                         <div class="flex space-x-2">
                           <a


### PR DESCRIPTION
## Summary

- **Thread page**: reply cards are now clickable (navigate to sub-thread); all note IDs upgraded to `nevent1` encoding with relay hints for better discoverability; wider relay set for reply fetches using source relay + tag hints; embedded `nostr:` references suppressed inside reply content (were showing redundant parent quote blocks); reply card padding increased for breathing room
- **Comment thread lines**: `CommentCard` now shows a continuous vertical thread line — parent avatar drops a line down to its children, nested cards use a `border-left` at the same x-position with `gap: 0` between them so all segments join into one unbroken line; nested indent aligns with parent content column; parent quote block replaced with compact "Replying to @name" indicator
- **Notifications**: `notificationStore` now subscribes to kind:1111 NIP-22 comments with both `#P` (recipe author) and `#p` (reply target) filters — recipe authors were never receiving notifications before
- **Comment icon fallback**: `NoteTotalComments` navigates to the note thread when no inline-comments container is found (profile pages, thread page, etc.)

## Test plan

- [ ] Open a note thread (`/note1...` or `/nevent1...`) and confirm reply cards are clickable → navigates to the reply's own thread
- [ ] Verify no embedded quote blocks appear inside reply cards
- [ ] Open feed, expand inline comments on a note that has nested replies — confirm "Replying to @name" shows for nested cards with a connected vertical line
- [ ] Click the comment icon (💬) on a note outside the feed → should navigate to the thread page
- [ ] Post a NIP-22 comment on a recipe and verify the recipe author receives a notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)