### PR TITLE
feat(note): inline X/Twitter post embeds for note content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.587",
+  "version": "4.2.588",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.575",
+  "version": "4.2.576",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/NoteContent.svelte
+++ b/src/components/NoteContent.svelte
@@ -7,6 +7,7 @@
   import NofferButton from './clink/NofferButton.svelte';
   import LinkPreview from './LinkPreview.svelte';
   import VideoPreview from './VideoPreview.svelte';
+  import TwitterEmbed from './TwitterEmbed.svelte';
   import MediaCarousel from './MediaCarousel.svelte';
   import { processContentWithProfiles } from '$lib/contentProcessor';
   import MediaLightbox from './MediaLightbox.svelte';
@@ -85,6 +86,12 @@
     if (target) target.style.display = 'none';
   }
 
+  // x.com/USER/status/ID or twitter.com/USER/status/ID, tolerating a
+  // trailing /photo/1, /video/1, or query string.
+  const TWITTER_STATUS_RE =
+    /^https?:\/\/(?:www\.|mobile\.)?(?:x|twitter)\.com\/[^/]+\/status(?:es)?\/\d+/i;
+  const isTwitterStatus = (url?: string): boolean => !!url && TWITTER_STATUS_RE.test(url);
+
   function isMediaPart(part?: { type?: string; url?: string }): boolean {
     return Boolean(
       part?.type === 'url' && part.url && (isImageUrl(part.url) || isVideoUrl(part.url))
@@ -142,7 +149,7 @@
     }
     if (part.type === 'url') {
       if (!part.url) return false;
-      return isImageUrl(part.url) || isVideoUrl(part.url) || showLinkPreviews;
+      return isImageUrl(part.url) || isVideoUrl(part.url) || isTwitterStatus(part.url) || showLinkPreviews;
     }
     return false;
   }
@@ -405,6 +412,8 @@
         </div>
       {:else if part.url && isVideoUrl(part.url)}
         <VideoPreview url={part.url} />
+      {:else if part.url && isTwitterStatus(part.url)}
+        <TwitterEmbed tweetUrl={part.url} />
       {:else if showLinkPreviews && part.url}
         <LinkPreview url={part.url} />
       {:else}

--- a/src/components/NoteContent.svelte
+++ b/src/components/NoteContent.svelte
@@ -149,7 +149,7 @@
     }
     if (part.type === 'url') {
       if (!part.url) return false;
-      return isImageUrl(part.url) || isVideoUrl(part.url) || isTwitterStatus(part.url) || showLinkPreviews;
+      return isImageUrl(part.url) || isVideoUrl(part.url) || showLinkPreviews;
     }
     return false;
   }

--- a/src/components/TwitterEmbed.svelte
+++ b/src/components/TwitterEmbed.svelte
@@ -1,12 +1,4 @@
-<script lang="ts">
-  import { onMount } from 'svelte';
-  import SealCheckIcon from 'phosphor-svelte/lib/SealCheck';
-  import HeartIcon from 'phosphor-svelte/lib/Heart';
-  import ChatCircleIcon from 'phosphor-svelte/lib/ChatCircle';
-
-  // Original x.com/twitter.com status URL found in the note.
-  export let tweetUrl: string;
-
+<script lang="ts" context="module">
   interface TwitterMedia {
     type: 'photo' | 'video';
     url: string;
@@ -26,7 +18,19 @@
     media: TwitterMedia | null;
   }
 
+  // Module-level so every instance shares it — the same tweet appearing in
+  // the feed and again in the note view fetches the proxy only once.
   const cache = new Map<string, TwitterMeta | null>();
+</script>
+
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import SealCheckIcon from 'phosphor-svelte/lib/SealCheck';
+  import HeartIcon from 'phosphor-svelte/lib/Heart';
+  import ChatCircleIcon from 'phosphor-svelte/lib/ChatCircle';
+
+  // Original x.com/twitter.com status URL found in the note.
+  export let tweetUrl: string;
   let meta: TwitterMeta | null = null;
   let loading = true;
   let playingVideo = false;

--- a/src/components/TwitterEmbed.svelte
+++ b/src/components/TwitterEmbed.svelte
@@ -1,0 +1,213 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import SealCheckIcon from 'phosphor-svelte/lib/SealCheck';
+  import HeartIcon from 'phosphor-svelte/lib/Heart';
+  import ChatCircleIcon from 'phosphor-svelte/lib/ChatCircle';
+
+  // Original x.com/twitter.com status URL found in the note.
+  export let tweetUrl: string;
+
+  interface TwitterMedia {
+    type: 'photo' | 'video';
+    url: string;
+    posterUrl?: string;
+    width: number;
+    height: number;
+  }
+  interface TwitterMeta {
+    text: string;
+    name: string;
+    screenName: string;
+    verified: boolean;
+    avatarUrl: string;
+    createdAt: string;
+    likeCount: number;
+    replyCount: number;
+    media: TwitterMedia | null;
+  }
+
+  const cache = new Map<string, TwitterMeta | null>();
+  let meta: TwitterMeta | null = null;
+  let loading = true;
+  let playingVideo = false;
+
+  onMount(async () => {
+    if (cache.has(tweetUrl)) {
+      meta = cache.get(tweetUrl) ?? null;
+      loading = false;
+      return;
+    }
+    try {
+      const res = await fetch(`/api/twitter-embed?url=${encodeURIComponent(tweetUrl)}`);
+      if (res.ok) {
+        const data = await res.json();
+        if (data && !data.error && data.name) {
+          meta = data as TwitterMeta;
+        }
+      }
+    } catch {
+      // Silently fall back to a plain link — the note is still readable.
+    }
+    cache.set(tweetUrl, meta);
+    loading = false;
+  });
+
+  function formatDate(iso: string): string {
+    try {
+      const d = new Date(iso);
+      const time = d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+      const date = d.toLocaleDateString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric'
+      });
+      return `${time} · ${date}`;
+    } catch {
+      return '';
+    }
+  }
+
+  function formatCount(n: number): string {
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(1).replace(/\.0$/, '')}K`;
+    return String(n);
+  }
+</script>
+
+{#if !loading && meta}
+  <!-- whitespace-normal: see YouTubeEmbed — NoteContent's container can
+       inherit white-space: pre-wrap, which would otherwise turn the
+       whitespace between these lines into full line-height gaps. -->
+  <div
+    class="my-1 w-full overflow-hidden rounded-lg border whitespace-normal"
+    style="border-color: var(--color-input-border); background-color: var(--color-card-sunken)"
+  >
+    <a
+      href={tweetUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="block px-3 pt-3 hover:opacity-90 transition-opacity"
+    >
+      <div class="flex items-center justify-between gap-2">
+        <div class="flex items-center gap-2 min-w-0">
+          {#if meta.avatarUrl}
+            <img
+              src={meta.avatarUrl}
+              alt=""
+              class="w-9 h-9 rounded-full flex-shrink-0"
+              loading="lazy"
+            />
+          {/if}
+          <div class="min-w-0 flex flex-col leading-tight">
+            <div class="flex items-center gap-1 min-w-0">
+              <span class="text-sm font-semibold truncate" style="color: var(--color-text-primary)">
+                {meta.name}
+              </span>
+              {#if meta.verified}
+                <SealCheckIcon size={15} weight="fill" class="flex-shrink-0 text-primary" />
+              {/if}
+            </div>
+            <span class="text-xs text-caption truncate">@{meta.screenName}</span>
+          </div>
+        </div>
+        <!-- X logo mark -->
+        <svg viewBox="0 0 24 24" width="18" height="18" class="flex-shrink-0" style="color: var(--color-text-primary)" aria-hidden="true">
+          <path
+            fill="currentColor"
+            d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"
+          />
+        </svg>
+      </div>
+
+      {#if meta.text}
+        <p
+          class="text-sm leading-snug mt-2 whitespace-pre-wrap"
+          style="color: var(--color-text-primary)"
+        >
+          {meta.text}
+        </p>
+      {/if}
+    </a>
+
+    {#if meta.media}
+      <div class="mt-2 relative w-full bg-black" style="aspect-ratio: {meta.media.width} / {meta.media.height};">
+        {#if meta.media.type === 'photo'}
+          <a href={tweetUrl} target="_blank" rel="noopener noreferrer">
+            <img
+              src={meta.media.url}
+              alt=""
+              class="absolute inset-0 w-full h-full object-cover"
+              loading="lazy"
+            />
+          </a>
+        {:else if playingVideo}
+          <!-- svelte-ignore a11y-media-has-caption -->
+          <video
+            class="absolute inset-0 w-full h-full"
+            src={meta.media.url}
+            controls
+            autoplay
+            playsinline
+          ></video>
+        {:else}
+          <button
+            type="button"
+            class="group absolute inset-0 w-full h-full cursor-pointer"
+            on:click={() => (playingVideo = true)}
+            aria-label="Play video"
+          >
+            {#if meta.media.posterUrl}
+              <img
+                src={meta.media.posterUrl}
+                alt=""
+                class="absolute inset-0 w-full h-full object-cover"
+                loading="lazy"
+              />
+            {/if}
+            <span
+              class="absolute inset-0 flex items-center justify-center bg-black/20 transition-colors group-hover:bg-black/35"
+            >
+              <span
+                class="rounded-full bg-white/90 p-3 shadow-lg transition-transform group-hover:scale-110 group-hover:bg-white"
+              >
+                <svg viewBox="0 0 24 24" width="22" height="22" class="text-gray-900" fill="currentColor">
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+              </span>
+            </span>
+          </button>
+        {/if}
+      </div>
+    {/if}
+
+    <a
+      href={tweetUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="flex items-center gap-4 px-3 py-2 mt-1 text-xs text-caption hover:opacity-80 transition-opacity"
+    >
+      {#if meta.createdAt}
+        <span>{formatDate(meta.createdAt)}</span>
+      {/if}
+      <span class="flex items-center gap-1">
+        <HeartIcon size={13} />
+        {formatCount(meta.likeCount)}
+      </span>
+      <span class="flex items-center gap-1">
+        <ChatCircleIcon size={13} />
+        {formatCount(meta.replyCount)}
+      </span>
+    </a>
+  </div>
+{:else if !loading}
+  <!-- Couldn't resolve the tweet (deleted, private, or rate-limited) — fall
+       back to a plain link so the note stays readable. -->
+  <a
+    href={tweetUrl}
+    target="_blank"
+    rel="noopener noreferrer"
+    class="text-orange-500 hover:text-orange-600 hover:underline break-all"
+  >
+    {tweetUrl}
+  </a>
+{/if}

--- a/src/routes/api/twitter-embed/+server.ts
+++ b/src/routes/api/twitter-embed/+server.ts
@@ -1,0 +1,119 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+/**
+ * Server-side proxy for X/Twitter's syndication endpoint.
+ *
+ * cdn.syndication.twimg.com/tweet-result is the same undocumented endpoint
+ * X's own widgets.js and tools like react-tweet use to render tweet embeds
+ * without an API key. It only sends Access-Control-Allow-Origin for
+ * platform.twitter.com, so the client can't call it directly — this fetches
+ * it server-side (no CORS) and returns just the fields the embed needs.
+ */
+
+const STATUS_ID_RE =
+  /^(?:https?:\/\/)?(?:www\.|mobile\.)?(?:x|twitter)\.com\/[^/]+\/status(?:es)?\/(\d+)/i;
+
+interface TwitterMeta {
+  text: string;
+  name: string;
+  screenName: string;
+  verified: boolean;
+  avatarUrl: string;
+  createdAt: string;
+  likeCount: number;
+  replyCount: number;
+  media: { type: 'photo' | 'video'; url: string; posterUrl?: string; width: number; height: number } | null;
+}
+
+function extractStatusId(rawUrl: string): string | null {
+  const m = rawUrl.match(STATUS_ID_RE);
+  return m ? m[1] : null;
+}
+
+// The token X's own embed widget derives from the tweet id — reverse
+// engineered and used by every open-source tweet-embed tool (e.g. react-tweet).
+function tokenFor(id: string): string {
+  return ((Number(id) / 1e15) * Math.PI).toString(36).replace(/(0+|\.)/g, '');
+}
+
+// Strip the trailing t.co media link the API always appends to `text`, and
+// swap any other t.co links for their expanded/display form.
+function cleanText(text: string, entities: any): string {
+  let out = text;
+  for (const m of entities?.media ?? []) {
+    if (m.url) out = out.split(m.url).join('').trim();
+  }
+  for (const u of entities?.urls ?? []) {
+    if (u.url && u.expanded_url) out = out.split(u.url).join(u.expanded_url);
+  }
+  return out.trim();
+}
+
+export const GET: RequestHandler = async ({ url, fetch }) => {
+  const target = url.searchParams.get('url') || '';
+  const statusId = extractStatusId(target);
+  if (!statusId) throw error(400, 'Invalid or missing tweet url');
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 5000);
+
+    const endpoint = `https://cdn.syndication.twimg.com/tweet-result?id=${statusId}&token=${tokenFor(statusId)}`;
+    const res = await fetch(endpoint, { signal: controller.signal }).finally(() => clearTimeout(timer));
+
+    if (!res.ok) return json({ error: true }, { headers: cacheHeaders(600) });
+
+    const data = (await res.json()) as Record<string, any>;
+    if (!data || data.__typename !== 'Tweet' || !data.user) {
+      return json({ error: true }, { headers: cacheHeaders(600) });
+    }
+
+    let media: TwitterMeta['media'] = null;
+    const detail = data.mediaDetails?.[0];
+    if (detail?.type === 'video' && data.video) {
+      // Prefer the highest-bitrate mp4 variant — HLS (.m3u8) needs a player
+      // library we don't ship, plain <video> can't play it.
+      const mp4s = (data.video.variants ?? []).filter((v: any) => v.type === 'video/mp4');
+      const best = mp4s.sort((a: any, b: any) => (b.bitrate ?? 0) - (a.bitrate ?? 0))[0];
+      if (best) {
+        media = {
+          type: 'video',
+          url: best.src,
+          posterUrl: data.video.poster,
+          width: detail.original_info?.width ?? 16,
+          height: detail.original_info?.height ?? 9
+        };
+      }
+    } else if (detail?.type === 'photo') {
+      media = {
+        type: 'photo',
+        url: detail.media_url_https,
+        width: detail.original_info?.width ?? 1,
+        height: detail.original_info?.height ?? 1
+      };
+    }
+
+    const meta: TwitterMeta = {
+      text: cleanText(data.note_tweet?.text || data.text || '', data.entities),
+      name: data.user.name || '',
+      screenName: data.user.screen_name || '',
+      verified: !!(data.user.is_blue_verified || data.user.verified),
+      avatarUrl: data.user.profile_image_url_https || '',
+      createdAt: data.created_at || '',
+      likeCount: data.favorite_count ?? 0,
+      replyCount: data.conversation_count ?? 0,
+      media
+    };
+
+    return json(meta, { headers: cacheHeaders(60 * 60 * 24) });
+  } catch {
+    return json({ error: true }, { headers: cacheHeaders(600) });
+  }
+};
+
+function cacheHeaders(sMaxAge: number): Record<string, string> {
+  return {
+    'Cache-Control': `public, max-age=60, s-maxage=${sMaxAge}, stale-while-revalidate=86400`
+  };
+}


### PR DESCRIPTION
## Summary

x.com/twitter.com status links in notes rendered as a plain URL. This detects them and renders a rich card instead, matching how other clients (Jumble, Amethyst) preview cross-posted X content.

## Changes

- **New `/api/twitter-embed` proxy** — X's syndication endpoint (`cdn.syndication.twimg.com/tweet-result`) is the same undocumented endpoint X's own embed widget and open-source tools like `react-tweet` use, but sends no CORS header for our origin, so this fetches it server-side using the well-known token-derivation formula and returns clean JSON (name, handle, verified, avatar, text, media, likes, replies). Strips the trailing `t.co` media link from the tweet text.
- **New `TwitterEmbed.svelte`** — avatar / name / verified badge / handle header, tweet text, media (photo, or video via a click-to-play facade over the direct mp4 — no iframe, no loading X's `widgets.js`), and a footer with timestamp · likes · replies linking out to the tweet. Card background uses `--color-card-sunken` so it reads as embedded content distinct from the note itself, in both light and dark mode.
- **`NoteContent.svelte`** — detects x.com/twitter.com status URLs (tolerating a trailing `/photo/1` or `/video/1`) and dispatches to the embed, same pattern as the YouTube embed (#498).

## Known limitation

Tweets over ~280 characters (X's long-tweet/"Article" feature) only get a truncated preview with no "Show more" expansion — the syndication endpoint doesn't expose the full extended text without X's private authenticated API. The same limitation affects `react-tweet` and other unofficial embed tools built on this endpoint.

## Testing

- `pnpm run check` — 0 errors
- Drove a real note embedding `x.com/chrisvtom/status/2066279533204934749` in a headless browser: avatar, name, verified badge, handle, tweet text, video (with poster + click-to-play), timestamp, like/reply counts all render correctly.
- Verified card background is visually distinct from the note in both light and dark mode.

🥟 Folded with [Claude Code](https://claude.com/claude-code)