### PR TITLE
fix(search): multi-word search queries and mention dropdown z-index

### DIFF
--- a/src/components/MentionDropdown.svelte
+++ b/src/components/MentionDropdown.svelte
@@ -155,10 +155,9 @@
 {/if}
 
 <style>
-	/* PR #143 fix #3: z-index 50 -> 1000 */
 	.mention-dropdown {
 		position: absolute;
-		z-index: 1000;
+		z-index: 10001;
 		width: 280px;
 		max-width: calc(100vw - 2rem);
 		background: var(--color-input-bg);

--- a/src/components/TagsSearchAutocomplete.svelte
+++ b/src/components/TagsSearchAutocomplete.svelte
@@ -43,9 +43,9 @@
 
   function handleInputChange(event: Event) {
     const input = event.target as HTMLInputElement;
-    tagquery = input.value.trim();
+    tagquery = input.value;
 
-    const rawQuery = tagquery;
+    const rawQuery = tagquery.trim();
     const normalizedQuery = rawQuery.toLowerCase();
 
     // Clear previous timeout
@@ -322,7 +322,7 @@
   <form
     class="flex"
     on:submit|preventDefault={() => {
-      if (tagquery) {
+      if (tagquery.trim()) {
         // If it's a note identifier, navigate directly
         if (searchResults.note) {
           selectNote(searchResults.note.id);
@@ -346,7 +346,7 @@
         }
 
         // Fallback: treat as tag search if no results
-        action(tagquery);
+        action(tagquery.trim());
         tagquery = '';
         searchResults = { tags: [], recipes: [], users: [], note: null };
       }


### PR DESCRIPTION
## Summary

- **Search multi-word queries**: `tagquery` was trimmed on every keystroke via `bind:value` two-way sync, stripping trailing spaces before the next word could be typed — making queries like \"pizza beans\" impossible to enter. Raw value is now preserved in `tagquery`; trim is applied only for search logic and on submit.
- **Mention dropdown z-index**: The `@` autocomplete list was at `z-index: 1000` but the modal backdrop sits at `z-index: 10000`, causing the dropdown to render behind the composer. Bumped to `10001`.

## Test plan

- [ ] Open search bar, type a multi-word query (e.g. "vegan pasta") — space should not be eaten between words
- [ ] Recipe autocomplete results should appear for multi-word queries
- [ ] Open the note composer, type `@zap` — mention dropdown should appear on top of the modal
- [ ] Verify no regression on single-word tag/user/recipe search

🍕 Generated with [Claude Code](https://claude.com/claude-code)