### PR TITLE
feat(notes): render lnbc invoices as inline pay cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.549",
+  "version": "4.2.550",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.548",
+  "version": "4.2.549",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/LightningInvoiceCard.svelte
+++ b/src/components/LightningInvoiceCard.svelte
@@ -1,0 +1,304 @@
+<script lang="ts">
+  import { decode } from '@gandlaf21/bolt11-decode';
+  import LightningIcon from 'phosphor-svelte/lib/Lightning';
+  import CopyIcon from 'phosphor-svelte/lib/Copy';
+  import QrCodeIcon from 'phosphor-svelte/lib/QrCode';
+  import { qr } from '@svelte-put/qr/svg';
+  import { sendPayment, walletConnected } from '$lib/wallet';
+  import { weblnConnected } from '$lib/wallet/webln';
+  import { bitcoinConnectEnabled, bitcoinConnectWalletInfo } from '$lib/wallet/bitcoinConnect';
+  import { showToast } from '$lib/toast';
+
+  export let invoice: string;
+
+  // --- decode ---
+  let amountSats: number | null = null;
+  let description: string | null = null;
+  let isExpired = false;
+  let decodeError = false;
+
+  try {
+    const decoded = decode(invoice.toLowerCase().replace(/^lightning:/i, ''));
+    const amountSection = decoded.sections.find((s: any) => s.name === 'amount');
+    if (amountSection?.value) amountSats = Math.floor(Number(amountSection.value) / 1000);
+    const descSection = decoded.sections.find((s: any) => s.name === 'description');
+    description = descSection?.value ?? null;
+    const ts = decoded.sections.find((s: any) => s.name === 'timestamp')?.value ?? 0;
+    const exp = decoded.sections.find((s: any) => s.name === 'expiry')?.value ?? 3600;
+    isExpired = Math.floor(Date.now() / 1000) > ts + exp;
+  } catch {
+    decodeError = true;
+  }
+
+  // --- wallet ---
+  $: hasWallet =
+    $walletConnected ||
+    $weblnConnected ||
+    ($bitcoinConnectEnabled && $bitcoinConnectWalletInfo.connected);
+
+  // --- pay state ---
+  let paying = false;
+  let paySuccess = false;
+  let payFailed = false;
+
+  async function pay() {
+    if (isExpired || paying || paySuccess) return;
+    paying = true;
+    payFailed = false;
+    try {
+      const result = await sendPayment(invoice);
+      if (result.success) {
+        paySuccess = true;
+      } else {
+        payFailed = true;
+        showToast(result.error || 'Payment failed');
+      }
+    } catch (e: any) {
+      payFailed = true;
+      showToast(e?.message || 'Payment failed');
+    } finally {
+      paying = false;
+    }
+  }
+
+  function copyInvoice(e: MouseEvent) {
+    e.stopPropagation();
+    navigator.clipboard.writeText(invoice);
+    showToast('Copied');
+  }
+
+  // --- QR popup ---
+  let showQr = false;
+  function toggleQr(e: MouseEvent) {
+    e.stopPropagation();
+    showQr = !showQr;
+  }
+
+</script>
+
+{#if !decodeError}
+  <div class="ln-card" class:ln-expired={isExpired}>
+    <!-- Header -->
+    <div class="ln-header">
+      <div class="ln-title">
+        <LightningIcon size={16} weight="fill" class="ln-bolt" />
+        <span>Lightning Invoice</span>
+      </div>
+      {#if isExpired}
+        <span class="ln-badge ln-badge--expired">Expired</span>
+      {:else if paySuccess}
+        <span class="ln-badge ln-badge--paid">Paid ✓</span>
+      {/if}
+    </div>
+
+    <!-- Amount -->
+    <div class="ln-amount" class:ln-amount--expired={isExpired}>
+      {#if amountSats !== null}
+        {amountSats.toLocaleString()} sats
+      {:else}
+        Any amount
+      {/if}
+    </div>
+
+    <!-- Description -->
+    {#if description}
+      <div class="ln-description">{description}</div>
+    {/if}
+
+    <!-- Actions -->
+    <div class="ln-actions">
+      <button class="ln-icon-btn" on:click={copyInvoice} title="Copy invoice" aria-label="Copy invoice">
+        <CopyIcon size={18} />
+      </button>
+
+      <button
+        class="ln-pay-btn"
+        class:ln-pay-btn--disabled={isExpired || paySuccess || !hasWallet}
+        disabled={isExpired || paySuccess || paying}
+        on:click|stopPropagation={pay}
+      >
+        {#if paying}
+          <span class="ln-spinner"></span> Paying…
+        {:else if paySuccess}
+          ✓ Paid
+        {:else if isExpired}
+          <LightningIcon size={15} weight="fill" /> Expired
+        {:else}
+          <LightningIcon size={15} weight="fill" /> Pay
+        {/if}
+      </button>
+
+      <button
+        class="ln-icon-btn"
+        class:ln-icon-btn--active={showQr}
+        on:click={toggleQr}
+        title="Show QR"
+        aria-label="Show QR code"
+      >
+        <QrCodeIcon size={18} />
+      </button>
+    </div>
+
+    <!-- Inline QR -->
+    {#if showQr}
+      <div class="ln-qr-inline">
+        <div class="ln-qr-inner">
+          <svg use:qr={{ data: invoice.toUpperCase(), width: 192, height: 192 }} style="color: black"></svg>
+        </div>
+        <p class="ln-qr-hint">Scan to pay</p>
+      </div>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .ln-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.875rem 1rem;
+    border-radius: 0.875rem;
+    border: 1px solid color-mix(in srgb, var(--color-primary) 40%, transparent);
+    background-color: var(--color-bg-secondary);
+    margin: 0.5rem 0;
+    max-width: 480px;
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-primary) 15%, transparent);
+  }
+  .ln-expired {
+    border-color: color-mix(in srgb, var(--color-caption) 40%, transparent);
+    box-shadow: none;
+  }
+
+  /* Header */
+  .ln-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .ln-title {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-weight: 600;
+    font-size: 0.875rem;
+    color: var(--color-text-primary);
+  }
+  :global(.ln-bolt) {
+    color: var(--color-primary);
+  }
+  .ln-badge {
+    font-size: 0.75rem;
+    font-weight: 600;
+    border-radius: 0.375rem;
+    padding: 0.125rem 0.5rem;
+  }
+  .ln-badge--expired { color: var(--color-danger); }
+  .ln-badge--paid { color: #22c55e; }
+
+  /* Amount */
+  .ln-amount {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--color-primary);
+    line-height: 1.2;
+  }
+  .ln-amount--expired {
+    opacity: 0.5;
+  }
+
+  /* Description */
+  .ln-description {
+    font-size: 0.875rem;
+    color: var(--color-text-secondary);
+    word-break: break-word;
+  }
+
+  /* Actions */
+  .ln-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 0.25rem;
+  }
+  .ln-icon-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.25rem;
+    height: 2.25rem;
+    border-radius: 50%;
+    border: none;
+    background-color: var(--color-input-bg);
+    color: var(--color-caption);
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: background-color 0.15s, color 0.15s;
+  }
+  .ln-icon-btn:hover {
+    color: var(--color-text-primary);
+  }
+  .ln-pay-btn {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.375rem;
+    height: 2.25rem;
+    border-radius: 9999px;
+    border: none;
+    background-color: var(--color-primary);
+    color: #fff;
+    font-weight: 600;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: opacity 0.15s;
+  }
+  .ln-pay-btn:hover:not(.ln-pay-btn--disabled) {
+    opacity: 0.85;
+  }
+  .ln-pay-btn--disabled {
+    background-color: var(--color-input-bg);
+    color: var(--color-caption);
+    cursor: default;
+  }
+  .ln-spinner {
+    width: 0.875rem;
+    height: 0.875rem;
+    border: 2px solid rgba(255,255,255,0.3);
+    border-top-color: #fff;
+    border-radius: 50%;
+    animation: spin 0.7s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+
+  /* Inline QR */
+  .ln-qr-inline {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid color-mix(in srgb, var(--color-input-border) 60%, transparent);
+  }
+  .ln-qr-inner {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: white;
+    border-radius: 0.75rem;
+    padding: 0.625rem;
+  }
+  .ln-qr-inner svg {
+    display: block;
+    width: 192px;
+    height: 192px;
+  }
+  .ln-qr-hint {
+    font-size: 0.75rem;
+    color: var(--color-caption);
+  }
+  .ln-icon-btn--active {
+    background-color: color-mix(in srgb, var(--color-primary) 15%, var(--color-input-bg));
+    color: var(--color-primary);
+  }
+</style>

--- a/src/components/LightningInvoiceCard.svelte
+++ b/src/components/LightningInvoiceCard.svelte
@@ -23,9 +23,13 @@
     if (amountSection?.value) amountSats = Math.floor(Number(amountSection.value) / 1000);
     const descSection = decoded.sections.find((s: any) => s.name === 'description');
     description = descSection?.value ?? null;
-    const ts = decoded.sections.find((s: any) => s.name === 'timestamp')?.value ?? 0;
-    const exp = decoded.sections.find((s: any) => s.name === 'expiry')?.value ?? 3600;
-    isExpired = Math.floor(Date.now() / 1000) > ts + exp;
+    // Coerce to Number: bolt11-decode section values can be strings, and
+    // `string + string` would concatenate and mis-flag expiry.
+    const ts = Number(decoded.sections.find((s: any) => s.name === 'timestamp')?.value ?? 0);
+    const exp = Number(decoded.sections.find((s: any) => s.name === 'expiry')?.value ?? 3600);
+    if (Number.isFinite(ts) && Number.isFinite(exp)) {
+      isExpired = Math.floor(Date.now() / 1000) > ts + exp;
+    }
   } catch {
     decodeError = true;
   }
@@ -42,7 +46,7 @@
   let payFailed = false;
 
   async function pay() {
-    if (isExpired || paying || paySuccess) return;
+    if (isExpired || paying || paySuccess || !hasWallet) return;
     paying = true;
     payFailed = false;
     try {
@@ -114,7 +118,8 @@
       <button
         class="ln-pay-btn"
         class:ln-pay-btn--disabled={isExpired || paySuccess || !hasWallet}
-        disabled={isExpired || paySuccess || paying}
+        disabled={isExpired || paySuccess || paying || !hasWallet}
+        title={!hasWallet && !isExpired && !paySuccess ? 'Connect a wallet to pay' : undefined}
         on:click|stopPropagation={pay}
       >
         {#if paying}
@@ -149,6 +154,10 @@
       </div>
     {/if}
   </div>
+{:else}
+  <!-- Decode failed (e.g. a false-positive regex match). Fall back to the raw
+       text so note content is never silently dropped. -->
+  <span class="ln-invalid">{invoice}</span>
 {/if}
 
 <style>
@@ -300,5 +309,10 @@
   .ln-icon-btn--active {
     background-color: color-mix(in srgb, var(--color-primary) 15%, var(--color-input-bg));
     color: var(--color-primary);
+  }
+
+  /* Fallback when the invoice can't be decoded — render raw text inline. */
+  .ln-invalid {
+    word-break: break-all;
   }
 </style>

--- a/src/components/LightningInvoiceCard.svelte
+++ b/src/components/LightningInvoiceCard.svelte
@@ -51,11 +51,11 @@
         paySuccess = true;
       } else {
         payFailed = true;
-        showToast(result.error || 'Payment failed');
+        showToast('error', result.error || 'Payment failed');
       }
     } catch (e: any) {
       payFailed = true;
-      showToast(e?.message || 'Payment failed');
+      showToast('error', e?.message || 'Payment failed');
     } finally {
       paying = false;
     }
@@ -64,7 +64,7 @@
   function copyInvoice(e: MouseEvent) {
     e.stopPropagation();
     navigator.clipboard.writeText(invoice);
-    showToast('Copied');
+    showToast('success', 'Copied');
   }
 
   // --- QR popup ---
@@ -143,7 +143,7 @@
     {#if showQr}
       <div class="ln-qr-inline">
         <div class="ln-qr-inner">
-          <svg use:qr={{ data: invoice.toUpperCase(), width: 192, height: 192 }} style="color: black"></svg>
+          <svg use:qr={{ data: invoice.toUpperCase() }} style="color: black; width: 192px; height: 192px;"></svg>
         </div>
         <p class="ln-qr-hint">Scan to pay</p>
       </div>

--- a/src/components/NoteContent.svelte
+++ b/src/components/NoteContent.svelte
@@ -335,8 +335,13 @@
         out.push({ type: 'lightning', invoice: m[0].replace(/^(?:lightning|nostr):/i, ''), key: `ln-${keyCounter++}` });
         last = m.index + m[0].length;
       }
-      if (last < text.length) out.push({ type: 'text', content: text.slice(last), key: `text-ln-${keyCounter++}` });
-      if (last === 0) out.push(part);
+      if (last === 0) {
+        // No invoice matched — keep the original text part untouched.
+        out.push(part);
+      } else if (last < text.length) {
+        // Trailing text after the final match.
+        out.push({ type: 'text', content: text.slice(last), key: `text-ln-${keyCounter++}` });
+      }
     }
     return out;
   }

--- a/src/components/NoteContent.svelte
+++ b/src/components/NoteContent.svelte
@@ -10,6 +10,7 @@
   import MediaCarousel from './MediaCarousel.svelte';
   import { processContentWithProfiles } from '$lib/contentProcessor';
   import MediaLightbox from './MediaLightbox.svelte';
+  import LightningInvoiceCard from './LightningInvoiceCard.svelte';
 
   export let content: string;
   export let className: string = '';
@@ -312,8 +313,32 @@
     return cut;
   }
   $: displayContent = shouldCollapse && !isExpanded ? truncateAtUrlBoundary(content, maxLength) : content;
-  $: finalParsedContent = parseContent(displayContent);
+  $: finalParsedContent = splitLightningInvoices(parseContent(displayContent));
   $: renderParts = groupMediaRuns(finalParsedContent);
+
+  const LIGHTNING_REGEX = /(?:(?:lightning|nostr):)?((lnbc|lntb|lnbcrt)[a-z0-9]{50,})/gi;
+
+  function splitLightningInvoices(parts: any[]): any[] {
+    const out: any[] = [];
+    let keyCounter = 0;
+    for (const part of parts) {
+      if (part.type !== 'text') { out.push(part); continue; }
+      LIGHTNING_REGEX.lastIndex = 0;
+      const text: string = part.content;
+      let last = 0;
+      let m;
+      while ((m = LIGHTNING_REGEX.exec(text)) !== null) {
+        if (m.index > last) {
+          out.push({ type: 'text', content: text.slice(last, m.index), key: `text-ln-${keyCounter++}` });
+        }
+        out.push({ type: 'lightning', invoice: m[0].replace(/^(?:lightning|nostr):/i, ''), key: `ln-${keyCounter++}` });
+        last = m.index + m[0].length;
+      }
+      if (last < text.length) out.push({ type: 'text', content: text.slice(last), key: `text-ln-${keyCounter++}` });
+      if (last === 0) out.push(part);
+    }
+    return out;
+  }
 
   // Preload profiles when content changes
   $: if (content) {
@@ -405,6 +430,8 @@
           {part.content}
         </button>
       {/if}
+    {:else if part.type === 'lightning'}
+      <LightningInvoiceCard invoice={part.invoice} />
     {/if}
   {/each}
 

--- a/src/components/clink/NofferPayModal.svelte
+++ b/src/components/clink/NofferPayModal.svelte
@@ -303,6 +303,7 @@
             <svg
               use:qr={{ data: lightningUri, shape: 'square' }}
               class="w-48 h-48"
+              style="color: black"
               aria-label="QR code for {lightningUri}"
             />
           </div>


### PR DESCRIPTION
## Summary
- Detects `lnbc…`, `lntb…`, `lnbcrt…` strings in note content (bare, `lightning:` prefixed, or `nostr:` prefixed) and renders them as interactive `LightningInvoiceCard` components
- Card shows amount in sats, description, copy button, pay button (uses connected NWC/WebLN/BitcoinConnect wallet), and a collapsible inline QR code
- QR expands inside the card on tap rather than opening a floating modal
- Also fixes QR invisible-in-dark-mode on `NofferPayModal` (`color: black` on the SVG)

## Test plan
- [ ] Post a note containing a raw `lnbc…` string — card should render inline
- [ ] Test with `lightning:lnbc…` and `nostr:lnbc…` prefixes — both should strip the prefix and render correctly
- [ ] Tap the QR icon — should expand inline below the action row, not open a modal
- [ ] Tap again — should collapse
- [ ] Open a CLINK offer modal in dark mode — QR should be visible (black on white)
- [ ] Expired invoice shows "Expired" badge and disabled pay button