### PR TITLE
feat(gif): reupload selected GIF to nostr.build instead of linking Giphy directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.554",
+  "version": "4.2.555",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/GifPicker.svelte
+++ b/src/components/GifPicker.svelte
@@ -3,7 +3,7 @@
   import Modal from './Modal.svelte';
   import MagnifyingGlassIcon from 'phosphor-svelte/lib/MagnifyingGlass';
   import SpinnerIcon from 'phosphor-svelte/lib/SpinnerGap';
-  import { uploadImage } from '$lib/mediaUpload';
+  import { uploadGif } from '$lib/mediaUpload';
   import { ndk } from '$lib/nostr';
   import { get } from 'svelte/store';
 
@@ -83,12 +83,16 @@
   async function selectGif(gif: GiphyGif) {
     if (uploading) return;
     const gifUrl = gif.images.downsized?.url || gif.images.original?.url;
+    if (!gifUrl) return;
     uploading = true;
     try {
       const res = await fetch(gifUrl);
+      if (!res.ok) throw new Error(`Failed to fetch GIF: HTTP ${res.status}`);
       const blob = await res.blob();
-      const file = new File([blob], `${gif.id}.gif`, { type: blob.type || 'image/gif' });
-      const hostedUrl = await uploadImage(get(ndk), file);
+      const contentType = res.headers.get('content-type') || blob.type || 'image/gif';
+      const ext = contentType.includes('webp') ? 'webp' : 'gif';
+      const file = new File([blob], `${gif.id}.${ext}`, { type: contentType });
+      const hostedUrl = await uploadGif(get(ndk), file);
       dispatch('select', { url: hostedUrl, title: gif.title });
       close();
     } catch (e) {
@@ -139,17 +143,23 @@
           <SpinnerIcon size={24} class="animate-spin" />
         </div>
       {:else if !API_KEY}
-        <div class="gif-grid">
-          {#each [
-            { id: 'test-gif', title: 'Test GIF', url: 'https://c.tenor.com/ozqCVlQw6M4AAAAd/tenor.gif' },
-            { id: 'test-webp', title: 'Test WebP', url: 'https://i.giphy.com/xT5LMzIK1AdZJ4cYW4.webp' },
-          ] as t}
-            <button class="gif-tile" disabled={uploading} title={t.title}
-              on:click={() => selectGif({ id: t.id, title: t.title, images: { fixed_width_small: { url: t.url, width: '200', height: '200' }, downsized: { url: t.url }, original: { url: t.url } } })}>
-              <img src={t.url} alt={t.title} class="gif-thumb" />
-            </button>
-          {/each}
-        </div>
+        {#if import.meta.env.DEV}
+          <div class="gif-grid">
+            {#each [
+              { id: 'test-gif', title: 'Test GIF', url: 'https://c.tenor.com/ozqCVlQw6M4AAAAd/tenor.gif' },
+              { id: 'test-webp', title: 'Test WebP', url: 'https://i.giphy.com/xT5LMzIK1AdZJ4cYW4.webp' },
+            ] as t}
+              <button class="gif-tile" disabled={uploading} title={t.title}
+                on:click={() => selectGif({ id: t.id, title: t.title, images: { fixed_width_small: { url: t.url, width: '200', height: '200' }, downsized: { url: t.url }, original: { url: t.url } } })}>
+                <img src={t.url} alt={t.title} class="gif-thumb" />
+              </button>
+            {/each}
+          </div>
+        {:else}
+          <div class="gif-empty">
+            <p>GIF search is not available</p>
+          </div>
+        {/if}
       {:else if gifs.length === 0 && query}
         <div class="gif-empty">
           <p>No GIFs found for "{query}"</p>

--- a/src/components/GifPicker.svelte
+++ b/src/components/GifPicker.svelte
@@ -3,6 +3,9 @@
   import Modal from './Modal.svelte';
   import MagnifyingGlassIcon from 'phosphor-svelte/lib/MagnifyingGlass';
   import SpinnerIcon from 'phosphor-svelte/lib/SpinnerGap';
+  import { uploadImage } from '$lib/mediaUpload';
+  import { ndk } from '$lib/nostr';
+  import { get } from 'svelte/store';
 
   export let open = false;
 
@@ -23,6 +26,7 @@
   let query = '';
   let gifs: GiphyGif[] = [];
   let loading = false;
+  let uploading = false;
   let debounceTimer: ReturnType<typeof setTimeout>;
   let searchInputEl: HTMLInputElement;
 
@@ -76,10 +80,24 @@
     }, 300);
   }
 
-  function selectGif(gif: GiphyGif) {
-    const url = gif.images.downsized?.url || gif.images.original?.url;
-    dispatch('select', { url, title: gif.title });
-    close();
+  async function selectGif(gif: GiphyGif) {
+    if (uploading) return;
+    const gifUrl = gif.images.downsized?.url || gif.images.original?.url;
+    uploading = true;
+    try {
+      const res = await fetch(gifUrl);
+      const blob = await res.blob();
+      const file = new File([blob], `${gif.id}.gif`, { type: blob.type || 'image/gif' });
+      const hostedUrl = await uploadImage(get(ndk), file);
+      dispatch('select', { url: hostedUrl, title: gif.title });
+      close();
+    } catch (e) {
+      console.error('[GifPicker] Upload failed, falling back to Giphy URL:', e);
+      dispatch('select', { url: gifUrl, title: gif.title });
+      close();
+    } finally {
+      uploading = false;
+    }
   }
 
   function close() {
@@ -109,14 +127,28 @@
     </div>
 
     <!-- Grid -->
-    <div class="gif-grid-container">
+    <div class="gif-grid-container" class:gif-grid-uploading={uploading}>
+      {#if uploading}
+        <div class="gif-upload-overlay">
+          <SpinnerIcon size={28} class="animate-spin" />
+          <span>Uploading…</span>
+        </div>
+      {/if}
       {#if loading && gifs.length === 0}
         <div class="gif-loading">
           <SpinnerIcon size={24} class="animate-spin" />
         </div>
       {:else if !API_KEY}
-        <div class="gif-empty">
-          <p>GIPHY API key not configured</p>
+        <div class="gif-grid">
+          {#each [
+            { id: 'test-gif', title: 'Test GIF', url: 'https://c.tenor.com/ozqCVlQw6M4AAAAd/tenor.gif' },
+            { id: 'test-webp', title: 'Test WebP', url: 'https://i.giphy.com/xT5LMzIK1AdZJ4cYW4.webp' },
+          ] as t}
+            <button class="gif-tile" disabled={uploading} title={t.title}
+              on:click={() => selectGif({ id: t.id, title: t.title, images: { fixed_width_small: { url: t.url, width: '200', height: '200' }, downsized: { url: t.url }, original: { url: t.url } } })}>
+              <img src={t.url} alt={t.title} class="gif-thumb" />
+            </button>
+          {/each}
         </div>
       {:else if gifs.length === 0 && query}
         <div class="gif-empty">
@@ -128,6 +160,7 @@
             <button
               class="gif-tile"
               on:click={() => selectGif(gif)}
+              disabled={uploading}
               title={gif.title}
             >
               <img
@@ -197,9 +230,30 @@
   }
 
   .gif-grid-container {
+    position: relative;
     max-height: 50vh;
     overflow-y: auto;
     border-radius: 8px;
+  }
+
+  .gif-grid-uploading {
+    pointer-events: none;
+  }
+
+  .gif-upload-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    background: rgba(0, 0, 0, 0.55);
+    border-radius: 8px;
+    color: #fff;
+    font-size: 14px;
+    font-weight: 500;
   }
 
   .gif-grid {

--- a/src/lib/mediaUpload.ts
+++ b/src/lib/mediaUpload.ts
@@ -3,6 +3,7 @@ import type NDK from '@nostr-dev-kit/ndk';
 
 const NOSTR_BUILD_URL = 'https://nostr.build/api/v2/upload/files';
 const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
+const MAX_GIF_SIZE = 15 * 1024 * 1024; // 15MB — animated files are often larger than static images
 const MAX_VIDEO_SIZE = 50 * 1024 * 1024; // 50MB
 const MAX_VIDEO_DURATION = 60; // seconds
 
@@ -164,6 +165,26 @@ export async function uploadImage(ndk: NDK, file: File): Promise<string> {
     return result.data[0].url;
   }
   throw new Error(result?.message || result?.error || 'Failed to upload image');
+}
+
+/**
+ * Upload a GIF or animated WebP, returning the URL on success.
+ * Uses a higher 15MB limit since animated files are often larger than static images.
+ * Throws on validation failure or upload error.
+ */
+export async function uploadGif(ndk: NDK, file: File): Promise<string> {
+  if (file.size > MAX_GIF_SIZE) {
+    throw new Error('GIF must be less than 15MB');
+  }
+
+  const body = new FormData();
+  body.append('file[]', file);
+  const result = await uploadToNostrBuild(ndk, body);
+
+  if (result?.data?.[0]?.url) {
+    return result.data[0].url;
+  }
+  throw new Error(result?.message || result?.error || 'Failed to upload GIF');
 }
 
 /**


### PR DESCRIPTION
## Summary

- GIF picker previously inserted raw Giphy CDN URLs directly into posts
- Now fetches the selected GIF as a blob and uploads it through the existing NIP-96 pipeline (nostr.build) before inserting the URL — same path as pasted/attached images
- Keeps all post media self-hosted; no third-party Giphy links in published notes
- Shows a semi-transparent upload overlay with spinner while transferring, disables grid tiles to prevent double-submit
- Falls back to the original Giphy URL if upload fails so the user is never blocked
- Matches the behaviour in the Wisp Android app

> **Note:** This PR uses the existing NIP-96 upload pipeline (nostr.build), not Blossom (BUD-01/02). See #477.

## Test plan

- [ ] Open GIF picker, select a GIF — verify spinner appears and URL inserted is `image.nostr.build/...`
- [ ] Confirm animated GIF plays correctly after posting
- [ ] Confirm WebP GIFs (Giphy serves some thumbnails as WebP) upload and render correctly
- [ ] Simulate upload failure (e.g. sign out mid-flow) — verify fallback Giphy URL is used and post still works

## Roadmap

- [ ] #477 — Blossom upload support (BUD-01/02) with `kind:10063` server list

🍕 Cooked with [Claude Code](https://claude.com/claude-code)