### PR TITLE
Fix Google Drive-token popup blocked on mobile Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.579",
+  "version": "4.2.580",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/LoginOverlay.svelte
+++ b/src/components/LoginOverlay.svelte
@@ -19,7 +19,8 @@
   import { showToast } from '$lib/toast';
   import { loginOverlayOpen } from '$lib/stores/loginOverlay';
   import {
-    signInToGoogle,
+    getGoogleSub,
+    connectDrive,
     restoreFromBackup,
     createAndUploadBackup,
     type GoogleSession
@@ -71,7 +72,12 @@
   // tile rather than leading users into a flow that would immediately error.
   $: googleBackupEnabled = !!publicEnv.PUBLIC_GOOGLE_WEB_CLIENT_ID;
   let googleModal = false;
-  let googleStep: 'signin' | 'setPin' | 'enterPin' = 'signin';
+  // Two-tap flow (iOS-safe): 'signin' renders the SIWG button (identity →
+  // `sub`); 'connectDrive' shows an explicit button whose tap opens the Drive
+  // token popup synchronously (mobile Safari blocks popups opened after an
+  // async gap). Then set/enter-PIN.
+  let googleStep: 'signin' | 'connectDrive' | 'setPin' | 'enterPin' = 'signin';
+  let googleSub: string | null = null;
   let googleSession: GoogleSession | null = null;
   let googleButtonContainer: HTMLDivElement | null = null;
   let googleSignInStarted = false;
@@ -207,6 +213,7 @@
   function openGoogleModal() {
     googleModal = true;
     googleStep = 'signin';
+    googleSub = null;
     googleSession = null;
     googlePin = '';
     googlePinConfirm = '';
@@ -215,19 +222,42 @@
     googleSignInStarted = false;
   }
 
+  // Step 1: identity. The GSI button resolves via its own callback; on success
+  // we advance to the explicit Drive-connect tap (step 2).
   async function renderAndAwaitGoogle() {
     if (!authManager || !googleButtonContainer) return;
     googleError = '';
     try {
-      const session = await signInToGoogle(googleButtonContainer);
+      googleSub = await getGoogleSub(googleButtonContainer);
+      googleStep = 'connectDrive';
+    } catch (error: any) {
+      googleError = error?.message || 'Google sign-in failed';
+      // Leave googleSignInStarted=true so the reactive block doesn't re-fire in
+      // a loop; the modal shows a "Try again" button that re-opens the flow.
+    }
+  }
+
+  // Step 2: Drive authorization. connectDrive() must run synchronously in this
+  // tap — do NOT await anything before it, or mobile Safari blocks the popup.
+  // (`googleBusy = true` is a synchronous assignment; it doesn't insert an await
+  // before connectDrive, so the popup still opens inside the gesture.)
+  async function connectGoogleDrive() {
+    if (!authManager || !googleSub) {
+      googleError = 'Please sign in with Google first.';
+      return;
+    }
+    googleError = '';
+    googleBusy = true;
+    try {
+      const session = await connectDrive(googleSub);
       googleSession = session;
       googlePin = '';
       googlePinConfirm = '';
       googleStep = session.existingFileId ? 'enterPin' : 'setPin';
     } catch (error: any) {
-      googleError = error?.message || 'Google sign-in failed';
-      // Leave googleSignInStarted=true so the reactive block doesn't re-fire in
-      // a loop; the modal shows a "Try again" button that re-opens the flow.
+      googleError = error?.message || 'Could not connect to Google Drive. Please try again.';
+    } finally {
+      googleBusy = false;
     }
   }
 
@@ -414,6 +444,7 @@
     nip46UniversalModal = false;
     googleModal = false;
     googleStep = 'signin';
+    googleSub = null;
     googleSession = null;
     googleSignInStarted = false;
     googlePin = '';
@@ -704,6 +735,7 @@
       <h2 class="login-modal-title">
         {#if googleStep === 'setPin'}🔐 Set a backup PIN
         {:else if googleStep === 'enterPin'}🔓 Enter your backup PIN
+        {:else if googleStep === 'connectDrive'}☁️ Connect Google Drive
         {:else}☁️ Continue with Google{/if}
       </h2>
       <div class="flex flex-col gap-4">
@@ -718,12 +750,25 @@
         {#if googleStep === 'signin'}
           <div class="flex flex-col items-center gap-3 py-2">
             <div bind:this={googleButtonContainer} class="min-h-[44px]"></div>
-            {#if !googleError && !googleSession}
+            {#if !googleError && !googleSub}
               <p class="text-xs text-caption text-center">
-                Approve Google sign-in, then Drive access — two quick prompts.
+                Step 1 of 2 — sign in with Google, then authorize Drive access.
               </p>
             {/if}
           </div>
+        {:else if googleStep === 'connectDrive'}
+          <div class="bg-input border rounded-lg p-3" style="border-color: var(--color-input-border)">
+            <p class="text-sm" style="color: var(--color-text-primary)">
+              ✓ Signed in with Google. Step 2 of 2 — authorize access to your private Drive backup
+              folder so we can store or read your encrypted key.
+            </p>
+          </div>
+          {#if googleBusy}
+            <div class="flex items-center justify-center gap-2 py-2">
+              <div class="animate-spin h-4 w-4 border-2 border-orange-500 border-t-transparent rounded-full"></div>
+              <p class="text-sm" style="color: var(--color-text-primary)">Connecting to Google Drive…</p>
+            </div>
+          {/if}
         {:else if googleStep === 'setPin'}
           <div
             class="bg-input border rounded-lg p-3"
@@ -808,6 +853,10 @@
 
         {#if googleStep === 'signin' && googleError}
           <Button on:click={openGoogleModal} primary={true}>Try again</Button>
+        {:else if googleStep === 'connectDrive'}
+          <Button on:click={connectGoogleDrive} primary={true} disabled={googleBusy}>
+            {googleBusy ? 'Connecting…' : 'Connect Google Drive'}
+          </Button>
         {:else if googleStep === 'setPin'}
           <Button
             on:click={submitGoogleSetPin}

--- a/src/lib/googleBackup/gis.ts
+++ b/src/lib/googleBackup/gis.ts
@@ -208,41 +208,52 @@ export function getGoogleIdentity(
  * Request an OAuth access token scoped to drive.appdata via the GIS token
  * client. Separate popup from getGoogleIdentity (see file header). Returns the
  * access token string used as the Bearer for Drive REST calls.
+ *
+ * ⚠️ iOS-CRITICAL: this MUST be invoked synchronously inside a user-gesture
+ * handler (a real tap), with NO `await`/`.then` between the tap and this call.
+ * The token client opens a popup via window.open, and mobile Safari blocks any
+ * popup opened after an async gap ("Failed to open popup window"). We therefore
+ * do NOT await loadGoogleIdentityServices() here — GIS must already be loaded
+ * (getGoogleIdentity loads it during the identity step). The Promise executor
+ * below runs synchronously when the Promise is constructed, so requestAccessToken
+ * fires in the same tick as the caller's tap. `await requestDriveAccessToken()`
+ * is safe because the call expression is evaluated (opening the popup) before
+ * the await suspends.
  */
-export function getDriveAccessToken(): Promise<string> {
-  return loadGoogleIdentityServices().then(
-    () =>
-      new Promise<string>((resolve, reject) => {
-        const accounts = googleAccounts();
-        if (!accounts) {
-          reject(new Error('Google Identity Services unavailable'));
-          return;
+export function requestDriveAccessToken(): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const accounts = googleAccounts();
+    if (!accounts) {
+      reject(
+        new Error('Google Identity Services is not loaded yet. Please sign in with Google first.')
+      );
+      return;
+    }
+    const clientId = getWebClientId();
+    let settled = false;
+    const client = accounts.oauth2.initTokenClient({
+      client_id: clientId,
+      scope: DRIVE_APPDATA_SCOPE,
+      callback: (res: GisTokenResponse) => {
+        if (settled) return;
+        settled = true;
+        if (res.access_token) {
+          resolve(res.access_token);
+        } else {
+          reject(
+            new Error(
+              res.error_description || res.error || 'Google did not return a Drive access token'
+            )
+          );
         }
-        const clientId = getWebClientId();
-        let settled = false;
-        const client = accounts.oauth2.initTokenClient({
-          client_id: clientId,
-          scope: DRIVE_APPDATA_SCOPE,
-          callback: (res: GisTokenResponse) => {
-            if (settled) return;
-            settled = true;
-            if (res.access_token) {
-              resolve(res.access_token);
-            } else {
-              reject(
-                new Error(
-                  res.error_description || res.error || 'Google did not return a Drive access token'
-                )
-              );
-            }
-          },
-          error_callback: (err) => {
-            if (settled) return;
-            settled = true;
-            reject(new Error(err.message || err.type || 'Google authorization was cancelled'));
-          }
-        });
-        client.requestAccessToken();
-      })
-  );
+      },
+      error_callback: (err) => {
+        if (settled) return;
+        settled = true;
+        reject(new Error(err.message || err.type || 'Google authorization was cancelled'));
+      }
+    });
+    // Synchronous — opens the consent popup in the caller's gesture (see above).
+    client.requestAccessToken();
+  });
 }

--- a/src/lib/googleBackup/googleBackupFlow.ts
+++ b/src/lib/googleBackup/googleBackupFlow.ts
@@ -9,7 +9,7 @@
  * authMethod.
  */
 
-import { getDriveAccessToken, getGoogleIdentity } from './gis';
+import { requestDriveAccessToken, getGoogleIdentity } from './gis';
 import { listBackups, downloadBackup, uploadBackup } from './driveBackup';
 import { deriveBackupKey, encryptNsec, decryptNsec } from './googleBackupCrypto';
 import { bytesToHex } from '@noble/hashes/utils.js';
@@ -22,13 +22,24 @@ export interface GoogleSession {
 }
 
 /**
- * Sign in to Google (renders the SIWG button into `container`), obtain the
- * Drive access token, and check for an existing backup. Two Google prompts:
- * identity, then Drive authorization (Approach A).
+ * Step 1 of the two-tap flow: render the SIWG button into `container` and
+ * resolve with the decoded ID-token `sub`. Loads GIS as a side effect, so by
+ * the time step 2 runs the token client can be invoked synchronously.
  */
-export async function signInToGoogle(container: HTMLElement): Promise<GoogleSession> {
+export async function getGoogleSub(container: HTMLElement): Promise<string> {
   const { sub } = await getGoogleIdentity(container);
-  const accessToken = await getDriveAccessToken();
+  return sub;
+}
+
+/**
+ * Step 2 of the two-tap flow: request the drive.appdata token and check for an
+ * existing backup. MUST be called from a user-gesture handler with no `await`
+ * before it — requestDriveAccessToken opens a popup that mobile Safari blocks
+ * outside a gesture. The `await requestDriveAccessToken()` expression evaluates
+ * (opening the popup) before the await suspends, so the gesture is preserved.
+ */
+export async function connectDrive(sub: string): Promise<GoogleSession> {
+  const accessToken = await requestDriveAccessToken();
   const backups = await listBackups(accessToken);
   return { sub, accessToken, existingFileId: backups[0]?.fileId ?? null };
 }


### PR DESCRIPTION
## Fix: Google Drive-token popup blocked on mobile Safari

Follow-up to #504. On iOS mobile Safari the identity step worked ("Continue as …", client ID accepted), but the **second** step — the `drive.appdata` token popup — failed with **"Failed to open popup window."** Desktop was unaffected.

### Root cause
The token popup was opened by `requestAccessToken()` inside a `.then()`-deferred promise, chained after the identity step (`await getGoogleIdentity()` → `await getDriveAccessToken()`). That put `window.open` in a **microtask with no user activation** — and the identity itself resolves inside GIS's own credential callback, not our gesture. Mobile Safari blocks any popup opened outside a synchronous user gesture; desktop browsers are lenient about the gap, which is why it only surfaced on iOS.

### Fix — Option A, uniform two-tap (approved)
Keep Approach A's two Google prompts, but make the second an **explicit tap** so the popup opens in-gesture:

- **`gis.ts`** — `requestDriveAccessToken()` (replaces `getDriveAccessToken`) no longer awaits the GIS load; its Promise executor calls `requestAccessToken()` **synchronously**, so `await requestDriveAccessToken()` fires the popup in the caller's gesture before suspending. GIS is already loaded from step 1.
- **`googleBackupFlow.ts`** — `signInToGoogle` split into `getGoogleSub` (identity) and `connectDrive` (token + list), one per tap.
- **`LoginOverlay.svelte`** — uniform two-tap on every platform: SIWG button → **"Connect Google Drive"** button whose click drives `connectDrive` synchronously. No redirect flow, no backend, no UA-gating, single code path.

### Why not `ux_mode: 'redirect'`
The redirect mode belongs to GIS's **code client**, not the token client we use; switching would require a server-side code→token exchange holding the Google **client secret** — breaking the no-secrets, client-only design. Not worth it for a popup-timing fix.

### Parity contract — untouched
`sub` still decoded identically (`decodeJwtSub` unchanged), `drive.appdata` scope constant unchanged, **zero crypto changes**. The 7/7 known-answer fixture test passes as-is. Only *when/how* `requestAccessToken()` is invoked changed.

### Verification
- `npx vitest run src/lib/googleBackup` → 7/7 pass
- `svelte-check` → 0 errors
- ⏳ **Pending:** live re-test on iOS mobile Safari (the platform that surfaced the bug) on a deploy of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
