### PR TITLE
fix(note): query relay hints additively, not as a pool replacement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.587",
+  "version": "4.2.588",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.575",
+  "version": "4.2.576",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/routes/[nip19]/+page.svelte
+++ b/src/routes/[nip19]/+page.svelte
@@ -205,10 +205,18 @@
           extraUrls.add(tag[2]);
         }
       }
+      // Query the default pool AND the extra relays. A relaySet passed to
+      // subscribe() is queried exclusively, so restricting to the extras alone
+      // (as before) meant replies on the default pool were missed whenever an
+      // event carried hints — and none at all if those hints were unreachable.
       if (extraUrls.size > 0 && $ndk) {
-        relaySet = NDKRelaySet.fromRelayUrls([...extraUrls].slice(0, 3), $ndk, true);
+        const poolUrls = Array.from($ndk.pool?.relays?.keys?.() ?? []);
+        const merged = [...new Set([...poolUrls, ...extraUrls])];
+        if (merged.length > 0) {
+          relaySet = NDKRelaySet.fromRelayUrls(merged, $ndk, true);
+        }
       }
-    } catch { /* non-fatal */ }
+    } catch { /* non-fatal — fall back to the default pool */ }
 
     const sub = $ndk.subscribe(filter, { closeOnEose: false }, relaySet);
 
@@ -297,12 +305,22 @@
           ids: [eventId]
         };
 
-        // Include relay hints from nevent1 when fetching the main event
+        // Include relay hints from nevent1 when fetching the main event — but
+        // ADDITIVELY, on top of the default pool. NDK queries a passed relaySet
+        // exclusively, so building it from the hints alone means a note whose
+        // hints are dead or paywalled (e.g. 503/403) never loads even though it
+        // lives on the default relays. Merge the current pool with the hints so
+        // both are queried; if the pool can't be read, fall back to no set
+        // (default pool) rather than a hints-only set.
         let eventRelaySet: NDKRelaySet | undefined;
         if (neventRelays.length > 0 && $ndk) {
           try {
-            eventRelaySet = NDKRelaySet.fromRelayUrls(neventRelays, $ndk, true);
-          } catch { /* non-fatal */ }
+            const poolUrls = Array.from($ndk.pool?.relays?.keys?.() ?? []);
+            const merged = [...new Set([...poolUrls, ...neventRelays])];
+            if (merged.length > 0) {
+              eventRelaySet = NDKRelaySet.fromRelayUrls(merged, $ndk, true);
+            }
+          } catch { /* non-fatal — fall back to the default pool */ }
         }
 
         const subscription = $ndk.subscribe(filter, { closeOnEose: false }, eventRelaySet);

--- a/src/routes/[nip19]/+page.svelte
+++ b/src/routes/[nip19]/+page.svelte
@@ -209,10 +209,13 @@
       // subscribe() is queried exclusively, so restricting to the extras alone
       // (as before) meant replies on the default pool were missed whenever an
       // event carried hints — and none at all if those hints were unreachable.
+      // If the pool is empty or unreadable (e.g. during startup), leave the
+      // set undefined so NDK uses its default pool — a set built from hints
+      // alone would reintroduce the exclusive hints-only behavior.
       if (extraUrls.size > 0 && $ndk) {
         const poolUrls = Array.from($ndk.pool?.relays?.keys?.() ?? []);
-        const merged = [...new Set([...poolUrls, ...extraUrls])];
-        if (merged.length > 0) {
+        if (poolUrls.length > 0) {
+          const merged = [...new Set([...poolUrls, ...[...extraUrls].slice(0, 3)])];
           relaySet = NDKRelaySet.fromRelayUrls(merged, $ndk, true);
         }
       }
@@ -310,14 +313,14 @@
         // exclusively, so building it from the hints alone means a note whose
         // hints are dead or paywalled (e.g. 503/403) never loads even though it
         // lives on the default relays. Merge the current pool with the hints so
-        // both are queried; if the pool can't be read, fall back to no set
-        // (default pool) rather than a hints-only set.
+        // both are queried; if the pool is empty or can't be read, fall back
+        // to no set (default pool) rather than a hints-only set.
         let eventRelaySet: NDKRelaySet | undefined;
         if (neventRelays.length > 0 && $ndk) {
           try {
             const poolUrls = Array.from($ndk.pool?.relays?.keys?.() ?? []);
-            const merged = [...new Set([...poolUrls, ...neventRelays])];
-            if (merged.length > 0) {
+            if (poolUrls.length > 0) {
+              const merged = [...new Set([...poolUrls, ...neventRelays])];
               eventRelaySet = NDKRelaySet.fromRelayUrls(merged, $ndk, true);
             }
           } catch { /* non-fatal — fall back to the default pool */ }


### PR DESCRIPTION
## Problem

Notes and their replies sometimes failed to load with **"Note not found"** even though the event was live and visible in other clients.

Root cause: the note view built its NDK `relaySet` from a note's embedded relay hints **alone** and passed it to `subscribe()`. NDK queries a passed relaySet **exclusively** (ignoring the default pool), so when a note's hints were dead or paywalled the client queried only those and found nothing — despite the note being widely available on the default relays.

Reproduced with a live note whose `nevent` hints were `elites.nostrati.org` (→ 503) and `creatr.nostr.wine` (→ 403, paid). The note itself was on `nos.lol` and the rest of the default pool, but the hints-only query never reached them.

## Fix

`src/routes/[nip19]/+page.svelte`:

- **`loadEvent`** — merge the current pool relays with the `nevent` hints (union) instead of a hints-only set.
- **`fetchReplies`** — same fix. Its comment already claimed "default pool + extras", but the code only queried the extras (capped at 3), so replies living on the default pool were missed whenever an event carried hints — and none loaded at all if those hints were unreachable.

Both paths fall back to the default pool if the pool can't be read, so the change can only widen coverage, never narrow it.

## Testing

- `pnpm run check` — 0 errors
- Drove the failing note in a headless browser against the dev server: before the fix it rendered "Note not found"; after, the note content renders correctly.

🍲 Simmered with [Claude Code](https://claude.com/claude-code)