### PR TITLE
fix(toast): raise z-index above modal backdrop

### DIFF
--- a/src/components/ToastContainer.svelte
+++ b/src/components/ToastContainer.svelte
@@ -5,7 +5,7 @@
    * $lib/toast and renders each message via the Toast component.
    *
    * Positioning: top-center, capped at the same width as the composer modal
-   * (max-w-xl / 36rem). z-index 9999 sits above all modals and the fixed header.
+   * (max-w-xl / 36rem). z-index 10001 sits above all modals (10000) and the fixed header.
    */
   import { toasts } from '$lib/toast';
   import Toast from './Toast.svelte';
@@ -31,7 +31,7 @@
     transform: translateX(-50%);
     width: calc(100vw - 2rem);
     max-width: 36rem;
-    z-index: 9999;
+    z-index: 10001;
     display: flex;
     flex-direction: column;
     gap: 0.5rem;


### PR DESCRIPTION
## Summary

- `ToastContainer` was at z-index 9999, but `Modal` backdrop was raised to z-10000 (PR #473) to clear the `LoginOverlay` layers at 9997
- Toasts triggered from inside a modal (e.g. wallet backup success/error) were landing just behind the modal backdrop and never reaching the visible layer
- Raised `ToastContainer` to z-index 10001 so the full stack is: LoginOverlay (9997) → Modal (10000) → Toast (10001)
- Affects all toasts app-wide — there is exactly one `ToastContainer` mounted at the root layout

## Test plan

- [ ] Trigger a success toast from inside a modal (e.g. back up wallet, restore from Nostr backup)
- [ ] Trigger an error toast from inside a modal
- [ ] Confirm toasts appear above the modal backdrop
- [ ] Confirm toasts still appear correctly outside of modals

🍞 Cooked with [Claude Code](https://claude.com/claude-code)