### PR TITLE
fix(og): server-side social preview cards for note, reads & profile links

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.575",
+  "version": "4.2.577",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,6 +1,16 @@
 import type { Handle, HandleServerError } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
-import { isCrawler, matchRecipeOgRoute, renderRecipeOgForCrawler } from '$lib/recipeOgHtml.server';
+import {
+  isCrawler,
+  matchRecipeOgRoute,
+  renderRecipeOgForCrawler,
+  matchNoteOgRoute,
+  renderNoteOgForCrawler,
+  matchReadsOgRoute,
+  renderReadsOgForCrawler,
+  matchProfileOgRoute,
+  renderProfileOgForCrawler
+} from '$lib/recipeOgHtml.server';
 
 /**
  * Log the real server-side error (with stack) instead of letting SvelteKit
@@ -101,10 +111,21 @@ async function maybeRenderBotOg(event: Parameters<Handle>[0]['event']): Promise<
   try {
     if (event.request.method !== 'GET') return null;
     if (!isCrawler(event.request.headers.get('user-agent'))) return null;
-    const matched = matchRecipeOgRoute(event.url.pathname);
-    if (!matched) return null;
 
-    const html = await renderRecipeOgForCrawler(matched.prefix, matched.slug, event.url.origin);
+    const path = event.url.pathname;
+    const recipe = matchRecipeOgRoute(path);
+    const note = recipe ? null : matchNoteOgRoute(path);
+    const reads = recipe || note ? null : matchReadsOgRoute(path);
+    const profile = recipe || note || reads ? null : matchProfileOgRoute(path);
+    if (!recipe && !note && !reads && !profile) return null;
+
+    const html = recipe
+      ? await renderRecipeOgForCrawler(recipe.prefix, recipe.slug, event.url.origin)
+      : note
+        ? await renderNoteOgForCrawler(note.slug, event.url.origin)
+        : reads
+          ? await renderReadsOgForCrawler(reads.slug, event.url.origin)
+          : await renderProfileOgForCrawler(profile!.slug, event.url.origin, path);
     return new Response(html, {
       status: 200,
       headers: {

--- a/src/lib/noteOg.server.ts
+++ b/src/lib/noteOg.server.ts
@@ -1,0 +1,159 @@
+/**
+ * Server-only resolver for NOTE (kind:1) Open Graph metadata used by the
+ * crawler branch of the `handle` hook.
+ *
+ * Notes are the most-shared link type but had no server-side OG: the layout
+ * suppresses its generic tags for `/note1…` / `/nevent1…` routes (they're in
+ * `hasCustomOgTags`), yet the note's real tags are fetched client-side, so a
+ * JS-less crawler saw an empty card. This resolves the note event AND its
+ * author profile SERVER-SIDE (raw WebSocket relay race — no NDK, keeping the
+ * worker bundle small, same constraint as the recipe path) and builds a card.
+ *
+ * Mirrors recipeOg.server.ts: never throws, never hangs past the timeout.
+ */
+
+import { nip19 } from 'nostr-tools';
+import { raceRelays } from './recipePackOg.server';
+import {
+  capRecipeDescription,
+  type OgEventLike,
+  type RecipeOgMeta
+} from './recipeOgMeta';
+
+// The note event is the card; the author profile is a best-effort enrichment.
+// They're bounded SEPARATELY so a slow kind:0 relay can never consume the
+// note's budget and drop the whole card.
+const NOTE_TIMEOUT_MS = 4000;
+const AUTHOR_TIMEOUT_MS = 1500;
+const FALLBACK_IMAGE = 'https://zap.cooking/social-share.png';
+// First raster image URL in the note body → used as the card image.
+const IMG_RE = /(https?:\/\/[^\s"']+\.(?:jpe?g|png|gif|webp|avif|bmp)(?:\?[^\s"']*)?)/i;
+// Trailing punctuation that markdown/plain text can leave on a captured URL
+// (e.g. from `![](url)` or `(url).`) — strip it so og:image stays valid.
+const TRAILING_PUNCT_RE = /[)\]}.,!?;'"]+$/;
+
+/** Resolve `p`, but never take longer than `ms`; on timeout or error → `fallback`. */
+function withTimeout<T>(p: Promise<T>, ms: number, fallback: T): Promise<T> {
+  return Promise.race([
+    p.catch(() => fallback),
+    new Promise<T>((resolve) => setTimeout(() => resolve(fallback), ms))
+  ]);
+}
+
+interface NoteAuthor {
+  name?: string;
+  picture?: string;
+}
+
+export interface NoteOgData {
+  event: OgEventLike;
+  author: NoteAuthor;
+}
+
+/** Emitted when the note can't be resolved — a generic but valid note card. */
+export const FALLBACK_NOTE_OG: RecipeOgMeta = {
+  pageTitle: 'Note - zap.cooking',
+  ogTitle: 'A note on Zap Cooking',
+  description: 'A note shared on zap.cooking - Food. Friends. Freedom.',
+  image: FALLBACK_IMAGE,
+  publishedAt: null,
+  authorPubkey: null
+};
+
+/** note1… / nevent1… / raw-hex → event id, or null. */
+function decodeNoteId(slug: string): string | null {
+  if (/^[0-9a-f]{64}$/i.test(slug)) return slug;
+  try {
+    const decoded = nip19.decode(slug);
+    if (decoded.type === 'note') return decoded.data as string;
+    if (decoded.type === 'nevent') return (decoded.data as nip19.EventPointer).id;
+  } catch {
+    /* fall through */
+  }
+  return null;
+}
+
+function toOgEvent(evt: unknown): OgEventLike | null {
+  if (!evt || typeof evt !== 'object') return null;
+  const e = evt as Record<string, unknown>;
+  if (!Array.isArray(e.tags)) return null;
+  return {
+    tags: e.tags as string[][],
+    content: typeof e.content === 'string' ? e.content : '',
+    pubkey: typeof e.pubkey === 'string' ? e.pubkey : undefined,
+    created_at: typeof e.created_at === 'number' ? e.created_at : undefined,
+    kind: typeof e.kind === 'number' ? e.kind : undefined
+  };
+}
+
+async function resolveNote(slug: string): Promise<NoteOgData | null> {
+  const id = decodeNoteId(slug);
+  if (!id) return null;
+
+  // Bound the note fetch on its own budget.
+  const event = toOgEvent(await withTimeout(raceRelays({ ids: [id] }), NOTE_TIMEOUT_MS, null));
+  if (!event) return null;
+
+  // Author kind:0 profile — best-effort, on its OWN short budget so it can't
+  // starve the note. A timeout just yields a generic title/image.
+  let author: NoteAuthor = {};
+  if (event.pubkey) {
+    const meta = await withTimeout(
+      raceRelays({ kinds: [0], authors: [event.pubkey] }),
+      AUTHOR_TIMEOUT_MS,
+      null
+    );
+    const content = (meta as Record<string, unknown> | null)?.content;
+    if (typeof content === 'string') {
+      try {
+        const p = JSON.parse(content) as Record<string, string>;
+        author = {
+          name: p.display_name || p.displayName || p.name,
+          picture: p.picture
+        };
+      } catch {
+        /* malformed profile JSON — keep empty author */
+      }
+    }
+  }
+
+  return { event, author };
+}
+
+function cleanNoteText(content: string): string {
+  return content
+    .replace(/https?:\/\/[^\s]+/g, '')
+    .replace(/nostr:[^\s]+/g, '')
+    .replace(/#\[\d+\]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function getNoteOgMeta({ event, author }: NoteOgData): RecipeOgMeta {
+  const name = author.name?.trim();
+  const text = cleanNoteText(event.content);
+  const imageInBody = event.content.match(IMG_RE)?.[1]?.replace(TRAILING_PUNCT_RE, '');
+
+  return {
+    pageTitle: name ? `${name} on zap.cooking` : 'Note - zap.cooking',
+    ogTitle: name ? `${name} on Zap Cooking` : 'A note on Zap Cooking',
+    description:
+      capRecipeDescription(text) || 'A note shared on zap.cooking - Food. Friends. Freedom.',
+    image: imageInBody || author.picture || FALLBACK_IMAGE,
+    publishedAt: typeof event.created_at === 'number' ? event.created_at : null,
+    authorPubkey: typeof event.pubkey === 'string' ? event.pubkey : null
+  };
+}
+
+/**
+ * Resolve a note for OG rendering. Never throws; the note and author fetches
+ * are each independently time-bounded (see NOTE_TIMEOUT_MS / AUTHOR_TIMEOUT_MS)
+ * so a slow author lookup can't drop the note card.
+ */
+export async function fetchNoteForOg(slug: string): Promise<NoteOgData | null> {
+  try {
+    return await resolveNote(slug);
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/profileOg.server.ts
+++ b/src/lib/profileOg.server.ts
@@ -1,0 +1,88 @@
+/**
+ * Server-only resolver for PROFILE (kind:0) Open Graph metadata used by the
+ * crawler branch of the `handle` hook.
+ *
+ * Profile links (`/npub1…`, `/nprofile1…`, `/user/npub1…`) previewed as the
+ * generic site card because their real tags are fetched client-side. This
+ * resolves the author's kind:0 metadata SERVER-SIDE (raw-WebSocket relay race,
+ * no NDK — same bundle-safe approach as recipes/notes) into a profile card.
+ *
+ * Never throws, never hangs past the timeout.
+ */
+
+import { nip19 } from 'nostr-tools';
+import { raceRelays } from './recipePackOg.server';
+import { capRecipeDescription, type RecipeOgMeta } from './recipeOgMeta';
+
+const RESOLVE_TIMEOUT_MS = 4000;
+const FALLBACK_IMAGE = 'https://zap.cooking/social-share.png';
+
+/** Emitted when the profile can't be resolved — a generic but valid card. */
+export const FALLBACK_PROFILE_OG: RecipeOgMeta = {
+  pageTitle: 'Profile - zap.cooking',
+  ogTitle: 'A cook on Zap Cooking',
+  description: 'A profile on zap.cooking - Food. Friends. Freedom.',
+  image: FALLBACK_IMAGE,
+  publishedAt: null,
+  authorPubkey: null
+};
+
+/** npub1… / nprofile1… / raw-hex → hex pubkey, or null. */
+function decodePubkey(slug: string): string | null {
+  if (/^[0-9a-f]{64}$/i.test(slug)) return slug;
+  try {
+    const decoded = nip19.decode(slug);
+    if (decoded.type === 'npub') return decoded.data as string;
+    if (decoded.type === 'nprofile') return (decoded.data as nip19.ProfilePointer).pubkey;
+  } catch {
+    /* fall through */
+  }
+  return null;
+}
+
+async function resolveProfile(slug: string): Promise<RecipeOgMeta | null> {
+  const pubkey = decodePubkey(slug);
+  if (!pubkey) return null;
+
+  const meta = await raceRelays({ kinds: [0], authors: [pubkey] });
+  const content = (meta as Record<string, unknown> | null)?.content;
+  if (typeof content !== 'string') return null;
+
+  let profile: Record<string, string>;
+  try {
+    profile = JSON.parse(content) as Record<string, string>;
+  } catch {
+    return null;
+  }
+
+  const name = (profile.display_name || profile.displayName || profile.name || '').trim();
+  const about = (profile.about || '').replace(/\s+/g, ' ').trim();
+  // Prefer the wide banner for the large card; fall back to the avatar.
+  const image = profile.banner || profile.picture || FALLBACK_IMAGE;
+
+  return {
+    pageTitle: name ? `${name} - zap.cooking` : 'Profile - zap.cooking',
+    ogTitle: name || 'A cook on Zap Cooking',
+    description: about
+      ? capRecipeDescription(about)
+      : 'A profile on zap.cooking - Food. Friends. Freedom.',
+    image,
+    publishedAt: null,
+    authorPubkey: null
+  };
+}
+
+/**
+ * Resolve a profile's OG metadata. Never throws and never hangs past
+ * RESOLVE_TIMEOUT_MS — returns null on decode failure, timeout, or not-found.
+ */
+export async function fetchProfileOgMeta(slug: string): Promise<RecipeOgMeta | null> {
+  try {
+    const timeout = new Promise<null>((resolve) =>
+      setTimeout(() => resolve(null), RESOLVE_TIMEOUT_MS)
+    );
+    return await Promise.race([resolveProfile(slug), timeout]);
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/recipeOgHtml.server.ts
+++ b/src/lib/recipeOgHtml.server.ts
@@ -20,6 +20,8 @@
 
 import { getRecipeOgMeta, FALLBACK_RECIPE_OG, type RecipeOgMeta } from './recipeOgMeta';
 import { fetchRecipeEventForOg } from './recipeOg.server';
+import { fetchNoteForOg, getNoteOgMeta, FALLBACK_NOTE_OG } from './noteOg.server';
+import { fetchProfileOgMeta, FALLBACK_PROFILE_OG } from './profileOg.server';
 
 /**
  * Crawler / link-unfurl User-Agents. Matched case-insensitively.
@@ -54,6 +56,43 @@ export function matchRecipeOgRoute(pathname: string): { prefix: string; slug: st
   // nip19.decode() and the hex test in recipeOg.server.ts both accept it as-is.
   return { prefix: m[1], slug: m[2] };
 }
+
+/** Top-level note routes (`/note1…`, `/nevent1…`) get bot OG injection too. */
+const NOTE_ROUTE_RE = /^\/((?:note1|nevent1)[0-9a-z]+)\/?$/i;
+
+export function matchNoteOgRoute(pathname: string): { slug: string } | null {
+  const m = pathname.match(NOTE_ROUTE_RE);
+  if (!m) return null;
+  return { slug: m[1] };
+}
+
+/** Long-form article routes (`/reads/naddr1…`). */
+const READS_ROUTE_RE = /^\/reads\/([^/]+)\/?$/;
+
+export function matchReadsOgRoute(pathname: string): { slug: string } | null {
+  const m = pathname.match(READS_ROUTE_RE);
+  if (!m) return null;
+  return { slug: m[1] };
+}
+
+/** Profile routes: `/npub1…`, `/nprofile1…`, and `/user/npub1…`. */
+const PROFILE_ROUTE_RE = /^\/(?:user\/)?((?:npub1|nprofile1)[0-9a-z]+)\/?$/i;
+
+export function matchProfileOgRoute(pathname: string): { slug: string } | null {
+  const m = pathname.match(PROFILE_ROUTE_RE);
+  if (!m) return null;
+  return { slug: m[1] };
+}
+
+/** Generic article card when a `/reads/` event can't be resolved. */
+const FALLBACK_ARTICLE_OG: RecipeOgMeta = {
+  pageTitle: 'Article - zap.cooking',
+  ogTitle: 'An article on Zap Cooking',
+  description: 'A long-form article shared on zap.cooking - Food. Friends. Freedom.',
+  image: 'https://zap.cooking/social-share.png',
+  publishedAt: null,
+  authorPubkey: null
+};
 
 function escapeAttr(value: string): string {
   return value
@@ -125,6 +164,61 @@ export async function renderRecipeOgForCrawler(
   try {
     const event = await fetchRecipeEventForOg(slug);
     if (event) meta = getRecipeOgMeta(event);
+  } catch {
+    /* keep fallback meta */
+  }
+  return renderDocument(meta, canonicalUrl);
+}
+
+/**
+ * Build the standalone crawler document for a matched note route. Never throws
+ * and never hangs: on any failure or relay timeout it emits a safe generic
+ * note card so the bot still gets a valid 200.
+ */
+export async function renderNoteOgForCrawler(slug: string, origin: string): Promise<string> {
+  const canonicalUrl = `${origin}/${slug}`;
+  let meta: RecipeOgMeta = FALLBACK_NOTE_OG;
+  try {
+    const data = await fetchNoteForOg(slug);
+    if (data) meta = getNoteOgMeta(data);
+  } catch {
+    /* keep fallback meta */
+  }
+  return renderDocument(meta, canonicalUrl);
+}
+
+/**
+ * Build the standalone crawler document for a `/reads/naddr…` article. Reuses
+ * the recipe resolver/derivation (both are kind:30023 with title/summary/image
+ * tags), with a generic article fallback. Never throws or hangs.
+ */
+export async function renderReadsOgForCrawler(slug: string, origin: string): Promise<string> {
+  const canonicalUrl = `${origin}/reads/${slug}`;
+  let meta: RecipeOgMeta = FALLBACK_ARTICLE_OG;
+  try {
+    const event = await fetchRecipeEventForOg(slug);
+    if (event) meta = getRecipeOgMeta(event);
+  } catch {
+    /* keep fallback meta */
+  }
+  return renderDocument(meta, canonicalUrl);
+}
+
+/**
+ * Build the standalone crawler document for a profile route (`/npub1…`,
+ * `/nprofile1…`, `/user/npub1…`). `pathname` is passed through so the canonical
+ * URL matches the actual route (top-level vs `/user/`). Never throws or hangs.
+ */
+export async function renderProfileOgForCrawler(
+  slug: string,
+  origin: string,
+  pathname: string
+): Promise<string> {
+  const canonicalUrl = `${origin}${pathname}`;
+  let meta: RecipeOgMeta = FALLBACK_PROFILE_OG;
+  try {
+    const resolved = await fetchProfileOgMeta(slug);
+    if (resolved) meta = resolved;
   } catch {
     /* keep fallback meta */
   }


### PR DESCRIPTION
## Summary

Shared zap.cooking links previewed blank or as the generic site card everywhere except recipes. Only recipe routes had server-side crawler OG; notes, long-form articles, and profiles fell through — the layout suppressed generic tags for some routes, and JS-less crawlers never saw the client-fetched tags.

This extends the existing bot-OG `handle` hook (raw-WebSocket relay race, no NDK — same bundle-safe approach as the recipe path) to three more content types:

- **Notes** — `/note1…`, `/nevent1…` → author name, note text, first image (→ author avatar → site image)
- **Long-form articles** — `/reads/naddr…` → article title, summary, image (reuses the kind:30023 resolver + `getRecipeOgMeta`)
- **Profiles** — `/npub1…`, `/nprofile1…`, `/user/npub1…` → display name, bio, banner (→ avatar → site image)

Each returns a standalone `summary_large_image` document with `cache-control: no-store` (fresh per scrape, never mixed with the human SPA), a 4s resolve ceiling, and a graceful generic fallback on any failure. Humans still fall through to the SPA unchanged.

## Files
- `src/lib/noteOg.server.ts`, `src/lib/profileOg.server.ts` — new resolvers
- `src/lib/recipeOgHtml.server.ts` — route matchers + renderers (reusing `renderDocument`)
- `src/hooks.server.ts` — dispatch recipe → note → reads → profile

## Testing
- `pnpm run check` passes.
- **Verified live** on the fork's Vercel deploy with a crawler UA (`facebookexternalhit`):
  - profile `/npub1…` → "The Daniel 🖖" + bio + avatar
  - `/user/npub1…` → same
  - note `/note1…` → note text + image
  - `/reads/naddr…` → article title + summary + image
- Human UA still receives the SPA; recipe routes unaffected.

🍜 Cooked up with [Claude Code](https://claude.com/claude-code)
