### PR TITLE
fix(note): unify thread reply layout, tighten spacing, add reply-target indicator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.579",
+  "version": "4.2.580",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.575",
+  "version": "4.2.576",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/CustomName.svelte
+++ b/src/components/CustomName.svelte
@@ -7,6 +7,9 @@
   export let pubkey: string;
   export let className: string = '';
   export let showNpub: boolean = false;
+  // Set false when the name is purely informational (no click behavior) so we
+  // don't render a keyboard-focusable button that does nothing.
+  export let interactive: boolean = true;
 
   const dispatch = createEventDispatcher();
 
@@ -72,35 +75,44 @@
   $: npub = formatNpub(pubkey);
 </script>
 
-<span
-  class="name {className}"
-  on:click={() => dispatch('click')}
-  role="button"
-  tabindex="0"
-  on:keydown={(e) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      dispatch('click');
-    }
-  }}
->
-  {displayName}
-  {#if showNpub}
-    <span class="npub">({npub})</span>
-  {/if}
-</span>
+{#if interactive}
+  <span
+    class="name name--interactive {className}"
+    on:click={() => dispatch('click')}
+    role="button"
+    tabindex="0"
+    on:keydown={(e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        dispatch('click');
+      }
+    }}
+  >
+    {displayName}
+    {#if showNpub}
+      <span class="npub">({npub})</span>
+    {/if}
+  </span>
+{:else}
+  <span class="name {className}">
+    {displayName}
+    {#if showNpub}
+      <span class="npub">({npub})</span>
+    {/if}
+  </span>
+{/if}
 
 <style>
-  .name {
+  .name--interactive {
     cursor: pointer;
     transition: color 0.2s ease;
   }
 
-  .name:hover {
+  .name--interactive:hover {
     color: #ec4700;
   }
 
-  .name:focus {
+  .name--interactive:focus {
     outline: 2px solid #ec4700;
     outline-offset: 2px;
     border-radius: 2px;

--- a/src/components/NoteContent.svelte
+++ b/src/components/NoteContent.svelte
@@ -319,7 +319,38 @@
   }
   $: displayContent = shouldCollapse && !isExpanded ? truncateAtUrlBoundary(content, maxLength) : content;
   $: finalParsedContent = splitLightningInvoices(parseContent(displayContent));
-  $: renderParts = groupMediaRuns(finalParsedContent);
+  // Whitespace, including zero-width / BOM characters that String.trim() leaves
+  // behind but that still occupy a line box under white-space: pre-wrap.
+  const WHITESPACE_ONLY = /^[\s\u200B\u200C\u200D\u2060\uFEFF]*$/;
+  const isWhitespaceText = (p?: { type?: string; content?: string }) =>
+    p?.type === 'text' && WHITESPACE_ONLY.test(p.content ?? '');
+  const isBlockOrMedia = (p?: { type?: string; prefix?: string; url?: string }) =>
+    p?.type === 'media-gallery' || isBlockPart(p);
+
+  // Strip whitespace-only text parts that only add dead vertical space: the
+  // ones at the very start/end of the note, and the blank lines authors leave
+  // around images/embeds (which bring their own margins). Under pre-wrap those
+  // render as full empty lines — e.g. the big gap between a trailing image and
+  // the action bar. Blank lines strictly between two text runs are kept so
+  // intentional paragraph breaks survive.
+  function normalizeParts<T extends { type: string; content?: string }>(parts: T[]): T[] {
+    const out = parts.filter((p, i) => {
+      if (!isWhitespaceText(p)) return true;
+      const atEdge = i === 0 || i === parts.length - 1;
+      const nearBlock = isBlockOrMedia(parts[i - 1]) || isBlockOrMedia(parts[i + 1]);
+      return !(atEdge || nearBlock);
+    });
+    if (out.length && out[0].type === 'text') {
+      out[0] = { ...out[0], content: (out[0].content ?? '').replace(/^\s+/, '') };
+    }
+    if (out.length && out[out.length - 1].type === 'text') {
+      const last = out[out.length - 1];
+      out[out.length - 1] = { ...last, content: (last.content ?? '').replace(/\s+$/, '') };
+    }
+    return out;
+  }
+
+  $: renderParts = normalizeParts(groupMediaRuns(finalParsedContent));
 
   const LIGHTNING_REGEX = /(?:(?:lightning|nostr):)?((lnbc|lntb|lnbcrt)[a-z0-9]{50,})/gi;
 
@@ -360,12 +391,15 @@
   }
 </script>
 
-<div
-  class="whitespace-pre-wrap break-words note-content {className} w-full"
-  style="white-space: pre-wrap;"
->
+<!-- white-space: pre-wrap lives on the text spans, NOT this container. On the
+     container it would also render the template's own inter-block whitespace
+     (newlines/indentation between the {#each}/{#if} branches) as literal text,
+     leaving a ~1-line dead gap after the last block element (e.g. below a
+     trailing image) on every note. Per-span pre-wrap keeps the author's real
+     newlines while letting the container collapse template whitespace. -->
+<div class="break-words note-content {className} w-full">
   {#each renderParts as part, i}
-    {#if part.type === 'text'}<span>{part.content}</span>
+    {#if part.type === 'text'}<span class="whitespace-pre-wrap break-words">{part.content}</span>
     {:else if part.type === 'media-gallery'}
       <!-- Consecutive media URLs render as a swipeable carousel:
            peeking 4:5 tiles with a count badge. -->

--- a/src/components/NoteContent.svelte
+++ b/src/components/NoteContent.svelte
@@ -326,6 +326,11 @@
     p?.type === 'text' && WHITESPACE_ONLY.test(p.content ?? '');
   const isBlockOrMedia = (p?: { type?: string; prefix?: string; url?: string }) =>
     p?.type === 'media-gallery' || isBlockPart(p);
+  // Edge trims remove only *complete* blank lines (everything up to/from the
+  // newline nearest the content, zero-width chars included) so same-line
+  // indentation before the first character or after the last is preserved.
+  const LEADING_BLANK_LINES = /^[\s\u200B\u200C\u200D\u2060\uFEFF]*\n/;
+  const TRAILING_BLANK_LINES = /\n[\s\u200B\u200C\u200D\u2060\uFEFF]*$/;
 
   // Strip whitespace-only text parts that only add dead vertical space: the
   // ones at the very start/end of the note, and the blank lines authors leave
@@ -341,11 +346,11 @@
       return !(atEdge || nearBlock);
     });
     if (out.length && out[0].type === 'text') {
-      out[0] = { ...out[0], content: (out[0].content ?? '').replace(/^\s+/, '') };
+      out[0] = { ...out[0], content: (out[0].content ?? '').replace(LEADING_BLANK_LINES, '') };
     }
     if (out.length && out[out.length - 1].type === 'text') {
       const last = out[out.length - 1];
-      out[out.length - 1] = { ...last, content: (last.content ?? '').replace(/\s+$/, '') };
+      out[out.length - 1] = { ...last, content: (last.content ?? '').replace(TRAILING_BLANK_LINES, '') };
     }
     return out;
   }

--- a/src/components/comments/ReplyComposer.svelte
+++ b/src/components/comments/ReplyComposer.svelte
@@ -38,6 +38,15 @@
 	import { showToast } from '$lib/toast';
 	import { timerSettings, saveTimerSettings, loadTimerSettings } from '$lib/timerSettings';
 	import NoteContent from '../NoteContent.svelte';
+	import CustomName from '../CustomName.svelte';
+
+	// Who this composer actually replies to: the specific comment (replyTo)
+	// when set, otherwise the root/parent event. Surfaced in the UI so the
+	// user can't accidentally reply to the wrong note (e.g. the thread root /
+	// themselves) without noticing.
+	$: replyTargetPubkey =
+		(replyTo ?? parentEvent)?.author?.pubkey || (replyTo ?? parentEvent)?.pubkey || '';
+	$: replyingToSelf = !!replyTargetPubkey && replyTargetPubkey === $userPublickey;
 
 	/**
 	 * Root event for NIP-22 / NIP-10 tag-building. Passed verbatim to
@@ -363,6 +372,17 @@
 </script>
 
 <div class="reply-composer" class:reply-composer--compact={compact}>
+	{#if replyTargetPubkey}
+		<div class="rc-replying-to">
+			<span class="rc-replying-to-label">Replying to</span>
+			{#if replyingToSelf}
+				<span>your own post</span>
+			{:else}
+				<CustomName pubkey={replyTargetPubkey} />
+			{/if}
+		</div>
+	{/if}
+
 	<!-- Write / Preview tab bar -->
 	<div class="rc-tab-bar">
 		<button
@@ -695,6 +715,21 @@
 		flex-direction: column;
 		gap: 0.5rem;
 		margin-top: 0.75rem;
+	}
+
+	/* Makes the reply target explicit so you can't accidentally answer the
+	   wrong note (e.g. the thread root / yourself). */
+	.rc-replying-to {
+		display: flex;
+		align-items: center;
+		gap: 0.3rem;
+		font-size: 0.8125rem;
+		font-weight: 500;
+		color: var(--color-text-primary);
+	}
+	.rc-replying-to-label {
+		color: var(--color-caption);
+		font-weight: 400;
 	}
 
 	.reply-composer--compact {

--- a/src/components/comments/ReplyComposer.svelte
+++ b/src/components/comments/ReplyComposer.svelte
@@ -378,7 +378,7 @@
 			{#if replyingToSelf}
 				<span>your own post</span>
 			{:else}
-				<CustomName pubkey={replyTargetPubkey} />
+				<CustomName pubkey={replyTargetPubkey} interactive={false} />
 			{/if}
 		</div>
 	{/if}

--- a/src/routes/[nip19]/+page.svelte
+++ b/src/routes/[nip19]/+page.svelte
@@ -699,8 +699,8 @@
          and Iris, and gives a wider, more readable reading column than
          indenting the body under the avatar. Parent-thread context notes
          above keep the compact indented layout. -->
-    <article class="py-6">
-      <div class="flex items-start justify-between gap-3 mb-3">
+    <article class="py-4">
+      <div class="flex items-start justify-between gap-3 mb-2">
         <div class="flex items-center gap-3 min-w-0">
           <a
             href="/user/{nip19.npubEncode(event.author?.hexpubkey || event.pubkey)}"
@@ -730,7 +730,7 @@
         </div>
         <PostActionsMenu {event} />
       </div>
-      <div class="text-[17px] leading-relaxed mb-4" style="color: var(--color-text-primary)">
+      <div class="text-[17px] leading-normal mb-2" style="color: var(--color-text-primary)">
         {#if event.kind === 1068}
           <PollDisplay {event} />
         {:else}
@@ -741,9 +741,7 @@
     </article>
 
     <!-- Replies Section -->
-    <div class="mt-2">
-
-
+    <div class="mt-1">
       <!-- Replies List -->
       {#if loadingReplies}
         <div class="space-y-3">
@@ -773,56 +771,53 @@
                   tabindex="0"
                   on:keydown|self={(e) => e.key === 'Enter' && goto(noteUrl(reply))}
                 >
-                  <div class="flex space-x-3">
-                    <a
-                      href="/user/{nip19.npubEncode(reply.author?.hexpubkey || reply.pubkey)}"
-                      class="flex-shrink-0"
-                      on:click|stopPropagation
-                    >
-                      <Avatar pubkey={reply.author?.hexpubkey || reply.pubkey} size={32} />
-                    </a>
-                    <div class="flex-1 min-w-0">
-                      <div class="flex items-center justify-between mb-1">
-                        <div class="flex items-center space-x-2 min-w-0">
-                          <a
-                            href="/user/{nip19.npubEncode(reply.author?.hexpubkey || reply.pubkey)}"
-                            class="font-medium text-sm transition-colors username-link truncate min-w-0"
-                            style="color: var(--color-text-primary)"
-                            on:click|stopPropagation
-                          >
-                            <CustomName pubkey={reply.author?.hexpubkey || reply.pubkey} />
-                          </a>
-                          <span class="text-xs flex-shrink-0" style="color: var(--color-caption)">·</span>
-                          <span class="text-xs whitespace-nowrap flex-shrink-0" style="color: var(--color-caption)">
-                            {reply.created_at ? formatTimeAgo(reply.created_at) : ''}
-                          </span>
-                        </div>
-                        <span on:click|stopPropagation>
-                          <PostActionsMenu event={reply} />
+                  <div class="flex items-center justify-between gap-3 mb-2">
+                    <div class="flex items-center gap-3 min-w-0">
+                      <a
+                        href="/user/{nip19.npubEncode(reply.author?.hexpubkey || reply.pubkey)}"
+                        class="flex-shrink-0"
+                        on:click|stopPropagation
+                      >
+                        <Avatar pubkey={reply.author?.hexpubkey || reply.pubkey} size={32} />
+                      </a>
+                      <div class="flex flex-col min-w-0">
+                        <a
+                          href="/user/{nip19.npubEncode(reply.author?.hexpubkey || reply.pubkey)}"
+                          class="font-semibold text-[15px] transition-colors username-link truncate min-w-0"
+                          style="color: var(--color-text-primary)"
+                          on:click|stopPropagation
+                        >
+                          <CustomName pubkey={reply.author?.hexpubkey || reply.pubkey} />
+                        </a>
+                        <span class="text-xs" style="color: var(--color-caption)">
+                          {reply.created_at ? formatTimeAgo(reply.created_at) : ''}
                         </span>
                       </div>
-                      <div
-                        class="text-base leading-relaxed"
-                        style="color: var(--color-text-primary)"
-                      >
-                        {#if reply.kind === 1068}
-                          <PollDisplay event={reply} />
-                        {:else}
-                          <NoteContent content={reply.content} showNostrEmbeds={false} />
-                        {/if}
-                      </div>
-                      <!-- Reply actions -->
-                      <div class="mt-2" on:click|stopPropagation>
-                        <NoteActionBar event={reply} />
-                      </div>
                     </div>
+                    <span on:click|stopPropagation>
+                      <PostActionsMenu event={reply} />
+                    </span>
+                  </div>
+                  <div
+                    class="text-[14px] leading-normal"
+                    style="color: var(--color-text-primary)"
+                  >
+                    {#if reply.kind === 1068}
+                      <PollDisplay event={reply} />
+                    {:else}
+                      <NoteContent content={reply.content} showNostrEmbeds={false} />
+                    {/if}
+                  </div>
+                  <!-- Reply actions -->
+                  <div class="mt-2" on:click|stopPropagation>
+                    <NoteActionBar event={reply} />
                   </div>
                 </article>
 
                 <!-- Nested Replies (1 level deep shown inline) -->
                 {#each getNestedReplies(reply.id).slice(0, 2) as nestedReply (nestedReply.id)}
                   {#if !$mutedPubkeys.has(nestedReply.author?.hexpubkey || nestedReply.pubkey)}
-                    <div class="ml-8 pl-3">
+                    <div class="ml-4 pl-4 border-l-2" style="border-color: var(--color-input-border)">
                       <article
                         class="py-2 cursor-pointer hover:bg-[var(--color-bg-hover,rgba(255,255,255,0.03))] rounded"
                         on:click={(e) => gotoNoteUnlessInteractive(e, nestedReply)}
@@ -830,60 +825,57 @@
                         tabindex="0"
                         on:keydown|self={(e) => e.key === 'Enter' && goto(noteUrl(nestedReply))}
                       >
-                        <div class="flex space-x-2">
-                          <a
-                            href="/user/{nip19.npubEncode(
-                              nestedReply.author?.hexpubkey || nestedReply.pubkey
-                            )}"
-                            class="flex-shrink-0"
-                            on:click|stopPropagation
-                          >
-                            <Avatar
-                              pubkey={nestedReply.author?.hexpubkey || nestedReply.pubkey}
-                              size={24}
-                            />
-                          </a>
-                          <div class="flex-1 min-w-0">
-                            <div class="flex items-center justify-between mb-0.5">
-                              <div class="flex items-center space-x-2 min-w-0">
-                                <a
-                                  href="/user/{nip19.npubEncode(
-                                    nestedReply.author?.hexpubkey || nestedReply.pubkey
-                                  )}"
-                                  class="font-medium text-sm transition-colors username-link truncate min-w-0"
-                                  style="color: var(--color-text-primary)"
-                                  on:click|stopPropagation
-                                >
-                                  <CustomName
-                                    pubkey={nestedReply.author?.hexpubkey || nestedReply.pubkey}
-                                  />
-                                </a>
-                                <span class="text-xs flex-shrink-0" style="color: var(--color-caption)">·</span>
-                                <span class="text-xs whitespace-nowrap flex-shrink-0" style="color: var(--color-caption)">
-                                  {nestedReply.created_at
-                                    ? formatTimeAgo(nestedReply.created_at)
-                                    : ''}
-                                </span>
-                              </div>
-                              <span on:click|stopPropagation>
-                                <PostActionsMenu event={nestedReply} />
+                        <div class="flex items-center justify-between gap-2 mb-2">
+                          <div class="flex items-center gap-2 min-w-0">
+                            <a
+                              href="/user/{nip19.npubEncode(
+                                nestedReply.author?.hexpubkey || nestedReply.pubkey
+                              )}"
+                              class="flex-shrink-0"
+                              on:click|stopPropagation
+                            >
+                              <Avatar
+                                pubkey={nestedReply.author?.hexpubkey || nestedReply.pubkey}
+                                size={24}
+                              />
+                            </a>
+                            <div class="flex flex-col min-w-0">
+                              <a
+                                href="/user/{nip19.npubEncode(
+                                  nestedReply.author?.hexpubkey || nestedReply.pubkey
+                                )}"
+                                class="font-semibold text-sm transition-colors username-link truncate min-w-0"
+                                style="color: var(--color-text-primary)"
+                                on:click|stopPropagation
+                              >
+                                <CustomName
+                                  pubkey={nestedReply.author?.hexpubkey || nestedReply.pubkey}
+                                />
+                              </a>
+                              <span class="text-xs" style="color: var(--color-caption)">
+                                {nestedReply.created_at
+                                  ? formatTimeAgo(nestedReply.created_at)
+                                  : ''}
                               </span>
                             </div>
-                            <div
-                              class="text-sm leading-relaxed"
-                              style="color: var(--color-text-primary)"
-                            >
-                              {#if nestedReply.kind === 1068}
-                                <PollDisplay event={nestedReply} />
-                              {:else}
-                                <NoteContent content={nestedReply.content} showNostrEmbeds={false} />
-                              {/if}
-                            </div>
-                            <!-- Nested reply actions -->
-                            <div class="mt-1.5" on:click|stopPropagation>
-                              <NoteActionBar event={nestedReply} variant="compact" />
-                            </div>
                           </div>
+                          <span on:click|stopPropagation>
+                            <PostActionsMenu event={nestedReply} />
+                          </span>
+                        </div>
+                        <div
+                          class="text-[13px] leading-normal"
+                          style="color: var(--color-text-primary)"
+                        >
+                          {#if nestedReply.kind === 1068}
+                            <PollDisplay event={nestedReply} />
+                          {:else}
+                            <NoteContent content={nestedReply.content} showNostrEmbeds={false} />
+                          {/if}
+                        </div>
+                        <!-- Nested reply actions -->
+                        <div class="mt-1.5" on:click|stopPropagation>
+                          <NoteActionBar event={nestedReply} variant="compact" />
                         </div>
                       </article>
                     </div>
@@ -894,7 +886,8 @@
                 {#if getNestedReplies(reply.id).length > 2}
                   <a
                     href="{noteUrl(reply)}"
-                    class="ml-8 pl-3 py-2 block text-xs text-primary hover:opacity-80"
+                    class="ml-4 pl-4 border-l-2 py-2 block text-xs text-primary hover:opacity-80"
+                    style="border-color: var(--color-input-border)"
                   >
                     Show {getNestedReplies(reply.id).length - 2} more {getNestedReplies(reply.id)
                       .length -
@@ -967,7 +960,7 @@
   .reply-card {
     background-color: var(--color-card-sunken);
     border-radius: 0.5rem;
-    padding: 0.875rem 1rem;
+    padding: 0.75rem 1rem;
   }
 
   /* Username hover - orange color */


### PR DESCRIPTION
## Summary

A readability pass on the note-view thread. Replies previously used a different, cramped layout from the focused note and had inverted font sizing, and every note carried a phantom blank line below its last element.

## Changes

- **Unified reply layout** — replies now use the same header-then-full-width-content layout as the focused note (avatar + name/time row, body spanning the full column) instead of an indented column beside the avatar. Applied to both direct and nested replies, so text and images get the full reading width.
- **Clear font hierarchy** — focused note body 17px, direct reply 14px, nested reply 13px. Previously replies were near-parity with the note, so they read as *larger* than the post they were answering.
- **Tighter spacing** — reduced article padding, header/content margins, and reply-card padding to remove excess vertical gaps.
- **`NoteContent` phantom gap fix** — moved `white-space: pre-wrap` from the container onto the text spans. On the container it also rendered the template's inter-block whitespace (the newlines/indentation between `{#each}`/`{#if}` branches) as a literal ~1-line gap after the last element — e.g. a dead space below a trailing image — on *every* note. Per-span `pre-wrap` preserves authors' real newlines while the container collapses template whitespace. Also drops leading/trailing and block-adjacent blank-line parts.
- **Reply-target indicator** — the reply composer now shows "Replying to <name>" (or "Replying to your own post") so it's clear which comment a reply targets, avoiding accidental replies to the thread root or yourself.

## Testing

- `pnpm run check` — 0 errors
- Verified the `NoteContent` fix by measuring the rendered DOM: `.note-content` height dropped 310px → 281px and the trailing line box is gone; author newlines still render.

🌽 Plated with [Claude Code](https://claude.com/claude-code)