### PR TITLE
fix(modal): raise z-index above login overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.553",
+  "version": "4.2.554",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -146,7 +146,7 @@
       on:click|self={close}
       role="presentation"
       transition:blur={{ duration: 250 }}
-      class="fixed top-0 left-0 z-50 w-full h-full backdrop-brightness-50 backdrop-blur"
+      class="fixed top-0 left-0 z-[10000] w-full h-full backdrop-brightness-50 backdrop-blur"
     >
       <dialog
         bind:this={dialogEl}


### PR DESCRIPTION
## Summary

- `LoginOverlay` renders `position:fixed` layers at z-index 9995–9997, creating a stacking context that trapped `Modal`'s backdrop (`z-50` = 50) behind it
- Buttons on the login screen (Scan QR, Bunker URI, Import key) were no longer opening their modals
- Raised `Modal` backdrop from `z-50` to `z-[10000]` so it always clears the overlay

## Test plan

- [ ] Open the login screen
- [ ] Click "Scan QR" — QR scanner modal opens correctly
- [ ] Click "Bunker URI" — Bunker URI modal opens correctly
- [ ] Click "Import key" — import key modal opens correctly
- [ ] Verify modals on other pages (e.g. recipe, profile) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)