### PR TITLE
fix(community): enlarge signed-out feed headline and spacing

### DIFF
--- a/src/routes/community/+page.svelte
+++ b/src/routes/community/+page.svelte
@@ -222,9 +222,9 @@
   <div class="px-4 max-w-2xl mx-auto community-page w-full">
     <!-- Orientation text for signed-out users -->
     {#if $userPublickey === ''}
-      <div class="mb-4 pt-1">
-        <p class="text-sm text-caption">Food. Friends. Freedom.</p>
-        <p class="text-xs text-caption mt-0.5">
+      <div class="mb-6 pt-4 pb-2">
+        <p class="text-xl font-semibold text-caption">Food. Friends. Freedom. ⚡</p>
+        <p class="text-sm text-caption mt-2">
           People share meals, recipes, and food ideas here. <a
             href="/login"
             class="text-caption hover:opacity-80 underline">Sign in</a


### PR DESCRIPTION
## Summary
- "Food. Friends. Freedom." headline was `text-sm` — same visual weight as the body copy beneath it
- Bumped to `text-xl font-semibold`, added a ⚡ at the end
- Increased block padding (`pt-4 pb-2 mb-6`) and line spacing between headline and body (`mt-2`)

## Test plan
- [ ] View the community feed while signed out — headline should be noticeably larger than the body copy
- [ ] Sign in — block should not appear