### PR TITLE
fix(og): restore recipe link-preview metadata for social crawlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.549",
+  "version": "4.2.550",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.550",
+  "version": "4.2.551",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/NoteEmbed.svelte
+++ b/src/components/NoteEmbed.svelte
@@ -433,7 +433,7 @@
 {:else if event}
   <div
     class="parent-quote-embed my-2 cursor-pointer hover:opacity-90 transition-opacity"
-    on:click|stopPropagation={(e) => { if ((e.target as HTMLElement).closest('a, button')) return; handleCardClick(); }}
+    on:click|stopPropagation={(e) => { if (e.target instanceof Element && e.target.closest('a, button')) return; handleCardClick(); }}
     role="link"
     tabindex="0"
     on:keydown|self={(e) => e.key === 'Enter' && handleCardClick()}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,6 @@
 import type { Handle, HandleServerError } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
+import { isCrawler, matchRecipeOgRoute, renderRecipeOgForCrawler } from '$lib/recipeOgHtml.server';
 
 /**
  * Log the real server-side error (with stack) instead of letting SvelteKit
@@ -28,13 +29,13 @@ const ALLOW_METHODS = 'GET, POST, PATCH, OPTIONS';
 const ALLOW_HEADERS = 'Content-Type, Authorization, Nostr-Authorization';
 
 const TRUSTED_ORIGINS = env.CORS_ORIGIN
-  ? env.CORS_ORIGIN.split(',').map(o => o.trim())
+  ? env.CORS_ORIGIN.split(',').map((o) => o.trim())
   : [
       'https://zap.cooking',
       'https://www.zap.cooking',
       'http://localhost:5173',
       'http://localhost:5174',
-      'capacitor://localhost',
+      'capacitor://localhost'
     ];
 
 function isTrustedOrigin(origin: string | null): boolean {
@@ -62,9 +63,7 @@ function applyVaryOrigin(headers: Headers): void {
     return;
   }
 
-  const varyValues = existingVary
-    .split(',')
-    .map(value => value.trim().toLowerCase());
+  const varyValues = existingVary.split(',').map((value) => value.trim().toLowerCase());
 
   if (!varyValues.includes('origin')) {
     headers.set('Vary', `${existingVary}, Origin`);
@@ -76,7 +75,7 @@ function buildCorsHeaders(origin: string | null, useWildcard: boolean): Headers 
     'Access-Control-Allow-Origin': useWildcard ? '*' : (origin ?? ''),
     'Access-Control-Allow-Methods': ALLOW_METHODS,
     'Access-Control-Allow-Headers': ALLOW_HEADERS,
-    'Access-Control-Max-Age': '86400',
+    'Access-Control-Max-Age': '86400'
   });
 
   if (!useWildcard && origin) {
@@ -86,7 +85,50 @@ function buildCorsHeaders(origin: string | null, useWildcard: boolean): Headers 
   return headers;
 }
 
+/**
+ * Bot-only OG injection. Social crawlers don't run JS, so the client-fetched
+ * recipe event never populates the OG tags for them — they'd only ever see the
+ * static placeholders. For a crawler UA on a recipe route we resolve the recipe
+ * SERVER-SIDE (raw WebSocket, no NDK) and return a minimal standalone document.
+ *
+ * This deliberately does NOT use a `+page.server.ts` / server `data` dependency:
+ * that is what made #454 request `__data.json` against an OOM'd worker and 500.
+ * Crawlers issue a single document GET and never request `__data.json`, so this
+ * path cannot reintroduce that. Returns null (→ normal SPA resolve) for humans,
+ * non-matching routes, or ANY error — it must never throw or 500.
+ */
+async function maybeRenderBotOg(event: Parameters<Handle>[0]['event']): Promise<Response | null> {
+  try {
+    if (event.request.method !== 'GET') return null;
+    if (!isCrawler(event.request.headers.get('user-agent'))) return null;
+    const matched = matchRecipeOgRoute(event.url.pathname);
+    if (!matched) return null;
+
+    const html = await renderRecipeOgForCrawler(matched.prefix, matched.slug, event.url.origin);
+    return new Response(html, {
+      status: 200,
+      headers: {
+        'content-type': 'text/html; charset=utf-8',
+        // CRITICAL: never let this UA-specific document into a shared cache.
+        // Cloudflare's edge cache keys on URL and does NOT honour
+        // `Vary: User-Agent`, so a `public` bot document could be replayed to a
+        // real browser (serving humans the SPA-less crawler shell) or vice
+        // versa. `no-store` keeps the bot path fully separate from the human
+        // SPA path. Crawlers re-fetch on each scrape anyway; the fetch is fast.
+        'cache-control': 'no-store',
+        vary: 'User-Agent'
+      }
+    });
+  } catch (e) {
+    console.error('[bot OG] falling through to SPA', e);
+    return null;
+  }
+}
+
 export const handle: Handle = async ({ event, resolve }) => {
+  const botOg = await maybeRenderBotOg(event);
+  if (botOg) return botOg;
+
   const isApiRoute = event.url.pathname.startsWith('/api/');
   const origin = event.request.headers.get('origin');
   const trustedOrigin = isTrustedOrigin(origin);

--- a/src/lib/recipeOg.server.ts
+++ b/src/lib/recipeOg.server.ts
@@ -1,0 +1,80 @@
+/**
+ * Server-only resolver for recipe Open Graph metadata used by the crawler
+ * branch of the `handle` hook.
+ *
+ * Reuses the proven, NDK-free raw-WebSocket relay race from
+ * `recipePackOg.server.ts` (the same code path that serves `/pack/[naddr]` OG
+ * in production today). No NDK on the server — that keeps the worker bundle
+ * small, which is the whole point: a bloated bundle OOM'd at build time and was
+ * the root cause of the #454 500s.
+ *
+ * The slug may be an `naddr1…` (decode → identifier/pubkey/kind) or a raw hex
+ * event id, mirroring `recipe/[slug]/+page.svelte`'s `loadData()`.
+ */
+
+import { nip19 } from 'nostr-tools';
+import { raceRelays } from './recipePackOg.server';
+import { GATED_RECIPE_KIND } from './consts';
+import type { OgEventLike } from './recipeOgMeta';
+
+/** Hard ceiling on the whole resolve so a wedged relay can never delay the
+ * crawler response indefinitely. raceRelays already times out each socket at
+ * 3.5s; this is belt-and-suspenders so the hook always settles fast. */
+const RESOLVE_TIMEOUT_MS = 4000;
+
+function toOgEvent(evt: unknown): OgEventLike | null {
+  if (!evt || typeof evt !== 'object') return null;
+  const e = evt as Record<string, unknown>;
+  if (!Array.isArray(e.tags)) return null;
+  return {
+    tags: e.tags as string[][],
+    content: typeof e.content === 'string' ? e.content : '',
+    pubkey: typeof e.pubkey === 'string' ? e.pubkey : undefined,
+    created_at: typeof e.created_at === 'number' ? e.created_at : undefined,
+    kind: typeof e.kind === 'number' ? e.kind : undefined
+  };
+}
+
+async function resolveEvent(slug: string): Promise<OgEventLike | null> {
+  if (slug.startsWith('naddr1')) {
+    let decoded;
+    try {
+      decoded = nip19.decode(slug);
+    } catch {
+      return null;
+    }
+    if (decoded.type !== 'naddr') return null;
+    const pointer = decoded.data as nip19.AddressPointer;
+    if (!pointer.identifier || !pointer.pubkey) return null;
+
+    // Support both regular recipes (30023) and premium recipes (GATED_RECIPE_KIND).
+    const recipeKind = pointer.kind === GATED_RECIPE_KIND ? GATED_RECIPE_KIND : 30023;
+    const evt = await raceRelays({
+      kinds: [recipeKind],
+      authors: [pointer.pubkey],
+      '#d': [pointer.identifier]
+    });
+    return toOgEvent(evt);
+  }
+
+  // Raw hex event id.
+  if (!/^[0-9a-f]{64}$/i.test(slug)) return null;
+  const evt = await raceRelays({ ids: [slug] });
+  return toOgEvent(evt);
+}
+
+/**
+ * Resolve a recipe event for OG rendering. Never throws and never hangs past
+ * RESOLVE_TIMEOUT_MS — returns null on decode failure, timeout, or not-found,
+ * letting the caller emit safe fallback meta.
+ */
+export async function fetchRecipeEventForOg(slug: string): Promise<OgEventLike | null> {
+  try {
+    const timeout = new Promise<null>((resolve) =>
+      setTimeout(() => resolve(null), RESOLVE_TIMEOUT_MS)
+    );
+    return await Promise.race([resolveEvent(slug), timeout]);
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/recipeOgHtml.server.ts
+++ b/src/lib/recipeOgHtml.server.ts
@@ -22,12 +22,21 @@ import { getRecipeOgMeta, FALLBACK_RECIPE_OG, type RecipeOgMeta } from './recipe
 import { fetchRecipeEventForOg } from './recipeOg.server';
 
 /**
- * Crawler / link-unfurl User-Agents. Matched case-insensitively. Kept broad on
- * purpose: a false positive only means a bot-style minimal document is served
- * to a non-bot, which still renders fine; a false negative means a missing card.
+ * Crawler / link-unfurl User-Agents. Matched case-insensitively.
+ *
+ * A false positive is NOT harmless: a real human matched here would get the
+ * empty-body crawler document instead of the SPA, breaking the page for them.
+ * So tokens that also appear in human in-app browser UAs are matched only in
+ * their dedicated-crawler form, never as a bare word:
+ *   - `WhatsApp/<n>`  — the link-preview fetcher; the WhatsApp in-app webview
+ *     carries a normal `Mozilla/…` UA and must fall through to the SPA.
+ *   - `Pinterest/<n>` / `Pinterestbot` — likewise (bare "Pinterest" appears in
+ *     the Pinterest in-app browser).
+ * Snapchat and bare "Yahoo" are intentionally omitted: their in-app browsers
+ * carry those words and neither is a recipe link-unfurler worth the risk.
  */
 const CRAWLER_UA =
-  /(facebookexternalhit|facebookcatalog|Facebot|Twitterbot|LinkedInBot|Slackbot|Slack-ImgProxy|Discordbot|TelegramBot|WhatsApp|Pinterest|redditbot|Googlebot|Google-InspectionTool|bingbot|Applebot|Embedly|Quora Link Preview|vkShare|W3C_Validator|outbrain|SkypeUriPreview|nuzzel|Bitlybot|Yahoo|Baiduspider|ia_archiver|MetaInspector|Iframely|SummalyBot|TelegramBot|Mastodon|Pleroma|Snapchat|Yeti)/i;
+  /(facebookexternalhit|facebookcatalog|Facebot|Twitterbot|LinkedInBot|Slackbot|Slack-ImgProxy|Discordbot|TelegramBot|WhatsApp\/\d|Pinterest\/\d|Pinterestbot|redditbot|Googlebot|Google-InspectionTool|bingbot|Applebot|Embedly|Quora Link Preview|vkShare|W3C_Validator|outbrain|SkypeUriPreview|nuzzel|Bitlybot|Baiduspider|ia_archiver|MetaInspector|Iframely|SummalyBot|Mastodon|Pleroma|Yeti)/i;
 
 /** Only these route prefixes get bot OG injection. */
 const ROUTE_RE = /^\/(recipe|r)\/([^/]+)\/?$/;
@@ -39,13 +48,11 @@ export function isCrawler(userAgent: string | null): boolean {
 export function matchRecipeOgRoute(pathname: string): { prefix: string; slug: string } | null {
   const m = pathname.match(ROUTE_RE);
   if (!m) return null;
-  let slug = m[2];
-  try {
-    slug = decodeURIComponent(slug);
-  } catch {
-    /* keep raw on malformed escape */
-  }
-  return { prefix: m[1], slug };
+  // Use the raw, still-encoded path segment. naddr1…/hex slugs are URL-safe so
+  // there is nothing to decode, and decoding could fold in a space or a '%2F'
+  // → '/' that corrupts the canonical/og:url or makes it mismatch the request.
+  // nip19.decode() and the hex test in recipeOg.server.ts both accept it as-is.
+  return { prefix: m[1], slug: m[2] };
 }
 
 function escapeAttr(value: string): string {

--- a/src/lib/recipeOgHtml.server.ts
+++ b/src/lib/recipeOgHtml.server.ts
@@ -1,0 +1,125 @@
+/**
+ * Server-only: detect social crawlers and render a minimal standalone OG
+ * document for recipe routes.
+ *
+ * WHY this exists (read before touching): recipe OG/Twitter tags are derived
+ * reactively from a Nostr event fetched ONLY client-side, so crawlers — which
+ * don't run JS — see placeholder defaults. The fix #454 deliberately removed
+ * `+page.server.ts` from these routes because a server `data` dependency made
+ * the client request `__data.json`, which 500'd against an OOM'd worker. So we
+ * must NOT reintroduce any server load. Instead the `handle` hook returns this
+ * tiny document for crawler User-Agents only — crawlers issue a single document
+ * GET, never request `__data.json`, and never touch the service worker, so this
+ * path cannot reintroduce the #454 mechanism. Human requests fall through to the
+ * unchanged client SPA.
+ *
+ * Option (a) from the brief: build a minimal standalone HTML head rather than
+ * transforming the full SSR page — lightest, lowest memory, given the OOM
+ * history.
+ */
+
+import { getRecipeOgMeta, FALLBACK_RECIPE_OG, type RecipeOgMeta } from './recipeOgMeta';
+import { fetchRecipeEventForOg } from './recipeOg.server';
+
+/**
+ * Crawler / link-unfurl User-Agents. Matched case-insensitively. Kept broad on
+ * purpose: a false positive only means a bot-style minimal document is served
+ * to a non-bot, which still renders fine; a false negative means a missing card.
+ */
+const CRAWLER_UA =
+  /(facebookexternalhit|facebookcatalog|Facebot|Twitterbot|LinkedInBot|Slackbot|Slack-ImgProxy|Discordbot|TelegramBot|WhatsApp|Pinterest|redditbot|Googlebot|Google-InspectionTool|bingbot|Applebot|Embedly|Quora Link Preview|vkShare|W3C_Validator|outbrain|SkypeUriPreview|nuzzel|Bitlybot|Yahoo|Baiduspider|ia_archiver|MetaInspector|Iframely|SummalyBot|TelegramBot|Mastodon|Pleroma|Snapchat|Yeti)/i;
+
+/** Only these route prefixes get bot OG injection. */
+const ROUTE_RE = /^\/(recipe|r)\/([^/]+)\/?$/;
+
+export function isCrawler(userAgent: string | null): boolean {
+  return !!userAgent && CRAWLER_UA.test(userAgent);
+}
+
+export function matchRecipeOgRoute(pathname: string): { prefix: string; slug: string } | null {
+  const m = pathname.match(ROUTE_RE);
+  if (!m) return null;
+  let slug = m[2];
+  try {
+    slug = decodeURIComponent(slug);
+  } catch {
+    /* keep raw on malformed escape */
+  }
+  return { prefix: m[1], slug };
+}
+
+function escapeAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/'/g, '&#39;');
+}
+
+function renderDocument(meta: RecipeOgMeta, canonicalUrl: string): string {
+  const url = escapeAttr(canonicalUrl);
+  const title = escapeAttr(meta.ogTitle);
+  const desc = escapeAttr(meta.description);
+  const image = escapeAttr(meta.image);
+  const pageTitle = escapeAttr(meta.pageTitle);
+
+  const lines = [
+    '<!doctype html>',
+    '<html lang="en"><head>',
+    '<meta charset="utf-8" />',
+    `<title>${pageTitle}</title>`,
+    `<meta name="description" content="${desc}" />`,
+    `<link rel="canonical" href="${url}" />`,
+    '<meta property="og:type" content="article" />',
+    `<meta property="og:url" content="${url}" />`,
+    `<meta property="og:title" content="${title}" />`,
+    `<meta property="og:description" content="${desc}" />`,
+    `<meta property="og:image" content="${image}" />`,
+    `<meta property="og:image:secure_url" content="${image}" />`,
+    '<meta property="og:site_name" content="zap.cooking" />'
+  ];
+
+  if (meta.publishedAt !== null) {
+    const iso = escapeAttr(new Date(meta.publishedAt * 1000).toISOString());
+    lines.push(`<meta property="article:published_time" content="${iso}" />`);
+  }
+  if (meta.authorPubkey) {
+    lines.push(
+      `<meta property="article:author" content="${escapeAttr(`https://zap.cooking/p/${meta.authorPubkey}`)}" />`
+    );
+  }
+
+  lines.push(
+    '<meta name="twitter:card" content="summary_large_image" />',
+    '<meta name="twitter:site" content="@zapcooking" />',
+    `<meta name="twitter:url" content="${url}" />`,
+    `<meta name="twitter:title" content="${title}" />`,
+    `<meta name="twitter:description" content="${desc}" />`,
+    `<meta name="twitter:image" content="${image}" />`,
+    '</head><body></body></html>'
+  );
+
+  return lines.join('\n');
+}
+
+/**
+ * Build the standalone crawler document for a matched recipe route. NEVER
+ * throws and never hangs: on any failure or relay timeout it emits safe
+ * fallback meta so the bot still gets a valid 200 card.
+ */
+export async function renderRecipeOgForCrawler(
+  prefix: string,
+  slug: string,
+  origin: string
+): Promise<string> {
+  const canonicalUrl = `${origin}/${prefix}/${slug}`;
+  let meta: RecipeOgMeta = FALLBACK_RECIPE_OG;
+  try {
+    const event = await fetchRecipeEventForOg(slug);
+    if (event) meta = getRecipeOgMeta(event);
+  } catch {
+    /* keep fallback meta */
+  }
+  return renderDocument(meta, canonicalUrl);
+}

--- a/src/lib/recipeOgMeta.ts
+++ b/src/lib/recipeOgMeta.ts
@@ -1,0 +1,184 @@
+/**
+ * Single source of truth for recipe Open Graph / Twitter-card metadata.
+ *
+ * The same title/description/image derivation must run in TWO places that
+ * cannot be allowed to drift:
+ *   1. the client `<svelte:head>` in `recipe/[slug]` and `r/[naddr]`, fed an
+ *      NDKEvent fetched in-browser;
+ *   2. the server `handle` hook (`src/hooks.server.ts`), fed a raw relay event
+ *      JSON for crawler User-Agents only.
+ *
+ * Both call `getRecipeOgMeta()` with a plain `{ tags, content, ... }` shape, so
+ * an NDKEvent and a raw relay event are both accepted structurally. Keep this
+ * file free of NDK / SvelteKit imports so it is safe to pull into the worker
+ * bundle (bundle OOM was the original disease behind the #454 500s).
+ */
+
+export interface OgEventLike {
+  tags: string[][];
+  content: string;
+  pubkey?: string;
+  created_at?: number;
+  kind?: number;
+}
+
+export interface RecipeOgMeta {
+  /** For the document `<title>` — e.g. "Pancakes - zap.cooking". */
+  pageTitle: string;
+  /** og:title / twitter:title — raw title, no site suffix. */
+  ogTitle: string;
+  /** description / og:description / twitter:description, capped at ~155 chars. */
+  description: string;
+  /** og:image / twitter:image — always an absolute raster URL. */
+  image: string;
+  /** Unix seconds for article:published_time, or null. */
+  publishedAt: number | null;
+  /** Author hex pubkey for article:author, or null. */
+  authorPubkey: string | null;
+}
+
+const FALLBACK_IMAGE = 'https://zap.cooking/social-share.png';
+
+/**
+ * Emitted when no event is available (loading, not found, relay timeout, or a
+ * crawler request that couldn't resolve in time). Mirrors the static defaults
+ * the client `<svelte:head>` renders before its NDK fetch settles, so a bot
+ * always receives a valid card.
+ */
+export const FALLBACK_RECIPE_OG: RecipeOgMeta = {
+  pageTitle: 'Recipe - zap.cooking',
+  ogTitle: 'Recipe',
+  description: 'A recipe shared on zap.cooking - Food. Friends. Freedom.',
+  image: FALLBACK_IMAGE,
+  publishedAt: null,
+  authorPubkey: null
+};
+
+function findTag(event: OgEventLike, name: string): string | undefined {
+  return event.tags?.find((tag) => tag[0] === name)?.[1];
+}
+
+/**
+ * Cap a description at ~155 chars for Facebook/social previews, preferring a
+ * sentence boundary, then a word boundary, before hard-truncating with an
+ * ellipsis. Ported verbatim from the original reactive `og_desc` block.
+ */
+export function capRecipeDescription(d: string): string {
+  if (!d || d.length <= 155) return d;
+  const t = d.slice(0, 155);
+  const ls = Math.max(t.lastIndexOf('.'), t.lastIndexOf('!'), t.lastIndexOf('?'));
+  if (ls > 80) return d.slice(0, ls + 1);
+  const sp = t.lastIndexOf(' ');
+  return (sp > 80 ? t.slice(0, sp) : t) + '...';
+}
+
+/**
+ * Build the long-form description: summary tag → structured recipe metadata
+ * (servings / timing / ingredients) → cleaned content → static fallback.
+ * Ported verbatim from the original reactive `og_description` block.
+ */
+function deriveLongDescription(event: OgEventLike): string {
+  const summary = findTag(event, 'summary');
+  if (summary) return summary;
+
+  if (event.content) {
+    const title = findTag(event, 'title') || '';
+    const parts: string[] = [];
+
+    const servingsMatch = event.content.match(/##\s*Servings\s*\n+([^\n#]+)/i);
+    if (servingsMatch) {
+      const servings = servingsMatch[1].trim();
+      if (servings) parts.push(servings);
+    }
+
+    const totalMatch = event.content.match(/Total:\s*([^\n,]+)/i);
+    const prepMatch = event.content.match(/Prep:\s*([^\n,]+)/i);
+    const cookMatch = event.content.match(/Cook:\s*([^\n,]+)/i);
+    if (totalMatch) {
+      parts.push(`Ready in ${totalMatch[1].trim()}`);
+    } else if (prepMatch && cookMatch) {
+      parts.push(`Prep: ${prepMatch[1].trim()}, Cook: ${cookMatch[1].trim()}`);
+    }
+
+    const ingredientsSection = event.content.match(/##\s*Ingredients\s*\n([\s\S]*?)(?=##|$)/i);
+    if (ingredientsSection) {
+      const ingredients = ingredientsSection[1]
+        .split('\n')
+        .filter((line: string) => line.trim().startsWith('-') || line.trim().startsWith('*'))
+        .map((line: string) =>
+          line
+            .replace(/^[\s*-]+/, '')
+            .replace(/\s*\(.*?\)\s*/g, '')
+            .trim()
+        )
+        .filter((i: string) => i.length > 0 && i.length < 80);
+
+      if (ingredients.length > 0) {
+        const preview = ingredients.slice(0, 3).join(', ');
+        if (ingredients.length > 3) {
+          parts.push(`${ingredients.length} ingredients including ${preview}`);
+        } else {
+          parts.push(`Made with ${preview}`);
+        }
+      }
+    }
+
+    if (parts.length > 0) {
+      return title ? `${title}. ${parts.join('. ')}.` : parts.join('. ') + '.';
+    }
+
+    // Fall back to cleaned content extraction
+    const text = event.content
+      .replace(/^#+\s+/gm, '')
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+      .replace(/!\[([^\]]*)\]\([^)]+\)/g, '')
+      .replace(/\*\*([^*]+)\*\*/g, '$1')
+      .replace(/\*([^*]+)\*/g, '$1')
+      .replace(/`([^`]+)`/g, '$1')
+      .replace(/\n+/g, ' ')
+      .trim();
+
+    if (text.length > 155) {
+      const truncated = text.slice(0, 155);
+      const lastSpace = truncated.lastIndexOf(' ');
+      const lastSentence = Math.max(
+        truncated.lastIndexOf('.'),
+        truncated.lastIndexOf('!'),
+        truncated.lastIndexOf('?')
+      );
+      if (lastSentence > 80) return text.slice(0, lastSentence + 1);
+      return (lastSpace > 80 ? truncated.slice(0, lastSpace) : truncated) + '...';
+    }
+    return text || 'A delicious recipe shared on zap.cooking';
+  }
+  return 'A delicious recipe shared on zap.cooking';
+}
+
+/**
+ * Derive the full set of recipe OG metadata from an event (or the static
+ * fallback when `event` is null). The single function both the client head and
+ * the server crawler hook call.
+ */
+export function getRecipeOgMeta(event: OgEventLike | null): RecipeOgMeta {
+  if (!event) return FALLBACK_RECIPE_OG;
+
+  const titleTag = findTag(event, 'title');
+  const dTag = findTag(event, 'd');
+  const content = event.content ?? '';
+
+  // <title> heading: title → d → '...'
+  const pageHeading = titleTag || dTag || '...';
+  // og:title: title → first 60 chars of content
+  const ogTitle = titleTag || content.slice(0, 60) + '...';
+
+  const image = findTag(event, 'image') || FALLBACK_IMAGE;
+
+  return {
+    pageTitle: `${pageHeading} - zap.cooking`,
+    ogTitle,
+    description: capRecipeDescription(deriveLongDescription(event)),
+    image,
+    publishedAt: typeof event.created_at === 'number' ? event.created_at : null,
+    authorPubkey: typeof event.pubkey === 'string' ? event.pubkey : null
+  };
+}

--- a/src/lib/recipePackOg.server.ts
+++ b/src/lib/recipePackOg.server.ts
@@ -31,9 +31,10 @@ export interface RecipePreview {
 	image?: string;
 }
 
-interface RelayFilter {
+export interface RelayFilter {
 	kinds?: number[];
 	authors?: string[];
+	ids?: string[];
 	'#d'?: string[];
 	[k: string]: unknown;
 }
@@ -136,7 +137,7 @@ function fetchEventFromRelay(
  * Uses a single AbortController so winning settles all pending fetches
  * immediately — no zombie sockets waiting on FETCH_TIMEOUT_MS.
  */
-async function raceRelays(filter: RelayFilter): Promise<any | null> {
+export async function raceRelays(filter: RelayFilter): Promise<any | null> {
 	if (typeof WebSocket === 'undefined') return null;
 	const controller = new AbortController();
 	return new Promise((resolve) => {

--- a/src/routes/[nip19]/+page.svelte
+++ b/src/routes/[nip19]/+page.svelte
@@ -737,7 +737,7 @@
                 <article
                   class="py-8 border-b last:border-0 cursor-pointer hover:bg-[var(--color-bg-hover,rgba(255,255,255,0.03))]"
                   style="border-color: var(--color-input-border)"
-                  on:click={(e) => { if ((e.target as HTMLElement).closest('a, button')) return; goto(noteUrl(reply)); }}
+                  on:click={(e) => { if (e.target instanceof Element && e.target.closest('a, button')) return; goto(noteUrl(reply)); }}
                   role="link"
                   tabindex="0"
                   on:keydown|self={(e) => e.key === 'Enter' && goto(noteUrl(reply))}
@@ -794,7 +794,7 @@
                     <div class="ml-8 pl-3">
                       <article
                         class="py-2 cursor-pointer hover:bg-[var(--color-bg-hover,rgba(255,255,255,0.03))] rounded"
-                        on:click={(e) => { if ((e.target as HTMLElement).closest('a, button')) return; goto(noteUrl(nestedReply)); }}
+                        on:click={(e) => { if (e.target instanceof Element && e.target.closest('a, button')) return; goto(noteUrl(nestedReply)); }}
                         role="link"
                         tabindex="0"
                         on:keydown|self={(e) => e.key === 'Enter' && goto(noteUrl(nestedReply))}

--- a/src/routes/r/[naddr]/+page.svelte
+++ b/src/routes/r/[naddr]/+page.svelte
@@ -8,6 +8,7 @@
   import Recipe from '../../../components/Recipe/Recipe.svelte';
   import PanLoader from '../../../components/PanLoader.svelte';
   import { GATED_RECIPE_KIND, RECIPE_TAGS } from '$lib/consts';
+  import { getRecipeOgMeta } from '$lib/recipeOgMeta';
   import ArrowLeftIcon from 'phosphor-svelte/lib/ArrowLeft';
   import { stripTrackingParams } from '$lib/utils/stripTrackingParams';
 
@@ -26,29 +27,29 @@
 
   async function loadData() {
     if (!$page.params.naddr) return;
-    
+
     loading = true;
     error = null;
-    
+
     try {
       const slug = $page.params.naddr;
-      
+
       if (slug.startsWith('naddr1')) {
         const a = nip19.decode(slug);
         if (a.type !== 'naddr') {
           throw new Error('Invalid naddr format');
         }
         const b = a.data;
-        
+
         // Support both regular recipes (30023) and premium recipes (35000)
         const recipeKind = b.kind === GATED_RECIPE_KIND ? GATED_RECIPE_KIND : 30023;
-        
+
         naddr = nip19.naddrEncode({
           identifier: b.identifier,
           pubkey: b.pubkey,
           kind: recipeKind
         });
-        
+
         // Add timeout protection for recipe loading
         const fetchPromise: Promise<NDKEvent | null> = $ndk.fetchEvent({
           '#d': [b.identifier],
@@ -56,7 +57,10 @@
           kinds: [recipeKind as number]
         });
         const timeoutPromise = new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error('Recipe loading timeout - relays may be unreachable')), 10000)
+          setTimeout(
+            () => reject(new Error('Recipe loading timeout - relays may be unreachable')),
+            10000
+          )
         );
 
         const e = await Promise.race<NDKEvent | null>([fetchPromise, timeoutPromise]);
@@ -78,132 +82,35 @@
   }
 
   // OG/meta derived entirely from the client-fetched NDK event, with static
-  // defaults until it loads. No server load — see <svelte:head>.
-  $: pageHeading = event
-    ? event.tags.find((e) => e[0] == 'title')?.[1] || event.tags.find((e) => e[0] == 'd')?.[1] || '...'
-    : 'Recipe';
-
-  $: metaTitleBase = event
-    ? event.tags.find((tag) => tag[0] === 'title')?.[1] || event.content.slice(0, 60) + '...'
-    : 'Recipe';
-
-  $: fullPageTitle = `${pageHeading} - zap.cooking`;
-  $: fullMetaTitle = `${metaTitleBase} - zap.cooking`;
-
-  // OG title: raw title without site suffix (site_name handles branding)
-  $: og_title = event
-    ? metaTitleBase
-    : 'Recipe';
-
-  // Description: prefer summary, then build from recipe metadata, then clean content
-  $: og_description = event
-    ? (() => {
-        // Try summary tag first
-        const summary = event.tags?.find((tag) => tag[0] === 'summary')?.[1];
-        if (summary) return summary;
-
-        // Try to build structured description from recipe metadata in content
-        if (event.content) {
-          const title = event.tags?.find((tag) => tag[0] === 'title')?.[1] || '';
-          const parts: string[] = [];
-
-          const servingsMatch = event.content.match(/##\s*Servings\s*\n+([^\n#]+)/i);
-          if (servingsMatch) {
-            const servings = servingsMatch[1].trim();
-            if (servings) parts.push(servings);
-          }
-
-          const totalMatch = event.content.match(/Total:\s*([^\n,]+)/i);
-          const prepMatch = event.content.match(/Prep:\s*([^\n,]+)/i);
-          const cookMatch = event.content.match(/Cook:\s*([^\n,]+)/i);
-          if (totalMatch) {
-            parts.push(`Ready in ${totalMatch[1].trim()}`);
-          } else if (prepMatch && cookMatch) {
-            parts.push(`Prep: ${prepMatch[1].trim()}, Cook: ${cookMatch[1].trim()}`);
-          }
-
-          const ingredientsSection = event.content.match(/##\s*Ingredients\s*\n([\s\S]*?)(?=##|$)/i);
-          if (ingredientsSection) {
-            const ingredients = ingredientsSection[1]
-              .split('\n')
-              .filter((line: string) => line.trim().startsWith('-') || line.trim().startsWith('*'))
-              .map((line: string) => line.replace(/^[\s*-]+/, '').replace(/\s*\(.*?\)\s*/g, '').trim())
-              .filter((i: string) => i.length > 0 && i.length < 80);
-
-            if (ingredients.length > 0) {
-              const preview = ingredients.slice(0, 3).join(', ');
-              if (ingredients.length > 3) {
-                parts.push(`${ingredients.length} ingredients including ${preview}`);
-              } else {
-                parts.push(`Made with ${preview}`);
-              }
-            }
-          }
-
-          if (parts.length > 0) {
-            return title ? `${title}. ${parts.join('. ')}.` : parts.join('. ') + '.';
-          }
-
-          // Fall back to cleaned content extraction
-          let text = event.content
-            .replace(/^#+\s+/gm, '')
-            .replace(/\[([^\]]+)\]\([^\)]+\)/g, '$1')
-            .replace(/!\[([^\]]*)\]\([^\)]+\)/g, '')
-            .replace(/\*\*([^\*]+)\*\*/g, '$1')
-            .replace(/\*([^\*]+)\*/g, '$1')
-            .replace(/`([^`]+)`/g, '$1')
-            .replace(/\n+/g, ' ')
-            .trim();
-
-          if (text.length > 155) {
-            const truncated = text.slice(0, 155);
-            const lastSpace = truncated.lastIndexOf(' ');
-            const lastSentence = Math.max(truncated.lastIndexOf('.'), truncated.lastIndexOf('!'), truncated.lastIndexOf('?'));
-            if (lastSentence > 80) return text.slice(0, lastSentence + 1);
-            return (lastSpace > 80 ? truncated.slice(0, lastSpace) : truncated) + '...';
-          }
-          return text || 'A delicious recipe shared on zap.cooking';
-        }
-        return 'A delicious recipe shared on zap.cooking';
-      })()
-    : 'A recipe shared on zap.cooking - Food. Friends. Freedom.';
-  
-  $: og_image = event
-    ? (event.tags?.find((tag) => tag[0] === 'image')?.[1] || 'https://zap.cooking/social-share.png')
-    : 'https://zap.cooking/social-share.png';
-
-  // Cap description at ~155 chars for Facebook/social preview
-  $: og_desc = (() => {
-    const d = og_description;
-    if (!d || d.length <= 155) return d;
-    const t = d.slice(0, 155);
-    const ls = Math.max(t.lastIndexOf('.'), t.lastIndexOf('!'), t.lastIndexOf('?'));
-    if (ls > 80) return d.slice(0, ls + 1);
-    const sp = t.lastIndexOf(' ');
-    return (sp > 80 ? t.slice(0, sp) : t) + '...';
-  })();
-  $: publishedAt = event?.created_at ?? null;
+  // defaults until it loads. No server load — see <svelte:head>. The same
+  // derivation runs server-side for crawler UAs in src/hooks.server.ts, so both
+  // paths share getRecipeOgMeta() and can't drift.
+  $: ogMeta = getRecipeOgMeta(event);
 
   // Check if this is a longform article (not a recipe) to show "Back to Reads" link
-  $: isLongformArticle = event && event.kind === 30023 && !event.tags.some(
-    (tag) => tag[0] === 't' && RECIPE_TAGS.includes(tag[1]?.toLowerCase() || '')
-  );
+  $: isLongformArticle =
+    event &&
+    event.kind === 30023 &&
+    !event.tags.some((tag) => tag[0] === 't' && RECIPE_TAGS.includes(tag[1]?.toLowerCase() || ''));
 </script>
 
 <svelte:head>
-  <title>{fullPageTitle || 'Recipe - zap.cooking'}</title>
-  <meta name="description" content={og_desc} />
+  <title>{ogMeta.pageTitle}</title>
+  <meta name="description" content={ogMeta.description} />
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="article" />
   <meta property="og:url" content={`https://zap.cooking/r/${$page.params.naddr}`} />
-  <meta property="og:title" content={og_title} />
-  <meta property="og:description" content={og_desc} />
-  <meta property="og:image" content={og_image} />
-  <meta property="og:image:secure_url" content={og_image} />
+  <meta property="og:title" content={ogMeta.ogTitle} />
+  <meta property="og:description" content={ogMeta.description} />
+  <meta property="og:image" content={ogMeta.image} />
+  <meta property="og:image:secure_url" content={ogMeta.image} />
   <meta property="og:site_name" content="zap.cooking" />
-  {#if publishedAt !== null}
-    <meta property="article:published_time" content={new Date(publishedAt * 1000).toISOString()} />
+  {#if ogMeta.publishedAt !== null}
+    <meta
+      property="article:published_time"
+      content={new Date(ogMeta.publishedAt * 1000).toISOString()}
+    />
   {/if}
   {#if event?.pubkey}
     <meta property="article:author" content={`https://zap.cooking/p/${event.pubkey}`} />
@@ -212,9 +119,9 @@
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:url" content={`https://zap.cooking/r/${$page.params.naddr}`} />
-  <meta name="twitter:title" content={og_title} />
-  <meta name="twitter:description" content={og_desc} />
-  <meta name="twitter:image" content={og_image} />
+  <meta name="twitter:title" content={ogMeta.ogTitle} />
+  <meta name="twitter:description" content={ogMeta.description} />
+  <meta name="twitter:image" content={ogMeta.image} />
 </svelte:head>
 
 <!-- Back to Reads link for longform articles -->
@@ -246,7 +153,7 @@
       Try Again
     </button>
   </div>
-{:else if event && (event.tags.some(t => t[0] === 'deleted') || !event.content || event.content.trim() === '')}
+{:else if event && (event.tags.some((t) => t[0] === 'deleted') || !event.content || event.content.trim() === '')}
   <div class="flex flex-col justify-center items-center page-loader gap-4">
     <h1 class="text-2xl font-bold" style="color: var(--color-text-primary);">Recipe Deleted</h1>
     <p class="text-caption">This recipe has been deleted by its author.</p>

--- a/src/routes/recipe/[slug]/+page.svelte
+++ b/src/routes/recipe/[slug]/+page.svelte
@@ -9,6 +9,7 @@
   import Recipe from '../../../components/Recipe/Recipe.svelte';
   import PanLoader from '../../../components/PanLoader.svelte';
   import { GATED_RECIPE_KIND } from '$lib/consts';
+  import { getRecipeOgMeta } from '$lib/recipeOgMeta';
   import { stripTrackingParams } from '$lib/utils/stripTrackingParams';
 
   let event: NDKEvent | null = null;
@@ -26,10 +27,10 @@
 
   async function loadData() {
     if (!$page.params.slug) return;
-    
+
     loading = true;
     error = null;
-    
+
     try {
       if ($page.params.slug.startsWith('naddr1')) {
         const a = nip19.decode($page.params.slug);
@@ -37,16 +38,16 @@
           throw new Error('Invalid naddr format');
         }
         const b = a.data;
-        
+
         // Support both regular recipes (30023) and premium recipes (35000)
         const recipeKind = b.kind === GATED_RECIPE_KIND ? GATED_RECIPE_KIND : 30023;
-        
+
         naddr = nip19.naddrEncode({
           identifier: b.identifier,
           pubkey: b.pubkey,
           kind: recipeKind
         });
-        
+
         // Add timeout protection for recipe loading
         const fetchPromise: Promise<NDKEvent | null> = $ndk.fetchEvent({
           '#d': [b.identifier],
@@ -54,9 +55,12 @@
           kinds: [recipeKind as number]
         });
         const timeoutPromise = new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error('Recipe loading timeout - relays may be unreachable')), 10000)
+          setTimeout(
+            () => reject(new Error('Recipe loading timeout - relays may be unreachable')),
+            10000
+          )
         );
-        
+
         const e = await Promise.race<NDKEvent | null>([fetchPromise, timeoutPromise]);
         if (e) {
           event = e;
@@ -69,9 +73,12 @@
         // Add timeout protection for direct event ID loading
         const fetchPromise: Promise<NDKEvent | null> = $ndk.fetchEvent($page.params.slug);
         const timeoutPromise = new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error('Recipe loading timeout - relays may be unreachable')), 10000)
+          setTimeout(
+            () => reject(new Error('Recipe loading timeout - relays may be unreachable')),
+            10000
+          )
         );
-        
+
         const e = await Promise.race<NDKEvent | null>([fetchPromise, timeoutPromise]);
         if (e) {
           event = e;
@@ -101,127 +108,29 @@
   }
 
   // OG/meta derived entirely from the client-fetched NDK event, with static
-  // defaults until it loads. No server load — see <svelte:head>.
-  $: pageHeading = event
-    ? event.tags.find((e) => e[0] == 'title')?.[1] || event.tags.find((e) => e[0] == 'd')?.[1] || '...'
-    : 'Recipe';
-
-  $: metaTitleBase = event
-    ? event.tags.find((tag) => tag[0] === 'title')?.[1] || event.content.slice(0, 60) + '...'
-    : 'Recipe';
-
-  $: fullPageTitle = `${pageHeading} - zap.cooking`;
-  $: fullMetaTitle = `${metaTitleBase} - zap.cooking`;
-
-  // OG title: raw title without site suffix (site_name handles branding)
-  $: og_title = event
-    ? metaTitleBase
-    : 'Recipe';
-
-  // Description: prefer summary, then build from recipe metadata, then clean content
-  $: og_description = event
-    ? (() => {
-        // Try summary tag first
-        const summary = event.tags?.find((tag) => tag[0] === 'summary')?.[1];
-        if (summary) return summary;
-
-        // Try to build structured description from recipe metadata in content
-        if (event.content) {
-          const title = event.tags?.find((tag) => tag[0] === 'title')?.[1] || '';
-          const parts: string[] = [];
-
-          const servingsMatch = event.content.match(/##\s*Servings\s*\n+([^\n#]+)/i);
-          if (servingsMatch) {
-            const servings = servingsMatch[1].trim();
-            if (servings) parts.push(servings);
-          }
-
-          const totalMatch = event.content.match(/Total:\s*([^\n,]+)/i);
-          const prepMatch = event.content.match(/Prep:\s*([^\n,]+)/i);
-          const cookMatch = event.content.match(/Cook:\s*([^\n,]+)/i);
-          if (totalMatch) {
-            parts.push(`Ready in ${totalMatch[1].trim()}`);
-          } else if (prepMatch && cookMatch) {
-            parts.push(`Prep: ${prepMatch[1].trim()}, Cook: ${cookMatch[1].trim()}`);
-          }
-
-          const ingredientsSection = event.content.match(/##\s*Ingredients\s*\n([\s\S]*?)(?=##|$)/i);
-          if (ingredientsSection) {
-            const ingredients = ingredientsSection[1]
-              .split('\n')
-              .filter((line: string) => line.trim().startsWith('-') || line.trim().startsWith('*'))
-              .map((line: string) => line.replace(/^[\s*-]+/, '').replace(/\s*\(.*?\)\s*/g, '').trim())
-              .filter((i: string) => i.length > 0 && i.length < 80);
-
-            if (ingredients.length > 0) {
-              const preview = ingredients.slice(0, 3).join(', ');
-              if (ingredients.length > 3) {
-                parts.push(`${ingredients.length} ingredients including ${preview}`);
-              } else {
-                parts.push(`Made with ${preview}`);
-              }
-            }
-          }
-
-          if (parts.length > 0) {
-            return title ? `${title}. ${parts.join('. ')}.` : parts.join('. ') + '.';
-          }
-
-          // Fall back to cleaned content extraction
-          let text = event.content
-            .replace(/^#+\s+/gm, '')
-            .replace(/\[([^\]]+)\]\([^\)]+\)/g, '$1')
-            .replace(/!\[([^\]]*)\]\([^\)]+\)/g, '')
-            .replace(/\*\*([^\*]+)\*\*/g, '$1')
-            .replace(/\*([^\*]+)\*/g, '$1')
-            .replace(/`([^`]+)`/g, '$1')
-            .replace(/\n+/g, ' ')
-            .trim();
-
-          if (text.length > 155) {
-            const truncated = text.slice(0, 155);
-            const lastSpace = truncated.lastIndexOf(' ');
-            const lastSentence = Math.max(truncated.lastIndexOf('.'), truncated.lastIndexOf('!'), truncated.lastIndexOf('?'));
-            if (lastSentence > 80) return text.slice(0, lastSentence + 1);
-            return (lastSpace > 80 ? truncated.slice(0, lastSpace) : truncated) + '...';
-          }
-          return text || 'A delicious recipe shared on zap.cooking';
-        }
-        return 'A delicious recipe shared on zap.cooking';
-      })()
-    : 'A recipe shared on zap.cooking - Food. Friends. Freedom.';
-  
-  $: og_image = event
-    ? (event.tags?.find((tag) => tag[0] === 'image')?.[1] || 'https://zap.cooking/social-share.png')
-    : 'https://zap.cooking/social-share.png';
-
-  // Cap description at ~155 chars for Facebook/social preview
-  $: og_desc = (() => {
-    const d = og_description;
-    if (!d || d.length <= 155) return d;
-    const t = d.slice(0, 155);
-    const ls = Math.max(t.lastIndexOf('.'), t.lastIndexOf('!'), t.lastIndexOf('?'));
-    if (ls > 80) return d.slice(0, ls + 1);
-    const sp = t.lastIndexOf(' ');
-    return (sp > 80 ? t.slice(0, sp) : t) + '...';
-  })();
-  $: publishedAt = event?.created_at ?? null;
+  // defaults until it loads. No server load — see <svelte:head>. The same
+  // derivation runs server-side for crawler UAs in src/hooks.server.ts, so both
+  // paths share getRecipeOgMeta() and can't drift.
+  $: ogMeta = getRecipeOgMeta(event);
 </script>
 
 <svelte:head>
-  <title>{fullPageTitle || 'Recipe - zap.cooking'}</title>
-  <meta name="description" content={og_desc} />
+  <title>{ogMeta.pageTitle}</title>
+  <meta name="description" content={ogMeta.description} />
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="article" />
   <meta property="og:url" content={`https://zap.cooking/recipe/${$page.params.slug}`} />
-  <meta property="og:title" content={og_title} />
-  <meta property="og:description" content={og_desc} />
-  <meta property="og:image" content={og_image} />
-  <meta property="og:image:secure_url" content={og_image} />
+  <meta property="og:title" content={ogMeta.ogTitle} />
+  <meta property="og:description" content={ogMeta.description} />
+  <meta property="og:image" content={ogMeta.image} />
+  <meta property="og:image:secure_url" content={ogMeta.image} />
   <meta property="og:site_name" content="zap.cooking" />
-  {#if publishedAt !== null}
-    <meta property="article:published_time" content={new Date(publishedAt * 1000).toISOString()} />
+  {#if ogMeta.publishedAt !== null}
+    <meta
+      property="article:published_time"
+      content={new Date(ogMeta.publishedAt * 1000).toISOString()}
+    />
   {/if}
   {#if event?.pubkey}
     <meta property="article:author" content={`https://zap.cooking/p/${event.pubkey}`} />
@@ -230,9 +139,9 @@
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:url" content={`https://zap.cooking/recipe/${$page.params.slug}`} />
-  <meta name="twitter:title" content={og_title} />
-  <meta name="twitter:description" content={og_desc} />
-  <meta name="twitter:image" content={og_image} />
+  <meta name="twitter:title" content={ogMeta.ogTitle} />
+  <meta name="twitter:description" content={ogMeta.description} />
+  <meta name="twitter:image" content={ogMeta.image} />
 </svelte:head>
 
 {#if loading}
@@ -250,7 +159,7 @@
       Try Again
     </button>
   </div>
-{:else if event && (event.tags.some(t => t[0] === 'deleted') || !event.content || event.content.trim() === '')}
+{:else if event && (event.tags.some((t) => t[0] === 'deleted') || !event.content || event.content.trim() === '')}
   <div class="flex flex-col justify-center items-center page-loader gap-4">
     <h1 class="text-2xl font-bold" style="color: var(--color-text-primary);">Recipe Deleted</h1>
     <p class="text-caption">This recipe has been deleted by its author.</p>

--- a/test-og-tags.js
+++ b/test-og-tags.js
@@ -1,71 +1,114 @@
 #!/usr/bin/env node
 /**
- * Test script to verify Open Graph meta tags for recipe pages
- * 
+ * Test script to verify Open Graph meta tags for recipe pages.
+ *
+ * Fakes a facebookexternalhit crawler User-Agent so the server `handle` hook
+ * (src/hooks.server.ts) renders real recipe OG tags instead of the client-side
+ * placeholders. Exercises BOTH recipe route shapes: /recipe/<naddr> and
+ * /r/<naddr>.
+ *
  * Usage:
  *   1. Start local dev server: pnpm dev:cloudflare
  *   2. In another terminal: node test-og-tags.js <recipe-naddr>
- * 
+ *
  * Example:
  *   node test-og-tags.js naddr1qvzqqqr4gupzq44he2prxpk7qcde4fu6nrw4ktn7aa5erpgya4vpcrpld7fajwquqqwhg6rfwvkkjuedvykhgetnwskz6mn0wskkzttjv43kjur995lx8uqx
  */
 
-const recipeNaddr = process.argv[2] || 'naddr1qvzqqqr4gupzq44he2prxpk7qcde4fu6nrw4ktn7aa5erpgya4vpcrpld7fajwquqqwhg6rfwvkkjuedvykhgetnwskz6mn0wskkzttjv43kjur995lx8uqx';
+const recipeNaddr =
+  process.argv[2] ||
+  'naddr1qvzqqqr4gupzq44he2prxpk7qcde4fu6nrw4ktn7aa5erpgya4vpcrpld7fajwquqqwhg6rfwvkkjuedvykhgetnwskz6mn0wskkzttjv43kjur995lx8uqx';
 const baseUrl = process.env.TEST_URL || 'http://localhost:8788';
 
-async function testOGTags() {
-  const url = `${baseUrl}/recipe/${recipeNaddr}`;
+// Placeholder values the client renders before its NDK fetch settles. If a
+// crawler sees these, the server-side injection did NOT run.
+const PLACEHOLDER_TITLE = 'Recipe';
+const PLACEHOLDER_DESC = 'A recipe shared on zap.cooking - Food. Friends. Freedom.';
+
+function extract(html) {
+  return {
+    ogTitle: html.match(/<meta\s+property=["']og:title["']\s+content=["']([^"']*)["']/i)?.[1],
+    ogDescription: html.match(
+      /<meta\s+property=["']og:description["']\s+content=["']([^"']*)["']/i
+    )?.[1],
+    ogImage: html.match(/<meta\s+property=["']og:image["']\s+content=["']([^"']*)["']/i)?.[1],
+    ogUrl: html.match(/<meta\s+property=["']og:url["']\s+content=["']([^"']*)["']/i)?.[1],
+    twitterCard: html.match(/<meta\s+name=["']twitter:card["']\s+content=["']([^"']*)["']/i)?.[1]
+  };
+}
+
+async function testPath(path) {
+  const url = `${baseUrl}${path}`;
   console.log(`\n🧪 Testing OG tags for: ${url}\n`);
 
-  try {
-    const response = await fetch(url, {
-      headers: {
-        'User-Agent': 'facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)'
-      }
-    });
-
-    if (!response.ok) {
-      console.error(`❌ HTTP ${response.status}: ${response.statusText}`);
-      process.exit(1);
+  const response = await fetch(url, {
+    headers: {
+      'User-Agent': 'facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)'
     }
+  });
 
-    const html = await response.text();
-    
-    // Extract meta tags
-    const ogTitle = html.match(/<meta\s+property=["']og:title["']\s+content=["']([^"']+)["']/i)?.[1];
-    const ogDescription = html.match(/<meta\s+property=["']og:description["']\s+content=["']([^"']+)["']/i)?.[1];
-    const ogImage = html.match(/<meta\s+property=["']og:image["']\s+content=["']([^"']+)["']/i)?.[1];
-    const ogUrl = html.match(/<meta\s+property=["']og:url["']\s+content=["']([^"']+)["']/i)?.[1];
-    const twitterCard = html.match(/<meta\s+name=["']twitter:card["']\s+content=["']([^"']+)["']/i)?.[1];
+  if (!response.ok) {
+    console.error(`❌ HTTP ${response.status}: ${response.statusText}`);
+    return false;
+  }
 
-    console.log('📋 Results:');
-    console.log('─'.repeat(60));
-    console.log(`✅ og:title:      ${ogTitle || '❌ MISSING'}`);
-    console.log(`✅ og:description: ${ogDescription ? ogDescription.substring(0, 60) + '...' : '❌ MISSING'}`);
-    console.log(`✅ og:image:       ${ogImage || '❌ MISSING'}`);
-    console.log(`✅ og:url:         ${ogUrl || '❌ MISSING'}`);
-    console.log(`✅ twitter:card:   ${twitterCard || '❌ MISSING'}`);
-    console.log('─'.repeat(60));
+  const html = await response.text();
+  const { ogTitle, ogDescription, ogImage, ogUrl, twitterCard } = extract(html);
 
-    const allPresent = ogTitle && ogDescription && ogImage && ogUrl && twitterCard;
-    
-    if (allPresent) {
-      console.log('\n✅ All OG tags are present!');
-      console.log('\n💡 Test with social media validators:');
-      console.log(`   - Facebook: https://developers.facebook.com/tools/debug/?q=${encodeURIComponent(url)}`);
-      console.log(`   - Twitter:  https://cards-dev.twitter.com/validator`);
-      console.log(`   - LinkedIn: https://www.linkedin.com/post-inspector/inspect/${encodeURIComponent(url)}`);
-    } else {
-      console.log('\n❌ Some OG tags are missing!');
-      process.exit(1);
+  console.log('📋 Results:');
+  console.log('─'.repeat(60));
+  console.log(`   og:title:       ${ogTitle || '❌ MISSING'}`);
+  console.log(
+    `   og:description: ${ogDescription ? ogDescription.substring(0, 60) + '…' : '❌ MISSING'}`
+  );
+  console.log(`   og:image:       ${ogImage || '❌ MISSING'}`);
+  console.log(`   og:url:         ${ogUrl || '❌ MISSING'}`);
+  console.log(`   twitter:card:   ${twitterCard || '❌ MISSING'}`);
+  console.log('─'.repeat(60));
+
+  const allPresent = ogTitle && ogDescription && ogImage && ogUrl && twitterCard;
+  if (!allPresent) {
+    console.log('❌ Some OG tags are missing!');
+    return false;
+  }
+
+  const isPlaceholder = ogTitle === PLACEHOLDER_TITLE && ogDescription === PLACEHOLDER_DESC;
+  if (isPlaceholder) {
+    console.log(
+      '⚠️  OG tags are the generic PLACEHOLDERS — server-side injection did not resolve the recipe.'
+    );
+    console.log('   (This is acceptable as a timeout fallback, but not when the recipe exists.)');
+    return false;
+  }
+
+  console.log('✅ Real recipe OG tags present.');
+  return true;
+}
+
+async function main() {
+  const paths = [`/recipe/${recipeNaddr}`, `/r/${recipeNaddr}`];
+  const results = [];
+  for (const path of paths) {
+    try {
+      results.push(await testPath(path));
+    } catch (error) {
+      console.error(`\n❌ Error testing ${path}: ${error.message}`);
+      console.log('\n💡 Make sure the dev server is running:  pnpm dev:cloudflare');
+      results.push(false);
     }
-  } catch (error) {
-    console.error(`\n❌ Error: ${error.message}`);
-    console.log('\n💡 Make sure the dev server is running:');
-    console.log('   pnpm dev:cloudflare');
+  }
+
+  const allOk = results.every(Boolean);
+  console.log('\n' + '═'.repeat(60));
+  if (allOk) {
+    console.log('✅ All recipe routes return real OG tags!');
+    console.log('\n💡 Validate with social media debuggers:');
+    console.log(`   - Facebook: https://developers.facebook.com/tools/debug/`);
+    console.log(`   - LinkedIn: https://www.linkedin.com/post-inspector/`);
+  } else {
+    console.log('❌ One or more recipe routes failed.');
     process.exit(1);
   }
 }
 
-testOGTags();
-
+main();


### PR DESCRIPTION
## Problem
Recipe links shared on Facebook/X/Discord/Slack/iMessage/LinkedIn/Telegram showed only generic fallback metadata (title "Recipe", the static social-share.png) instead of the real recipe title/description/photo.

**Root cause:** `recipe/[slug]` and `r/[naddr]` derive their OG/Twitter tags reactively from a Nostr event fetched **only client-side**. Crawlers don't run JS, so during SSR the event is null and they only ever see the placeholder defaults.

## Approach — bot-only OG injection in `hooks.server.ts`
For crawler User-Agents on a recipe route, the existing `handle` hook resolves the recipe **server-side** (raw WebSocket, no NDK) and returns a minimal standalone `<head>` document. All other requests fall through to the unchanged client SPA.

### Why NOT a `+page.server.ts`
PR #454 (commit `e3e7973`) deliberately removed the server loads from these routes to stop intermittent 500s: a page server load makes the client request `__data.json`, which 500'd against an OOM'd worker — a **structural** failure *around* the load, not a thrown exception. Crawlers issue a single document GET, never request `__data.json`, and never use the service worker, so document-level injection **cannot** reintroduce that mechanism. Human requests are byte-for-byte unchanged; no new server `data` dependency is added.

## Changes
- **`src/lib/recipeOgMeta.ts`** — pure title/description/image derivation (summary → structured recipe metadata → cleaned content, 155-char cap). Single source of truth now shared by the client `<svelte:head>` **and** the server hook, so the two can't drift.
- **`src/lib/recipeOg.server.ts`** — server recipe fetch reusing `raceRelays` (now exported) from `recipePackOg.server.ts` — the same proven NDK-free relay race `/pack/[naddr]` uses in production. Handles `naddr1…` and raw hex ids; kinds 30023 + `GATED_RECIPE_KIND`; 4s hard timeout.
- **`src/lib/recipeOgHtml.server.ts`** — crawler-UA regex, minimal HTML builder, always-safe fallback meta.
- **`src/hooks.server.ts`** — `maybeRenderBotOg` branch; never throws (falls through to the SPA on any error/timeout, returning 200 — never 500).
- Both recipe `+page.svelte` files refactored onto the shared helper (rendered output unchanged for humans).
- **`test-og-tags.js`** now covers both `/recipe/` and `/r/` and flags placeholder responses.

### Cache safety
The bot response is `Cache-Control: no-store`. Cloudflare's edge cache keys on URL and does **not** honour `Vary: User-Agent`, so a `public` bot document would be replayed to real browsers (and vice versa). `no-store` keeps the bot path fully separate from the human SPA path. *(Caught and fixed during local testing — bot-then-human on the same URL was reproducibly serving the crawler shell to the browser before this.)*

## Incidental build fix
`main` was already build-broken after #463: inline `(e.target as HTMLElement)` TS casts in Svelte markup handlers fail the Svelte 4 parser (`pnpm build` and `pnpm check` both failed). Replaced with `e.target instanceof Element` in `[nip19]/+page.svelte` and `NoteEmbed.svelte` (3 one-line changes). This also cleared the pre-existing parse errors, taking `pnpm check` from 8 errors → 0.

## Verification
- `node test-og-tags.js <naddr>` reports real og:title / og:description / og:image / og:url / twitter:card on **both** `/recipe/` and `/r/`.
- Human request → full SPA shell; no `__data.json` for these routes; no `+page.server.ts`/`+page.ts` added (route dirs contain only `+page.svelte`).
- Non-resolvable recipe / forced relay timeout → **HTTP 200 with fallback meta, never 500**.
- `pnpm build` passes (Cloudflare worker bundle, no OOM); `pnpm check` = 0 errors.

## Optional follow-up (not in this PR)
The same #454 removal also stripped OG from `user/[slug]`, `reads/[naddr]`, `premium/recipe/[slug]`, and `market/kitchen/[npub]`. The same hook can be extended to those route+kind combinations later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)