### PR TITLE
feat(reads): add Reads nav tab, filter feed to curated topics, link explore section headings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.557",
+  "version": "4.2.558",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.558",
+  "version": "4.2.559",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.559",
+  "version": "4.2.560",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/BottomNav.svelte
+++ b/src/components/BottomNav.svelte
@@ -4,7 +4,7 @@
   import ForkKnifeIcon from 'phosphor-svelte/lib/ForkKnife';
   import FlameIcon from 'phosphor-svelte/lib/Flame';
   import BellIcon from 'phosphor-svelte/lib/Bell';
-  import ChartBarHorizontalIcon from 'phosphor-svelte/lib/ChartBarHorizontal';
+  import NewspaperIcon from 'phosphor-svelte/lib/Newspaper';
   import StorefrontIcon from 'phosphor-svelte/lib/Storefront';
   import { page } from '$app/stores';
   import { unreadCount } from '$lib/notificationStore';
@@ -67,9 +67,9 @@
     <StorefrontIcon class="self-center" size={22} />
     <span class="sr-only">Market</span>
   </a>
-  <a href="/polls" class="nav-tab" class:active={pathname.startsWith('/polls')}>
-    <ChartBarHorizontalIcon class="self-center" size={22} />
-    <span class="sr-only">Polls</span>
+  <a href="/reads" class="nav-tab" class:active={pathname.startsWith('/reads') || pathname.startsWith('/r/')}>
+    <NewspaperIcon class="self-center" size={22} />
+    <span class="sr-only">Reads</span>
   </a>
   <a
     href="/notifications"

--- a/src/components/DesktopSideNav.svelte
+++ b/src/components/DesktopSideNav.svelte
@@ -12,6 +12,7 @@
   import FlameIcon from 'phosphor-svelte/lib/Flame';
   import EnvelopeSimpleIcon from 'phosphor-svelte/lib/EnvelopeSimple';
 
+  import NewspaperIcon from 'phosphor-svelte/lib/Newspaper';
   import CookbookIcon from 'phosphor-svelte/lib/BookOpen';
   import ShoppingCartIcon from 'phosphor-svelte/lib/ShoppingCart';
   import WalletIcon from 'phosphor-svelte/lib/Wallet';
@@ -55,6 +56,12 @@
       // URL redirects through to /recipes — avoids a flash of unhighlighted
       // tab during the 301 round-trip on cold links.
       match: (p) => p.startsWith('/recipes') || p.startsWith('/recent')
+    },
+    {
+      href: '/reads',
+      label: 'Reads',
+      icon: NewspaperIcon,
+      match: (p) => p.startsWith('/reads') || p.startsWith('/r/')
     },
     {
       href: '/polls',

--- a/src/components/table/FeedSection.svelte
+++ b/src/components/table/FeedSection.svelte
@@ -2,7 +2,7 @@
   import { createEventDispatcher, onMount, onDestroy } from 'svelte';
   import FilterBar from './FilterBar.svelte';
   import ArticleCard from '../ArticleCard.svelte';
-  import { filterByCategory, sortArticles, limitArticlesPerAuthor, deduplicatePreviewArticles, type ArticleData, type SortOption } from '$lib/articleUtils';
+  import { filterByCategory, sortArticles, limitArticlesPerAuthor, deduplicatePreviewArticles, isRelevantToReads, type ArticleData, type SortOption } from '$lib/articleUtils';
 
   export let articles: ArticleData[] = [];
   export let loading: boolean = false;
@@ -25,8 +25,11 @@
     selectedSort = 'newest';
   }
 
-  // Filter out cover articles and articles without real images (no placeholders in reads)
-  $: feedArticles = articles.filter((a) => !coverArticleIds.includes(a.id) && a.imageUrl);
+  // Filter out cover articles, articles without real images (no placeholders in
+  // reads), and off-topic content that doesn't match any curated reads topic.
+  $: feedArticles = articles.filter(
+    (a) => !coverArticleIds.includes(a.id) && a.imageUrl && isRelevantToReads(a)
+  );
   $: dedupedArticles = deduplicatePreviewArticles(feedArticles);
   $: authorLimitedArticles = limitArticlesPerAuthor(dedupedArticles, 3); // Max 3 per author
   $: filteredArticles = filterByCategory(authorLimitedArticles, selectedCategory);

--- a/src/lib/articleUtils.ts
+++ b/src/lib/articleUtils.ts
@@ -730,12 +730,21 @@ const READS_BLOCKLIST_TAGS = new Set<string>([
  * articles matching none of the topics are treated as off-topic and excluded.
  */
 export function isRelevantToReads(article: ArticleData): boolean {
-  // Exclusion takes priority: drop altcoin/other-chain promo even if it also
-  // carries a curated tag like `nostr` or `bitcoin`.
-  if (article.tags.some((tag) => READS_BLOCKLIST_TAGS.has(tag.toLowerCase()))) {
-    return false;
+  // Single pass over tags: enforce the blocklist (which takes priority) and
+  // record whether any curated tag was present, lowercasing each tag once.
+  let hasRelevantTag = false;
+  for (const tag of article.tags) {
+    const normalized = tag.toLowerCase();
+    // Exclusion takes priority: drop altcoin/other-chain promo even if it also
+    // carries a curated tag like `nostr` or `bitcoin`.
+    if (READS_BLOCKLIST_TAGS.has(normalized)) {
+      return false;
+    }
+    if (RELEVANT_READS_TAGS.has(normalized)) {
+      hasRelevantTag = true;
+    }
   }
-  if (article.tags.some((tag) => RELEVANT_READS_TAGS.has(tag.toLowerCase()))) {
+  if (hasRelevantTag) {
     return true;
   }
   return hasFoodKeywordsInTitle(article.title);

--- a/src/lib/articleUtils.ts
+++ b/src/lib/articleUtils.ts
@@ -701,6 +701,46 @@ export function filterByCategory(articles: ArticleData[], category: string): Art
   );
 }
 
+// Union of every curated category tag (Food, Farming, Bitcoin, Nostr, Travel,
+// Philosophy, Health). Used as a relevance gate so the reads feed only shows
+// content belonging to one of its topics — keeping out crime, war news, sports,
+// cross-posted blockchain spam, and other off-topic longform.
+const RELEVANT_READS_TAGS = new Set<string>(
+  Object.entries(ARTICLE_TAG_CATEGORIES)
+    .filter(([category]) => category !== 'All')
+    .flatMap(([, tags]) => tags)
+    .map((tag) => tag.toLowerCase())
+);
+
+// Off-topic markers that exclude an article even when it also carries a curated
+// tag. Altcoin/other-chain promo (BCH, Bitcoin Cash, Hive, etc.) routinely
+// piggybacks a `nostr` or `bitcoin` tag to reach Nostr feeds; this blocklist
+// keeps that content out of the reads page regardless of its other tags.
+const READS_BLOCKLIST_TAGS = new Set<string>([
+  'bch', 'bitcoincash', 'bcash',
+  'hive', 'hiveblockchain', 'leofinance',
+  'steem', 'steemit'
+]);
+
+/**
+ * Check whether an article belongs to one of the reads page's curated topics.
+ * An article is relevant if it carries a tag for any category, or its title
+ * contains food keywords (mirroring the Food category's title matching).
+ * Articles carrying a blocklisted off-topic tag are always excluded, and
+ * articles matching none of the topics are treated as off-topic and excluded.
+ */
+export function isRelevantToReads(article: ArticleData): boolean {
+  // Exclusion takes priority: drop altcoin/other-chain promo even if it also
+  // carries a curated tag like `nostr` or `bitcoin`.
+  if (article.tags.some((tag) => READS_BLOCKLIST_TAGS.has(tag.toLowerCase()))) {
+    return false;
+  }
+  if (article.tags.some((tag) => RELEVANT_READS_TAGS.has(tag.toLowerCase()))) {
+    return true;
+  }
+  return hasFoodKeywordsInTitle(article.title);
+}
+
 // ═══════════════════════════════════════════════════════════════
 // ARTICLE DATA CONVERSION
 // ═══════════════════════════════════════════════════════════════

--- a/src/routes/explore/+page.svelte
+++ b/src/routes/explore/+page.svelte
@@ -38,6 +38,7 @@
   import type { PageData } from './$types';
   import { exploreNavTick } from '$lib/exploreNav';
   import { dragScroll } from '$lib/dragScroll';
+  import CaretRightIcon from 'phosphor-svelte/lib/CaretRight';
 
   // Accept SvelteKit props to prevent warnings
   export let data: PageData;
@@ -399,10 +400,20 @@
 
       <!-- Fresh from the Kitchen -->
       <section class="flex flex-col gap-4" data-section="fresh-kitchen">
-        <h2 class="text-2xl font-bold flex items-center gap-2">
-          <span>🍳</span>
-          <span>Fresh from the Kitchen</span>
-        </h2>
+        <a
+          href="/recipes"
+          class="group flex items-center gap-2 w-fit transition-colors hover:text-primary"
+        >
+          <h2 class="text-2xl font-bold flex items-center gap-2">
+            <span>🍳</span>
+            <span>Fresh from the Kitchen</span>
+          </h2>
+          <CaretRightIcon
+            size={18}
+            weight="bold"
+            class="opacity-50 transition-all group-hover:opacity-100 group-hover:translate-x-0.5"
+          />
+        </a>
         {#if loadingDiscover}
           <div class="flex gap-4 overflow-x-auto pb-2 -mx-4 px-4">
             {#each Array(6) as _}
@@ -495,10 +506,20 @@
       <!-- Food Stories & Articles -->
       <section class="flex flex-col gap-4">
         <div class="px-4 -mx-4 sm:px-0 sm:mx-0">
-          <h2 class="text-2xl font-bold flex items-center gap-2">
-            <span>📖</span>
-            <span>Food Stories & Articles</span>
-          </h2>
+          <a
+            href="/reads"
+            class="group flex items-center gap-2 w-fit transition-colors hover:text-primary"
+          >
+            <h2 class="text-2xl font-bold flex items-center gap-2">
+              <span>📖</span>
+              <span>Food Stories & Articles</span>
+            </h2>
+            <CaretRightIcon
+              size={18}
+              weight="bold"
+              class="opacity-50 transition-all group-hover:opacity-100 group-hover:translate-x-0.5"
+            />
+          </a>
           <p class="text-sm text-caption">
             Recent longform articles about food, farming, homesteading, and food culture.
           </p>
@@ -560,7 +581,7 @@
           Browse by category
         </h2>
         <div class="flex gap-2.5 overflow-x-auto py-2 -mx-4 px-4 scrollbar-hide touch-pan-x" use:dragScroll>
-          {#each [{ emoji: '🥩', label: 'Beef' }, { emoji: '🍗', label: 'Chicken' }, { emoji: '🐟', label: 'Fish' }, { emoji: '🌱', label: 'Vegan' }, { emoji: '🍝', label: 'Pasta' }, { emoji: '🍕', label: 'Pizza' }, { emoji: '🥘', label: 'Soup' }, { emoji: '🥪', label: 'Sandwich' }, { emoji: '🍚', label: 'Rice' }, { emoji: '🥚', label: 'Eggs' }, { emoji: '🥔', label: 'Potato' }, { emoji: '🧀', label: 'Cheese' }] as cat}
+          {#each [{ emoji: '🥩', label: 'Beef' }, { emoji: '🍗', label: 'Chicken' }, { emoji: '🥓', label: 'Pork' }, { emoji: '🐟', label: 'Fish' }, { emoji: '🦐', label: 'Seafood' }, { emoji: '🦃', label: 'Turkey' }, { emoji: '🌱', label: 'Vegan' }, { emoji: '🥗', label: 'Salad' }, { emoji: '🍝', label: 'Pasta' }, { emoji: '🍜', label: 'Noodles' }, { emoji: '🍕', label: 'Pizza' }, { emoji: '🥘', label: 'Soup' }, { emoji: '🥪', label: 'Sandwich' }, { emoji: '🍚', label: 'Rice' }, { emoji: '🍞', label: 'Bread' }, { emoji: '🥚', label: 'Eggs' }, { emoji: '🥔', label: 'Potato' }, { emoji: '🧀', label: 'Cheese' }, { emoji: '🍄', label: 'Mushrooms' }, { emoji: '🍅', label: 'Tomato' }, { emoji: '🧄', label: 'Garlic' }, { emoji: '🌶️', label: 'Peppers' }, { emoji: '🍫', label: 'Chocolate' }, { emoji: '🍎', label: 'Apple' }] as cat}
             <button type="button" class="category-chip" on:click={() => goto(`/tag/${cat.label}`)}>
               <span class="text-xl">{cat.emoji}</span>
               <span class="text-xs font-medium" style="color: var(--color-text-primary);"

--- a/src/routes/explore/+page.svelte
+++ b/src/routes/explore/+page.svelte
@@ -404,7 +404,7 @@
           href="/recipes"
           class="group flex items-center gap-2 w-fit transition-colors hover:text-primary"
         >
-          <h2 class="text-2xl font-bold flex items-center gap-2">
+          <h2 class="text-2xl font-bold flex items-center gap-2 transition-colors group-hover:text-primary">
             <span>🍳</span>
             <span>Fresh from the Kitchen</span>
           </h2>
@@ -510,7 +510,7 @@
             href="/reads"
             class="group flex items-center gap-2 w-fit transition-colors hover:text-primary"
           >
-            <h2 class="text-2xl font-bold flex items-center gap-2">
+            <h2 class="text-2xl font-bold flex items-center gap-2 transition-colors group-hover:text-primary">
               <span>📖</span>
               <span>Food Stories & Articles</span>
             </h2>

--- a/src/routes/reads/+page.svelte
+++ b/src/routes/reads/+page.svelte
@@ -271,7 +271,19 @@
     }, 2000);
   }
 
-  // Fetch general (all-topic) articles to fill non-food categories
+  // Non-food category hashtags (Bitcoin, Nostr, Travel, Philosophy, Health).
+  // High-signal tags per category, kept under the ~25-tag relay cap. Using
+  // targeted tags instead of an open firehose keeps off-topic longform (crime,
+  // war news, sports, cross-posted blockchain spam) out of the feed and cache.
+  const NON_FOOD_HASHTAGS = [
+    'bitcoin', 'btc', 'lightning', 'sats',
+    'nostr', 'grownostr', 'zap',
+    'travel', 'adventure', 'wanderlust', 'roadtrip', 'backpacking',
+    'philosophy', 'stoicism', 'mindfulness', 'meditation', 'ethics',
+    'health', 'wellness', 'nutrition', 'fitness', 'exercise'
+  ];
+
+  // Fetch non-food category articles to fill the Bitcoin/Nostr/Travel/etc tabs
   async function fetchGeneralArticles(startGeneration: number) {
     if (!$ndk || !browser) return;
 
@@ -279,7 +291,7 @@
       const newArticles: ArticleData[] = [];
 
       const { events } = await fetchArticles($ndk, {
-        hashtags: [], // No hashtag filter — all topics
+        hashtags: NON_FOOD_HASHTAGS,
         limit: 500,
         skipPrimal: true,
         onEvent: (event: NDKEvent) => {

--- a/src/routes/reads/+page.svelte
+++ b/src/routes/reads/+page.svelte
@@ -236,10 +236,10 @@
 
       const startGen = getCurrentRelayGeneration();
 
-      // General (all-topic) fetch so non-food categories aren't empty
+      // Non-food category fetch so Bitcoin/Nostr/Travel/etc. tabs aren't empty
       setTimeout(() => {
         if (getCurrentRelayGeneration() === startGen) {
-          fetchGeneralArticles(startGen);
+          fetchNonFoodArticles(startGen);
         }
       }, 1000);
 
@@ -262,11 +262,11 @@
     // Primary: food-tagged articles for cover + Food/Farming categories
     fetchWithOutbox(forceRefresh, startGeneration);
 
-    // Secondary: general articles (no hashtag filter) for All/Bitcoin/Nostr/etc.
+    // Secondary: non-food articles (targeted category hashtags) for Bitcoin/Nostr/etc.
     // Runs in parallel, slightly delayed so food articles paint first
     setTimeout(() => {
       if (getCurrentRelayGeneration() === startGeneration) {
-        fetchGeneralArticles(startGeneration);
+        fetchNonFoodArticles(startGeneration);
       }
     }, 2000);
   }
@@ -284,7 +284,7 @@
   ];
 
   // Fetch non-food category articles to fill the Bitcoin/Nostr/Travel/etc tabs
-  async function fetchGeneralArticles(startGeneration: number) {
+  async function fetchNonFoodArticles(startGeneration: number) {
     if (!$ndk || !browser) return;
 
     try {
@@ -319,12 +319,12 @@
         articles = [...articles, ...newArticles].sort((a, b) => b.publishedAt - a.publishedAt);
       }
 
-      // Cache the general articles too
+      // Cache the non-food articles too
       if (events.length > 0 && browser) {
         cacheFeedEvents(events).catch(() => {});
       }
     } catch (err) {
-      console.warn('[Reads] General article fetch error:', err);
+      console.warn('[Reads] Non-food article fetch error:', err);
     }
   }
 


### PR DESCRIPTION
## Summary

Gives the reads section a direct navigation path, keeps off-topic content out of the reads feed, and makes the explore page's section headings navigable.

### Reads navigation
- Adds a **Reads** entry to the desktop side nav (between Recipes and Polls) and the mobile bottom nav (replacing Polls, which remains on desktop). The reads section previously had no direct navigation path.

### Reads feed relevance
- Filters the reads feed to its seven curated topics (Food, Farming, Bitcoin, Nostr, Travel, Philosophy, Health) via a new `isRelevantToReads` gate applied at the display chokepoint, so off-topic longform (crime, war news, sports, cross-posted blockchain spam) is excluded regardless of source.
- A blocklist drops altcoin/other-chain promo (BCH, Bitcoin Cash, Hive, etc.) even when it piggybacks a `nostr` or `bitcoin` tag.
- The non-food fetch now queries targeted category hashtags instead of an open firehose, so off-topic content no longer enters the feed or cache at the source.

### Explore page
- The **Fresh from the Kitchen** and **Food Stories & Articles** headings now link to `/recipes` and `/reads`, with a caret affordance (visible on mobile, brightens on hover).
- **Browse by category** expanded from 12 to 24 chips, with the added categories drawn from the canonical `CURATED_TAGS` so every `/tag` route resolves.

## Note
Better reads content optimization is still in the works — this pass prioritizes correctness (relevant content only, no junk) over feed density. Follow-up work will tune coverage and depth (additional curated topics, per-author limits, fetch window).

## Testing
- `svelte-check`: 0 errors.
- Verified locally: reads feed shows on-topic content only, BCH/altcoin promo no longer appears, Reads nav tab routes correctly, section heading links navigate, and all 24 category chips resolve to valid `/tag` routes.

🥕 Generated with [Claude Code](https://claude.com/claude-code)