### PR TITLE
fix(mentions): food nickname fallback, relay hints, and nevent1 copy for notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.562",
+  "version": "4.2.563",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.561",
+  "version": "4.2.562",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.560",
+  "version": "4.2.561",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.564",
+  "version": "4.2.565",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.563",
+  "version": "4.2.564",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/NoteContent.svelte
+++ b/src/components/NoteContent.svelte
@@ -418,6 +418,7 @@
         <ProfileLink
           nostrString={part.content}
           colorClass="text-orange-500 hover:text-orange-600"
+          fallbackToRaw={false}
         />
       {:else if part.prefix === 'nevent1' || part.prefix === 'note1'}
         {#if showNostrEmbeds}

--- a/src/components/PostActionsMenu.svelte
+++ b/src/components/PostActionsMenu.svelte
@@ -40,7 +40,11 @@
   async function handleCopy() {
     if (!browser) return;
 
-    const noteId = nip19.noteEncode(event.id);
+    const noteId = nip19.neventEncode({
+      id: event.id,
+      author: event.pubkey,
+      kind: event.kind
+    });
     try {
       await navigator.clipboard.writeText(noteId);
       copied = true;
@@ -60,7 +64,11 @@
 
   async function handleCopyLink() {
     if (!browser) return;
-    const noteId = nip19.noteEncode(event.id);
+    const noteId = nip19.neventEncode({
+      id: event.id,
+      author: event.pubkey,
+      kind: event.kind
+    });
     const url = `${window.location.origin}/${noteId}`;
 
     try {

--- a/src/components/ProfileLink.svelte
+++ b/src/components/ProfileLink.svelte
@@ -26,15 +26,20 @@
     pubkey = decodeNostrProfile(nostrString);
   }
 
-  // When the initial fetch times out (relay not ready on cold load),
-  // retry via resolveProfile which uses nprofile relay hints + purplepag.es.
-  // Null is not cached, so this re-hits the network.
+  // Initial fetch times out because relay connections aren't established
+  // yet on cold page load. Wait 3s for the pool to stabilize, then
+  // retry via NDKUser.fetchProfile() which checks Dexie cache first and
+  // then queries the connected pool — no hard timeout, resolves on EOSE.
   async function backgroundRetry() {
-    if (destroyed || !$ndk) return;
+    if (destroyed || !$ndk || !pubkey) return;
+    await new Promise(r => setTimeout(r, 3000));
+    if (destroyed) return;
     try {
-      const profile = await resolveProfile(nostrString, $ndk);
+      const user = $ndk.getUser({ pubkey });
+      const ndkProfile = await user.fetchProfile();
       if (destroyed) return;
-      if (profile) displayName = formatDisplayName(profile);
+      const name = ndkProfile?.displayName || ndkProfile?.name;
+      if (name) displayName = name;
     } catch { /* ignore */ }
   }
 

--- a/src/components/ProfileLink.svelte
+++ b/src/components/ProfileLink.svelte
@@ -27,16 +27,14 @@
   }
 
   // When the initial fetch times out (relay not ready on cold load),
-  // retry once using NDK's native user.fetchProfile() which has no
-  // hard timeout and will resolve when the relay catches up.
-  async function backgroundRetry(pk: string) {
+  // retry via resolveProfile which uses nprofile relay hints + purplepag.es.
+  // Null is not cached, so this re-hits the network.
+  async function backgroundRetry() {
     if (destroyed || !$ndk) return;
     try {
-      const user = $ndk.getUser({ pubkey: pk });
-      const profile = await user.fetchProfile();
+      const profile = await resolveProfile(nostrString, $ndk);
       if (destroyed) return;
-      const name = profile?.displayName || profile?.name;
-      if (name) displayName = name;
+      if (profile) displayName = formatDisplayName(profile);
     } catch { /* ignore */ }
   }
 
@@ -58,13 +56,13 @@
           displayName = getAnonChefName(pubkey);
           // Initial fetch timed out — profile may exist but relay wasn't
           // ready yet. Retry in background; update if we find the name.
-          if (pubkey) backgroundRetry(pubkey);
+          backgroundRetry();
         }
       } else if (fallbackToRaw) {
         displayName = nostrString;
       } else {
         displayName = getAnonChefName(pubkey);
-        if (pubkey) backgroundRetry(pubkey);
+        backgroundRetry();
       }
     } catch (err) {
       console.error('Failed to resolve profile:', err);
@@ -75,7 +73,7 @@
         // Same friendly fallback on resolution error — the user doesn't
         // care that it was a network blip vs. a missing profile.
         displayName = getAnonChefName(pubkey);
-        if (pubkey) backgroundRetry(pubkey);
+        backgroundRetry();
       }
     } finally {
       isLoading = false;

--- a/src/components/ProfileLink.svelte
+++ b/src/components/ProfileLink.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, onDestroy } from 'svelte';
   import { goto } from '$app/navigation';
   import { nip19 } from 'nostr-tools';
   import { profileActions, profiles, loadingProfiles, profileErrors } from '$lib/profileStore';
@@ -17,10 +17,27 @@
   let isLoading: boolean = false;
   let error: string | null = null;
   let pubkey: string | null = null;
+  let destroyed = false;
+
+  onDestroy(() => { destroyed = true; });
 
   // Get pubkey for navigation
   $: {
     pubkey = decodeNostrProfile(nostrString);
+  }
+
+  // When the initial fetch times out (relay not ready on cold load),
+  // retry once using NDK's native user.fetchProfile() which has no
+  // hard timeout and will resolve when the relay catches up.
+  async function backgroundRetry(pk: string) {
+    if (destroyed || !$ndk) return;
+    try {
+      const user = $ndk.getUser({ pubkey: pk });
+      const profile = await user.fetchProfile();
+      if (destroyed) return;
+      const name = profile?.displayName || profile?.name;
+      if (name) displayName = name;
+    } catch { /* ignore */ }
   }
 
   // Load profile on mount
@@ -39,11 +56,15 @@
           // through to a generic "Anon Chef" if we couldn't decode a
           // pubkey from nostrString.
           displayName = getAnonChefName(pubkey);
+          // Initial fetch timed out — profile may exist but relay wasn't
+          // ready yet. Retry in background; update if we find the name.
+          if (pubkey) backgroundRetry(pubkey);
         }
       } else if (fallbackToRaw) {
         displayName = nostrString;
       } else {
         displayName = getAnonChefName(pubkey);
+        if (pubkey) backgroundRetry(pubkey);
       }
     } catch (err) {
       console.error('Failed to resolve profile:', err);
@@ -54,6 +75,7 @@
         // Same friendly fallback on resolution error — the user doesn't
         // care that it was a network blip vs. a missing profile.
         displayName = getAnonChefName(pubkey);
+        if (pubkey) backgroundRetry(pubkey);
       }
     } finally {
       isLoading = false;

--- a/src/components/RichTextNostr.svelte
+++ b/src/components/RichTextNostr.svelte
@@ -230,7 +230,7 @@
         {token.content}
       </button>
     {:else if token.type === 'npub'}
-      <ProfileLink nostrString={token.raw || `nostr:${token.content}`} />
+      <ProfileLink nostrString={token.raw || `nostr:${token.content}`} fallbackToRaw={false} />
     {:else if token.type === 'naddr'}
       <div class="my-2">
         <NoteEmbed nostrString={token.raw || token.content} depth={0} />

--- a/src/lib/profileResolver.ts
+++ b/src/lib/profileResolver.ts
@@ -61,17 +61,20 @@ function cleanupCache(): void {
 
 // Decode nostr profile string to get pubkey
 export function decodeNostrProfile(nostrString: string): string | null {
+  return decodeNostrProfileFull(nostrString)?.pubkey ?? null;
+}
+
+// Decode nostr profile string to get pubkey AND any embedded relay hints.
+export function decodeNostrProfileFull(nostrString: string): { pubkey: string; relays: string[] } | null {
   try {
-    // Handle both nprofile1 and npub1 formats
     if (!nostrString.startsWith('nostr:nprofile1') && !nostrString.startsWith('nostr:npub1')) {
       return null;
     }
-    
     const decoded = nip19.decode(nostrString.replace('nostr:', ''));
     if (decoded.type === 'nprofile') {
-      return decoded.data.pubkey;
+      return { pubkey: decoded.data.pubkey, relays: decoded.data.relays ?? [] };
     } else if (decoded.type === 'npub') {
-      return decoded.data;
+      return { pubkey: decoded.data, relays: [] };
     }
     return null;
   } catch (error) {
@@ -97,7 +100,7 @@ const PROFILE_RELAY_URLS = [
 ];
 
 // Fetch profile data from relays
-async function fetchProfileFromRelays(pubkey: string, ndkInstance: NDK): Promise<ProfileData | null> {
+async function fetchProfileFromRelays(pubkey: string, ndkInstance: NDK, hintRelays?: string[]): Promise<ProfileData | null> {
   try {
     if (!ndkInstance) {
       return null;
@@ -109,15 +112,17 @@ async function fetchProfileFromRelays(pubkey: string, ndkInstance: NDK): Promise
 
     // Build an explicit relay set: NDK's connected pool relays
     // (whatever the page already has open — nos.lol, damus, primal
-    // in default mode) plus the canonical profile relays.
-    // NDK's `user.fetchProfile()` doesn't let us widen the relay set,
-    // so we drop down to fetchEvent + parse the kind:0 manually.
+    // in default mode) plus the canonical profile relays plus any
+    // relay hints embedded in the nprofile string.
     const { NDKRelaySet } = await import('@nostr-dev-kit/ndk');
     const relayUrls = new Set<string>();
     if (ndkInstance.pool?.relays) {
       for (const [url] of ndkInstance.pool.relays) relayUrls.add(url);
     }
     for (const url of PROFILE_RELAY_URLS) relayUrls.add(url);
+    if (hintRelays) {
+      for (const url of hintRelays) relayUrls.add(url);
+    }
 
     const relays = [];
     for (const url of relayUrls) {
@@ -212,10 +217,11 @@ export async function resolveProfile(nostrString: string, ndkInstance: NDK): Pro
       return null;
     }
 
-    const pubkey = decodeNostrProfile(nostrString);
-    if (!pubkey) {
+    const decoded = decodeNostrProfileFull(nostrString);
+    if (!decoded) {
       return null;
     }
+    const { pubkey, relays: hintRelays } = decoded;
 
     // Check cache first
     const cached = profileCache[pubkey];
@@ -223,8 +229,8 @@ export async function resolveProfile(nostrString: string, ndkInstance: NDK): Pro
       return cached;
     }
 
-    // Fetch from relays
-    const profile = await fetchProfileFromRelays(pubkey, ndkInstance);
+    // Fetch from relays, including any hint relays embedded in the nprofile.
+    const profile = await fetchProfileFromRelays(pubkey, ndkInstance, hintRelays);
     if (profile) {
       profileCache[pubkey] = profile;
       cleanupCache();


### PR DESCRIPTION
## Summary

- Unresolved `nostr:nprofile1...` mentions in note content now display a stable food nickname (e.g. "Tomato Traveler") instead of the raw bech32 string — nickname is deterministic per pubkey so the same author always gets the same name
- Relay hints embedded in nprofile strings are now extracted and included in the profile fetch relay set, improving resolution for users whose kind:0 isn't on the default pool relays
- Background retry added to `ProfileLink`: waits 3s for relay pool to connect, then re-fetches via `user.fetchProfile()` (Dexie cache-aware, no hard timeout)
- "Copy Note ID" and "Copy Link" in the note actions menu now produce `nevent1` format (with author and kind) instead of bare `note1`

## Deferred

Profile name still not visibly updating from the retry in some cases — tracked in issue #485.

## Test plan

- [ ] Open a note that mentions a user whose profile takes time to load — should show a food nickname, not the raw `nostr:nprofile1...` string
- [ ] After ~8s on a cold load, the food nickname should swap to the real display name for any resolvable profiles
- [ ] "Copy Note ID" from the `...` menu — paste into another client, confirm it decodes as `nevent1` with author/kind metadata
- [ ] "Copy Link" — URL should contain `nevent1...` and resolve correctly at `/nevent1...`

🥙 Generated with [Claude Code](https://claude.com/claude-code)