### PR TITLE
fix(explore): retry longform article load when NDK connects after mount

### DIFF
--- a/src/components/LongformFoodFeed.svelte
+++ b/src/components/LongformFoodFeed.svelte
@@ -24,6 +24,17 @@
     loading = false;
   }
 
+  // Guard against multiple load attempts (handles race between mount and connection)
+  let _loadAttempted = false;
+
+  // Trigger load as soon as NDK is connected — covers both "already connected on mount"
+  // and "connected after mount" cases. Without this, if the component mounts before
+  // the first relay connects, loadLongformArticles() exits early and never retries.
+  $: if ($ndkConnected && !_loadAttempted) {
+    _loadAttempted = true;
+    loadLongformArticles();
+  }
+
   // Display the best source — shared store or local fetch
   $: displayArticles = sharedFoodArticles.length > localArticles.length
     ? sharedFoodArticles
@@ -118,7 +129,9 @@
   }
 
   onMount(() => {
-    loadLongformArticles();
+    // Load is triggered by the $ndkConnected reactive above.
+    // If already connected, it fires synchronously during initialization.
+    // `loading` stays true (skeleton visible) until connection is ready.
   });
 
   onDestroy(() => {


### PR DESCRIPTION
## Summary

- `LongformFoodFeed` called `loadLongformArticles()` from `onMount`, which exits early and sets `loading = false` if `$ndkConnected` is false at mount time — common since WebSocket relay connections are async
- No retry path existed, so the component permanently showed "No longform articles found yet." whenever the relay hadn't connected by the time the component mounted
- Replace the `onMount` call with a `$: if ($ndkConnected && !_loadAttempted)` reactive that fires once as soon as the connection is ready, covering both "already connected on mount" (fires synchronously during component init) and "connected after mount" cases
- `_loadAttempted` guard prevents re-triggering on relay switches
- `loading` stays `true` while waiting so the skeleton placeholder is visible rather than the empty state

## Test plan

- [ ] Navigate to `/explore` immediately after a cold page load — longform articles should appear once relays connect (skeleton visible while waiting)
- [ ] Navigate to `/explore` after the app has been open a while — articles should load as before (reactive fires immediately since connection is already established)
- [ ] Confirm no duplicate load on fast connections (articles appear once, not twice)

🍕 Generated with [Claude Code](https://claude.com/claude-code)