### PR TITLE
feat(notes): readability overhaul — typography, grid, card feed/threads, right rail, footer

### DIFF
--- a/docs/proposals/note-preview-line-truncation.md
+++ b/docs/proposals/note-preview-line-truncation.md
@@ -1,0 +1,50 @@
+# Issue: Line-based truncation for collapsed note previews
+
+## Problem
+
+Collapsed note previews (`NoteContent.svelte`) truncate by **character count**
+(`maxLength`, currently 500) rather than by visual rows. Two consequences:
+
+- The preview length varies with content width and font — a 500-char cut is a
+  different number of lines depending on the viewport, so previews look ragged.
+- It originally sliced mid-word (e.g. "…has been a catal"). This is now mitigated
+  by backing up to the last word boundary, but the cut still isn't aligned to a
+  consistent number of rows.
+
+## What we want
+
+A collapsed preview clamped to a fixed number of **lines** (e.g. 6–8 rows of
+text), with a "View more" toggle, so every preview is visually consistent
+regardless of viewport width.
+
+## Why it wasn't done now
+
+Note content is **mixed** — text, inline images, media carousels, quoted-note
+embeds, lightning invoices. A naive CSS `line-clamp` on the rendered container
+would clamp/clip media parts (cut an image in half, hide an embed) rather than
+just trimming trailing text, so it can't be dropped in as-is.
+
+## Possible approaches
+
+1. **Text-only line-clamp + media below the fold.** Clamp only the leading text
+   block to N lines via CSS `-webkit-line-clamp`; treat any media/embeds as
+   always-expanded blocks that live under the "View more" boundary. Requires
+   splitting the parsed parts into "leading text" vs "rich blocks".
+2. **Measure-and-cut.** After render, measure line height and the container, then
+   compute how many characters fit in N rows and re-truncate. Accurate but adds a
+   layout-measure pass and reflow per note (perf cost in long feeds).
+3. **Hybrid.** Keep the character cap as a cheap upper bound, then apply a CSS
+   line-clamp to the text spans only for the visual ceiling.
+
+Approach 1 is likely the cleanest: it keeps truncation purely declarative for the
+common text-only case and sidesteps measuring.
+
+## Affected code
+
+- `src/components/NoteContent.svelte` — `shouldCollapse`, `truncateAtUrlBoundary`,
+  `displayContent`, `renderParts`, and the "View more / View less" toggle.
+
+## Current state
+
+Word-boundary truncation is in place (no more mid-word slices). This issue tracks
+the larger move to consistent line-based previews.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.562",
+  "version": "4.2.563",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.561",
+  "version": "4.2.562",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.560",
+  "version": "4.2.561",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.564",
+  "version": "4.2.565",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.563",
+  "version": "4.2.564",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.565",
+  "version": "4.2.566",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/app.css
+++ b/src/app.css
@@ -87,6 +87,8 @@ body {
   --color-text-secondary: #4b5563;
   --color-bg-primary: #ffffff;
   --color-bg-secondary: #f9fafb;
+  /* Sunken surface — a shade DARKER than the page (recessed panels). */
+  --color-card-sunken: #f1f2f4;
   --color-skeleton-base: #e5e7eb;
   --color-skeleton-highlight: #f3f4f6;
 
@@ -120,6 +122,8 @@ html.dark {
   --color-text-secondary: #d1d5db;
   --color-bg-primary: #111827;
   --color-bg-secondary: #1f2937;
+  /* Sunken surface — a shade DARKER than the page (recessed panels). */
+  --color-card-sunken: #0c111c;
   --color-skeleton-base: #1f2937;
   --color-skeleton-highlight: #374151;
 

--- a/src/components/FollowButton.svelte
+++ b/src/components/FollowButton.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+  import { NDKEvent } from '@nostr-dev-kit/ndk';
+  import UserPlusIcon from 'phosphor-svelte/lib/UserPlus';
+  import { ndk, userPublickey } from '$lib/nostr';
+  import { getFollowedPubkeys, followListReady } from '$lib/followListCache';
+  import { loginOverlayOpen } from '$lib/stores/loginOverlay';
+
+  export let pubkey: string;
+  /** Visual size — 'sm' for dense rail rows, 'md' for standalone use. */
+  export let size: 'sm' | 'md' = 'sm';
+
+  let justFollowed = false;
+  let busy = false;
+
+  // Already following (from the loaded contact cache) or just followed this
+  // session. The button is follow-only — once followed, it hides entirely.
+  $: following = justFollowed || ($followListReady && getFollowedPubkeys().has(pubkey));
+  $: isSelf = $userPublickey !== '' && $userPublickey === pubkey;
+  $: show = !isSelf && !following;
+
+  async function follow(e: MouseEvent) {
+    // The button often sits inside a clickable row/link — keep the click local.
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (busy) return;
+    if ($userPublickey === '') {
+      loginOverlayOpen.set(true);
+      return;
+    }
+
+    busy = true;
+    try {
+      const activePubkey = $ndk?.activeUser?.pubkey;
+      let existingContent = '';
+      let existingTags: string[][] = [];
+
+      if (activePubkey) {
+        const existing = await $ndk.fetchEvent({ kinds: [3], authors: [activePubkey], limit: 1 });
+        if (existing) {
+          existingContent = existing.content || '';
+          existingTags = existing.tags || [];
+        }
+      }
+
+      const otherTags = existingTags.filter((t) => t[0] !== 'p');
+      const followed = new Set(existingTags.filter((t) => t[0] === 'p').map((t) => t[1]));
+      followed.add(pubkey);
+
+      const contactEvent = new NDKEvent($ndk);
+      contactEvent.kind = 3;
+      contactEvent.content = existingContent;
+      contactEvent.tags = [...otherTags, ...Array.from(followed).map((pk) => ['p', pk])];
+
+      await contactEvent.publish();
+      justFollowed = true;
+    } catch (error) {
+      console.error('[FollowButton] Failed to follow:', error);
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+{#if show}
+  <button
+    type="button"
+    class="follow-btn {size}"
+    on:click={follow}
+    disabled={busy}
+    title="Follow"
+    aria-label="Follow"
+  >
+    <UserPlusIcon size={size === 'sm' ? 16 : 18} weight="bold" />
+  </button>
+{/if}
+
+<style>
+  /* Quiet circular icon button — no border, subtle fill, brightens on hover. */
+  .follow-btn {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    border: 0;
+    cursor: pointer;
+    background-color: var(--color-input-bg);
+    color: var(--color-text-secondary);
+    transition:
+      color 140ms ease,
+      background-color 140ms ease;
+  }
+  .follow-btn.sm {
+    width: 1.75rem;
+    height: 1.75rem;
+  }
+  .follow-btn.md {
+    width: 2rem;
+    height: 2rem;
+  }
+  .follow-btn:hover {
+    color: var(--color-primary);
+    background-color: var(--color-accent-gray);
+  }
+  .follow-btn:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+</style>

--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -5375,6 +5375,9 @@
     padding: 1.125rem 1.25rem;
     background-color: var(--color-card-sunken);
     border-radius: 1rem;
+    /* Horizontal padding exposed so full-bleed media (image galleries) can
+       pull out to the card edges. */
+    --media-bleed-x: 1.25rem;
   }
 
   /* Carousel touch behavior - allow both vertical (feed) and horizontal (carousel) scrolling */

--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -5370,11 +5370,10 @@
     contain: layout style;
     content-visibility: auto;
     contain-intrinsic-size: auto 400px;
-    /* Each note is its own subtle card (slightly elevated surface) instead of
-       being separated by a hairline rule — easier to scan mixed-length notes. */
+    /* Each note is its own card on a sunken (slightly darker) surface, no
+       border — easier to scan mixed-length notes without hairline clutter. */
     padding: 1.125rem 1.25rem;
-    background-color: var(--color-bg-secondary);
-    border: 1px solid var(--color-input-border);
+    background-color: var(--color-card-sunken);
     border-radius: 1rem;
   }
 

--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -4885,7 +4885,7 @@
         </div>
       </div>
     {:else}
-      <div class="space-y-0 w-full">
+      <div class="space-y-3 w-full">
         {#each events as event (event.id)}
           <div
             use:renderZoneAction={event.id}
@@ -5370,8 +5370,12 @@
     contain: layout style;
     content-visibility: auto;
     contain-intrinsic-size: auto 400px;
-    padding: 24px 0 24px 4px;
-    border-bottom: 1px solid var(--color-input-border);
+    /* Each note is its own subtle card (slightly elevated surface) instead of
+       being separated by a hairline rule — easier to scan mixed-length notes. */
+    padding: 1.125rem 1.25rem;
+    background-color: var(--color-bg-secondary);
+    border: 1px solid var(--color-input-border);
+    border-radius: 1rem;
   }
 
   /* Carousel touch behavior - allow both vertical (feed) and horizontal (carousel) scrolling */

--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -926,6 +926,17 @@
     }
   }
 
+  // Click anywhere on a feed card (except on a link, button, or while
+  // selecting text) to open the single-note view.
+  function gotoNoteFromCard(e: MouseEvent, ev: NDKEvent) {
+    if (e.target instanceof Element && e.target.closest('a, button, input, textarea, [role="button"]')) {
+      return;
+    }
+    if (typeof window !== 'undefined' && window.getSelection()?.toString()) return;
+    const href = noteHrefFromEventId(ev.id);
+    if (href) goto(href);
+  }
+
   // Extract the first quoted note ID from content (for quote reposts)
   function getQuotedNoteId(event: NDKEvent): string | null {
     try {
@@ -4908,8 +4919,18 @@
             reactions: { count: engagementStoreValue.reactions.count },
             comments: { count: engagementStoreValue.comments.count }
           }}
+          <!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->
           <article
-            class="w-full"
+            class="w-full cursor-pointer"
+            on:click={(e) => gotoNoteFromCard(e, event)}
+            role="link"
+            tabindex="0"
+            on:keydown|self={(e) => {
+              if (e.key === 'Enter') {
+                const href = noteHrefFromEventId(event.id);
+                if (href) goto(href);
+              }
+            }}
           >
             {#if getRepostedBy(event)}
               {@const reposterPubkey = getRepostedBy(event) || ''}

--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -30,38 +30,79 @@
 </script>
 
 <footer
-  class="footer mt-12 mb-20 lg:mb-0 print:hidden"
+  class="footer mt-8 mb-20 lg:mb-0 print:hidden"
   style="background-color: var(--color-bg-primary);"
 >
-  <div class="mx-auto max-w-7xl footer-inner">
-    <div class="flex flex-col items-center footer-content">
-      <!-- Logo (dual-img CSS swap; matches app.html pre-paint rule for no flash) -->
-      <img
-        src="/zapcooking-text-light.svg"
-        alt="zap.cooking"
-        class="footer-logo logo-light dark:hidden"
-      />
-      <img
-        src="/zapcooking-text-dark.svg"
-        alt=""
-        aria-hidden="true"
-        class="footer-logo logo-dark hidden dark:block"
-      />
+  <div class="footer-inner">
+    <!-- Utility links — de-emphasized (rarely clicked). -->
+    <nav class="footer-links text-caption">
+      <button
+        on:click={() => (supportModalOpen = true)}
+        class="text-orange-500 hover:text-orange-600 font-semibold transition-colors cursor-pointer bg-transparent border-0 p-0"
+        type="button"
+      >
+        ⚡ Support
+      </button>
+      <span class="footer-sep">·</span>
+      <a href="/about" class="hover:text-primary transition-colors">About</a>
+      <span class="footer-sep">·</span>
+      <a href="/founders" class="hover:text-primary transition-colors">Founders</a>
+      <span class="footer-sep">·</span>
+      <a href="/sponsors" class="hover:text-primary transition-colors">Sponsors</a>
+      <span class="footer-sep">·</span>
+      <a
+        href="https://github.com/zapcooking/frontend/issues/new"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="hover:text-primary transition-colors">Report a Bug</a
+      >
+      <span class="footer-sep">·</span>
+      <a href="/terms" class="hover:text-primary transition-colors">Terms</a>
+      <span class="footer-sep">·</span>
+      <a href="/privacy" class="hover:text-primary transition-colors">Privacy</a>
+      <span class="footer-sep">·</span>
+      <a href="/disclosure" class="hover:text-primary transition-colors">Disclosure</a>
+    </nav>
 
-      <!-- Tagline -->
-      <p class="footer-tagline text-caption">Recipes on Nostr, built in the open.</p>
+    <!-- Meta row: copyright, version, Guardrail, and social icons inline. -->
+    <div class="footer-meta text-caption">
+      <span>&copy; {currentYear} zap.cooking</span>
+      <span class="footer-sep">·</span>
+      <span>v{VERSION}</span>
+      <span class="footer-sep">·</span>
+      <a
+        href={`https://github.com/zapcooking/frontend/commit/${BUILD_HASH}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="hover:text-primary transition-colors"
+        title="View commit on GitHub">build {BUILD_HASH}</a
+      >
+      <span class="footer-sep">·</span>
+      <span>
+        Guardrail by <a
+          href="/user/npub16ndruwfg7dsdhnp3w8zvqrg0r2rn3wucnttgrg5acm2lhqpkepkqncr9qr"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="hover:text-primary transition-colors">@branta</a
+        > since Block 933,735 ✅
+      </span>
+    </div>
 
-      <!-- Social Icons -->
-      <div class="flex footer-icons">
+    <!-- Bottom row: muted 1-color logo + social icons together. -->
+    <div class="footer-bottom">
+      <a href="/explore" class="footer-brand" aria-label="zap.cooking home">
+        <span class="footer-logo" aria-hidden="true"></span>
+      </a>
+      <div class="footer-social">
         <a
           href="/user/npub1xxdd8eusvdxmaph3fkuu9x2mymhrcc3ghe2l38zv0l4f4nqp659qskkt7a"
           target="_blank"
           rel="noopener noreferrer"
-          class="w-8 h-8 rounded-full flex items-center justify-center text-caption hover:text-primary transition-colors"
-          style="background-color: var(--color-input-bg);"
+          class="hover:text-primary transition-colors"
           title="Follow on Nostr"
+          aria-label="Follow on Nostr"
         >
-          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 16.12 18.8">
+          <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 16.12 18.8">
             <path
               d="M14.36.03c-.5-.1-.85.09-1.01.52-.26.61-.09,1.4.45,1.98.25.26.53.48.8.72.2.17.38.37.55.57.46.57-.03,1.61-.14,1.73-.4.42-.75.49-1.45.46-.68-.03-2.46-.94-3.4-.97-2.32-.07-3.93,1-4.48,1.28-.81.42-1.97.44-2.01.45-.53.04-1.61.08-2.15.27-.76.21-1.17.56-1.45,1.34-.09.34-.1.64.02.82.27.4.98.74,1.31.92.17.1.5-.02.56-.07.37-.25.69-.44,1.12-.5.09-.01.7-.12,1.01.1.22.16.41.26.67.38.46.21,1.47.47,1.49.48.14.04.31.11.31.23,0,.17-1.61,1.52-1.7,1.56-.41.16-.64.43-.72.82-.03.13-.08.25-.15.36-.26.38-1.42,2.02-1.73,2.48-.15.21-.3.32-.51.35-.3.05-.53.06-.65.27-.08.14-.03.4.02.58.06.2-.1.44-.11.47-.14.28-.2.55-.18.82,0,.11.01.37.2.37.18.01.23-.11.25-.15.03-.05.13-.27.16-.32.12-.22.57-.69.62-.74.16-.18,2.56-3.48,2.56-3.48.13-.17.27-.35.49-.44.3-.11.52-.38.58-.69.01-.07.97-.81,1.38-1.12.15-.11,1.05-.47,1.07-.47,0,0-.82,1.25-1.08,1.91-.04.11-.11.47-.03.65.11.28.36.4.64.32.09-.03.16-.07.24-.11.03-.02.07-.04.1-.05l.1-.05c.08-.04.15-.08.23-.1.28-.09.55-.18.83-.26l.56-.17c.39-.12.79-.25,1.18-.37.09-.03.17-.06.28-.05.06,0,.12.02.15.11,0,0,.05.27.21.38.12.07.26.1.4.09.12,0,.27.03.34.09l.1.08c.07.05.14.09.22.11.06.02.18.02.25-.05.07-.08.05-.2.04-.24-.01-.05-.04-.09-.07-.13l-.06-.09c-.06-.09-.11-.18-.17-.27-.16-.25-.33-.5-.50-.75-.18-.26-.45-.36-.8-.31-.14.02-3.13.95-3.16.96.16-.3,1.12-1.62,1.39-1.79.2-.12.28-.23.65-.29.71-.12,2.24-.48,2.63-.75.74-.54.8-1.76.79-2-.01-.24.07-.41.28-.53.1-.06,1.25-.69,1.81-1.62.33-.54.51-1.13.44-1.77-.03-.42-.19-.81-.45-1.14-.24-.3-.54-.51-.83-.74-.14-.12-.53-.44-.58-.62-.06-.22.03-.44.23-.51.3-.1.8-.1,1.09-.08.25.02.5-.07.51-.17.01-.1-.14-.25-.33-.3-.15-.04-.39-.09-.53-.18-.25-.17-.51-.48-.86-.55"
             />
@@ -71,19 +112,19 @@
           href="https://github.com/zapcooking/frontend"
           target="_blank"
           rel="noopener noreferrer"
-          class="w-8 h-8 rounded-full flex items-center justify-center text-caption hover:text-primary transition-colors"
-          style="background-color: var(--color-input-bg);"
+          class="hover:text-primary transition-colors"
           title="View on GitHub"
+          aria-label="View on GitHub"
         >
-          <GithubLogo size={16} weight="fill" />
+          <GithubLogo size={14} weight="fill" />
         </a>
         <a
           href="https://branta.pro/network#Zap-Cooking"
           target="_blank"
           rel="noopener noreferrer"
-          class="w-8 h-8 rounded-full flex items-center justify-center text-caption hover:text-primary transition-colors"
-          style="background-color: var(--color-input-bg);"
+          class="hover:text-primary transition-colors"
           title="Branta Verified"
+          aria-label="Branta Verified"
         >
           <svg class="w-3.5 h-3.5" viewBox="0 0 42 23" fill="currentColor">
             <path
@@ -92,71 +133,6 @@
           </svg>
         </a>
       </div>
-
-      <!-- Branta Guardrail -->
-      <p class="text-xs text-caption">
-        Running Guardrail by <a
-          href="/user/npub16ndruwfg7dsdhnp3w8zvqrg0r2rn3wucnttgrg5acm2lhqpkepkqncr9qr"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="hover:text-primary transition-colors">@branta</a
-        > since Block 933,735 ✅
-      </p>
-
-      <!-- Utility Links -->
-      <div class="flex flex-wrap items-center justify-center footer-links text-caption">
-        <button
-          on:click={() => (supportModalOpen = true)}
-          class="text-orange-500 hover:text-orange-600 font-bold transition-colors cursor-pointer bg-transparent border-0 p-0"
-          type="button"
-        >
-          ⚡ Support
-        </button>
-        <span>|</span>
-        <a href="/about" class="hover:text-primary transition-colors">About</a>
-        <span>|</span>
-        <a href="/founders" class="hover:text-primary transition-colors">Founders</a>
-        <span>|</span>
-        <a href="/sponsors" class="hover:text-primary transition-colors">Sponsors</a>
-        <span>|</span>
-        <a
-          href="https://github.com/zapcooking/frontend/issues/new"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="hover:text-primary transition-colors"
-        >
-          Report a Bug
-        </a>
-        <span>|</span>
-        <a href="/terms" class="hover:text-primary transition-colors">Terms</a>
-        <span>|</span>
-        <a href="/privacy" class="hover:text-primary transition-colors">Privacy</a>
-        <span>|</span>
-        <a href="/disclosure" class="hover:text-primary transition-colors">Disclosure</a>
-        <span>|</span>
-        <a
-          href="https://github.com/zapcooking/frontend/blob/main/LICENSE"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="hover:text-primary transition-colors"
-        >
-          MIT License
-        </a>
-      </div>
-
-      <!-- Copyright and Version -->
-      <p class="footer-copyright text-caption">
-        &copy; {currentYear} zap.cooking · v{VERSION} ·
-        <a
-          href={`https://github.com/zapcooking/frontend/commit/${BUILD_HASH}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="hover:text-primary transition-colors"
-          title="View commit on GitHub"
-        >
-          build {BUILD_HASH}
-        </a>
-      </p>
     </div>
   </div>
 </footer>
@@ -182,7 +158,13 @@
             use:qr={{
               data: 'lightning:ZapCooking@getalby.com',
               logo: 'https://zap.cooking/favicon.svg',
-              shape: 'circle'
+              shape: 'circle',
+              // Force black modules so the QR stays scannable in dark mode
+              // (they otherwise inherit the theme's light text color). The
+              // container's bg-white supplies the light background.
+              moduleFill: '#000000',
+              anchorOuterFill: '#000000',
+              anchorInnerFill: '#000000'
             }}
           />
         </div>
@@ -236,80 +218,87 @@
 {/if}
 
 <style>
-  /* Desktop/tablet defaults */
+  /* Compact two-row footer: a de-emphasized links row and a meta row.
+     Both wrap and center, so the footer stays short at every width. */
   .footer {
-    padding-top: 1.5rem;
-    padding-bottom: 1.5rem;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+    border-top: 1px solid var(--color-input-border);
   }
 
+  /* Stacked footer: links row, meta row, then a bottom row with the muted
+     1-color logo and social icons together. Left-aligned to the content
+     grid; wraps cleanly at any width. */
   .footer-inner {
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.625rem;
+    max-width: 42rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
   }
 
-  .footer-content {
+  .footer-links,
+  .footer-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+    line-height: 1.2;
+    text-align: left;
+  }
+
+  .footer-sep {
+    opacity: 0.4;
+  }
+
+  /* Bottom row: logo + icons together. */
+  .footer-bottom {
+    display: flex;
+    align-items: center;
     gap: 1rem;
+    margin-top: 0.125rem;
   }
 
+  .footer-brand {
+    flex: none;
+    display: inline-flex;
+    align-items: center;
+  }
+  /* Current wordmark recolored to one muted color via CSS mask (917:123). */
   .footer-logo {
-    height: 1.5rem;
+    display: block;
+    width: 7rem;
+    height: 0.9375rem;
+    background-color: var(--color-caption);
+    opacity: 0.8;
+    -webkit-mask: url('/zapcooking-text-light.svg') no-repeat center / contain;
+    mask: url('/zapcooking-text-light.svg') no-repeat center / contain;
+    transition: opacity 140ms ease;
+  }
+  .footer-brand:hover .footer-logo {
+    opacity: 1;
   }
 
-  .footer-tagline {
-    font-size: 0.75rem;
-    line-height: 1.25rem;
-  }
-
-  .footer-icons {
-    gap: 1rem;
-  }
-
-  .footer-links {
-    gap: 0.5rem;
-    font-size: 0.75rem;
-  }
-
-  .footer-copyright {
-    font-size: 0.75rem;
+  .footer-social {
+    flex: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.875rem;
   }
 
   /* Mobile compact styles (480px and below) */
   @media (max-width: 480px) {
     .footer {
-      padding-top: 0.875rem;
-      padding-bottom: 0.875rem;
       margin-top: 2rem;
     }
 
-    .footer-inner {
-      padding-left: 1rem;
-      padding-right: 1rem;
-    }
-
-    .footer-content {
-      gap: 0.5rem;
-    }
-
-    .footer-logo {
-      height: 1.25rem;
-    }
-
-    .footer-tagline {
-      font-size: 0.625rem;
-      line-height: 1rem;
-    }
-
-    .footer-icons {
-      gap: 0.75rem;
-    }
-
-    .footer-links {
-      gap: 0.375rem;
-      font-size: 0.625rem;
-    }
-
-    .footer-copyright {
-      font-size: 0.625rem;
+    .footer-links,
+    .footer-meta {
+      font-size: 0.6875rem;
     }
   }
 </style>

--- a/src/components/MediaCarousel.svelte
+++ b/src/components/MediaCarousel.svelte
@@ -190,7 +190,7 @@
     </button>
   {/if}
 {:else if items.length > 1}
-  <div class="relative group">
+  <div class="relative group gallery-bleed">
     <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
     <div
       bind:this={scroller}
@@ -297,6 +297,22 @@
   }
 
   /* ── Multi-item gallery ──────────────────────────────────────── */
+  /* Bleed the gallery out to the card edges by the host's horizontal padding
+     (exposed as --media-bleed-x), but pad the scroller's left so the first
+     tile rests INSET (rounded corners + left margin preserved) at rest. The
+     right side reaches the card edge so the peek shows, and as you scroll the
+     images slide past both edges. Falls back to no bleed outside a card. */
+  .gallery-bleed {
+    margin-inline: calc(-1 * var(--media-bleed-x, 0px));
+  }
+  .gallery-bleed .media-carousel {
+    /* Equal inset on both ends: first tile rests inset-left, last tile rests
+       inset-right. The right padding is trailing content (off-screen at rest),
+       so the initial peek still reaches the right card edge. */
+    padding-inline: var(--media-bleed-x, 0px);
+    scroll-padding-inline: var(--media-bleed-x, 0px);
+  }
+
   .media-carousel {
     display: flex;
     gap: 6px; /* keep in sync with TILE_GAP_PX */

--- a/src/components/NoteContent.svelte
+++ b/src/components/NoteContent.svelte
@@ -446,21 +446,23 @@
   {/each}
 
   {#if shouldCollapse}
-    <button
-      on:click={toggleExpanded}
-      class="mt-2 text-sm font-medium transition-colors inline-flex items-center gap-1"
-      style="color: var(--color-primary);"
-    >
-      {isExpanded ? 'View less' : 'View more'}
-      <svg
-        class="w-4 h-4 transition-transform {isExpanded ? 'rotate-180' : ''}"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
+    <div class="mt-3 flex justify-center">
+      <button
+        on:click={toggleExpanded}
+        class="text-sm font-medium transition-colors inline-flex items-center gap-1"
+        style="color: var(--color-primary);"
       >
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-      </svg>
-    </button>
+        {isExpanded ? 'View less' : 'View more'}
+        <svg
+          class="w-4 h-4 transition-transform {isExpanded ? 'rotate-180' : ''}"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+    </div>
   {/if}
 </div>
 

--- a/src/components/NoteContent.svelte
+++ b/src/components/NoteContent.svelte
@@ -300,10 +300,10 @@
 
   // Check if content should be collapsed
   $: shouldCollapse = collapsible && content.length > maxLength;
-  // Extend the truncation point to include any URL that was cut mid-way,
-  // so its file extension survives and isImageUrl() classifies it correctly.
+  // Truncate the preview at a word boundary so we never slice through a word.
+  // If a URL straddles the limit, extend to include the whole URL instead, so
+  // its file extension survives and isImageUrl() classifies it correctly.
   function truncateAtUrlBoundary(text: string, limit: number): string {
-    const cut = text.substring(0, limit);
     const urlRegex = /https?:\/\/[^\s]+/g;
     let m;
     while ((m = urlRegex.exec(text)) !== null) {
@@ -311,7 +311,11 @@
         return text.substring(0, m.index + m[0].length);
       }
     }
-    return cut;
+    // Back up to the last whitespace before the limit so the cut lands between
+    // words, not mid-word.
+    const cut = text.substring(0, limit);
+    const boundary = Math.max(cut.lastIndexOf(' '), cut.lastIndexOf('\n'));
+    return (boundary > 0 ? cut.substring(0, boundary) : cut).trimEnd();
   }
   $: displayContent = shouldCollapse && !isExpanded ? truncateAtUrlBoundary(content, maxLength) : content;
   $: finalParsedContent = splitLightningInvoices(parseContent(displayContent));

--- a/src/components/NoteTotalZaps.svelte
+++ b/src/components/NoteTotalZaps.svelte
@@ -287,7 +287,7 @@
     {#each visibleZappers as zapper (zapper.pubkey)}
       <button
         on:click|stopPropagation={handleCountClick}
-        class="zap-pill flex items-center gap-1 h-6 pl-1 pr-2 rounded-full bg-accent-gray hover:bg-yellow-500/20 transition-colors cursor-pointer flex-shrink-0 {zapper.pubkey ===
+        class="zap-pill flex items-center gap-1 h-6 pl-1 pr-2 rounded-full transition-colors cursor-pointer flex-shrink-0 {zapper.pubkey ===
         $userPublickey
           ? 'ring-1 ring-yellow-500'
           : ''}"
@@ -301,7 +301,7 @@
     {#if hiddenCount > 0}
       <button
         on:click|stopPropagation={handleCountClick}
-        class="zap-pill flex items-center gap-1 h-6 pl-1.5 pr-2 rounded-full bg-accent-gray hover:bg-yellow-500/20 text-caption text-xs font-semibold cursor-pointer transition-colors flex-shrink-0"
+        class="zap-pill flex items-center gap-1 h-6 pl-1.5 pr-2 rounded-full text-caption text-xs font-semibold cursor-pointer transition-colors flex-shrink-0"
         title="{hiddenCount} more zappers ({formatAmount(totalSats)} sats total)"
       >
         <LightningIcon size={12} class="text-yellow-500 flex-shrink-0" weight="fill" />
@@ -366,7 +366,7 @@
     {#each visibleZappers as zapper (zapper.pubkey)}
       <button
         on:click|stopPropagation={handleCountClick}
-        class="zap-pill flex items-center gap-1 h-6 pl-1 pr-2 rounded-full bg-accent-gray hover:bg-yellow-500/20 transition-colors cursor-pointer flex-shrink-0 {zapper.pubkey ===
+        class="zap-pill flex items-center gap-1 h-6 pl-1 pr-2 rounded-full transition-colors cursor-pointer flex-shrink-0 {zapper.pubkey ===
         $userPublickey
           ? 'ring-1 ring-yellow-500'
           : ''}"
@@ -382,7 +382,7 @@
     {#if hiddenCount > 0}
       <button
         on:click|stopPropagation={handleCountClick}
-        class="zap-pill flex items-center gap-1 h-6 pl-1.5 pr-2 rounded-full bg-accent-gray hover:bg-yellow-500/20 text-caption text-xs font-semibold cursor-pointer transition-colors flex-shrink-0"
+        class="zap-pill flex items-center gap-1 h-6 pl-1.5 pr-2 rounded-full text-caption text-xs font-semibold cursor-pointer transition-colors flex-shrink-0"
         title="{hiddenCount} more zappers ({formatAmount(totalSats)} sats total)"
       >
         <LightningIcon size={12} class="text-yellow-500 flex-shrink-0" weight="fill" />
@@ -464,8 +464,12 @@
 
 <style>
   .zap-pill {
-    border: 1px solid rgba(245, 158, 11, 0.4);
-    box-shadow: 0 0 10px rgba(245, 158, 11, 0.25);
+    background-color: var(--color-input-bg);
+    box-shadow: inset 0 0 0 1px transparent;
+    transition: background-color 140ms ease, box-shadow 140ms ease;
+  }
+  .zap-pill:hover {
+    box-shadow: inset 0 0 0 1px rgba(245, 158, 11, 0.55);
   }
 
   /* Contain horizontal scroll so Safari doesn't pull the whole page sideways */

--- a/src/components/PersonRow.svelte
+++ b/src/components/PersonRow.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { nip19 } from 'nostr-tools';
+  import { ndk } from '$lib/nostr';
+  import { resolveProfileByPubkey } from '$lib/profileResolver';
+  import Avatar from './Avatar.svelte';
+  import CustomName from './CustomName.svelte';
+  import FollowButton from './FollowButton.svelte';
+
+  export let pubkey: string;
+  export let showBio: boolean = true;
+
+  let bio = '';
+  let npub = '';
+
+  $: npub = (() => {
+    try {
+      return nip19.npubEncode(pubkey);
+    } catch {
+      return '';
+    }
+  })();
+
+  onMount(async () => {
+    if (!showBio || !$ndk) return;
+    try {
+      const profile = await resolveProfileByPubkey(pubkey, $ndk);
+      bio = profile?.about?.trim() || '';
+    } catch {
+      bio = '';
+    }
+  });
+</script>
+
+<div class="person-row">
+  <a href="/user/{npub}" class="person-avatar" aria-label="View profile">
+    <Avatar {pubkey} size={40} />
+  </a>
+  <div class="person-info">
+    <div class="person-top">
+      <a href="/user/{npub}" class="person-name">
+        <CustomName {pubkey} />
+      </a>
+      <FollowButton {pubkey} />
+    </div>
+    {#if showBio && bio}
+      <p class="person-bio">{bio}</p>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .person-row {
+    display: flex;
+    gap: 0.625rem;
+    align-items: flex-start;
+  }
+  .person-avatar {
+    flex-shrink: 0;
+  }
+  .person-info {
+    flex: 1;
+    min-width: 0;
+  }
+  .person-top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    /* Reserve the follow-button height so rows without a button (already
+       followed) keep the same height and stay vertically aligned. */
+    min-height: 1.75rem;
+  }
+  .person-name {
+    font-weight: 600;
+    font-size: 0.875rem;
+    color: var(--color-text-primary);
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    transition: color 140ms ease;
+  }
+  .person-name:hover {
+    color: var(--color-primary);
+  }
+  .person-bio {
+    margin-top: 0.25rem;
+    font-size: 0.8125rem;
+    line-height: 1.35;
+    color: var(--color-caption);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+</style>

--- a/src/components/PostActionsMenu.svelte
+++ b/src/components/PostActionsMenu.svelte
@@ -157,7 +157,7 @@
     title="More options"
     aria-label="More options"
   >
-    <DotsThree size={20} class="text-caption" weight="regular" />
+    <DotsThree size={24} weight="bold" style="color: var(--color-text-secondary);" />
   </button>
 
   {#if menuOpen}

--- a/src/components/RailCard.svelte
+++ b/src/components/RailCard.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  export let title: string = '';
+</script>
+
+<section class="rail-card">
+  {#if title}
+    <h3 class="rail-card-title">{title}</h3>
+  {/if}
+  <div class="rail-card-body">
+    <slot />
+  </div>
+</section>
+
+<style>
+  /* Quiet by design: no box or fill, so the rail reads as secondary content
+     and doesn't pull focus from the reading column. */
+  .rail-card {
+    background: transparent;
+    border: 0;
+    padding: 0;
+  }
+  .rail-card-title {
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    margin-bottom: 1.25rem;
+    color: var(--color-caption);
+  }
+  .rail-card-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+</style>

--- a/src/components/Reactions/ReactionPills.svelte
+++ b/src/components/Reactions/ReactionPills.svelte
@@ -109,24 +109,22 @@
 </script>
 
 {#if $store.reactions.groups.length > 0}
-  <div class="flex flex-wrap gap-1 mb-2">
+  <div class="flex flex-wrap gap-1.5 mb-2">
     {#each visibleGroups as group (group.emoji)}
       <button
         type="button"
-        class="flex items-center gap-1 h-6 px-1.5 rounded-full border text-sm transition-colors cursor-pointer {group.userReacted
-          ? 'border-primary bg-primary/20'
-          : 'border-transparent bg-accent-gray hover:border-primary hover:bg-primary/20'}"
+        class="reaction-pill {group.userReacted ? 'is-active' : ''}"
         on:click={() => handlePillClick(group.emoji)}
         title={group.userReacted ? `You reacted with ${group.emoji}` : `React with ${group.emoji}`}
       >
-        <span class="text-base">{group.emoji}</span>
-        <span class="text-caption text-xs">{group.count}</span>
+        <span class="reaction-emoji">{group.emoji}</span>
+        <span class="reaction-count">{group.count}</span>
       </button>
     {/each}
 
     {#if hiddenCount > 0}
       <span
-        class="flex items-center gap-1 h-6 px-2 rounded-full bg-accent-gray text-caption text-xs"
+        class="reaction-pill reaction-pill--more"
         title="{hiddenCount} more emoji types ({hiddenReactionCount} reactions)"
       >
         +{hiddenReactionCount}
@@ -134,3 +132,39 @@
     {/if}
   </div>
 {/if}
+
+<style>
+  .reaction-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3125rem;
+    height: 1.625rem;
+    padding: 0 0.625rem;
+    border-radius: 999px;
+    background-color: var(--color-input-bg);
+    box-shadow: inset 0 0 0 1px transparent;
+    cursor: pointer;
+    transition: background-color 140ms ease, box-shadow 140ms ease;
+  }
+  .reaction-pill:hover {
+    box-shadow: inset 0 0 0 1px var(--color-primary);
+  }
+  .reaction-pill.is-active {
+    background-color: color-mix(in srgb, var(--color-primary) 16%, transparent);
+    box-shadow: inset 0 0 0 1px var(--color-primary);
+  }
+  .reaction-pill--more {
+    cursor: default;
+  }
+  .reaction-emoji {
+    font-size: 0.875rem;
+    line-height: 1;
+  }
+  .reaction-count {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    font-variant-numeric: tabular-nums;
+  }
+</style>
+

--- a/src/components/RightRail.svelte
+++ b/src/components/RightRail.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  // Supplementary content column shown to the right of the main reading
+  // column when the viewport is wide enough (2xl+). Never holds essential
+  // content — it's hidden below the breakpoint, where the main column stands
+  // alone. Sticky so it stays in view while the main column scrolls.
+</script>
+
+<aside class="right-rail">
+  <div class="right-rail-inner">
+    <slot />
+  </div>
+</aside>
+
+<style>
+  .right-rail {
+    display: none;
+    flex: none;
+    width: 20rem;
+  }
+  /* Match Tailwind's 2xl breakpoint (1536px) — only appears when the content
+     area has room for the reading column plus the rail. */
+  @media (min-width: 1536px) {
+    .right-rail {
+      display: block;
+    }
+  }
+  .right-rail-inner {
+    position: sticky;
+    top: calc(var(--header-h, 4rem) + 2.5rem);
+    /* Align the rail's first item with the page's top control (e.g. the
+       note view's back button, which sits in a pt-4 container). */
+    margin-top: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+</style>

--- a/src/components/comments/CommentCard.svelte
+++ b/src/components/comments/CommentCard.svelte
@@ -308,6 +308,14 @@
     padding: 0.5rem 0;
   }
 
+  /* Recipe comments render as sunken cards (a shade darker than the page),
+     matching the note-thread reply treatment. */
+  .comment-card--recipe {
+    background-color: var(--color-card-sunken);
+    border-radius: 0.5rem;
+    padding: 0.875rem 1rem;
+  }
+
   .comment-row {
     display: flex;
     gap: 0.5rem;
@@ -418,10 +426,14 @@
     padding-left: 1.375rem; /* 22px → content at 16+2+22 = 40px = parent content start */
   }
 
+  /* Nested recipe replies indent as sunken cards; the indent conveys nesting
+     so no border-left thread line is needed inside the card. */
   .comment-card--recipe.nested {
-    margin-left: 1.25rem;   /* 20px = center of 40px avatar */
-    border-left: 2px solid var(--color-input-border);
-    padding-left: 1.875rem; /* 30px → content at 20+2+30 = 52px = parent content start */
+    margin-left: 1.5rem;
+    padding-left: 1rem;
+  }
+  .comment-card--recipe .thread-line {
+    display: none;
   }
 
   /* ── Replying-to indicator ──────────────────────────────────────── */

--- a/src/components/comments/CommentThread.svelte
+++ b/src/components/comments/CommentThread.svelte
@@ -102,7 +102,7 @@
   <section id="comments-section" class="space-y-6">
     <h2 class="text-2xl font-bold">Comments</h2>
 
-    <div class="comments-list">
+    <div class="comments-list comments-list--recipe">
       {#if $events.length === 0}
         <p class="text-caption">No comments yet. Be the first to comment!</p>
       {:else}
@@ -211,5 +211,10 @@
     display: flex;
     flex-direction: column;
     gap: 0;
+  }
+
+  /* Recipe comments are sunken cards — space them out. */
+  .comments-list--recipe {
+    gap: 0.75rem;
   }
 </style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -547,12 +547,16 @@
         style="background-color: var(--color-bg-primary); padding-top: var(--header-h);"
       >
         <div
-          class="px-4 min-w-0 max-w-full {$page.url.pathname.startsWith('/messages') ||
+          class="px-4 min-w-0 max-w-full flex flex-col min-h-full {$page.url.pathname.startsWith('/messages') ||
           $page.url.pathname.startsWith('/groups')
             ? ''
             : 'pb-16 xl:pb-8'}"
         >
-          <slot />
+          <!-- Grow the page content so the footer is pushed to the bottom on
+               short pages instead of floating mid-viewport. -->
+          <div class="flex-1 min-w-0 max-w-full">
+            <slot />
+          </div>
           {#if !$page.url.pathname.startsWith('/messages') && !$page.url.pathname.startsWith('/groups')}
             <Footer />
           {/if}

--- a/src/routes/[nip19]/+page.svelte
+++ b/src/routes/[nip19]/+page.svelte
@@ -18,6 +18,9 @@
   import { stripTrackingParams } from '$lib/utils/stripTrackingParams';
   import PostActionsMenu from '../../components/PostActionsMenu.svelte';
   import ReplyComposer from '../../components/comments/ReplyComposer.svelte';
+  import RightRail from '../../components/RightRail.svelte';
+  import RailCard from '../../components/RailCard.svelte';
+  import PersonRow from '../../components/PersonRow.svelte';
 
   let decoded: any = null;
   let event: NDKEvent | null = null;
@@ -436,6 +439,26 @@
     return false;
   });
 
+  // People in this note: author first, then anyone mentioned (p-tags), then
+  // reply authors — deduped, mute-filtered, and capped for the rail.
+  $: participants = (() => {
+    const order: string[] = [];
+    const seen = new Set<string>();
+    const add = (pk?: string | null) => {
+      if (!pk || seen.has(pk) || $mutedPubkeys.has(pk)) return;
+      seen.add(pk);
+      order.push(pk);
+    };
+    if (event) {
+      add(event.author?.hexpubkey || event.pubkey);
+      for (const t of event.tags || []) {
+        if (t[0] === 'p' && t[1]) add(t[1]);
+      }
+    }
+    for (const r of directReplies) add(r.author?.hexpubkey || r.pubkey);
+    return order.slice(0, 12);
+  })();
+
   // Get nested replies for a comment
   function getNestedReplies(parentId: string): NDKEvent[] {
     return replies.filter((r) => {
@@ -492,7 +515,8 @@
   <meta name="twitter:image" content={ogImage} />
 </svelte:head>
 
-<div class="max-w-2xl mx-auto px-4">
+<div class="note-page-layout">
+  <div class="max-w-2xl px-4 w-full min-w-0">
   <!-- Back link -->
   {#if !loading}
     <div class="pt-4 pb-2">
@@ -669,48 +693,51 @@
     {/if}
 
     <!-- Main Note -->
+    <!-- Focused note uses a header-on-top, full-width-body layout (avatar +
+         name/time in a row, content spanning the full column below). This
+         matches the focused-note presentation in Jumble, Primal, YakiHonne,
+         and Iris, and gives a wider, more readable reading column than
+         indenting the body under the avatar. Parent-thread context notes
+         above keep the compact indented layout. -->
     <article class="py-6">
-      <div class="flex space-x-3">
-        <a
-          href="/user/{nip19.npubEncode(event.author?.hexpubkey || event.pubkey)}"
-          class="flex-shrink-0"
-        >
-          <Avatar
-            className="cursor-pointer"
-            pubkey={event.author?.hexpubkey || event.pubkey}
-            size={40}
-          />
-        </a>
-        <div class="flex-1 min-w-0">
-          <div class="flex items-start justify-between">
-            <div class="flex-1 min-w-0">
-              <div class="flex items-center space-x-2 mb-2 flex-wrap">
-                <a
-                  href="/user/{nip19.npubEncode(event.author?.hexpubkey || event.pubkey)}"
-                  class="font-semibold text-sm transition-colors username-link truncate min-w-0"
-                  style="color: var(--color-text-primary)"
-                >
-                  <CustomName pubkey={event.author?.hexpubkey || event.pubkey} />
-                </a>
-                <span class="text-sm flex-shrink-0" style="color: var(--color-caption)">·</span>
-                <span class="text-sm whitespace-nowrap flex-shrink-0" style="color: var(--color-caption)">
-                  {event.created_at ? formatTimeAgo(event.created_at) : 'Unknown time'}
-                </span>
-                <ClientAttribution tags={event.tags} enableEnrichment={true} />
-              </div>
-              <div class="text-base leading-relaxed mb-3" style="color: var(--color-text-primary)">
-                {#if event.kind === 1068}
-                  <PollDisplay {event} />
-                {:else}
-                  <NoteContent content={event.content} />
-                {/if}
-              </div>
+      <div class="flex items-start justify-between gap-3 mb-3">
+        <div class="flex items-center gap-3 min-w-0">
+          <a
+            href="/user/{nip19.npubEncode(event.author?.hexpubkey || event.pubkey)}"
+            class="flex-shrink-0"
+          >
+            <Avatar
+              className="cursor-pointer"
+              pubkey={event.author?.hexpubkey || event.pubkey}
+              size={44}
+            />
+          </a>
+          <div class="flex flex-col min-w-0">
+            <a
+              href="/user/{nip19.npubEncode(event.author?.hexpubkey || event.pubkey)}"
+              class="font-semibold text-base transition-colors username-link truncate min-w-0"
+              style="color: var(--color-text-primary)"
+            >
+              <CustomName pubkey={event.author?.hexpubkey || event.pubkey} />
+            </a>
+            <div class="flex items-center space-x-2 flex-wrap">
+              <span class="text-sm whitespace-nowrap flex-shrink-0" style="color: var(--color-caption)">
+                {event.created_at ? formatTimeAgo(event.created_at) : 'Unknown time'}
+              </span>
+              <ClientAttribution tags={event.tags} enableEnrichment={true} />
             </div>
-            <PostActionsMenu {event} />
           </div>
-          <NoteActionBar {event} />
         </div>
+        <PostActionsMenu {event} />
       </div>
+      <div class="text-[17px] leading-relaxed mb-4" style="color: var(--color-text-primary)">
+        {#if event.kind === 1068}
+          <PollDisplay {event} />
+        {:else}
+          <NoteContent content={event.content} />
+        {/if}
+      </div>
+      <NoteActionBar {event} />
     </article>
 
     <!-- Replies Section -->
@@ -911,11 +938,30 @@
       {/if}
     </div>
   {/if}
+  </div>
+
+  {#if event && !error && participants.length > 0}
+    <RightRail>
+      <RailCard title="People in this thread">
+        {#each participants as pk (pk)}
+          <PersonRow pubkey={pk} />
+        {/each}
+      </RailCard>
+    </RightRail>
+  {/if}
 </div>
 
 
 <style>
   /* Thread page styles */
+
+  /* Two-column layout: reading column + right rail (rail self-hides below
+     2xl via RightRail's own media query). Left-aligned to the content grid. */
+  .note-page-layout {
+    display: flex;
+    align-items: flex-start;
+    gap: 3rem;
+  }
 
   /* Username hover - orange color */
   .username-link:hover {

--- a/src/routes/[nip19]/+page.svelte
+++ b/src/routes/[nip19]/+page.svelte
@@ -741,7 +741,7 @@
     </article>
 
     <!-- Replies Section -->
-    <div class="border-t mt-2" style="border-color: var(--color-input-border)">
+    <div class="mt-2">
 
 
       <!-- Replies List -->
@@ -762,13 +762,12 @@
           No replies yet. {#if !$userPublickey}<a href="/login?redirect={encodeURIComponent($page.url.pathname)}" class="underline hover:opacity-80" style="color: var(--color-primary)">Sign in</a> to reply!{:else}Be the first to reply!{/if}
         </p>
       {:else}
-        <div class="space-y-0">
+        <div class="space-y-3">
           {#each directReplies as reply (reply.id)}
             {#if !$mutedPubkeys.has(reply.author?.hexpubkey || reply.pubkey)}
-              <div>
+              <div class="reply-card">
                 <article
-                  class="py-8 border-b last:border-0 cursor-pointer hover:bg-[var(--color-bg-hover,rgba(255,255,255,0.03))]"
-                  style="border-color: var(--color-input-border)"
+                  class="cursor-pointer"
                   on:click={(e) => gotoNoteUnlessInteractive(e, reply)}
                   role="link"
                   tabindex="0"
@@ -913,8 +912,8 @@
 
       <!-- Reply Input -->
       {#if $userPublickey}
-        <div class="mt-4 p-3 rounded-lg" style="background-color: var(--color-bg-secondary)">
-          <div class="flex gap-3 items-start">
+        <div class="mt-4 px-4 py-3.5 rounded-lg" style="background-color: var(--color-card-sunken)">
+          <div class="flex space-x-3 items-start">
             <div class="flex-shrink-0">
               <Avatar pubkey={$userPublickey} size={32} />
             </div>
@@ -930,8 +929,8 @@
         </div>
       {:else}
         <div
-          class="mt-4 p-3 rounded-lg text-sm"
-          style="background-color: var(--color-bg-secondary); color: var(--color-caption)"
+          class="mt-4 px-4 py-3.5 rounded-lg text-sm"
+          style="background-color: var(--color-card-sunken); color: var(--color-caption)"
         >
           <a href="/login" class="text-primary hover:underline font-medium">Log in</a> to reply
         </div>
@@ -961,6 +960,14 @@
     display: flex;
     align-items: flex-start;
     gap: 3rem;
+  }
+
+  /* Each reply is a filled panel (no border), a shade darker than the page,
+     matching the reply composer box below the list. */
+  .reply-card {
+    background-color: var(--color-card-sunken);
+    border-radius: 0.5rem;
+    padding: 0.875rem 1rem;
   }
 
   /* Username hover - orange color */

--- a/src/routes/community/+page.svelte
+++ b/src/routes/community/+page.svelte
@@ -219,7 +219,7 @@
 </svelte:head>
 
 <PullToRefresh bind:this={pullToRefreshEl} on:refresh={handleRefresh}>
-  <div class="px-4 max-w-2xl mx-auto community-page w-full">
+  <div class="px-4 max-w-2xl community-page w-full">
     <!-- Orientation text for signed-out users -->
     {#if $userPublickey === ''}
       <div class="mb-6 pt-4 pb-2">

--- a/src/routes/recipe/[slug]/+page.svelte
+++ b/src/routes/recipe/[slug]/+page.svelte
@@ -8,7 +8,9 @@
   import { onMount } from 'svelte';
   import Recipe from '../../../components/Recipe/Recipe.svelte';
   import PanLoader from '../../../components/PanLoader.svelte';
-  import { GATED_RECIPE_KIND } from '$lib/consts';
+  import RightRail from '../../../components/RightRail.svelte';
+  import RailCard from '../../../components/RailCard.svelte';
+  import { GATED_RECIPE_KIND, RECIPE_TAGS } from '$lib/consts';
   import { getRecipeOgMeta } from '$lib/recipeOgMeta';
   import { stripTrackingParams } from '$lib/utils/stripTrackingParams';
 
@@ -16,6 +18,56 @@
   let naddr: string = '';
   let loading = true;
   let error: string | null = null;
+
+  // "More from this chef" rail — other recipes by the same author.
+  let moreRecipes: { naddr: string; title: string; image: string }[] = [];
+  let moreFetchedFor = '';
+
+  $: if (event && event.id !== moreFetchedFor) {
+    moreFetchedFor = event.id;
+    loadMoreFromChef(event);
+  }
+
+  async function loadMoreFromChef(current: NDKEvent) {
+    moreRecipes = [];
+    if (!$ndk || !current.pubkey) return;
+    try {
+      const events = await $ndk.fetchEvents({
+        kinds: [30023],
+        authors: [current.pubkey],
+        limit: 30
+      });
+      const items: { naddr: string; title: string; image: string }[] = [];
+      for (const ev of events) {
+        if (ev.id === current.id) continue;
+        const isRecipe = ev.tags.some(
+          (t) => t[0] === 't' && RECIPE_TAGS.includes((t[1] || '').toLowerCase())
+        );
+        if (!isRecipe) continue;
+        const dTag = ev.tags.find((t) => t[0] === 'd')?.[1];
+        if (!dTag) continue;
+        let naddrEnc = '';
+        try {
+          naddrEnc = nip19.naddrEncode({
+            identifier: dTag,
+            kind: ev.kind || 30023,
+            pubkey: ev.pubkey
+          });
+        } catch {
+          continue;
+        }
+        items.push({
+          naddr: naddrEnc,
+          title: ev.tags.find((t) => t[0] === 'title')?.[1] || dTag,
+          image: ev.tags.find((t) => t[0] === 'image')?.[1] || ''
+        });
+        if (items.length >= 5) break;
+      }
+      moreRecipes = items;
+    } catch (err) {
+      console.error('[recipe] Failed to load more from chef:', err);
+    }
+  }
 
   onMount(() => stripTrackingParams($page.url));
 
@@ -168,9 +220,66 @@
     </a>
   </div>
 {:else if event}
-  <Recipe {event} />
+  <div class="recipe-page-layout">
+    <div class="recipe-main flex-1 min-w-0">
+      <Recipe {event} />
+    </div>
+    {#if moreRecipes.length > 0}
+      <RightRail>
+        <RailCard title="More from this chef">
+          {#each moreRecipes as r (r.naddr)}
+            <a class="recipe-rail-row" href="/recipe/{r.naddr}">
+              <span
+                class="recipe-rail-thumb"
+                style:background-image={r.image ? `url('${r.image}')` : 'none'}
+              ></span>
+              <span class="recipe-rail-title">{r.title}</span>
+            </a>
+          {/each}
+        </RailCard>
+      </RightRail>
+    {/if}
+  </div>
 {:else}
   <div class="flex justify-center items-center page-loader">
     <PanLoader />
   </div>
 {/if}
+
+<style>
+  .recipe-page-layout {
+    display: flex;
+    align-items: flex-start;
+    gap: 3rem;
+  }
+  .recipe-rail-row {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    min-width: 0;
+  }
+  .recipe-rail-thumb {
+    flex-shrink: 0;
+    width: 2.75rem;
+    height: 2.75rem;
+    border-radius: 0.5rem;
+    background-color: var(--color-input-bg);
+    background-size: cover;
+    background-position: center;
+  }
+  .recipe-rail-title {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text-primary);
+    line-height: 1.3;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    transition: color 140ms ease;
+  }
+  .recipe-rail-row:hover .recipe-rail-title {
+    color: var(--color-primary);
+  }
+</style>

--- a/src/routes/user/[slug]/+page.svelte
+++ b/src/routes/user/[slug]/+page.svelte
@@ -1892,7 +1892,7 @@
   </div>
 </Modal>
 
-<div class="max-w-4xl mx-auto w-full">
+<div class="max-w-4xl w-full px-4">
   <!-- Profile Banner. Below xl (no sidebar) it's full-bleed and flush under
        the top bar with square corners. At xl it's a contained, fixed-size
        rounded card constrained to the content column — never wider than the

--- a/src/routes/user/[slug]/+page.svelte
+++ b/src/routes/user/[slug]/+page.svelte
@@ -2506,17 +2506,19 @@
 {/if}
 
 <style>
-  /* Below xl (no sidebar) the banner is full-bleed: symmetric
-     viewport-relative margins stretch it to the viewport width (= the top
-     bar), clipped by #app-scroll's overflow-x-hidden. At xl it's contained to
-     the content container (margins reset to 0) so it's a fixed-size card that
-     is never wider than the top bar. */
+  /* Below xl (no sidebar) the banner is full-bleed to the viewport width.
+     The content column is left-aligned (Option A) and inset by the layout +
+     page horizontal padding (1rem + 1rem = 2rem), so pull the banner left by
+     that amount and span the full viewport; #app-scroll's overflow-x-hidden
+     clips any scrollbar overshoot. At xl it's contained to the content
+     container (a fixed-size card, never wider than the top bar). */
   .banner-fullbleed {
-    margin-left: calc(50% - 50vw);
-    margin-right: calc(50% - 50vw);
+    width: 100vw;
+    margin-left: -2rem;
   }
   @media (min-width: 1280px) {
     .banner-fullbleed {
+      width: auto;
       margin-left: 0;
       margin-right: 0;
     }


### PR DESCRIPTION
## Summary

A broad pass on note presentation and surrounding layout to make Zap Cooking's reading experience competitive with Jumble/Primal/YakiHonne/Iris.

### Note typography & interaction
- Focused note uses a full-width body (no avatar indent) at 17px for a wider reading column.
- Larger, bolder, more visible `…` actions menu button.
- "View more / less" toggle moved to its own centered line.
- Collapsed previews truncate at a word boundary (no more mid-word slices).
- **Click anywhere on a feed card** (community + profile feeds) to open the single-note view; links, buttons, media, and text selection are left alone.

### Layout grid (Option A — left-aligned)
- Community feed, note view, and profile content are left-aligned under the header search bar (reserving the right space for a rail) instead of floating centered.

### Cards & palette
- Community feed items, note-view replies, and recipe comments render as cards on a new `--color-card-sunken` surface (a shade darker than the page in both themes), no borders.
- Reply card + composer share the sunken surface with aligned avatars.
- Refined reaction/zap pills: subtle chips instead of heavy gray blobs; dropped the permanent orange glow on zap pills.
- Image galleries bleed to the card edges — first tile rests inset-left (rounded), the peek reaches the right edge, equal inset at the end.

### Right rail (2xl+)
- New `RightRail`, `RailCard`, `PersonRow`, `FollowButton` (quiet icon, hidden for people already followed).
- Note view: "People in this thread". Recipe page: "More from this chef".

### Footer
- Compact stacked layout, 1-color masked wordmark, removed redundant MIT License link, dark-mode-safe support QR, and sticky-to-bottom on short pages.

## Not in this batch (planned follow-ups)
- **Right rail phase 2**: "Suggested chefs" + "Trending tags" on the community/reads feeds.
- **Extend Option A** to the remaining pages (reads page, recipe list, and the other ~35 pages that still center their column).
- **Line-based preview truncation** (clamp to N rows for text + media) — written up in `docs/proposals/note-preview-line-truncation.md`.
- **Recipe page polish**: left-align the shared `Recipe` article to the grid; move the recipe comment composers onto the sunken palette.
- **Parent-thread context notes**: card them for full consistency with replies.

## Testing
- `svelte-check`: 0 errors.
- Verified locally at ≥1536px: rail appears, feed/thread cards + galleries render correctly, click-to-open works, footer sticks on short pages.

🥘 Generated with [Claude Code](https://claude.com/claude-code)