### PR TITLE
fix(lightbox): portal to body so it's closable from transformed modals

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.568",
+  "version": "4.2.569",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/MediaLightbox.svelte
+++ b/src/components/MediaLightbox.svelte
@@ -11,10 +11,18 @@
    * backdrop gutters, outside the photo frame.
    */
   import { onMount, onDestroy } from 'svelte';
+  import { portal } from './Modal.svelte';
 
   export let images: string[] = [];
   export let index = 0;
   export let onClose: () => void = () => {};
+
+  // Render at document.body so the lightbox escapes any transformed /
+  // stacking-context ancestor (e.g. the composer modal dialog, which uses
+  // a CSS transform — that would otherwise size our fixed overlay to the
+  // dialog and let the nav strips paint over it, hiding the close button).
+  const portalTarget: HTMLElement | null =
+    typeof document !== 'undefined' ? document.body : null;
 
   $: count = images.length;
   $: multiple = count > 1;
@@ -143,7 +151,8 @@
 
 <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-noninteractive-element-interactions -->
 <div
-  class="fixed inset-0 z-50 bg-black/85 overflow-hidden"
+  class="fixed inset-0 z-[10001] bg-black/85 overflow-hidden"
+  use:portal={portalTarget ?? document.body}
   on:click={onClose}
   role="dialog"
   aria-modal="true"


### PR DESCRIPTION
## Summary

Fixes the image lightbox being hard to close when opened from inside a transformed modal — most visibly the **composer preview** on mobile.

## Problem

The composer dialog uses a CSS `transform`. A `position: fixed` descendant is positioned relative to the nearest transformed ancestor, not the viewport — so the lightbox's `fixed inset-0` overlay sized itself to the composer dialog instead of the screen, and its `z-50` was trapped in the dialog's stacking context. The nav strips painted over it and the close button landed in a cramped/covered spot, making it very hard to dismiss (especially on touch).

## Fix

- Portal the lightbox to `document.body` so it escapes any transformed / stacking-context ancestor and covers the true viewport.
- Raise its z-index above modal backdrops (`z-[10001]`) so it sits above both the mobile composer overlay and the desktop modal backdrop.

Close button (X), backdrop tap, and Escape now all work full-screen on mobile and desktop. Also hardens the lightbox anywhere else it might open inside a transformed container.

## Testing
- `pnpm run check` passes (no new errors).
- Verified: composer → add image → Preview → tap image → full-screen lightbox with an easily reachable close.

🍜 Generated with [Claude Code](https://claude.com/claude-code)
