### PR TITLE
Passkey-wrapped nsec vault (Phase 1: web-only local vault)

### DIFF
--- a/docs/passkey-vault-manual-tests.md
+++ b/docs/passkey-vault-manual-tests.md
@@ -1,0 +1,63 @@
+# Passkey vault (Phase 1) — manual test checklist
+
+Feature: passkey-wrapped nsec vault replacing plaintext `nostrcooking_privateKey`
+storage. Run on **Chrome desktop** (Google Password Manager or local profile
+passkeys) and **Android Chrome** (GPM passkey). Status column: fill in per run.
+
+Setup for most cases: log in by pasting an nsec (a throwaway test key) on a
+browser profile with clean site data for zap.cooking.
+
+## Enrollment & migration
+
+| # | Steps | Expected | Chrome desktop | Android Chrome |
+|---|-------|----------|----------------|----------------|
+| 1 | Log in with pasted nsec | "Protect your key with a passkey" prompt appears (bottom card); copy says the passkey is NOT a backup and points to Settings → Security | ☐ | ☐ |
+| 2 | Prompt → "Not now" | Prompt disappears; never reappears after reloads; `nostrcooking_privateKey` still in localStorage | ☐ | ☐ |
+| 3 | Prompt → "Set up passkey" → complete both ceremonies | Success copy; `nostrcooking_vault_v1` present; `nostrcooking_privateKey` GONE; session still works (post a note) | ☐ | ☐ |
+| 4 | Same as 3 but cancel the passkey sheet | No error banner; plaintext key untouched; no vault record | ☐ | ☐ |
+| 5 | Settings → Security → "Set up passkey protection" (after dismissing prompt in 2) | Same behavior as 3 | ☐ | ☐ |
+
+## Unlock / restore
+
+| # | Steps | Expected | Chrome desktop | Android Chrome |
+|---|-------|----------|----------------|----------------|
+| 6 | After enrollment, reload the app | Not logged in; login overlay auto-opens with "Unlock with passkey" on top, other methods below | ☐ | ☐ |
+| 7 | Unlock with passkey | Logged in as the same account; localStorage has NO `nostrcooking_privateKey`; vault record still present | ☐ | ☐ |
+| 8 | Reload → cancel the passkey sheet | Overlay stays open, no error banner, all other login methods clickable; vault record intact | ☐ | ☐ |
+| 9 | After 8, paste the same nsec | Logged in; still NO plaintext key written (adopted vault); vault record intact | ☐ | ☐ |
+| 10 | Reload → dismiss overlay (X) | Anonymous browsing works; Login button re-opens overlay with unlock card | ☐ | ☐ |
+
+## Post-migration functionality (in-memory key)
+
+| # | Steps | Expected | Chrome desktop | Android Chrome |
+|---|-------|----------|----------------|----------------|
+| 11 | While unlocked: open a DM conversation | Decrypts without errors | ☐ | ☐ |
+| 12 | While unlocked: marketplace → message a seller | Encrypt/send works | ☐ | ☐ |
+| 13 | While unlocked: wallet → create a relay backup (NWC or Spark seed) | Backup creation allowed and succeeds (exercises `canCreateNostrBackup`/`getPrivateKey` in-memory path) | ☐ | ☐ |
+| 14 | Settings → Security → Reveal Private Key | nsec revealed from memory, matches the original key | ☐ | ☐ |
+
+## Removal / downgrade
+
+| # | Steps | Expected | Chrome desktop | Android Chrome |
+|---|-------|----------|----------------|----------------|
+| 15 | Settings → Security → "Remove passkey protection…" → confirm → complete passkey ceremony | Plaintext key restored in localStorage; vault record gone; session continues as privateKey; backup warning shown before ceremony | ☐ | ☐ |
+| 16 | Same but cancel the ceremony | Nothing changes: record present, no plaintext | ☐ | ☐ |
+
+## Conflict / replace flows
+
+| # | Steps | Expected | Chrome desktop | Android Chrome |
+|---|-------|----------|----------------|----------------|
+| 17 | With a vault enrolled (locked), paste a DIFFERENT account's nsec | "Replace saved login?" confirmation; Cancel → nothing changes; Confirm → vault deleted, new account logged in with plaintext (legacy) | ☐ | ☐ |
+| 18 | With a vault enrolled, "Create Profile" (fresh keys) | Plain-language "saved login for another account" confirmation before proceeding | ☐ | ☐ |
+| 19 | With a vault enrolled, Google Drive restore of the SAME account | Logs in silently adopting the vault; no plaintext written | ☐ | ☐ |
+| 20 | With a vault enrolled, Google Drive restore of a DIFFERENT account | Replace confirmation, then legacy login on confirm | ☐ | ☐ |
+
+## Non-regression
+
+| # | Steps | Expected | Chrome desktop | Android Chrome |
+|---|-------|----------|----------------|----------------|
+| 21 | NIP-07 extension login + logout | Unchanged | ☐ | n/a |
+| 22 | NIP-46 bunker paste login + reload restore | Unchanged | ☐ | ☐ |
+| 23 | Logout while enrolled | Logged out; vault record survives; next load shows unlock overlay | ☐ | ☐ |
+| 24 | iOS Capacitor build (simulator ok) | No passkey UI anywhere: no prompt, no settings card, login form unchanged | n/a | n/a (iOS) |
+| 25 | Legacy user (plaintext key, never enrolls) across reloads | Behavior identical to before this change | ☐ | ☐ |

--- a/docs/passkey-vault-manual-tests.md
+++ b/docs/passkey-vault-manual-tests.md
@@ -4,6 +4,13 @@ Feature: passkey-wrapped nsec vault replacing plaintext `nostrcooking_privateKey
 storage. Run on **Chrome desktop** (Google Password Manager or local profile
 passkeys) and **Android Chrome** (GPM passkey). Status column: fill in per run.
 
+**Test surface: `zap.cooking` / `staging.zap.cooking` ONLY.** rp.id is fixed to
+`zap.cooking`; the feature is deliberately absent (no prompt, no settings card,
+no unlock card) on previews (`*.pages.dev`), localhost, and any other origin —
+seeing no passkey UI there is expected behavior, not a bug. Passkeys created by
+pre-ruling preview builds are orphans bound to their preview origin; delete
+them from your password manager.
+
 Setup for most cases: log in by pasting an nsec (a throwaway test key) on a
 browser profile with clean site data for zap.cooking.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.586",
+  "version": "4.2.587",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.583",
+  "version": "4.2.584",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.584",
+  "version": "4.2.585",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.582",
+  "version": "4.2.583",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.580",
+  "version": "4.2.581",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.581",
+  "version": "4.2.582",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.585",
+  "version": "4.2.586",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/LoginOverlay.svelte
+++ b/src/components/LoginOverlay.svelte
@@ -10,7 +10,8 @@
   import QRCode from 'svelte-qrcode';
 
   import { nip19 } from 'nostr-tools';
-  import { createAuthManager, type AuthState } from '$lib/authManager';
+  import { createAuthManager, VaultConflictError, type AuthState } from '$lib/authManager';
+  import { getVaultRecord, isCeremonyCancelled, type VaultRecord } from '$lib/passkeyVault';
   import { onMount, onDestroy, tick } from 'svelte';
   import { env as publicEnv } from '$env/dynamic/public';
   import { platformIsIOS } from '$lib/platform';
@@ -110,8 +111,77 @@
   // UX state for extension detection warning
   let showMissingSignerNotice = false;
 
+  // Passkey vault: unlock card state (shown when a vault record exists and
+  // the user isn't authenticated). All other login methods stay visible
+  // below it — a cancelled/failed unlock is never a dead end.
+  let vaultRecord: VaultRecord | null = null;
+  let vaultNpub = '';
+  let vaultUnlockBusy = false;
+  let vaultUnlockError = '';
+
+  // Vault conflict confirmation: signing in with a key that differs from the
+  // enrolled vault's account requires an explicit "replace" confirmation
+  // (see VaultConflictError in authManager).
+  let vaultConflictOpen = false;
+  let vaultConflictMessage = '';
+  let vaultConflictRetry: (() => Promise<void>) | null = null;
+  let vaultConflictBusy = false;
+
+  function raiseVaultConflict(message: string, retry: () => Promise<void>) {
+    vaultConflictMessage = message;
+    vaultConflictRetry = retry;
+    vaultConflictOpen = true;
+  }
+
+  async function confirmVaultConflict() {
+    if (!vaultConflictRetry) return;
+    vaultConflictBusy = true;
+    try {
+      await vaultConflictRetry();
+      vaultConflictOpen = false;
+      vaultConflictRetry = null;
+      vaultRecord = getVaultRecord();
+    } catch (error: any) {
+      vaultConflictMessage = error?.message || 'Sign-in failed. Please try again.';
+    } finally {
+      vaultConflictBusy = false;
+    }
+  }
+
+  function cancelVaultConflict() {
+    vaultConflictOpen = false;
+    vaultConflictRetry = null;
+    vaultConflictBusy = false;
+  }
+
+  async function unlockVaultPasskey() {
+    if (!authManager) return;
+    vaultUnlockBusy = true;
+    vaultUnlockError = '';
+    try {
+      // Success closes the overlay via the auth-state subscription.
+      await authManager.unlockVault();
+    } catch (error: any) {
+      // A dismissed passkey sheet is a normal outcome — no error banner; the
+      // other sign-in methods below remain available either way.
+      vaultUnlockError = isCeremonyCancelled(error)
+        ? ''
+        : error?.message || 'Could not unlock with this passkey.';
+    } finally {
+      vaultUnlockBusy = false;
+    }
+  }
+
   onMount(() => {
     try {
+      vaultRecord = getVaultRecord();
+      if (vaultRecord) {
+        try {
+          vaultNpub = `${nip19.npubEncode(vaultRecord.pubkey).slice(0, 16)}…`;
+        } catch {
+          vaultNpub = '';
+        }
+      }
       authManager = createAuthManager($ndk);
       if (authManager) {
         authState = authManager.getState();
@@ -173,10 +243,20 @@
     try {
       nsecError = '';
       if (!nsecInput.trim()) { nsecError = 'Please enter a private key'; return; }
-      await authManager.authenticateWithPrivateKey(nsecInput.trim());
+      const nsec = nsecInput.trim();
+      await authManager.authenticateWithPrivateKey(nsec);
       nsecModal = false;
       nsecInput = '';
     } catch (error) {
+      if (error instanceof VaultConflictError) {
+        const nsec = nsecInput.trim();
+        raiseVaultConflict(error.message, async () => {
+          await authManager.authenticateWithPrivateKey(nsec, { replaceVault: true });
+          nsecModal = false;
+          nsecInput = '';
+        });
+        return;
+      }
       nsecError = authState.error || 'Invalid private key';
       console.error('Private key login failed:', error);
     }
@@ -275,6 +355,28 @@
       return;
     }
     googleError = '';
+
+    // A fresh keypair always differs from any enrolled vault account, so
+    // confirm the replacement BEFORE uploading anything to Drive. Plain
+    // "saved login" copy: this is a signup surface, not a vault settings UI.
+    if (getVaultRecord()) {
+      raiseVaultConflict(
+        'This browser has a saved login for another account. Creating a new profile will ' +
+          "remove that saved login — make sure the other account's key is backed up first.",
+        () => runGoogleSetPin(true)
+      );
+      return;
+    }
+    // Errors surface via googleError inside; swallow the rethrow that only
+    // exists for the conflict-confirm dialog's error display.
+    await runGoogleSetPin(false).catch(() => {});
+  }
+
+  async function runGoogleSetPin(replaceVault: boolean) {
+    if (!authManager || !googleSession) {
+      googleError = 'Google session expired. Please try again.';
+      return;
+    }
     googleBusy = true;
     // Let the loading state paint before the synchronous PBKDF2(600k) blocks
     // the main thread, so the button doesn't feel frozen.
@@ -285,10 +387,11 @@
       // uploaded to Drive, then logged in via the private-key path.
       const keypair = authManager.generateKeyPair();
       const nsecHex = await createAndUploadBackup(googleSession, googlePin, keypair.privateKey);
-      await authManager.authenticateWithPrivateKey(nsecHex);
+      await authManager.authenticateWithPrivateKey(nsecHex, { replaceVault });
       modalCleanup();
     } catch (error: any) {
       googleError = error?.message || 'Could not create your backup. Please try again.';
+      throw error;
     } finally {
       googleBusy = false;
     }
@@ -318,6 +421,20 @@
       await authManager.authenticateWithPrivateKey(nsecHex);
       modalCleanup();
     } catch (error) {
+      if (error instanceof VaultConflictError) {
+        // The restored backup belongs to a different account than the
+        // enrolled vault. Same-account restores adopt the vault silently.
+        raiseVaultConflict(error.message, async () => {
+          const nsecHex = await restoreFromBackup(
+            googleSession!,
+            googleSession!.existingFileId!,
+            googlePin
+          );
+          await authManager.authenticateWithPrivateKey(nsecHex, { replaceVault: true });
+          modalCleanup();
+        });
+        return;
+      }
       // A wrong PIN fails the NIP-44 HMAC and throws — never a silent wrong-key
       // login. Don't echo the raw crypto error to the user.
       console.error('[GoogleBackup] restore failed:', error);
@@ -365,7 +482,7 @@
     backupDownloaded = true;
   }
 
-  async function useGeneratedKeys(skipProfile = false) {
+  async function useGeneratedKeys(skipProfile = false, replaceVault = false) {
     if (!generatedKeys || !authManager) return;
     const profileName = newAccountUsername.trim();
     const profileBio = newAccountBio.trim();
@@ -374,7 +491,20 @@
       const privateKeyHex = Array.from(generatedKeys.privateKey)
         .map((b) => b.toString(16).padStart(2, '0'))
         .join('');
-      await authManager.authenticateWithPrivateKey(privateKeyHex);
+      try {
+        await authManager.authenticateWithPrivateKey(privateKeyHex, { replaceVault });
+      } catch (error) {
+        if (error instanceof VaultConflictError) {
+          // Signup surface — plain "saved login" copy, no vault jargon.
+          raiseVaultConflict(
+            'This browser has a saved login for another account. Creating a new profile will ' +
+              "remove that saved login — make sure the other account's key is backed up first.",
+            () => useGeneratedKeys(skipProfile, true)
+          );
+          return;
+        }
+        throw error;
+      }
       const hasProfileData = !skipProfile && (profileName || profileBio || profilePicture);
       if (hasProfileData) {
         const { NDKEvent } = await import('@nostr-dev-kit/ndk');
@@ -470,6 +600,9 @@
     nip46PairingUri = '';
     nip46PairingStatus = 'Waiting for approval…';
     nip46PairingError = '';
+    vaultConflictOpen = false;
+    vaultConflictRetry = null;
+    vaultConflictBusy = false;
   }
 
   let showPictureUrlInput = false;
@@ -1021,6 +1154,28 @@
     </div>
   </Modal>
 
+  <!-- Vault conflict confirmation: replacing the enrolled passkey login
+       requires an explicit decision — it deletes the wrapped key for the
+       other account on this device. -->
+  <Modal bind:open={vaultConflictOpen} cleanup={cancelVaultConflict} noHeader>
+    <div class="login-modal-body">
+      <h2 class="login-modal-title">⚠️ Replace saved login?</h2>
+      <div class="flex flex-col gap-4">
+        <div class="bg-input border rounded-lg p-3" style="border-color: var(--color-input-border)">
+          <p class="text-sm text-caption">{vaultConflictMessage}</p>
+        </div>
+        <div class="flex gap-2">
+          <Button on:click={confirmVaultConflict} primary={true} disabled={vaultConflictBusy}>
+            {vaultConflictBusy ? 'Signing in…' : 'Replace saved login'}
+          </Button>
+          <Button on:click={cancelVaultConflict} primary={false} disabled={vaultConflictBusy}>
+            Cancel
+          </Button>
+        </div>
+      </div>
+    </div>
+  </Modal>
+
   <SuggestedFollowsModal
     bind:open={showSuggestedFollows}
     userPubkey={newAccountPubkey}
@@ -1067,6 +1222,28 @@
         <img src="/zapcooking-text-dark.svg" alt="" aria-hidden="true" class="signin-wordmark-img signin-wordmark-img--dark" />
       </h1>
       <p class="signin-tagline">Share recipes and get paid by your community.</p>
+
+      {#if vaultRecord && !authState.isAuthenticated}
+        <!-- Locked passkey vault: unlock is the primary action, but every
+             other method stays below — cancelling here is never a dead end,
+             and nothing can delete the vault from this screen. -->
+        <button
+          type="button"
+          on:click={unlockVaultPasskey}
+          disabled={vaultUnlockBusy || authState.isLoading}
+          aria-label="Unlock your saved key with a passkey"
+          class="signin-cta-primary"
+        >
+          <span>{vaultUnlockBusy ? 'Waiting for passkey…' : '🔒 Unlock with passkey'}</span>
+        </button>
+        <p class="signin-vault-hint">
+          Welcome back{vaultNpub ? ` ${vaultNpub}` : ''} — your key is encrypted on this device.
+        </p>
+        {#if vaultUnlockError}
+          <div class="signin-error" role="alert">{vaultUnlockError}</div>
+        {/if}
+        <div class="signin-divider" aria-hidden="true"><span>or sign in another way</span></div>
+      {/if}
 
       <button type="button" on:click={loginWithNIP07} disabled={authState.isLoading} aria-label="Sign in to Zap Cooking using your Nostr browser extension" class="signin-cta-primary">
         <span>{authState.isLoading ? 'Connecting…' : 'Sign in with Browser Signer'}</span>
@@ -1308,6 +1485,13 @@
     font-weight: 400;
     color: var(--color-caption);
     margin: 0 0 1.75rem;
+    line-height: 1.5;
+  }
+
+  .signin-vault-hint {
+    font-size: 0.8125rem;
+    color: var(--color-caption);
+    margin: 0.625rem 0 0;
     line-height: 1.5;
   }
 

--- a/src/components/LoginOverlay.svelte
+++ b/src/components/LoginOverlay.svelte
@@ -11,7 +11,12 @@
 
   import { nip19 } from 'nostr-tools';
   import { createAuthManager, VaultConflictError, type AuthState } from '$lib/authManager';
-  import { getVaultRecord, isCeremonyCancelled, type VaultRecord } from '$lib/passkeyVault';
+  import {
+    detectSupport,
+    getVaultRecord,
+    isCeremonyCancelled,
+    type VaultRecord
+  } from '$lib/passkeyVault';
   import { onMount, onDestroy, tick } from 'svelte';
   import { env as publicEnv } from '$env/dynamic/public';
   import { platformIsIOS } from '$lib/platform';
@@ -118,6 +123,10 @@
   let vaultNpub = '';
   let vaultUnlockBusy = false;
   let vaultUnlockError = '';
+  // Unlock card is also gated on platform support: a leftover record on an
+  // unsupported origin (e.g. an old preview build's localStorage) must not
+  // offer an unlock that can no longer bind to the real rp id.
+  let vaultSupported = false;
 
   // Vault conflict confirmation: signing in with a key that differs from the
   // enrolled vault's account requires an explicit "replace" confirmation
@@ -181,6 +190,7 @@
         } catch {
           vaultNpub = '';
         }
+        detectSupport().then((s) => (vaultSupported = s !== 'none'));
       }
       authManager = createAuthManager($ndk);
       if (authManager) {
@@ -1223,7 +1233,7 @@
       </h1>
       <p class="signin-tagline">Share recipes and get paid by your community.</p>
 
-      {#if vaultRecord && !authState.isAuthenticated}
+      {#if vaultRecord && vaultSupported && !authState.isAuthenticated}
         <!-- Locked passkey vault: unlock is the primary action, but every
              other method stays below — cancelling here is never a dead end,
              and nothing can delete the vault from this screen. -->

--- a/src/components/PasskeyEnrollPrompt.svelte
+++ b/src/components/PasskeyEnrollPrompt.svelte
@@ -1,0 +1,198 @@
+<script lang="ts">
+  /**
+   * Dismissible migration prompt: offers (never forces) moving a plaintext
+   * localStorage nsec into the passkey vault. Web-only by construction —
+   * shouldOfferEnrollment is false whenever detectSupport() is 'none'
+   * (which includes every Capacitor build).
+   *
+   * The plaintext key is deleted only inside AuthManager.enrollVault after
+   * the round-trip verification; a dismissed or failed prompt changes
+   * nothing.
+   */
+  import { onMount, onDestroy } from 'svelte';
+  import { browser } from '$app/environment';
+  import { getAuthManager, type AuthState } from '$lib/authManager';
+  import {
+    detectSupport,
+    getVaultRecord,
+    shouldOfferEnrollment,
+    isCeremonyCancelled,
+    VAULT_PROMPT_DISMISSED_KEY,
+    type VaultSupport
+  } from '$lib/passkeyVault';
+
+  let support: VaultSupport = 'none';
+  let authState: AuthState | null = null;
+  let unsubscribe: (() => void) | null = null;
+  let visible = false;
+  let busy = false;
+  let done = false;
+  let errorMsg = '';
+
+  function evaluate() {
+    if (!browser || !authState || busy || done) return;
+    visible = shouldOfferEnrollment({
+      authMethod: authState.authMethod,
+      isAuthenticated: authState.isAuthenticated,
+      hasPlaintextKey: !!localStorage.getItem('nostrcooking_privateKey'),
+      hasVault: !!getVaultRecord(),
+      support,
+      dismissed: localStorage.getItem(VAULT_PROMPT_DISMISSED_KEY) === '1'
+    });
+  }
+
+  onMount(async () => {
+    support = await detectSupport();
+    const am = getAuthManager();
+    if (!am) return;
+    authState = am.getState();
+    unsubscribe = am.subscribe((s: AuthState) => {
+      authState = s;
+      evaluate();
+    });
+    evaluate();
+  });
+
+  onDestroy(() => unsubscribe?.());
+
+  function dismiss() {
+    if (browser) localStorage.setItem(VAULT_PROMPT_DISMISSED_KEY, '1');
+    visible = false;
+  }
+
+  async function setUp() {
+    const am = getAuthManager();
+    if (!am) return;
+    busy = true;
+    errorMsg = '';
+    try {
+      await am.enrollVault();
+      done = true;
+    } catch (e) {
+      if (isCeremonyCancelled(e)) {
+        errorMsg = '';
+      } else {
+        errorMsg =
+          e instanceof Error && /PRF|prf/.test(e.message)
+            ? "Your passkey provider doesn't support the required feature. Nothing was changed — your key stays as it was. (A passkey may have been created in your password manager; it's safe to delete.)"
+            : e instanceof Error
+              ? e.message
+              : 'Could not set up the passkey. Nothing was changed.';
+      }
+    } finally {
+      busy = false;
+      evaluate();
+    }
+  }
+</script>
+
+{#if visible || done}
+  <aside class="vault-prompt" aria-label="Protect your key with a passkey">
+    {#if done}
+      <p class="vault-prompt-title">🔒 Passkey protection is on</p>
+      <p class="vault-prompt-body">
+        Your key is no longer stored in plain text in this browser. You'll unlock with your passkey
+        next time. Remember: the passkey is <strong>not</strong> a backup — keep your nsec backup
+        safe.
+      </p>
+      <div class="vault-prompt-actions">
+        <button type="button" class="vault-prompt-primary" on:click={() => (done = false)}>
+          Done
+        </button>
+      </div>
+    {:else}
+      <p class="vault-prompt-title">🔑 Protect your key with a passkey</p>
+      <p class="vault-prompt-body">
+        Your Nostr key is currently stored in plain text in this browser. A passkey encrypts it so
+        only you can unlock it. The passkey is <strong>not</strong> a backup of your key — make
+        sure your nsec is backed up first (Settings → Security → Reveal Private Key).
+      </p>
+      {#if errorMsg}
+        <p class="vault-prompt-error" role="alert">{errorMsg}</p>
+      {/if}
+      <div class="vault-prompt-actions">
+        <button type="button" class="vault-prompt-primary" on:click={setUp} disabled={busy}>
+          {busy ? 'Waiting for passkey…' : 'Set up passkey'}
+        </button>
+        <a href="/settings" class="vault-prompt-link">Back up first</a>
+        <button type="button" class="vault-prompt-dismiss" on:click={dismiss} disabled={busy}>
+          Not now
+        </button>
+      </div>
+    {/if}
+  </aside>
+{/if}
+
+<style>
+  .vault-prompt {
+    position: fixed;
+    right: 1rem;
+    bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
+    z-index: 60;
+    max-width: 22rem;
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-input-border);
+    border-radius: 14px;
+    padding: 1rem 1.125rem;
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
+  }
+  @media (max-width: 480px) {
+    .vault-prompt {
+      left: 1rem;
+      right: 1rem;
+      max-width: none;
+      /* Clear the mobile bottom nav */
+      bottom: calc(4.5rem + env(safe-area-inset-bottom, 0px));
+    }
+  }
+  .vault-prompt-title {
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: var(--color-text-primary);
+    margin: 0 0 0.375rem;
+  }
+  .vault-prompt-body {
+    font-size: 0.8125rem;
+    color: var(--color-caption);
+    line-height: 1.5;
+    margin: 0 0 0.75rem;
+  }
+  .vault-prompt-error {
+    font-size: 0.8125rem;
+    color: #ef4444;
+    margin: 0 0 0.75rem;
+  }
+  .vault-prompt-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+  .vault-prompt-primary {
+    background: var(--color-primary, #f97316);
+    color: #fff;
+    border: none;
+    border-radius: 10px;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    padding: 0.5rem 0.875rem;
+    cursor: pointer;
+  }
+  .vault-prompt-primary:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  .vault-prompt-link {
+    font-size: 0.8125rem;
+    color: var(--color-primary, #f97316);
+    text-decoration: underline;
+  }
+  .vault-prompt-dismiss {
+    background: none;
+    border: none;
+    font-size: 0.8125rem;
+    color: var(--color-caption);
+    cursor: pointer;
+    margin-left: auto;
+  }
+</style>

--- a/src/components/PasskeyVaultSection.svelte
+++ b/src/components/PasskeyVaultSection.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+  /**
+   * Settings → Security card for the passkey vault: enroll, status, and the
+   * unlock-gated removal/downgrade flow. Renders nothing on platforms
+   * without WebAuthn (Capacitor builds, old browsers) unless a vault record
+   * already exists (which shouldn't be possible there, but status beats
+   * silence if it ever happens).
+   */
+  import { onMount, onDestroy, createEventDispatcher } from 'svelte';
+  import { getAuthManager, type AuthState } from '$lib/authManager';
+  import {
+    detectSupport,
+    isCeremonyCancelled,
+    type VaultSupport
+  } from '$lib/passkeyVault';
+  import ShieldCheckIcon from 'phosphor-svelte/lib/ShieldCheck';
+
+  const dispatch = createEventDispatcher();
+
+  let support: VaultSupport = 'none';
+  let status: 'none' | 'locked' | 'unlocked' = 'none';
+  let authState: AuthState | null = null;
+  let unsubscribe: (() => void) | null = null;
+  let busy = false;
+  let notice = '';
+  let errorMsg = '';
+  let confirmingRemoval = false;
+
+  function refresh() {
+    const am = getAuthManager();
+    status = am?.getVaultStatus() ?? 'none';
+    authState = am?.getState() ?? null;
+  }
+
+  onMount(async () => {
+    support = await detectSupport();
+    refresh();
+    unsubscribe = getAuthManager()?.subscribe(() => refresh()) ?? null;
+  });
+
+  onDestroy(() => unsubscribe?.());
+
+  $: canEnroll =
+    support === 'full' &&
+    status === 'none' &&
+    !!authState?.isAuthenticated &&
+    authState?.authMethod === 'privateKey';
+
+  function friendlyError(e: unknown, fallback: string): string {
+    if (isCeremonyCancelled(e)) return '';
+    return e instanceof Error ? e.message : fallback;
+  }
+
+  async function enroll() {
+    const am = getAuthManager();
+    if (!am) return;
+    busy = true;
+    errorMsg = '';
+    notice = '';
+    try {
+      await am.enrollVault();
+      notice =
+        'Passkey protection is on. Your key is no longer stored in plain text in this browser. ' +
+        'The passkey is not a backup — keep your revealed nsec somewhere safe.';
+      dispatch('changed');
+    } catch (e) {
+      errorMsg = friendlyError(e, 'Could not set up the passkey. Nothing was changed.');
+    } finally {
+      busy = false;
+      refresh();
+    }
+  }
+
+  async function remove() {
+    const am = getAuthManager();
+    if (!am) return;
+    busy = true;
+    errorMsg = '';
+    notice = '';
+    try {
+      await am.removeVault();
+      confirmingRemoval = false;
+      notice =
+        'Passkey removed. Your key is stored in this browser again — anyone with access to this ' +
+        'browser profile can read it.';
+      dispatch('changed');
+    } catch (e) {
+      errorMsg = friendlyError(e, 'Could not remove the passkey. Nothing was changed.');
+    } finally {
+      busy = false;
+      refresh();
+    }
+  }
+</script>
+
+{#if status !== 'none' || canEnroll}
+  <div class="border-t border-[var(--color-input-border)] pt-5">
+    <div class="flex items-center gap-2 mb-1">
+      <ShieldCheckIcon
+        size={18}
+        class={status !== 'none' ? 'text-green-500' : 'text-caption'}
+        weight={status !== 'none' ? 'fill' : 'regular'}
+      />
+      <p class="text-sm font-medium" style="color: var(--color-text-primary)">Passkey Protection</p>
+    </div>
+
+    {#if status !== 'none'}
+      <p class="text-xs text-caption mb-3">
+        Your Nostr key is encrypted on this device and unlocked with your passkey. The passkey is
+        <strong>not</strong> a backup of your key — if you lose both the passkey and your nsec
+        backup, the account is unrecoverable.
+      </p>
+
+      {#if !confirmingRemoval}
+        <button
+          type="button"
+          class="px-4 py-2 bg-red-500/10 hover:bg-red-500/20 text-red-500 rounded-lg text-sm font-medium transition-colors"
+          on:click={() => (confirmingRemoval = true)}
+          disabled={busy}
+        >
+          Remove passkey protection…
+        </button>
+      {:else}
+        <div
+          class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3 mb-3"
+        >
+          <p class="text-xs text-red-700 dark:text-red-300">
+            Removing the passkey stores your key in plain text in this browser again. Before
+            continuing, make sure you have your nsec backed up — use "Reveal Private Key" below
+            after removal, or confirm you already saved it. You'll be asked to unlock with your
+            passkey to confirm.
+          </p>
+        </div>
+        <div class="flex gap-2">
+          <button
+            type="button"
+            class="px-4 py-2 bg-red-500 hover:bg-red-600 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50"
+            on:click={remove}
+            disabled={busy}
+          >
+            {busy ? 'Waiting for passkey…' : 'Unlock & remove'}
+          </button>
+          <button
+            type="button"
+            class="px-4 py-2 bg-secondary hover:bg-accent-gray rounded-lg text-sm transition-colors"
+            style="color: var(--color-text-primary)"
+            on:click={() => (confirmingRemoval = false)}
+            disabled={busy}
+          >
+            Cancel
+          </button>
+        </div>
+      {/if}
+    {:else}
+      <p class="text-xs text-caption mb-3">
+        Your key is currently stored in plain text in this browser. A passkey encrypts it so only
+        you can unlock it. The passkey is <strong>not</strong> a backup — reveal and save your nsec
+        below first.
+      </p>
+      <button
+        type="button"
+        class="px-4 py-2 bg-secondary hover:bg-accent-gray rounded-lg text-sm font-medium transition-colors disabled:opacity-50"
+        style="color: var(--color-text-primary)"
+        on:click={enroll}
+        disabled={busy}
+      >
+        {busy ? 'Waiting for passkey…' : 'Set up passkey protection'}
+      </button>
+    {/if}
+
+    {#if notice}
+      <p class="text-xs mt-2" style="color: #16a34a">{notice}</p>
+    {/if}
+    {#if errorMsg}
+      <p class="text-xs mt-2" style="color: #ef4444">{errorMsg}</p>
+    {/if}
+  </div>
+{/if}

--- a/src/components/PasskeyVaultSection.svelte
+++ b/src/components/PasskeyVaultSection.svelte
@@ -10,15 +10,17 @@
   import { getAuthManager, type AuthState } from '$lib/authManager';
   import {
     detectSupport,
+    getVaultRecord,
     isCeremonyCancelled,
     type VaultSupport
   } from '$lib/passkeyVault';
+  import { resolveVaultSection } from '$lib/securitySections';
   import ShieldCheckIcon from 'phosphor-svelte/lib/ShieldCheck';
 
   const dispatch = createEventDispatcher();
 
   let support: VaultSupport = 'none';
-  let status: 'none' | 'locked' | 'unlocked' = 'none';
+  let recordPubkey: string | null = null;
   let authState: AuthState | null = null;
   let unsubscribe: (() => void) | null = null;
   let busy = false;
@@ -28,8 +30,8 @@
 
   function refresh() {
     const am = getAuthManager();
-    status = am?.getVaultStatus() ?? 'none';
     authState = am?.getState() ?? null;
+    recordPubkey = getVaultRecord()?.pubkey ?? null;
   }
 
   onMount(async () => {
@@ -40,11 +42,15 @@
 
   onDestroy(() => unsubscribe?.());
 
-  $: canEnroll =
-    support === 'full' &&
-    status === 'none' &&
-    !!authState?.isAuthenticated &&
-    authState?.authMethod === 'privateKey';
+  // Identity-bound gating: enrolled UI only when the live session owns the
+  // record; offer only for plaintext nsec sessions. Foreign records and
+  // nip07/nip46/anonymous sessions render nothing (vault inert there).
+  $: card = resolveVaultSection({
+    support,
+    sessionMethod: authState?.isAuthenticated ? authState.authMethod : null,
+    sessionPubkey: authState?.publicKey ?? '',
+    recordPubkey
+  });
 
   function friendlyError(e: unknown, fallback: string): string {
     if (isCeremonyCancelled(e)) return '';
@@ -93,18 +99,18 @@
   }
 </script>
 
-{#if status !== 'none' || canEnroll}
+{#if card}
   <div class="border-t border-[var(--color-input-border)] pt-5">
     <div class="flex items-center gap-2 mb-1">
       <ShieldCheckIcon
         size={18}
-        class={status !== 'none' ? 'text-green-500' : 'text-caption'}
-        weight={status !== 'none' ? 'fill' : 'regular'}
+        class={card === 'enrolled' ? 'text-green-500' : 'text-caption'}
+        weight={card === 'enrolled' ? 'fill' : 'regular'}
       />
       <p class="text-sm font-medium" style="color: var(--color-text-primary)">Passkey Protection</p>
     </div>
 
-    {#if status !== 'none'}
+    {#if card === 'enrolled'}
       <p class="text-xs text-caption mb-3">
         Your Nostr key is encrypted on this device and unlocked with your passkey. The passkey is
         <strong>not</strong> a backup of your key — if you lose both the passkey and your nsec

--- a/src/lib/authManager.passkey.test.ts
+++ b/src/lib/authManager.passkey.test.ts
@@ -1,0 +1,383 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import fixture from '../test/fixtures/vault-v1.json';
+
+/**
+ * AuthManager ↔ passkey-vault integration. NDK is mocked (like
+ * authManager.nip46.test.ts) but with pubkeys derived for real so the
+ * vault's pubkey-equality logic is exercised honestly; the WebAuthn
+ * authenticator is mocked; the vault crypto runs unmocked against the
+ * fixture vectors.
+ */
+
+vi.mock('$app/environment', () => ({ browser: true }));
+
+vi.mock('@nostr-dev-kit/ndk', async () => {
+  const { getPublicKey } = await import('nostr-tools');
+  const toBytes = (hex: string) =>
+    Uint8Array.from(hex.match(/.{2}/g)!.map((b: string) => parseInt(b, 16)));
+
+  class NDKPrivateKeySigner {
+    privateKey: string;
+    constructor(pk: string) {
+      this.privateKey = pk;
+    }
+    static generate() {
+      return new NDKPrivateKeySigner('11'.repeat(32));
+    }
+    async user() {
+      const pubkey = getPublicKey(toBytes(this.privateKey));
+      return { pubkey, hexpubkey: pubkey };
+    }
+  }
+  class NDKNip46Signer {}
+  class NDKNip07Signer {
+    async user(): Promise<never> {
+      throw new Error('no NIP-07 extension in tests');
+    }
+  }
+  class NDKRelaySet {
+    static fromRelayUrls() {
+      return {};
+    }
+  }
+  return {
+    NDKPrivateKeySigner,
+    NDKNip46Signer,
+    NDKNip07Signer,
+    NDKRelaySet,
+    NDKSubscriptionCacheUsage: { ONLY_RELAY: 'ONLY_RELAY' }
+  };
+});
+
+import { AuthManager, VaultConflictError } from './authManager';
+import { VAULT_STORAGE_KEY, type VaultRecord } from './passkeyVault';
+import { hexToBytes, bytesToB64 } from './passkeyVaultCrypto';
+
+const PK_KEY = 'nostrcooking_privateKey';
+const PUB_KEY = 'nostrcooking_loggedInPublicKey';
+const OTHER_NSEC = '22'.repeat(32); // valid scalar, different account
+
+function fixtureRecord(): VaultRecord {
+  return {
+    version: 1,
+    pubkey: fixture.pubkeyHex,
+    nsecCiphertext: fixture.expectedNsecCiphertextB64,
+    createdAt: 1,
+    keys: [
+      {
+        credentialId: fixture.credentialIdB64url,
+        wrappedDek: fixture.expectedWrappedDekB64,
+        dekIv: bytesToB64(hexToBytes(fixture.dekIvHex)),
+        addedAt: 1
+      }
+    ]
+  };
+}
+
+function fakeAssertion(prfBytes: Uint8Array) {
+  return {
+    id: fixture.credentialIdB64url,
+    rawId: new ArrayBuffer(0),
+    type: 'public-key',
+    getClientExtensionResults: () => ({ prf: { results: { first: prfBytes.slice().buffer } } })
+  };
+}
+
+function makeNdk() {
+  return { signer: null as any, activeUser: null as any };
+}
+
+let store: Map<string, string>;
+let credentials: { create: ReturnType<typeof vi.fn>; get: ReturnType<typeof vi.fn> };
+let ndk: ReturnType<typeof makeNdk>;
+
+const seedVault = () => store.set(VAULT_STORAGE_KEY, JSON.stringify(fixtureRecord()));
+const vaultInStore = () => store.get(VAULT_STORAGE_KEY);
+const flush = () => new Promise((r) => setTimeout(r, 20));
+
+beforeEach(() => {
+  store = new Map();
+  (globalThis as any).localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => store.set(k, String(v)),
+    removeItem: (k: string) => store.delete(k),
+    clear: () => store.clear()
+  };
+  credentials = { create: vi.fn(), get: vi.fn() };
+  vi.stubGlobal('navigator', { credentials });
+  vi.stubGlobal('window', {
+    isSecureContext: true,
+    PublicKeyCredential: function PublicKeyCredential() {}
+  });
+  ndk = makeNdk();
+});
+
+describe('re-login with an existing vault (the re-login hole)', () => {
+  it('same pubkey: adopts the vault, never persists plaintext', async () => {
+    seedVault();
+    const am = new AuthManager(ndk);
+    await am.authenticateWithPrivateKey(fixture.nsecHex);
+
+    const state = am.getState();
+    expect(state.isAuthenticated).toBe(true);
+    expect(state.authMethod).toBe('passkey');
+    expect(state.publicKey).toBe(fixture.pubkeyHex);
+    expect(store.get(PK_KEY)).toBeUndefined();
+    expect(vaultInStore()).toBeDefined();
+    expect(am.getVaultStatus()).toBe('unlocked');
+  });
+
+  it('same pubkey via nsec1 bech32 input also adopts', async () => {
+    seedVault();
+    const { nip19 } = await import('nostr-tools');
+    const nsec = nip19.nsecEncode(hexToBytes(fixture.nsecHex));
+    const am = new AuthManager(ndk);
+    await am.authenticateWithPrivateKey(nsec);
+    expect(am.getState().authMethod).toBe('passkey');
+    expect(store.get(PK_KEY)).toBeUndefined();
+  });
+
+  it('different pubkey: throws VaultConflictError and mutates nothing', async () => {
+    seedVault();
+    const am = new AuthManager(ndk);
+    await expect(am.authenticateWithPrivateKey(OTHER_NSEC)).rejects.toThrow(VaultConflictError);
+
+    expect(am.getState().isAuthenticated).toBe(false);
+    expect(ndk.signer).toBeNull();
+    expect(store.get(PK_KEY)).toBeUndefined();
+    expect(JSON.parse(vaultInStore()!)).toEqual(fixtureRecord());
+  });
+
+  it('different pubkey with replaceVault: deletes the record, proceeds legacy', async () => {
+    seedVault();
+    const am = new AuthManager(ndk);
+    await am.authenticateWithPrivateKey(OTHER_NSEC, { replaceVault: true });
+
+    expect(am.getState().isAuthenticated).toBe(true);
+    expect(am.getState().authMethod).toBe('privateKey');
+    expect(store.get(PK_KEY)).toBe(OTHER_NSEC);
+    expect(vaultInStore()).toBeUndefined();
+  });
+
+  it('no vault: legacy behavior unchanged (plaintext persisted)', async () => {
+    const am = new AuthManager(ndk);
+    await am.authenticateWithPrivateKey(fixture.nsecHex);
+    expect(am.getState().authMethod).toBe('privateKey');
+    expect(store.get(PK_KEY)).toBe(fixture.nsecHex);
+  });
+});
+
+describe('escape hatch: cancelled unlock is never destructive', () => {
+  it('cancel unlock → paste nsec → session live, vault re-adopted, not orphaned', async () => {
+    seedVault();
+    const am = new AuthManager(ndk);
+
+    credentials.get.mockRejectedValue(new DOMException('user cancelled', 'NotAllowedError'));
+    await expect(am.unlockVault()).rejects.toThrow();
+
+    // Cancel left everything intact and surfaced no error banner.
+    expect(am.getState().isAuthenticated).toBe(false);
+    expect(am.getState().error).toBeNull();
+    expect(JSON.parse(vaultInStore()!)).toEqual(fixtureRecord());
+
+    // Escape hatch: paste the nsec — full session, vault still enrolled.
+    await am.authenticateWithPrivateKey(fixture.nsecHex);
+    expect(am.getState().isAuthenticated).toBe(true);
+    expect(am.getState().authMethod).toBe('passkey');
+    expect(store.get(PK_KEY)).toBeUndefined();
+    expect(JSON.parse(vaultInStore()!)).toEqual(fixtureRecord());
+  });
+
+  it('a failed (non-cancel) unlock surfaces an error but keeps the record', async () => {
+    seedVault();
+    const am = new AuthManager(ndk);
+    const wrong = hexToBytes(fixture.prfOutputHex);
+    wrong[0] ^= 0xff;
+    credentials.get.mockResolvedValue(fakeAssertion(wrong));
+
+    await expect(am.unlockVault()).rejects.toThrow();
+    expect(am.getState().isAuthenticated).toBe(false);
+    expect(am.getState().error).toBeTruthy();
+    expect(JSON.parse(vaultInStore()!)).toEqual(fixtureRecord());
+  });
+});
+
+describe('unlockVault', () => {
+  it('starts a memory-only session from the vault', async () => {
+    seedVault();
+    const am = new AuthManager(ndk);
+    credentials.get.mockResolvedValue(fakeAssertion(hexToBytes(fixture.prfOutputHex)));
+
+    await am.unlockVault();
+
+    const state = am.getState();
+    expect(state.isAuthenticated).toBe(true);
+    expect(state.authMethod).toBe('passkey');
+    expect(state.publicKey).toBe(fixture.pubkeyHex);
+    expect(ndk.signer?.privateKey).toBe(fixture.nsecHex);
+    expect(store.get(PK_KEY)).toBeUndefined();
+    expect(store.get(PUB_KEY)).toBe(fixture.pubkeyHex);
+    expect(am.getSessionPrivateKeyHex()).toBe(fixture.nsecHex);
+  });
+});
+
+describe('session restore (initializeFromStorage)', () => {
+  it('locked vault: stays unauthenticated and wipes nothing', async () => {
+    seedVault();
+    store.set(PUB_KEY, fixture.pubkeyHex);
+    const am = new AuthManager(ndk);
+    await flush();
+
+    expect(am.getState().isAuthenticated).toBe(false);
+    expect(am.getVaultStatus()).toBe('locked');
+    // Crucially the NIP-07 restore path (which clearStorage()s on failure)
+    // was never attempted: both keys survive.
+    expect(store.get(PUB_KEY)).toBe(fixture.pubkeyHex);
+    expect(vaultInStore()).toBeDefined();
+  });
+
+  it('interrupted enrollment (plaintext + same-pubkey record): completes the deletion', async () => {
+    seedVault();
+    store.set(PK_KEY, fixture.nsecHex);
+    store.set(PUB_KEY, fixture.pubkeyHex);
+    const am = new AuthManager(ndk);
+    await vi.waitFor(() => expect(am.getState().isAuthenticated).toBe(true));
+
+    expect(am.getState().authMethod).toBe('passkey');
+    expect(store.get(PK_KEY)).toBeUndefined();
+    expect(vaultInStore()).toBeDefined();
+  });
+
+  it('plaintext restore without a vault stays legacy', async () => {
+    store.set(PK_KEY, fixture.nsecHex);
+    store.set(PUB_KEY, fixture.pubkeyHex);
+    const am = new AuthManager(ndk);
+    await vi.waitFor(() => expect(am.getState().isAuthenticated).toBe(true));
+    expect(am.getState().authMethod).toBe('privateKey');
+    expect(store.get(PK_KEY)).toBe(fixture.nsecHex);
+  });
+});
+
+describe('logout', () => {
+  it('clears session state but keeps the vault record', async () => {
+    seedVault();
+    const am = new AuthManager(ndk);
+    credentials.get.mockResolvedValue(fakeAssertion(hexToBytes(fixture.prfOutputHex)));
+    await am.unlockVault();
+
+    await am.logout();
+
+    expect(am.getState().isAuthenticated).toBe(false);
+    expect(ndk.signer).toBeNull();
+    expect(store.get(PUB_KEY)).toBeUndefined();
+    expect(store.get(PK_KEY)).toBeUndefined();
+    expect(JSON.parse(vaultInStore()!)).toEqual(fixtureRecord());
+    expect(am.getVaultStatus()).toBe('locked');
+  });
+});
+
+describe('enrollVault', () => {
+  it('happy path: record written, plaintext deleted only after verification', async () => {
+    const am = new AuthManager(ndk);
+    await am.authenticateWithPrivateKey(fixture.nsecHex);
+    expect(store.get(PK_KEY)).toBe(fixture.nsecHex);
+
+    credentials.create.mockResolvedValue({
+      id: fixture.credentialIdB64url,
+      rawId: new ArrayBuffer(0),
+      type: 'public-key',
+      getClientExtensionResults: () => ({ prf: { enabled: true } })
+    });
+    credentials.get.mockResolvedValue(fakeAssertion(hexToBytes(fixture.prfOutputHex)));
+
+    await am.enrollVault();
+
+    expect(store.get(PK_KEY)).toBeUndefined();
+    expect(am.getState().authMethod).toBe('passkey');
+    const record = JSON.parse(vaultInStore()!);
+    expect(record.pubkey).toBe(fixture.pubkeyHex);
+    expect(am.getVaultStatus()).toBe('unlocked');
+  });
+
+  it('PRF verification failure aborts with no data loss', async () => {
+    const am = new AuthManager(ndk);
+    await am.authenticateWithPrivateKey(fixture.nsecHex);
+
+    credentials.create.mockResolvedValue({
+      id: fixture.credentialIdB64url,
+      rawId: new ArrayBuffer(0),
+      type: 'public-key',
+      getClientExtensionResults: () => ({})
+    });
+    credentials.get.mockResolvedValue({
+      id: fixture.credentialIdB64url,
+      rawId: new ArrayBuffer(0),
+      type: 'public-key',
+      getClientExtensionResults: () => ({}) // no PRF on get either
+    });
+
+    await expect(am.enrollVault()).rejects.toThrow();
+    // Plaintext untouched, no record, session still live as privateKey.
+    expect(store.get(PK_KEY)).toBe(fixture.nsecHex);
+    expect(vaultInStore()).toBeUndefined();
+    expect(am.getState().authMethod).toBe('privateKey');
+    expect(am.getState().isAuthenticated).toBe(true);
+  });
+
+  it('refuses to enroll for non-nsec sessions', async () => {
+    const am = new AuthManager(ndk);
+    await expect(am.enrollVault()).rejects.toThrow(/requires an active/);
+  });
+});
+
+describe('removeVault (downgrade)', () => {
+  it('requires a fresh unlock, restores plaintext, then deletes the record', async () => {
+    seedVault();
+    const am = new AuthManager(ndk);
+    credentials.get.mockResolvedValue(fakeAssertion(hexToBytes(fixture.prfOutputHex)));
+    await am.unlockVault();
+    credentials.get.mockClear();
+    credentials.get.mockResolvedValue(fakeAssertion(hexToBytes(fixture.prfOutputHex)));
+
+    await am.removeVault();
+
+    expect(credentials.get).toHaveBeenCalledTimes(1); // fresh ceremony
+    expect(store.get(PK_KEY)).toBe(fixture.nsecHex);
+    expect(vaultInStore()).toBeUndefined();
+    expect(am.getState().authMethod).toBe('privateKey');
+    expect(am.getState().isAuthenticated).toBe(true);
+    expect(am.getVaultStatus()).toBe('none');
+  });
+
+  it('a cancelled removal ceremony changes nothing', async () => {
+    seedVault();
+    const am = new AuthManager(ndk);
+    credentials.get.mockRejectedValue(new DOMException('cancelled', 'NotAllowedError'));
+    await expect(am.removeVault()).rejects.toThrow();
+    expect(store.get(PK_KEY)).toBeUndefined();
+    expect(JSON.parse(vaultInStore()!)).toEqual(fixtureRecord());
+  });
+});
+
+describe('getSessionPrivateKeyHex', () => {
+  it('reads the in-memory signer for passkey sessions (nothing in storage)', async () => {
+    seedVault();
+    const am = new AuthManager(ndk);
+    credentials.get.mockResolvedValue(fakeAssertion(hexToBytes(fixture.prfOutputHex)));
+    await am.unlockVault();
+    expect(store.get(PK_KEY)).toBeUndefined();
+    expect(am.getSessionPrivateKeyHex()).toBe(fixture.nsecHex);
+  });
+
+  it('falls back to localStorage for legacy sessions', async () => {
+    const am = new AuthManager(ndk);
+    await am.authenticateWithPrivateKey(fixture.nsecHex);
+    ndk.signer = null; // even with the signer gone, legacy storage still answers
+    expect(am.getSessionPrivateKeyHex()).toBe(fixture.nsecHex);
+  });
+
+  it('returns null when there is no nsec session', () => {
+    const am = new AuthManager(ndk);
+    expect(am.getSessionPrivateKeyHex()).toBeNull();
+  });
+});

--- a/src/lib/authManager.passkey.test.ts
+++ b/src/lib/authManager.passkey.test.ts
@@ -371,9 +371,38 @@ describe('removeVault (downgrade)', () => {
   it('a cancelled removal ceremony changes nothing', async () => {
     seedVault();
     const am = new AuthManager(ndk);
+    credentials.get.mockResolvedValue(fakeAssertion(hexToBytes(fixture.prfOutputHex)));
+    await am.unlockVault(); // matching session — the guard is not what's under test here
     credentials.get.mockRejectedValue(new DOMException('cancelled', 'NotAllowedError'));
+
     await expect(am.removeVault()).rejects.toThrow();
     expect(store.get(PK_KEY)).toBeUndefined();
+    expect(JSON.parse(vaultInStore()!)).toEqual(fixtureRecord());
+    expect(am.getState().authMethod).toBe('passkey'); // session unchanged
+  });
+
+  it('refuses when the session belongs to a different account — no ceremony, nothing written (B ruling)', async () => {
+    // Shape of the staging repro: live session for account B, vault record
+    // for account A sitting in the same browser.
+    const am = new AuthManager(ndk);
+    await am.authenticateWithPrivateKey(OTHER_NSEC);
+    seedVault(); // fixture-pubkey record appears "later" (multi-account browser)
+    const sessionPubkeyBefore = am.getState().publicKey;
+
+    await expect(am.removeVault()).rejects.toThrow(/different account/);
+
+    expect(credentials.get).not.toHaveBeenCalled(); // refused BEFORE any passkey prompt
+    expect(JSON.parse(vaultInStore()!)).toEqual(fixtureRecord()); // record intact
+    expect(store.get(PK_KEY)).toBe(OTHER_NSEC); // B's own legacy key untouched
+    expect(am.getState().publicKey).toBe(sessionPubkeyBefore); // no identity switch
+    expect(am.getState().authMethod).toBe('privateKey');
+  });
+
+  it('refuses when not authenticated at all', async () => {
+    seedVault();
+    const am = new AuthManager(ndk);
+    await expect(am.removeVault()).rejects.toThrow(/different account/);
+    expect(credentials.get).not.toHaveBeenCalled();
     expect(JSON.parse(vaultInStore()!)).toEqual(fixtureRecord());
   });
 });

--- a/src/lib/authManager.passkey.test.ts
+++ b/src/lib/authManager.passkey.test.ts
@@ -52,6 +52,7 @@ vi.mock('@nostr-dev-kit/ndk', async () => {
 import { AuthManager, VaultConflictError } from './authManager';
 import { VAULT_STORAGE_KEY, type VaultRecord } from './passkeyVault';
 import { hexToBytes, bytesToB64 } from './passkeyVaultCrypto';
+import { resolveSecuritySections } from './securitySections';
 
 const PK_KEY = 'nostrcooking_privateKey';
 const PUB_KEY = 'nostrcooking_loggedInPublicKey';
@@ -218,6 +219,24 @@ describe('unlockVault', () => {
     expect(store.get(PK_KEY)).toBeUndefined();
     expect(store.get(PUB_KEY)).toBe(fixture.pubkeyHex);
     expect(am.getSessionPrivateKeyHex()).toBe(fixture.nsecHex);
+  });
+
+  it('settings reveal in an unlocked passkey session shows the enrolled nsec, never a NIP-07 section', async () => {
+    seedVault();
+    const am = new AuthManager(ndk);
+    credentials.get.mockResolvedValue(fakeAssertion(hexToBytes(fixture.prfOutputHex)));
+    await am.unlockVault();
+
+    // Exactly the inputs Settings → Security derives after unlock.
+    const sk = am.getSessionPrivateKeyHex();
+    const section = resolveSecuritySections({
+      sk,
+      storedAuthMethod: store.get('nostrcooking_authMethod') ?? null,
+      sessionMethod: am.getState().authMethod
+    });
+    expect(section).toBe('privateKey');
+    expect(sk).toBe(fixture.nsecHex); // revealed value === enrolled nsec
+    expect(store.get(PK_KEY)).toBeUndefined(); // and it never came from storage
   });
 });
 

--- a/src/lib/authManager.ts
+++ b/src/lib/authManager.ts
@@ -13,6 +13,14 @@ import * as nip44 from 'nostr-tools/nip44';
 import * as nip04 from 'nostr-tools/nip04';
 import { fetchNip46UserPubkey, sendNip46Rpc } from './nip46Rpc';
 import { Nip44LocalSigner } from './nip44LocalSigner';
+import {
+  getVaultRecord,
+  deleteVaultRecord,
+  enrollPasskey,
+  unlockPasskey,
+  isCeremonyCancelled
+} from './passkeyVault';
+import { hexToBytes } from './passkeyVaultCrypto';
 
 // Permissions requested in the NIP-46 connect handshake. NDK 2.10's
 // blockUntilReady omits the perms param entirely, so permission-enforcing
@@ -35,7 +43,10 @@ export interface AuthState {
   isAuthenticated: boolean;
   user: NDKUser | null;
   publicKey: string;
-  authMethod: 'nip07' | 'privateKey' | 'anonymous' | 'nip46' | null;
+  // 'passkey' = an nsec session whose key lives ONLY in memory, restored by
+  // unlocking the passkey vault (nostrcooking_vault_v1) instead of plaintext
+  // localStorage. Same signer type as 'privateKey' underneath.
+  authMethod: 'nip07' | 'privateKey' | 'anonymous' | 'nip46' | 'passkey' | null;
   isLoading: boolean;
   error: string | null;
   // NIP-46 auth-challenge URL surfaced when a popup blocker prevents us
@@ -62,6 +73,32 @@ export interface AuthOptions {
   method: 'nip07' | 'privateKey' | 'anonymous' | 'nip46';
   privateKey?: string;
   bunkerConnectionString?: string;
+}
+
+/**
+ * Thrown by authenticateWithPrivateKey when a passkey vault exists for a
+ * DIFFERENT pubkey than the key being logged in. Replacing the vault deletes
+ * the wrapped nsec for that other account, so it requires explicit user
+ * confirmation (retry with { replaceVault: true }). The message is written
+ * for end users so unhandled callers still surface something sane.
+ */
+export class VaultConflictError extends Error {
+  vaultPubkey: string;
+  constructor(vaultPubkey: string) {
+    let label = vaultPubkey;
+    try {
+      label = `${nip19.npubEncode(vaultPubkey).slice(0, 16)}…`;
+    } catch {
+      /* keep hex */
+    }
+    super(
+      `This browser has a saved passkey login for another account (${label}). ` +
+        `Signing in with a different key will remove that saved login — make sure the other ` +
+        `account's key is backed up first.`
+    );
+    this.name = 'VaultConflictError';
+    this.vaultPubkey = vaultPubkey;
+  }
 }
 
 export class AuthManager {
@@ -143,8 +180,24 @@ export class AuthManager {
           await this.authenticateWithPrivateKey(storedPrivateKey);
         } catch (error) {
           console.error('Failed to restore authentication:', error);
-          this.clearStorage();
+          // A vault/plaintext pubkey mismatch shouldn't be reachable, but if
+          // it ever is (multi-tab race), wiping storage here would destroy a
+          // real key. Leave both in place and stay unauthenticated instead.
+          if (!(error instanceof VaultConflictError)) {
+            this.clearStorage();
+          }
         }
+      } else if (getVaultRecord()) {
+        // Passkey vault present with no plaintext key: the session is LOCKED.
+        // Deliberately stay unauthenticated (the app browses anonymously) and
+        // let the UI offer "Unlock with passkey" — WebAuthn get() needs a user
+        // gesture (Safari requires transient activation), so restore cannot
+        // drive the ceremony itself. This is a resting state, not an error:
+        // never clearStorage here, a locked vault must survive reloads and
+        // cancelled unlocks. Must precede the pubkey-only branch below, which
+        // would otherwise attempt a NIP-07 restore (unlock persists
+        // nostrcooking_loggedInPublicKey) and wipe storage when none exists.
+        return;
       } else if (storedPublicKey) {
         try {
           await this.authenticateWithNIP07();
@@ -204,8 +257,18 @@ export class AuthManager {
     }
   }
 
-  // Authenticate with private key
-  async authenticateWithPrivateKey(privateKey: string): Promise<void> {
+  // Authenticate with private key.
+  //
+  // Vault interplay: when a passkey vault exists for the SAME pubkey, the
+  // vault is adopted — the key stays memory-only (authMethod 'passkey') and
+  // plaintext is never (re)persisted, so pasting your nsec after a cancelled
+  // unlock doesn't reopen the XSS hole enrollment closed. A vault for a
+  // DIFFERENT pubkey throws VaultConflictError unless opts.replaceVault,
+  // which callers may only set after explicit user confirmation.
+  async authenticateWithPrivateKey(
+    privateKey: string,
+    opts?: { replaceVault?: boolean }
+  ): Promise<void> {
     this.updateState({ isLoading: true, error: null });
 
     try {
@@ -235,6 +298,22 @@ export class AuthManager {
       if (!/^[0-9a-fA-F]{64}$/.test(pk)) {
         throw new Error('Invalid private key format - expected 64 hex characters or nsec1 key');
       }
+      pk = pk.toLowerCase();
+
+      // Vault check happens BEFORE any signer/state mutation so a conflict
+      // abort leaves both NDK and storage exactly as they were.
+      const derivedPubkey = getPublicKey(hexToBytes(pk));
+      const vault = getVaultRecord();
+      let adoptVault = false;
+      if (vault) {
+        if (vault.pubkey === derivedPubkey) {
+          adoptVault = true;
+        } else if (opts?.replaceVault) {
+          deleteVaultRecord();
+        } else {
+          throw new VaultConflictError(vault.pubkey);
+        }
+      }
 
       const signer = new NDKPrivateKeySigner(pk);
       this.ndk.signer = signer;
@@ -246,13 +325,22 @@ export class AuthManager {
         isAuthenticated: true,
         user,
         publicKey,
-        authMethod: 'privateKey',
+        authMethod: adoptVault ? 'passkey' : 'privateKey',
         isLoading: false,
         error: null
       });
 
       localStorage.setItem('nostrcooking_loggedInPublicKey', publicKey);
-      localStorage.setItem('nostrcooking_privateKey', pk);
+      if (adoptVault) {
+        // Pubkey equality proves the verified vault wraps this same key, so
+        // any plaintext copy here is a leftover from an interrupted
+        // enrollment (record written, deletion crashed) — removing it
+        // completes that verified enrollment rather than violating the
+        // "delete only on verified success" rule.
+        localStorage.removeItem('nostrcooking_privateKey');
+      } else {
+        localStorage.setItem('nostrcooking_privateKey', pk);
+      }
     } catch (error) {
       console.error('Private key authentication failed:', error);
       this.updateState({
@@ -1364,6 +1452,126 @@ export class AuthManager {
     }
   }
 
+  // ============================================================
+  // Passkey vault (see src/lib/passkeyVault.ts)
+  // ============================================================
+
+  // Vault status for UI gating. 'locked' = a record exists but the current
+  // session isn't the unlocked vault session (including: not logged in at
+  // all, or logged in via another method while someone's vault sits here).
+  getVaultStatus(): 'none' | 'locked' | 'unlocked' {
+    if (!getVaultRecord()) return 'none';
+    return this.authState.isAuthenticated && this.authState.authMethod === 'passkey'
+      ? 'unlocked'
+      : 'locked';
+  }
+
+  // The session's private key, memory-first. Backs the settings nsec reveal
+  // for passkey sessions (whose key exists nowhere in storage) and stays
+  // compatible with legacy plaintext sessions via the localStorage fallback.
+  getSessionPrivateKeyHex(): string | null {
+    if (!browser) return null;
+    const method = this.authState.authMethod;
+    if (method === 'privateKey' || method === 'passkey') {
+      // Duck-typed on the value, not the class name — minification mangles
+      // constructor names in production builds.
+      const hex = (this.ndk?.signer as { privateKey?: string } | null)?.privateKey;
+      if (typeof hex === 'string' && /^[0-9a-fA-F]{64}$/.test(hex)) return hex.toLowerCase();
+    }
+    const stored = localStorage.getItem('nostrcooking_privateKey');
+    if (stored && /^[0-9a-fA-F]{64}$/.test(stored)) return stored.toLowerCase();
+    return null;
+  }
+
+  // Unlock the vault via a passkey ceremony and start the nsec session with
+  // the key in memory only. Failure (including user cancel) is NEVER
+  // destructive: the record and all storage stay untouched.
+  async unlockVault(): Promise<void> {
+    if (!browser) throw new Error('Browser environment required');
+    const record = getVaultRecord();
+    if (!record) throw new Error('No passkey vault found on this device');
+
+    this.updateState({ isLoading: true, error: null });
+    try {
+      const privkeyHex = await unlockPasskey(record);
+      const signer = new NDKPrivateKeySigner(privkeyHex);
+      this.ndk.signer = signer;
+      const user = await signer.user();
+
+      this.updateState({
+        isAuthenticated: true,
+        user,
+        publicKey: user.hexpubkey,
+        authMethod: 'passkey',
+        isLoading: false,
+        error: null
+      });
+      localStorage.setItem('nostrcooking_loggedInPublicKey', user.hexpubkey);
+    } catch (error) {
+      this.ndk.signer = null;
+      this.updateState({
+        isAuthenticated: false,
+        user: null,
+        publicKey: '',
+        authMethod: null,
+        isLoading: false,
+        // A dismissed passkey sheet is a normal outcome, not an error banner.
+        error: isCeremonyCancelled(error)
+          ? null
+          : error instanceof Error
+            ? error.message
+            : 'Passkey unlock failed'
+      });
+      throw error;
+    }
+  }
+
+  // Enroll a passkey for the current nsec session. The plaintext key is
+  // deleted ONLY after enrollPasskey has verified a full round-trip on a
+  // real get() assertion; any earlier failure leaves storage untouched.
+  async enrollVault(): Promise<void> {
+    if (!browser) throw new Error('Browser environment required');
+    const { isAuthenticated, authMethod, publicKey } = this.authState;
+    if (!isAuthenticated || (authMethod !== 'privateKey' && authMethod !== 'passkey')) {
+      throw new Error('Passkey protection requires an active private-key session');
+    }
+    const privkeyHex = this.getSessionPrivateKeyHex();
+    if (!privkeyHex) throw new Error('Session private key unavailable');
+
+    let label = 'Zap Cooking';
+    try {
+      label = `Zap Cooking · ${nip19.npubEncode(publicKey).slice(0, 13)}…`;
+    } catch {
+      /* keep default */
+    }
+    await enrollPasskey(privkeyHex, publicKey, label);
+    localStorage.removeItem('nostrcooking_privateKey');
+    this.updateState({ authMethod: 'passkey' });
+  }
+
+  // Remove the vault (downgrade to plaintext-localStorage sessions). Requires
+  // a FRESH unlock ceremony even when the session is already unlocked — it
+  // proves user presence at removal time and guarantees we hold the nsec for
+  // the downgrade. Write order: plaintext first, record deletion second, so
+  // there is never a moment where neither exists.
+  async removeVault(): Promise<void> {
+    if (!browser) throw new Error('Browser environment required');
+    const record = getVaultRecord();
+    if (!record) return;
+
+    const privkeyHex = await unlockPasskey(record);
+    localStorage.setItem('nostrcooking_privateKey', privkeyHex);
+    localStorage.setItem('nostrcooking_loggedInPublicKey', record.pubkey);
+    deleteVaultRecord();
+
+    if (this.authState.isAuthenticated && this.authState.publicKey === record.pubkey) {
+      if (!this.ndk.signer) this.ndk.signer = new NDKPrivateKeySigner(privkeyHex);
+      this.updateState({ authMethod: 'privateKey' });
+    } else {
+      await this.authenticateWithPrivateKey(privkeyHex);
+    }
+  }
+
   // Logout and clear all authentication data
   async logout(): Promise<void> {
     // Clear NIP-46 signer if present
@@ -1388,7 +1596,10 @@ export class AuthManager {
     this.ndk.signer = null;
   }
 
-  // Clear localStorage
+  // Clear localStorage. The passkey vault record (nostrcooking_vault_v1) is
+  // deliberately NOT in this list: logout ends the session but must leave the
+  // vault intact so the user can unlock again later. Removal is an explicit,
+  // unlock-gated settings action (removeVault).
   private clearStorage(): void {
     if (browser) {
       if (this.nip46ResponseSub) {

--- a/src/lib/authManager.ts
+++ b/src/lib/authManager.ts
@@ -1559,17 +1559,26 @@ export class AuthManager {
     const record = getVaultRecord();
     if (!record) return;
 
+    // Defense-in-depth (B ruling): removal is only valid inside the session
+    // that owns the record. Without this, a user in a DIFFERENT account's
+    // session (e.g. NIP-07) who completed the foreign ceremony would get the
+    // other account's nsec written to plaintext and their live session
+    // silently switched to it. Refuse BEFORE any ceremony, independent of
+    // whatever UI gating exists above.
+    if (!this.authState.isAuthenticated || this.authState.publicKey !== record.pubkey) {
+      throw new Error(
+        'This passkey vault belongs to a different account than the current session. ' +
+          'Sign in as that account to remove it.'
+      );
+    }
+
     const privkeyHex = await unlockPasskey(record);
     localStorage.setItem('nostrcooking_privateKey', privkeyHex);
     localStorage.setItem('nostrcooking_loggedInPublicKey', record.pubkey);
     deleteVaultRecord();
 
-    if (this.authState.isAuthenticated && this.authState.publicKey === record.pubkey) {
-      if (!this.ndk.signer) this.ndk.signer = new NDKPrivateKeySigner(privkeyHex);
-      this.updateState({ authMethod: 'privateKey' });
-    } else {
-      await this.authenticateWithPrivateKey(privkeyHex);
-    }
+    if (!this.ndk.signer) this.ndk.signer = new NDKPrivateKeySigner(privkeyHex);
+    this.updateState({ authMethod: 'privateKey' });
   }
 
   // Logout and clear all authentication data

--- a/src/lib/encryptionService.passkey.test.ts
+++ b/src/lib/encryptionService.passkey.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import fixture from '../test/fixtures/vault-v1.json';
+import { getPublicKey } from 'nostr-tools';
+
+/**
+ * encryptionService signer-key detection for passkey-vault sessions.
+ *
+ * The key requirement (Gate 2 ruling): detection must NOT rely on the
+ * signer's class name — minification mangles constructor names in
+ * production. These tests use a signer class whose name contains no
+ * "PrivateKeySigner" substring at all; a name-based implementation of
+ * getPrivateKey() would fail them.
+ */
+
+vi.mock('$app/environment', () => ({ browser: true }));
+
+const { fakeNdk } = vi.hoisted(() => ({ fakeNdk: { signer: null as unknown } }));
+vi.mock('$lib/nostr', async () => {
+  const { writable } = await import('svelte/store');
+  return { ndk: writable(fakeNdk) };
+});
+
+import { hasEncryptionSupport, encrypt, decrypt } from './encryptionService';
+import { hexToBytes } from './passkeyVaultCrypto';
+
+// Deliberately mangled name — simulates production minification output.
+class Xq {
+  privateKey: string;
+  constructor(pk: string) {
+    this.privateKey = pk;
+  }
+}
+
+let store: Map<string, string>;
+
+beforeEach(() => {
+  store = new Map();
+  (globalThis as any).localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => store.set(k, String(v)),
+    removeItem: (k: string) => store.delete(k),
+    clear: () => store.clear()
+  };
+  (globalThis as any).window = {}; // no window.nostr
+  fakeNdk.signer = null;
+});
+
+describe('in-memory signer key detection (duck-typed, minification-proof)', () => {
+  it('hasEncryptionSupport is true with a mangled-name signer and empty localStorage', () => {
+    fakeNdk.signer = new Xq(fixture.nsecHex);
+    expect(store.get('nostrcooking_privateKey')).toBeUndefined();
+    expect(hasEncryptionSupport()).toBe(true);
+  });
+
+  it('hasEncryptionSupport is false without a key anywhere', () => {
+    fakeNdk.signer = new Xq('not-a-key'); // property present but not 64-hex
+    expect(hasEncryptionSupport()).toBe(false);
+  });
+
+  it('encrypt/decrypt round-trip using ONLY the in-memory signer key', async () => {
+    fakeNdk.signer = new Xq(fixture.nsecHex);
+    const selfPubkey = getPublicKey(hexToBytes(fixture.nsecHex));
+
+    const { ciphertext, method } = await encrypt(selfPubkey, 'passkey vault says hi');
+    expect(method).toBe('nip44');
+    // Nothing was ever read from (or written to) localStorage.
+    expect(store.size).toBe(0);
+
+    await expect(decrypt(selfPubkey, ciphertext, 'nip44')).resolves.toBe('passkey vault says hi');
+  });
+
+  it('a NIP-46-shaped signer (no privateKey getter) cannot leak a key', async () => {
+    fakeNdk.signer = { remotePubkey: 'ab'.repeat(32) }; // no privateKey property
+    expect(hasEncryptionSupport()).toBe(false);
+    await expect(encrypt('cd'.repeat(32), 'x')).rejects.toThrow();
+  });
+
+  it('legacy plaintext sessions still work via the localStorage fallback', () => {
+    fakeNdk.signer = null;
+    store.set('nostrcooking_privateKey', fixture.nsecHex);
+    expect(hasEncryptionSupport()).toBe(true);
+  });
+});

--- a/src/lib/encryptionService.ts
+++ b/src/lib/encryptionService.ts
@@ -120,10 +120,28 @@ type SignerWithEncryption = {
 };
 
 /**
- * Get private key from localStorage if available
+ * Get the session private key: in-memory signer first, localStorage second.
+ *
+ * Passkey-vault sessions keep the nsec ONLY in the NDK signer — nothing in
+ * localStorage — so the signer must be consulted first. Detection is
+ * duck-typed on the value (a 64-hex `privateKey` property, which in NDK 2.10
+ * only NDKPrivateKeySigner and its subclasses expose): class-name checks are
+ * mangled by minification in production, and NDKNip46Signer has no such
+ * getter so a bunker session can never leak its ephemeral client key here.
  */
 function getPrivateKey(): string | null {
   if (!browser) return null;
+
+  try {
+    const signer = get(ndk).signer as { privateKey?: string } | null | undefined;
+    const hex = signer?.privateKey;
+    if (typeof hex === 'string' && /^[0-9a-fA-F]{64}$/.test(hex)) {
+      return hex.toLowerCase();
+    }
+  } catch {
+    /* fall through to stored key */
+  }
+
   const stored = localStorage.getItem('nostrcooking_privateKey');
   if (!stored) return null;
 

--- a/src/lib/passkeyVault.test.ts
+++ b/src/lib/passkeyVault.test.ts
@@ -219,6 +219,12 @@ describe('unlockPasskey', () => {
 });
 
 describe('detectSupport', () => {
+  function stubCapabilities(caps: (() => Promise<unknown>) | undefined) {
+    const pkc: any = function PublicKeyCredential() {};
+    if (caps) pkc.getClientCapabilities = caps;
+    vi.stubGlobal('window', { isSecureContext: true, PublicKeyCredential: pkc });
+  }
+
   it("returns 'none' when PublicKeyCredential is absent", async () => {
     vi.stubGlobal('window', { isSecureContext: true });
     expect(await detectSupport()).toBe('none');
@@ -232,14 +238,46 @@ describe('detectSupport', () => {
     expect(await detectSupport()).toBe('none');
   });
 
+  it("returns 'full' when getClientCapabilities reports extension:prf true", async () => {
+    stubCapabilities(async () => ({ 'extension:prf': true }));
+    expect(await detectSupport()).toBe('full');
+  });
+
   it("returns 'no-prf' when getClientCapabilities reports extension:prf false", async () => {
-    const pkc: any = function PublicKeyCredential() {};
-    pkc.getClientCapabilities = async () => ({ 'extension:prf': false });
-    vi.stubGlobal('window', { isSecureContext: true, PublicKeyCredential: pkc });
+    stubCapabilities(async () => ({ 'extension:prf': false }));
     expect(await detectSupport()).toBe('no-prf');
   });
 
-  it("returns provisional 'full' when capabilities are unavailable", async () => {
+  it("returns provisional 'full' when the extension:prf key is ABSENT (Safari shape)", async () => {
+    // Verbatim getClientCapabilities() result observed on Safari/macOS:
+    // Safari omits extension keys entirely. Per the WebAuthn spec an absent
+    // capability means "unknown", not "unsupported" — the feature must be
+    // shown and the enrollment ceremony stays the authoritative check.
+    stubCapabilities(async () => ({
+      conditionalCreate: true,
+      conditionalGet: true,
+      hybridTransport: true,
+      passkeyPlatformAuthenticator: true,
+      relatedOrigins: true,
+      userVerifyingPlatformAuthenticator: true
+    }));
+    expect(await detectSupport()).toBe('full');
+  });
+
+  it("returns provisional 'full' when getClientCapabilities is missing (pre-17.4 browsers)", async () => {
+    stubCapabilities(undefined);
+    expect(await detectSupport()).toBe('full');
+  });
+
+  it("returns provisional 'full' when getClientCapabilities throws", async () => {
+    stubCapabilities(async () => {
+      throw new Error('boom');
+    });
+    expect(await detectSupport()).toBe('full');
+  });
+
+  it("returns provisional 'full' when getClientCapabilities resolves to a non-object", async () => {
+    stubCapabilities(async () => undefined);
     expect(await detectSupport()).toBe('full');
   });
 });

--- a/src/lib/passkeyVault.test.ts
+++ b/src/lib/passkeyVault.test.ts
@@ -32,7 +32,7 @@ const NEW_CRED_ID = 'bmV3LWNyZWQtaWQtMDE'; // b64url of "new-cred-id-01"
 
 function fakeCredential(
   idB64url: string,
-  ext: { prfResult?: Uint8Array; prfEnabled?: boolean } = {}
+  ext: { prfResult?: Uint8Array; prfEnabled?: boolean; prfAsOffsetView?: boolean } = {}
 ) {
   const raw = b64urlToBytes(idB64url);
   return {
@@ -41,6 +41,16 @@ function fakeCredential(
     type: 'public-key',
     getClientExtensionResults: () => {
       if (ext.prfResult) {
+        if (ext.prfAsOffsetView) {
+          // Some authenticator bridges hand back a TypedArray VIEW at a
+          // nonzero offset inside a larger buffer instead of a bare
+          // ArrayBuffer. getPrfResult must honor byteOffset/byteLength.
+          const padded = new Uint8Array(8 + ext.prfResult.length + 8);
+          padded.set(ext.prfResult, 8);
+          return {
+            prf: { results: { first: new Uint8Array(padded.buffer, 8, ext.prfResult.length) } }
+          };
+        }
         // Return a copy: production zeroizes the PRF buffer after use, and
         // reusing one Uint8Array across mocked ceremonies would leak that.
         return { prf: { results: { first: ext.prfResult.slice().buffer } } };
@@ -223,6 +233,13 @@ describe('unlockPasskey', () => {
     let caught: unknown;
     await unlockPasskey(fixtureRecord()).catch((e) => (caught = e));
     expect(isCeremonyCancelled(caught)).toBe(true);
+  });
+
+  it('accepts a PRF result delivered as a TypedArray view at a nonzero offset', async () => {
+    credentials.get.mockResolvedValue(
+      fakeCredential(fixture.credentialIdB64url, { prfResult: PRF_BYTES(), prfAsOffsetView: true })
+    );
+    await expect(unlockPasskey(fixtureRecord())).resolves.toBe(fixture.nsecHex);
   });
 });
 

--- a/src/lib/passkeyVault.test.ts
+++ b/src/lib/passkeyVault.test.ts
@@ -85,6 +85,10 @@ beforeEach(() => {
     isSecureContext: true,
     PublicKeyCredential: function PublicKeyCredential() {}
   });
+  // The feature is origin-gated (C ruling): rp.id is always 'zap.cooking'
+  // and detectSupport() is 'none' anywhere else, so tests must declare an
+  // on-domain origin. Off-domain cases are covered explicitly below.
+  vi.stubGlobal('location', { hostname: 'zap.cooking' });
 });
 
 describe('vault record storage', () => {
@@ -116,8 +120,12 @@ describe('enrollPasskey', () => {
     expect(record.keys).toHaveLength(1);
     expect(record.keys[0].credentialId).toBe(NEW_CRED_ID);
     expect(getVaultRecord()).toEqual(record);
+    // Credentials bind to the fixed production rp id, never the origin.
+    const createArgs = credentials.create.mock.calls[0][0].publicKey;
+    expect(createArgs.rp.id).toBe('zap.cooking');
     // The verify-get must have pinned allowCredentials to the new credential.
     const getArgs = credentials.get.mock.calls[0][0].publicKey;
+    expect(getArgs.rpId).toBe('zap.cooking');
     expect(getArgs.allowCredentials).toHaveLength(1);
     expect(getArgs.userVerification).toBe('required');
 
@@ -278,6 +286,24 @@ describe('detectSupport', () => {
 
   it("returns provisional 'full' when getClientCapabilities resolves to a non-object", async () => {
     stubCapabilities(async () => undefined);
+    expect(await detectSupport()).toBe('full');
+  });
+
+  it("returns 'none' on unsupported origins regardless of WebAuthn availability (C ruling)", async () => {
+    for (const hostname of [
+      'feat-passkey-nsec-vault.frontend-hvd.pages.dev',
+      'localhost',
+      'zap.cooking.evil.example' // suffix must not match via substring tricks
+    ]) {
+      vi.stubGlobal('location', { hostname });
+      stubCapabilities(async () => ({ 'extension:prf': true }));
+      expect(await detectSupport()).toBe('none');
+    }
+  });
+
+  it("staging.zap.cooking is a supported origin (the pre-prod test surface)", async () => {
+    vi.stubGlobal('location', { hostname: 'staging.zap.cooking' });
+    stubCapabilities(async () => ({ 'extension:prf': true }));
     expect(await detectSupport()).toBe('full');
   });
 });

--- a/src/lib/passkeyVault.test.ts
+++ b/src/lib/passkeyVault.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import fixture from '../test/fixtures/vault-v1.json';
+
+/**
+ * WebAuthn ceremony tests with a mocked navigator.credentials. The crypto
+ * underneath runs REAL (passkeyVaultCrypto) — only the authenticator is
+ * faked, so these tests prove the enroll→verify→persist and unlock→decrypt
+ * plumbing end to end against the fixture vectors.
+ */
+
+vi.mock('$app/environment', () => ({ browser: true }));
+
+import {
+  enrollPasskey,
+  unlockPasskey,
+  getVaultRecord,
+  saveVaultRecord,
+  deleteVaultRecord,
+  detectSupport,
+  shouldOfferEnrollment,
+  isCeremonyCancelled,
+  PrfUnsupportedError,
+  UnlockFailedError,
+  VAULT_STORAGE_KEY,
+  type VaultRecord
+} from './passkeyVault';
+import { hexToBytes, bytesToB64, b64urlToBytes } from './passkeyVaultCrypto';
+import { NDKPrivateKeySigner } from '@nostr-dev-kit/ndk';
+
+const PRF_BYTES = () => hexToBytes(fixture.prfOutputHex);
+const NEW_CRED_ID = 'bmV3LWNyZWQtaWQtMDE'; // b64url of "new-cred-id-01"
+
+function fakeCredential(
+  idB64url: string,
+  ext: { prfResult?: Uint8Array; prfEnabled?: boolean } = {}
+) {
+  const raw = b64urlToBytes(idB64url);
+  return {
+    id: idB64url,
+    rawId: raw.buffer,
+    type: 'public-key',
+    getClientExtensionResults: () => {
+      if (ext.prfResult) {
+        // Return a copy: production zeroizes the PRF buffer after use, and
+        // reusing one Uint8Array across mocked ceremonies would leak that.
+        return { prf: { results: { first: ext.prfResult.slice().buffer } } };
+      }
+      if (ext.prfEnabled !== undefined) return { prf: { enabled: ext.prfEnabled } };
+      return {};
+    }
+  };
+}
+
+function fixtureRecord(): VaultRecord {
+  return {
+    version: 1,
+    pubkey: fixture.pubkeyHex,
+    nsecCiphertext: fixture.expectedNsecCiphertextB64,
+    createdAt: 1,
+    keys: [
+      {
+        credentialId: fixture.credentialIdB64url,
+        wrappedDek: fixture.expectedWrappedDekB64,
+        dekIv: bytesToB64(hexToBytes(fixture.dekIvHex)),
+        addedAt: 1
+      }
+    ]
+  };
+}
+
+let store: Map<string, string>;
+let credentials: { create: ReturnType<typeof vi.fn>; get: ReturnType<typeof vi.fn> };
+
+beforeEach(() => {
+  store = new Map();
+  (globalThis as any).localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => store.set(k, String(v)),
+    removeItem: (k: string) => store.delete(k),
+    clear: () => store.clear()
+  };
+  credentials = { create: vi.fn(), get: vi.fn() };
+  vi.stubGlobal('navigator', { credentials });
+  vi.stubGlobal('window', {
+    isSecureContext: true,
+    PublicKeyCredential: function PublicKeyCredential() {}
+  });
+});
+
+describe('vault record storage', () => {
+  it('round-trips a valid record', () => {
+    saveVaultRecord(fixtureRecord());
+    expect(getVaultRecord()).toEqual(fixtureRecord());
+    deleteVaultRecord();
+    expect(getVaultRecord()).toBeNull();
+  });
+
+  it('rejects malformed records instead of throwing', () => {
+    store.set(VAULT_STORAGE_KEY, 'not-json');
+    expect(getVaultRecord()).toBeNull();
+    store.set(VAULT_STORAGE_KEY, JSON.stringify({ version: 2, pubkey: fixture.pubkeyHex }));
+    expect(getVaultRecord()).toBeNull();
+    store.set(VAULT_STORAGE_KEY, JSON.stringify({ ...fixtureRecord(), keys: [] }));
+    expect(getVaultRecord()).toBeNull();
+  });
+});
+
+describe('enrollPasskey', () => {
+  it('happy path: create → verify-on-get → record persisted, then unlockable', async () => {
+    credentials.create.mockResolvedValue(fakeCredential(NEW_CRED_ID, { prfEnabled: true }));
+    credentials.get.mockResolvedValue(fakeCredential(NEW_CRED_ID, { prfResult: PRF_BYTES() }));
+
+    const record = await enrollPasskey(fixture.nsecHex, fixture.pubkeyHex, 'Test');
+
+    expect(record.pubkey).toBe(fixture.pubkeyHex);
+    expect(record.keys).toHaveLength(1);
+    expect(record.keys[0].credentialId).toBe(NEW_CRED_ID);
+    expect(getVaultRecord()).toEqual(record);
+    // The verify-get must have pinned allowCredentials to the new credential.
+    const getArgs = credentials.get.mock.calls[0][0].publicKey;
+    expect(getArgs.allowCredentials).toHaveLength(1);
+    expect(getArgs.userVerification).toBe('required');
+
+    // The persisted record decrypts with the same PRF output.
+    credentials.get.mockResolvedValue(
+      fakeCredential(NEW_CRED_ID, { prfResult: PRF_BYTES() })
+    );
+    await expect(unlockPasskey(record)).resolves.toBe(fixture.nsecHex);
+  });
+
+  it('aborts without persisting when create() reports prf.enabled === false', async () => {
+    credentials.create.mockResolvedValue(fakeCredential(NEW_CRED_ID, { prfEnabled: false }));
+    await expect(enrollPasskey(fixture.nsecHex, fixture.pubkeyHex, 'Test')).rejects.toThrow(
+      PrfUnsupportedError
+    );
+    expect(credentials.get).not.toHaveBeenCalled();
+    expect(getVaultRecord()).toBeNull();
+  });
+
+  it('aborts without persisting when get() returns no PRF result (create alone is never trusted)', async () => {
+    credentials.create.mockResolvedValue(fakeCredential(NEW_CRED_ID, { prfEnabled: true }));
+    credentials.get.mockResolvedValue(fakeCredential(NEW_CRED_ID, {}));
+    await expect(enrollPasskey(fixture.nsecHex, fixture.pubkeyHex, 'Test')).rejects.toThrow(
+      PrfUnsupportedError
+    );
+    expect(getVaultRecord()).toBeNull();
+  });
+
+  it('bubbles user cancellation without persisting', async () => {
+    credentials.create.mockRejectedValue(new DOMException('cancelled', 'NotAllowedError'));
+    let caught: unknown;
+    await enrollPasskey(fixture.nsecHex, fixture.pubkeyHex, 'Test').catch((e) => (caught = e));
+    expect(isCeremonyCancelled(caught)).toBe(true);
+    expect(getVaultRecord()).toBeNull();
+  });
+
+  it('rejects a private key that does not match the pubkey', async () => {
+    await expect(enrollPasskey('11'.repeat(32), fixture.pubkeyHex, 'Test')).rejects.toThrow(
+      /does not match/
+    );
+    expect(credentials.create).not.toHaveBeenCalled();
+  });
+
+  it('passes existing credentials as excludeCredentials on create()', async () => {
+    saveVaultRecord(fixtureRecord());
+    credentials.create.mockResolvedValue(fakeCredential(NEW_CRED_ID, { prfEnabled: true }));
+    credentials.get.mockResolvedValue(fakeCredential(NEW_CRED_ID, { prfResult: PRF_BYTES() }));
+    await enrollPasskey(fixture.nsecHex, fixture.pubkeyHex, 'Test');
+    const createArgs = credentials.create.mock.calls[0][0].publicKey;
+    expect(createArgs.excludeCredentials).toHaveLength(1);
+    expect(new Uint8Array(createArgs.excludeCredentials[0].id)).toEqual(
+      b64urlToBytes(fixture.credentialIdB64url)
+    );
+  });
+});
+
+describe('unlockPasskey', () => {
+  it('decrypts the fixture record with the fixture PRF output', async () => {
+    credentials.get.mockResolvedValue(
+      fakeCredential(fixture.credentialIdB64url, { prfResult: PRF_BYTES() })
+    );
+    await expect(unlockPasskey(fixtureRecord())).resolves.toBe(fixture.nsecHex);
+    const getArgs = credentials.get.mock.calls[0][0].publicKey;
+    expect(new Uint8Array(getArgs.allowCredentials[0].id)).toEqual(
+      b64urlToBytes(fixture.credentialIdB64url)
+    );
+  });
+
+  it('fails closed with a wrong PRF output and leaves the record intact', async () => {
+    const wrong = PRF_BYTES();
+    wrong[0] ^= 0xff;
+    saveVaultRecord(fixtureRecord());
+    credentials.get.mockResolvedValue(
+      fakeCredential(fixture.credentialIdB64url, { prfResult: wrong })
+    );
+    await expect(unlockPasskey(fixtureRecord())).rejects.toThrow(UnlockFailedError);
+    expect(getVaultRecord()).toEqual(fixtureRecord());
+  });
+
+  it('fails closed when the assertion uses a credential not in the record', async () => {
+    credentials.get.mockResolvedValue(fakeCredential(NEW_CRED_ID, { prfResult: PRF_BYTES() }));
+    await expect(unlockPasskey(fixtureRecord())).rejects.toThrow(UnlockFailedError);
+  });
+
+  it('fails closed when the decrypted key does not match the record pubkey', async () => {
+    const tampered = { ...fixtureRecord(), pubkey: 'ab'.repeat(32) };
+    credentials.get.mockResolvedValue(
+      fakeCredential(fixture.credentialIdB64url, { prfResult: PRF_BYTES() })
+    );
+    await expect(unlockPasskey(tampered)).rejects.toThrow(UnlockFailedError);
+  });
+
+  it('bubbles user cancellation as a cancellation', async () => {
+    credentials.get.mockRejectedValue(new DOMException('cancelled', 'NotAllowedError'));
+    let caught: unknown;
+    await unlockPasskey(fixtureRecord()).catch((e) => (caught = e));
+    expect(isCeremonyCancelled(caught)).toBe(true);
+  });
+});
+
+describe('detectSupport', () => {
+  it("returns 'none' when PublicKeyCredential is absent", async () => {
+    vi.stubGlobal('window', { isSecureContext: true });
+    expect(await detectSupport()).toBe('none');
+  });
+
+  it("returns 'none' outside a secure context", async () => {
+    vi.stubGlobal('window', {
+      isSecureContext: false,
+      PublicKeyCredential: function PublicKeyCredential() {}
+    });
+    expect(await detectSupport()).toBe('none');
+  });
+
+  it("returns 'no-prf' when getClientCapabilities reports extension:prf false", async () => {
+    const pkc: any = function PublicKeyCredential() {};
+    pkc.getClientCapabilities = async () => ({ 'extension:prf': false });
+    vi.stubGlobal('window', { isSecureContext: true, PublicKeyCredential: pkc });
+    expect(await detectSupport()).toBe('no-prf');
+  });
+
+  it("returns provisional 'full' when capabilities are unavailable", async () => {
+    expect(await detectSupport()).toBe('full');
+  });
+});
+
+describe('shouldOfferEnrollment', () => {
+  const base = {
+    authMethod: 'privateKey' as string | null,
+    isAuthenticated: true,
+    hasPlaintextKey: true,
+    hasVault: false,
+    support: 'full' as const,
+    dismissed: false
+  };
+
+  it('offers only for authenticated plaintext-key sessions with full support', () => {
+    expect(shouldOfferEnrollment(base)).toBe(true);
+  });
+
+  const negativeCases: Array<[string, Parameters<typeof shouldOfferEnrollment>[0]]> = [
+    ['not authenticated', { ...base, isAuthenticated: false }],
+    ['nip07 session', { ...base, authMethod: 'nip07' }],
+    ['nip46 session', { ...base, authMethod: 'nip46' }],
+    ['already enrolled', { ...base, hasVault: true }],
+    ['no plaintext key', { ...base, hasPlaintextKey: false }],
+    ['no PRF support', { ...base, support: 'no-prf' }],
+    ['no WebAuthn', { ...base, support: 'none' }],
+    ['dismissed', { ...base, dismissed: true }]
+  ];
+  for (const [label, ctx] of negativeCases) {
+    it(`does not offer when ${label}`, () => {
+      expect(shouldOfferEnrollment(ctx)).toBe(false);
+    });
+  }
+});
+
+describe('NDK contract (real NDK, no mock)', () => {
+  it('NDKPrivateKeySigner.privateKey returns the hex key encryptionService expects', () => {
+    const signer = new NDKPrivateKeySigner(fixture.nsecHex);
+    expect(signer.privateKey).toBe(fixture.nsecHex);
+    expect(signer.privateKey).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/src/lib/passkeyVault.ts
+++ b/src/lib/passkeyVault.ts
@@ -33,10 +33,18 @@ import { getPublicKey } from 'nostr-tools';
 export const VAULT_STORAGE_KEY = 'nostrcooking_vault_v1';
 export const VAULT_PROMPT_DISMISSED_KEY = 'nostrcooking_vault_prompt_dismissed';
 
-/** rp.id: fixed on production (related-origins file already deployed), host-default elsewhere (dev). */
-function rpIdForOrigin(): string | undefined {
+/**
+ * All credentials bind to the production rp id — never the current origin.
+ * A hostname-derived rp.id (the previous behavior) let preview/pages.dev
+ * builds mint working passkeys bound to throwaway origins; per the C ruling
+ * the feature is instead cleanly ABSENT off zap.cooking/*.zap.cooking (see
+ * isSupportedOrigin), and staging.zap.cooking is the pre-prod test surface.
+ */
+export const RP_ID = 'zap.cooking';
+
+function isSupportedOrigin(): boolean {
   const host = typeof location !== 'undefined' ? location.hostname : '';
-  return host === 'zap.cooking' || host.endsWith('.zap.cooking') ? 'zap.cooking' : undefined;
+  return host === RP_ID || host.endsWith(`.${RP_ID}`);
 }
 
 export interface VaultKeyEntry {
@@ -122,6 +130,7 @@ export type VaultSupport = 'full' | 'no-prf' | 'none';
  */
 export async function detectSupport(): Promise<VaultSupport> {
   if (!browser || isNative()) return 'none';
+  if (!isSupportedOrigin()) return 'none';
   if (!window.isSecureContext) return 'none';
   const pkc = (window as any).PublicKeyCredential;
   if (!pkc || !navigator.credentials?.create) return 'none';
@@ -193,7 +202,7 @@ async function assertWithPrf(
   const assertion = (await navigator.credentials.get({
     publicKey: {
       challenge: randomChallenge() as BufferSource,
-      rpId: rpIdForOrigin(),
+      rpId: RP_ID,
       allowCredentials: credentialIds.map((id) => ({
         type: 'public-key' as const,
         id: b64urlToBytes(id) as BufferSource
@@ -238,7 +247,7 @@ export async function enrollPasskey(
   const created = (await navigator.credentials.create({
     publicKey: {
       challenge: randomChallenge() as BufferSource,
-      rp: { id: rpIdForOrigin(), name: 'Zap Cooking' },
+      rp: { id: RP_ID, name: 'Zap Cooking' },
       user: {
         id: hexToBytes(pubkey) as BufferSource,
         name: userLabel,

--- a/src/lib/passkeyVault.ts
+++ b/src/lib/passkeyVault.ts
@@ -1,0 +1,336 @@
+/**
+ * Passkey-wrapped nsec vault (Phase 1: local-only, web-only).
+ *
+ * WebAuthn PRF ceremonies + the localStorage vault record. Crypto lives in
+ * passkeyVaultCrypto.ts; AuthManager owns all session state and is the ONLY
+ * module allowed to touch `nostrcooking_privateKey` — this module never
+ * reads or writes the plaintext key, so the "delete plaintext only on
+ * verified enrollment success" invariant is enforceable in one place.
+ *
+ * Platform: the feature is web-only. Capacitor WebViews (iOS WKWebView has
+ * no WebAuthn at all; Android WebView has no usable PRF) are excluded
+ * explicitly via isNative() in addition to API feature detection.
+ */
+
+import { browser } from '$app/environment';
+import { isNative } from '$lib/platform';
+import {
+  PRF_INPUT,
+  b64urlToBytes,
+  bytesToB64,
+  b64ToBytes,
+  hexToBytes,
+  deriveKek,
+  wrapDek,
+  unwrapDek,
+  encryptNsec,
+  decryptNsec,
+  generateDek,
+  zeroize
+} from '$lib/passkeyVaultCrypto';
+import { getPublicKey } from 'nostr-tools';
+
+export const VAULT_STORAGE_KEY = 'nostrcooking_vault_v1';
+export const VAULT_PROMPT_DISMISSED_KEY = 'nostrcooking_vault_prompt_dismissed';
+
+/** rp.id: fixed on production (related-origins file already deployed), host-default elsewhere (dev). */
+function rpIdForOrigin(): string | undefined {
+  const host = typeof location !== 'undefined' ? location.hostname : '';
+  return host === 'zap.cooking' || host.endsWith('.zap.cooking') ? 'zap.cooking' : undefined;
+}
+
+export interface VaultKeyEntry {
+  credentialId: string; // base64url rawId
+  wrappedDek: string; // base64
+  dekIv: string; // base64
+  addedAt: number;
+}
+
+export interface VaultRecord {
+  version: 1;
+  pubkey: string; // hex
+  nsecCiphertext: string; // NIP-44 v2 payload (base64)
+  createdAt: number;
+  keys: VaultKeyEntry[];
+}
+
+export class PasskeyVaultError extends Error {}
+/** Authenticator/provider has no usable PRF — enrollment must not proceed. */
+export class PrfUnsupportedError extends PasskeyVaultError {}
+/** Post-enroll round-trip verification failed — nothing was persisted. */
+export class EnrollVerifyError extends PasskeyVaultError {}
+/** Unlock ceremony completed but decryption failed (wrong credential/PRF). */
+export class UnlockFailedError extends PasskeyVaultError {}
+
+/** True when the user dismissed/cancelled the WebAuthn prompt. */
+export function isCeremonyCancelled(e: unknown): boolean {
+  return e instanceof DOMException && (e.name === 'NotAllowedError' || e.name === 'AbortError');
+}
+
+// ── Vault record storage ────────────────────────────────────────
+
+function isValidRecord(r: any): r is VaultRecord {
+  return (
+    !!r &&
+    r.version === 1 &&
+    typeof r.pubkey === 'string' &&
+    /^[0-9a-f]{64}$/.test(r.pubkey) &&
+    typeof r.nsecCiphertext === 'string' &&
+    r.nsecCiphertext.length > 0 &&
+    Array.isArray(r.keys) &&
+    r.keys.length > 0 &&
+    r.keys.every(
+      (k: any) =>
+        k &&
+        typeof k.credentialId === 'string' &&
+        typeof k.wrappedDek === 'string' &&
+        typeof k.dekIv === 'string'
+    )
+  );
+}
+
+export function getVaultRecord(): VaultRecord | null {
+  if (!browser) return null;
+  try {
+    const raw = localStorage.getItem(VAULT_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return isValidRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveVaultRecord(record: VaultRecord): void {
+  localStorage.setItem(VAULT_STORAGE_KEY, JSON.stringify(record));
+}
+
+export function deleteVaultRecord(): void {
+  if (!browser) return;
+  localStorage.removeItem(VAULT_STORAGE_KEY);
+}
+
+// ── Feature detection ───────────────────────────────────────────
+
+export type VaultSupport = 'full' | 'no-prf' | 'none';
+
+/**
+ * 'none'   — no WebAuthn surface at all (native app, insecure context, old browser)
+ * 'no-prf' — WebAuthn present but the platform reports no PRF support
+ * 'full'   — PRF believed available. Still provisional: only the enrollment
+ *            ceremony's verify-on-get proves it for the actual provider.
+ */
+export async function detectSupport(): Promise<VaultSupport> {
+  if (!browser || isNative()) return 'none';
+  if (!window.isSecureContext) return 'none';
+  const pkc = (window as any).PublicKeyCredential;
+  if (!pkc || !navigator.credentials?.create) return 'none';
+  try {
+    if (typeof pkc.getClientCapabilities === 'function') {
+      const caps = await pkc.getClientCapabilities();
+      const prf = caps?.['extension:prf'];
+      if (prf === false) return 'no-prf';
+      return 'full'; // true, or capability not reported → provisional
+    }
+  } catch {
+    /* capability probe failed — fall through to provisional */
+  }
+  return 'full';
+}
+
+/** Pure predicate for the migration prompt (unit-tested). */
+export function shouldOfferEnrollment(ctx: {
+  authMethod: string | null;
+  isAuthenticated: boolean;
+  hasPlaintextKey: boolean;
+  hasVault: boolean;
+  support: VaultSupport;
+  dismissed: boolean;
+}): boolean {
+  return (
+    ctx.isAuthenticated &&
+    ctx.authMethod === 'privateKey' &&
+    ctx.hasPlaintextKey &&
+    !ctx.hasVault &&
+    ctx.support === 'full' &&
+    !ctx.dismissed
+  );
+}
+
+// ── Ceremonies ──────────────────────────────────────────────────
+
+function randomChallenge(): Uint8Array {
+  // No server verifies these ceremonies; the challenge only prevents replay
+  // inside the WebAuthn API itself.
+  return crypto.getRandomValues(new Uint8Array(32));
+}
+
+function prfExtensionEval(): { prf: { eval: { first: Uint8Array } } } {
+  return { prf: { eval: { first: new TextEncoder().encode(PRF_INPUT) } } };
+}
+
+function getPrfResult(cred: PublicKeyCredential): Uint8Array | null {
+  const ext = (cred.getClientExtensionResults() as any)?.prf;
+  const first = ext?.results?.first;
+  if (!first) return null;
+  const bytes = first instanceof ArrayBuffer ? new Uint8Array(first) : new Uint8Array(first.buffer ?? first);
+  return bytes.length === 32 ? bytes : null;
+}
+
+/**
+ * Assert with the given credentials + PRF eval and return {credentialId, prfOutput}.
+ * Shared by enrollment-verify and unlock.
+ */
+async function assertWithPrf(
+  credentialIds: string[]
+): Promise<{ credentialId: string; prfOutput: Uint8Array }> {
+  const assertion = (await navigator.credentials.get({
+    publicKey: {
+      challenge: randomChallenge() as BufferSource,
+      rpId: rpIdForOrigin(),
+      allowCredentials: credentialIds.map((id) => ({
+        type: 'public-key' as const,
+        id: b64urlToBytes(id) as BufferSource
+      })),
+      userVerification: 'required',
+      extensions: prfExtensionEval() as any
+    }
+  })) as PublicKeyCredential | null;
+  if (!assertion) throw new UnlockFailedError('Passkey assertion returned no credential');
+  const prfOutput = getPrfResult(assertion);
+  if (!prfOutput) {
+    throw new PrfUnsupportedError('Passkey provider did not return a PRF result on get()');
+  }
+  return { credentialId: assertion.id, prfOutput };
+}
+
+/**
+ * Full enrollment ceremony. Creates a passkey, then IMMEDIATELY does a get()
+ * and verifies the PRF output round-trips a wrap/unwrap + nsec encrypt/decrypt
+ * before anything is persisted — several providers only return PRF results on
+ * get(), so create()-time signals are never trusted alone. On any failure the
+ * vault storage is left untouched (an orphan passkey may remain in the user's
+ * provider; we cannot delete authenticator-side credentials).
+ */
+export async function enrollPasskey(
+  privkeyHex: string,
+  pubkey: string,
+  userLabel: string
+): Promise<VaultRecord> {
+  const normalizedKey = privkeyHex.toLowerCase();
+  if (getPublicKey(hexToBytes(normalizedKey)) !== pubkey) {
+    throw new PasskeyVaultError('private key does not match the session pubkey');
+  }
+
+  // Exclude credentials already in a record so providers refuse duplicates.
+  const existing = getVaultRecord();
+  const excludeCredentials = (existing?.keys ?? []).map((k) => ({
+    type: 'public-key' as const,
+    id: b64urlToBytes(k.credentialId) as BufferSource
+  }));
+
+  const created = (await navigator.credentials.create({
+    publicKey: {
+      challenge: randomChallenge() as BufferSource,
+      rp: { id: rpIdForOrigin(), name: 'Zap Cooking' },
+      user: {
+        id: hexToBytes(pubkey) as BufferSource,
+        name: userLabel,
+        displayName: userLabel
+      },
+      pubKeyCredParams: [
+        { type: 'public-key', alg: -7 }, // ES256
+        { type: 'public-key', alg: -257 } // RS256
+      ],
+      authenticatorSelection: {
+        residentKey: 'required',
+        requireResidentKey: true,
+        userVerification: 'required'
+      },
+      excludeCredentials,
+      extensions: { prf: {} } as any
+    }
+  })) as PublicKeyCredential | null;
+  if (!created) throw new PasskeyVaultError('Passkey creation returned no credential');
+
+  const createExt = (created.getClientExtensionResults() as any)?.prf;
+  if (createExt && createExt.enabled === false) {
+    throw new PrfUnsupportedError('Passkey provider reported PRF unsupported on create()');
+  }
+
+  // Verify-on-get: derive the KEK from a real assertion, never from create().
+  const { credentialId, prfOutput } = await assertWithPrf([created.id]);
+
+  const kek = deriveKek(prfOutput);
+  const dek = generateDek();
+  let verifyDek: Uint8Array | null = null;
+  try {
+    const { wrappedDek, iv } = await wrapDek(dek, kek);
+    const nsecCiphertext = encryptNsec(normalizedKey, dek);
+
+    // Round-trip with independently unwrapped material before persisting.
+    verifyDek = await unwrapDek(wrappedDek, iv, kek);
+    if (decryptNsec(nsecCiphertext, verifyDek) !== normalizedKey) {
+      throw new EnrollVerifyError('Vault round-trip verification failed');
+    }
+
+    const now = Date.now();
+    const record: VaultRecord = {
+      version: 1,
+      pubkey,
+      nsecCiphertext,
+      createdAt: now,
+      keys: [
+        {
+          credentialId,
+          wrappedDek: bytesToB64(wrappedDek),
+          dekIv: bytesToB64(iv),
+          addedAt: now
+        }
+      ]
+    };
+    saveVaultRecord(record);
+    return record;
+  } catch (e) {
+    if (e instanceof PasskeyVaultError) throw e;
+    throw new EnrollVerifyError(
+      `Vault verification failed: ${e instanceof Error ? e.message : String(e)}`
+    );
+  } finally {
+    zeroize(kek, dek, verifyDek, prfOutput);
+  }
+}
+
+/**
+ * Unlock ceremony: assert with any enrolled credential, unwrap the DEK, and
+ * return the decrypted 64-hex private key (memory only — callers must never
+ * persist it). Fails closed on any mismatch; never mutates storage.
+ */
+export async function unlockPasskey(record: VaultRecord): Promise<string> {
+  const { credentialId, prfOutput } = await assertWithPrf(
+    record.keys.map((k) => k.credentialId)
+  );
+  const entry = record.keys.find((k) => k.credentialId === credentialId);
+  if (!entry) {
+    zeroize(prfOutput);
+    throw new UnlockFailedError('Assertion used a credential not present in the vault');
+  }
+
+  const kek = deriveKek(prfOutput);
+  let dek: Uint8Array | null = null;
+  try {
+    dek = await unwrapDek(b64ToBytes(entry.wrappedDek), b64ToBytes(entry.dekIv), kek);
+    const privkeyHex = decryptNsec(record.nsecCiphertext, dek);
+    if (getPublicKey(hexToBytes(privkeyHex)) !== record.pubkey) {
+      throw new UnlockFailedError('Decrypted key does not match the vault pubkey');
+    }
+    return privkeyHex;
+  } catch (e) {
+    if (e instanceof PasskeyVaultError) throw e;
+    throw new UnlockFailedError(
+      `Could not decrypt the vault with this passkey: ${e instanceof Error ? e.message : String(e)}`
+    );
+  } finally {
+    zeroize(kek, dek, prfOutput);
+  }
+}

--- a/src/lib/passkeyVault.ts
+++ b/src/lib/passkeyVault.ts
@@ -130,7 +130,13 @@ export async function detectSupport(): Promise<VaultSupport> {
       const caps = await pkc.getClientCapabilities();
       const prf = caps?.['extension:prf'];
       if (prf === false) return 'no-prf';
-      return 'full'; // true, or capability not reported → provisional
+      // true → full; ABSENT → provisional 'full'. Safari omits extension
+      // keys from getClientCapabilities entirely, and per the WebAuthn spec
+      // an absent capability means "unknown", not "unsupported" — only an
+      // explicit false may hide the feature. The enrollment ceremony
+      // (prf.enabled on create + PRF output verified on get) remains the
+      // authoritative check either way.
+      return 'full';
     }
   } catch {
     /* capability probe failed — fall through to provisional */

--- a/src/lib/passkeyVault.ts
+++ b/src/lib/passkeyVault.ts
@@ -110,6 +110,10 @@ export function getVaultRecord(): VaultRecord | null {
 }
 
 export function saveVaultRecord(record: VaultRecord): void {
+  // Throw rather than silently return outside the browser: a silent no-op
+  // here would let an enrollment "succeed" without a persisted record, and
+  // AuthManager deletes the plaintext key right after.
+  if (!browser) throw new Error('saveVaultRecord requires a browser environment');
   localStorage.setItem(VAULT_STORAGE_KEY, JSON.stringify(record));
 }
 
@@ -188,7 +192,20 @@ function getPrfResult(cred: PublicKeyCredential): Uint8Array | null {
   const ext = (cred.getClientExtensionResults() as any)?.prf;
   const first = ext?.results?.first;
   if (!first) return null;
-  const bytes = first instanceof ArrayBuffer ? new Uint8Array(first) : new Uint8Array(first.buffer ?? first);
+  // Spec says ArrayBuffer, but tolerate TypedArray/DataView results from
+  // authenticator bridges — honoring byteOffset/byteLength, since a view
+  // into a larger buffer must not be read whole (it would fail the 32-byte
+  // check on a valid PRF output). Deliberately kept as a VIEW, not a copy:
+  // callers zeroize the returned bytes, and scrubbing in place also clears
+  // the extension-result buffer itself.
+  let bytes: Uint8Array;
+  if (first instanceof ArrayBuffer) {
+    bytes = new Uint8Array(first);
+  } else if (ArrayBuffer.isView(first)) {
+    bytes = new Uint8Array(first.buffer, first.byteOffset, first.byteLength);
+  } else {
+    return null;
+  }
   return bytes.length === 32 ? bytes : null;
 }
 

--- a/src/lib/passkeyVaultCrypto.test.ts
+++ b/src/lib/passkeyVaultCrypto.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import fixture from '../test/fixtures/vault-v1.json';
+import {
+  PRF_INPUT,
+  HKDF_SALT,
+  HKDF_INFO,
+  deriveKek,
+  wrapDek,
+  unwrapDek,
+  encryptNsec,
+  decryptNsec,
+  generateDek,
+  hexToBytes,
+  bytesToB64,
+  b64ToBytes,
+  bytesToB64url,
+  b64urlToBytes,
+  zeroize
+} from './passkeyVaultCrypto';
+import { getPublicKey } from 'nostr-tools';
+import { __testing as googleBackupNip44 } from './googleBackup/googleBackupCrypto';
+
+/**
+ * Vault v1 crypto vectors. The fixture file is the parity contract for the
+ * Android implementation (Phase 3) — if any assertion here fails after a
+ * dependency bump, the vault FORMAT changed and existing vaults would break.
+ */
+
+const bytesToHex = (b: Uint8Array) =>
+  Array.from(b)
+    .map((x) => x.toString(16).padStart(2, '0'))
+    .join('');
+
+const prfOutput = () => hexToBytes(fixture.prfOutputHex);
+const dek = () => hexToBytes(fixture.dekHex);
+const dekIv = () => hexToBytes(fixture.dekIvHex);
+const kek = () => hexToBytes(fixture.expectedKekHex);
+
+describe('fixture self-consistency', () => {
+  it('constants match the module', () => {
+    expect(fixture.constants.prfInput).toBe(PRF_INPUT);
+    expect(fixture.constants.hkdfSalt).toBe(HKDF_SALT);
+    expect(fixture.constants.hkdfInfo).toBe(HKDF_INFO);
+  });
+
+  it('pubkey derives from the fixture nsec', () => {
+    expect(getPublicKey(hexToBytes(fixture.nsecHex))).toBe(fixture.pubkeyHex);
+  });
+});
+
+describe('deriveKek', () => {
+  it('matches the fixture vector', () => {
+    expect(bytesToHex(deriveKek(prfOutput()))).toBe(fixture.expectedKekHex);
+  });
+
+  it('rejects non-32-byte PRF output', () => {
+    expect(() => deriveKek(new Uint8Array(31))).toThrow(/32 bytes/);
+  });
+});
+
+describe('wrapDek / unwrapDek', () => {
+  it('wrap matches the fixture vector with the fixed IV', async () => {
+    const { wrappedDek, iv } = await wrapDek(dek(), kek(), dekIv());
+    expect(bytesToB64(wrappedDek)).toBe(fixture.expectedWrappedDekB64);
+    expect(bytesToHex(iv)).toBe(fixture.dekIvHex);
+  });
+
+  it('unwrap recovers the DEK from the fixture ciphertext', async () => {
+    const out = await unwrapDek(b64ToBytes(fixture.expectedWrappedDekB64), dekIv(), kek());
+    expect(bytesToHex(out)).toBe(fixture.dekHex);
+  });
+
+  it('fails closed on a tampered wrapped DEK (GCM tag)', async () => {
+    const tampered = b64ToBytes(fixture.expectedWrappedDekB64);
+    tampered[3] ^= 0x01;
+    await expect(unwrapDek(tampered, dekIv(), kek())).rejects.toThrow();
+  });
+
+  it('fails closed under the wrong KEK', async () => {
+    const wrongKek = kek();
+    wrongKek[0] ^= 0xff;
+    await expect(
+      unwrapDek(b64ToBytes(fixture.expectedWrappedDekB64), dekIv(), wrongKek)
+    ).rejects.toThrow();
+  });
+
+  it('uses a random 12-byte IV when none is injected', async () => {
+    const a = await wrapDek(dek(), kek());
+    const b = await wrapDek(dek(), kek());
+    expect(a.iv).toHaveLength(12);
+    expect(bytesToHex(a.iv)).not.toBe(bytesToHex(b.iv));
+  });
+});
+
+describe('encryptNsec / decryptNsec', () => {
+  it('matches the fixture vector with the fixed nonce', () => {
+    expect(encryptNsec(fixture.nsecHex, dek(), hexToBytes(fixture.nip44NonceHex))).toBe(
+      fixture.expectedNsecCiphertextB64
+    );
+  });
+
+  it('decrypts the fixture ciphertext', () => {
+    expect(decryptNsec(fixture.expectedNsecCiphertextB64, dek())).toBe(fixture.nsecHex);
+  });
+
+  it('cross-validates against the independent googleBackupCrypto NIP-44 implementation', () => {
+    // Two separately written NIP-44-with-raw-key implementations exist in this
+    // repo (nostr-tools here, the hand-rolled Android-parity port for Google
+    // backup). They must agree — this is the strongest local evidence that the
+    // Android port in Phase 3 will interoperate.
+    expect(googleBackupNip44.nip44Decrypt(fixture.expectedNsecCiphertextB64, dek())).toBe(
+      fixture.nsecHex
+    );
+    const theirs = googleBackupNip44.nip44EncryptWithNonce(
+      fixture.nsecHex,
+      dek(),
+      hexToBytes(fixture.nip44NonceHex)
+    );
+    expect(theirs).toBe(fixture.expectedNsecCiphertextB64);
+  });
+
+  it('round-trips with a random nonce', () => {
+    const ct = encryptNsec(fixture.nsecHex, dek());
+    expect(ct).not.toBe(fixture.expectedNsecCiphertextB64);
+    expect(decryptNsec(ct, dek())).toBe(fixture.nsecHex);
+  });
+
+  it('fails closed under the wrong DEK (NIP-44 HMAC)', () => {
+    const wrongDek = dek();
+    wrongDek[0] ^= 0xff;
+    expect(() => decryptNsec(fixture.expectedNsecCiphertextB64, wrongDek)).toThrow();
+  });
+
+  it('rejects non-hex plaintext on encrypt', () => {
+    expect(() => encryptNsec('nsec1notahexkey', dek())).toThrow(/hex/);
+    expect(() => encryptNsec(fixture.nsecHex.toUpperCase(), dek())).toThrow(/hex/);
+  });
+});
+
+describe('helpers', () => {
+  it('base64url round-trips the fixture credential id', () => {
+    const bytes = b64urlToBytes(fixture.credentialIdB64url);
+    expect(bytesToB64url(bytes)).toBe(fixture.credentialIdB64url);
+    expect(bytes).toHaveLength(16);
+  });
+
+  it('generateDek returns 32 random bytes', () => {
+    const a = generateDek();
+    const b = generateDek();
+    expect(a).toHaveLength(32);
+    expect(bytesToHex(a)).not.toBe(bytesToHex(b));
+  });
+
+  it('zeroize clears buffers and tolerates null', () => {
+    const buf = hexToBytes('deadbeef');
+    zeroize(buf, null, undefined);
+    expect(Array.from(buf)).toEqual([0, 0, 0, 0]);
+  });
+});

--- a/src/lib/passkeyVaultCrypto.ts
+++ b/src/lib/passkeyVaultCrypto.ts
@@ -1,0 +1,138 @@
+/**
+ * Passkey-vault crypto primitives (vault format v1).
+ *
+ * Envelope layout — every constant here is part of the on-disk format and
+ * the Android Phase 3 parity contract (fixtures: src/test/fixtures/vault-v1.json):
+ *
+ *   passkey PRF(PRF_INPUT) ──HKDF-SHA256(salt, info)──▶ KEK (32B)
+ *   KEK ──AES-256-GCM(dekIv)──▶ wraps random DEK (32B)
+ *   DEK ──NIP-44 v2 (DEK in place of the ECDH conversation key)──▶ nsecCiphertext
+ *
+ * The NIP-44-with-raw-key construction deliberately mirrors the Android
+ * Google-backup crypto (BackupCrypto.kt / googleBackupCrypto.ts): nostr-tools
+ * `nip44.v2.encrypt/decrypt` use the 32-byte conversation key directly as the
+ * HKDF-expand PRK — ECDH only ever happens inside getConversationKey, which
+ * this module never calls.
+ *
+ * Pure module: no WebAuthn, no storage, no Svelte imports — everything is
+ * bytes in / bytes out so the vectors can be pinned. IV/nonce parameters are
+ * injectable for the fixture tests ONLY; production callers must omit them.
+ */
+
+import { hkdf } from '@noble/hashes/hkdf.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import * as nip44 from 'nostr-tools/nip44';
+
+/** PRF extension eval input (UTF-8). Changing this orphans every vault. */
+export const PRF_INPUT = 'zap.cooking/nsec-vault/v1';
+/** HKDF salt/info for KEK derivation. Same warning as above. */
+export const HKDF_SALT = 'zap.cooking/nsec-vault/v1';
+export const HKDF_INFO = 'kek-aes256-gcm';
+
+const utf8 = (s: string) => new TextEncoder().encode(s);
+
+export function hexToBytes(hex: string): Uint8Array {
+  if (!/^([0-9a-fA-F]{2})+$/.test(hex)) throw new Error('invalid hex');
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  return out;
+}
+
+export function bytesToB64(bytes: Uint8Array): string {
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+export function b64ToBytes(s: string): Uint8Array {
+  return Uint8Array.from(atob(s), (c) => c.charCodeAt(0));
+}
+
+export function bytesToB64url(bytes: Uint8Array): string {
+  return bytesToB64(bytes).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function b64urlToBytes(s: string): Uint8Array {
+  const b64 = s.replace(/-/g, '+').replace(/_/g, '/');
+  return b64ToBytes(b64 + '='.repeat((4 - (b64.length % 4)) % 4));
+}
+
+/** Best-effort scrub of key material. Strings can't be zeroed in JS; pass buffers. */
+export function zeroize(...buffers: Array<Uint8Array | null | undefined>): void {
+  for (const b of buffers) b?.fill(0);
+}
+
+/** PRF output → 32-byte KEK. */
+export function deriveKek(prfOutput: Uint8Array): Uint8Array {
+  if (prfOutput.length !== 32) throw new Error('PRF output must be 32 bytes');
+  return hkdf(sha256, prfOutput, utf8(HKDF_SALT), utf8(HKDF_INFO), 32);
+}
+
+/** AES-256-GCM wrap of the DEK under the KEK. `iv` injectable for tests only. */
+export async function wrapDek(
+  dek: Uint8Array,
+  kek: Uint8Array,
+  iv?: Uint8Array
+): Promise<{ wrappedDek: Uint8Array; iv: Uint8Array }> {
+  if (dek.length !== 32) throw new Error('DEK must be 32 bytes');
+  if (kek.length !== 32) throw new Error('KEK must be 32 bytes');
+  const usedIv = iv ?? crypto.getRandomValues(new Uint8Array(12));
+  if (usedIv.length !== 12) throw new Error('IV must be 12 bytes');
+  const key = await crypto.subtle.importKey('raw', kek as BufferSource, 'AES-GCM', false, [
+    'encrypt'
+  ]);
+  const ct = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv: usedIv as BufferSource },
+    key,
+    dek as BufferSource
+  );
+  return { wrappedDek: new Uint8Array(ct), iv: usedIv };
+}
+
+/** AES-256-GCM unwrap. Throws (fails closed) on tag mismatch / wrong KEK. */
+export async function unwrapDek(
+  wrappedDek: Uint8Array,
+  iv: Uint8Array,
+  kek: Uint8Array
+): Promise<Uint8Array> {
+  if (kek.length !== 32) throw new Error('KEK must be 32 bytes');
+  const key = await crypto.subtle.importKey('raw', kek as BufferSource, 'AES-GCM', false, [
+    'decrypt'
+  ]);
+  const pt = new Uint8Array(
+    await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: iv as BufferSource },
+      key,
+      wrappedDek as BufferSource
+    )
+  );
+  if (pt.length !== 32) throw new Error('unwrapped DEK is not 32 bytes');
+  return pt;
+}
+
+/**
+ * Encrypt the 64-char hex private key under the DEK (NIP-44 v2 payload).
+ * `nonce` injectable for tests only.
+ */
+export function encryptNsec(privkeyHex: string, dek: Uint8Array, nonce?: Uint8Array): string {
+  if (!/^[0-9a-f]{64}$/.test(privkeyHex)) {
+    throw new Error('private key must be 64 lowercase hex characters');
+  }
+  if (dek.length !== 32) throw new Error('DEK must be 32 bytes');
+  return nip44.v2.encrypt(privkeyHex, dek, nonce);
+}
+
+/** Decrypt the nsec envelope. Throws on HMAC failure (wrong DEK) or bad shape. */
+export function decryptNsec(payload: string, dek: Uint8Array): string {
+  if (dek.length !== 32) throw new Error('DEK must be 32 bytes');
+  const hex = nip44.v2.decrypt(payload, dek);
+  if (!/^[0-9a-f]{64}$/.test(hex)) {
+    throw new Error('decrypted vault payload is not a 32-byte hex key');
+  }
+  return hex;
+}
+
+/** Random 32-byte DEK. */
+export function generateDek(): Uint8Array {
+  return crypto.getRandomValues(new Uint8Array(32));
+}

--- a/src/lib/securitySections.test.ts
+++ b/src/lib/securitySections.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { resolveSecuritySections } from './securitySections';
+import {
+  resolveSecuritySections,
+  resolveVaultSection,
+  resolveDisplayPubkey
+} from './securitySections';
 
 /**
  * Settings → Security per-method section rendering. Regression tests for the
@@ -65,5 +69,79 @@ describe('resolveSecuritySections', () => {
     expect(
       resolveSecuritySections({ sk: null, storedAuthMethod: null, sessionMethod: 'anonymous' })
     ).toBe(null);
+  });
+});
+
+describe('resolveVaultSection — identity-bound gating matrix', () => {
+  const SESSION_PK = 'a7'.repeat(32);
+  const OTHER_PK = '77'.repeat(32);
+
+  function ctx(
+    sessionMethod: string | null,
+    recordPubkey: string | null,
+    support: 'full' | 'no-prf' | 'none' = 'full'
+  ) {
+    return {
+      support,
+      sessionMethod,
+      sessionPubkey: sessionMethod ? SESSION_PK : '',
+      recordPubkey
+    };
+  }
+
+  // 5 methods × {no record, matching record, mismatched record}, support 'full'.
+  // Only nsec sessions ever see the card; enrolled additionally requires the
+  // session to OWN the record (the staging bug: nip07 + foreign record
+  // rendered "Remove passkey protection…").
+  const matrix: Array<[string | null, [string | null, string | null, string | null]]> = [
+    //  method            no record   matching     mismatched
+    ['privateKey', ['offer', 'enrolled', null]],
+    ['passkey', [null, 'enrolled', null]], // passkey session without a record is unreachable
+    ['nip07', [null, null, null]],
+    ['nip46', [null, null, null]],
+    [null, [null, null, null]] // anonymous / not authenticated
+  ];
+
+  for (const [method, [noRecord, matching, mismatched]] of matrix) {
+    const label = method ?? 'anonymous';
+    it(`${label}: no record → ${noRecord}, matching → ${matching}, mismatched → ${mismatched}`, () => {
+      expect(resolveVaultSection(ctx(method, null))).toBe(noRecord);
+      expect(resolveVaultSection(ctx(method, SESSION_PK))).toBe(matching);
+      expect(resolveVaultSection(ctx(method, OTHER_PK))).toBe(mismatched);
+    });
+  }
+
+  it("support 'none' hides everything, even a matching enrolled record", () => {
+    expect(resolveVaultSection(ctx('privateKey', SESSION_PK, 'none'))).toBe(null);
+    expect(resolveVaultSection(ctx('privateKey', null, 'none'))).toBe(null);
+  });
+
+  it("support 'no-prf' never offers enrollment but still shows a matching enrolled record", () => {
+    expect(resolveVaultSection(ctx('privateKey', null, 'no-prf'))).toBe(null);
+    expect(resolveVaultSection(ctx('privateKey', SESSION_PK, 'no-prf'))).toBe('enrolled');
+  });
+});
+
+describe('resolveDisplayPubkey — npub display source', () => {
+  const STATE_PK = 'a7'.repeat(32);
+  const STORED_PK = '77'.repeat(32);
+
+  it('prefers live session state (regression: state fires before storage persists)', () => {
+    // The bug shape: subscription fired during updateState(), localStorage
+    // write had not happened yet — the display must still show the pubkey.
+    expect(resolveDisplayPubkey(STATE_PK, null)).toBe(STATE_PK);
+  });
+
+  it('state wins over a stale stored value', () => {
+    expect(resolveDisplayPubkey(STATE_PK, STORED_PK)).toBe(STATE_PK);
+  });
+
+  it('falls back to the stored value when logged out (pre-existing behavior)', () => {
+    expect(resolveDisplayPubkey('', STORED_PK)).toBe(STORED_PK);
+    expect(resolveDisplayPubkey(undefined, STORED_PK)).toBe(STORED_PK);
+  });
+
+  it('null when neither exists', () => {
+    expect(resolveDisplayPubkey('', null)).toBe(null);
   });
 });

--- a/src/lib/securitySections.test.ts
+++ b/src/lib/securitySections.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { resolveSecuritySections } from './securitySections';
+
+/**
+ * Settings → Security per-method section rendering. Regression tests for the
+ * staging bug where an unlocked passkey session (and a locked vault at rest)
+ * rendered a false "Browser Extension (NIP-07)" section: the old template
+ * inferred NIP-07 by elimination from "pubkey present, no plaintext key".
+ */
+
+const NSEC = 'e8'.repeat(32);
+
+describe('resolveSecuritySections', () => {
+  it('legacy plaintext session → privateKey reveal (unchanged)', () => {
+    expect(
+      resolveSecuritySections({ sk: NSEC, storedAuthMethod: null, sessionMethod: 'privateKey' })
+    ).toBe('privateKey');
+  });
+
+  it('unlocked passkey session → privateKey reveal (Conflict-2a: key from memory)', () => {
+    expect(
+      resolveSecuritySections({ sk: NSEC, storedAuthMethod: null, sessionMethod: 'passkey' })
+    ).toBe('privateKey');
+  });
+
+  it('confirmed NIP-07 session → nip07 section', () => {
+    expect(
+      resolveSecuritySections({ sk: null, storedAuthMethod: null, sessionMethod: 'nip07' })
+    ).toBe('nip07');
+  });
+
+  it('NIP-46 session → nip46 section, from the persisted flag even mid-reconnect', () => {
+    expect(
+      resolveSecuritySections({ sk: null, storedAuthMethod: 'nip46', sessionMethod: 'nip46' })
+    ).toBe('nip46');
+    // Reconnect still in flight: persisted flag alone must be enough so the
+    // bunker info renders immediately on load (pre-existing behavior).
+    expect(
+      resolveSecuritySections({ sk: null, storedAuthMethod: 'nip46', sessionMethod: null })
+    ).toBe('nip46');
+  });
+
+  it('locked vault at rest → NO method section (was falsely nip07)', () => {
+    // pk is present in localStorage in this state (unlock persists it,
+    // logout clears it) — it must not matter: the decision takes no pk input
+    // at all, so inference-by-elimination is impossible by construction.
+    expect(
+      resolveSecuritySections({ sk: null, storedAuthMethod: null, sessionMethod: null })
+    ).toBe(null);
+  });
+
+  it('unlocked passkey before the key state refreshes → NO section, never nip07 (staging repro shape)', () => {
+    expect(
+      resolveSecuritySections({ sk: null, storedAuthMethod: null, sessionMethod: 'passkey' })
+    ).toBe(null);
+  });
+
+  it('NIP-07 during restore (state not yet confirmed) → NO section (truthful over optimistic)', () => {
+    expect(
+      resolveSecuritySections({ sk: null, storedAuthMethod: null, sessionMethod: null })
+    ).toBe(null);
+  });
+
+  it('anonymous / logged out → NO section', () => {
+    expect(
+      resolveSecuritySections({ sk: null, storedAuthMethod: null, sessionMethod: 'anonymous' })
+    ).toBe(null);
+  });
+});

--- a/src/lib/securitySections.ts
+++ b/src/lib/securitySections.ts
@@ -32,3 +32,54 @@ export function resolveSecuritySections(ctx: {
   // Locked vault at rest, restore in flight, or logged out: no method section.
   return null;
 }
+
+export type VaultSectionState = 'offer' | 'enrolled' | null;
+
+/**
+ * Decides whether Settings → Security shows passkey-vault management UI.
+ *
+ * The vault is identity-bound: management renders ONLY inside an nsec
+ * session (privateKey/passkey) whose pubkey owns the record. A record for a
+ * different account — or any nip07/nip46/anonymous session — gets NO
+ * management UI: the vault is inert there, and account mismatch is owned by
+ * the login-time VaultConflictError flow, not settings. This gate is the UI
+ * layer; AuthManager.removeVault independently refuses a pubkey mismatch
+ * (defense-in-depth per the B ruling).
+ */
+export function resolveVaultSection(ctx: {
+  support: 'full' | 'no-prf' | 'none';
+  /** Live AuthManager authMethod, or null when not authenticated. */
+  sessionMethod: string | null;
+  /** Live session pubkey ('' when not authenticated). */
+  sessionPubkey: string;
+  /** Vault record pubkey, or null when no record exists. */
+  recordPubkey: string | null;
+}): VaultSectionState {
+  if (ctx.support === 'none') return null;
+  const nsecSession = ctx.sessionMethod === 'privateKey' || ctx.sessionMethod === 'passkey';
+  if (!nsecSession || !ctx.sessionPubkey) return null;
+  if (ctx.recordPubkey) {
+    return ctx.recordPubkey === ctx.sessionPubkey ? 'enrolled' : null;
+  }
+  // No record: offer enrollment only for plaintext sessions with confirmed
+  // PRF support ('no-prf' would fail the ceremony; a passkey session without
+  // a record is not a reachable state).
+  return ctx.support === 'full' && ctx.sessionMethod === 'privateKey' ? 'offer' : null;
+}
+
+/**
+ * The npub shown in Settings → Security. Live AuthManager state first:
+ * every auth flow calls updateState() BEFORE persisting to localStorage, so
+ * a subscription-driven localStorage read races the write and can miss it
+ * (the "No public key found" bug). The stored value remains as a fallback so
+ * a logged-out page still shows the last-known identity, as it always has.
+ * (Follow-up filed: fix the state-fires-before-persist ordering in
+ * AuthManager itself, or document a "subscribers read state, not storage"
+ * invariant.)
+ */
+export function resolveDisplayPubkey(
+  statePubkey: string | null | undefined,
+  storedPubkey: string | null
+): string | null {
+  return statePubkey || storedPubkey;
+}

--- a/src/lib/securitySections.ts
+++ b/src/lib/securitySections.ts
@@ -1,0 +1,34 @@
+/**
+ * Decides which per-method session section Settings → Security renders.
+ *
+ * Extracted to a pure function so the render decision is unit-testable
+ * (this repo has no Svelte component-test infra). History: the page used to
+ * infer NIP-07 by elimination — "pubkey present, no plaintext key, not
+ * nip46 ⇒ browser extension" — which predated the passkey vault and falsely
+ * matched both unlocked passkey sessions (until `sk` refreshes) and a locked
+ * vault at rest. NIP-07 now renders only on a confirmed nip07 session from
+ * AuthManager state: truthful beats optimistic, so on a hard page load the
+ * section appears when restore completes rather than at first paint.
+ */
+
+export type SecuritySection = 'privateKey' | 'nip46' | 'nip07' | null;
+
+export function resolveSecuritySections(ctx: {
+  /** Session nsec hex — in-memory signer first (passkey), localStorage fallback (legacy). */
+  sk: string | null;
+  /** Persisted nostrcooking_authMethod — only ever 'nip46' or null today. */
+  storedAuthMethod: string | null;
+  /** Live AuthManager state authMethod ('nip07' | 'privateKey' | 'passkey' | 'nip46' | null). */
+  sessionMethod: string | null;
+}): SecuritySection {
+  // An available key (legacy plaintext or unlocked passkey) always shows the
+  // reveal section — the passkey case is the Gate 1 Conflict-2a requirement.
+  if (ctx.sk) return 'privateKey';
+  // NIP-46 keeps its persisted-flag condition: bunker info should render
+  // immediately on load, even while the (slow, relay-bound) reconnect runs.
+  if (ctx.storedAuthMethod === 'nip46') return 'nip46';
+  // Explicit confirmation only — never inferred from "pubkey and nothing else".
+  if (ctx.sessionMethod === 'nip07') return 'nip07';
+  // Locked vault at rest, restore in flight, or logged out: no method section.
+  return null;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -17,7 +17,13 @@
   import ToastContainer from '../components/ToastContainer.svelte';
   import PendingIndicator from '../components/PendingIndicator.svelte';
   import LoginOverlay from '../components/LoginOverlay.svelte';
+  import PasskeyEnrollPrompt from '../components/PasskeyEnrollPrompt.svelte';
   import { loginOverlayOpen } from '$lib/stores/loginOverlay';
+
+  // Soft-launch gate for the passkey migration prompt. While false, existing
+  // plaintext-key users are never prompted — enrollment is reachable only
+  // via Settings → Security. Flip to true to start actively migrating users.
+  const PASSKEY_ENROLL_PROMPT_ENABLED = false;
   import { createAuthManager, type AuthState } from '$lib/authManager';
   import { stopMessageSubscription, clearMessages } from '$lib/stores/messages';
   import { clearDecryptCache } from '$lib/encryptionService';
@@ -344,6 +350,21 @@
       authManager = createAuthManager($ndk);
       authState = authManager.getState();
 
+      // Locked passkey vault (record present, no plaintext key, no bunker):
+      // surface the unlock overlay once on startup. The user can dismiss it
+      // and browse anonymously; the Login button re-opens it. Guarded on the
+      // other restore inputs so an in-flight plaintext/NIP-46 restore doesn't
+      // flash the overlay.
+      if (
+        browser &&
+        !authState.isAuthenticated &&
+        authManager.getVaultStatus?.() === 'locked' &&
+        !localStorage.getItem('nostrcooking_privateKey') &&
+        localStorage.getItem('nostrcooking_authMethod') !== 'nip46'
+      ) {
+        loginOverlayOpen.set(true);
+      }
+
       // Subscribe to auth state changes
       unsubscribe = authManager.subscribe((state: AuthState) => {
         authState = state;
@@ -585,6 +606,9 @@
       <WalletModal />
       {#if $loginOverlayOpen}
         <LoginOverlay />
+      {/if}
+      {#if PASSKEY_ENROLL_PROMPT_ENABLED && authManager}
+        <PasskeyEnrollPrompt />
       {/if}
       <ToastContainer />
       <PendingIndicator />

--- a/src/routes/onboarding/+page.svelte
+++ b/src/routes/onboarding/+page.svelte
@@ -6,7 +6,7 @@
   import { ndk, userPublickey } from '$lib/nostr';
   import { onMount, onDestroy } from 'svelte';
   import Button from '../../components/Button.svelte';
-  import { createAuthManager, type AuthState } from '$lib/authManager';
+  import { createAuthManager, VaultConflictError, type AuthState } from '$lib/authManager';
   import { Fetch } from 'hurdak';
   import { DEFAULT_PROFILE_IMAGE } from '$lib/consts';
 
@@ -19,6 +19,11 @@
   let npub = '';
 
   let disableStepButtons = false;
+  // Set when a passkey vault for another account exists on this browser:
+  // the first Continue surfaces the warning, a second Continue confirms the
+  // replacement (see VaultConflictError in authManager).
+  let vaultConflictMessage = '';
+  let confirmReplaceVault = false;
   let name = '';
   let username = '';
   let picture = DEFAULT_PROFILE_IMAGE;
@@ -73,7 +78,23 @@
         const privateKeyHex = Array.from(generatedKeys.privateKey)
           .map((b) => b.toString(16).padStart(2, '0'))
           .join('');
-        await authManager.authenticateWithPrivateKey(privateKeyHex);
+        try {
+          await authManager.authenticateWithPrivateKey(privateKeyHex, {
+            replaceVault: confirmReplaceVault
+          });
+          vaultConflictMessage = '';
+        } catch (error) {
+          if (error instanceof VaultConflictError) {
+            vaultConflictMessage =
+              'This browser has a saved login for another account. Continuing will remove that ' +
+              "saved login — make sure the other account's key is backed up first. Press " +
+              'Continue again to proceed.';
+            confirmReplaceVault = true;
+            disableStepButtons = false;
+            return;
+          }
+          throw error;
+        }
       }
     }
 
@@ -425,6 +446,10 @@
     </div>
   {:else}
     <p>Okay, now you are ready to explore Nostr.</p>
+  {/if}
+
+  {#if vaultConflictMessage}
+    <p class="text-sm text-red-500 mb-3" role="alert">{vaultConflictMessage}</p>
   {/if}
 
   <div class="flex mb-4">

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -18,6 +18,7 @@
   import Accordion from '../../components/Accordion.svelte';
   import NostrBackupSection from '../../components/NostrBackupSection.svelte';
   import PasskeyVaultSection from '../../components/PasskeyVaultSection.svelte';
+  import { resolveSecuritySections } from '$lib/securitySections';
   import { nip19 } from 'nostr-tools';
   import { theme, type Theme } from '$lib/themeStore';
   import { displayCurrency, SUPPORTED_CURRENCIES, type CurrencyCode } from '$lib/currencyStore';
@@ -279,6 +280,12 @@
   let showDisconnectConfirm = false;
   let privateKeyRevealed = false;
 
+  // Live AuthManager session method ('nip07' | 'privateKey' | 'passkey' |
+  // 'nip46' | null). Drives which per-method Security section renders — see
+  // resolveSecuritySections. Distinct from `authMethod` (the persisted
+  // localStorage flag, which only ever holds 'nip46').
+  let sessionMethod: string | null = null;
+
   // The private key comes from the auth manager (in-memory signer first):
   // passkey-vault sessions keep the nsec ONLY in memory, so reading
   // localStorage alone would hide the reveal/export UI from enrolled users.
@@ -288,7 +295,10 @@
     sk = authManager?.getSessionPrivateKeyHex() ?? localStorage.getItem('nostrcooking_privateKey');
     pk = localStorage.getItem('nostrcooking_loggedInPublicKey');
     authMethod = localStorage.getItem('nostrcooking_authMethod');
+    sessionMethod = authManager?.getState().authMethod ?? null;
   }
+
+  $: securitySection = resolveSecuritySections({ sk, storedAuthMethod: authMethod, sessionMethod });
 
   if (browser) {
     relays = getCurrentRelays();
@@ -309,10 +319,39 @@
     // Update connection status periodically
     const interval = setInterval(updateConnectedRelays, 5000);
     // Keep the key display in sync with auth changes (e.g. a passkey unlock
-    // or enrollment happening while this page is mounted).
-    const unsubAuth = getAuthManager()?.subscribe(() => refreshKeyState());
+    // or enrollment happening while this page is mounted). On a HARD load of
+    // /settings the page mounts before the layout's onMount has created the
+    // AuthManager (Svelte mounts children first), so a one-shot subscribe
+    // here silently attaches nothing and the post-unlock state change is
+    // never observed — retry briefly until the manager exists.
+    // TODO(follow-up): expose an AuthManager-ready signal from the layout
+    // instead of polling for it here.
+    let unsubAuth: (() => void) | null = null;
+    let authRetry: ReturnType<typeof setInterval> | null = null;
+    const attachAuthSubscription = (): boolean => {
+      const am = getAuthManager();
+      if (!am) return false;
+      unsubAuth = am.subscribe(() => refreshKeyState());
+      refreshKeyState();
+      return true;
+    };
+    if (!attachAuthSubscription()) {
+      let tries = 0;
+      authRetry = setInterval(() => {
+        if (attachAuthSubscription() || ++tries >= 20) {
+          if (authRetry) clearInterval(authRetry);
+          authRetry = null;
+          if (!unsubAuth) {
+            console.warn(
+              '[Settings] AuthManager never became available — session key display may be stale'
+            );
+          }
+        }
+      }, 500);
+    }
     return () => {
       clearInterval(interval);
+      if (authRetry) clearInterval(authRetry);
       unsubAuth?.();
     };
   });
@@ -1443,8 +1482,8 @@
         <!-- Passkey Vault (renders nothing when unsupported/not applicable) -->
         <PasskeyVaultSection on:changed={refreshKeyState} />
 
-        <!-- Private Key -->
-        {#if sk}
+        <!-- Private Key (legacy plaintext OR unlocked passkey session) -->
+        {#if securitySection === 'privateKey'}
           <div class="border-t border-[var(--color-input-border)] pt-5">
             <p class="text-sm font-medium mb-1 text-red-500">Private Key (nsec)</p>
             <p class="text-xs text-caption mb-3">Never share this with anyone. Keep it secret.</p>
@@ -1515,7 +1554,7 @@
               </button>
             {/if}
           </div>
-        {:else if authMethod === 'nip46'}
+        {:else if securitySection === 'nip46'}
           <div class="border-t border-[var(--color-input-border)] pt-5">
             <div class="flex items-center gap-2 mb-2">
               <ShieldCheckIcon size={18} class="text-green-500" weight="fill" />
@@ -1528,7 +1567,7 @@
               app.
             </p>
           </div>
-        {:else if pk}
+        {:else if securitySection === 'nip07'}
           <div class="border-t border-[var(--color-input-border)] pt-5">
             <div class="flex items-center gap-2 mb-2">
               <ShieldCheckIcon size={18} class="text-green-500" weight="fill" />

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -18,7 +18,7 @@
   import Accordion from '../../components/Accordion.svelte';
   import NostrBackupSection from '../../components/NostrBackupSection.svelte';
   import PasskeyVaultSection from '../../components/PasskeyVaultSection.svelte';
-  import { resolveSecuritySections } from '$lib/securitySections';
+  import { resolveSecuritySections, resolveDisplayPubkey } from '$lib/securitySections';
   import { nip19 } from 'nostr-tools';
   import { theme, type Theme } from '$lib/themeStore';
   import { displayCurrency, SUPPORTED_CURRENCIES, type CurrencyCode } from '$lib/currencyStore';
@@ -292,10 +292,16 @@
   function refreshKeyState() {
     if (!browser) return;
     const authManager = getAuthManager();
+    const state = authManager?.getState();
     sk = authManager?.getSessionPrivateKeyHex() ?? localStorage.getItem('nostrcooking_privateKey');
-    pk = localStorage.getItem('nostrcooking_loggedInPublicKey');
+    // Live state first: auth flows notify subscribers BEFORE persisting, so
+    // a localStorage-only read here can race the write and miss the pubkey.
+    pk = resolveDisplayPubkey(
+      state?.publicKey,
+      localStorage.getItem('nostrcooking_loggedInPublicKey')
+    );
     authMethod = localStorage.getItem('nostrcooking_authMethod');
-    sessionMethod = authManager?.getState().authMethod ?? null;
+    sessionMethod = state?.authMethod ?? null;
   }
 
   $: securitySection = resolveSecuritySections({ sk, storedAuthMethod: authMethod, sessionMethod });

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -17,6 +17,7 @@
   import Modal from '../../components/Modal.svelte';
   import Accordion from '../../components/Accordion.svelte';
   import NostrBackupSection from '../../components/NostrBackupSection.svelte';
+  import PasskeyVaultSection from '../../components/PasskeyVaultSection.svelte';
   import { nip19 } from 'nostr-tools';
   import { theme, type Theme } from '$lib/themeStore';
   import { displayCurrency, SUPPORTED_CURRENCIES, type CurrencyCode } from '$lib/currencyStore';
@@ -278,11 +279,20 @@
   let showDisconnectConfirm = false;
   let privateKeyRevealed = false;
 
-  if (browser) {
-    relays = getCurrentRelays();
-    sk = localStorage.getItem('nostrcooking_privateKey');
+  // The private key comes from the auth manager (in-memory signer first):
+  // passkey-vault sessions keep the nsec ONLY in memory, so reading
+  // localStorage alone would hide the reveal/export UI from enrolled users.
+  function refreshKeyState() {
+    if (!browser) return;
+    const authManager = getAuthManager();
+    sk = authManager?.getSessionPrivateKeyHex() ?? localStorage.getItem('nostrcooking_privateKey');
     pk = localStorage.getItem('nostrcooking_loggedInPublicKey');
     authMethod = localStorage.getItem('nostrcooking_authMethod');
+  }
+
+  if (browser) {
+    relays = getCurrentRelays();
+    refreshKeyState();
 
     const authManager = getAuthManager();
     if (authManager) {
@@ -298,7 +308,13 @@
     loadTimerSettings();
     // Update connection status periodically
     const interval = setInterval(updateConnectedRelays, 5000);
-    return () => clearInterval(interval);
+    // Keep the key display in sync with auth changes (e.g. a passkey unlock
+    // or enrollment happening while this page is mounted).
+    const unsubAuth = getAuthManager()?.subscribe(() => refreshKeyState());
+    return () => {
+      clearInterval(interval);
+      unsubAuth?.();
+    };
   });
 
   async function disconnectBunker() {
@@ -1423,6 +1439,9 @@
             <p class="text-caption text-sm italic">No public key found</p>
           {/if}
         </div>
+
+        <!-- Passkey Vault (renders nothing when unsupported/not applicable) -->
+        <PasskeyVaultSection on:changed={refreshKeyState} />
 
         <!-- Private Key -->
         {#if sk}

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1465,7 +1465,7 @@
                 type="button"
                 class="px-3 py-2 bg-secondary hover:bg-accent-gray rounded-lg text-sm transition-colors flex items-center gap-1.5"
                 style="color: var(--color-text-primary)"
-                on:click={() => copyToClipboard(nip19.npubEncode(pk), 'public')}
+                on:click={() => pk && copyToClipboard(nip19.npubEncode(pk), 'public')}
               >
                 {#if copiedKey === 'public'}
                   <CheckIcon size={16} class="text-green-500" />

--- a/src/test/fixtures/vault-v1.json
+++ b/src/test/fixtures/vault-v1.json
@@ -1,0 +1,18 @@
+{
+  "description": "Passkey vault v1 parity fixtures. Deterministic vectors for the web implementation (passkeyVaultCrypto.ts) and the future Android port (Phase 3). Do not regenerate: these values are the cross-platform contract.",
+  "constants": {
+    "prfInput": "zap.cooking/nsec-vault/v1",
+    "hkdfSalt": "zap.cooking/nsec-vault/v1",
+    "hkdfInfo": "kek-aes256-gcm"
+  },
+  "prfOutputHex": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+  "expectedKekHex": "e4f2820a862d28b465b54c306f91fdd08c62f71e75978aedf3e8a0c8d05a08c2",
+  "dekHex": "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf",
+  "dekIvHex": "101112131415161718191a1b",
+  "expectedWrappedDekB64": "QbqCNc5eZfFDmHYDoD2BFDdQLmq7+Nd9iVrAzj8gmu9LkbCcYwTiY1PIblOqEc4X",
+  "nsecHex": "e8b4f3c2a1d05e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f",
+  "pubkeyHex": "06cc216aff26ab90fd977ee70307cee8eae8b2ca5f990e3093b2a4a1320ba1e3",
+  "nip44NonceHex": "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f",
+  "expectedNsecCiphertextB64": "AkBBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fiHr8ke7GBO64K6zEpQALvthQqX1T4tbgc4smBdOowQjgRbWXSdVATYWPJp2p7TH6BEI//bL2YRGzQGDMbBPi9lFvlEqrRRqrhPp+EAVXBJ1KgkHO16qKcI1Qsa2yTv3vg9Y=",
+  "credentialIdB64url": "wMHCw8TFxsfIycrLzM3Ozw"
+}


### PR DESCRIPTION
## What

Replaces plaintext `nostrcooking_privateKey` localStorage storage with a passkey-gated encrypted vault using the WebAuthn PRF extension. The nsec remains the Nostr identity; the passkey is only the lock. **Phase 1 scope: local vault, web only** — no server sync, no Android/iOS app changes, NIP-07/NIP-46/anonymous flows untouched.

## Envelope (vault format v1)

```
passkey PRF("zap.cooking/nsec-vault/v1")
  → HKDF-SHA256 (salt "zap.cooking/nsec-vault/v1", info "kek-aes256-gcm") → 32-byte KEK
  → AES-256-GCM (12-byte IV) wraps a random 32-byte DEK
  → DEK used directly as the NIP-44 v2 conversation key over the nsec hex
```

The raw-key NIP-44 construction mirrors the Android `BackupCrypto.kt` pattern. `src/test/fixtures/vault-v1.json` (committed first, separately) is the **frozen parity contract** for the Android implementation in Phase 3 — do not regenerate. The stored record (`nostrcooking_vault_v1`) uses a `keys[]` array so a second passkey can be added later without a format change (multi-passkey UI is out of scope).

## Behavior

- **Enrollment** (Settings → Security): create passkey → immediately `get()` and verify the PRF output round-trips a full wrap/unwrap + encrypt/decrypt **before anything is persisted** (several providers only return PRF on `get()`; `create()` is never trusted alone). Plaintext is deleted only after verified success.
- **Locked state**: vault present + not unlocked = unauthenticated; the login overlay auto-opens with "Unlock with passkey" on top and every other login method below. Cancelled/failed unlock is never destructive.
- **Re-login hole closed**: pasting the same account's nsec (including Google Drive restore) adopts the vault — no plaintext re-persisted. A different account's key raises an explicit "Replace saved login?" confirmation (`VaultConflictError`); signup surfaces use plain "saved login" copy, no vault jargon.
- **Removal/downgrade** is gated on a fresh unlock ceremony and writes plaintext back *before* deleting the record (never a moment with neither).
- **`encryptionService.getPrivateKey()`** now reads the in-memory signer key first — detection is duck-typed on a 64-hex `signer.privateKey` value, never class-name strings (minification mangles them). DMs, marketplace messages, and wallet relay backups keep working post-migration; the settings nsec reveal works from memory for enrolled users.
- `excludeCredentials` is populated from the existing record on `create()`.

## Soft-launch flag

The migration prompt (`PasskeyEnrollPrompt`) is implemented and tested but **gated OFF** for this release via `PASSKEY_ENROLL_PROMPT_ENABLED = false` in `src/routes/+layout.svelte` (a plain const gating the component mount — chosen over an env var since flipping it is a deliberate one-line code change that should go through review). Enrollment is reachable only via **Settings → Security** for the soft launch.

## Testing

- **328/328 vitest** (70 new): fixture-vector crypto tests (KEK, GCM wrap/unwrap incl. tamper fail-closed, NIP-44 envelope) with **cross-validation against the repo's independent `googleBackupCrypto` NIP-44 implementation**; mocked-authenticator ceremony tests (enroll verify-on-get, PRF-absent aborts, unlock fail-closed paths); AuthManager integration (vault adoption, conflict/replace, cancel-unlock → paste-nsec escape hatch, interrupted-enrollment reconciliation, logout keeps record); NDK `privateKey` hex contract; minification-proof signer detection (tested against a signer class named `Xq`).
- **svelte-check**: no errors in changed files (1 pre-existing error in `CulinaryMesh.svelte`, untouched).
- **`pnpm build`**: passes.
- **Manual checklist**: `docs/passkey-vault-manual-tests.md` (25 cases) — to be run before merge on Chrome desktop and Android Chrome (GPM passkey); iOS Capacitor build must show no trace of the feature (excluded structurally via the `platformIsIOS` branch + `isNative()` gate).

Note: the "Workers Builds" checks on this repo always fail and are ignorable (Cloudflare Pages serves the site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)