### PR TITLE
Vault-sync server endpoints (passkey cross-device, Phase 2 — PR 1/2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.589",
+  "version": "4.2.590",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.590",
+  "version": "4.2.591",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -47,6 +47,19 @@ declare global {
             delete(key: string): Promise<void>;
             list(options?: { prefix?: string; limit?: number }): Promise<{ keys: { name: string }[] }>;
           };
+          /**
+           * KV namespace for passkey vault-sync blobs, keyed by
+           * sha256(credentialId) hex ONLY — never indexed by pubkey (R2).
+           * Also holds the vault-sync routes' rate-limit buckets and
+           * challenge tombstones.
+           */
+          VAULT_SYNC?: {
+            get(key: string, type?: 'text' | 'json'): Promise<string | unknown | null>;
+            put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>;
+            delete(key: string): Promise<void>;
+          };
+          /** HMAC key for vault-sync challenges. Distinct values in Production and Preview. */
+          VAULT_SYNC_CHALLENGE_SECRET?: string;
         };
       }
   }

--- a/src/lib/server/vaultSync/blob.server.ts
+++ b/src/lib/server/vaultSync/blob.server.ts
@@ -1,0 +1,77 @@
+/**
+ * Vault-sync blob validation. The blob is the client's vault-v1 record
+ * VERBATIM (src/test/fixtures/vault-v1.json is the frozen contract); the
+ * server checks shape and size but NEVER decrypts and NEVER logs contents
+ * (R2 ruling — enforced by test).
+ *
+ * The shape rules duplicate the client's isValidRecord (passkeyVault.ts)
+ * rather than importing it: that module is browser-only ($app/environment,
+ * platform detection). Future cleanup: extract shared record types.
+ */
+
+export const MAX_BLOB_BYTES = 4096;
+
+export interface BlobValidationResult {
+  pubkey: string;
+}
+
+/**
+ * Validate a vault blob string. Returns the record pubkey on success,
+ * throws on any violation. `assertingCredentialId` must appear in keys[]
+ * — an assertion from credential X may only write a blob that credential
+ * X can unlock.
+ */
+export function validateBlob(
+  blob: string,
+  assertingCredentialId: string
+): BlobValidationResult {
+  if (new TextEncoder().encode(blob).length > MAX_BLOB_BYTES) {
+    throw new Error('blob too large');
+  }
+  let record: any;
+  try {
+    record = JSON.parse(blob);
+  } catch {
+    throw new Error('blob not JSON');
+  }
+  if (!record || record.version !== 1) throw new Error('blob version unsupported');
+  if (typeof record.pubkey !== 'string' || !/^[0-9a-f]{64}$/.test(record.pubkey)) {
+    throw new Error('blob pubkey invalid');
+  }
+  if (typeof record.nsecCiphertext !== 'string' || record.nsecCiphertext.length === 0) {
+    throw new Error('blob nsecCiphertext invalid');
+  }
+  if (!Array.isArray(record.keys) || record.keys.length === 0) {
+    throw new Error('blob keys invalid');
+  }
+  for (const k of record.keys) {
+    if (
+      !k ||
+      typeof k.credentialId !== 'string' ||
+      typeof k.wrappedDek !== 'string' ||
+      typeof k.dekIv !== 'string'
+    ) {
+      throw new Error('blob key entry invalid');
+    }
+  }
+  if (!record.keys.some((k: any) => k.credentialId === assertingCredentialId)) {
+    throw new Error('asserting credential not in blob keys');
+  }
+  return { pubkey: record.pubkey };
+}
+
+/** Stored KV value shape for a vault-sync entry. */
+export interface VaultSyncEntry {
+  version: 1;
+  blob: string;
+  /** SPKI DER from create()'s getPublicKey(), base64url. */
+  credentialPublicKey: string;
+  /** COSE algorithm from getPublicKeyAlgorithm(): -7 (ES256) or -257 (RS256). */
+  alg: number;
+  /** Last observed counter. Stored, never enforced (synced passkeys report 0). */
+  signCount: number;
+  updatedAt: number;
+}
+
+/** 12 months + grace (R4 ruling); refreshed on upload and successful fetch. */
+export const ENTRY_TTL_S = 370 * 24 * 60 * 60;

--- a/src/lib/server/vaultSync/challenge.server.ts
+++ b/src/lib/server/vaultSync/challenge.server.ts
@@ -1,0 +1,110 @@
+/**
+ * Stateless HMAC-signed challenges for the vault-sync endpoints.
+ *
+ * Design (Gate 1, investigator's choice, ratified): challenges are
+ * self-authenticating — base64url(nonce(32) || issuedAt(8, ms BE) ||
+ * HMAC-SHA256(nonce || issuedAt)) under VAULT_SYNC_CHALLENGE_SECRET — so
+ * issuance costs no KV read. Redemption verifies the MAC and the 2-minute
+ * expiry, then writes a best-effort short-TTL tombstone for single-use.
+ * KV's eventual consistency means single-use is not a hard guarantee
+ * cross-PoP; that's acceptable because a replayed assertion can only
+ * re-fetch the same ciphertext the captor already saw — it can never
+ * produce PRF output.
+ */
+
+export const CHALLENGE_TTL_MS = 2 * 60 * 1000;
+const TOMBSTONE_TTL_S = 180;
+const TOMBSTONE_PREFIX = 'challenge-used:';
+
+type KVLike = {
+  get(key: string, type?: 'text' | 'json'): Promise<string | unknown | null>;
+  put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>;
+};
+
+function b64url(bytes: Uint8Array): string {
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function fromB64url(s: string): Uint8Array {
+  const b64 = s.replace(/-/g, '+').replace(/_/g, '/');
+  return Uint8Array.from(atob(b64 + '='.repeat((4 - (b64.length % 4)) % 4)), (c) =>
+    c.charCodeAt(0)
+  );
+}
+
+async function hmacKey(secret: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign', 'verify']
+  );
+}
+
+/** Issue a challenge. `now` is injectable for tests only. */
+export async function issueChallenge(
+  secret: string,
+  now = Date.now()
+): Promise<{ challenge: string; expiresAt: number }> {
+  const payload = new Uint8Array(40);
+  crypto.getRandomValues(payload.subarray(0, 32));
+  new DataView(payload.buffer).setBigUint64(32, BigInt(now), false);
+  const mac = new Uint8Array(
+    await crypto.subtle.sign('HMAC', await hmacKey(secret), payload as BufferSource)
+  );
+  const challenge = new Uint8Array(72);
+  challenge.set(payload, 0);
+  challenge.set(mac, 40);
+  return { challenge: b64url(challenge), expiresAt: now + CHALLENGE_TTL_MS };
+}
+
+/**
+ * Redeem a challenge: MAC valid, within TTL, not already redeemed.
+ * Throws on any failure (callers map to the uniform 404).
+ */
+export async function redeemChallenge(
+  kv: KVLike | undefined,
+  secret: string,
+  challenge: string,
+  now = Date.now()
+): Promise<void> {
+  let bytes: Uint8Array;
+  try {
+    bytes = fromB64url(challenge);
+  } catch {
+    throw new Error('challenge not base64url');
+  }
+  if (bytes.length !== 72) throw new Error('challenge wrong length');
+
+  const payload = bytes.subarray(0, 40);
+  const mac = bytes.subarray(40);
+  const valid = await crypto.subtle.verify(
+    'HMAC',
+    await hmacKey(secret),
+    mac as BufferSource,
+    payload as BufferSource
+  );
+  if (!valid) throw new Error('challenge MAC invalid');
+
+  const issuedAt = Number(new DataView(bytes.buffer, bytes.byteOffset).getBigUint64(32, false));
+  if (now < issuedAt || now - issuedAt > CHALLENGE_TTL_MS) {
+    throw new Error('challenge expired');
+  }
+
+  // Best-effort single-use tombstone (see header for why best-effort).
+  if (kv) {
+    const digest = new Uint8Array(
+      await crypto.subtle.digest('SHA-256', bytes as BufferSource)
+    );
+    const key =
+      TOMBSTONE_PREFIX +
+      Array.from(digest)
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+    if (await kv.get(key)) throw new Error('challenge already redeemed');
+    await kv.put(key, '1', { expirationTtl: TOMBSTONE_TTL_S });
+  }
+}

--- a/src/lib/server/vaultSync/common.server.ts
+++ b/src/lib/server/vaultSync/common.server.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared plumbing for the vault-sync routes: uniform failure response,
+ * assertion body decoding, KV key derivation.
+ */
+
+import { json } from '@sveltejs/kit';
+import { b64urlToBytes, verifyAssertion, type VerifiedAssertion } from './webauthn.server';
+import { redeemChallenge } from './challenge.server';
+
+/**
+ * Every auth-shaped failure returns EXACTLY this (pinned by tests): an
+ * attacker must not be able to distinguish "no such blob" from "bad
+ * signature" from "expired challenge" (no oracle — Gate 2 ruling).
+ */
+export function uniform404() {
+  return json({ error: 'not_found' }, { status: 404 });
+}
+
+export type VaultSyncKV = {
+  get(key: string, type?: 'text' | 'json'): Promise<string | unknown | null>;
+  put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>;
+  delete(key: string): Promise<void>;
+};
+
+export interface VaultSyncEnv {
+  kv: VaultSyncKV;
+  secret: string;
+}
+
+/** Missing bindings are a server misconfiguration, not an auth failure. */
+export function getEnv(platform: App.Platform | undefined): VaultSyncEnv | null {
+  const kv = platform?.env?.VAULT_SYNC;
+  const secret = platform?.env?.VAULT_SYNC_CHALLENGE_SECRET;
+  if (!kv || !secret) return null;
+  return { kv: kv as VaultSyncKV, secret };
+}
+
+export async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', bytes as BufferSource));
+  return Array.from(digest)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/** Wire shape of an assertion in request bodies (all base64url). */
+export interface AssertionBody {
+  credentialId: string;
+  signature: string;
+  authenticatorData: string;
+  clientDataJSON: string;
+}
+
+export function isAssertionBody(a: any): a is AssertionBody {
+  return (
+    !!a &&
+    typeof a.credentialId === 'string' &&
+    typeof a.signature === 'string' &&
+    typeof a.authenticatorData === 'string' &&
+    typeof a.clientDataJSON === 'string'
+  );
+}
+
+/**
+ * Full assertion check: challenge extraction + redemption, then WebAuthn
+ * verification against the given SPKI. Throws on any failure — callers
+ * catch and return uniform404().
+ */
+export async function checkAssertion(
+  env: VaultSyncEnv,
+  assertion: AssertionBody,
+  spkiB64url: string,
+  alg: number
+): Promise<VerifiedAssertion> {
+  const clientDataJSON = b64urlToBytes(assertion.clientDataJSON);
+  // The challenge lives inside clientDataJSON; redeem it BEFORE signature
+  // work so a replayed challenge is rejected as cheaply as possible.
+  let challenge: string;
+  try {
+    challenge = JSON.parse(new TextDecoder().decode(clientDataJSON)).challenge;
+  } catch {
+    throw new Error('clientDataJSON unparseable');
+  }
+  if (typeof challenge !== 'string') throw new Error('no challenge in clientDataJSON');
+  await redeemChallenge(env.kv, env.secret, challenge);
+
+  return verifyAssertion(
+    {
+      signature: b64urlToBytes(assertion.signature),
+      authenticatorData: b64urlToBytes(assertion.authenticatorData),
+      clientDataJSON
+    },
+    b64urlToBytes(spkiB64url),
+    alg,
+    challenge
+  );
+}

--- a/src/lib/server/vaultSync/endpoints.test.ts
+++ b/src/lib/server/vaultSync/endpoints.test.ts
@@ -1,0 +1,500 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fixture from '../../../test/fixtures/vault-sync-v1.json';
+import { issueChallenge } from './challenge.server';
+import { b64urlToBytes } from './webauthn.server';
+import { POST as challengePOST } from '../../../routes/api/vault-sync/challenge/+server';
+import { PUT as uploadPUT } from '../../../routes/api/vault-sync/+server';
+import {
+  POST as fetchPOST,
+  DELETE as deleteDELETE
+} from '../../../routes/api/vault-sync/[credentialIdHash]/+server';
+
+/**
+ * Endpoint tests against the real route handlers with a map-backed KV stub.
+ * Assertions are minted at RUNTIME over fresh challenges (the fixture's
+ * canned challenge is time-fixed and would be expired here) using the
+ * fixture's test-only private key — signatures verify against the same
+ * SPKI a real client would register, and the blob is the frozen vault-v1
+ * record verbatim.
+ */
+
+const SECRET = fixture.secret;
+const CRED_ID = fixture.credentialIdB64url;
+const AUTH_DATA = b64urlToBytes(fixture.authenticatorDataB64url);
+
+let store: Map<string, { value: string; ttl?: number }>;
+function makeKv() {
+  return {
+    get: async (k: string, type?: string) => {
+      const e = store.get(k);
+      if (!e) return null;
+      return type === 'json' ? JSON.parse(e.value) : e.value;
+    },
+    put: async (k: string, value: string, options?: { expirationTtl?: number }) => {
+      store.set(k, { value, ttl: options?.expirationTtl });
+    },
+    delete: async (k: string) => void store.delete(k)
+  };
+}
+
+let kv: ReturnType<typeof makeKv>;
+let platform: any;
+const event = (request: Request, params: Record<string, string> = {}) =>
+  ({ request, platform, params, getClientAddress: () => '203.0.113.5' }) as any;
+
+async function credentialIdHash(credIdB64url = CRED_ID): Promise<string> {
+  const digest = new Uint8Array(
+    await crypto.subtle.digest('SHA-256', b64urlToBytes(credIdB64url) as BufferSource)
+  );
+  return Array.from(digest)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function rawToDer(raw: Uint8Array): Uint8Array {
+  const encodeInt = (bytes: Uint8Array): Uint8Array => {
+    let i = 0;
+    while (i < bytes.length - 1 && bytes[i] === 0) i++;
+    let body = bytes.slice(i);
+    if (body[0] & 0x80) body = new Uint8Array([0, ...body]);
+    return new Uint8Array([0x02, body.length, ...body]);
+  };
+  const r = encodeInt(raw.slice(0, 32));
+  const s = encodeInt(raw.slice(32));
+  return new Uint8Array([0x30, r.length + s.length, ...r, ...s]);
+}
+
+function b64url(bytes: Uint8Array): string {
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/** Mint a fresh, valid assertion (or a broken variant) at runtime. */
+async function mintAssertion(
+  opts: { wrongKey?: boolean; challenge?: string; credentialId?: string } = {}
+) {
+  const challenge = opts.challenge ?? (await issueChallenge(SECRET)).challenge;
+  const jwk = (opts.wrongKey ? fixture.wrongPrivateJwk : fixture.privateJwk) as JsonWebKey;
+  const key = await crypto.subtle.importKey('jwk', jwk, { name: 'ECDSA', namedCurve: 'P-256' }, false, ['sign']);
+  const cdj = new TextEncoder().encode(
+    JSON.stringify({ type: 'webauthn.get', challenge, origin: fixture.origin })
+  );
+  const signed = new Uint8Array(AUTH_DATA.length + 32);
+  signed.set(AUTH_DATA, 0);
+  signed.set(
+    new Uint8Array(await crypto.subtle.digest('SHA-256', cdj as BufferSource)),
+    AUTH_DATA.length
+  );
+  const raw = new Uint8Array(
+    await crypto.subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, key, signed as BufferSource)
+  );
+  return {
+    credentialId: opts.credentialId ?? CRED_ID,
+    signature: b64url(rawToDer(raw)),
+    authenticatorData: fixture.authenticatorDataB64url,
+    clientDataJSON: b64url(cdj)
+  };
+}
+
+function putRequest(body: unknown): Request {
+  return new Request('https://zap.cooking/api/vault-sync', {
+    method: 'PUT',
+    body: JSON.stringify(body)
+  });
+}
+
+async function uploadFixtureBlob() {
+  const res = await uploadPUT(
+    event(
+      putRequest({
+        blob: fixture.blob,
+        spki: fixture.spkiB64url,
+        alg: fixture.alg,
+        assertion: await mintAssertion()
+      })
+    )
+  );
+  expect(res.status).toBe(200);
+}
+
+beforeEach(() => {
+  store = new Map();
+  kv = makeKv();
+  platform = { env: { VAULT_SYNC: kv, VAULT_SYNC_CHALLENGE_SECRET: SECRET } };
+});
+
+describe('POST /api/vault-sync/challenge', () => {
+  it('issues a redeemable challenge', async () => {
+    const res = await challengePOST(event(new Request('https://zap.cooking', { method: 'POST' })));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(typeof body.challenge).toBe('string');
+    expect(body.expiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it('503 when bindings are missing', async () => {
+    platform = { env: {} };
+    const res = await challengePOST(event(new Request('https://zap.cooking', { method: 'POST' })));
+    expect(res.status).toBe(503);
+  });
+});
+
+describe('PUT /api/vault-sync (upload)', () => {
+  it('TOFU first upload: stores entry keyed by sha256(credentialId) with TTL', async () => {
+    await uploadFixtureBlob();
+    const key = await credentialIdHash();
+    const entry = store.get(key);
+    expect(entry).toBeDefined();
+    const parsed = JSON.parse(entry!.value);
+    expect(parsed.blob).toBe(fixture.blob);
+    expect(parsed.credentialPublicKey).toBe(fixture.spkiB64url);
+    expect(parsed.alg).toBe(-7);
+    expect(entry!.ttl).toBe(370 * 24 * 60 * 60);
+  });
+
+  it('first upload without spki/alg → 400', async () => {
+    const res = await uploadPUT(
+      event(putRequest({ blob: fixture.blob, assertion: await mintAssertion() }))
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('first upload with a wrong-key assertion → uniform 404 (TOFU is possession-proving)', async () => {
+    const res = await uploadPUT(
+      event(
+        putRequest({
+          blob: fixture.blob,
+          spki: fixture.spkiB64url,
+          alg: fixture.alg,
+          assertion: await mintAssertion({ wrongKey: true })
+        })
+      )
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'not_found' });
+    expect(store.get(await credentialIdHash())).toBeUndefined();
+  });
+
+  it('update verifies against the STORED key — wrong key cannot overwrite', async () => {
+    await uploadFixtureBlob();
+    const res = await uploadPUT(
+      event(
+        putRequest({
+          blob: fixture.blob,
+          // Attacker submits their own spki on update; it must be ignored
+          // and the assertion checked against the stored key.
+          spki: 'attacker-key',
+          alg: -7,
+          assertion: await mintAssertion({ wrongKey: true })
+        })
+      )
+    );
+    expect(res.status).toBe(404);
+    const stored = JSON.parse(store.get(await credentialIdHash())!.value);
+    expect(stored.credentialPublicKey).toBe(fixture.spkiB64url);
+  });
+
+  it('oversized blob → 413 before any crypto', async () => {
+    const res = await uploadPUT(
+      event(
+        putRequest({
+          blob: 'x'.repeat(4097),
+          spki: fixture.spkiB64url,
+          alg: fixture.alg,
+          assertion: await mintAssertion()
+        })
+      )
+    );
+    expect(res.status).toBe(413);
+  });
+
+  it('malformed JSON body → 400', async () => {
+    const res = await uploadPUT(
+      event(
+        new Request('https://zap.cooking/api/vault-sync', { method: 'PUT', body: 'not-json' })
+      )
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('blob whose keys[] lacks the asserting credential → uniform 404', async () => {
+    const record = JSON.parse(fixture.blob);
+    record.keys[0].credentialId = 'c29tZW9uZS1lbHNl';
+    const res = await uploadPUT(
+      event(
+        putRequest({
+          blob: JSON.stringify(record),
+          spki: fixture.spkiB64url,
+          alg: fixture.alg,
+          assertion: await mintAssertion()
+        })
+      )
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'not_found' });
+  });
+
+  it('reused challenge → uniform 404 (tombstone)', async () => {
+    const { challenge } = await issueChallenge(SECRET);
+    const first = await uploadPUT(
+      event(
+        putRequest({
+          blob: fixture.blob,
+          spki: fixture.spkiB64url,
+          alg: fixture.alg,
+          assertion: await mintAssertion({ challenge })
+        })
+      )
+    );
+    expect(first.status).toBe(200);
+    const replay = await uploadPUT(
+      event(
+        putRequest({
+          blob: fixture.blob,
+          spki: fixture.spkiB64url,
+          alg: fixture.alg,
+          assertion: await mintAssertion({ challenge })
+        })
+      )
+    );
+    expect(replay.status).toBe(404);
+  });
+});
+
+describe('POST /api/vault-sync/:hash (fetch)', () => {
+  it('happy path: returns the blob and refreshes the TTL + signCount', async () => {
+    await uploadFixtureBlob();
+    const key = await credentialIdHash();
+    store.get(key)!.ttl = 1; // stomp so the refresh is observable
+
+    const res = await fetchPOST(
+      event(
+        new Request('https://zap.cooking', {
+          method: 'POST',
+          body: JSON.stringify({ assertion: await mintAssertion() })
+        }),
+        { credentialIdHash: key }
+      )
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).blob).toBe(fixture.blob);
+    expect(store.get(key)!.ttl).toBe(370 * 24 * 60 * 60);
+  });
+
+  it('absent entry → uniform 404', async () => {
+    const res = await fetchPOST(
+      event(
+        new Request('https://zap.cooking', {
+          method: 'POST',
+          body: JSON.stringify({ assertion: await mintAssertion() })
+        }),
+        { credentialIdHash: await credentialIdHash() }
+      )
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'not_found' });
+  });
+
+  it('wrong-key assertion → uniform 404, blob not returned', async () => {
+    await uploadFixtureBlob();
+    const res = await fetchPOST(
+      event(
+        new Request('https://zap.cooking', {
+          method: 'POST',
+          body: JSON.stringify({ assertion: await mintAssertion({ wrongKey: true }) })
+        }),
+        { credentialIdHash: await credentialIdHash() }
+      )
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('path hash not matching the asserting credential → uniform 404', async () => {
+    await uploadFixtureBlob();
+    const res = await fetchPOST(
+      event(
+        new Request('https://zap.cooking', {
+          method: 'POST',
+          body: JSON.stringify({ assertion: await mintAssertion() })
+        }),
+        { credentialIdHash: 'ab'.repeat(32) }
+      )
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('uniform-404 sweep: every auth-shaped failure is byte-identical', async () => {
+    await uploadFixtureBlob();
+    const key = await credentialIdHash();
+    const expired = (await issueChallenge(SECRET, Date.now() - 10 * 60 * 1000)).challenge;
+    const cases: Array<() => Promise<Response>> = [
+      // absent entry (different credential id → different hash)
+      async () =>
+        fetchPOST(
+          event(
+            new Request('https://zap.cooking', {
+              method: 'POST',
+              body: JSON.stringify({
+                assertion: await mintAssertion({ credentialId: 'b3RoZXItY3JlZA' })
+              })
+            }),
+            { credentialIdHash: await credentialIdHash('b3RoZXItY3JlZA') }
+          )
+        ),
+      // wrong key
+      async () =>
+        fetchPOST(
+          event(
+            new Request('https://zap.cooking', {
+              method: 'POST',
+              body: JSON.stringify({ assertion: await mintAssertion({ wrongKey: true }) })
+            }),
+            { credentialIdHash: key }
+          )
+        ),
+      // expired challenge
+      async () =>
+        fetchPOST(
+          event(
+            new Request('https://zap.cooking', {
+              method: 'POST',
+              body: JSON.stringify({ assertion: await mintAssertion({ challenge: expired }) })
+            }),
+            { credentialIdHash: key }
+          )
+        ),
+      // path mismatch
+      async () =>
+        fetchPOST(
+          event(
+            new Request('https://zap.cooking', {
+              method: 'POST',
+              body: JSON.stringify({ assertion: await mintAssertion() })
+            }),
+            { credentialIdHash: 'cd'.repeat(32) }
+          )
+        )
+    ];
+    for (const run of cases) {
+      const res = await run();
+      expect(res.status).toBe(404);
+      expect(await res.text()).toBe(JSON.stringify({ error: 'not_found' }));
+    }
+  });
+});
+
+describe('DELETE /api/vault-sync/:hash', () => {
+  it('verified assertion deletes the entry', async () => {
+    await uploadFixtureBlob();
+    const key = await credentialIdHash();
+    const res = await deleteDELETE(
+      event(
+        new Request('https://zap.cooking', {
+          method: 'DELETE',
+          body: JSON.stringify({ assertion: await mintAssertion() })
+        }),
+        { credentialIdHash: key }
+      )
+    );
+    expect(res.status).toBe(200);
+    expect(store.get(key)).toBeUndefined();
+  });
+
+  it('absent entry → uniform 404 (no existence oracle; client treats as already-gone)', async () => {
+    const res = await deleteDELETE(
+      event(
+        new Request('https://zap.cooking', {
+          method: 'DELETE',
+          body: JSON.stringify({ assertion: await mintAssertion() })
+        }),
+        { credentialIdHash: await credentialIdHash() }
+      )
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'not_found' });
+  });
+
+  it('wrong-key assertion cannot delete', async () => {
+    await uploadFixtureBlob();
+    const key = await credentialIdHash();
+    const res = await deleteDELETE(
+      event(
+        new Request('https://zap.cooking', {
+          method: 'DELETE',
+          body: JSON.stringify({ assertion: await mintAssertion({ wrongKey: true }) })
+        }),
+        { credentialIdHash: key }
+      )
+    );
+    expect(res.status).toBe(404);
+    expect(store.get(key)).toBeDefined();
+  });
+});
+
+describe('rate limiting', () => {
+  it('fetch trips the per-hour bucket at 20', async () => {
+    let last: Response | null = null;
+    for (let i = 0; i < 21; i++) {
+      last = await fetchPOST(
+        event(new Request('https://zap.cooking', { method: 'POST', body: 'x' }), {
+          credentialIdHash: 'ab'.repeat(32)
+        })
+      );
+    }
+    expect(last!.status).toBe(429);
+    expect((await last!.json()).error).toBe('rate_limited');
+  });
+});
+
+describe('never-log (R2)', () => {
+  const spies: Array<ReturnType<typeof vi.spyOn>> = [];
+  let captured: string[];
+
+  beforeEach(() => {
+    captured = [];
+    for (const method of ['log', 'warn', 'error', 'info', 'debug'] as const) {
+      spies.push(
+        vi.spyOn(console, method).mockImplementation((...args: unknown[]) => {
+          captured.push(args.map((a) => String(a)).join(' '));
+        })
+      );
+    }
+  });
+
+  afterEach(() => {
+    spies.forEach((s) => s.mockRestore());
+    spies.length = 0;
+  });
+
+  it('no endpoint logs blob contents on success or failure', async () => {
+    await uploadFixtureBlob();
+    const key = await credentialIdHash();
+    await fetchPOST(
+      event(
+        new Request('https://zap.cooking', {
+          method: 'POST',
+          body: JSON.stringify({ assertion: await mintAssertion() })
+        }),
+        { credentialIdHash: key }
+      )
+    );
+    // Failures too — catch blocks must not console.error the body.
+    await uploadPUT(
+      event(
+        putRequest({
+          blob: fixture.blob,
+          spki: fixture.spkiB64url,
+          alg: fixture.alg,
+          assertion: await mintAssertion({ wrongKey: true })
+        })
+      )
+    );
+
+    const ciphertextFragment = JSON.parse(fixture.blob).nsecCiphertext.slice(0, 24);
+    const all = captured.join('\n');
+    expect(all).not.toContain('nsecCiphertext');
+    expect(all).not.toContain(ciphertextFragment);
+    expect(all).not.toContain(fixture.blob.slice(0, 40));
+  });
+});

--- a/src/lib/server/vaultSync/webauthn.server.test.ts
+++ b/src/lib/server/vaultSync/webauthn.server.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import fixture from '../../../test/fixtures/vault-sync-v1.json';
+import {
+  verifyAssertion,
+  parseAuthenticatorData,
+  derToRawEcdsa,
+  isAllowedOrigin,
+  b64urlToBytes,
+  bytesToB64url
+} from './webauthn.server';
+import { issueChallenge, redeemChallenge, CHALLENGE_TTL_MS } from './challenge.server';
+
+/**
+ * Vector suite for the dependency-free WebAuthn verifier and the HMAC
+ * challenge module. All canned vectors come from vault-sync-v1.json
+ * (generated once; the assertion is over a challenge issued by the real
+ * challenge module at fixed time fixture.issuedAtMs).
+ */
+
+const SPKI = b64urlToBytes(fixture.spkiB64url);
+const AUTH_DATA = b64urlToBytes(fixture.authenticatorDataB64url);
+const CDJ = b64urlToBytes(fixture.clientDataJSONB64url);
+
+function assertionInput(overrides: Partial<Record<'signature' | 'authenticatorData' | 'clientDataJSON', Uint8Array>> = {}) {
+  return {
+    signature: overrides.signature ?? b64urlToBytes(fixture.signatureB64url),
+    authenticatorData: overrides.authenticatorData ?? AUTH_DATA,
+    clientDataJSON: overrides.clientDataJSON ?? CDJ
+  };
+}
+
+describe('verifyAssertion', () => {
+  it('accepts the canned valid assertion and reports signCount', async () => {
+    const result = await verifyAssertion(assertionInput(), SPKI, fixture.alg, fixture.challenge);
+    expect(result.signCount).toBe(0);
+  });
+
+  it('rejects a signature from the wrong key', async () => {
+    await expect(
+      verifyAssertion(
+        assertionInput({ signature: b64urlToBytes(fixture.wrongKeySignatureB64url) }),
+        SPKI,
+        fixture.alg,
+        fixture.challenge
+      )
+    ).rejects.toThrow();
+  });
+
+  it('rejects a tampered signature', async () => {
+    await expect(
+      verifyAssertion(
+        assertionInput({ signature: b64urlToBytes(fixture.tamperedSignatureB64url) }),
+        SPKI,
+        fixture.alg,
+        fixture.challenge
+      )
+    ).rejects.toThrow();
+  });
+
+  it('rejects a challenge mismatch', async () => {
+    await expect(
+      verifyAssertion(assertionInput(), SPKI, fixture.alg, 'different-challenge')
+    ).rejects.toThrow(/challenge/);
+  });
+
+  it('rejects when the UV flag is clear (validly signed)', async () => {
+    await expect(
+      verifyAssertion(
+        assertionInput({
+          authenticatorData: b64urlToBytes(fixture.authenticatorDataNoUvB64url),
+          signature: b64urlToBytes(fixture.signatureNoUvB64url)
+        }),
+        SPKI,
+        fixture.alg,
+        fixture.challenge
+      )
+    ).rejects.toThrow(/UV/);
+  });
+
+  it('rejects a wrong rpIdHash', async () => {
+    const badAuthData = AUTH_DATA.slice();
+    badAuthData[0] ^= 0xff;
+    await expect(
+      verifyAssertion(
+        assertionInput({ authenticatorData: badAuthData }),
+        SPKI,
+        fixture.alg,
+        fixture.challenge
+      )
+    ).rejects.toThrow(/rpIdHash/);
+  });
+
+  it('rejects a disallowed origin (validly structured clientDataJSON)', async () => {
+    const cdj = JSON.parse(new TextDecoder().decode(CDJ));
+    cdj.origin = 'https://evil.example';
+    await expect(
+      verifyAssertion(
+        assertionInput({ clientDataJSON: new TextEncoder().encode(JSON.stringify(cdj)) }),
+        SPKI,
+        fixture.alg,
+        fixture.challenge
+      )
+    ).rejects.toThrow(/origin/);
+  });
+
+  it('rejects a webauthn.create clientData type', async () => {
+    const cdj = JSON.parse(new TextDecoder().decode(CDJ));
+    cdj.type = 'webauthn.create';
+    await expect(
+      verifyAssertion(
+        assertionInput({ clientDataJSON: new TextEncoder().encode(JSON.stringify(cdj)) }),
+        SPKI,
+        fixture.alg,
+        fixture.challenge
+      )
+    ).rejects.toThrow(/type/);
+  });
+
+  it('rejects an unsupported algorithm', async () => {
+    await expect(
+      verifyAssertion(assertionInput(), SPKI, -8, fixture.challenge)
+    ).rejects.toThrow(/algorithm/);
+  });
+});
+
+describe('parseAuthenticatorData', () => {
+  it('parses rpIdHash, flags and signCount', () => {
+    const parsed = parseAuthenticatorData(AUTH_DATA);
+    expect(parsed.userPresent).toBe(true);
+    expect(parsed.userVerified).toBe(true);
+    expect(parsed.signCount).toBe(0);
+    expect(parsed.rpIdHash).toHaveLength(32);
+  });
+
+  it('reads a big-endian signCount', () => {
+    const data = AUTH_DATA.slice();
+    data[33] = 0x00;
+    data[34] = 0x01;
+    data[35] = 0x02;
+    data[36] = 0x03;
+    expect(parseAuthenticatorData(data).signCount).toBe(0x010203);
+  });
+
+  it('rejects short input', () => {
+    expect(() => parseAuthenticatorData(new Uint8Array(36))).toThrow(/short/);
+  });
+});
+
+describe('derToRawEcdsa', () => {
+  it('round-trips the fixture signature to 64 raw bytes', () => {
+    const raw = derToRawEcdsa(b64urlToBytes(fixture.signatureB64url));
+    expect(raw).toHaveLength(64);
+  });
+
+  it('handles integers with leading-zero sign bytes', () => {
+    // r = 0x00||0xFF...(32), s = 0x01...(31 bytes → left-padded)
+    const r = new Uint8Array(33);
+    r[0] = 0x00;
+    r.fill(0xff, 1);
+    const s = new Uint8Array(31).fill(0x01);
+    const der = new Uint8Array([
+      0x30, 2 + 33 + 2 + 31,
+      0x02, 33, ...r,
+      0x02, 31, ...s
+    ]);
+    const raw = derToRawEcdsa(der);
+    expect(raw[0]).toBe(0xff); // sign byte stripped
+    expect(raw[32]).toBe(0x00); // s left-padded
+    expect(raw[33]).toBe(0x01);
+  });
+
+  it('rejects trailing bytes and non-sequences', () => {
+    const valid = b64urlToBytes(fixture.signatureB64url);
+    expect(() => derToRawEcdsa(new Uint8Array([...valid, 0x00]))).toThrow();
+    expect(() => derToRawEcdsa(new Uint8Array([0x31, 0x00]))).toThrow(/sequence/);
+  });
+});
+
+describe('isAllowedOrigin', () => {
+  it('allows production and subdomains, https only', () => {
+    expect(isAllowedOrigin('https://zap.cooking')).toBe(true);
+    expect(isAllowedOrigin('https://staging.zap.cooking')).toBe(true);
+    expect(isAllowedOrigin('http://zap.cooking')).toBe(false);
+    expect(isAllowedOrigin('https://feat-x.frontend-hvd.pages.dev')).toBe(false);
+    expect(isAllowedOrigin('https://zap.cooking.evil.example')).toBe(false);
+    expect(isAllowedOrigin('not a url')).toBe(false);
+  });
+});
+
+describe('challenge module', () => {
+  let store: Map<string, string>;
+  const kv = {
+    get: async (k: string) => store.get(k) ?? null,
+    put: async (k: string, v: string) => void store.set(k, v)
+  };
+
+  beforeEach(() => {
+    store = new Map();
+  });
+
+  it('issues and redeems within the TTL', async () => {
+    await expect(
+      redeemChallenge(kv, fixture.secret, fixture.challenge, fixture.issuedAtMs + 1000)
+    ).resolves.toBeUndefined();
+  });
+
+  it('rejects a stale challenge', async () => {
+    await expect(
+      redeemChallenge(kv, fixture.secret, fixture.challenge, fixture.issuedAtMs + CHALLENGE_TTL_MS + 1)
+    ).rejects.toThrow(/expired/);
+  });
+
+  it('rejects reuse (tombstone)', async () => {
+    await redeemChallenge(kv, fixture.secret, fixture.challenge, fixture.issuedAtMs + 1000);
+    await expect(
+      redeemChallenge(kv, fixture.secret, fixture.challenge, fixture.issuedAtMs + 2000)
+    ).rejects.toThrow(/redeemed/);
+  });
+
+  it('rejects a challenge minted under a different secret', async () => {
+    const { challenge } = await issueChallenge('other-secret', fixture.issuedAtMs);
+    await expect(
+      redeemChallenge(kv, fixture.secret, challenge, fixture.issuedAtMs + 1000)
+    ).rejects.toThrow(/MAC/);
+  });
+
+  it('rejects malformed challenges', async () => {
+    await expect(redeemChallenge(kv, fixture.secret, 'AAAA', Date.now())).rejects.toThrow();
+    await expect(redeemChallenge(kv, fixture.secret, '!!!', Date.now())).rejects.toThrow();
+  });
+
+  it('fresh challenges verify end-to-end with a runtime-signed assertion', async () => {
+    // Proves the fixture privateJwk matches the fixture SPKI and that the
+    // whole pipeline works for challenges minted NOW (endpoint tests rely
+    // on this).
+    const { challenge } = await issueChallenge(fixture.secret);
+    const key = await crypto.subtle.importKey(
+      'jwk',
+      fixture.privateJwk as JsonWebKey,
+      { name: 'ECDSA', namedCurve: 'P-256' },
+      false,
+      ['sign']
+    );
+    const cdj = new TextEncoder().encode(
+      JSON.stringify({ type: 'webauthn.get', challenge, origin: fixture.origin })
+    );
+    const signed = new Uint8Array(AUTH_DATA.length + 32);
+    signed.set(AUTH_DATA, 0);
+    signed.set(
+      new Uint8Array(await crypto.subtle.digest('SHA-256', cdj as BufferSource)),
+      AUTH_DATA.length
+    );
+    const rawSig = new Uint8Array(
+      await crypto.subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, key, signed as BufferSource)
+    );
+    // raw → DER (mirror of the generator's helper)
+    const encodeInt = (bytes: Uint8Array): Uint8Array => {
+      let i = 0;
+      while (i < bytes.length - 1 && bytes[i] === 0) i++;
+      let body = bytes.slice(i);
+      if (body[0] & 0x80) body = new Uint8Array([0, ...body]);
+      return new Uint8Array([0x02, body.length, ...body]);
+    };
+    const r = encodeInt(rawSig.slice(0, 32));
+    const s = encodeInt(rawSig.slice(32));
+    const der = new Uint8Array([0x30, r.length + s.length, ...r, ...s]);
+
+    await expect(
+      verifyAssertion(
+        { signature: der, authenticatorData: AUTH_DATA, clientDataJSON: cdj },
+        SPKI,
+        fixture.alg,
+        challenge
+      )
+    ).resolves.toEqual({ signCount: 0 });
+    expect(bytesToB64url(b64urlToBytes(fixture.credentialIdB64url))).toBe(
+      fixture.credentialIdB64url
+    );
+  });
+});

--- a/src/lib/server/vaultSync/webauthn.server.ts
+++ b/src/lib/server/vaultSync/webauthn.server.ts
@@ -1,0 +1,214 @@
+/**
+ * Minimal WebAuthn assertion verification for the vault-sync endpoints.
+ *
+ * Deliberately dependency-free (Gate 1 ruling): we never parse attestation
+ * objects — clients register with the SPKI DER from
+ * AuthenticatorAttestationResponse.getPublicKey(), so verification reduces
+ * to fixed-offset authenticatorData parsing, clientDataJSON checks, and a
+ * WebCrypto signature verify. Supports the two algorithms Phase 1 requests
+ * at create(): ES256 (-7) and RS256 (-257).
+ *
+ * Security posture notes:
+ * - rpIdHash is pinned to sha256('zap.cooking') — same constant the client
+ *   enforces (passkeyVault.ts RP_ID).
+ * - UV (user verification) flag is REQUIRED; Phase 1 ceremonies always set
+ *   userVerification: 'required'.
+ * - signCount: stored last-seen only, NEVER enforced to increment — synced
+ *   passkeys (GPM, iCloud Keychain) report 0 or regress by design, so an
+ *   increment check would lock out exactly the credentials this feature
+ *   exists for (per ruling, Gate 2 addition 4).
+ */
+
+export const RP_ID = 'zap.cooking';
+
+/** Origins allowed to produce assertions (mirrors the client origin gate). */
+export function isAllowedOrigin(origin: string): boolean {
+  try {
+    const url = new URL(origin);
+    if (url.protocol !== 'https:') return false;
+    return url.hostname === RP_ID || url.hostname.endsWith(`.${RP_ID}`);
+  } catch {
+    return false;
+  }
+}
+
+export interface ParsedAuthenticatorData {
+  rpIdHash: Uint8Array;
+  userPresent: boolean;
+  userVerified: boolean;
+  signCount: number;
+}
+
+export function parseAuthenticatorData(data: Uint8Array): ParsedAuthenticatorData {
+  if (data.length < 37) throw new Error('authenticatorData too short');
+  const flags = data[32];
+  return {
+    rpIdHash: data.slice(0, 32),
+    userPresent: (flags & 0x01) !== 0,
+    userVerified: (flags & 0x04) !== 0,
+    signCount: (data[33] << 24) | (data[34] << 16) | (data[35] << 8) | data[36]
+  };
+}
+
+/**
+ * Convert an ASN.1/DER-encoded ECDSA signature (what authenticators emit)
+ * to the raw r||s form WebCrypto verifies. Each integer is left-padded or
+ * trimmed to 32 bytes (P-256).
+ */
+export function derToRawEcdsa(der: Uint8Array): Uint8Array {
+  let offset = 0;
+  if (der[offset++] !== 0x30) throw new Error('invalid DER: no sequence');
+  let seqLen = der[offset++];
+  if (seqLen & 0x80) {
+    const lenBytes = seqLen & 0x7f;
+    if (lenBytes < 1 || lenBytes > 2) throw new Error('invalid DER: bad length');
+    seqLen = 0;
+    for (let i = 0; i < lenBytes; i++) seqLen = (seqLen << 8) | der[offset++];
+  }
+  if (offset + seqLen !== der.length) throw new Error('invalid DER: length mismatch');
+
+  const readInt = (): Uint8Array => {
+    if (der[offset++] !== 0x02) throw new Error('invalid DER: no integer');
+    let len = der[offset++];
+    if (len & 0x80) throw new Error('invalid DER: overlong integer');
+    let bytes = der.slice(offset, offset + len);
+    offset += len;
+    // Strip leading zero sign bytes, then left-pad to 32.
+    while (bytes.length > 32 && bytes[0] === 0x00) bytes = bytes.slice(1);
+    if (bytes.length > 32) throw new Error('invalid DER: integer too long');
+    const out = new Uint8Array(32);
+    out.set(bytes, 32 - bytes.length);
+    return out;
+  };
+
+  const r = readInt();
+  const s = readInt();
+  if (offset !== der.length) throw new Error('invalid DER: trailing bytes');
+  const raw = new Uint8Array(64);
+  raw.set(r, 0);
+  raw.set(s, 32);
+  return raw;
+}
+
+async function sha256(data: Uint8Array): Promise<Uint8Array> {
+  return new Uint8Array(await crypto.subtle.digest('SHA-256', data as BufferSource));
+}
+
+let rpIdHashCache: Uint8Array | null = null;
+async function expectedRpIdHash(): Promise<Uint8Array> {
+  if (!rpIdHashCache) rpIdHashCache = await sha256(new TextEncoder().encode(RP_ID));
+  return rpIdHashCache;
+}
+
+function constantTimeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let r = 0;
+  for (let i = 0; i < a.length; i++) r |= a[i] ^ b[i];
+  return r === 0;
+}
+
+export function b64urlToBytes(s: string): Uint8Array {
+  const b64 = s.replace(/-/g, '+').replace(/_/g, '/');
+  return Uint8Array.from(atob(b64 + '='.repeat((4 - (b64.length % 4)) % 4)), (c) =>
+    c.charCodeAt(0)
+  );
+}
+
+export function bytesToB64url(bytes: Uint8Array): string {
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export interface AssertionInput {
+  /** Raw signature bytes from the assertion (DER for ES256). */
+  signature: Uint8Array;
+  authenticatorData: Uint8Array;
+  clientDataJSON: Uint8Array;
+}
+
+export interface VerifiedAssertion {
+  /** Last-seen counter for storage. Never used for enforcement (see header). */
+  signCount: number;
+}
+
+/**
+ * Verify a WebAuthn assertion. Throws on ANY failure — callers map every
+ * throw to the uniform 404 (no oracle). Returns the observed signCount.
+ *
+ * @param expectedChallenge exact challenge string the client was issued
+ *   (base64url) — compared against clientDataJSON.challenge.
+ */
+export async function verifyAssertion(
+  input: AssertionInput,
+  spkiDer: Uint8Array,
+  coseAlg: number,
+  expectedChallenge: string
+): Promise<VerifiedAssertion> {
+  // 1. clientDataJSON: type, challenge, origin.
+  let clientData: { type?: string; challenge?: string; origin?: string };
+  try {
+    clientData = JSON.parse(new TextDecoder().decode(input.clientDataJSON));
+  } catch {
+    throw new Error('clientDataJSON not JSON');
+  }
+  if (clientData.type !== 'webauthn.get') throw new Error('wrong clientData type');
+  if (
+    typeof clientData.challenge !== 'string' ||
+    clientData.challenge !== expectedChallenge
+  ) {
+    throw new Error('challenge mismatch');
+  }
+  if (typeof clientData.origin !== 'string' || !isAllowedOrigin(clientData.origin)) {
+    throw new Error('origin not allowed');
+  }
+
+  // 2. authenticatorData: rpIdHash + UV.
+  const authData = parseAuthenticatorData(input.authenticatorData);
+  if (!constantTimeEqual(authData.rpIdHash, await expectedRpIdHash())) {
+    throw new Error('rpIdHash mismatch');
+  }
+  if (!authData.userPresent) throw new Error('UP flag not set');
+  if (!authData.userVerified) throw new Error('UV flag not set');
+
+  // 3. Signature over authenticatorData || sha256(clientDataJSON).
+  const signedData = new Uint8Array(input.authenticatorData.length + 32);
+  signedData.set(input.authenticatorData, 0);
+  signedData.set(await sha256(input.clientDataJSON), input.authenticatorData.length);
+
+  let ok: boolean;
+  if (coseAlg === -7) {
+    const key = await crypto.subtle.importKey(
+      'spki',
+      spkiDer as BufferSource,
+      { name: 'ECDSA', namedCurve: 'P-256' },
+      false,
+      ['verify']
+    );
+    ok = await crypto.subtle.verify(
+      { name: 'ECDSA', hash: 'SHA-256' },
+      key,
+      derToRawEcdsa(input.signature) as BufferSource,
+      signedData as BufferSource
+    );
+  } else if (coseAlg === -257) {
+    const key = await crypto.subtle.importKey(
+      'spki',
+      spkiDer as BufferSource,
+      { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+      false,
+      ['verify']
+    );
+    ok = await crypto.subtle.verify(
+      'RSASSA-PKCS1-v1_5',
+      key,
+      input.signature as BufferSource,
+      signedData as BufferSource
+    );
+  } else {
+    throw new Error(`unsupported algorithm ${coseAlg}`);
+  }
+  if (!ok) throw new Error('signature verification failed');
+
+  return { signCount: authData.signCount };
+}

--- a/src/routes/api/vault-sync/+server.ts
+++ b/src/routes/api/vault-sync/+server.ts
@@ -1,0 +1,98 @@
+/**
+ * PUT /api/vault-sync — upload or update a vault-sync blob.
+ *
+ * SINGLE upload path, always assertion-gated (Gate 2 ruling: no
+ * assertion-less PUT variant). First upload (no KV entry) is
+ * TOFU-hardened: the assertion is verified against the SUBMITTED SPKI, so
+ * even registration proves live possession of the credential's private
+ * key. Updates verify against the STORED SPKI — an entry's public key is
+ * never overwritten.
+ *
+ * Privacy (R2 ruling): KV is keyed by sha256(credentialId) only; the
+ * pubkey↔credentialId linkage exists only inside the opaque value; request
+ * bodies and blob contents are never logged (pinned by test).
+ */
+
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import {
+  getEnv,
+  uniform404,
+  sha256Hex,
+  checkAssertion,
+  isAssertionBody
+} from '$lib/server/vaultSync/common.server';
+import { b64urlToBytes } from '$lib/server/vaultSync/webauthn.server';
+import {
+  validateBlob,
+  MAX_BLOB_BYTES,
+  ENTRY_TTL_S,
+  type VaultSyncEntry
+} from '$lib/server/vaultSync/blob.server';
+import { checkPerIpRateLimit } from '$lib/ipRateLimit.server';
+
+export const PUT: RequestHandler = async ({ request, platform, getClientAddress }) => {
+  const env = getEnv(platform);
+  if (!env) return json({ error: 'not_configured' }, { status: 503 });
+
+  const limited = await checkPerIpRateLimit(env.kv, {
+    ip: getClientAddress(),
+    scope: 'vault-sync-upload',
+    perHour: 10,
+    perDay: 40
+  });
+  if (limited.limited) return json(limited.body, { status: 429 });
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'bad_request' }, { status: 400 });
+  }
+  if (typeof body?.blob !== 'string' || !isAssertionBody(body?.assertion)) {
+    return json({ error: 'bad_request' }, { status: 400 });
+  }
+  // Size gate before any crypto — cheap rejection for oversized payloads.
+  if (new TextEncoder().encode(body.blob).length > MAX_BLOB_BYTES) {
+    return json({ error: 'too_large' }, { status: 413 });
+  }
+
+  try {
+    const credentialId: string = body.assertion.credentialId;
+    const kvKey = await sha256Hex(b64urlToBytes(credentialId));
+    const existing = (await env.kv.get(kvKey, 'json')) as VaultSyncEntry | null;
+
+    let spki: string;
+    let alg: number;
+    if (existing) {
+      // Update: stored key wins; submitted spki (if any) is ignored.
+      spki = existing.credentialPublicKey;
+      alg = existing.alg;
+    } else {
+      // TOFU first upload: SPKI + alg required, assertion must verify
+      // against exactly what is being registered.
+      if (typeof body.spki !== 'string' || (body.alg !== -7 && body.alg !== -257)) {
+        return json({ error: 'bad_request' }, { status: 400 });
+      }
+      spki = body.spki;
+      alg = body.alg;
+    }
+
+    const verified = await checkAssertion(env, body.assertion, spki, alg);
+    validateBlob(body.blob, credentialId);
+
+    const entry: VaultSyncEntry = {
+      version: 1,
+      blob: body.blob,
+      credentialPublicKey: spki,
+      alg,
+      signCount: verified.signCount,
+      updatedAt: Date.now()
+    };
+    await env.kv.put(kvKey, JSON.stringify(entry), { expirationTtl: ENTRY_TTL_S });
+    return json({ ok: true });
+  } catch {
+    // Auth-shaped or shape-validation failure — uniform, no detail, no logs.
+    return uniform404();
+  }
+};

--- a/src/routes/api/vault-sync/[credentialIdHash]/+server.ts
+++ b/src/routes/api/vault-sync/[credentialIdHash]/+server.ts
@@ -1,0 +1,137 @@
+/**
+ * POST /api/vault-sync/:credentialIdHash → { blob }   (assertion-gated fetch)
+ * DELETE /api/vault-sync/:credentialIdHash            (assertion-gated, idempotent)
+ *
+ * Fetch uses POST so the assertion travels in the body, never in URLs or
+ * access logs. The path param must equal sha256(assertion.credentialId) —
+ * an assertion can only ever address its own entry.
+ *
+ * Why assertion-gated at all: the blob is ciphertext, but a provider-
+ * account compromise yields the synced passkey; a freely fetchable blob
+ * would hand such an attacker both halves. Requiring a live verified
+ * ceremony makes blob retrieval demand the same act that produces the PRF
+ * (Phase 1 security-review ruling).
+ *
+ * On success, fetch refreshes the entry TTL by rewriting it (KV has no
+ * touch primitive) — R4: entries live ~12 months past last use; expiry
+ * costs sync only, never identity (next nsec login re-uploads).
+ */
+
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import {
+  getEnv,
+  uniform404,
+  sha256Hex,
+  checkAssertion,
+  isAssertionBody,
+  type VaultSyncEnv
+} from '$lib/server/vaultSync/common.server';
+import { b64urlToBytes } from '$lib/server/vaultSync/webauthn.server';
+import { ENTRY_TTL_S, type VaultSyncEntry } from '$lib/server/vaultSync/blob.server';
+import { checkPerIpRateLimit } from '$lib/ipRateLimit.server';
+
+interface VerifiedRequest {
+  env: VaultSyncEnv;
+  kvKey: string;
+  entry: VaultSyncEntry;
+  signCount: number;
+}
+
+/**
+ * Shared verification for fetch and delete. Returns null for anything
+ * auth-shaped (caller responds uniform404). Throws nothing.
+ *
+ * An ABSENT entry is also null: with no stored public key the assertion is
+ * unverifiable, and any non-404 response for absent keys would be an
+ * existence oracle — a garbage assertion would get 200 for absent hashes
+ * and 404 for present ones. DELETE idempotency therefore lives client-side
+ * (a 404 on DELETE means "desired state holds"); see the PR notes for the
+ * rulings-conflict flag on this point.
+ */
+async function verifyRequest(
+  request: Request,
+  platform: App.Platform | undefined,
+  paramHash: string
+): Promise<VerifiedRequest | 'bad_request' | null> {
+  const env = getEnv(platform);
+  if (!env) return null;
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return 'bad_request';
+  }
+  if (!isAssertionBody(body?.assertion)) return 'bad_request';
+
+  try {
+    const kvKey = await sha256Hex(b64urlToBytes(body.assertion.credentialId));
+    // The addressed entry must be the asserting credential's own.
+    if (kvKey !== paramHash.toLowerCase()) return null;
+
+    const entry = (await env.kv.get(kvKey, 'json')) as VaultSyncEntry | null;
+    if (!entry) return null;
+    const verified = await checkAssertion(
+      env,
+      body.assertion,
+      entry.credentialPublicKey,
+      entry.alg
+    );
+    return { env, kvKey, entry, signCount: verified.signCount };
+  } catch {
+    return null;
+  }
+}
+
+export const POST: RequestHandler = async ({ request, platform, params, getClientAddress }) => {
+  const env = getEnv(platform);
+  if (!env) return json({ error: 'not_configured' }, { status: 503 });
+
+  // Fetch is the abuse target (Gate 2 addition 1) — tightest bucket.
+  const limited = await checkPerIpRateLimit(env.kv, {
+    ip: getClientAddress(),
+    scope: 'vault-sync-fetch',
+    perHour: 20,
+    perDay: 60
+  });
+  if (limited.limited) return json(limited.body, { status: 429 });
+
+  const result = await verifyRequest(request, platform, params.credentialIdHash);
+  if (result === 'bad_request') return json({ error: 'bad_request' }, { status: 400 });
+  if (!result) return uniform404();
+
+  // TTL refresh on successful fetch (R4). Also records last-seen signCount
+  // — stored only, never enforced: synced passkeys report 0 / regress by
+  // design (Gate 2 addition 4).
+  const refreshed: VaultSyncEntry = {
+    ...result.entry,
+    signCount: result.signCount,
+    updatedAt: Date.now()
+  };
+  await result.env.kv.put(result.kvKey, JSON.stringify(refreshed), {
+    expirationTtl: ENTRY_TTL_S
+  });
+
+  return json({ blob: result.entry.blob });
+};
+
+export const DELETE: RequestHandler = async ({ request, platform, params, getClientAddress }) => {
+  const env = getEnv(platform);
+  if (!env) return json({ error: 'not_configured' }, { status: 503 });
+
+  const limited = await checkPerIpRateLimit(env.kv, {
+    ip: getClientAddress(),
+    scope: 'vault-sync-delete',
+    perHour: 10,
+    perDay: 30
+  });
+  if (limited.limited) return json(limited.body, { status: 429 });
+
+  const result = await verifyRequest(request, platform, params.credentialIdHash);
+  if (result === 'bad_request') return json({ error: 'bad_request' }, { status: 400 });
+  if (!result) return uniform404();
+
+  await result.env.kv.delete(result.kvKey);
+  return json({ ok: true });
+};

--- a/src/routes/api/vault-sync/challenge/+server.ts
+++ b/src/routes/api/vault-sync/challenge/+server.ts
@@ -1,0 +1,27 @@
+/**
+ * POST /api/vault-sync/challenge → { challenge, expiresAt }
+ *
+ * Stateless HMAC challenge issuance for vault-sync assertions (see
+ * $lib/server/vaultSync/challenge.server.ts). Rate-limited per IP.
+ */
+
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { issueChallenge } from '$lib/server/vaultSync/challenge.server';
+import { getEnv } from '$lib/server/vaultSync/common.server';
+import { checkPerIpRateLimit } from '$lib/ipRateLimit.server';
+
+export const POST: RequestHandler = async ({ platform, getClientAddress }) => {
+  const env = getEnv(platform);
+  if (!env) return json({ error: 'not_configured' }, { status: 503 });
+
+  const limited = await checkPerIpRateLimit(env.kv, {
+    ip: getClientAddress(),
+    scope: 'vault-sync-challenge',
+    perHour: 30,
+    perDay: 100
+  });
+  if (limited.limited) return json(limited.body, { status: 429 });
+
+  return json(await issueChallenge(env.secret));
+};

--- a/src/test/fixtures/vault-sync-v1.json
+++ b/src/test/fixtures/vault-sync-v1.json
@@ -1,0 +1,41 @@
+{
+  "description": "Vault-sync v1 server test vectors. TEST-ONLY P-256 keypair (private JWK committed deliberately so tests can mint assertions over fresh challenges). Canned vectors pin byte-level verification; blob is the frozen vault-v1 record verbatim (Android Phase 3 contract).",
+  "secret": "test-vault-sync-secret",
+  "issuedAtMs": 1750000000000,
+  "origin": "https://zap.cooking",
+  "rpId": "zap.cooking",
+  "challenge": "gZTPg4Acnrnc--OyxKN1WvnE28JebgGhUDqMOFhYxLUAAAGXdCDcAF4D00w1Yrd7lHYOY064pIHZPoDyimSviLlGuwAXy3j6",
+  "credentialIdB64url": "wMHCw8TFxsfIycrLzM3Ozw",
+  "spkiB64url": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETU3CMUFHlctzU4_wRvwyu7qnatxT_Yd3xofJip38ilh1pFhGxNvZ-46K4S5ZrfPmFqd5S4br4ys2PHaekFeEyA",
+  "alg": -7,
+  "privateJwk": {
+    "key_ops": [
+      "sign"
+    ],
+    "ext": true,
+    "kty": "EC",
+    "x": "TU3CMUFHlctzU4_wRvwyu7qnatxT_Yd3xofJip38ilg",
+    "y": "daRYRsTb2fuOiuEuWa3z5haneUuG6-MrNjx2npBXhMg",
+    "crv": "P-256",
+    "d": "QRTd4InEg8q6u2ZVXyhV5UQLSBFh8po7UbOWEPUsEko"
+  },
+  "wrongPrivateJwk": {
+    "key_ops": [
+      "sign"
+    ],
+    "ext": true,
+    "kty": "EC",
+    "x": "b3aPTSbPZ2t66P23xTuyJa9GhXPeSazH3h6BXggOBhw",
+    "y": "tGRrdeUNIU7Ce8C3gfLrqjqCD8rUd1pequ6_Im0OW4I",
+    "crv": "P-256",
+    "d": "q-sUIHnb7UUZ-iUb7wYdGkT7lV7-8OV4HjV5266Ta60"
+  },
+  "authenticatorDataB64url": "w7vfwSkcuTFumtH0b-b4RgU9NaqWWuny2Wjw6adj-sEFAAAAAA",
+  "authenticatorDataNoUvB64url": "w7vfwSkcuTFumtH0b-b4RgU9NaqWWuny2Wjw6adj-sEBAAAAAA",
+  "clientDataJSONB64url": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiZ1pUUGc0QWNucm5jLS1PeXhLTjFXdm5FMjhKZWJnR2hVRHFNT0ZoWXhMVUFBQUdYZENEY0FGNEQwMHcxWXJkN2xIWU9ZMDY0cElIWlBvRHlpbVN2aUxsR3V3QVh5M2o2Iiwib3JpZ2luIjoiaHR0cHM6Ly96YXAuY29va2luZyJ9",
+  "signatureB64url": "MEYCIQC8wWE9ymAf_76qI5-7gGLgOV4uRtYokOmBxiWPJlt-5gIhANKz0bCa1MtbyoAaDpupre9g4fEGumm2xZcO3_iGWgaD",
+  "signatureNoUvB64url": "MEUCIQC5DiUeFzkmXNsZAHtRQnA8rnfXQNGYzCbtAfzXpt-GlwIgSCbh45OHhC6VI4u_6Y6g_3bVmlA4nuV1cGH0aNl5cS4",
+  "wrongKeySignatureB64url": "MEUCIQC3Qhcu7rgTcEY19pRiRfcJckHQLEDcyKpSHMB97u6svAIgbODSVPmdWLJj4DuVt7epQ6E_IQVY03QyPQiqrovX1Xs",
+  "tamperedSignatureB64url": "MEYCIQC8wWE9ymAf_76qI5-7gGLgOV4uRtYokOmBxiWPJlt-5gIhANKz0bCa1MtbyoAaDpupre9g4fEGumm2xZcO3_iGWgaC",
+  "blob": "{\"version\":1,\"pubkey\":\"06cc216aff26ab90fd977ee70307cee8eae8b2ca5f990e3093b2a4a1320ba1e3\",\"nsecCiphertext\":\"AkBBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fiHr8ke7GBO64K6zEpQALvthQqX1T4tbgc4smBdOowQjgRbWXSdVATYWPJp2p7TH6BEI//bL2YRGzQGDMbBPi9lFvlEqrRRqrhPp+EAVXBJ1KgkHO16qKcI1Qsa2yTv3vg9Y=\",\"createdAt\":1,\"keys\":[{\"credentialId\":\"wMHCw8TFxsfIycrLzM3Ozw\",\"wrappedDek\":\"QbqCNc5eZfFDmHYDoD2BFDdQLmq7+Nd9iVrAzj8gmu9LkbCcYwTiY1PIblOqEc4X\",\"dekIv\":\"EBESExQVFhcYGRob\",\"addedAt\":1}]}"
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -19,6 +19,14 @@
     {
       "binding": "NOURISH_FLAGS",
       "id": "62b1fc47ff274697923fc65e51592734"
+    },
+    {
+      // Passkey vault-sync blobs (plus the routes' rate-limit buckets and
+      // challenge tombstones). preview_id is REQUIRED: preview deployments
+      // must never read or write production vault blobs.
+      "binding": "VAULT_SYNC",
+      "id": "4f550842d84c45549c4d30a3cd3f10c3",
+      "preview_id": "97815021dedf4b3483669f99e6aa1347"
     }
   ]
 }


### PR DESCRIPTION
## What

Server half of cross-device passkey sign-in: assertion-gated Workers KV storage for the Phase 1 vault record as an opaque blob. **Deployable inert** — no client code calls these endpoints until PR 2 (client integration, behind a const flag per R3).

## ⚠️ One rulings-conflict resolved in favor of no-oracle — needs sign-off

The approved "DELETE idempotent (absent key → success)" collides with "uniform 404 for every auth-shaped failure": an absent entry has **no stored public key**, so its assertion is unverifiable — returning 200 for absent keys while present-keys-with-bad-assertions get 404 would let anyone probe blob existence with garbage assertions. Implemented oracle-free: **absent → uniform 404**, and DELETE idempotency moves client-side (PR 2 treats DELETE 404 as "already gone" = success). Pinned by test. If you want the literal ruling instead, it's a two-line change — but it buys the oracle.

## Endpoints (`/api/vault-sync/`, all IP-rate-limited via the existing `ipRateLimit.server.ts`, separate scopes)

| Route | Behavior |
|---|---|
| `POST /challenge` | Stateless HMAC challenge (nonce+issuedAt under `VAULT_SYNC_CHALLENGE_SECRET`), 2-min TTL, best-effort single-use tombstone |
| `PUT /` | Upload/update — single path, **always assertion-gated**; first upload TOFU-hardened (verify against submitted SPKI); updates verify against stored SPKI, never overwritten |
| `POST /:credentialIdHash` | Assertion-gated fetch (assertion in body, never URLs); path must equal sha256(asserting credentialId); TTL refresh on success |
| `DELETE /:credentialIdHash` | Assertion-gated; absent → uniform 404 (see flag above) |

- **Verification is dependency-free** (Gate 1 ruling): SPKI from `getPublicKey()` + WebCrypto; fixed-offset authenticatorData parse; DER→raw ECDSA; rpIdHash pinned to sha256('zap.cooking'); https origin allowlist; UV required. `signCount` stored, never enforced (synced passkeys report 0/regress by design — comment at the verify site).
- **Privacy (R2)**: KV keyed sha256(credentialId) hex only, no pubkey indexing anywhere; blob contents never logged — enforced by a console-spy test.
- **TTL (R4)**: 370 days, refreshed on upload and successful fetch. Expiry costs sync only, never identity — next nsec login re-uploads.
- **Preview isolation**: `VAULT_SYNC` declared with explicit `preview_id`; previews never touch production blobs.

## Testing

42 new tests (**399/399 total**): assertion vectors (valid / wrong key / tampered / UV-clear / wrong rpIdHash / wrong origin / wrong type / unsupported alg), challenge module (expiry, tombstone reuse, wrong secret, malformed), endpoints (TOFU, stored-key-wins update, 400/413 taxonomy, **uniform-404 byte-identical sweep**, TTL refresh, delete, rate-limit trip, never-log). The blob in every server test is the frozen `vault-v1.json` record **verbatim** — the same bytes Android Phase 3 will send. Test vectors committed first as their own commit; the fixture keypair is test-only (private JWK committed deliberately so tests mint fresh-challenge assertions at runtime).

svelte-check 0 errors; production build clean (all three endpoints bundle).

## Deploy checklist (dashboard/CLI steps I can't or shouldn't do unilaterally)

KV namespaces are **already created** and wired in `wrangler.jsonc`:
- `VAULT_SYNC` (production): `4f550842d84c45549c4d30a3cd3f10c3`
- `VAULT_SYNC_PREVIEW`: `97815021dedf4b3483669f99e6aa1347`

Remaining, per Gate 2 addition 5 (distinct values per environment — staging must not 500 like /api/membership does):
1. Dashboard → Pages → frontend → Settings → **Bindings**: confirm the Git-integration build picks up `VAULT_SYNC` from wrangler.jsonc for BOTH Production and Preview (the existing three namespaces were also dashboard-confirmed).
2. Settings → **Environment variables** → add `VAULT_SYNC_CHALLENGE_SECRET` as a **Secret**: one 32+-byte random value for Production, a **different** one for Preview. CLI equivalent: `openssl rand -hex 32 | wrangler pages secret put VAULT_SYNC_CHALLENGE_SECRET --project-name=zapcooking-frontend` (dashboard needed for the Preview-scoped value).
3. Verify on staging after deploy: `curl -X POST https://staging.zap.cooking/api/vault-sync/challenge` → 200 with `{challenge, expiresAt}` (503 means the secret or binding is missing).

Known-ignorable: the "Workers Builds" checks fail as always; Pages is the real deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)