### PR TITLE
Cross-device passkey sign-in client (Phase 2 — PR 2/2, gated off)

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -11,6 +11,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Guard against the staging-only PASSKEY_SYNC_ENABLED flip reaching main
+  # (e.g. via a staging→main merge or cherry-pick). The flip is committed
+  # directly on the staging branch and must never merge back; production
+  # launch of vault sync is a deliberate main-side change that also updates
+  # this guard.
+  flag-guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: PASSKEY_SYNC_ENABLED must be false on main 🚫
+        run: |
+          if ! grep -q "export const PASSKEY_SYNC_ENABLED = false" src/lib/passkeySync.ts; then
+            echo "::error file=src/lib/passkeySync.ts::PASSKEY_SYNC_ENABLED is not false."
+            echo "The staging-only flag flip must never reach main. If this is the"
+            echo "deliberate production launch of passkey vault sync, update this guard"
+            echo "in the same PR."
+            exit 1
+          fi
+
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/docs/passkey-vault-manual-tests.md
+++ b/docs/passkey-vault-manual-tests.md
@@ -64,6 +64,11 @@ browser profile with clean site data for zap.cooking.
 Prereqs: staging or production only (previews have no passkey UI by design);
 `VAULT_SYNC` bound and `VAULT_SYNC_CHALLENGE_SECRET` set in the environment.
 
+Note on failed blob deletes (P2-7/P2-9): if the server DELETE fails, the
+orphaned blob is not retried — it remains assertion-gated (unreadable without
+the passkey ceremony) and expires via the 370-day KV TTL. This is by design,
+not data loss.
+
 | # | Steps | Expected | Status |
 |---|-------|----------|--------|
 | P2-1 | Enroll with "Enable sign-in on other devices" checked (default) | Exactly TWO passkey prompts (create + verify); Settings shows sync On; server has the blob | ☐ |

--- a/docs/passkey-vault-manual-tests.md
+++ b/docs/passkey-vault-manual-tests.md
@@ -59,6 +59,26 @@ browser profile with clean site data for zap.cooking.
 | 19 | With a vault enrolled, Google Drive restore of the SAME account | Logs in silently adopting the vault; no plaintext written | ☐ | ☐ |
 | 20 | With a vault enrolled, Google Drive restore of a DIFFERENT account | Replace confirmation, then legacy login on confirm | ☐ | ☐ |
 
+## Phase 2 — cross-device sign-in (requires PASSKEY_SYNC_ENABLED = true build)
+
+Prereqs: staging or production only (previews have no passkey UI by design);
+`VAULT_SYNC` bound and `VAULT_SYNC_CHALLENGE_SECRET` set in the environment.
+
+| # | Steps | Expected | Status |
+|---|-------|----------|--------|
+| P2-1 | Enroll with "Enable sign-in on other devices" checked (default) | Exactly TWO passkey prompts (create + verify); Settings shows sync On; server has the blob | ☐ |
+| P2-2 | Enroll with the toggle unchecked | Two prompts; no network calls to /api/vault-sync; Settings shows sync Off | ☐ |
+| P2-3 | New-device sign-in, same ecosystem: Safari↔Safari (iCloud) | Device B: "Sign in with passkey" → one biometric → signed in as the real identity; localStorage has the record, NO plaintext key; subsequent reloads unlock locally (no network) | ☐ |
+| P2-4 | Same, Chrome desktop ↔ Android Chrome (GPM) | Same as P2-3 | ☐ |
+| P2-5 | Cross-ecosystem miss (enrolled in iCloud, try on Android/GPM) | Passkey not offered by the provider — EXPECTED, not a bug; user falls through to nsec/other login | ☐ |
+| P2-6 | Hybrid/QR cross-device assertion (scan QR to phone) | If the provider drops PRF: clean "did not provide the required key material" error, normal methods still available, nothing persisted | ☐ |
+| P2-7 | Settings → toggle sync OFF | One passkey confirmation (disclosed in copy); blob gone (verify: sign-in fails on a cleared second device); toggle Off | ☐ |
+| P2-8 | Settings → toggle sync back ON | One passkey confirmation (disclosed in copy); blob re-uploaded; new-device sign-in works again | ☐ |
+| P2-9 | Remove passkey protection while sync is on | Single ceremony (no extra prompt for the delete); server blob gone; local downgrade as Phase 1 | ☐ |
+| P2-10 | Pre-Phase-2 vault (enrolled before this build): Settings sync area | "Re-create passkey & enable" card with orphan-passkey + extra-prompt copy; completing it enables sync; old provider passkey deletable | ☐ |
+| P2-11 | Enrollment with the network blocked (devtools offline after page load) | Enrollment still succeeds locally; sync retries silently on next unlock (verify with devtools online: PUT fires during unlock, single prompt) | ☐ |
+| P2-12 | Conflict-replace (different account's nsec over a synced vault) | Local record replaced after confirm; NO vault-sync network call; original owner's other devices still sign in (R4) | ☐ |
+
 ## Non-regression
 
 | # | Steps | Expected | Chrome desktop | Android Chrome |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.593",
+  "version": "4.2.594",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.592",
+  "version": "4.2.593",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.594",
+  "version": "4.2.595",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/LoginOverlay.svelte
+++ b/src/components/LoginOverlay.svelte
@@ -32,6 +32,7 @@
     type GoogleSession
   } from '$lib/googleBackup/googleBackupFlow';
   import { isValidPin } from '$lib/googleBackup/googleBackupCrypto';
+  import { PASSKEY_SYNC_ENABLED, shouldOfferSyncSignIn } from '$lib/passkeySync';
 
   let authManager: any = null;
   let authState: AuthState = {
@@ -181,16 +182,46 @@
     }
   }
 
+  // Cross-device sign-in (Phase 2, behind PASSKEY_SYNC_ENABLED): only on
+  // devices WITHOUT a local record — the unlock card owns that surface and
+  // needs no network. Every failure falls through to the normal methods
+  // below; nothing is persisted on failure.
+  $: showSyncSignIn = shouldOfferSyncSignIn({
+    flagEnabled: PASSKEY_SYNC_ENABLED,
+    hasLocalRecord: !!vaultRecord,
+    supported: vaultSupported,
+    isAuthenticated: authState.isAuthenticated
+  });
+
+  async function signInWithSyncedPasskey() {
+    if (!authManager) return;
+    vaultUnlockBusy = true;
+    vaultUnlockError = '';
+    try {
+      await authManager.signInWithPasskeySync();
+      vaultRecord = getVaultRecord(); // device is a Phase 1 device now
+    } catch (error: any) {
+      vaultUnlockError = isCeremonyCancelled(error)
+        ? ''
+        : error?.message ||
+          'Passkey sign-in did not complete. You can sign in another way below.';
+    } finally {
+      vaultUnlockBusy = false;
+    }
+  }
+
   onMount(() => {
     try {
       vaultRecord = getVaultRecord();
+      if (vaultRecord || PASSKEY_SYNC_ENABLED) {
+        detectSupport().then((s) => (vaultSupported = s !== 'none'));
+      }
       if (vaultRecord) {
         try {
           vaultNpub = `${nip19.npubEncode(vaultRecord.pubkey).slice(0, 16)}…`;
         } catch {
           vaultNpub = '';
         }
-        detectSupport().then((s) => (vaultSupported = s !== 'none'));
       }
       authManager = createAuthManager($ndk);
       if (authManager) {
@@ -1248,6 +1279,26 @@
         </button>
         <p class="signin-vault-hint">
           Welcome back{vaultNpub ? ` ${vaultNpub}` : ''} — your key is encrypted on this device.
+        </p>
+        {#if vaultUnlockError}
+          <div class="signin-error" role="alert">{vaultUnlockError}</div>
+        {/if}
+        <div class="signin-divider" aria-hidden="true"><span>or sign in another way</span></div>
+      {:else if showSyncSignIn}
+        <!-- New-device sign-in via a provider-synced passkey (Phase 2). One
+             biometric ceremony; every failure leaves the normal methods
+             below fully available and persists nothing. -->
+        <button
+          type="button"
+          on:click={signInWithSyncedPasskey}
+          disabled={vaultUnlockBusy || authState.isLoading}
+          aria-label="Sign in with a passkey synced from another device"
+          class="signin-cta-primary"
+        >
+          <span>{vaultUnlockBusy ? 'Waiting for passkey…' : '🔑 Sign in with passkey'}</span>
+        </button>
+        <p class="signin-vault-hint">
+          Set up passkey protection on another device? Sign in with the same passkey here.
         </p>
         {#if vaultUnlockError}
           <div class="signin-error" role="alert">{vaultUnlockError}</div>

--- a/src/components/PasskeyVaultSection.svelte
+++ b/src/components/PasskeyVaultSection.svelte
@@ -15,6 +15,11 @@
     type VaultSupport
   } from '$lib/passkeyVault';
   import { resolveVaultSection } from '$lib/securitySections';
+  import {
+    PASSKEY_SYNC_ENABLED,
+    isSyncEnabled,
+    syncableKeyEntry
+  } from '$lib/passkeySync';
   import ShieldCheckIcon from 'phosphor-svelte/lib/ShieldCheck';
 
   const dispatch = createEventDispatcher();
@@ -28,10 +33,19 @@
   let errorMsg = '';
   let confirmingRemoval = false;
 
+  // Cross-device sync state (Phase 2, behind PASSKEY_SYNC_ENABLED).
+  let syncOn = false;
+  let recordSyncable = false;
+  // R1: toggle at enrollment, DEFAULT ON.
+  let enrollWithSync = true;
+
   function refresh() {
     const am = getAuthManager();
     authState = am?.getState() ?? null;
-    recordPubkey = getVaultRecord()?.pubkey ?? null;
+    const record = getVaultRecord();
+    recordPubkey = record?.pubkey ?? null;
+    syncOn = isSyncEnabled();
+    recordSyncable = !!syncableKeyEntry(record);
   }
 
   onMount(async () => {
@@ -64,13 +78,57 @@
     errorMsg = '';
     notice = '';
     try {
-      await am.enrollVault();
+      await am.enrollVault(PASSKEY_SYNC_ENABLED ? { sync: enrollWithSync } : undefined);
       notice =
         'Passkey protection is on. Your key is no longer stored in plain text in this browser. ' +
         'The passkey is not a backup — keep your revealed nsec somewhere safe.';
       dispatch('changed');
     } catch (e) {
       errorMsg = friendlyError(e, 'Could not set up the passkey. Nothing was changed.');
+    } finally {
+      busy = false;
+      refresh();
+    }
+  }
+
+  async function toggleSync() {
+    const am = getAuthManager();
+    if (!am) return;
+    busy = true;
+    errorMsg = '';
+    notice = '';
+    const turningOn = !syncOn;
+    try {
+      await am.setVaultSync(turningOn);
+      notice = turningOn
+        ? 'Cross-device sign-in is on. An encrypted copy of your key is stored on Zap Cooking servers.'
+        : 'Cross-device sign-in is off. The encrypted copy was removed from Zap Cooking servers.';
+      dispatch('changed');
+    } catch (e) {
+      errorMsg = friendlyError(e, 'Could not change cross-device sign-in. Nothing was changed.');
+    } finally {
+      busy = false;
+      refresh();
+    }
+  }
+
+  async function migrateForSync() {
+    const am = getAuthManager();
+    if (!am) return;
+    busy = true;
+    errorMsg = '';
+    notice = '';
+    try {
+      // Guided re-enrollment: new credential, fresh DEK, record replaced,
+      // then uploaded. The OLD passkey becomes an orphan in the user's
+      // provider (copy below tells them it is safe to delete).
+      await am.enrollVault({ sync: true, migrate: true });
+      notice =
+        'Done — your passkey was re-created with cross-device sign-in. The previous ' +
+        '"Zap Cooking" passkey in your password manager is no longer used and can be deleted.';
+      dispatch('changed');
+    } catch (e) {
+      errorMsg = friendlyError(e, 'Could not re-create the passkey. Nothing was changed.');
     } finally {
       busy = false;
       refresh();
@@ -116,6 +174,63 @@
         <strong>not</strong> a backup of your key — if you lose both the passkey and your nsec
         backup, the account is unrecoverable.
       </p>
+
+      {#if PASSKEY_SYNC_ENABLED && !confirmingRemoval}
+        <div
+          class="bg-input border rounded-lg p-3 mb-3"
+          style="border-color: var(--color-input-border)"
+        >
+          <div class="flex items-center justify-between gap-3">
+            <div>
+              <p class="text-sm font-medium" style="color: var(--color-text-primary)">
+                Sign in on other devices
+              </p>
+              <p class="text-xs text-caption mt-0.5">
+                {#if recordSyncable}
+                  {syncOn
+                    ? 'On — an encrypted copy of your key is stored on Zap Cooking servers. Only your passkey can unlock it. Turning this off requires a quick passkey confirmation.'
+                    : 'Off — your key exists only on this device. Turning this on stores an encrypted copy on Zap Cooking servers and requires a quick passkey confirmation.'}
+                {:else}
+                  This passkey was created before cross-device sign-in existed.
+                {/if}
+              </p>
+            </div>
+            {#if recordSyncable}
+              <button
+                type="button"
+                role="switch"
+                aria-checked={syncOn}
+                aria-label="Sign in on other devices"
+                class="flex-shrink-0 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors {syncOn
+                  ? 'bg-green-500/15 text-green-600'
+                  : 'bg-secondary text-caption'}"
+                on:click={toggleSync}
+                disabled={busy}
+              >
+                {busy ? 'Waiting…' : syncOn ? 'On' : 'Off'}
+              </button>
+            {/if}
+          </div>
+          {#if !recordSyncable}
+            <div class="mt-2">
+              <p class="text-xs text-caption mb-2">
+                To enable it, the passkey needs to be re-created: one extra passkey prompt, and the
+                old "Zap Cooking" passkey left in your password manager can be deleted afterwards.
+                Your Nostr key does not change.
+              </p>
+              <button
+                type="button"
+                class="px-3 py-1.5 bg-secondary hover:bg-accent-gray rounded-lg text-xs font-medium transition-colors disabled:opacity-50"
+                style="color: var(--color-text-primary)"
+                on:click={migrateForSync}
+                disabled={busy}
+              >
+                {busy ? 'Waiting for passkey…' : 'Re-create passkey & enable'}
+              </button>
+            </div>
+          {/if}
+        </div>
+      {/if}
 
       {#if !confirmingRemoval}
         <button
@@ -163,6 +278,20 @@
         you can unlock it. The passkey is <strong>not</strong> a backup — reveal and save your nsec
         below first.
       </p>
+      {#if PASSKEY_SYNC_ENABLED}
+        <!-- R1(b): opt-in toggle at enrollment, default ON, plain disclosure. -->
+        <label class="flex items-start gap-2 mb-3 cursor-pointer">
+          <input type="checkbox" bind:checked={enrollWithSync} disabled={busy} class="mt-0.5" />
+          <span class="text-xs text-caption">
+            <span class="font-medium" style="color: var(--color-text-primary)">
+              Enable sign-in on other devices.
+            </span>
+            Stores an encrypted copy of your key on Zap Cooking's servers — only your passkey can
+            unlock it, and you can turn this off any time in Settings (turning it off later
+            requires a quick passkey confirmation).
+          </span>
+        </label>
+      {/if}
       <button
         type="button"
         class="px-4 py-2 bg-secondary hover:bg-accent-gray rounded-lg text-sm font-medium transition-colors disabled:opacity-50"

--- a/src/lib/authManager.sync.test.ts
+++ b/src/lib/authManager.sync.test.ts
@@ -1,0 +1,436 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import fixture from '../test/fixtures/vault-v1.json';
+
+/**
+ * AuthManager ↔ vault-sync integration with PASSKEY_SYNC_ENABLED forced ON
+ * (partial module mock — everything else in passkeySync runs real). Mocked
+ * fetch + mocked authenticator; crypto real against the frozen vectors.
+ */
+
+vi.mock('$app/environment', () => ({ browser: true }));
+
+vi.mock('./passkeySync', async (importOriginal: () => Promise<unknown>) => {
+  const real = (await importOriginal()) as Record<string, unknown>;
+  return { ...real, PASSKEY_SYNC_ENABLED: true };
+});
+
+vi.mock('@nostr-dev-kit/ndk', async () => {
+  const { getPublicKey } = await import('nostr-tools');
+  const toBytes = (hex: string) =>
+    Uint8Array.from(hex.match(/.{2}/g)!.map((b: string) => parseInt(b, 16)));
+  class NDKPrivateKeySigner {
+    privateKey: string;
+    constructor(pk: string) {
+      this.privateKey = pk;
+    }
+    async user() {
+      const pubkey = getPublicKey(toBytes(this.privateKey));
+      return { pubkey, hexpubkey: pubkey };
+    }
+  }
+  class NDKNip46Signer {}
+  class NDKNip07Signer {}
+  class NDKRelaySet {
+    static fromRelayUrls() {
+      return {};
+    }
+  }
+  return {
+    NDKPrivateKeySigner,
+    NDKNip46Signer,
+    NDKNip07Signer,
+    NDKRelaySet,
+    NDKSubscriptionCacheUsage: { ONLY_RELAY: 'ONLY_RELAY' }
+  };
+});
+
+import { AuthManager, VaultConflictError } from './authManager';
+import { VAULT_STORAGE_KEY, type VaultRecord } from './passkeyVault';
+import { SYNC_ENABLED_KEY, SYNC_PENDING_KEY } from './passkeySync';
+import { hexToBytes, bytesToB64 } from './passkeyVaultCrypto';
+
+const CRED_ID = fixture.credentialIdB64url;
+const PK_KEY = 'nostrcooking_privateKey';
+const OTHER_NSEC = '22'.repeat(32);
+
+function fixtureRecord(withSpki = true): VaultRecord {
+  return {
+    version: 1,
+    pubkey: fixture.pubkeyHex,
+    nsecCiphertext: fixture.expectedNsecCiphertextB64,
+    createdAt: 1,
+    keys: [
+      {
+        credentialId: CRED_ID,
+        wrappedDek: fixture.expectedWrappedDekB64,
+        dekIv: bytesToB64(hexToBytes(fixture.dekIvHex)),
+        addedAt: 1,
+        ...(withSpki ? { spki: 'dGVzdC1zcGtp', alg: -7 } : {})
+      }
+    ]
+  };
+}
+
+function fakeCredential(
+  credId: string,
+  ext: { prfResult?: Uint8Array; prfEnabled?: boolean; spki?: boolean } = {}
+) {
+  const raw = Uint8Array.from(atob(credId.replace(/-/g, '+').replace(/_/g, '/') + '=='), (c) =>
+    c.charCodeAt(0)
+  );
+  return {
+    id: credId,
+    rawId: raw.buffer,
+    type: 'public-key',
+    response: {
+      signature: new Uint8Array([1]).buffer,
+      authenticatorData: new Uint8Array([2]).buffer,
+      clientDataJSON: new Uint8Array([3]).buffer,
+      getPublicKey: () => (ext.spki === false ? null : new Uint8Array([9, 9]).buffer),
+      getPublicKeyAlgorithm: () => -7
+    },
+    getClientExtensionResults: () => {
+      if (ext.prfResult) return { prf: { results: { first: ext.prfResult.slice().buffer } } };
+      if (ext.prfEnabled !== undefined) return { prf: { enabled: ext.prfEnabled } };
+      return {};
+    }
+  };
+}
+
+let store: Map<string, string>;
+let fetchMock: ReturnType<typeof vi.fn>;
+let credentials: { create: ReturnType<typeof vi.fn>; get: ReturnType<typeof vi.fn> };
+let ndk: { signer: any; activeUser: any };
+
+const json = (status: number, body: unknown) =>
+  new Response(JSON.stringify(body), { status });
+const flush = () => new Promise((r) => setTimeout(r, 10));
+const seedVault = (withSpki = true) =>
+  store.set(VAULT_STORAGE_KEY, JSON.stringify(fixtureRecord(withSpki)));
+
+/** Server that accepts everything; records calls by method+path. */
+function acceptingServer() {
+  fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+    if (String(url).endsWith('/challenge')) {
+      return json(200, { challenge: 'c2VydmVyLWNoYWxsZW5nZQ', expiresAt: Date.now() + 120000 });
+    }
+    return json(200, { ok: true, blob: JSON.stringify(fixtureRecord()) });
+  });
+}
+
+function callsTo(method: string): Array<[string, RequestInit | undefined]> {
+  return fetchMock.mock.calls.filter(([, init]: any) => (init?.method ?? 'GET') === method);
+}
+
+beforeEach(() => {
+  store = new Map();
+  (globalThis as any).localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => store.set(k, String(v)),
+    removeItem: (k: string) => store.delete(k),
+    clear: () => store.clear()
+  };
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+  credentials = { create: vi.fn(), get: vi.fn() };
+  vi.stubGlobal('navigator', { credentials });
+  vi.stubGlobal('window', {
+    isSecureContext: true,
+    PublicKeyCredential: function PublicKeyCredential() {}
+  });
+  ndk = { signer: null, activeUser: null };
+});
+
+describe('enrollment with sync', () => {
+  async function loggedInManager() {
+    const am = new AuthManager(ndk);
+    await am.authenticateWithPrivateKey(fixture.nsecHex);
+    return am;
+  }
+
+  it('sync ON: two prompts total, TOFU PUT sent with the verify-get assertion', async () => {
+    acceptingServer();
+    const am = await loggedInManager();
+    credentials.create.mockResolvedValue(fakeCredential(CRED_ID, { prfEnabled: true }));
+    credentials.get.mockResolvedValue(
+      fakeCredential(CRED_ID, { prfResult: hexToBytes(fixture.prfOutputHex) })
+    );
+
+    await am.enrollVault({ sync: true });
+    await flush();
+
+    // Two-prompt budget (Gate 2 addition 2): exactly one create, one get.
+    expect(credentials.create).toHaveBeenCalledTimes(1);
+    expect(credentials.get).toHaveBeenCalledTimes(1);
+
+    const puts = callsTo('PUT');
+    expect(puts).toHaveLength(1);
+    const body = JSON.parse(puts[0][1]!.body as string);
+    expect(body.spki).toBeDefined();
+    expect(body.assertion.credentialId).toBe(CRED_ID);
+    expect(store.get(SYNC_ENABLED_KEY)).toBe('1');
+    expect(store.get(SYNC_PENDING_KEY)).toBeUndefined();
+    expect(store.get(PK_KEY)).toBeUndefined(); // plaintext still deleted
+  });
+
+  it('sync OFF: no network calls at all, toggle recorded off', async () => {
+    const am = await loggedInManager();
+    fetchMock.mockClear();
+    credentials.create.mockResolvedValue(fakeCredential(CRED_ID, { prfEnabled: true }));
+    credentials.get.mockResolvedValue(
+      fakeCredential(CRED_ID, { prfResult: hexToBytes(fixture.prfOutputHex) })
+    );
+    await am.enrollVault({ sync: false });
+    await flush();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(store.get(SYNC_ENABLED_KEY)).toBe('0');
+  });
+
+  it('upload failure never fails enrollment; pending flag set', async () => {
+    fetchMock.mockImplementation(async (url: string) =>
+      String(url).endsWith('/challenge')
+        ? json(200, { challenge: 'YQ', expiresAt: Date.now() + 120000 })
+        : json(500, {})
+    );
+    const am = await loggedInManager();
+    credentials.create.mockResolvedValue(fakeCredential(CRED_ID, { prfEnabled: true }));
+    credentials.get.mockResolvedValue(
+      fakeCredential(CRED_ID, { prfResult: hexToBytes(fixture.prfOutputHex) })
+    );
+
+    await am.enrollVault({ sync: true });
+    await flush();
+
+    expect(am.getState().authMethod).toBe('passkey'); // enrollment succeeded
+    expect(store.get(VAULT_STORAGE_KEY)).toBeDefined();
+    expect(store.get(PK_KEY)).toBeUndefined();
+    expect(store.get(SYNC_PENDING_KEY)).toBe('1');
+  });
+
+  it('challenge fetch failure degrades to pending, enrollment succeeds with a local challenge', async () => {
+    fetchMock.mockRejectedValue(new TypeError('offline'));
+    const am = await loggedInManager();
+    fetchMock.mockClear();
+    fetchMock.mockRejectedValue(new TypeError('offline'));
+    credentials.create.mockResolvedValue(fakeCredential(CRED_ID, { prfEnabled: true }));
+    credentials.get.mockResolvedValue(
+      fakeCredential(CRED_ID, { prfResult: hexToBytes(fixture.prfOutputHex) })
+    );
+    await am.enrollVault({ sync: true });
+    expect(am.getState().authMethod).toBe('passkey');
+    expect(store.get(SYNC_PENDING_KEY)).toBe('1');
+  });
+});
+
+describe('pending-upload retry on unlock', () => {
+  it('retries the upload with the unlock ceremony assertion (single prompt)', async () => {
+    seedVault();
+    store.set(SYNC_ENABLED_KEY, '1');
+    store.set(SYNC_PENDING_KEY, '1');
+    acceptingServer();
+    const am = new AuthManager(ndk);
+    credentials.get.mockResolvedValue(
+      fakeCredential(CRED_ID, { prfResult: hexToBytes(fixture.prfOutputHex) })
+    );
+
+    await am.unlockVault();
+    await flush();
+
+    expect(credentials.get).toHaveBeenCalledTimes(1); // one ceremony, dual use
+    expect(callsTo('PUT')).toHaveLength(1);
+    expect(store.get(SYNC_PENDING_KEY)).toBeUndefined();
+  });
+
+  it('no pending flag → unlock makes zero network calls', async () => {
+    seedVault();
+    store.set(SYNC_ENABLED_KEY, '1');
+    const am = new AuthManager(ndk);
+    credentials.get.mockResolvedValue(
+      fakeCredential(CRED_ID, { prfResult: hexToBytes(fixture.prfOutputHex) })
+    );
+    await am.unlockVault();
+    await flush();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('challenge fetch failure → unlock still succeeds offline, flag survives', async () => {
+    seedVault();
+    store.set(SYNC_ENABLED_KEY, '1');
+    store.set(SYNC_PENDING_KEY, '1');
+    fetchMock.mockRejectedValue(new TypeError('offline'));
+    const am = new AuthManager(ndk);
+    credentials.get.mockResolvedValue(
+      fakeCredential(CRED_ID, { prfResult: hexToBytes(fixture.prfOutputHex) })
+    );
+    await am.unlockVault();
+    expect(am.getState().isAuthenticated).toBe(true);
+    expect(store.get(SYNC_PENDING_KEY)).toBe('1');
+  });
+});
+
+describe('removal issues DELETE with the reused ceremony', () => {
+  async function unlockedManager() {
+    seedVault();
+    store.set(SYNC_ENABLED_KEY, '1');
+    acceptingServer();
+    const am = new AuthManager(ndk);
+    credentials.get.mockResolvedValue(
+      fakeCredential(CRED_ID, { prfResult: hexToBytes(fixture.prfOutputHex) })
+    );
+    await am.unlockVault();
+    fetchMock.mockClear();
+    acceptingServer();
+    credentials.get.mockClear();
+    return am;
+  }
+
+  it('one ceremony serves both the downgrade and the DELETE', async () => {
+    const am = await unlockedManager();
+    await am.removeVault();
+    await flush();
+
+    expect(credentials.get).toHaveBeenCalledTimes(1);
+    const deletes = callsTo('DELETE');
+    expect(deletes).toHaveLength(1);
+    expect(String(deletes[0][0])).toMatch(/\/api\/vault-sync\/[0-9a-f]{64}$/);
+    expect(store.get(PK_KEY)).toBe(fixture.nsecHex);
+    expect(store.get(VAULT_STORAGE_KEY)).toBeUndefined();
+    expect(store.get(SYNC_ENABLED_KEY)).toBe('0');
+  });
+
+  it('DELETE returning 404 is already-gone: removal completes with no error state (ruling pin)', async () => {
+    const am = await unlockedManager();
+    fetchMock.mockImplementation(async (url: string) =>
+      String(url).endsWith('/challenge')
+        ? json(200, { challenge: 'YQ', expiresAt: Date.now() + 120000 })
+        : json(404, { error: 'not_found' })
+    );
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(am.removeVault()).resolves.toBeUndefined();
+    await flush();
+
+    expect(am.getState().authMethod).toBe('privateKey'); // downgrade done
+    expect(warnSpy).not.toHaveBeenCalled(); // 404 = success, not even a warning
+    expect(callsTo('DELETE')).toHaveLength(1); // no retry loop
+    expect(store.get(SYNC_PENDING_KEY)).toBeUndefined(); // no retry state
+    warnSpy.mockRestore();
+  });
+});
+
+describe('sync toggle (R1 kill-switch)', () => {
+  async function unlockedManager() {
+    seedVault();
+    acceptingServer();
+    const am = new AuthManager(ndk);
+    credentials.get.mockResolvedValue(
+      fakeCredential(CRED_ID, { prfResult: hexToBytes(fixture.prfOutputHex) })
+    );
+    await am.unlockVault();
+    fetchMock.mockClear();
+    acceptingServer();
+    credentials.get.mockClear();
+    return am;
+  }
+
+  it('toggle ON: one ceremony, TOFU PUT, flag set', async () => {
+    const am = await unlockedManager();
+    store.set(SYNC_ENABLED_KEY, '0');
+    await am.setVaultSync(true);
+    expect(credentials.get).toHaveBeenCalledTimes(1);
+    expect(callsTo('PUT')).toHaveLength(1);
+    expect(store.get(SYNC_ENABLED_KEY)).toBe('1');
+  });
+
+  it('toggle OFF: one ceremony, DELETE, flag cleared', async () => {
+    const am = await unlockedManager();
+    store.set(SYNC_ENABLED_KEY, '1');
+    await am.setVaultSync(false);
+    expect(credentials.get).toHaveBeenCalledTimes(1);
+    expect(callsTo('DELETE')).toHaveLength(1);
+    expect(store.get(SYNC_ENABLED_KEY)).toBe('0');
+  });
+
+  it('toggle ON with a failed upload stays OFF and reports', async () => {
+    const am = await unlockedManager();
+    store.set(SYNC_ENABLED_KEY, '0');
+    fetchMock.mockImplementation(async (url: string) =>
+      String(url).endsWith('/challenge')
+        ? json(200, { challenge: 'YQ', expiresAt: Date.now() + 120000 })
+        : json(500, {})
+    );
+    await expect(am.setVaultSync(true)).rejects.toThrow(/remains off/);
+    expect(store.get(SYNC_ENABLED_KEY)).toBe('0');
+    expect(store.get(SYNC_PENDING_KEY)).toBeUndefined(); // failed opt-in ≠ pending
+  });
+
+  it('pre-Phase-2 record (no SPKI) → refuses with re-enrollment guidance, no ceremony', async () => {
+    seedVault(false);
+    acceptingServer();
+    const am = new AuthManager(ndk);
+    credentials.get.mockResolvedValue(
+      fakeCredential(CRED_ID, { prfResult: hexToBytes(fixture.prfOutputHex) })
+    );
+    await am.unlockVault();
+    credentials.get.mockClear();
+    await expect(am.setVaultSync(true)).rejects.toThrow(/Re-create/);
+    expect(credentials.get).not.toHaveBeenCalled();
+  });
+});
+
+describe('new-device sign-in (signInWithPasskeySync)', () => {
+  it('establishes the session AND writes the record (device becomes Phase 1)', async () => {
+    acceptingServer();
+    const am = new AuthManager(ndk);
+    credentials.get.mockResolvedValue(
+      fakeCredential(CRED_ID, { prfResult: hexToBytes(fixture.prfOutputHex) })
+    );
+
+    await am.signInWithPasskeySync();
+
+    const state = am.getState();
+    expect(state.isAuthenticated).toBe(true);
+    expect(state.authMethod).toBe('passkey');
+    expect(state.publicKey).toBe(fixture.pubkeyHex);
+    expect(ndk.signer?.privateKey).toBe(fixture.nsecHex);
+    expect(store.get(PK_KEY)).toBeUndefined(); // never plaintext
+    expect(JSON.parse(store.get(VAULT_STORAGE_KEY)!).pubkey).toBe(fixture.pubkeyHex);
+    expect(store.get(SYNC_ENABLED_KEY)).toBe('1');
+  });
+
+  it('failed decrypt persists nothing and leaves the user logged out', async () => {
+    const bad = fixtureRecord();
+    bad.nsecCiphertext = bad.nsecCiphertext.slice(0, -8) + 'AAAAAAA=';
+    fetchMock.mockImplementation(async (url: string) =>
+      String(url).endsWith('/challenge')
+        ? json(200, { challenge: 'YQ', expiresAt: Date.now() + 120000 })
+        : json(200, { blob: JSON.stringify(bad) })
+    );
+    const am = new AuthManager(ndk);
+    credentials.get.mockResolvedValue(
+      fakeCredential(CRED_ID, { prfResult: hexToBytes(fixture.prfOutputHex) })
+    );
+
+    await expect(am.signInWithPasskeySync()).rejects.toThrow();
+    expect(am.getState().isAuthenticated).toBe(false);
+    expect(store.get(VAULT_STORAGE_KEY)).toBeUndefined();
+    expect(ndk.signer).toBeNull();
+  });
+});
+
+describe('conflict-replace makes NO network call (R4 regression)', () => {
+  it('replacing a synced vault with a different account touches only local storage', async () => {
+    seedVault();
+    store.set(SYNC_ENABLED_KEY, '1');
+    const am = new AuthManager(ndk);
+
+    await expect(am.authenticateWithPrivateKey(OTHER_NSEC)).rejects.toThrow(VaultConflictError);
+    await am.authenticateWithPrivateKey(OTHER_NSEC, { replaceVault: true });
+    await flush();
+
+    expect(am.getState().isAuthenticated).toBe(true);
+    expect(store.get(VAULT_STORAGE_KEY)).toBeUndefined(); // local record gone
+    expect(fetchMock).not.toHaveBeenCalled(); // server blob untouched — R4
+    expect(credentials.get).not.toHaveBeenCalled(); // and no ceremony either
+  });
+});

--- a/src/lib/authManager.ts
+++ b/src/lib/authManager.ts
@@ -15,12 +15,25 @@ import { fetchNip46UserPubkey, sendNip46Rpc } from './nip46Rpc';
 import { Nip44LocalSigner } from './nip44LocalSigner';
 import {
   getVaultRecord,
+  saveVaultRecord,
   deleteVaultRecord,
   enrollPasskey,
   unlockPasskey,
   isCeremonyCancelled
 } from './passkeyVault';
 import { hexToBytes } from './passkeyVaultCrypto';
+import {
+  PASSKEY_SYNC_ENABLED,
+  isSyncEnabled,
+  setSyncEnabled,
+  isUploadPending,
+  setUploadPending,
+  syncableKeyEntry,
+  fetchChallengeSafe,
+  uploadVault,
+  deleteVaultBlob,
+  signInWithPasskey
+} from './passkeySync';
 
 // Permissions requested in the NIP-46 connect handshake. NDK 2.10's
 // blockUntilReady omits the perms param entirely, so permission-enforcing
@@ -1493,7 +1506,24 @@ export class AuthManager {
 
     this.updateState({ isLoading: true, error: null });
     try {
-      const privkeyHex = await unlockPasskey(record);
+      // Pending-upload retry piggybacks on THIS ceremony: fetch a server
+      // challenge first so the unlock assertion is redeemable for the PUT.
+      // Challenge fetch failure degrades to a normal (offline-capable)
+      // unlock and the flag simply stays set. Never a second prompt.
+      let serverChallenge: string | null = null;
+      if (
+        PASSKEY_SYNC_ENABLED &&
+        isSyncEnabled() &&
+        isUploadPending() &&
+        syncableKeyEntry(record)
+      ) {
+        serverChallenge = await fetchChallengeSafe();
+      }
+
+      const { privkeyHex, assertion } = await unlockPasskey(
+        record,
+        serverChallenge ? { serverChallenge } : undefined
+      );
       const signer = new NDKPrivateKeySigner(privkeyHex);
       this.ndk.signer = signer;
       const user = await signer.user();
@@ -1507,6 +1537,11 @@ export class AuthManager {
         error: null
       });
       localStorage.setItem('nostrcooking_loggedInPublicKey', user.hexpubkey);
+
+      if (serverChallenge && assertion) {
+        // Fire-and-forget: uploadVault manages the pending flag itself.
+        void uploadVault(record, assertion);
+      }
     } catch (error) {
       this.ndk.signer = null;
       this.updateState({
@@ -1529,7 +1564,19 @@ export class AuthManager {
   // Enroll a passkey for the current nsec session. The plaintext key is
   // deleted ONLY after enrollPasskey has verified a full round-trip on a
   // real get() assertion; any earlier failure leaves storage untouched.
-  async enrollVault(): Promise<void> {
+  //
+  // opts.sync (R1 toggle, default ON in the UI): when true, the verify-get
+  // ceremony signs over a server challenge so its assertion doubles as the
+  // vault-sync TOFU PUT — enrollment is ALWAYS exactly two prompts (create
+  // + verify-get), sync on or off. Upload failure never fails enrollment:
+  // the pending flag retries on the next unlock's ceremony.
+  //
+  // opts.migrate: guided re-enrollment for pre-Phase-2 records (no stored
+  // SPKI). Mints a NEW credential (excludeCredentials must be empty — the
+  // provider would refuse otherwise), re-encrypts under a fresh DEK, and
+  // replaces the record; the old passkey becomes a provider-side orphan
+  // (disclosed in the UI copy).
+  async enrollVault(opts?: { sync?: boolean; migrate?: boolean }): Promise<void> {
     if (!browser) throw new Error('Browser environment required');
     const { isAuthenticated, authMethod, publicKey } = this.authState;
     if (!isAuthenticated || (authMethod !== 'privateKey' && authMethod !== 'passkey')) {
@@ -1544,9 +1591,31 @@ export class AuthManager {
     } catch {
       /* keep default */
     }
-    await enrollPasskey(privkeyHex, publicKey, label);
+
+    const wantSync = PASSKEY_SYNC_ENABLED && opts?.sync === true;
+    const serverChallenge = wantSync ? await fetchChallengeSafe() : null;
+
+    const { record, assertion } = await enrollPasskey(privkeyHex, publicKey, label, {
+      ...(serverChallenge ? { serverChallenge } : {}),
+      ...(opts?.migrate ? { excludeExisting: false } : {})
+    });
     localStorage.removeItem('nostrcooking_privateKey');
     this.updateState({ authMethod: 'passkey' });
+
+    if (wantSync) {
+      setSyncEnabled(true);
+      if (serverChallenge && assertion && syncableKeyEntry(record)) {
+        void uploadVault(record, assertion);
+      } else if (syncableKeyEntry(record)) {
+        // Challenge fetch failed — the local vault is complete; the upload
+        // retries on the next unlock's ceremony (pending flag).
+        setUploadPending(true);
+      }
+      // No syncable entry (provider without getPublicKey): sync simply
+      // cannot happen for this credential — nothing to retry.
+    } else if (opts?.sync === false) {
+      setSyncEnabled(false);
+    }
   }
 
   // Remove the vault (downgrade to plaintext-localStorage sessions). Requires
@@ -1572,13 +1641,120 @@ export class AuthManager {
       );
     }
 
-    const privkeyHex = await unlockPasskey(record);
+    // Removal's fresh unlock ceremony doubles as the server-blob DELETE
+    // assertion (single prompt — never a second). Challenge fetch failure
+    // degrades to local-only removal; the orphaned blob expires via the
+    // server's 370-day TTL (R4 backstop).
+    let serverChallenge: string | null = null;
+    if (PASSKEY_SYNC_ENABLED && isSyncEnabled() && syncableKeyEntry(record)) {
+      serverChallenge = await fetchChallengeSafe();
+    }
+
+    const { privkeyHex, assertion } = await unlockPasskey(
+      record,
+      serverChallenge ? { serverChallenge } : undefined
+    );
     localStorage.setItem('nostrcooking_privateKey', privkeyHex);
     localStorage.setItem('nostrcooking_loggedInPublicKey', record.pubkey);
     deleteVaultRecord();
+    setSyncEnabled(false);
+    setUploadPending(false);
+
+    if (serverChallenge && assertion) {
+      // Best-effort, never blocks the downgrade; 404 = already gone.
+      void deleteVaultBlob(assertion);
+    }
 
     if (!this.ndk.signer) this.ndk.signer = new NDKPrivateKeySigner(privkeyHex);
     this.updateState({ authMethod: 'privateKey' });
+  }
+
+  // New-device sign-in via a synced passkey (Phase 2). ONE ceremony: the
+  // discoverable get() carries both the server challenge (gates the blob
+  // fetch) and prf.eval (decrypts it). Only after the decrypted key
+  // byte-verifies against the record pubkey do we establish the session and
+  // persist the record — the device then behaves as a Phase 1 device
+  // (subsequent unlocks are local, no network). Any failure leaves storage
+  // untouched and the caller falls through to normal login.
+  async signInWithPasskeySync(): Promise<void> {
+    if (!browser) throw new Error('Browser environment required');
+    if (!PASSKEY_SYNC_ENABLED) throw new Error('Passkey sign-in is not enabled');
+
+    this.updateState({ isLoading: true, error: null });
+    try {
+      const { privkeyHex, record } = await signInWithPasskey();
+
+      const signer = new NDKPrivateKeySigner(privkeyHex);
+      this.ndk.signer = signer;
+      const user = await signer.user();
+
+      this.updateState({
+        isAuthenticated: true,
+        user,
+        publicKey: user.hexpubkey,
+        authMethod: 'passkey',
+        isLoading: false,
+        error: null
+      });
+      localStorage.setItem('nostrcooking_loggedInPublicKey', user.hexpubkey);
+      // Session is live — NOW persist (a failed decrypt never reaches here).
+      saveVaultRecord(record);
+      setSyncEnabled(true);
+    } catch (error) {
+      this.ndk.signer = null;
+      this.updateState({
+        isAuthenticated: false,
+        user: null,
+        publicKey: '',
+        authMethod: null,
+        isLoading: false,
+        error: isCeremonyCancelled(error)
+          ? null
+          : error instanceof Error
+            ? error.message
+            : 'Passkey sign-in failed'
+      });
+      throw error;
+    }
+  }
+
+  // Toggle cross-device sync for an enrolled vault (R1 kill-switch). Both
+  // directions need one passkey ceremony (disclosed in the UI copy): OFF
+  // must produce a DELETE assertion; ON-later must produce the TOFU PUT
+  // assertion. Same ownership guard as removeVault.
+  async setVaultSync(on: boolean): Promise<void> {
+    if (!browser) throw new Error('Browser environment required');
+    if (!PASSKEY_SYNC_ENABLED) throw new Error('Passkey sync is not enabled');
+    const record = getVaultRecord();
+    if (!record) throw new Error('No passkey vault found on this device');
+    if (!this.authState.isAuthenticated || this.authState.publicKey !== record.pubkey) {
+      throw new Error('Vault sync can only be changed from the account that owns the vault.');
+    }
+    if (!syncableKeyEntry(record)) {
+      throw new Error(
+        'This vault was created before cross-device sign-in existed. Re-create the passkey to enable it.'
+      );
+    }
+
+    const serverChallenge = await fetchChallengeSafe();
+    if (!serverChallenge) {
+      throw new Error('Could not reach the sync service. Nothing was changed.');
+    }
+    const { assertion } = await unlockPasskey(record, { serverChallenge });
+    if (!assertion) throw new Error('Passkey did not produce a usable confirmation.');
+
+    if (on) {
+      const ok = await uploadVault(record, assertion);
+      if (!ok) {
+        setUploadPending(false); // uploadVault set it; a failed opt-in stays OFF
+        throw new Error('Could not upload the encrypted vault. Sync remains off.');
+      }
+      setSyncEnabled(true);
+    } else {
+      await deleteVaultBlob(assertion); // 404 = already gone (idempotent)
+      setSyncEnabled(false);
+      setUploadPending(false);
+    }
   }
 
   // Logout and clear all authentication data

--- a/src/lib/passkeySync.test.ts
+++ b/src/lib/passkeySync.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import fixture from '../test/fixtures/vault-v1.json';
+
+/**
+ * passkeySync unit tests: mocked fetch + mocked authenticator, REAL crypto
+ * against the frozen vault-v1 vectors — the blob served by the mocked
+ * server is byte-compatible with what the vault-sync endpoints store.
+ */
+
+vi.mock('$app/environment', () => ({ browser: true }));
+
+import {
+  signInWithPasskey,
+  uploadVault,
+  deleteVaultBlob,
+  fetchChallengeSafe,
+  syncableKeyEntry,
+  shouldOfferSyncSignIn,
+  isUploadPending,
+  setUploadPending,
+  SyncSignInError,
+  SYNC_PENDING_KEY
+} from './passkeySync';
+import { VAULT_STORAGE_KEY, type VaultRecord, type AssertionWire } from './passkeyVault';
+import { hexToBytes, bytesToB64, b64urlToBytes, bytesToB64url } from './passkeyVaultCrypto';
+
+const CRED_ID = fixture.credentialIdB64url;
+
+function fixtureRecord(withSpki = true): VaultRecord {
+  return {
+    version: 1,
+    pubkey: fixture.pubkeyHex,
+    nsecCiphertext: fixture.expectedNsecCiphertextB64,
+    createdAt: 1,
+    keys: [
+      {
+        credentialId: CRED_ID,
+        wrappedDek: fixture.expectedWrappedDekB64,
+        dekIv: bytesToB64(hexToBytes(fixture.dekIvHex)),
+        addedAt: 1,
+        ...(withSpki ? { spki: 'dGVzdC1zcGtp', alg: -7 } : {})
+      }
+    ]
+  };
+}
+
+const WIRE: AssertionWire = {
+  credentialId: CRED_ID,
+  signature: 'c2ln',
+  authenticatorData: 'YXV0aA',
+  clientDataJSON: 'Y2Rq'
+};
+
+function assertionCredential(prfBytes: Uint8Array | null, credId = CRED_ID) {
+  return {
+    id: credId,
+    rawId: b64urlToBytes(credId).buffer,
+    type: 'public-key',
+    response: {
+      signature: new Uint8Array([1, 2, 3]).buffer,
+      authenticatorData: new Uint8Array([4, 5, 6]).buffer,
+      clientDataJSON: new Uint8Array([7, 8, 9]).buffer
+    },
+    getClientExtensionResults: () =>
+      prfBytes ? { prf: { results: { first: prfBytes.slice().buffer } } } : {}
+  };
+}
+
+let store: Map<string, string>;
+let fetchMock: ReturnType<typeof vi.fn>;
+let credentials: { get: ReturnType<typeof vi.fn> };
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+/** Standard happy server: challenge then blob. */
+function happyServer(blob: string) {
+  fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+    if (String(url).endsWith('/challenge')) {
+      return jsonResponse(200, { challenge: 'c2VydmVyLWNoYWxsZW5nZQ', expiresAt: Date.now() + 120000 });
+    }
+    if (init?.method === 'POST') return jsonResponse(200, { blob });
+    return jsonResponse(200, { ok: true });
+  });
+}
+
+beforeEach(() => {
+  store = new Map();
+  (globalThis as any).localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => store.set(k, String(v)),
+    removeItem: (k: string) => store.delete(k),
+    clear: () => store.clear()
+  };
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+  credentials = { get: vi.fn() };
+  vi.stubGlobal('navigator', { credentials });
+});
+
+describe('signInWithPasskey (new device)', () => {
+  it('happy path: one ceremony, blob fetched, decrypted, key verified', async () => {
+    happyServer(JSON.stringify(fixtureRecord()));
+    credentials.get.mockResolvedValue(assertionCredential(hexToBytes(fixture.prfOutputHex)));
+
+    const { privkeyHex, record } = await signInWithPasskey();
+
+    expect(privkeyHex).toBe(fixture.nsecHex);
+    expect(record.pubkey).toBe(fixture.pubkeyHex);
+    // Exactly ONE ceremony, with server challenge AND prf.eval together,
+    // discoverable (empty allowCredentials).
+    expect(credentials.get).toHaveBeenCalledTimes(1);
+    const getArgs = credentials.get.mock.calls[0][0].publicKey;
+    expect(getArgs.allowCredentials).toEqual([]);
+    expect(bytesToB64url(new Uint8Array(getArgs.challenge))).toBe('c2VydmVyLWNoYWxsZW5nZQ');
+    expect(getArgs.extensions.prf.eval.first).toBeDefined();
+    // Nothing persisted by this module — persistence is AuthManager's call.
+    expect(store.get(VAULT_STORAGE_KEY)).toBeUndefined();
+  });
+
+  it('challenge fetch failure → SyncSignInError, no ceremony, nothing persisted', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(503, { error: 'not_configured' }));
+    await expect(signInWithPasskey()).rejects.toThrow(SyncSignInError);
+    expect(credentials.get).not.toHaveBeenCalled();
+    expect(store.size).toBe(0);
+  });
+
+  it('blob fetch 404 → SyncSignInError, nothing persisted', async () => {
+    fetchMock.mockImplementation(async (url: string) =>
+      String(url).endsWith('/challenge')
+        ? jsonResponse(200, { challenge: 'YQ', expiresAt: Date.now() + 120000 })
+        : jsonResponse(404, { error: 'not_found' })
+    );
+    credentials.get.mockResolvedValue(assertionCredential(hexToBytes(fixture.prfOutputHex)));
+    await expect(signInWithPasskey()).rejects.toThrow(/No synced sign-in/);
+    expect(store.size).toBe(0);
+  });
+
+  it('missing PRF output (hybrid/QR shape) → fails closed before any fetch of the blob', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(200, { challenge: 'YQ', expiresAt: Date.now() + 120000 })
+    );
+    credentials.get.mockResolvedValue(assertionCredential(null));
+    await expect(signInWithPasskey()).rejects.toThrow(/key material/);
+    // challenge fetch happened; blob fetch must NOT have.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('tampered blob (wrong ciphertext) → SyncSignInError, nothing persisted', async () => {
+    const bad = fixtureRecord();
+    bad.nsecCiphertext = bad.nsecCiphertext.slice(0, -8) + 'AAAAAAA=';
+    happyServer(JSON.stringify(bad));
+    credentials.get.mockResolvedValue(assertionCredential(hexToBytes(fixture.prfOutputHex)));
+    await expect(signInWithPasskey()).rejects.toThrow(SyncSignInError);
+    expect(store.size).toBe(0);
+  });
+
+  it('blob whose pubkey does not match the decrypted key → rejected', async () => {
+    const swapped = fixtureRecord();
+    swapped.pubkey = 'ab'.repeat(32);
+    happyServer(JSON.stringify(swapped));
+    credentials.get.mockResolvedValue(assertionCredential(hexToBytes(fixture.prfOutputHex)));
+    await expect(signInWithPasskey()).rejects.toThrow(SyncSignInError);
+  });
+
+  it('blob lacking the asserting credential → rejected', async () => {
+    happyServer(JSON.stringify(fixtureRecord()));
+    credentials.get.mockResolvedValue(
+      assertionCredential(hexToBytes(fixture.prfOutputHex), 'b3RoZXItY3JlZA')
+    );
+    await expect(signInWithPasskey()).rejects.toThrow(SyncSignInError);
+  });
+});
+
+describe('uploadVault', () => {
+  it('success clears the pending flag and sends blob+spki+assertion', async () => {
+    setUploadPending(true);
+    fetchMock.mockResolvedValue(jsonResponse(200, { ok: true }));
+    const ok = await uploadVault(fixtureRecord(), WIRE);
+    expect(ok).toBe(true);
+    expect(isUploadPending()).toBe(false);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.spki).toBe('dGVzdC1zcGtp');
+    expect(body.alg).toBe(-7);
+    expect(JSON.parse(body.blob).pubkey).toBe(fixture.pubkeyHex);
+    expect(body.assertion).toEqual(WIRE);
+  });
+
+  it('failure sets the pending flag (enrollment is never failed by upload)', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(500, {}));
+    expect(await uploadVault(fixtureRecord(), WIRE)).toBe(false);
+    expect(isUploadPending()).toBe(true);
+  });
+
+  it('network throw sets the pending flag', async () => {
+    fetchMock.mockRejectedValue(new TypeError('network down'));
+    expect(await uploadVault(fixtureRecord(), WIRE)).toBe(false);
+    expect(isUploadPending()).toBe(true);
+  });
+
+  it('record without SPKI (pre-Phase-2) is not uploadable', async () => {
+    expect(await uploadVault(fixtureRecord(false), WIRE)).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteVaultBlob — client-side idempotency (ruling pin)', () => {
+  it('404 is treated as already-gone: resolves cleanly, no retry state, no error', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    fetchMock.mockResolvedValue(jsonResponse(404, { error: 'not_found' }));
+
+    await expect(deleteVaultBlob(WIRE)).resolves.toBeUndefined();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1); // no retry loop
+    expect(warnSpy).not.toHaveBeenCalled(); // not even a warning — it's success
+    expect(store.get(SYNC_PENDING_KEY)).toBeUndefined(); // no retry state
+    warnSpy.mockRestore();
+  });
+
+  it('non-404 failure logs and abandons (TTL is the backstop) — never throws', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    fetchMock.mockResolvedValue(jsonResponse(500, {}));
+    await expect(deleteVaultBlob(WIRE)).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  it('targets sha256(credentialId) in the path', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, { ok: true }));
+    await deleteVaultBlob(WIRE);
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toMatch(/\/api\/vault-sync\/[0-9a-f]{64}$/);
+  });
+});
+
+describe('helpers', () => {
+  it('fetchChallengeSafe never throws', async () => {
+    fetchMock.mockRejectedValue(new TypeError('offline'));
+    expect(await fetchChallengeSafe()).toBeNull();
+  });
+
+  it('syncableKeyEntry requires spki with a supported alg', () => {
+    expect(syncableKeyEntry(fixtureRecord())).toBeTruthy();
+    expect(syncableKeyEntry(fixtureRecord(false))).toBeNull();
+    expect(syncableKeyEntry(null)).toBeNull();
+    const badAlg = fixtureRecord();
+    (badAlg.keys[0] as any).alg = -8;
+    expect(syncableKeyEntry(badAlg)).toBeNull();
+  });
+
+  it('shouldOfferSyncSignIn matrix', () => {
+    const base = {
+      flagEnabled: true,
+      hasLocalRecord: false,
+      supported: true,
+      isAuthenticated: false
+    };
+    expect(shouldOfferSyncSignIn(base)).toBe(true);
+    expect(shouldOfferSyncSignIn({ ...base, flagEnabled: false })).toBe(false);
+    // Local record present → the unlock card owns the surface.
+    expect(shouldOfferSyncSignIn({ ...base, hasLocalRecord: true })).toBe(false);
+    expect(shouldOfferSyncSignIn({ ...base, supported: false })).toBe(false);
+    expect(shouldOfferSyncSignIn({ ...base, isAuthenticated: true })).toBe(false);
+  });
+});

--- a/src/lib/passkeySync.ts
+++ b/src/lib/passkeySync.ts
@@ -1,0 +1,303 @@
+/**
+ * Passkey vault sync — Phase 2 client (cross-device sign-in).
+ *
+ * Talks to /api/vault-sync/: the Phase 1 vault record travels as an opaque
+ * server-side blob so a provider-synced passkey can sign the user in on a
+ * brand-new device. The server never decrypts; every request is gated by a
+ * WebAuthn assertion over a server challenge (Phase 1 security ruling: a
+ * provider-account compromise alone must not yield both the passkey and the
+ * ciphertext without a live verified ceremony).
+ *
+ * Sync is BEST-EFFORT everywhere: the local vault is the product. Upload
+ * failure never fails enrollment (dirty flag + retry piggybacked on the
+ * next unlock's ceremony); DELETE failure is logged and left to the
+ * server-side 370-day TTL; any sign-in failure falls through to normal
+ * login with nothing persisted.
+ */
+
+import { browser } from '$app/environment';
+import {
+  RP_ID,
+  isCeremonyCancelled,
+  saveVaultRecord,
+  type AssertionWire,
+  type VaultRecord
+} from '$lib/passkeyVault';
+import {
+  PRF_INPUT,
+  b64urlToBytes,
+  bytesToB64url,
+  b64ToBytes,
+  hexToBytes,
+  deriveKek,
+  unwrapDek,
+  decryptNsec,
+  zeroize
+} from '$lib/passkeyVaultCrypto';
+import { getPublicKey } from 'nostr-tools';
+
+/**
+ * Soft-launch gate (R3): while false, no sync UI renders and no sync
+ * network calls are made anywhere — Phase 2 ships dark. Flip deliberately.
+ */
+export const PASSKEY_SYNC_ENABLED = false;
+
+/** '1' = user opted in (R1 default-ON at enrollment); '0' = explicitly off.
+ * ABSENT = off — pre-Phase-2 enrollments must never surprise-upload. */
+export const SYNC_ENABLED_KEY = 'nostrcooking_vault_sync_enabled';
+/** Set when an upload failed; retried on the next unlock ceremony. */
+export const SYNC_PENDING_KEY = 'nostrcooking_vault_sync_pending';
+
+export class PasskeySyncError extends Error {}
+/** Sign-in failed before anything was persisted — caller falls through. */
+export class SyncSignInError extends PasskeySyncError {}
+
+export function isSyncEnabled(): boolean {
+  return browser && localStorage.getItem(SYNC_ENABLED_KEY) === '1';
+}
+
+export function setSyncEnabled(on: boolean): void {
+  if (browser) localStorage.setItem(SYNC_ENABLED_KEY, on ? '1' : '0');
+}
+
+export function isUploadPending(): boolean {
+  return browser && localStorage.getItem(SYNC_PENDING_KEY) === '1';
+}
+
+export function setUploadPending(pending: boolean): void {
+  if (!browser) return;
+  if (pending) localStorage.setItem(SYNC_PENDING_KEY, '1');
+  else localStorage.removeItem(SYNC_PENDING_KEY);
+}
+
+/** The record's syncable entry (has SPKI). Pre-Phase-2 records return null. */
+export function syncableKeyEntry(record: VaultRecord | null) {
+  if (!record) return null;
+  return (
+    record.keys.find((k) => typeof k.spki === 'string' && (k.alg === -7 || k.alg === -257)) ??
+    null
+  );
+}
+
+// ── HTTP ────────────────────────────────────────────────────────
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', bytes as BufferSource));
+  return Array.from(digest)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/** Fetch a server challenge. Throws on any failure. */
+export async function fetchChallenge(): Promise<string> {
+  const res = await fetch('/api/vault-sync/challenge', { method: 'POST' });
+  if (!res.ok) throw new PasskeySyncError(`challenge fetch failed (${res.status})`);
+  const body = await res.json();
+  if (typeof body?.challenge !== 'string') throw new PasskeySyncError('bad challenge response');
+  return body.challenge;
+}
+
+/** Like fetchChallenge but never throws — sync is best-effort. */
+export async function fetchChallengeSafe(): Promise<string | null> {
+  try {
+    return await fetchChallenge();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Upload the vault record. The assertion must be over a server challenge
+ * from the SAME ceremony budget (enrollment verify-get or an unlock).
+ * Returns true on success; false marks the upload pending for retry.
+ */
+export async function uploadVault(
+  record: VaultRecord,
+  assertion: AssertionWire
+): Promise<boolean> {
+  const entry = syncableKeyEntry(record);
+  if (!entry) return false;
+  try {
+    const res = await fetch('/api/vault-sync', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        blob: JSON.stringify(record),
+        spki: entry.spki,
+        alg: entry.alg,
+        assertion
+      })
+    });
+    if (!res.ok) {
+      setUploadPending(true);
+      return false;
+    }
+    setUploadPending(false);
+    return true;
+  } catch {
+    setUploadPending(true);
+    return false;
+  }
+}
+
+/**
+ * Delete the server blob. Best-effort by ruling: a 404 is SUCCESS (the
+ * uniform-404 design means "absent or unauthorized are indistinguishable";
+ * for the owner's own delete that reads as already-gone — idempotency lives
+ * here, client-side). Other failures are logged and abandoned: after
+ * removal there is no credential left to assert with, so the server-side
+ * 370-day TTL is the backstop. Never throws, never schedules retries.
+ */
+export async function deleteVaultBlob(assertion: AssertionWire): Promise<void> {
+  try {
+    const hash = await sha256Hex(b64urlToBytes(assertion.credentialId));
+    const res = await fetch(`/api/vault-sync/${hash}`, {
+      method: 'DELETE',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ assertion })
+    });
+    if (!res.ok && res.status !== 404) {
+      console.warn('[VaultSync] blob delete failed; server TTL is the backstop', res.status);
+    }
+  } catch (e) {
+    console.warn('[VaultSync] blob delete failed; server TTL is the backstop', e);
+  }
+}
+
+// ── New-device sign-in ──────────────────────────────────────────
+
+export interface SyncSignInResult {
+  /** Decrypted key — memory only; AuthManager builds the signer from it. */
+  privkeyHex: string;
+  /** The fetched record — AuthManager persists it AFTER the session is live. */
+  record: VaultRecord;
+}
+
+function isValidRecordShape(r: any): r is VaultRecord {
+  return (
+    !!r &&
+    r.version === 1 &&
+    typeof r.pubkey === 'string' &&
+    /^[0-9a-f]{64}$/.test(r.pubkey) &&
+    typeof r.nsecCiphertext === 'string' &&
+    Array.isArray(r.keys) &&
+    r.keys.length > 0 &&
+    r.keys.every(
+      (k: any) =>
+        k &&
+        typeof k.credentialId === 'string' &&
+        typeof k.wrappedDek === 'string' &&
+        typeof k.dekIv === 'string'
+    )
+  );
+}
+
+/**
+ * The whole new-device flow, ONE ceremony: server challenge → discoverable
+ * get() (empty allowCredentials — the user picks their passkey) with
+ * challenge AND prf.eval in the same prompt → assertion-gated blob fetch →
+ * local decrypt with the PRF-derived KEK → byte-verify the key against the
+ * record pubkey. Throws SyncSignInError (or the cancellation DOMException)
+ * with NOTHING persisted; only AuthManager persists, after the session is
+ * established.
+ */
+export async function signInWithPasskey(): Promise<SyncSignInResult> {
+  if (!browser) throw new SyncSignInError('browser required');
+
+  const challenge = await fetchChallenge().catch(() => {
+    throw new SyncSignInError('Could not reach the sign-in service');
+  });
+
+  const cred = (await navigator.credentials.get({
+    publicKey: {
+      challenge: b64urlToBytes(challenge) as BufferSource,
+      rpId: RP_ID,
+      allowCredentials: [],
+      userVerification: 'required',
+      extensions: { prf: { eval: { first: new TextEncoder().encode(PRF_INPUT) } } } as any
+    }
+  })) as PublicKeyCredential | null;
+  if (!cred) throw new SyncSignInError('No credential returned');
+
+  const res = cred.response as AuthenticatorAssertionResponse;
+  const ext = (cred.getClientExtensionResults() as any)?.prf?.results?.first;
+  let prfOutput: Uint8Array | null = null;
+  if (ext instanceof ArrayBuffer) prfOutput = new Uint8Array(ext);
+  else if (ArrayBuffer.isView(ext)) {
+    prfOutput = new Uint8Array(ext.buffer, ext.byteOffset, ext.byteLength);
+  }
+  if (!prfOutput || prfOutput.length !== 32) {
+    // Hybrid/QR cross-device assertions historically drop PRF — fail closed,
+    // the overlay falls through to normal login.
+    throw new SyncSignInError('This passkey flow did not provide the required key material');
+  }
+
+  const assertion: AssertionWire = {
+    credentialId: cred.id,
+    signature: bytesToB64url(new Uint8Array(res.signature)),
+    authenticatorData: bytesToB64url(new Uint8Array(res.authenticatorData)),
+    clientDataJSON: bytesToB64url(new Uint8Array(res.clientDataJSON))
+  };
+
+  let blob: string;
+  try {
+    const hash = await sha256Hex(b64urlToBytes(cred.id));
+    const httpRes = await fetch(`/api/vault-sync/${hash}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ assertion })
+    });
+    if (!httpRes.ok) throw new Error(String(httpRes.status));
+    const body = await httpRes.json();
+    if (typeof body?.blob !== 'string') throw new Error('no blob');
+    blob = body.blob;
+  } catch {
+    zeroize(prfOutput);
+    throw new SyncSignInError('No synced sign-in found for this passkey');
+  }
+
+  // Decrypt locally. A blob that does not decrypt cleanly to the record's
+  // own pubkey is NEVER returned (and therefore never persisted).
+  const kek = deriveKek(prfOutput);
+  let dek: Uint8Array | null = null;
+  try {
+    const record = JSON.parse(blob);
+    if (!isValidRecordShape(record)) throw new Error('bad record shape');
+    const entry = record.keys.find((k) => k.credentialId === cred.id);
+    if (!entry) throw new Error('credential not in record');
+    dek = await unwrapDek(b64ToBytes(entry.wrappedDek), b64ToBytes(entry.dekIv), kek);
+    const privkeyHex = decryptNsec(record.nsecCiphertext, dek);
+    if (getPublicKey(hexToBytes(privkeyHex)) !== record.pubkey) {
+      throw new Error('decrypted key does not match record pubkey');
+    }
+    return { privkeyHex, record };
+  } catch (e) {
+    throw new SyncSignInError(
+      `Could not unlock the synced vault: ${e instanceof Error ? e.message : String(e)}`
+    );
+  } finally {
+    zeroize(kek, dek, prfOutput);
+  }
+}
+
+/** Predicate for the LoginOverlay button (unit-tested). */
+export function shouldOfferSyncSignIn(ctx: {
+  flagEnabled: boolean;
+  hasLocalRecord: boolean;
+  supported: boolean;
+  isAuthenticated: boolean;
+}): boolean {
+  // A local record means the existing unlock card owns the surface — no
+  // network involved; sync sign-in is strictly for record-less devices.
+  return ctx.flagEnabled && ctx.supported && !ctx.hasLocalRecord && !ctx.isAuthenticated;
+}
+
+/** Persist a fetched record locally — the device becomes a Phase 1 device. */
+export function adoptSyncedRecord(record: VaultRecord): void {
+  saveVaultRecord(record);
+  // The record arrived via sync, so sync is evidently what the user wants
+  // on this account; subsequent uploads from this device keep it fresh.
+  setSyncEnabled(true);
+}
+
+export { isCeremonyCancelled };

--- a/src/lib/passkeyVault.test.ts
+++ b/src/lib/passkeyVault.test.ts
@@ -32,13 +32,27 @@ const NEW_CRED_ID = 'bmV3LWNyZWQtaWQtMDE'; // b64url of "new-cred-id-01"
 
 function fakeCredential(
   idB64url: string,
-  ext: { prfResult?: Uint8Array; prfEnabled?: boolean; prfAsOffsetView?: boolean } = {}
+  ext: {
+    prfResult?: Uint8Array;
+    prfEnabled?: boolean;
+    prfAsOffsetView?: boolean;
+    spki?: Uint8Array;
+  } = {}
 ) {
   const raw = b64urlToBytes(idB64url);
   return {
     id: idB64url,
     rawId: raw.buffer,
     type: 'public-key',
+    response: {
+      // Assertion-shaped fields (harmlessly present on create-shaped mocks).
+      signature: new Uint8Array([1]).buffer,
+      authenticatorData: new Uint8Array([2]).buffer,
+      clientDataJSON: new Uint8Array([3]).buffer,
+      // Attestation-shaped accessors, used when this mocks a create() result.
+      getPublicKey: () => (ext.spki ? ext.spki.buffer : null),
+      getPublicKeyAlgorithm: () => -7
+    },
     getClientExtensionResults: () => {
       if (ext.prfResult) {
         if (ext.prfAsOffsetView) {
@@ -124,7 +138,8 @@ describe('enrollPasskey', () => {
     credentials.create.mockResolvedValue(fakeCredential(NEW_CRED_ID, { prfEnabled: true }));
     credentials.get.mockResolvedValue(fakeCredential(NEW_CRED_ID, { prfResult: PRF_BYTES() }));
 
-    const record = await enrollPasskey(fixture.nsecHex, fixture.pubkeyHex, 'Test');
+    const { record, assertion } = await enrollPasskey(fixture.nsecHex, fixture.pubkeyHex, 'Test');
+    expect(assertion?.credentialId).toBe(NEW_CRED_ID); // verify-get assertion captured
 
     expect(record.pubkey).toBe(fixture.pubkeyHex);
     expect(record.keys).toHaveLength(1);
@@ -143,7 +158,7 @@ describe('enrollPasskey', () => {
     credentials.get.mockResolvedValue(
       fakeCredential(NEW_CRED_ID, { prfResult: PRF_BYTES() })
     );
-    await expect(unlockPasskey(record)).resolves.toBe(fixture.nsecHex);
+    await expect(unlockPasskey(record)).resolves.toMatchObject({ privkeyHex: fixture.nsecHex });
   });
 
   it('aborts without persisting when create() reports prf.enabled === false', async () => {
@@ -172,6 +187,47 @@ describe('enrollPasskey', () => {
     expect(getVaultRecord()).toBeNull();
   });
 
+  it('captures SPKI/alg into the key entry when the provider exposes getPublicKey', async () => {
+    const spkiBytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+    credentials.create.mockResolvedValue(
+      fakeCredential(NEW_CRED_ID, { prfEnabled: true, spki: spkiBytes })
+    );
+    credentials.get.mockResolvedValue(fakeCredential(NEW_CRED_ID, { prfResult: PRF_BYTES() }));
+    const { record } = await enrollPasskey(fixture.nsecHex, fixture.pubkeyHex, 'Test');
+    expect(record.keys[0].spki).toBe('3q2-7w'); // b64url(deadbeef)
+    expect(record.keys[0].alg).toBe(-7);
+    // Enrollment without getPublicKey still succeeds — fields just absent.
+    credentials.create.mockResolvedValue(fakeCredential(NEW_CRED_ID, { prfEnabled: true }));
+    credentials.get.mockResolvedValue(fakeCredential(NEW_CRED_ID, { prfResult: PRF_BYTES() }));
+    const { record: plain } = await enrollPasskey(fixture.nsecHex, fixture.pubkeyHex, 'Test');
+    expect(plain.keys[0].spki).toBeUndefined();
+  });
+
+  it('signs the verify-get over a server challenge when provided (two-prompt budget)', async () => {
+    credentials.create.mockResolvedValue(fakeCredential(NEW_CRED_ID, { prfEnabled: true }));
+    credentials.get.mockResolvedValue(fakeCredential(NEW_CRED_ID, { prfResult: PRF_BYTES() }));
+    const serverChallenge = 'c2VydmVyLWNoYWxsZW5nZQ';
+    const { assertion } = await enrollPasskey(fixture.nsecHex, fixture.pubkeyHex, 'Test', {
+      serverChallenge
+    });
+    // Exactly one create + one get: the TOFU PUT assertion comes from the
+    // SAME verify-get prompt, never a third ceremony.
+    expect(credentials.create).toHaveBeenCalledTimes(1);
+    expect(credentials.get).toHaveBeenCalledTimes(1);
+    const getArgs = credentials.get.mock.calls[0][0].publicKey;
+    expect(new Uint8Array(getArgs.challenge)).toEqual(b64urlToBytes(serverChallenge));
+    expect(assertion?.credentialId).toBe(NEW_CRED_ID);
+  });
+
+  it('migration opt-out of excludeCredentials (excludeExisting: false)', async () => {
+    saveVaultRecord(fixtureRecord());
+    credentials.create.mockResolvedValue(fakeCredential(NEW_CRED_ID, { prfEnabled: true }));
+    credentials.get.mockResolvedValue(fakeCredential(NEW_CRED_ID, { prfResult: PRF_BYTES() }));
+    await enrollPasskey(fixture.nsecHex, fixture.pubkeyHex, 'Test', { excludeExisting: false });
+    const createArgs = credentials.create.mock.calls[0][0].publicKey;
+    expect(createArgs.excludeCredentials).toEqual([]);
+  });
+
   it('rejects a private key that does not match the pubkey', async () => {
     await expect(enrollPasskey('11'.repeat(32), fixture.pubkeyHex, 'Test')).rejects.toThrow(
       /does not match/
@@ -197,7 +253,9 @@ describe('unlockPasskey', () => {
     credentials.get.mockResolvedValue(
       fakeCredential(fixture.credentialIdB64url, { prfResult: PRF_BYTES() })
     );
-    await expect(unlockPasskey(fixtureRecord())).resolves.toBe(fixture.nsecHex);
+    await expect(unlockPasskey(fixtureRecord())).resolves.toMatchObject({
+      privkeyHex: fixture.nsecHex
+    });
     const getArgs = credentials.get.mock.calls[0][0].publicKey;
     expect(new Uint8Array(getArgs.allowCredentials[0].id)).toEqual(
       b64urlToBytes(fixture.credentialIdB64url)
@@ -239,7 +297,9 @@ describe('unlockPasskey', () => {
     credentials.get.mockResolvedValue(
       fakeCredential(fixture.credentialIdB64url, { prfResult: PRF_BYTES(), prfAsOffsetView: true })
     );
-    await expect(unlockPasskey(fixtureRecord())).resolves.toBe(fixture.nsecHex);
+    await expect(unlockPasskey(fixtureRecord())).resolves.toMatchObject({
+      privkeyHex: fixture.nsecHex
+    });
   });
 });
 

--- a/src/lib/passkeyVault.ts
+++ b/src/lib/passkeyVault.ts
@@ -18,6 +18,7 @@ import {
   PRF_INPUT,
   b64urlToBytes,
   bytesToB64,
+  bytesToB64url,
   b64ToBytes,
   hexToBytes,
   deriveKek,
@@ -52,6 +53,16 @@ export interface VaultKeyEntry {
   wrappedDek: string; // base64
   dekIv: string; // base64
   addedAt: number;
+  /**
+   * Credential public key (SPKI DER, base64url) + COSE alg, captured from
+   * create()'s getPublicKey() at enrollment. OPTIONAL extension over the
+   * frozen v1 shape (Phase 1 records lack it; validation never requires
+   * it): public material only, needed for the vault-sync TOFU upload and
+   * for re-enabling sync after toggle-off. Records missing it can only
+   * gain sync via guided re-enrollment.
+   */
+  spki?: string;
+  alg?: number;
 }
 
 export interface VaultRecord {
@@ -210,15 +221,53 @@ function getPrfResult(cred: PublicKeyCredential): Uint8Array | null {
 }
 
 /**
- * Assert with the given credentials + PRF eval and return {credentialId, prfOutput}.
- * Shared by enrollment-verify and unlock.
+ * Wire form of a WebAuthn assertion (all base64url), matching what the
+ * vault-sync endpoints verify. Only meaningful server-side when the
+ * ceremony used a SERVER-issued challenge; assertions over local random
+ * challenges are returned too but are not redeemable.
+ */
+export interface AssertionWire {
+  credentialId: string;
+  signature: string;
+  authenticatorData: string;
+  clientDataJSON: string;
+}
+
+export interface CeremonyOptions {
+  /**
+   * Server-issued challenge (base64url, from POST /api/vault-sync/challenge).
+   * When set, the ceremony signs over it so the SAME prompt's assertion can
+   * authenticate a vault-sync request — this is how enrollment stays at two
+   * prompts (verify-get doubles as the TOFU PUT assertion) and how removal
+   * reuses its single unlock ceremony for DELETE.
+   */
+  serverChallenge?: string;
+}
+
+function wireAssertion(cred: PublicKeyCredential): AssertionWire | null {
+  const res = cred.response as AuthenticatorAssertionResponse | undefined;
+  if (!res?.signature || !res?.authenticatorData || !res?.clientDataJSON) return null;
+  return {
+    credentialId: cred.id,
+    signature: bytesToB64url(new Uint8Array(res.signature)),
+    authenticatorData: bytesToB64url(new Uint8Array(res.authenticatorData)),
+    clientDataJSON: bytesToB64url(new Uint8Array(res.clientDataJSON))
+  };
+}
+
+/**
+ * Assert with the given credentials + PRF eval. Shared by enrollment-verify
+ * and unlock. Returns the assertion wire form alongside the PRF output.
  */
 async function assertWithPrf(
-  credentialIds: string[]
-): Promise<{ credentialId: string; prfOutput: Uint8Array }> {
+  credentialIds: string[],
+  opts?: CeremonyOptions
+): Promise<{ credentialId: string; prfOutput: Uint8Array; assertion: AssertionWire | null }> {
   const assertion = (await navigator.credentials.get({
     publicKey: {
-      challenge: randomChallenge() as BufferSource,
+      challenge: (opts?.serverChallenge
+        ? b64urlToBytes(opts.serverChallenge)
+        : randomChallenge()) as BufferSource,
       rpId: RP_ID,
       allowCredentials: credentialIds.map((id) => ({
         type: 'public-key' as const,
@@ -233,7 +282,7 @@ async function assertWithPrf(
   if (!prfOutput) {
     throw new PrfUnsupportedError('Passkey provider did not return a PRF result on get()');
   }
-  return { credentialId: assertion.id, prfOutput };
+  return { credentialId: assertion.id, prfOutput, assertion: wireAssertion(assertion) };
 }
 
 /**
@@ -244,11 +293,30 @@ async function assertWithPrf(
  * vault storage is left untouched (an orphan passkey may remain in the user's
  * provider; we cannot delete authenticator-side credentials).
  */
+export interface EnrollResult {
+  record: VaultRecord;
+  /**
+   * The verify-get assertion. When opts.serverChallenge was provided this is
+   * redeemable as the vault-sync TOFU PUT assertion (two-prompt budget).
+   */
+  assertion: AssertionWire | null;
+}
+
+export interface EnrollOptions extends CeremonyOptions {
+  /**
+   * Set false for guided re-enrollment (migration of pre-Phase-2 records):
+   * the point is to mint a NEW credential while the old one still exists on
+   * the provider, and excludeCredentials would make the provider refuse.
+   */
+  excludeExisting?: boolean;
+}
+
 export async function enrollPasskey(
   privkeyHex: string,
   pubkey: string,
-  userLabel: string
-): Promise<VaultRecord> {
+  userLabel: string,
+  opts?: EnrollOptions
+): Promise<EnrollResult> {
   const normalizedKey = privkeyHex.toLowerCase();
   if (getPublicKey(hexToBytes(normalizedKey)) !== pubkey) {
     throw new PasskeyVaultError('private key does not match the session pubkey');
@@ -256,10 +324,13 @@ export async function enrollPasskey(
 
   // Exclude credentials already in a record so providers refuse duplicates.
   const existing = getVaultRecord();
-  const excludeCredentials = (existing?.keys ?? []).map((k) => ({
-    type: 'public-key' as const,
-    id: b64urlToBytes(k.credentialId) as BufferSource
-  }));
+  const excludeCredentials =
+    opts?.excludeExisting === false
+      ? []
+      : (existing?.keys ?? []).map((k) => ({
+          type: 'public-key' as const,
+          id: b64urlToBytes(k.credentialId) as BufferSource
+        }));
 
   const created = (await navigator.credentials.create({
     publicKey: {
@@ -290,8 +361,27 @@ export async function enrollPasskey(
     throw new PrfUnsupportedError('Passkey provider reported PRF unsupported on create()');
   }
 
+  // Capture the credential public key for vault-sync (SPKI DER — no CBOR
+  // attestation parsing anywhere). Public material; absence just means sync
+  // is unavailable for this entry.
+  let spki: string | undefined;
+  let alg: number | undefined;
+  try {
+    const attRes = created.response as AuthenticatorAttestationResponse;
+    const spkiDer = attRes.getPublicKey?.();
+    const algNum = attRes.getPublicKeyAlgorithm?.();
+    if (spkiDer && (algNum === -7 || algNum === -257)) {
+      spki = bytesToB64url(new Uint8Array(spkiDer));
+      alg = algNum;
+    }
+  } catch {
+    /* provider without getPublicKey — sync unavailable, vault still fine */
+  }
+
   // Verify-on-get: derive the KEK from a real assertion, never from create().
-  const { credentialId, prfOutput } = await assertWithPrf([created.id]);
+  // With opts.serverChallenge this same prompt also produces the TOFU PUT
+  // assertion — enrollment must never grow a third ceremony.
+  const { credentialId, prfOutput, assertion } = await assertWithPrf([created.id], opts);
 
   const kek = deriveKek(prfOutput);
   const dek = generateDek();
@@ -317,12 +407,13 @@ export async function enrollPasskey(
           credentialId,
           wrappedDek: bytesToB64(wrappedDek),
           dekIv: bytesToB64(iv),
-          addedAt: now
+          addedAt: now,
+          ...(spki && alg !== undefined ? { spki, alg } : {})
         }
       ]
     };
     saveVaultRecord(record);
-    return record;
+    return { record, assertion };
   } catch (e) {
     if (e instanceof PasskeyVaultError) throw e;
     throw new EnrollVerifyError(
@@ -333,14 +424,28 @@ export async function enrollPasskey(
   }
 }
 
+export interface UnlockResult {
+  /** Decrypted 64-hex private key — memory only, callers must never persist it. */
+  privkeyHex: string;
+  credentialId: string;
+  /** Redeemable server-side only when opts.serverChallenge was provided. */
+  assertion: AssertionWire | null;
+}
+
 /**
  * Unlock ceremony: assert with any enrolled credential, unwrap the DEK, and
- * return the decrypted 64-hex private key (memory only — callers must never
- * persist it). Fails closed on any mismatch; never mutates storage.
+ * return the decrypted private key. Fails closed on any mismatch; never
+ * mutates storage. With opts.serverChallenge the same single prompt also
+ * yields a vault-sync-redeemable assertion (used by removal's DELETE and
+ * the pending-upload retry — no second prompt, ever).
  */
-export async function unlockPasskey(record: VaultRecord): Promise<string> {
-  const { credentialId, prfOutput } = await assertWithPrf(
-    record.keys.map((k) => k.credentialId)
+export async function unlockPasskey(
+  record: VaultRecord,
+  opts?: CeremonyOptions
+): Promise<UnlockResult> {
+  const { credentialId, prfOutput, assertion } = await assertWithPrf(
+    record.keys.map((k) => k.credentialId),
+    opts
   );
   const entry = record.keys.find((k) => k.credentialId === credentialId);
   if (!entry) {
@@ -356,7 +461,7 @@ export async function unlockPasskey(record: VaultRecord): Promise<string> {
     if (getPublicKey(hexToBytes(privkeyHex)) !== record.pubkey) {
       throw new UnlockFailedError('Decrypted key does not match the vault pubkey');
     }
-    return privkeyHex;
+    return { privkeyHex, credentialId, assertion };
   } catch (e) {
     if (e instanceof PasskeyVaultError) throw e;
     throw new UnlockFailedError(


### PR DESCRIPTION
## What

Client half of cross-device passkey sign-in, consuming the #507 endpoints. **Ships dark**: everything is behind `PASSKEY_SYNC_ENABLED = false` in `src/lib/passkeySync.ts` (R3) — no sync UI renders and no vault-sync network call is made anywhere while the flag is off. Staging flow: merge into the staging branch with the flag flipped.

## Flow highlights

- **New device**: "Sign in with passkey" (record-less devices only — a local record keeps the Phase 1 unlock card, zero network) → one discoverable ceremony carrying the server challenge **and** `prf.eval` → assertion-gated blob fetch → local decrypt → **byte-verify the derived pubkey against the record** → session established, record persisted (the device is a Phase 1 device from then on). Any failure: typed error, clean fallthrough to normal login, nothing persisted. A blob that fails decrypt is never written.
- **Ceremony budget (Gate 2 addition 2)**: enrollment is exactly **two prompts** with sync on or off — the verify-get signs over the server challenge, so its assertion doubles as the TOFU PUT. Removal and both toggle directions are one prompt each (unlock ceremony reused for DELETE/PUT). No provider forces a third prompt: the design adds zero ceremonies over Phase 1, so the stop-and-report condition never arose — asserted by tests (`create ×1, get ×1`).
- **DELETE idempotency (ruling pin)**: 404 = already-gone — resolves cleanly, no error, no warning, **no retry state** — pinned at both the `passkeySync` and `AuthManager` layers.
- **R1**: enrollment toggle default ON with plain "encrypted copy on Zap Cooking's servers" disclosure; settings kill-switch; **both** toggle directions disclose their passkey confirmation (addition 3).
- **Best-effort everywhere**: upload failure never fails enrollment (pending flag; retry rides the *next unlock's* ceremony — still one prompt); offline unlock works and keeps the flag.

## ⚠️ Two flagged deviations

1. **`VaultKeyEntry` gains optional `spki`/`alg`** (the credential public key from `create()`, base64url — public material, ~120 bytes). Without persisting it, upload-retry and toggle-on-later would be impossible (SPKI is only obtainable at create() time). The frozen v1 fixture and all Phase 1 records remain valid everywhere (client validation and server `validateBlob` never require the fields); records lacking them get sync via the approved guided re-enrollment. This is a format *extension*, not a change — flagging because "the blob IS the Phase 1 record" was spec language.
2. **"Deletion failure retried opportunistically" → implemented as log-and-abandon.** After removal no credential remains to assert with (the user may delete the passkey from their provider), so no viable retry vehicle exists; the server's 370-day TTL (R4) is the backstop, which is exactly what it was designed for.

## Pre-Phase-2 migration

Enrolled-before-this-build records (no stored SPKI) get a settings card: "Re-create passkey & enable" — copy explains the one extra prompt and that the old "Zap Cooking" passkey in their manager becomes deletable. Implemented via `enrollVault({ migrate: true })`, which skips `excludeCredentials` (the provider would otherwise refuse to mint the new credential).

## Testing

**435/435** (36 new): new-device happy path / fetch-fail / decrypt-fail / pubkey-mismatch / missing-PRF (hybrid QR shape) all fail closed with nothing persisted; upload-fail → enrollment still succeeds + pending retry on next unlock (single prompt, asserted); removal issues DELETE with exactly one ceremony; **404-idempotency pins**; toggle matrix incl. failed opt-in stays OFF; SPKI capture incl. provider-without-getPublicKey; two-prompt budget assertions; **conflict-replace makes zero network calls** (R4 regression). Sync-enabled AuthManager flows are tested via a partial module mock that flips only the flag — all other sync code runs real, crypto runs real against the frozen `vault-v1.json` vectors. svelte-check 0 errors; production build clean.

Manual checklist extended with 12 Phase 2 cases (`docs/passkey-vault-manual-tests.md`): Safari↔Safari (iCloud), Chrome↔Android (GPM), cross-ecosystem miss (expected), hybrid/QR fail-closed, both toggle directions, second-device delete verification, offline enrollment retry, conflict-replace.

Known-ignorable: "Workers Builds" checks fail as always; Pages is the real deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)