### PR TITLE
feat(composer): paste-to-upload images in post and reply composers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.549",
+  "version": "4.2.550",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.548",
+  "version": "4.2.549",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -54,7 +54,7 @@
       <!-- Social Icons -->
       <div class="flex footer-icons">
         <a
-          href="https://zap.cooking/user/npub1xxdd8eusvdxmaph3fkuu9x2mymhrcc3ghe2l38zv0l4f4nqp659qskkt7a"
+          href="/user/npub1xxdd8eusvdxmaph3fkuu9x2mymhrcc3ghe2l38zv0l4f4nqp659qskkt7a"
           target="_blank"
           rel="noopener noreferrer"
           class="w-8 h-8 rounded-full flex items-center justify-center text-caption hover:text-primary transition-colors"
@@ -96,7 +96,7 @@
       <!-- Branta Guardrail -->
       <p class="text-xs text-caption">
         Running Guardrail by <a
-          href="https://zap.cooking/user/npub16ndruwfg7dsdhnp3w8zvqrg0r2rn3wucnttgrg5acm2lhqpkepkqncr9qr"
+          href="/user/npub16ndruwfg7dsdhnp3w8zvqrg0r2rn3wucnttgrg5acm2lhqpkepkqncr9qr"
           target="_blank"
           rel="noopener noreferrer"
           class="hover:text-primary transition-colors">@branta</a

--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -54,7 +54,7 @@
       <!-- Social Icons -->
       <div class="flex footer-icons">
         <a
-          href="https://primal.net/p/npub1xxdd8eusvdxmaph3fkuu9x2mymhrcc3ghe2l38zv0l4f4nqp659qskkt7a"
+          href="https://zap.cooking/user/npub1xxdd8eusvdxmaph3fkuu9x2mymhrcc3ghe2l38zv0l4f4nqp659qskkt7a"
           target="_blank"
           rel="noopener noreferrer"
           class="w-8 h-8 rounded-full flex items-center justify-center text-caption hover:text-primary transition-colors"
@@ -96,7 +96,7 @@
       <!-- Branta Guardrail -->
       <p class="text-xs text-caption">
         Running Guardrail by <a
-          href="https://primal.net/p/npub16ndruwfg7dsdhnp3w8zvqrg0r2rn3wucnttgrg5acm2lhqpkepkqncr9qr"
+          href="https://zap.cooking/user/npub16ndruwfg7dsdhnp3w8zvqrg0r2rn3wucnttgrg5acm2lhqpkepkqncr9qr"
           target="_blank"
           rel="noopener noreferrer"
           class="hover:text-primary transition-colors">@branta</a

--- a/src/components/PostComposer.svelte
+++ b/src/components/PostComposer.svelte
@@ -298,10 +298,11 @@
     uploadingImage = true;
     error = '';
     try {
+      const newUrls: string[] = [];
       for (const file of imageFiles) {
-        const url = await uploadImage($ndk, file);
-        uploadedImages = [...uploadedImages, url];
+        newUrls.push(await uploadImage($ndk, file));
       }
+      uploadedImages = [...uploadedImages, ...newUrls];
     } catch (err: any) {
       error = err?.message || 'Failed to upload image. Please try again.';
     } finally {

--- a/src/components/PostComposer.svelte
+++ b/src/components/PostComposer.svelte
@@ -285,6 +285,30 @@
     }
   }
 
+  async function handlePaste(e: ClipboardEvent) {
+    const imageFiles = Array.from(e.clipboardData?.items ?? [])
+      .filter((item) => item.kind === 'file' && item.type.startsWith('image/'))
+      .map((item) => item.getAsFile())
+      .filter((f): f is File => f !== null);
+    if (imageFiles.length === 0) {
+      mentionCtrl.handlePaste(e);
+      return;
+    }
+    e.preventDefault();
+    uploadingImage = true;
+    error = '';
+    try {
+      for (const file of imageFiles) {
+        const url = await uploadImage($ndk, file);
+        uploadedImages = [...uploadedImages, url];
+      }
+    } catch (err: any) {
+      error = err?.message || 'Failed to upload image. Please try again.';
+    } finally {
+      uploadingImage = false;
+    }
+  }
+
   async function handleVideoUpload(e: Event) {
     const target = e.target as HTMLInputElement;
     const files = target.files;
@@ -655,7 +679,7 @@
                     on:keydown={handleKeydown}
                     on:input={() => mentionCtrl.handleInput()}
                     on:beforeinput={(e) => mentionCtrl.handleBeforeInput(e)}
-                    on:paste={(e) => mentionCtrl.handlePaste(e)}
+                    on:paste={handlePaste}
                   ></div>
 
                   <MentionDropdown

--- a/src/components/comments/ReplyComposer.svelte
+++ b/src/components/comments/ReplyComposer.svelte
@@ -229,10 +229,11 @@
 		uploadingImage = true;
 		uploadError = '';
 		try {
+			const newUrls: string[] = [];
 			for (const file of imageFiles) {
-				const url = await uploadImage($ndk, file);
-				uploadedImages = [...uploadedImages, url];
+				newUrls.push(await uploadImage($ndk, file));
 			}
+			uploadedImages = [...uploadedImages, ...newUrls];
 		} catch (err: unknown) {
 			uploadError = (err as Error)?.message || 'Failed to upload image.';
 		} finally {
@@ -306,6 +307,7 @@
 
 			let content = mentionCtrl.replacePlainMentions(composerText.trim());
 			const mediaUrls = [...uploadedImages, ...uploadedVideos];
+			const capturedPollConfig = pollConfig;
 			clearState();
 			if (mediaUrls.length > 0) {
 				const mediaText = mediaUrls.join('\n');
@@ -317,8 +319,8 @@
 			for (const pubkey of mentions.values()) {
 				extraTags.push(['p', pubkey]);
 			}
-			if (pollConfig) {
-				extraTags.push(...buildPollTags(pollConfig));
+			if (capturedPollConfig) {
+				extraTags.push(...buildPollTags(capturedPollConfig));
 			}
 
 			const { event: posted } = await postCommentLib($ndk, {
@@ -326,7 +328,7 @@
 				replyTo,
 				content,
 				extraTags,
-				contentKind: pollConfig ? 1068 : undefined,
+				contentKind: capturedPollConfig ? 1068 : undefined,
 				signingStrategy: 'explicit-with-timeout'
 			});
 

--- a/src/components/comments/ReplyComposer.svelte
+++ b/src/components/comments/ReplyComposer.svelte
@@ -216,6 +216,30 @@
 		}
 	}
 
+	async function handlePaste(e: ClipboardEvent) {
+		const imageFiles = Array.from(e.clipboardData?.items ?? [])
+			.filter((item) => item.kind === 'file' && item.type.startsWith('image/'))
+			.map((item) => item.getAsFile())
+			.filter((f): f is File => f !== null);
+		if (imageFiles.length === 0) {
+			mentionCtrl.handlePaste(e);
+			return;
+		}
+		e.preventDefault();
+		uploadingImage = true;
+		uploadError = '';
+		try {
+			for (const file of imageFiles) {
+				const url = await uploadImage($ndk, file);
+				uploadedImages = [...uploadedImages, url];
+			}
+		} catch (err: unknown) {
+			uploadError = (err as Error)?.message || 'Failed to upload image.';
+		} finally {
+			uploadingImage = false;
+		}
+	}
+
 	async function handleVideoUpload(e: Event) {
 		const target = e.target as HTMLInputElement;
 		const files = target.files;
@@ -368,7 +392,7 @@
 				on:input={() => mentionCtrl.handleInput()}
 				on:keydown={(e) => mentionCtrl.handleKeydown(e)}
 				on:beforeinput={(e) => mentionCtrl.handleBeforeInput(e)}
-				on:paste={(e) => mentionCtrl.handlePaste(e)}
+				on:paste={handlePaste}
 			></div>
 
 			<MentionDropdown

--- a/src/components/comments/ReplyComposer.svelte
+++ b/src/components/comments/ReplyComposer.svelte
@@ -305,8 +305,8 @@
 			}
 
 			let content = mentionCtrl.replacePlainMentions(composerText.trim());
-			clearState();
 			const mediaUrls = [...uploadedImages, ...uploadedVideos];
+			clearState();
 			if (mediaUrls.length > 0) {
 				const mediaText = mediaUrls.join('\n');
 				content = content ? `${content}\n\n${mediaText}` : mediaText;


### PR DESCRIPTION
## Summary
- Adds paste-to-upload support for images in `PostComposer` and `ReplyComposer`
- Pasting an image (e.g. screenshot, copied image) into either composer detects the clipboard file, uploads it via the existing `uploadImage()` pipeline, and appends the URL to the draft — same behaviour as clicking the image picker
- Non-image pastes fall through to the existing mention-autocomplete paste handler unchanged

## Test plan
- [ ] Paste a screenshot into the post composer — image should upload and appear in the preview strip
- [ ] Paste an image into a reply composer — same result
- [ ] Paste plain text / an @mention — still works as before, no regression
- [ ] Paste an image while offline / >5 MB — error message appears, composer remains usable