### PR TITLE
Fix NIP-46 bunker login: explicit connect handshake, authUrl handling, error surfacing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.578",
+  "version": "4.2.579",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.577",
+  "version": "4.2.578",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/LoginOverlay.svelte
+++ b/src/components/LoginOverlay.svelte
@@ -473,6 +473,22 @@
             <p class="text-sm" style="color: var(--color-danger, #ef4444)">{bunkerError}</p>
           </div>
         {/if}
+        {#if authState.authChallengeUrl}
+          <div class="bg-input border rounded-lg p-2.5" style="border-color: var(--color-primary, #f97316)">
+            <p class="text-sm mb-1.5" style="color: var(--color-text-primary)">
+              Your signer needs browser approval. If a window didn't open, tap the link below:
+            </p>
+            <a
+              href={authState.authChallengeUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-sm underline break-all"
+              style="color: var(--color-primary, #f97316)"
+            >
+              {authState.authChallengeUrl}
+            </a>
+          </div>
+        {/if}
         {#if bunkerConnecting}
           <div class="bg-input border rounded-lg p-3" style="border-color: var(--color-primary, #f97316)">
             <div class="flex items-center gap-2">

--- a/src/lib/authManager.nip46.test.ts
+++ b/src/lib/authManager.nip46.test.ts
@@ -1,0 +1,423 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { nip19 } from 'nostr-tools';
+
+/**
+ * NIP-46 bunker paste-login tests.
+ *
+ * Seam: `@nostr-dev-kit/ndk` is mocked so `NDKNip46Signer` exposes a
+ * controllable `rpc` whose `sendRequest` we drive per-scenario. The real
+ * `sendNip46Rpc` / `fetchNip46UserPubkey` helpers run unmocked against that
+ * fake channel — the whole point is to exercise authManager's handshake
+ * logic, not NDK's transport. `$app/environment` is mocked to `browser:true`
+ * (the method early-returns otherwise). `localStorage` / `window` are stubbed
+ * on globalThis because this repo has no jsdom/happy-dom test env.
+ */
+
+vi.mock('$app/environment', () => ({ browser: true }));
+
+vi.mock('@nostr-dev-kit/ndk', () => {
+  const signers: any[] = [];
+  const calls: any[] = [];
+  let impl: (ctx: any) => void = () => {};
+
+  class NDKPrivateKeySigner {
+    privateKey: string;
+    constructor(pk: string) {
+      this.privateKey = pk;
+    }
+    static generate() {
+      return new NDKPrivateKeySigner('00'.repeat(32));
+    }
+    async user() {
+      return { pubkey: 'localpubkey' };
+    }
+  }
+
+  class NDKNip46Signer {
+    ndk: any;
+    token?: string;
+    remotePubkey: string;
+    remoteUser: { pubkey: string };
+    localSigner: any;
+    authUrlHandlers: Array<(url: string) => void> = [];
+    startListening: () => Promise<void>;
+    rpc: any;
+    constructor(ndk: any, token: string, localSigner: any) {
+      this.ndk = ndk;
+      const hasSecret = token.includes('#');
+      this.remotePubkey = hasSecret ? token.split('#')[0] : token;
+      this.token = hasSecret ? token.split('#')[1] : undefined;
+      this.remoteUser = { pubkey: this.remotePubkey };
+      this.localSigner = localSigner;
+      this.startListening = vi.fn(async () => {});
+      const self = this;
+      this.rpc = {
+        relaySet: undefined,
+        on(ev: string, cb: (url: string) => void) {
+          if (ev === 'authUrl') self.authUrlHandlers.push(cb);
+        },
+        sendRequest(remotePubkey: string, method: string, params: string[], kind: number, cb: any) {
+          calls.push({ remotePubkey, method, params, kind });
+          impl({ signer: self, remotePubkey, method, params, kind, cb });
+        }
+      };
+      signers.push(self);
+    }
+    async user() {
+      return this.remoteUser;
+    }
+  }
+
+  class NDKRelaySet {
+    urls: string[];
+    ndk: any;
+    constructor(urls: string[], ndk: any) {
+      this.urls = urls;
+      this.ndk = ndk;
+    }
+    static fromRelayUrls(urls: string[], ndk: any) {
+      return new NDKRelaySet(urls, ndk);
+    }
+  }
+
+  class NDKNip07Signer {}
+  const NDKSubscriptionCacheUsage = { ONLY_RELAY: 'ONLY_RELAY', CACHE_FIRST: 'CACHE_FIRST' };
+
+  return {
+    NDKNip46Signer,
+    NDKRelaySet,
+    NDKPrivateKeySigner,
+    NDKNip07Signer,
+    NDKSubscriptionCacheUsage,
+    __ndkTest: {
+      calls,
+      signers,
+      setImpl: (f: (ctx: any) => void) => {
+        impl = f;
+      },
+      reset: () => {
+        impl = () => {};
+        calls.length = 0;
+        signers.length = 0;
+      },
+      lastSigner: () => signers[signers.length - 1]
+    }
+  };
+});
+
+// Imported after the mocks so authManager binds to the fakes.
+import { AuthManager } from './authManager';
+import * as NDK from '@nostr-dev-kit/ndk';
+
+const ndkTest = (NDK as any).__ndkTest as {
+  calls: any[];
+  signers: any[];
+  setImpl: (f: (ctx: any) => void) => void;
+  reset: () => void;
+  lastSigner: () => any;
+};
+
+const SIGNER = 'b2'.repeat(32);
+const OTHER_SIGNER = 'c3'.repeat(32);
+const USER_PUBKEY = 'a1'.repeat(32);
+const SECRET = 'secret123';
+const KNOWN_KEY = 'cd'.repeat(32);
+const PENDING_KEY = 'nostrcooking_nip46_bunker_pending';
+const RELAY = 'wss://relay.example.com';
+const URI_WITH_SECRET = `bunker://${SIGNER}?relay=${RELAY}&secret=${SECRET}`;
+const URI_NO_SECRET = `bunker://${SIGNER}?relay=${RELAY}`;
+
+function makeNdk() {
+  return {
+    signer: null,
+    activeUser: null,
+    addExplicitRelay: vi.fn(),
+    connect: vi.fn().mockResolvedValue(undefined),
+    getUser: ({ pubkey }: { pubkey: string }) => ({ pubkey })
+  };
+}
+
+let store: Map<string, string>;
+let authManager: AuthManager;
+
+beforeEach(() => {
+  store = new Map();
+  (globalThis as any).localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => store.set(k, String(v)),
+    removeItem: (k: string) => store.delete(k),
+    clear: () => store.clear()
+  };
+  (globalThis as any).window = { open: vi.fn(() => null) };
+  ndkTest.reset();
+  authManager = new AuthManager(makeNdk());
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// Respond ack to connect and a valid pubkey to get_public_key.
+function happyImpl(pubkey = USER_PUBKEY) {
+  return ({ method, cb }: any) => {
+    if (method === 'connect') cb({ result: 'ack' });
+    else if (method === 'get_public_key') cb({ result: pubkey });
+  };
+}
+
+describe('parseNIP46ConnectionString', () => {
+  it('parses bunker:// with a secret', () => {
+    const r = authManager.parseNIP46ConnectionString(URI_WITH_SECRET);
+    expect(r).toEqual({ signerPubkey: SIGNER, relays: [RELAY], secret: SECRET });
+  });
+
+  it('parses bunker:// without a secret', () => {
+    const r = authManager.parseNIP46ConnectionString(URI_NO_SECRET);
+    expect(r).toEqual({ signerPubkey: SIGNER, relays: [RELAY], secret: undefined });
+  });
+
+  it('parses multiple relay params', () => {
+    const r = authManager.parseNIP46ConnectionString(
+      `bunker://${SIGNER}?relay=wss://a.example&relay=wss://b.example`
+    );
+    expect(r.relays).toEqual(['wss://a.example', 'wss://b.example']);
+  });
+
+  it('decodes an npub in the bunker hostname', () => {
+    const npub = nip19.npubEncode(SIGNER);
+    const r = authManager.parseNIP46ConnectionString(`bunker://${npub}?relay=${RELAY}`);
+    expect(r.signerPubkey).toBe(SIGNER);
+  });
+
+  it('parses a bare npub with relay hints', () => {
+    const npub = nip19.npubEncode(SIGNER);
+    const r = authManager.parseNIP46ConnectionString(`${npub} ${RELAY} wss://second.example`);
+    expect(r.signerPubkey).toBe(SIGNER);
+    expect(r.relays).toEqual([RELAY, 'wss://second.example']);
+  });
+
+  it('rejects nostrconnect:// URIs', () => {
+    expect(() => authManager.parseNIP46ConnectionString('nostrconnect://abc?relay=wss://x')).toThrow(
+      /nostrconnect/i
+    );
+  });
+
+  it('rejects a bunker URI with no relay', () => {
+    // The inner "No relay specified" message lacks the substring "Invalid",
+    // so the parser's catch re-throws it as the generic format error. This
+    // asserts the actual (pre-existing) surfaced message, not the inner one.
+    expect(() => authManager.parseNIP46ConnectionString(`bunker://${SIGNER}`)).toThrow(
+      /Invalid bunker connection string/i
+    );
+  });
+
+  it('rejects malformed input', () => {
+    expect(() => authManager.parseNIP46ConnectionString('not-a-connection-string')).toThrow();
+  });
+});
+
+describe('connect handshake', () => {
+  it('resolves on result: ack', async () => {
+    ndkTest.setImpl(happyImpl());
+    await authManager.authenticateWithNIP46(URI_WITH_SECRET);
+    expect(authManager.getState().isAuthenticated).toBe(true);
+    expect(authManager.getState().publicKey).toBe(USER_PUBKEY);
+  });
+
+  it('resolves when the signer echoes the secret', async () => {
+    ndkTest.setImpl(({ method, cb }: any) => {
+      if (method === 'connect') cb({ result: SECRET });
+      else if (method === 'get_public_key') cb({ result: USER_PUBKEY });
+    });
+    await authManager.authenticateWithNIP46(URI_WITH_SECRET);
+    expect(authManager.getState().isAuthenticated).toBe(true);
+  });
+
+  it('rejects an echoed value when no secret was sent (false-positive guard)', async () => {
+    ndkTest.setImpl(({ method, cb }: any) => {
+      // Without a secret, only 'ack' is success; an echo must not pass.
+      if (method === 'connect') cb({ result: 'some-unexpected-value' });
+      else if (method === 'get_public_key') cb({ result: USER_PUBKEY });
+    });
+    await expect(authManager.authenticateWithNIP46(URI_NO_SECRET)).rejects.toThrow(/single-use/i);
+    expect(ndkTest.calls.some((c) => c.method === 'get_public_key')).toBe(false);
+    expect(authManager.getState().isAuthenticated).toBe(false);
+  });
+
+  it('rejects with single-use guidance on a signer error', async () => {
+    ndkTest.setImpl(({ method, cb }: any) => {
+      if (method === 'connect') cb({ error: 'Not authorized' });
+    });
+    await expect(authManager.authenticateWithNIP46(URI_WITH_SECRET)).rejects.toThrow(
+      /single-use.*Not authorized/is
+    );
+    expect(ndkTest.calls.some((c) => c.method === 'get_public_key')).toBe(false);
+  });
+
+  it('rejects with timeout guidance when no response arrives', async () => {
+    vi.useFakeTimers();
+    ndkTest.setImpl(() => {
+      /* never responds */
+    });
+    const p = authManager.authenticateWithNIP46(URI_WITH_SECRET);
+    p.catch(() => {});
+    await vi.advanceTimersByTimeAsync(60000);
+    await expect(p).rejects.toThrow(/didn't respond/i);
+    expect(ndkTest.calls.some((c) => c.method === 'get_public_key')).toBe(false);
+  });
+
+  it('does not send get_public_key before connect succeeds (call order)', async () => {
+    ndkTest.setImpl(happyImpl());
+    await authManager.authenticateWithNIP46(URI_WITH_SECRET);
+    const methods = ndkTest.calls.map((c) => c.method);
+    expect(methods.indexOf('connect')).toBeLessThan(methods.indexOf('get_public_key'));
+  });
+
+  it('sends perms and the secret in connect param position 2', async () => {
+    ndkTest.setImpl(happyImpl());
+    await authManager.authenticateWithNIP46(URI_WITH_SECRET);
+    const connectCall = ndkTest.calls.find((c) => c.method === 'connect');
+    expect(connectCall.params[0]).toBe(SIGNER);
+    expect(connectCall.params[1]).toBe(SECRET);
+    expect(connectCall.params[2]).toContain('get_public_key');
+    expect(connectCall.params[2]).toContain('nip44_encrypt');
+  });
+
+  it('sends an empty-string secret in position 2 when the URI has none', async () => {
+    ndkTest.setImpl(happyImpl());
+    await authManager.authenticateWithNIP46(URI_NO_SECRET);
+    const connectCall = ndkTest.calls.find((c) => c.method === 'connect');
+    expect(connectCall.params[1]).toBe('');
+  });
+});
+
+describe('authUrl handling', () => {
+  it('opens a window with the challenge URL when popups are allowed', async () => {
+    (window as any).open = vi.fn(() => ({}) as any);
+    ndkTest.setImpl(({ signer, method, cb }: any) => {
+      if (method === 'connect') {
+        signer.authUrlHandlers.forEach((h: any) => h('https://approve.example/allow'));
+        cb({ result: 'ack' });
+      } else if (method === 'get_public_key') {
+        cb({ result: USER_PUBKEY });
+      }
+    });
+    await authManager.authenticateWithNIP46(URI_WITH_SECRET);
+    const openMock = (window as any).open as { mock: { calls: any[][] } };
+    expect(openMock.mock.calls[0][0]).toBe('https://approve.example/allow');
+    expect(openMock.mock.calls[0][1]).toBe('_blank');
+    // Cleared on success.
+    expect(authManager.getState().authChallengeUrl).toBeUndefined();
+  });
+
+  it('gives approval-pending guidance on timeout even when the popup opened', async () => {
+    // Human-in-the-loop timing: the tab opened successfully but the user is
+    // still approving when the 60s timer elapses. authUrlSeen is set at the
+    // top of the handler (not gated on popup blocking), so this must still
+    // surface "approval pending", not "check that your signer app is open".
+    vi.useFakeTimers();
+    (window as any).open = vi.fn(() => ({}) as any);
+    ndkTest.setImpl(({ signer, method }: any) => {
+      if (method === 'connect') {
+        signer.authUrlHandlers.forEach((h: any) => h('https://approve.example/opened'));
+        // No ack — user still approving in the opened tab.
+      }
+    });
+    const p = authManager.authenticateWithNIP46(URI_WITH_SECRET);
+    p.catch(() => {});
+    await vi.advanceTimersByTimeAsync(60000);
+    await expect(p).rejects.toThrow(/approval pending/i);
+    // Popup opened, so the URL is not surfaced in state.
+    expect(authManager.getState().authChallengeUrl).toBeUndefined();
+  });
+
+  it('surfaces the URL in state and gives approval-pending guidance when popup is blocked', async () => {
+    vi.useFakeTimers();
+    (window as any).open = vi.fn(() => null);
+    ndkTest.setImpl(({ signer, method }: any) => {
+      if (method === 'connect') {
+        signer.authUrlHandlers.forEach((h: any) => h('https://approve.example/blocked'));
+        // No ack — user must approve; original timer will elapse.
+      }
+    });
+    const p = authManager.authenticateWithNIP46(URI_WITH_SECRET);
+    p.catch(() => {});
+    await vi.advanceTimersByTimeAsync(60000);
+    await expect(p).rejects.toThrow(/approval pending/i);
+    expect(authManager.getState().authChallengeUrl).toBe('https://approve.example/blocked');
+  });
+});
+
+describe('ephemeral client key persistence', () => {
+  it('reuses a stored key for the same signer within the window', async () => {
+    store.set(
+      PENDING_KEY,
+      JSON.stringify({ signerPubkey: SIGNER, localPrivateKey: KNOWN_KEY, createdAt: Date.now() })
+    );
+    ndkTest.setImpl(({ method, cb }: any) => {
+      if (method === 'connect') cb({ error: 'nope' }); // fail so pending is kept
+    });
+    await expect(authManager.authenticateWithNIP46(URI_WITH_SECRET)).rejects.toThrow();
+    expect(ndkTest.lastSigner().localSigner.privateKey).toBe(KNOWN_KEY);
+    // Not overwritten on reuse.
+    expect(JSON.parse(store.get(PENDING_KEY)!).localPrivateKey).toBe(KNOWN_KEY);
+  });
+
+  it('generates a fresh key when the stored signer differs', async () => {
+    store.set(
+      PENDING_KEY,
+      JSON.stringify({
+        signerPubkey: OTHER_SIGNER,
+        localPrivateKey: KNOWN_KEY,
+        createdAt: Date.now()
+      })
+    );
+    ndkTest.setImpl(({ method, cb }: any) => {
+      if (method === 'connect') cb({ error: 'nope' });
+    });
+    await expect(authManager.authenticateWithNIP46(URI_WITH_SECRET)).rejects.toThrow();
+    const used = ndkTest.lastSigner().localSigner.privateKey;
+    expect(used).not.toBe(KNOWN_KEY);
+    expect(/^[0-9a-f]{64}$/.test(used)).toBe(true);
+    // Overwritten with the current signer + fresh key.
+    const pending = JSON.parse(store.get(PENDING_KEY)!);
+    expect(pending.signerPubkey).toBe(SIGNER);
+    expect(pending.localPrivateKey).toBe(used);
+  });
+
+  it('generates a fresh key when the stored key is expired', async () => {
+    store.set(
+      PENDING_KEY,
+      JSON.stringify({
+        signerPubkey: SIGNER,
+        localPrivateKey: KNOWN_KEY,
+        createdAt: Date.now() - 16 * 60 * 1000
+      })
+    );
+    ndkTest.setImpl(({ method, cb }: any) => {
+      if (method === 'connect') cb({ error: 'nope' });
+    });
+    await expect(authManager.authenticateWithNIP46(URI_WITH_SECRET)).rejects.toThrow();
+    expect(ndkTest.lastSigner().localSigner.privateKey).not.toBe(KNOWN_KEY);
+  });
+
+  it('clears the pending entry on successful auth', async () => {
+    store.set(
+      PENDING_KEY,
+      JSON.stringify({ signerPubkey: SIGNER, localPrivateKey: KNOWN_KEY, createdAt: Date.now() })
+    );
+    ndkTest.setImpl(happyImpl());
+    await authManager.authenticateWithNIP46(URI_WITH_SECRET);
+    expect(store.get(PENDING_KEY)).toBeUndefined();
+  });
+
+  it('keeps the pending entry on connect failure (retry path)', async () => {
+    ndkTest.setImpl(({ method, cb }: any) => {
+      if (method === 'connect') cb({ error: 'nope' });
+    });
+    await expect(authManager.authenticateWithNIP46(URI_WITH_SECRET)).rejects.toThrow();
+    expect(store.get(PENDING_KEY)).toBeDefined();
+    const pending = JSON.parse(store.get(PENDING_KEY)!);
+    expect(pending.signerPubkey).toBe(SIGNER);
+  });
+});

--- a/src/lib/authManager.nip46.test.ts
+++ b/src/lib/authManager.nip46.test.ts
@@ -129,8 +129,8 @@ const URI_NO_SECRET = `bunker://${SIGNER}?relay=${RELAY}`;
 
 function makeNdk() {
   return {
-    signer: null,
-    activeUser: null,
+    signer: null as any,
+    activeUser: null as any,
     addExplicitRelay: vi.fn(),
     connect: vi.fn().mockResolvedValue(undefined),
     getUser: ({ pubkey }: { pubkey: string }) => ({ pubkey })
@@ -139,6 +139,7 @@ function makeNdk() {
 
 let store: Map<string, string>;
 let authManager: AuthManager;
+let ndk: ReturnType<typeof makeNdk>;
 
 beforeEach(() => {
   store = new Map();
@@ -150,7 +151,8 @@ beforeEach(() => {
   };
   (globalThis as any).window = { open: vi.fn(() => null) };
   ndkTest.reset();
-  authManager = new AuthManager(makeNdk());
+  ndk = makeNdk();
+  authManager = new AuthManager(ndk);
 });
 
 afterEach(() => {
@@ -252,6 +254,8 @@ describe('connect handshake', () => {
       /single-use.*Not authorized/is
     );
     expect(ndkTest.calls.some((c) => c.method === 'get_public_key')).toBe(false);
+    // The abandoned signer must not linger on NDK once auth failed.
+    expect(ndk.signer).toBeNull();
   });
 
   it('rejects with timeout guidance when no response arrives', async () => {
@@ -329,6 +333,25 @@ describe('authUrl handling', () => {
     await expect(p).rejects.toThrow(/approval pending/i);
     // Popup opened, so the URL is not surfaced in state.
     expect(authManager.getState().authChallengeUrl).toBeUndefined();
+  });
+
+  it('ignores an auth challenge with a non-http(s) scheme (untrusted signer input)', async () => {
+    vi.useFakeTimers();
+    (window as any).open = vi.fn(() => null);
+    ndkTest.setImpl(({ signer, method }: any) => {
+      if (method === 'connect') {
+        signer.authUrlHandlers.forEach((h: any) => h('javascript:alert(document.cookie)'));
+        // No ack — falls through to timeout.
+      }
+    });
+    const p = authManager.authenticateWithNIP46(URI_WITH_SECRET);
+    p.catch(() => {});
+    await vi.advanceTimersByTimeAsync(60000);
+    // Never opened, never surfaced, and authUrlSeen stayed false so the
+    // timeout is the plain "didn't respond" message, not "approval pending".
+    expect(window.open).not.toHaveBeenCalled();
+    expect(authManager.getState().authChallengeUrl).toBeUndefined();
+    await expect(p).rejects.toThrow(/didn't respond/i);
   });
 
   it('surfaces the URL in state and gives approval-pending guidance when popup is blocked', async () => {

--- a/src/lib/authManager.ts
+++ b/src/lib/authManager.ts
@@ -3,6 +3,7 @@ import {
   NDKNip07Signer,
   NDKPrivateKeySigner,
   NDKNip46Signer,
+  NDKRelaySet,
   NDKSubscriptionCacheUsage,
   type NDKSubscription,
   type NDKUser
@@ -10,8 +11,25 @@ import {
 import { nip19, getPublicKey, generateSecretKey } from 'nostr-tools';
 import * as nip44 from 'nostr-tools/nip44';
 import * as nip04 from 'nostr-tools/nip04';
-import { fetchNip46UserPubkey } from './nip46Rpc';
+import { fetchNip46UserPubkey, sendNip46Rpc } from './nip46Rpc';
 import { Nip44LocalSigner } from './nip44LocalSigner';
+
+// Permissions requested in the NIP-46 connect handshake. NDK 2.10's
+// blockUntilReady omits the perms param entirely, so permission-enforcing
+// signers pre-grant nothing; sending them explicitly lets the signer
+// authorize the whole session in one approval.
+const NIP46_CONNECT_PERMS =
+  'get_public_key,sign_event,nip04_encrypt,nip04_decrypt,nip44_encrypt,nip44_decrypt';
+
+// localStorage key holding the in-flight ephemeral client key for a
+// bunker paste-login. NIP-46 authorizations bind to the client key, so a
+// retry with a fresh bunker URI (new single-use secret) can re-authorize
+// the SAME client key. Distinct from `nostrcooking_nip46_pending`, which
+// belongs to the nostrconnect:// QR flow — do not conflate them.
+const NIP46_BUNKER_PENDING_KEY = 'nostrcooking_nip46_bunker_pending';
+
+// How long a pending ephemeral client key may be reused across retries.
+const NIP46_BUNKER_PENDING_TTL_MS = 15 * 60 * 1000;
 
 export interface AuthState {
   isAuthenticated: boolean;
@@ -20,6 +38,10 @@ export interface AuthState {
   authMethod: 'nip07' | 'privateKey' | 'anonymous' | 'nip46' | null;
   isLoading: boolean;
   error: string | null;
+  // NIP-46 auth-challenge URL surfaced when a popup blocker prevents us
+  // from opening the signer's browser-approval window automatically. The
+  // bunker modal renders it as a tappable link. Undefined when not pending.
+  authChallengeUrl?: string;
 }
 
 export interface NIP46ConnectionInfo {
@@ -330,7 +352,8 @@ export class AuthManager {
 
   // Authenticate with NIP-46 bunker
   async authenticateWithNIP46(connectionString: string): Promise<void> {
-    this.updateState({ isLoading: true, error: null });
+    // Clear any stale auth-challenge link from a prior attempt.
+    this.updateState({ isLoading: true, error: null, authChallengeUrl: undefined });
 
     try {
       if (!browser) {
@@ -342,18 +365,56 @@ export class AuthManager {
       console.log('[NIP-46] Signer pubkey:', signerPubkey);
       console.log('[NIP-46] Relays:', relays);
 
-      // Generate a local ephemeral key for NIP-46 communication
-      const localPrivateKeyBytes = generateSecretKey();
-      const localPrivateKey = Array.from(localPrivateKeyBytes)
-        .map((b) => b.toString(16).padStart(2, '0'))
-        .join('');
+      // Resolve the local ephemeral client key. NIP-46 authorizations are
+      // bound to this key, so on retry we reuse a recently-stored key for
+      // the same signer: the user can generate a fresh bunker URI (with a
+      // new single-use secret) and re-authorize the SAME client without a
+      // second identity approval. Only reuse when the signer matches and
+      // the stored key is < 15 minutes old; otherwise generate + overwrite.
+      let localPrivateKey: string | null = null;
+      try {
+        const rawPending = localStorage.getItem(NIP46_BUNKER_PENDING_KEY);
+        if (rawPending) {
+          const pending = JSON.parse(rawPending) as {
+            signerPubkey?: string;
+            localPrivateKey?: string;
+            createdAt?: number;
+          };
+          const fresh =
+            typeof pending.createdAt === 'number' &&
+            Date.now() - pending.createdAt < NIP46_BUNKER_PENDING_TTL_MS;
+          if (
+            pending.signerPubkey === signerPubkey &&
+            typeof pending.localPrivateKey === 'string' &&
+            /^[0-9a-f]{64}$/i.test(pending.localPrivateKey) &&
+            fresh
+          ) {
+            localPrivateKey = pending.localPrivateKey;
+            console.log('[NIP-46] Reusing pending ephemeral client key for retry');
+          }
+        }
+      } catch (e) {
+        console.warn('[NIP-46] Could not read pending bunker key:', e);
+      }
+
+      if (!localPrivateKey) {
+        const localPrivateKeyBytes = generateSecretKey();
+        localPrivateKey = Array.from(localPrivateKeyBytes)
+          .map((b) => b.toString(16).padStart(2, '0'))
+          .join('');
+        localStorage.setItem(
+          NIP46_BUNKER_PENDING_KEY,
+          JSON.stringify({ signerPubkey, localPrivateKey, createdAt: Date.now() })
+        );
+      }
 
       // Create a local signer for the NIP-46 client. NIP-44-aware
       // wrapper: NDK 2.10's NDKPrivateKeySigner is NIP-04-only and the
       // RPC channel inherits its encrypt/decrypt — see Nip44LocalSigner.
       const localSigner = new Nip44LocalSigner(localPrivateKey);
 
-      // Add relays to NDK if not already present
+      // Add relays to NDK and connect BEFORE constructing the signer so the
+      // scoped RPC relay set (below) references relays already in the pool.
       for (const relay of relays) {
         try {
           this.ndk.addExplicitRelay(relay);
@@ -372,44 +433,100 @@ export class AuthManager {
       const signerToken = secret ? `${signerPubkey}#${secret}` : signerPubkey;
       this.nip46Signer = new NDKNip46Signer(this.ndk, signerToken, localSigner);
 
-      // Set internal properties that NDKNip46Signer needs
-      try {
-        (this.nip46Signer as any).bunkerPubkey = signerPubkey;
-        (this.nip46Signer as any)._bunkerPubkey = signerPubkey;
-        (this.nip46Signer as any).userPubkey = signerPubkey;
-        (this.nip46Signer as any)._userPubkey = signerPubkey;
-        const remoteUser = this.ndk.getUser({ pubkey: signerPubkey });
-        (this.nip46Signer as any)._remoteUser = remoteUser;
-        console.log('[NIP-46] Set signer internal properties');
-      } catch (e) {
-        console.warn('[NIP-46] Could not set signer properties:', e);
-      }
+      // Scope the RPC relay set to the bunker's relays. In the bunker-token
+      // construction path NDK leaves rpc.relaySet undefined, so NIP-46 RPC
+      // traffic would otherwise publish/subscribe against the entire pool.
+      (this.nip46Signer as any).rpc.relaySet = NDKRelaySet.fromRelayUrls(relays, this.ndk);
 
-      // Set the signer on NDK BEFORE blockUntilReady
+      // Handle auth-challenge (nsec.app-style browser approval). NDK emits
+      // 'authUrl' on the rpc instance (with the URL as the event arg) when a
+      // signer responds result:"auth_url". We bypass blockUntilReady, which
+      // is what normally bridges this event, so listen on rpc directly. This
+      // MUST be attached before connect is sent.
+      //
+      // authUrlSeen tags the human-in-the-loop case: once an auth challenge
+      // is issued, a subsequent connect timeout means the signer is alive
+      // and waiting on the user (not unreachable), so the timeout message
+      // and retry guidance differ (see below).
+      let authUrlSeen = false;
+      (this.nip46Signer as any).rpc.on('authUrl', (url: string) => {
+        console.log('[NIP-46] auth challenge:', url);
+        authUrlSeen = true;
+        let popup: Window | null = null;
+        try {
+          popup = window.open(url, '_blank', 'width=420,height=640');
+        } catch (e) {
+          console.warn('[NIP-46] window.open threw:', e);
+        }
+        if (!popup) {
+          // Popup blocked — surface the URL so the user can tap it manually.
+          this.updateState({ authChallengeUrl: url });
+        }
+      });
+
+      // Set the signer on NDK before driving the handshake.
       this.ndk.signer = this.nip46Signer;
 
-      console.log('[NIP-46] Connecting to bunker (this may take a moment)...');
-
-      // Some signers are inconsistent about connect "ack" semantics.
-      // Try blockUntilReady first, but still attempt get_public_key even
-      // if it times out — the RPC listener stays live, so get_public_key
-      // can succeed even when the connect ack didn't arrive.
+      // Arm the kind-24133 response subscription. startListening() arms it
+      // the moment ndk.subscribe is called; its promise only resolves on
+      // EOSE. With the RPC relay set scoped to the bunker's relays, a single
+      // slow/unreachable relay could hang that EOSE forever — so race a
+      // timeout and proceed, since the listener is live regardless of EOSE.
+      // (Trading the old silent failure for a silent hang would be no fix.)
       try {
-        const connectionTimeout = 30000; // 30 seconds
-        const timeoutPromise = new Promise<never>((_, reject) => {
-          setTimeout(
-            () => reject(new Error('Connection timeout - bunker not responding')),
-            connectionTimeout
-          );
-        });
-        await Promise.race([this.nip46Signer.blockUntilReady(), timeoutPromise]);
-        console.log('[NIP-46] Session established via connect');
+        const listenTimeout = new Promise<void>((resolve) => setTimeout(resolve, 10000));
+        await Promise.race([(this.nip46Signer as any).startListening(), listenTimeout]);
       } catch (e) {
-        console.warn(
-          '[NIP-46] connect phase timed out/failed, will still try get_public_key:',
-          e
+        console.warn('[NIP-46] startListening error (continuing, listener is live):', e);
+      }
+
+      console.log('[NIP-46] Sending connect handshake...');
+
+      // Explicit connect RPC with perms. Accept 'ack', or the echoed secret
+      // (spec-compliant for some signers) but ONLY when a secret was sent —
+      // otherwise an unexpected echo could pass as a false positive. Any
+      // other outcome fails the auth with actionable guidance; we no longer
+      // proceed to get_public_key on a failed/absent connect (which is what
+      // produced the "get_public_key: no permission" error).
+      let ack: string;
+      try {
+        // 60s: human-in-the-loop approval (popup or browser tab) is tight in
+        // 30s even without a popup blocker. Still a bounded wait.
+        ack = await sendNip46Rpc(
+          this.nip46Signer,
+          'connect',
+          [signerPubkey, secret ?? '', NIP46_CONNECT_PERMS],
+          60000
+        );
+      } catch (e) {
+        const raw = e instanceof Error ? e.message : String(e);
+        if (/timed out/i.test(raw)) {
+          // If an auth challenge was issued, the signer is alive and waiting
+          // on the user — NDK's re-armed handler would deliver a late ack,
+          // but our timer has already rejected. The persisted client key
+          // means the now-granted authorization carries over, so a plain
+          // retry (tap Connect again) succeeds.
+          if (authUrlSeen) {
+            throw new Error(
+              `Approval pending — finish approving in your signer, then tap Connect again. (${raw})`
+            );
+          }
+          throw new Error(
+            `Bunker didn't respond. Check that your signer app is open and online. (${raw})`
+          );
+        }
+        throw new Error(
+          `Connect was rejected. Bunker secrets are single-use — generate a fresh bunker URI in your signer app and try again. (${raw})`
         );
       }
+
+      const connectOk = ack === 'ack' || (secret !== undefined && ack === secret);
+      if (!connectOk) {
+        throw new Error(
+          `Connect was rejected. Bunker secrets are single-use — generate a fresh bunker URI in your signer app and try again. (unexpected connect response: ${JSON.stringify(ack)})`
+        );
+      }
+      console.log('[NIP-46] Connect acknowledged');
 
       console.log('[NIP-46] Getting user pubkey via get_public_key...');
 
@@ -436,7 +553,8 @@ export class AuthManager {
         publicKey: userPubkey,
         authMethod: 'nip46',
         isLoading: false,
-        error: null
+        error: null,
+        authChallengeUrl: undefined
       });
 
       // Store connection info for reconnection (redact secret for security)
@@ -456,6 +574,10 @@ export class AuthManager {
       localStorage.setItem('nostrcooking_loggedInPublicKey', userPubkey);
       localStorage.setItem('nostrcooking_authMethod', 'nip46');
       localStorage.setItem('nostrcooking_nip46', JSON.stringify(nip46Info));
+      // Success supersedes the pending ephemeral key (now persisted in
+      // nostrcooking_nip46 for reconnect). On FAILURE we deliberately keep
+      // it, so a retry with a fresh bunker URI reuses this authorized key.
+      localStorage.removeItem(NIP46_BUNKER_PENDING_KEY);
     } catch (error) {
       console.error('[NIP-46] Authentication failed:', error);
       this.nip46Signer = null;
@@ -513,19 +635,6 @@ export class AuthManager {
         ? `${nip46Info.signerPubkey}#${nip46Info.secret}`
         : nip46Info.signerPubkey;
       this.nip46Signer = new NDKNip46Signer(this.ndk, signerToken, localSigner);
-
-      // Set internal properties that NDKNip46Signer needs
-      try {
-        (this.nip46Signer as any).bunkerPubkey = nip46Info.signerPubkey;
-        (this.nip46Signer as any)._bunkerPubkey = nip46Info.signerPubkey;
-        (this.nip46Signer as any).userPubkey = nip46Info.signerPubkey;
-        (this.nip46Signer as any)._userPubkey = nip46Info.signerPubkey;
-        const remoteUser = this.ndk.getUser({ pubkey: nip46Info.signerPubkey });
-        (this.nip46Signer as any)._remoteUser = remoteUser;
-        console.log('[NIP-46] Set signer internal properties on reconnect');
-      } catch (e) {
-        console.warn('[NIP-46] Could not set signer properties:', e);
-      }
 
       // Set the signer on NDK BEFORE blockUntilReady
       this.ndk.signer = this.nip46Signer;
@@ -624,7 +733,8 @@ export class AuthManager {
       publicKey: '',
       authMethod: null,
       isLoading: false,
-      error: null
+      error: null,
+      authChallengeUrl: undefined
     });
 
     this.clearStorage();
@@ -1252,6 +1362,7 @@ export class AuthManager {
       localStorage.removeItem('nostrcooking_authMethod');
       localStorage.removeItem('nostrcooking_nip46');
       localStorage.removeItem('nostrcooking_nip46_pending');
+      localStorage.removeItem(NIP46_BUNKER_PENDING_KEY);
     }
   }
 

--- a/src/lib/authManager.ts
+++ b/src/lib/authManager.ts
@@ -451,16 +451,45 @@ export class AuthManager {
       let authUrlSeen = false;
       (this.nip46Signer as any).rpc.on('authUrl', (url: string) => {
         console.log('[NIP-46] auth challenge:', url);
+        // The URL comes from the remote signer's response — untrusted input.
+        // Only accept http(s) so a malicious/compromised signer cannot smuggle
+        // a javascript:/data: (or other-scheme) URL into window.open() or the
+        // modal's <a href>, which would be an XSS/phishing vector.
+        let safeUrl: string | null = null;
+        try {
+          const parsed = new URL(url);
+          if (parsed.protocol === 'https:' || parsed.protocol === 'http:') {
+            safeUrl = parsed.href;
+          }
+        } catch {
+          /* not a parseable URL */
+        }
+        if (!safeUrl) {
+          console.warn('[NIP-46] Ignoring auth challenge with unsupported URL:', url);
+          return;
+        }
         authUrlSeen = true;
         let popup: Window | null = null;
         try {
-          popup = window.open(url, '_blank', 'width=420,height=640');
+          // Not using the `noopener` window feature: it forces window.open to
+          // return null even on success, which would defeat the popup-blocked
+          // detection below. Instead sever `opener` on the returned handle to
+          // block reverse-tabnabbing. The manual <a> fallback in the modal
+          // carries rel="noopener noreferrer".
+          popup = window.open(safeUrl, '_blank', 'width=420,height=640');
+          if (popup) {
+            try {
+              popup.opener = null;
+            } catch {
+              /* cross-origin after navigation — best effort */
+            }
+          }
         } catch (e) {
           console.warn('[NIP-46] window.open threw:', e);
         }
         if (!popup) {
           // Popup blocked — surface the URL so the user can tap it manually.
-          this.updateState({ authChallengeUrl: url });
+          this.updateState({ authChallengeUrl: safeUrl });
         }
       });
 
@@ -581,6 +610,11 @@ export class AuthManager {
     } catch (error) {
       console.error('[NIP-46] Authentication failed:', error);
       this.nip46Signer = null;
+      // Also drop the abandoned signer from NDK. We set this.ndk.signer to the
+      // bunker signer before the handshake, so on failure it would otherwise
+      // dangle and let later app code sign through a stale/unauthorized signer
+      // while AuthState reports unauthenticated.
+      this.ndk.signer = null;
       this.updateState({
         isAuthenticated: false,
         user: null,
@@ -695,6 +729,10 @@ export class AuthManager {
     } catch (error) {
       console.error('[NIP-46] Reconnection failed:', error);
       this.nip46Signer = null;
+      // Same stale-signer hazard as authenticateWithNIP46: the signer was
+      // assigned to NDK before the handshake, so drop it here to keep NDK
+      // consistent with the unauthenticated state.
+      this.ndk.signer = null;
 
       // Don't clear storage immediately - user might want to retry
       this.updateState({


### PR DESCRIPTION
## Root cause

Users pasting a `bunker://` URI on `/explore` hit `get_public_key: no permission`.

`authenticateWithNIP46()` raced NDK's `blockUntilReady()` against a 30s timeout, **swallowed any failure with a `console.warn`, and called `get_public_key` anyway**. If the connect handshake never succeeded, the signer (Amber et al.) correctly rejected `get_public_key` from the unauthorized ephemeral client key with "no permission" — and the *real* error (spent single-use secret, missing approval, no ack) was discarded. The user saw a misleading downstream permission error instead of the actual connect failure.

Contributing factors (all confirmed against NDK 2.10.0 source):
- NIP-46 bunker secrets are single-use, but the flow generated a fresh ephemeral local key on every attempt, so no prior authorization ever carried over.
- NDK's RPC layer emits `authUrl` for nsec.app-style browser approval; nothing in `src/` listened, so the challenge never reached the user.
- NDK's `blockUntilReady` sends connect params with no `perms`, so permission-enforcing signers pre-grant nothing.

## The fixes

1. **Explicit connect RPC with perms.** Replaced the `blockUntilReady` race with an explicit `connect` sent through `sendNip46Rpc` including the perms string (`get_public_key,sign_event,nip04_encrypt,nip04_decrypt,nip44_encrypt,nip44_decrypt`). Accepts `ack`, or the echoed secret **only when a secret was sent** (false-positive guard). Any other outcome fails the auth with actionable guidance — we no longer proceed to `get_public_key` on a failed/absent connect. Connect timeout raised to 60s (human-in-the-loop approval).
2. **authUrl handling.** Listen on `signer.rpc` directly (we bypass `blockUntilReady`, which normally bridges the event), open the approval window, and — when a popup blocker returns `null` — surface the URL via a new `authState.authChallengeUrl` rendered as a tappable link in the bunker modal. `authUrlSeen` (set unconditionally at the top of the handler) makes a subsequent timeout report "approval pending — finish approving, then tap Connect again" rather than "bunker unreachable", for both the popup-opened and popup-blocked cases.
3. **Ephemeral key persistence.** `nostrcooking_nip46_bunker_pending` stores `{signerPubkey, localPrivateKey, createdAt}`. Reused when the signer matches and the key is < 15 min old; kept on failure (so a fresh bunker URI re-authorizes the same client key); cleared on success and explicit logout. Distinct from the nostrconnect flow's `nostrcooking_nip46_pending`.
4. **Relay-set scoping.** `rpc.relaySet` is `undefined` in the bunker-token path, so RPC traffic hit the whole pool; now scoped to the bunker's relays (built from relays already added to the pool).

Plus: **timeout-guarded `startListening()`** (its promise is EOSE-gated; a slow/unreachable scoped relay could hang it — the listener is live regardless, so we race a 10s timeout and proceed), and **deletion of the dead NDKNip46Signer property-poking block** (`bunkerPubkey`/`_bunkerPubkey`/`userPubkey`/`_userPubkey`/`_remoteUser` — none exist in NDK 2.10; `remotePubkey`/`remoteUser` are already constructor-set) in both `authenticateWithNIP46` and `reconnectNIP46`.

## User-visible failure paths

| Scenario | What the user sees |
|---|---|
| No response (timeout, no challenge) | *"Bunker didn't respond. Check that your signer app is open and online. (connect timed out)"* |
| Signer rejects (spent/consumed secret, no approval, bare rejection) | *"Connect was rejected. Bunker secrets are single-use — generate a fresh bunker URI in your signer app and try again. (connect: …raw…)"* |
| Unexpected non-ack result (incl. echo when no secret sent) | Same single-use guidance with `(unexpected connect response: "…")` |
| auth_url challenge, popup opens | Approval window opens; the same 60s connect await resolves once the user approves in-browser and the real `ack` arrives |
| auth_url challenge, popup blocked | URL rendered as a tappable link in the modal; on timeout → *"Approval pending — finish approving in your signer, then tap Connect again."* |

In all failure cases the persisted ephemeral key is **kept** (only success and explicit disconnect clear it), so a retry with a fresh bunker URI re-authorizes the same client key.

## Tests

`src/lib/authManager.nip46.test.ts` — 24 tests. Seam: `@nostr-dev-kit/ndk` mocked so `NDKNip46Signer` exposes a controllable `rpc.sendRequest`; the real `sendNip46Rpc`/`fetchNip46UserPubkey` run unmocked against it. Covers: parse regression (8 cases incl. nostrconnect rejection + malformed), connect outcomes (ack / secret-echo / echo-without-secret guard / signer-error / timeout / call-order / perms+secret params), authUrl (popup-opened, popup-blocked, timeout-after-challenge), and ephemeral-key persistence (reuse / fresh-on-different-signer / fresh-on-expired / cleared-on-success / kept-on-failure). Full suite: **250 passed**, svelte-check **0 errors**.

## Parity checklist (follow-ups — NOT in this PR)

- [ ] **`reconnectNIP46`**: apply perms-on-connect, authUrl handling, and relay-set scoping. Deliberately left on `blockUntilReady` here (only its dead property block was removed); behavior otherwise byte-for-byte.
- [ ] **Android app** (`zapcooking/zap_cooking_android`) NIP-46 path: same three checks (perms-on-connect, single-use-secret messaging, authUrl).
- [ ] **NDK upgrade PR**: this code now depends on NDK 2.10 internals — `signer.rpc.sendRequest`, `signer.startListening()`, and `signer.rpc.relaySet` / `rpc.on('authUrl')` (URL arrives as `response.error`; `sendRequest`'s returned promise never resolves — callback-driven). Note these so the migration knows exactly what breaks.

## Out-of-scope note

Pre-existing parse quirk: a relay-less `bunker://` URI surfaces the generic `"Invalid bunker connection string format"` because the inner `"No relay specified"` message lacks the substring `"Invalid"` and the parser's catch masks it. Not touched here (parse is out of scope); test asserts actual behavior. Easy follow-up if the specific message is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
