### PR TITLE
fix(api): NIP-98 auth for extract-recipe image/text

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,11 @@ MEMBERSHIP_ENABLED=true
 # Relay API Secret for pantry.zap.cooking
 RELAY_API_SECRET=your_relay_api_secret_here
 
+# Temporary rollout flag: when true, /api/extract-recipe accepts image/text
+# requests without a NIP-98 Authorization header (body pubkey only). Remove
+# after souschef deploy is confirmed and legacy log lines are quiet for 7 days.
+# EXTRACT_LEGACY_AUTH=true
+
 # ============================================
 # STRIPE CONFIGURATION (Credit Card Payments)
 # ============================================

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.574",
+  "version": "4.2.575",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.570",
+  "version": "4.2.571",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.573",
+  "version": "4.2.574",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.571",
+  "version": "4.2.572",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.572",
+  "version": "4.2.573",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -18,6 +18,8 @@ declare global {
           NOTIFICATION_PRIVATE_KEY?: string;
           CRON_SECRET?: string;
           MEMBERSHIP_ENABLED?: string;
+          /** Temporary rollout flag for /api/extract-recipe legacy body-pubkey auth. */
+          EXTRACT_LEGACY_AUTH?: string;
           /** OpenAI API key — used by /api/extract-recipe and /api/nourish. */
           OPENAI_API_KEY?: string;
           MEMBERSHIP_LIGHTNING_ADDRESS?: string;

--- a/src/lib/nip98.server.test.ts
+++ b/src/lib/nip98.server.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import {
   finalizeEvent,
   generateSecretKey,
@@ -12,13 +12,8 @@ import { normalizeUrl, sha256Hex } from './nip98';
 const ENDPOINT = 'https://zap.cooking/api/extract-recipe';
 const METHOD = 'POST';
 
-let sk: Uint8Array;
-let pubkey: string;
-
-beforeAll(() => {
-  sk = generateSecretKey();
-  pubkey = getPublicKey(sk);
-});
+const sk = generateSecretKey();
+const pubkey = getPublicKey(sk);
 
 async function signEvent(
   template: EventTemplate,

--- a/src/lib/nip98.server.test.ts
+++ b/src/lib/nip98.server.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  finalizeEvent,
+  generateSecretKey,
+  getPublicKey,
+  type EventTemplate,
+  type VerifiedEvent
+} from 'nostr-tools';
+import { verifyNip98 } from './nip98.server';
+import { normalizeUrl, sha256Hex } from './nip98';
+
+const ENDPOINT = 'https://zap.cooking/api/extract-recipe';
+const METHOD = 'POST';
+
+let sk: Uint8Array;
+let pubkey: string;
+
+beforeAll(() => {
+  sk = generateSecretKey();
+  pubkey = getPublicKey(sk);
+});
+
+async function signEvent(
+  template: EventTemplate,
+  secretKey: Uint8Array = sk
+): Promise<VerifiedEvent> {
+  return finalizeEvent(template, secretKey);
+}
+
+async function buildSignedAuthEvent(opts: {
+  url?: string;
+  method?: string;
+  bodyBytes?: Uint8Array;
+  created_at?: number;
+  kind?: number;
+  secretKey?: Uint8Array;
+}): Promise<VerifiedEvent> {
+  const tags: string[][] = [
+    ['u', normalizeUrl(opts.url ?? ENDPOINT)],
+    ['method', (opts.method ?? METHOD).toUpperCase()]
+  ];
+  if (opts.bodyBytes !== undefined) {
+    tags.push(['payload', await sha256Hex(opts.bodyBytes)]);
+  }
+  return signEvent(
+    {
+      kind: opts.kind ?? 27235,
+      created_at: opts.created_at ?? Math.floor(Date.now() / 1000),
+      tags,
+      content: ''
+    },
+    opts.secretKey ?? sk
+  );
+}
+
+function encodeAuthHeader(event: VerifiedEvent): string {
+  return `Nostr ${btoa(JSON.stringify(event))}`;
+}
+
+function makeRequest(opts: {
+  url?: string;
+  method?: string;
+  body?: string;
+  authorization?: string;
+}): Request {
+  const headers = new Headers({ 'Content-Type': 'application/json' });
+  if (opts.authorization) headers.set('Authorization', opts.authorization);
+  return new Request(opts.url ?? ENDPOINT, {
+    method: opts.method ?? METHOD,
+    headers,
+    body: opts.body
+  });
+}
+
+describe('verifyNip98', () => {
+  it('accepts a valid event and returns the signer pubkey when expectedPubkey is omitted', async () => {
+    const body = JSON.stringify({ type: 'text', textData: 'hello', pubkey });
+    const bodyBytes = new TextEncoder().encode(body);
+    const event = await buildSignedAuthEvent({ bodyBytes });
+    const request = makeRequest({ body, authorization: encodeAuthHeader(event) });
+
+    const result = await verifyNip98(request, { bodyBytes });
+    expect(result).toEqual({ ok: true, pubkey });
+  });
+
+  it('rejects wrong kind', async () => {
+    const body = '{}';
+    const bodyBytes = new TextEncoder().encode(body);
+    const event = await buildSignedAuthEvent({ bodyBytes, kind: 1 });
+    const request = makeRequest({ body, authorization: encodeAuthHeader(event) });
+
+    const result = await verifyNip98(request, { bodyBytes });
+    expect(result).toEqual({ ok: false, reason: 'wrong-kind' });
+  });
+
+  it('rejects bad signature', async () => {
+    const body = '{}';
+    const bodyBytes = new TextEncoder().encode(body);
+    const event = await buildSignedAuthEvent({ bodyBytes });
+    const tampered = { ...event, sig: '0'.repeat(128) };
+    const request = makeRequest({ body, authorization: encodeAuthHeader(tampered as VerifiedEvent) });
+
+    const result = await verifyNip98(request, { bodyBytes });
+    expect(result).toEqual({ ok: false, reason: 'invalid-signature' });
+  });
+
+  it('rejects tampered event id', async () => {
+    const body = '{}';
+    const bodyBytes = new TextEncoder().encode(body);
+    const event = await buildSignedAuthEvent({ bodyBytes });
+    const tampered = { ...event, id: 'f'.repeat(64) };
+    const request = makeRequest({ body, authorization: encodeAuthHeader(tampered as VerifiedEvent) });
+
+    const result = await verifyNip98(request, { bodyBytes });
+    expect(result).toEqual({ ok: false, reason: 'invalid-signature' });
+  });
+
+  it('rejects created_at more than 61s in the past', async () => {
+    const body = '{}';
+    const bodyBytes = new TextEncoder().encode(body);
+    const stale = Math.floor(Date.now() / 1000) - 61;
+    const event = await buildSignedAuthEvent({ bodyBytes, created_at: stale });
+    const request = makeRequest({ body, authorization: encodeAuthHeader(event) });
+
+    const result = await verifyNip98(request, { bodyBytes });
+    expect(result).toEqual({ ok: false, reason: 'stale-timestamp' });
+  });
+
+  it('rejects created_at more than 61s in the future', async () => {
+    const body = '{}';
+    const bodyBytes = new TextEncoder().encode(body);
+    const future = Math.floor(Date.now() / 1000) + 61;
+    const event = await buildSignedAuthEvent({ bodyBytes, created_at: future });
+    const request = makeRequest({ body, authorization: encodeAuthHeader(event) });
+
+    const result = await verifyNip98(request, { bodyBytes });
+    expect(result).toEqual({ ok: false, reason: 'stale-timestamp' });
+  });
+
+  it('rejects u-tag URL mismatch', async () => {
+    const body = '{}';
+    const bodyBytes = new TextEncoder().encode(body);
+    const event = await buildSignedAuthEvent({
+      bodyBytes,
+      url: 'https://zap.cooking/api/other-endpoint'
+    });
+    const request = makeRequest({ body, authorization: encodeAuthHeader(event) });
+
+    const result = await verifyNip98(request, { bodyBytes });
+    expect(result).toEqual({ ok: false, reason: 'url-mismatch' });
+  });
+
+  it('rejects method mismatch', async () => {
+    const body = '{}';
+    const bodyBytes = new TextEncoder().encode(body);
+    const event = await buildSignedAuthEvent({ bodyBytes, method: 'GET' });
+    const request = makeRequest({ body, authorization: encodeAuthHeader(event) });
+
+    const result = await verifyNip98(request, { bodyBytes });
+    expect(result).toEqual({ ok: false, reason: 'method-mismatch' });
+  });
+
+  it('rejects malformed base64', async () => {
+    const body = '{}';
+    const bodyBytes = new TextEncoder().encode(body);
+    const request = makeRequest({ body, authorization: 'Nostr !!!not-base64!!!' });
+
+    const result = await verifyNip98(request, { bodyBytes });
+    expect(result).toEqual({ ok: false, reason: 'malformed-header' });
+  });
+
+  it('rejects malformed JSON in header', async () => {
+    const body = '{}';
+    const bodyBytes = new TextEncoder().encode(body);
+    const request = makeRequest({
+      body,
+      authorization: `Nostr ${btoa('not json')}`
+    });
+
+    const result = await verifyNip98(request, { bodyBytes });
+    expect(result).toEqual({ ok: false, reason: 'malformed-header' });
+  });
+
+  it('rejects payload-tag mismatch when bodyBytes provided', async () => {
+    const signedBody = JSON.stringify({ type: 'text', textData: 'signed' });
+    const sentBody = JSON.stringify({ type: 'text', textData: 'sent' });
+    const signedBytes = new TextEncoder().encode(signedBody);
+    const sentBytes = new TextEncoder().encode(sentBody);
+    const event = await buildSignedAuthEvent({ bodyBytes: signedBytes });
+    const request = makeRequest({ body: sentBody, authorization: encodeAuthHeader(event) });
+
+    const result = await verifyNip98(request, { bodyBytes: sentBytes });
+    expect(result).toEqual({ ok: false, reason: 'payload-mismatch' });
+  });
+
+  it('rejects expectedPubkey mismatch when the param is provided', async () => {
+    const otherSk = generateSecretKey();
+    const body = '{}';
+    const bodyBytes = new TextEncoder().encode(body);
+    const event = await buildSignedAuthEvent({ bodyBytes, secretKey: otherSk });
+    const request = makeRequest({ body, authorization: encodeAuthHeader(event) });
+
+    const result = await verifyNip98(request, {
+      bodyBytes,
+      expectedPubkey: pubkey
+    });
+    expect(result).toEqual({ ok: false, reason: 'pubkey-mismatch' });
+  });
+
+  it('accepts when expectedPubkey matches the signer', async () => {
+    const body = '{}';
+    const bodyBytes = new TextEncoder().encode(body);
+    const event = await buildSignedAuthEvent({ bodyBytes });
+    const request = makeRequest({ body, authorization: encodeAuthHeader(event) });
+
+    const result = await verifyNip98(request, { bodyBytes, expectedPubkey: pubkey });
+    expect(result).toEqual({ ok: true, pubkey });
+  });
+});

--- a/src/lib/nip98.server.ts
+++ b/src/lib/nip98.server.ts
@@ -53,7 +53,8 @@ const DEFAULT_MAX_SKEW_SECONDS = 60;
 export async function verifyNip98(
   request: Request,
   opts: {
-    expectedPubkey: string;
+    /** When set, the signing pubkey must match (admin / check-status). Omitted → return event pubkey. */
+    expectedPubkey?: string;
     bodyBytes?: Uint8Array;
     maxSkewSeconds?: number;
   }
@@ -120,10 +121,9 @@ export async function verifyNip98(
     }
   }
 
-  // Identity gate — only the expected pubkey is authorized for this
-  // endpoint. Signature was valid (the caller proved they hold some
-  // key), but only ADMIN_PUBKEY is allowed to rescore.
-  if (event.pubkey !== opts.expectedPubkey) {
+  // Identity gate — when callers supply expectedPubkey (admin routes,
+  // check-status owner lookup), only that pubkey is authorized.
+  if (opts.expectedPubkey !== undefined && event.pubkey !== opts.expectedPubkey) {
     return { ok: false, reason: 'pubkey-mismatch' };
   }
 

--- a/src/routes/api/extract-recipe/+server.ts
+++ b/src/routes/api/extract-recipe/+server.ts
@@ -16,8 +16,10 @@
  *                            endpoint can't be used as a quieter bypass
  *                            of /public's cap.
  *   - type: 'image'|'text' — requires active membership (any tier).
- *                            `pubkey` is required and checked via
- *                            `hasActiveMembership`.
+ *                            Identity is proven via NIP-98 HTTP Auth
+ *                            (kind-27235 Authorization header). Legacy
+ *                            body-pubkey auth remains behind
+ *                            EXTRACT_LEGACY_AUTH for rollout compatibility.
  *
  * The "pubkey optional" part: for URL imports `pubkey` is no longer
  * required in the request body. The field is still accepted so existing
@@ -31,6 +33,7 @@ import { json, type RequestHandler } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { parseRecipe, type ParseInput } from '$lib/parseRecipe.server';
 import { checkPerIpRateLimit } from '$lib/ipRateLimit.server';
+import { verifyNip98 } from '$lib/nip98.server';
 
 // URL imports on this endpoint share the same per-IP cap as the public
 // sibling so a caller can't route around /public/'s rate limit by
@@ -46,9 +49,16 @@ export const POST: RequestHandler = async ({ request, getClientAddress, platform
       return json({ success: false, error: 'OpenAI API key not configured' }, { status: 500 });
     }
 
+    let bodyBytes: Uint8Array;
+    try {
+      bodyBytes = new Uint8Array(await request.arrayBuffer());
+    } catch {
+      return json({ success: false, error: 'Invalid request body' }, { status: 400 });
+    }
+
     let body: Record<string, unknown>;
     try {
-      body = (await request.json()) as Record<string, unknown>;
+      body = JSON.parse(new TextDecoder().decode(bodyBytes)) as Record<string, unknown>;
     } catch {
       return json({ success: false, error: 'Invalid JSON body' }, { status: 400 });
     }
@@ -64,20 +74,44 @@ export const POST: RequestHandler = async ({ request, getClientAddress, platform
 
     // Gate — image/text remain premium, URL is free for everyone.
     if (type === 'image' || type === 'text') {
+      let authPubkey: string;
+
+      if (request.headers.get('Authorization')) {
+        const verification = await verifyNip98(request, { bodyBytes });
+        if (!verification.ok) {
+          return json(
+            { success: false, error: 'Authentication required for AI recipe extraction' },
+            { status: 401 }
+          );
+        }
+        authPubkey = verification.pubkey;
+      } else {
+        const legacyAuth = platform?.env?.EXTRACT_LEGACY_AUTH || env.EXTRACT_LEGACY_AUTH;
+        if (legacyAuth?.toLowerCase() === 'true') {
+          console.log('extract-recipe: legacy body-pubkey auth used');
+          if (typeof pubkey !== 'string' || pubkey.trim().length === 0) {
+            return json(
+              { success: false, error: 'Authentication required for AI recipe extraction' },
+              { status: 401 }
+            );
+          }
+          authPubkey = pubkey.trim();
+        } else {
+          return json(
+            { success: false, error: 'Authentication required for AI recipe extraction' },
+            { status: 401 }
+          );
+        }
+      }
+
       const MEMBERSHIP_ENABLED =
         platform?.env?.MEMBERSHIP_ENABLED || env.MEMBERSHIP_ENABLED;
       if (MEMBERSHIP_ENABLED?.toLowerCase() === 'true') {
-        if (typeof pubkey !== 'string' || pubkey.trim().length === 0) {
-          return json(
-            { success: false, error: 'Premium membership required for AI recipe extraction' },
-            { status: 403 }
-          );
-        }
         const API_SECRET = platform?.env?.RELAY_API_SECRET || env.RELAY_API_SECRET;
         if (API_SECRET) {
           try {
             const { hasActiveMembership } = await import('$lib/membershipApi.server');
-            const isActive = await hasActiveMembership(pubkey, API_SECRET);
+            const isActive = await hasActiveMembership(authPubkey, API_SECRET);
             if (!isActive) {
               return json(
                 { success: false, error: 'Premium membership required for AI recipe extraction' },

--- a/src/routes/api/extract-recipe/extract-recipe.server.test.ts
+++ b/src/routes/api/extract-recipe/extract-recipe.server.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { env } from '$env/dynamic/private';
+import {
+  finalizeEvent,
+  generateSecretKey,
+  getPublicKey,
+  type EventTemplate,
+  type VerifiedEvent
+} from 'nostr-tools';
+import { normalizeUrl, sha256Hex } from '$lib/nip98';
+
+const { hasActiveMembership, parseRecipe, checkPerIpRateLimit } = vi.hoisted(() => ({
+  hasActiveMembership: vi.fn(),
+  parseRecipe: vi.fn(),
+  checkPerIpRateLimit: vi.fn()
+}));
+
+vi.mock('$lib/membershipApi.server', () => ({
+  hasActiveMembership
+}));
+
+vi.mock('$lib/parseRecipe.server', () => ({
+  parseRecipe
+}));
+
+vi.mock('$lib/ipRateLimit.server', () => ({
+  checkPerIpRateLimit
+}));
+
+import { POST } from './+server';
+
+const ENDPOINT = 'https://zap.cooking/api/extract-recipe';
+
+const MOCK_RECIPE = {
+  title: 'Test Recipe',
+  summary: '',
+  chefsnotes: '',
+  preptime: '',
+  cooktime: '',
+  servings: '',
+  ingredients: [],
+  directions: [],
+  tags: [],
+  imageUrls: []
+};
+
+let memberSk: Uint8Array;
+let memberPubkey: string;
+let nonMemberSk: Uint8Array;
+
+beforeEach(() => {
+  memberSk = generateSecretKey();
+  memberPubkey = getPublicKey(memberSk);
+  nonMemberSk = generateSecretKey();
+
+  env.OPENAI_API_KEY = 'test-openai-key';
+  env.MEMBERSHIP_ENABLED = 'true';
+  env.RELAY_API_SECRET = 'test-relay-secret';
+  delete env.EXTRACT_LEGACY_AUTH;
+
+  hasActiveMembership.mockReset();
+  hasActiveMembership.mockImplementation(async (pubkey: string) => pubkey === memberPubkey);
+
+  parseRecipe.mockReset();
+  parseRecipe.mockResolvedValue({ ok: true, recipe: MOCK_RECIPE });
+
+  checkPerIpRateLimit.mockReset();
+  checkPerIpRateLimit.mockResolvedValue({ limited: false });
+});
+
+async function signAuthEvent(opts: {
+  bodyString: string;
+  url?: string;
+  secretKey?: Uint8Array;
+}): Promise<VerifiedEvent> {
+  const bodyBytes = new TextEncoder().encode(opts.bodyString);
+  const tags: string[][] = [
+    ['u', normalizeUrl(opts.url ?? ENDPOINT)],
+    ['method', 'POST'],
+    ['payload', await sha256Hex(bodyBytes)]
+  ];
+  const template: EventTemplate = {
+    kind: 27235,
+    created_at: Math.floor(Date.now() / 1000),
+    tags,
+    content: ''
+  };
+  return finalizeEvent(template, opts.secretKey ?? memberSk);
+}
+
+function authHeader(event: VerifiedEvent): string {
+  return `Nostr ${btoa(JSON.stringify(event))}`;
+}
+
+async function invokePost(opts: {
+  body: Record<string, unknown>;
+  authorization?: string;
+}) {
+  const bodyString = JSON.stringify(opts.body);
+  const headers = new Headers({ 'Content-Type': 'application/json' });
+  if (opts.authorization) headers.set('Authorization', opts.authorization);
+
+  const request = new Request(ENDPOINT, { method: 'POST', headers, body: bodyString });
+
+  return POST({
+    request,
+    getClientAddress: () => '127.0.0.1',
+    platform: undefined
+  } as Parameters<typeof POST>[0]);
+}
+
+describe('POST /api/extract-recipe auth', () => {
+  it('image + valid NIP-98 header + active member → 200', async () => {
+    const body = {
+      type: 'image',
+      imageData: 'data:image/jpeg;base64,abc',
+      pubkey: memberPubkey
+    };
+    const bodyString = JSON.stringify(body);
+    const event = await signAuthEvent({ bodyString });
+    const response = await invokePost({ body, authorization: authHeader(event) });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.success).toBe(true);
+    expect(hasActiveMembership).toHaveBeenCalledWith(memberPubkey, 'test-relay-secret');
+  });
+
+  it('image + valid NIP-98 header + non-member → 403', async () => {
+    const body = {
+      type: 'image',
+      imageData: 'data:image/jpeg;base64,abc',
+      pubkey: getPublicKey(nonMemberSk)
+    };
+    const bodyString = JSON.stringify(body);
+    const event = await signAuthEvent({ bodyString, secretKey: nonMemberSk });
+    const response = await invokePost({ body, authorization: authHeader(event) });
+
+    expect(response.status).toBe(403);
+    const data = await response.json();
+    expect(data.error).toMatch(/Premium membership required/);
+  });
+
+  it('image + no header + EXTRACT_LEGACY_AUTH off → 401', async () => {
+    const body = {
+      type: 'image',
+      imageData: 'data:image/jpeg;base64,abc',
+      pubkey: memberPubkey
+    };
+    const response = await invokePost({ body });
+
+    expect(response.status).toBe(401);
+    expect(parseRecipe).not.toHaveBeenCalled();
+  });
+
+  it('image + no header + EXTRACT_LEGACY_AUTH on → 200 via legacy path', async () => {
+    env.EXTRACT_LEGACY_AUTH = 'true';
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      const body = {
+        type: 'image',
+        imageData: 'data:image/jpeg;base64,abc',
+        pubkey: memberPubkey
+      };
+      const response = await invokePost({ body });
+
+      expect(response.status).toBe(200);
+      expect(logSpy).toHaveBeenCalledWith('extract-recipe: legacy body-pubkey auth used');
+      expect(hasActiveMembership).toHaveBeenCalledWith(memberPubkey, 'test-relay-secret');
+    } finally {
+      logSpy.mockRestore();
+      delete env.EXTRACT_LEGACY_AUTH;
+    }
+  });
+
+  it('image + header signed for a different URL → 401', async () => {
+    const body = {
+      type: 'image',
+      imageData: 'data:image/jpeg;base64,abc',
+      pubkey: memberPubkey
+    };
+    const bodyString = JSON.stringify(body);
+    const event = await signAuthEvent({
+      bodyString,
+      url: 'https://zap.cooking/api/other-endpoint'
+    });
+    const response = await invokePost({ body, authorization: authHeader(event) });
+
+    expect(response.status).toBe(401);
+    expect(parseRecipe).not.toHaveBeenCalled();
+  });
+
+  it('url type + no header → 200 (rate limit mocked)', async () => {
+    const body = { type: 'url', url: 'https://example.com/recipe' };
+    const response = await invokePost({ body });
+
+    expect(response.status).toBe(200);
+    expect(hasActiveMembership).not.toHaveBeenCalled();
+    expect(checkPerIpRateLimit).toHaveBeenCalled();
+    expect(parseRecipe).toHaveBeenCalled();
+  });
+});

--- a/src/routes/souschef/+page.svelte
+++ b/src/routes/souschef/+page.svelte
@@ -18,6 +18,7 @@
     type AnonImportHandoff
   } from '$lib/anonImport';
   import { detectMode } from '$lib/souschefDetect';
+  import { signNip98AuthHeader } from '$lib/nip98';
   import Button from '../../components/Button.svelte';
   import TagsComboBox from '../../components/TagsComboBox.svelte';
   import StringComboBox from '../../components/StringComboBox.svelte';
@@ -381,10 +382,21 @@
         extractionProgress = 'Fetching and extracting recipe from URL...';
       }
 
+      const bodyString = JSON.stringify(requestBody);
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+
+      if (mode === 'image' || mode === 'text') {
+        headers.Authorization = await signNip98AuthHeader($ndk, {
+          method: 'POST',
+          url: `${location.origin}/api/extract-recipe`,
+          bodyString
+        });
+      }
+
       const response = await fetch('/api/extract-recipe', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(requestBody)
+        headers,
+        body: bodyString
       });
 
       const data = await response.json();


### PR DESCRIPTION
## Summary

- Extend `verifyNip98` so `expectedPubkey` is optional; when omitted the verifier returns the signer's pubkey (existing admin/check-status callers unchanged).
- Gate `POST /api/extract-recipe` image/text on NIP-98 HTTP Auth; derive membership pubkey from the verified event, not the body.
- Add `EXTRACT_LEGACY_AUTH` rollout flag (body-pubkey fallback + log line when enabled).
- Souschef sends `Authorization: Nostr …` for image/text via `signNip98AuthHeader` (settings-page pattern).

## Auth semantics

| Case | Status |
|------|--------|
| image/text, no `Authorization`, `EXTRACT_LEGACY_AUTH` off | **401** |
| image/text, valid NIP-98, not a member | **403** |
| image/text, valid NIP-98, active member | **200** |
| `type: url`, no header | **200** (unchanged; per-IP rate limit still applies) |

## curl verification (preview / local with env)

Set `OPENAI_API_KEY`, `MEMBERSHIP_ENABLED=true`, `RELAY_API_SECRET`, and **do not** set `EXTRACT_LEGACY_AUTH` (or set it to `false`).

```bash
BASE="https://<preview-host>"  # or http://localhost:8788 after wrangler pages dev

# 1) image, no header → 401
curl -sS -w '\nHTTP %{http_code}\n' -X POST "$BASE/api/extract-recipe" \
  -H 'Content-Type: application/json' \
  -d '{"type":"image","imageData":"data:image/jpeg;base64,abc","pubkey":"<hex>"}'

# 2) image, valid NIP-98 from non-member key → 403
#    (build header with signNip98AuthHeader / kind-27235 over exact body bytes)
curl -sS -w '\nHTTP %{http_code}\n' -X POST "$BASE/api/extract-recipe" \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Nostr <base64-event>' \
  -d '{"type":"image","imageData":"data:image/jpeg;base64,abc","pubkey":"<non-member-hex>"}'

# 3) image, valid NIP-98 from active member key → 200
curl -sS -w '\nHTTP %{http_code}\n' -X POST "$BASE/api/extract-recipe" \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Nostr <base64-event>' \
  -d '{"type":"image","imageData":"data:image/jpeg;base64,abc","pubkey":"<member-hex>"}'

# 4) url, no header → 200
curl -sS -w '\nHTTP %{http_code}\n' -X POST "$BASE/api/extract-recipe" \
  -H 'Content-Type: application/json' \
  -d '{"type":"url","url":"https://example.com/recipe"}'
```

Automated coverage: `src/lib/nip98.server.test.ts` (13 cases) and `src/routes/api/extract-recipe/extract-recipe.server.test.ts` (6 route cases including legacy log assertion).

## EXTRACT_LEGACY_AUTH removal plan

1. Deploy this PR with `EXTRACT_LEGACY_AUTH=true` in production so existing clients without NIP-98 keep working during souschef rollout.
2. Deploy souschef NIP-98 client change (included in this PR).
3. Monitor logs for `extract-recipe: legacy body-pubkey auth used` — target **7 quiet days**.
4. Follow-up PR: remove the fallback branch and delete the env flag (config-only rollback window closes).

## Test plan

- [x] `npm run test` — 226 passed
- [x] `npm run build` — succeeded
- [ ] Manual curl on Cloudflare preview with real member key (401/403/200/200 above)


Made with [Cursor](https://cursor.com)