### PR TITLE
fix(notifications): flush pre-EOSE buffer via timeout so history persists

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.553",
+  "version": "4.2.554",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/NotificationBell.svelte
+++ b/src/components/NotificationBell.svelte
@@ -19,6 +19,7 @@
   import {
     notifications,
     visibleNotifications,
+    notificationsLoading,
     type Notification
   } from '$lib/notificationStore';
   import {
@@ -334,6 +335,8 @@
         {#if rows.length === 0}
           {#if activeTab === 'dms' && $messagesLoading}
             <p class="notif-empty">Loading messages…</p>
+          {:else if activeTab !== 'dms' && $notificationsLoading}
+            <p class="notif-empty">Loading notifications…</p>
           {:else}
             <p class="notif-empty">Nothing here yet</p>
           {/if}

--- a/src/lib/notificationStore.ts
+++ b/src/lib/notificationStore.ts
@@ -123,6 +123,12 @@ function createNotificationStore() {
 export const notifications = createNotificationStore();
 
 /**
+ * True while the initial subscription is fetching (pre-EOSE / pre-timeout).
+ * Components should show a spinner instead of "Nothing here yet" while this is true.
+ */
+export const notificationsLoading = writable(false);
+
+/**
  * Notifications with muted users excluded.
  * Components should use this for display; raw `notifications` is for persistence/dedup only.
  */
@@ -195,6 +201,8 @@ export function subscribeToNotifications(ndk: NDK, userPubkey: string, forceFull
     activeSubscription.stop();
   }
 
+  notificationsLoading.set(true);
+
   // Use a longer lookback window (7 days) for better notification coverage
   // On force refresh, go back 7 days regardless of existing notifications
   const sevenDaysAgo = Math.floor(Date.now() / 1000) - 7 * 24 * 60 * 60;
@@ -239,6 +247,23 @@ export function subscribeToNotifications(ndk: NDK, userPubkey: string, forceFull
   let eoseReceived = false;
   const preEoseBuffer: NDKEvent[] = [];
 
+  function flushPreEoseBuffer() {
+    if (preEoseBuffer.length === 0) return;
+    const parsed: Notification[] = [];
+    const seenIds = new Set<string>();
+    for (const event of preEoseBuffer) {
+      if (seenIds.has(event.id)) continue;
+      seenIds.add(event.id);
+      const notification = parseNotification(event, userPubkey);
+      if (notification) {
+        parsed.push(notification);
+        if (event.kind === 9735) recordZapToSparkSdk(event);
+      }
+    }
+    preEoseBuffer.length = 0;
+    if (parsed.length > 0) notifications.addBulk(parsed);
+  }
+
   function handleEvent(event: NDKEvent, isRealtime: boolean) {
     // For zap receipts (9735), the pubkey is the zapper service, not the sender.
     // Self-zap filtering happens in parseNotification after extracting the real sender.
@@ -272,26 +297,20 @@ export function subscribeToNotifications(ndk: NDK, userPubkey: string, forceFull
 
   activeSubscription.on('eose', () => {
     eoseReceived = true;
-    if (preEoseBuffer.length === 0) return;
-
-    // Parse + dedup the buffer, then bulk-insert (one sort + one localStorage write)
-    const parsed: Notification[] = [];
-    const seenIds = new Set<string>();
-    for (const event of preEoseBuffer) {
-      if (seenIds.has(event.id)) continue;
-      seenIds.add(event.id);
-      const notification = parseNotification(event, userPubkey);
-      if (notification) {
-        parsed.push(notification);
-        if (event.kind === 9735) recordZapToSparkSdk(event);
-      }
-    }
-    preEoseBuffer.length = 0;
-
-    if (parsed.length > 0) {
-      notifications.addBulk(parsed);
-    }
+    flushPreEoseBuffer();
+    notificationsLoading.set(false);
   });
+
+  // Safety valve: some relays never send EOSE (or send it very late).
+  // After 10 s, flush whatever accumulated so history is always persisted
+  // to localStorage and shown in the UI — even if EOSE never arrives.
+  setTimeout(() => {
+    if (!eoseReceived) {
+      eoseReceived = true;
+      flushPreEoseBuffer();
+    }
+    notificationsLoading.set(false);
+  }, 10000);
 
   return activeSubscription;
 }

--- a/src/lib/notificationStore.ts
+++ b/src/lib/notificationStore.ts
@@ -295,7 +295,11 @@ export function subscribeToNotifications(ndk: NDK, userPubkey: string, forceFull
     handleEvent(event, eoseReceived);
   });
 
+  const thisSubscription = activeSubscription;
+
   activeSubscription.on('eose', () => {
+    if (activeSubscription !== thisSubscription) return;
+    clearTimeout(eoseTimer);
     eoseReceived = true;
     flushPreEoseBuffer();
     notificationsLoading.set(false);
@@ -304,7 +308,9 @@ export function subscribeToNotifications(ndk: NDK, userPubkey: string, forceFull
   // Safety valve: some relays never send EOSE (or send it very late).
   // After 10 s, flush whatever accumulated so history is always persisted
   // to localStorage and shown in the UI — even if EOSE never arrives.
-  setTimeout(() => {
+  // Guard against stale timers firing for a replaced subscription.
+  const eoseTimer = setTimeout(() => {
+    if (activeSubscription !== thisSubscription) return;
     if (!eoseReceived) {
       eoseReceived = true;
       flushPreEoseBuffer();

--- a/src/routes/[nip19]/+page.svelte
+++ b/src/routes/[nip19]/+page.svelte
@@ -176,11 +176,6 @@
     }
   }
 
-  function gotoNoteUnlessInteractive(e: MouseEvent, evt: NDKEvent) {
-    if (e.target instanceof Element && e.target.closest('a, button')) return;
-    goto(noteUrl(evt));
-  }
-
   // Fetch replies to this note
   function fetchReplies(eventId: string) {
     loadingReplies = true;

--- a/src/routes/[nip19]/+page.svelte
+++ b/src/routes/[nip19]/+page.svelte
@@ -157,6 +157,11 @@
     loadingParents = false;
   }
 
+  function gotoNoteUnlessInteractive(e: MouseEvent, evt: NDKEvent) {
+    if (e.target instanceof Element && e.target.closest('a, button')) return;
+    goto(noteUrl(evt));
+  }
+
   // Encode a note/reply event as nevent1 with relay hints for better discoverability.
   function noteUrl(evt: NDKEvent): string {
     const relayUrl = evt.relay?.url ?? (evt as any).onRelays?.[0]?.url;

--- a/src/routes/notifications/+page.svelte
+++ b/src/routes/notifications/+page.svelte
@@ -2,6 +2,7 @@
   import {
     notifications,
     visibleNotifications,
+    notificationsLoading,
     subscribeToNotifications,
     fetchOlderNotifications,
     type Notification
@@ -736,7 +737,12 @@
         </div>
       </div>
 
-      {#if $visibleNotifications.length === 0}
+      {#if $visibleNotifications.length === 0 && $notificationsLoading}
+      <div class="flex flex-col items-center text-center py-12 text-caption">
+        <BellIcon size={48} weight="regular" aria-hidden="true" />
+        <p class="mt-4 text-lg">Loading notifications…</p>
+      </div>
+    {:else if $visibleNotifications.length === 0}
       <div class="flex flex-col items-center text-center py-12 text-caption">
         <BellIcon size={48} weight="regular" aria-hidden="true" />
         <p class="mt-4 text-lg">No notifications yet</p>


### PR DESCRIPTION
## Summary

- **Root cause**: NDK subscriptions on some relays never fire the `eose` event. The notification store only flushed its pre-EOSE event buffer on `eose`, so if `eose` never arrived, nothing was ever written to localStorage — causing the bell panel and `/notifications` page to always show "Nothing here yet" even when events had been received.
- **Fix**: Added a 10-second timeout fallback that flushes the buffer regardless of whether `eose` fires, and sets a new `notificationsLoading` store to `false`. The UI shows "Loading notifications…" while fetching instead of prematurely showing the empty state.
- **Also fixed**: Three `as HTMLElement` casts inside Svelte template event handlers (rejected by `svelte-check`) replaced with `instanceof Element` guards and named helper functions — brings the build to 0 errors.

## Files changed

- `src/lib/notificationStore.ts` — `flushPreEoseBuffer()` helper, 10s timeout fallback, `notificationsLoading` export
- `src/components/NotificationBell.svelte` — show loading state while `notificationsLoading` is true
- `src/routes/notifications/+page.svelte` — show loading state before empty state
- `src/components/NoteEmbed.svelte` — `handleCardClickEvent` with `instanceof Element` guard
- `src/routes/[nip19]/+page.svelte` — `gotoNoteUnlessInteractive` with `instanceof Element` guard (reply + nested reply click handlers)

## Test plan

- [ ] Open the notifications bell — should show "Loading notifications…" briefly, then populate with real history
- [ ] Navigate to `/notifications` — same loading → populated behaviour
- [ ] On a relay-heavy connection where EOSE is slow/absent, history should still persist after ~10 seconds
- [ ] Clicking a reply card on a note page navigates correctly; clicking links/buttons inside the card does not trigger navigation