### PR TITLE
feat(composer): mobile composer overhaul — fullscreen inset panel, multi-image, touch sizing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.557",
+  "version": "4.2.558",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.558",
+  "version": "4.2.559",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.561",
+  "version": "4.2.562",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.560",
+  "version": "4.2.561",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.559",
+  "version": "4.2.560",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/CheffyLauncher.svelte
+++ b/src/components/CheffyLauncher.svelte
@@ -95,11 +95,12 @@
   .cheffy-launcher {
     position: fixed;
     right: 1.25rem;
-    /* One button above the create FAB: its bottom (40px nav + safe-area
-       + 1rem) + the 56px FAB + a 0.75rem gap. Mobile / tablet. */
+    /* One button above the create FAB: its bottom (--bottom-nav-height,
+       which already includes the safe-area inset, + 1rem) + the 56px FAB
+       + a 0.75rem gap. Mobile / tablet. Kept in sync with
+       CreateMenuButton's .create-menu-floating bottom. */
     bottom: calc(
-      40px + env(safe-area-inset-bottom, 0px) + 1rem + var(--timer-widget-offset, 0px) + 56px +
-        0.75rem
+      var(--bottom-nav-height, 56px) + 1rem + var(--timer-widget-offset, 0px) + 56px + 0.75rem
     );
     /* One below the create FAB / its expanded menu (both at z-index 40,
        with the menu's inner panel at z-index 45 within that stacking

--- a/src/components/CreateMenuButton.svelte
+++ b/src/components/CreateMenuButton.svelte
@@ -279,8 +279,11 @@
   .create-menu-floating {
     position: fixed;
     right: 1.25rem;
-    /* Bottom nav is 40px tall, positioned at safe-area-inset-bottom */
-    bottom: calc(40px + env(safe-area-inset-bottom, 0px) + 1rem + var(--timer-widget-offset, 0px));
+    /* Sit a comfortable gap above the bottom nav. --bottom-nav-height is
+       set by BottomNav and already includes the iOS safe-area inset, so we
+       don't add it again here (that double-counted and, with the taller
+       redesigned nav, left the FAB hugging the bar). */
+    bottom: calc(var(--bottom-nav-height, 56px) + 1rem + var(--timer-widget-offset, 0px));
     z-index: 40;
   }
 

--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -27,6 +27,7 @@
   export let wide = false;
   export let maxWidth: string | null = null;
   export let autoHeight = false;
+  export let fullScreenMobile = false;
 
   // Portal target - render at document body level. Initialized
   // synchronously when document is available so the dialog can mount
@@ -154,7 +155,7 @@
         transition:scale={{ duration: 250 }}
         aria-labelledby="title"
         aria-modal="true"
-        class="absolute m-0 top-1/2 left-1/2 px-4 md:px-8 pt-6 pb-8 rounded-3xl w-[calc(100%-2rem)] md:w-[calc(100vw-4em)] min-h-[50vh] md:min-h-0 max-h-[85dvh] md:max-h-[90dvh] -translate-x-1/2 -translate-y-1/2 flex flex-col"
+        class={`absolute m-0 px-4 md:px-8 pt-6 pb-8 flex flex-col md:top-1/2 md:left-1/2 md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-3xl md:w-[calc(100vw-4em)] md:min-h-0 md:max-h-[90dvh] ${fullScreenMobile ? 'fullscreen-dialog-mobile' : 'top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-3xl w-[calc(100%-2rem)] min-h-[50vh] max-h-[85dvh]'}`}
         class:modal-auto-height={autoHeight}
         class:max-w-xl={!wide && !maxWidth}
         class:max-w-2xl={wide && !maxWidth}
@@ -207,3 +208,26 @@
     }
   </style>
 {/if}
+
+<!-- Top-level style block — unlike the one above (nested inside the {#if},
+     which Svelte only renders as a literal DOM <style> tag rather than
+     compiling, so its :global() rules never apply), this one is a real
+     root-level style block and gets compiled/scoped normally. -->
+<style>
+  @media (max-width: 767.98px) {
+    :global(.fullscreen-dialog-mobile) {
+      top: 0;
+      left: 0;
+      transform: none;
+      width: 100%;
+      height: 100dvh;
+      max-height: 100dvh;
+      min-height: 100dvh;
+      border-radius: 0;
+      padding-top: max(1.5rem, env(safe-area-inset-top));
+      padding-bottom: max(2rem, env(safe-area-inset-bottom));
+      padding-left: max(1rem, env(safe-area-inset-left));
+      padding-right: max(1rem, env(safe-area-inset-right));
+    }
+  }
+</style>

--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -194,14 +194,14 @@
       overflow: hidden;
       touch-action: none;
     }
-    :global(.modal-auto-height) {
+    .modal-auto-height {
       min-height: 0 !important;
     }
-    :global(.compact-padding) {
+    .compact-padding {
       padding: 1rem 1rem 1.25rem;
     }
     @media (min-width: 768px) {
-      :global(.compact-padding) {
+      .compact-padding {
         padding-left: 1.5rem;
         padding-right: 1.5rem;
       }

--- a/src/components/PostComposer.svelte
+++ b/src/components/PostComposer.svelte
@@ -672,7 +672,7 @@
                   <div
                     bind:this={composerEl}
                     class={`composer-input w-full overflow-y-auto p-2 border-0 focus:outline-none focus:ring-0 bg-transparent ${variant === 'modal' ? 'min-h-[200px] max-h-[45vh]' : 'min-h-[120px] sm:min-h-[100px] max-h-[40vh]'}`}
-                    style="color: var(--color-text-primary);"
+                    style="color: var(--color-text-primary); touch-action: auto; user-select: text; -webkit-user-select: text;"
                     contenteditable={!posting}
                     role="textbox"
                     aria-multiline="true"

--- a/src/components/PostComposer.svelte
+++ b/src/components/PostComposer.svelte
@@ -72,6 +72,8 @@
   let uploadedImages: string[] = [];
   let uploadedVideos: string[] = [];
   let uploadingImage = false;
+  let uploadImageIndex = 0;
+  let uploadImageTotal = 0;
   let uploadingVideo = false;
   let imageInputEl: HTMLInputElement;
   let videoInputEl: HTMLInputElement;
@@ -269,10 +271,13 @@
     if (!files || files.length === 0) return;
 
     uploadingImage = true;
+    uploadImageTotal = files.length;
+    uploadImageIndex = 0;
     error = '';
 
     try {
       for (const file of Array.from(files)) {
+        uploadImageIndex += 1;
         const url = await uploadImage($ndk, file);
         uploadedImages = [...uploadedImages, url];
       }
@@ -838,6 +843,18 @@
 
         <!-- Action bar — pinned at bottom in modal, inline otherwise -->
         <div class="composer-footer {variant === 'modal' ? 'px-3 pb-3' : ''}">
+          {#if uploadingImage}
+            <div class="w-full h-1 rounded-full bg-input-border overflow-hidden -mt-1 mb-1">
+              {#if uploadImageTotal > 1}
+                <div
+                  class="h-full rounded-full bg-orange-500 transition-all duration-500"
+                  style="width: {(uploadImageIndex / uploadImageTotal) * 100}%"
+                ></div>
+              {:else}
+                <div class="h-full rounded-full bg-orange-500 upload-sweep"></div>
+              {/if}
+            </div>
+          {/if}
 
           <!-- Row 1: tools + status -->
           <div class="composer-tools-row">
@@ -867,7 +884,7 @@
                     </button>
                   </div>
                 {/if}
-                <input bind:this={imageInputEl} type="file" accept="image/*" class="sr-only" on:change={handleImageUpload} disabled={posting || uploadingImage || uploadingVideo} />
+                <input bind:this={imageInputEl} type="file" accept="image/*" multiple class="sr-only" on:change={handleImageUpload} disabled={posting || uploadingImage || uploadingVideo} />
                 <input bind:this={videoInputEl} type="file" accept="video/*" class="sr-only" on:change={handleVideoUpload} disabled={posting || uploadingImage || uploadingVideo} />
               </div>
 
@@ -883,7 +900,10 @@
             <!-- Right: status indicators -->
             <div class="flex items-center gap-2 text-xs text-caption">
               {#if uploadingImage}
-                <span>Uploading image…</span>
+                <span class="flex items-center gap-1">
+                  <svg class="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
+                  {uploadImageTotal > 1 ? `Uploading image ${uploadImageIndex} of ${uploadImageTotal}…` : 'Uploading image…'}
+                </span>
               {:else if uploadingVideo}
                 <span>Uploading video…</span>
               {:else if showCountdown}
@@ -1353,6 +1373,16 @@
     gap: 0.5rem;
     padding-top: 0.75rem;
     border-top: 1px solid var(--color-input-border);
+  }
+
+  @keyframes upload-sweep {
+    0% { width: 0%; margin-left: 0%; }
+    50% { width: 60%; margin-left: 20%; }
+    100% { width: 0%; margin-left: 100%; }
+  }
+
+  .upload-sweep {
+    animation: upload-sweep 1.4s ease-in-out infinite;
   }
 
   .composer-tools-row {

--- a/src/components/PostComposer.svelte
+++ b/src/components/PostComposer.svelte
@@ -624,7 +624,7 @@
 
 {#if $userPublickey !== '' || variant === 'modal'}
   <div
-    class={`rounded-xl relative ${variant === 'inline' ? 'mb-4' : 'flex-1 flex flex-col'} ${posting ? '' : 'bg-input transition-all'}`}
+    class={`rounded-xl relative ${variant === 'inline' ? 'mb-4' : 'flex-1 flex flex-col composer-modal'} ${posting ? '' : 'bg-input transition-all'}`}
     class:overflow-hidden={!isComposerOpen}
     class:overflow-visible={isComposerOpen}
     style={posting ? '' : 'border: 1px solid var(--color-input-border)'}
@@ -666,12 +666,12 @@
                 <button
                   type="button"
                   on:click={() => (showPreview = false)}
-                  class="px-3 py-1.5 text-xs font-medium transition-colors -mb-px border-b-2 {!showPreview ? 'text-primary border-primary' : 'text-caption border-transparent'}"
+                  class="composer-tab px-3 py-1.5 text-xs font-medium transition-colors -mb-px border-b-2 {!showPreview ? 'text-primary border-primary' : 'text-caption border-transparent'}"
                 >Write</button>
                 <button
                   type="button"
                   on:click={() => (showPreview = true)}
-                  class="px-3 py-1.5 text-xs font-medium transition-colors -mb-px border-b-2 {showPreview ? 'text-primary border-primary' : 'text-caption border-transparent'}"
+                  class="composer-tab px-3 py-1.5 text-xs font-medium transition-colors -mb-px border-b-2 {showPreview ? 'text-primary border-primary' : 'text-caption border-transparent'}"
                 >Preview</button>
               </div>
 
@@ -1475,5 +1475,32 @@
 
   .action-post-label {
     position: relative;
+  }
+
+  /* Upsize the fullscreen mobile composer for touch — bigger text, tabs,
+     tool icons, and action buttons. Scoped to the modal variant (which is
+     the fullscreen mobile sheet) at phone widths only. */
+  @media (max-width: 767.98px) {
+    .composer-modal .composer-input {
+      font-size: 18px;
+      line-height: 1.55;
+    }
+    .composer-modal .composer-tab {
+      font-size: 0.9375rem;
+      padding: 0.5rem 0.875rem;
+    }
+    .composer-modal .tool-btn {
+      padding: 0.5rem;
+    }
+    .composer-modal .tool-btn :global(svg),
+    .composer-modal .countdown-clock-btn :global(svg) {
+      width: 26px;
+      height: 26px;
+    }
+    .composer-modal .action-cancel,
+    .composer-modal .action-post {
+      padding: 0.75rem 1.5rem;
+      font-size: 1.0625rem;
+    }
   }
 </style>

--- a/src/components/PostComposer.svelte
+++ b/src/components/PostComposer.svelte
@@ -658,11 +658,18 @@
       <div class={`${variant === 'modal' ? 'flex-1 flex flex-col min-h-0' : 'p-3'}`}>
         <!-- Scrollable content area -->
         <div class={variant === 'modal' ? 'composer-scroll-area flex-1 overflow-y-auto min-h-0 p-3' : ''}>
-          <div class="flex gap-3">
-            <CustomAvatar pubkey={$userPublickey} size={36} />
+          <div class={variant === 'modal' ? 'min-w-0' : 'flex gap-3'}>
+            {#if variant === 'inline'}
+              <CustomAvatar pubkey={$userPublickey} size={36} />
+            {/if}
             <div class="flex-1 min-w-0">
-              <!-- Write / Preview tab bar -->
-              <div class="flex border-b mb-1" style="border-color: var(--color-input-border)">
+              <!-- Write / Preview tab bar. In the modal the avatar sits
+                   inline here so the write area can span the full width
+                   below it instead of being indented past the avatar. -->
+              <div class="flex items-center gap-2 border-b mb-1" style="border-color: var(--color-input-border)">
+                {#if variant === 'modal'}
+                  <CustomAvatar pubkey={$userPublickey} size={32} />
+                {/if}
                 <button
                   type="button"
                   on:click={() => (showPreview = false)}
@@ -1078,6 +1085,14 @@
     word-break: break-word;
     /* 16px on mobile avoids iOS focus-zoom; slightly smaller on desktop reads better */
     font-size: 16px;
+  }
+
+  /* Suppress the global branded focus-visible outline on the writing area —
+     the blinking caret already signals focus, and the box reads as an
+     unwanted border around the field. */
+  .composer-input:focus,
+  .composer-input:focus-visible {
+    outline: none;
   }
 
   @media (min-width: 768px) {

--- a/src/components/PostComposer.svelte
+++ b/src/components/PostComposer.svelte
@@ -286,6 +286,8 @@
       error = err?.message || 'Failed to upload image. Please try again.';
     } finally {
       uploadingImage = false;
+      uploadImageIndex = 0;
+      uploadImageTotal = 0;
       if (imageInputEl) imageInputEl.value = '';
     }
   }
@@ -312,6 +314,8 @@
       error = err?.message || 'Failed to upload image. Please try again.';
     } finally {
       uploadingImage = false;
+      uploadImageIndex = 0;
+      uploadImageTotal = 0;
     }
   }
 

--- a/src/components/PostModal.svelte
+++ b/src/components/PostModal.svelte
@@ -64,7 +64,7 @@
   }
 </script>
 
-<Modal bind:open allowOverflow={false} noHeader={true} wide={!isPosting} maxWidth={isPosting ? '22rem' : null} autoHeight={isPosting} cleanup={handleBackdropClose} locked={isPosting} fullScreenMobile={!isPosting}>
+<Modal bind:open allowOverflow={false} noHeader={true} wide={!isPosting} maxWidth={isPosting ? '22rem' : null} autoHeight={isPosting} cleanup={handleBackdropClose} locked={isPosting} fullScreenMobile={true}>
   <div class="flex flex-col gap-4 flex-1 min-h-0 overflow-hidden">
     <!-- Header: relay selector + contextual hint on left, X on right -->
     {#if !isPosting}

--- a/src/components/PostModal.svelte
+++ b/src/components/PostModal.svelte
@@ -65,16 +65,16 @@
 </script>
 
 <Modal bind:open allowOverflow={false} noHeader={true} wide={!isPosting} maxWidth={isPosting ? '22rem' : null} autoHeight={isPosting} cleanup={handleBackdropClose} locked={isPosting} fullScreenMobile={true}>
-  <div class="flex flex-col gap-4 flex-1 min-h-0 overflow-hidden">
+  <div class="composer-modal-body flex flex-col gap-4 flex-1 min-h-0 overflow-hidden">
     <!-- Header: relay selector + contextual hint on left, X on right -->
     {#if !isPosting}
-    <div class="flex items-start justify-between gap-2">
+    <div class="composer-modal-header flex items-start justify-between gap-2">
       <div class="flex items-center flex-wrap gap-x-2 gap-y-1">
-        <label for="relay-select" class="text-xs text-caption whitespace-nowrap">Post to:</label>
+        <label for="relay-select" class="composer-modal-label text-xs text-caption whitespace-nowrap">Post to:</label>
         <select
           id="relay-select"
           bind:value={selectedRelay}
-          class="px-2 py-1 text-xs rounded-lg border transition-colors"
+          class="composer-modal-select px-2 py-1 text-xs rounded-lg border transition-colors"
           style="
             background: var(--color-input-bg);
             border-color: var(--color-input-border);
@@ -85,14 +85,14 @@
           <option value="pantry">🏪 Pantry only</option>
         </select>
         {#if selectedRelay === 'pantry'}
-          <span class="text-[11px] text-caption"><span class="mr-1">🏪</span>If you're seeing this, you're early.</span>
+          <span class="composer-modal-hint text-[11px] text-caption"><span class="mr-1">🏪</span>If you're seeing this, you're early.</span>
         {:else}
-          <span class="text-[11px] text-caption"><span class="mr-1">📡</span>Posting to all connected relays.</span>
+          <span class="composer-modal-hint text-[11px] text-caption"><span class="mr-1">📡</span>All connected relays</span>
         {/if}
       </div>
 
       <button
-        class="cursor-pointer hover:opacity-80 transition-opacity flex-shrink-0"
+        class="composer-modal-close cursor-pointer hover:opacity-80 transition-opacity flex-shrink-0"
         style="color: var(--color-text-primary)"
         on:click={() => composer?.requestClose()}
         aria-label="Close"
@@ -164,5 +164,52 @@
   select option {
     background: var(--color-input-bg);
     color: var(--color-text-primary);
+  }
+
+  /* ===== Prototype: mobile composer framed like the wallet =====
+     On mobile/tablet (< lg, matching the bottom nav's visibility), inset
+     the composer into the region between the header and bottom nav and
+     drop the overlay below the nav strips so both stay visible/tappable,
+     exactly like the wallet panel. */
+  @media (max-width: 1023.98px) {
+    /* Overlay backdrop below the nav strips (header z-30, bottom nav z-40).
+       Non-nested :has(): match the backdrop by its child dialog that
+       contains a descendant .composer-modal-body. */
+    :global(div:has(> dialog .composer-modal-body)) {
+      z-index: 20 !important;
+    }
+
+    :global(dialog:has(.composer-modal-body)) {
+      top: var(--header-h) !important;
+      bottom: auto !important;
+      left: 0 !important;
+      right: auto !important;
+      width: 100dvw !important;
+      max-width: 100dvw !important;
+      height: calc(100dvh - var(--header-h) - var(--bottom-nav-height, 0px)) !important;
+      max-height: calc(100dvh - var(--header-h) - var(--bottom-nav-height, 0px)) !important;
+      min-height: 0 !important;
+      --tw-translate-x: 0px !important;
+      --tw-translate-y: 0px !important;
+      transform: translate(0px, 0px) !important;
+      border-radius: 0 !important;
+      margin: 0 !important;
+    }
+
+    /* Bump header visual elements for touch. */
+    .composer-modal-label {
+      font-size: 0.875rem;
+    }
+    .composer-modal-select {
+      font-size: 0.875rem;
+      padding: 0.375rem 0.625rem;
+    }
+    .composer-modal-hint {
+      font-size: 0.8125rem;
+    }
+    .composer-modal-close :global(svg) {
+      width: 28px;
+      height: 28px;
+    }
   }
 </style>

--- a/src/components/PostModal.svelte
+++ b/src/components/PostModal.svelte
@@ -64,7 +64,7 @@
   }
 </script>
 
-<Modal bind:open allowOverflow={false} noHeader={true} wide={!isPosting} maxWidth={isPosting ? '22rem' : null} autoHeight={isPosting} cleanup={handleBackdropClose} locked={isPosting}>
+<Modal bind:open allowOverflow={false} noHeader={true} wide={!isPosting} maxWidth={isPosting ? '22rem' : null} autoHeight={isPosting} cleanup={handleBackdropClose} locked={isPosting} fullScreenMobile={!isPosting}>
   <div class="flex flex-col gap-4 flex-1 min-h-0 overflow-hidden">
     <!-- Header: relay selector + contextual hint on left, X on right -->
     {#if !isPosting}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -558,13 +558,17 @@
           {/if}
         </div>
       </div>
-      {#if !$page.url.pathname.startsWith('/messages') && !$page.url.pathname.startsWith('/groups')}
+      {#if !$page.url.pathname.startsWith('/messages') && !$page.url.pathname.startsWith('/groups') && !$postComposerOpen}
         <CreateMenuButton variant="floating" />
       {/if}
       <BottomNav />
       <CookingToolsWidget />
       {#if showCheffy}
-        <CheffyLauncher />
+        <!-- Hide the floating Cheffy launcher while the composer is open so
+             it doesn't float over the inset composer panel. -->
+        {#if !$postComposerOpen}
+          <CheffyLauncher />
+        {/if}
         <CheffyMessenger />
       {/if}
       <UserSidePanel />


### PR DESCRIPTION
## Summary

Overhauls the mobile note composer.

### Composer core
- Fullscreen composer sheet on mobile.
- Multi-image picker with per-image upload progress.

### Mobile composer redesign (framed like the wallet)
- On mobile/tablet (`< lg`), the composer is inset into the region between the header and bottom nav, with its overlay dropped below the nav strips (`z-20`) so both stay visible/tappable — matching the wallet panel pattern.
- Avatar moved inline into the Write/Preview tab bar so the writing area spans the **full panel width** instead of being indented past the avatar.
- Suppressed the focus outline on the writing area (the caret already signals focus).
- Upsized for touch: 18px body text, larger tabs, 26px tool/clock icons, taller Cancel/Post buttons, bigger header controls.
- Shortened the all-relays hint to "All connected relays".
- While the composer is open, the floating compose FAB and Cheffy launcher are hidden so they don't float over the panel; both are also positioned off the real `--bottom-nav-height` so they clear the bottom nav.

## Notes
- The inset framing relies on the bottom nav's `--bottom-nav-height` and z-index layering; it renders correctly against the current nav and the redesigned nav (PRs #488/#489).

## Testing
- `pnpm run check` passes (no new errors).
- Verified across mobile, tablet, and desktop widths in a local dev server.

🥘 Generated with [Claude Code](https://claude.com/claude-code)
