### PR TITLE
fix(wallet): fix backup detection race condition on slow relays

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.554",
+  "version": "4.2.555",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/scripts/delete-spark-backup.mjs
+++ b/scripts/delete-spark-backup.mjs
@@ -53,10 +53,10 @@ console.log(`\nPubkey: ${nip19.npubEncode(pubkey)}`);
 const pool = new SimplePool();
 
 console.log('\nSearching for Spark backup events on relays...');
-const events = await pool.querySync(RELAYS, {
-  kinds:   [BACKUP_EVENT_KIND],
-  authors: [pubkey],
-});
+const events = await Promise.race([
+  pool.querySync(RELAYS, { kinds: [BACKUP_EVENT_KIND], authors: [pubkey] }),
+  new Promise(resolve => setTimeout(() => resolve([]), 10_000))
+]);
 
 const backups = events.filter(e =>
   e.tags.some(t => t[0] === 'd' && (t[1] === SPARK_D_TAG || t[1]?.startsWith(SPARK_D_TAG + ':')))
@@ -80,7 +80,11 @@ for (const e of backups) {
 console.log('\nOverwriting each backup with an empty replacement event...');
 
 for (const e of backups) {
-  const dTag = e.tags.find(t => t[0] === 'd')?.[1];
+  const dTag = e.tags.find(t => t[0] === 'd' && (t[1] === SPARK_D_TAG || t[1]?.startsWith(SPARK_D_TAG + ':')))?.[1];
+  if (!dTag) {
+    console.warn('  Skipping event with no matching Spark d-tag');
+    continue;
+  }
 
   const template = {
     kind:       BACKUP_EVENT_KIND,

--- a/scripts/delete-spark-backup.mjs
+++ b/scripts/delete-spark-backup.mjs
@@ -1,0 +1,101 @@
+/**
+ * Delete a corrupted Spark wallet backup from Nostr relays.
+ *
+ * Usage:
+ *   node scripts/delete-spark-backup.mjs <nsec>
+ *
+ * The script finds every kind:30078 event with a spark-wallet-backup d-tag
+ * published by the key, then overwrites each one with an empty replacement
+ * (same kind + d-tag, empty content, deleted:true tag). Replaceable events
+ * are deduplicated by relays, so the empty event wins once it propagates.
+ */
+
+import { finalizeEvent, getPublicKey, nip19 } from 'nostr-tools';
+import { SimplePool } from 'nostr-tools/pool';
+import { useWebSocketImplementation } from 'nostr-tools/pool';
+import WebSocket from 'ws';
+
+useWebSocketImplementation(WebSocket);
+
+const RELAYS = [
+  'wss://relay.damus.io',
+  'wss://relay.nostr.band',
+  'wss://nos.lol',
+  'wss://relay.primal.net',
+  'wss://nostr.wine',
+  'wss://relay.snort.social',
+];
+
+const BACKUP_EVENT_KIND = 30078;
+const SPARK_D_TAG        = 'spark-wallet-backup';
+
+// ── parse args ───────────────────────────────────────────────────────────────
+const [,, nsecArg] = process.argv;
+if (!nsecArg) {
+  console.error('Usage: node scripts/delete-spark-backup.mjs <nsec>');
+  process.exit(1);
+}
+
+let secretKey;
+try {
+  const decoded = nip19.decode(nsecArg);
+  if (decoded.type !== 'nsec') throw new Error('Not an nsec');
+  secretKey = decoded.data;
+} catch {
+  console.error('Invalid nsec — provide a bech32-encoded nsec1... key');
+  process.exit(1);
+}
+
+const pubkey = getPublicKey(secretKey);
+console.log(`\nPubkey: ${nip19.npubEncode(pubkey)}`);
+
+// ── fetch backups ────────────────────────────────────────────────────────────
+const pool = new SimplePool();
+
+console.log('\nSearching for Spark backup events on relays...');
+const events = await pool.querySync(RELAYS, {
+  kinds:   [BACKUP_EVENT_KIND],
+  authors: [pubkey],
+});
+
+const backups = events.filter(e =>
+  e.tags.some(t => t[0] === 'd' && (t[1] === SPARK_D_TAG || t[1]?.startsWith(SPARK_D_TAG + ':')))
+);
+
+if (backups.length === 0) {
+  console.log('No Spark backup events found.');
+  pool.close(RELAYS);
+  process.exit(0);
+}
+
+console.log(`\nFound ${backups.length} backup event(s):`);
+for (const e of backups) {
+  const dTag = e.tags.find(t => t[0] === 'd')?.[1] ?? '(no d-tag)';
+  const ts   = new Date(e.created_at * 1000).toISOString();
+  const enc  = e.tags.find(t => t[0] === 'encryption')?.[1] ?? 'unknown';
+  console.log(`  d-tag: ${dTag}   created: ${ts}   encryption: ${enc}`);
+}
+
+// ── overwrite each backup with an empty replacement ──────────────────────────
+console.log('\nOverwriting each backup with an empty replacement event...');
+
+for (const e of backups) {
+  const dTag = e.tags.find(t => t[0] === 'd')?.[1];
+
+  const template = {
+    kind:       BACKUP_EVENT_KIND,
+    created_at: Math.floor(Date.now() / 1000),
+    tags:       [['d', dTag], ['deleted', 'true']],
+    content:    '',
+  };
+
+  const signed = finalizeEvent(template, secretKey);
+  const results = await Promise.allSettled(pool.publish(RELAYS, signed));
+
+  const ok  = results.filter(r => r.status === 'fulfilled').length;
+  const err = results.filter(r => r.status === 'rejected').length;
+  console.log(`  ${dTag}: published to ${ok}/${RELAYS.length} relays (${err} failed)`);
+}
+
+console.log('\nDone. Backup events replaced — they will be treated as deleted by any relay that accepts replaceable events.');
+pool.close(RELAYS);

--- a/src/components/wallet/WalletPanel.svelte
+++ b/src/components/wallet/WalletPanel.svelte
@@ -313,10 +313,17 @@
     errorMessage = '';
   }
 
-  async function checkSparkBackupStatus(pubkey: string) {
+  // ndkReady fires on the FIRST relay WebSocket open. The rest of the pool
+  // connects incrementally, so an immediate scan may only hit 1-2 relays.
+  // We retry up to 3 times at increasing delays so slower relays have time
+  // to join before we give up. Retries stop as soon as a backup is found or
+  // the user connects a wallet.
+  const BACKUP_RELAY_RETRY_DELAYS = [3000, 8000, 14000];
+
+  async function checkSparkBackupStatus(pubkey: string, retryIndex = 0) {
     if (sparkBackupChecking) return;
     sparkBackupChecking = true;
-    sparkBackupExists = null;
+    if (retryIndex === 0) sparkBackupExists = null;
     try {
       sparkBackupExists = await Promise.race([
         hasSparkBackupInNostr(pubkey),
@@ -329,13 +336,21 @@
     } finally {
       sparkBackupChecking = false;
       lastSparkBackupCheckPubkey = pubkey;
+      const nextDelay = BACKUP_RELAY_RETRY_DELAYS[retryIndex];
+      if (!sparkBackupExists && nextDelay !== undefined && !$walletConnected) {
+        setTimeout(() => {
+          if (!$walletConnected && lastSparkBackupCheckPubkey === pubkey) {
+            checkSparkBackupStatus(pubkey, retryIndex + 1);
+          }
+        }, nextDelay);
+      }
     }
   }
 
-  async function checkNwcBackupStatus(pubkey: string) {
+  async function checkNwcBackupStatus(pubkey: string, retryIndex = 0) {
     if (nwcBackupChecking) return;
     nwcBackupChecking = true;
-    nwcBackupExists = null;
+    if (retryIndex === 0) nwcBackupExists = null;
     try {
       nwcBackupExists = await Promise.race([
         hasNwcBackupInNostr(pubkey),
@@ -348,6 +363,14 @@
     } finally {
       nwcBackupChecking = false;
       lastNwcBackupCheckPubkey = pubkey;
+      const nextDelay = BACKUP_RELAY_RETRY_DELAYS[retryIndex];
+      if (!nwcBackupExists && nextDelay !== undefined && !$walletConnected) {
+        setTimeout(() => {
+          if (!$walletConnected && lastNwcBackupCheckPubkey === pubkey) {
+            checkNwcBackupStatus(pubkey, retryIndex + 1);
+          }
+        }, nextDelay);
+      }
     }
   }
 

--- a/src/lib/spark/index.ts
+++ b/src/lib/spark/index.ts
@@ -1843,7 +1843,16 @@ export async function restoreSparkBackup(
 
   const normalizedMnemonic = normalizeMnemonic(mnemonic);
   if (!validateMnemonic(normalizedMnemonic)) {
-    throw new Error('Decrypted backup contains invalid mnemonic');
+    // The most common cause is a backup that was created by a NIP-46 remote
+    // signer before the guard was added. Those signers encrypted with an
+    // ephemeral session key, so decrypting with the user's identity key
+    // produces garbage that passes decrypt() but fails BIP-39 validation.
+    throw new Error(
+      'Backup decrypted but the recovery phrase is unreadable. ' +
+      'This usually means the backup was created while signed in with a remote signer (Amber, Primal) ' +
+      'that used a temporary session key. Sign in with the same signer app you used when the ' +
+      'backup was created, then try again. If that is not possible, restore from a written recovery phrase instead.'
+    );
   }
 
   await saveMnemonic(pubkey, normalizedMnemonic);
@@ -1895,8 +1904,32 @@ export async function hasSparkBackupInNostr(pubkey: string): Promise<boolean> {
   if (!browser) return false;
 
   try {
-    const backups = await listSparkBackups(pubkey);
-    return backups.length > 0;
+    const { ndk, ndkReady } = await import('$lib/nostr');
+    const { get } = await import('svelte/store');
+
+    await ndkReady;
+    const ndkInstance = get(ndk);
+
+    // Live subscription so NDK forwards it to relays that connect after this
+    // call — resolves true on the first non-deleted Spark backup event found,
+    // false after 7 s. listSparkBackups uses fetchEvents which only hits
+    // relays already connected at call time and is too slow for UI detection.
+    return await new Promise<boolean>((resolve) => {
+      const sub = ndkInstance.subscribe(
+        { kinds: [BACKUP_EVENT_KIND], authors: [pubkey] },
+        { closeOnEose: false }
+      );
+      const timer = setTimeout(() => { sub.stop(); resolve(false); }, 7000);
+
+      sub.on('event', (event: any) => {
+        const dTag = event.tags?.find((t: string[]) => t[0] === 'd')?.[1];
+        if (!dTag || !parseBackupTag(dTag)) return;
+        if (isDeletedBackupEvent(event) || !event.content) return;
+        clearTimeout(timer);
+        sub.stop();
+        resolve(true);
+      });
+    });
   } catch (error) {
     logger.warn('[Spark] Failed to check backup status:', String(error));
     return false;

--- a/src/lib/wallet/nwcBackup.ts
+++ b/src/lib/wallet/nwcBackup.ts
@@ -258,7 +258,9 @@ export async function hasNwcBackupInNostr(pubkey: string): Promise<boolean> {
       const sub = ndkInstance.subscribe(filter, { closeOnEose: false });
       const timer = setTimeout(() => { sub.stop(); resolve(false); }, 7000);
 
-      sub.on('event', () => {
+      sub.on('event', (event: any) => {
+        // Ignore delete markers (empty replacements published to overwrite a backup).
+        if (!event.content) return;
         clearTimeout(timer);
         sub.stop();
         resolve(true);

--- a/src/lib/wallet/nwcBackup.ts
+++ b/src/lib/wallet/nwcBackup.ts
@@ -249,8 +249,21 @@ export async function hasNwcBackupInNostr(pubkey: string): Promise<boolean> {
       '#d': [NWC_BACKUP_D_TAG]
     };
 
-    const events = await ndkInstance.fetchEvents(filter, { closeOnEose: true });
-    return !!events && events.size > 0;
+    // Use a live subscription rather than fetchEvents so NDK automatically
+    // forwards it to relays that connect after this call. fetchEvents with
+    // closeOnEose:true only queries currently-connected relays, missing any
+    // that join late. Resolve true the moment any matching event arrives;
+    // false after 7 s if nothing shows up.
+    return await new Promise<boolean>((resolve) => {
+      const sub = ndkInstance.subscribe(filter, { closeOnEose: false });
+      const timer = setTimeout(() => { sub.stop(); resolve(false); }, 7000);
+
+      sub.on('event', () => {
+        clearTimeout(timer);
+        sub.stop();
+        resolve(true);
+      });
+    });
   } catch (error) {
     console.warn('[NWC Backup] Failed to check backup status:', error);
     return false;


### PR DESCRIPTION
## Summary

- `fetchEvents(closeOnEose: true)` only queries relays connected at call time. On first load, slower relays haven't joined the pool yet, so backups stored there are missed — refreshing (when all relays are connected) always worked
- Switched `hasNwcBackupInNostr` and `hasSparkBackupInNostr` to live subscriptions (`closeOnEose: false`). NDK forwards active subscriptions to newly-connecting relays automatically; resolves `true` on the first matching event, `false` after 7 s
- Extended `WalletPanel` retry schedule from 1 retry to 3 retries at 3 s, 8 s, and 14 s as a belt-and-suspenders fallback
- Improved the "invalid mnemonic" error message for backups encrypted with a NIP-46 session key so users understand the cause and their options
- Added `scripts/delete-spark-backup.mjs` — dev-only Node.js script to find and overwrite corrupted kind:30078 Spark backups on relays

## Root cause

`ndkReady` resolves on the first relay WebSocket open, not when the full pool is connected. The wallet picker fires the backup scan immediately on open, catching only the fastest relay. `fetchEvents` with `closeOnEose: true` takes a snapshot — even with retries, each attempt only sees relays connected at that instant.

## Test plan

- [ ] Sign in with an account that has a Spark wallet backup on relays
- [ ] Open the wallet panel immediately after login — backup is detected without a page refresh
- [ ] Repeat with NWC backup
- [ ] Verify no regression on accounts with no backup (shows "No backup found" correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)