### PR TITLE
fix(note): stop auto-tagging published notes with #zapcooking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.575",
+  "version": "4.2.576",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/PostComposer.svelte
+++ b/src/components/PostComposer.svelte
@@ -477,7 +477,7 @@
       const mentions = mentionCtrl.parseMentions(postContent);
 
       event.content = postContent;
-      event.tags = [['t', 'zapcooking']];
+      event.tags = [];
 
       for (const pubkey of mentions.values()) {
         if (!event.tags.some((t) => t[0] === 'p' && t[1] === pubkey)) {

--- a/src/routes/feed-post/+page.svelte
+++ b/src/routes/feed-post/+page.svelte
@@ -42,12 +42,12 @@
         await authManager.ensureNip46SignerReady();
       }
 
-      // Create a note event with #zapcooking tag
+      // Create a note event
       const event = new NDKEvent($ndk);
       event.kind = 1;
       event.content = content.trim();
-      event.tags = [['t', 'zapcooking']];
-      
+      event.tags = [];
+
       // Add NIP-89 client tag
       addClientTagToEvent(event);
 
@@ -135,11 +135,7 @@
       </div>
     </div>
 
-    <div class="flex items-center justify-between">
-      <div class="text-sm text-gray-500">
-        Your post will include the <span class="font-medium text-yellow-600">#zapcooking</span> tag
-      </div>
-      
+    <div class="flex items-center justify-end">
       <div class="flex gap-3">
         <Button
           on:click={() => goto('/feed')}


### PR DESCRIPTION
## Summary

Every note published from the web/iOS composer silently got a hardcoded `['t', 'zapcooking']` tag. The Android app (a Wisp fork) never adds this, so notes posted from different zap.cooking platforms carried different tags for otherwise identical content. This removes it to match Android.

## Changes

- `PostComposer.svelte` — `event.tags` starts empty instead of seeded with the `zapcooking` hashtag.
- `feed-post/+page.svelte` — same fix, plus removed the now-inaccurate "Your post will include the #zapcooking tag" notice from the UI.

## Tradeoff worth knowing about

`zapcooking` is also one of ~50 hashtags `FoodstrFeedOptimized.svelte` uses (`FOOD_HASHTAGS`) to discover food content across all of nostr for the community feed. Auto-tagging every post guaranteed it surfaced there even without food-specific language in the post itself; without the tag, a post with no food hashtag may no longer appear in that broad discovery feed. Accepted as a reasonable tradeoff for cross-platform consistency — happy to revisit (e.g. as an opt-in setting) if it turns out to meaningfully hurt discoverability.

## Testing

- `pnpm run check` — 0 errors
- Confirmed no other production code path adds this tag (`grep -rn "'t', 'zapcooking'\]" src` returns nothing outside test fixtures, which use it as unrelated sample data and don't assert the app adds it).

🥐 Proofed with [Claude Code](https://claude.com/claude-code)