### PR TITLE
feat(note): inline YouTube embeds for note content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.576",
+  "version": "4.2.577",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.587",
+  "version": "4.2.588",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.575",
+  "version": "4.2.576",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/NoteContent.svelte
+++ b/src/components/NoteContent.svelte
@@ -7,6 +7,7 @@
   import NofferButton from './clink/NofferButton.svelte';
   import LinkPreview from './LinkPreview.svelte';
   import VideoPreview from './VideoPreview.svelte';
+  import YouTubeEmbed from './YouTubeEmbed.svelte';
   import MediaCarousel from './MediaCarousel.svelte';
   import { processContentWithProfiles } from '$lib/contentProcessor';
   import MediaLightbox from './MediaLightbox.svelte';
@@ -85,6 +86,49 @@
     if (target) target.style.display = 'none';
   }
 
+  // Parse a start-time token (?t= / &start=) into seconds. Accepts a bare
+  // number ("90") or a duration ("1m30s", "1h2m3s").
+  function parseYouTubeStart(t: string | null): number {
+    if (!t) return 0;
+    if (/^\d+$/.test(t)) return parseInt(t, 10);
+    const m = t.match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/);
+    if (!m || !m[0]) return 0;
+    return (+(m[1] || 0)) * 3600 + (+(m[2] || 0)) * 60 + (+(m[3] || 0));
+  }
+
+  // Extract a YouTube video id (+ optional start offset) from the common URL
+  // shapes: youtu.be/ID, youtube.com/watch?v=ID, /embed/ID, /shorts/ID,
+  // /live/ID, /v/ID. Returns null for anything that isn't a YouTube video.
+  function parseYouTube(url: string): { id: string; start: number } | null {
+    let u: URL;
+    try {
+      u = new URL(url);
+    } catch {
+      return null;
+    }
+    const host = u.hostname.replace(/^www\./, '');
+    let id = '';
+    if (host === 'youtu.be') {
+      id = u.pathname.slice(1).split('/')[0];
+    } else if (
+      host === 'youtube.com' ||
+      host === 'm.youtube.com' ||
+      host === 'music.youtube.com' ||
+      host === 'youtube-nocookie.com'
+    ) {
+      if (u.pathname === '/watch') {
+        id = u.searchParams.get('v') || '';
+      } else {
+        const m = u.pathname.match(/^\/(?:embed|shorts|live|v)\/([^/?#]+)/);
+        if (m) id = m[1];
+      }
+    }
+    if (!/^[A-Za-z0-9_-]{11}$/.test(id)) return null;
+    return { id, start: parseYouTubeStart(u.searchParams.get('t') || u.searchParams.get('start')) };
+  }
+
+  const isYouTube = (url?: string): boolean => !!url && parseYouTube(url) !== null;
+
   function isMediaPart(part?: { type?: string; url?: string }): boolean {
     return Boolean(
       part?.type === 'url' && part.url && (isImageUrl(part.url) || isVideoUrl(part.url))
@@ -142,7 +186,7 @@
     }
     if (part.type === 'url') {
       if (!part.url) return false;
-      return isImageUrl(part.url) || isVideoUrl(part.url) || showLinkPreviews;
+      return isImageUrl(part.url) || isVideoUrl(part.url) || isYouTube(part.url) || showLinkPreviews;
     }
     return false;
   }
@@ -403,6 +447,11 @@
             />
           </button>
         </div>
+      {:else if part.url && isYouTube(part.url)}
+        {@const yt = parseYouTube(part.url)}
+        {#if yt}
+          <YouTubeEmbed videoId={yt.id} start={yt.start} />
+        {/if}
       {:else if part.url && isVideoUrl(part.url)}
         <VideoPreview url={part.url} />
       {:else if showLinkPreviews && part.url}

--- a/src/components/NoteContent.svelte
+++ b/src/components/NoteContent.svelte
@@ -102,7 +102,9 @@
   function parseYouTube(url: string): { id: string; start: number } | null {
     let u: URL;
     try {
-      u = new URL(url);
+      // Notes sometimes carry HTML-escaped query separators (`&amp;t=`);
+      // unescape them so searchParams sees `t`/`start` rather than `amp;t`.
+      u = new URL(url.replace(/&amp;/g, '&'));
     } catch {
       return null;
     }

--- a/src/components/YouTubeEmbed.svelte
+++ b/src/components/YouTubeEmbed.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import PlayIcon from 'phosphor-svelte/lib/Play';
+
+  // 11-char YouTube video id, plus an optional start offset in seconds.
+  export let videoId: string;
+  export let start = 0;
+
+  // Facade pattern: show the lightweight thumbnail + a play button and only
+  // load YouTube's (heavy) iframe player once the user actually clicks. This
+  // keeps a feed/thread with several videos from pulling in a player per note.
+  let playing = false;
+
+  // hqdefault always exists for a valid id (unlike maxresdefault, which 404s
+  // for some uploads). Served from the privacy-friendly no-cookie host.
+  $: thumbnail = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
+  $: embedSrc =
+    `https://www.youtube-nocookie.com/embed/${videoId}` +
+    `?autoplay=1&rel=0${start > 0 ? `&start=${start}` : ''}`;
+</script>
+
+<div
+  class="my-1 relative w-full overflow-hidden rounded-lg bg-black"
+  style="aspect-ratio: 16 / 9;"
+>
+  {#if playing}
+    <iframe
+      class="absolute inset-0 h-full w-full"
+      src={embedSrc}
+      title="YouTube video player"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+      referrerpolicy="strict-origin-when-cross-origin"
+      allowfullscreen
+    ></iframe>
+  {:else}
+    <button
+      type="button"
+      class="group absolute inset-0 h-full w-full cursor-pointer"
+      on:click={() => (playing = true)}
+      aria-label="Play YouTube video"
+    >
+      <img
+        src={thumbnail}
+        alt="YouTube video thumbnail"
+        class="absolute inset-0 h-full w-full object-cover"
+        loading="lazy"
+      />
+      <span
+        class="absolute inset-0 flex items-center justify-center bg-black/30 transition-colors group-hover:bg-black/40"
+      >
+        <span
+          class="rounded-full bg-white/90 p-4 shadow-lg transition-transform group-hover:scale-110 group-hover:bg-white"
+        >
+          <PlayIcon size={32} weight="fill" class="ml-1 text-gray-900" />
+        </span>
+      </span>
+    </button>
+  {/if}
+</div>

--- a/src/components/YouTubeEmbed.svelte
+++ b/src/components/YouTubeEmbed.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import PlayIcon from 'phosphor-svelte/lib/Play';
+  import CaretRightIcon from 'phosphor-svelte/lib/CaretRight';
 
   // 11-char YouTube video id, plus an optional start offset in seconds.
   export let videoId: string;
@@ -16,43 +18,114 @@
   $: embedSrc =
     `https://www.youtube-nocookie.com/embed/${videoId}` +
     `?autoplay=1&rel=0${start > 0 ? `&start=${start}` : ''}`;
+  $: watchUrl =
+    `https://youtu.be/${videoId}` + (start > 0 ? `?t=${start}` : '');
+
+  // Title + channel name caption, mirroring how other clients (Amethyst,
+  // Jumble) show YouTube previews. YouTube's oEmbed endpoint sends no CORS
+  // header, so this goes through our own server proxy.
+  interface OEmbedMeta {
+    title: string;
+    authorName: string;
+  }
+  const oembedCache = new Map<string, OEmbedMeta | null>();
+  let meta: OEmbedMeta | null = null;
+
+  onMount(async () => {
+    if (oembedCache.has(videoId)) {
+      meta = oembedCache.get(videoId) ?? null;
+      return;
+    }
+    try {
+      const res = await fetch(`/api/youtube-oembed?v=${videoId}`);
+      if (res.ok) {
+        const data = await res.json();
+        if (data && !data.error && data.title) {
+          meta = { title: data.title, authorName: data.authorName || '' };
+        }
+      }
+    } catch {
+      // Silently fall back to video-only — the embed itself still works.
+    }
+    oembedCache.set(videoId, meta);
+  });
 </script>
 
+<!-- whitespace-normal: NoteContent's container inherits white-space: pre-wrap
+     for author text, which would otherwise cascade down and turn the
+     whitespace between this embed's caption lines into full line-height
+     gaps. Reset it locally so the caption renders tight regardless of the
+     ancestor's white-space mode. -->
 <div
-  class="my-1 relative w-full overflow-hidden rounded-lg bg-black"
-  style="aspect-ratio: 16 / 9;"
+  class="my-1 w-full overflow-hidden rounded-lg border whitespace-normal"
+  style="border-color: var(--color-input-border)"
 >
-  {#if playing}
-    <iframe
-      class="absolute inset-0 h-full w-full"
-      src={embedSrc}
-      title="YouTube video player"
-      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-      referrerpolicy="strict-origin-when-cross-origin"
-      allowfullscreen
-    ></iframe>
-  {:else}
-    <button
-      type="button"
-      class="group absolute inset-0 h-full w-full cursor-pointer"
-      on:click={() => (playing = true)}
-      aria-label="Play YouTube video"
-    >
-      <img
-        src={thumbnail}
-        alt="YouTube video thumbnail"
-        class="absolute inset-0 h-full w-full object-cover"
-        loading="lazy"
-      />
-      <span
-        class="absolute inset-0 flex items-center justify-center bg-black/30 transition-colors group-hover:bg-black/40"
+  <div class="relative w-full bg-black" style="aspect-ratio: 16 / 9;">
+    {#if playing}
+      <iframe
+        class="absolute inset-0 h-full w-full"
+        src={embedSrc}
+        title="YouTube video player"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        referrerpolicy="strict-origin-when-cross-origin"
+        allowfullscreen
+      ></iframe>
+    {:else}
+      <button
+        type="button"
+        class="group absolute inset-0 h-full w-full cursor-pointer"
+        on:click={() => (playing = true)}
+        aria-label="Play YouTube video"
       >
+        <img
+          src={thumbnail}
+          alt="YouTube video thumbnail"
+          class="absolute inset-0 h-full w-full object-cover"
+          loading="lazy"
+        />
         <span
-          class="rounded-full bg-white/90 p-4 shadow-lg transition-transform group-hover:scale-110 group-hover:bg-white"
+          class="absolute inset-0 flex items-center justify-center bg-black/30 transition-colors group-hover:bg-black/40"
         >
-          <PlayIcon size={32} weight="fill" class="ml-1 text-gray-900" />
+          <span
+            class="rounded-full bg-white/90 p-4 shadow-lg transition-transform group-hover:scale-110 group-hover:bg-white"
+          >
+            <PlayIcon size={32} weight="fill" class="ml-1 text-gray-900" />
+          </span>
         </span>
-      </span>
-    </button>
+      </button>
+    {/if}
+  </div>
+
+  {#if meta}
+    <a
+      href={watchUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="flex items-center gap-2 px-3 py-2.5 whitespace-normal hover:opacity-90 transition-opacity"
+      style="background-color: var(--color-card-sunken)"
+    >
+      <div class="min-w-0 flex-1">
+        <h4
+          class="text-sm font-semibold line-clamp-2 leading-snug"
+          style="color: var(--color-text-primary)"
+        >
+          {meta.title}
+        </h4>
+        <p class="text-xs text-caption mt-0.5 truncate">
+          youtube.com{meta.authorName ? ` · ${meta.authorName}` : ''}
+        </p>
+      </div>
+      <CaretRightIcon size={18} class="flex-shrink-0 text-caption" />
+    </a>
   {/if}
 </div>
+
+<style>
+  .line-clamp-2 {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+</style>

--- a/src/components/YouTubeEmbed.svelte
+++ b/src/components/YouTubeEmbed.svelte
@@ -37,7 +37,7 @@
       return;
     }
     try {
-      const res = await fetch(`/api/youtube-oembed?v=${videoId}`);
+      const res = await fetch(`/api/youtube-oembed?v=${encodeURIComponent(videoId)}`);
       if (res.ok) {
         const data = await res.json();
         if (data && !data.error && data.title) {

--- a/src/routes/api/youtube-oembed/+server.ts
+++ b/src/routes/api/youtube-oembed/+server.ts
@@ -1,0 +1,49 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+/**
+ * Server-side proxy for YouTube's oEmbed endpoint.
+ *
+ * YouTube's own og:description is the full video description, not the
+ * channel name, and the oEmbed endpoint sends no Access-Control-Allow-Origin
+ * header — so the client can't call it directly. This fetches it server-side
+ * (no CORS) and returns just the two fields the inline embed caption needs.
+ */
+
+const VIDEO_ID_RE = /^[A-Za-z0-9_-]{11}$/;
+
+export const GET: RequestHandler = async ({ url, fetch }) => {
+  const videoId = url.searchParams.get('v') || '';
+  if (!VIDEO_ID_RE.test(videoId)) throw error(400, 'Invalid video id');
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 5000);
+
+    const target = `https://www.youtube.com/oembed?url=${encodeURIComponent(
+      `https://www.youtube.com/watch?v=${videoId}`
+    )}&format=json`;
+
+    const res = await fetch(target, { signal: controller.signal }).finally(() =>
+      clearTimeout(timer)
+    );
+
+    if (!res.ok) return json({ error: true }, { headers: cacheHeaders(600) });
+
+    const data = (await res.json()) as { title?: string; author_name?: string };
+    if (!data.title) return json({ error: true }, { headers: cacheHeaders(600) });
+
+    return json(
+      { title: data.title, authorName: data.author_name || '' },
+      { headers: cacheHeaders(60 * 60 * 24 * 7) }
+    );
+  } catch {
+    return json({ error: true }, { headers: cacheHeaders(600) });
+  }
+};
+
+function cacheHeaders(sMaxAge: number): Record<string, string> {
+  return {
+    'Cache-Control': `public, max-age=60, s-maxage=${sMaxAge}, stale-while-revalidate=86400`
+  };
+}


### PR DESCRIPTION
## Summary

YouTube links in notes rendered as a plain URL (or a generic link-preview card). This detects them and renders an inline player with a title/channel caption instead.

## Changes

- **New `YouTubeEmbed.svelte`** — a facade: shows the video thumbnail + a play button and only loads YouTube's (heavy) iframe player once the user clicks, so a feed or thread with several videos doesn't pull in a player per note. Uses the privacy-friendly `youtube-nocookie.com` host, 16:9, lazy-loaded thumbnail.
- **Title/channel caption** — a tight card below the video: bold title, `youtube.com · Channel Name` beneath it, trailing chevron, linking out to the video on YouTube. Mirrors how other clients (iMessage, Amethyst) caption link/video previews.
- **New `/api/youtube-oembed` proxy** — YouTube's oEmbed endpoint has no CORS header, so this fetches it server-side and returns just the `title`/channel name the caption needs.
- **`NoteContent.svelte`** — `parseYouTube()` handles `youtu.be/ID`, `watch?v=ID`, `/embed/`, `/shorts/`, `/live/`, `/v/` plus `?t=` / `&start=` timestamps (bare seconds or `1m30s` form). YouTube URLs are dispatched ahead of the link-preview / plain-link fallbacks and marked block-level so surrounding spacing stays correct.

Because it lives in the shared `NoteContent`, YouTube links now embed everywhere notes render — the note view, replies, and the community feed.

## A layout bug found and fixed along the way

`NoteContent`'s container currently inherits `white-space: pre-wrap` (a separate issue, fixed in #496 but not yet merged here), which was cascading down into this embed and rendering the whitespace between the caption's lines as full line-height gaps (~28px per line — visibly broken). `YouTubeEmbed`'s root now explicitly resets `white-space: normal` so the caption renders tight regardless of merge order between this PR and #496.

## Before / after

| Before | After |
| --- | --- |
| Bare `https://youtu.be/…` link | Inline 16:9 thumbnail with a play button; click loads the `youtube-nocookie` player; a caption card below shows the title, domain, and channel name |
| <img width="360" src="https://github.com/user-attachments/assets/774f29dc-ba41-4866-9ad8-4a62e34b34d2" /> | <img width="360" alt="image" src="https://github.com/user-attachments/assets/82056c6f-3816-4e38-a86c-e4784870b65f" /> |

## Testing

- `pnpm run check` — 0 errors
- Drove a real note (`youtu.be/KLHRjaUBb3o`) in a headless browser against the dev server: the thumbnail facade renders, clicking swaps in `https://www.youtube-nocookie.com/embed/KLHRjaUBb3o?autoplay=1&rel=0`, and the caption card shows "Almost Pizza - SNL" / "youtube.com · Saturday Night Live" with the title-to-domain gap at 2px (down from ~30px before the white-space fix).

🍿 Popped with [Claude Code](https://claude.com/claude-code)
