### PR TITLE
Bind VAULT_SYNC preview namespace via env.preview (Pages ignores preview_id)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.595",
+  "version": "4.2.596",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -22,11 +22,41 @@
     },
     {
       // Passkey vault-sync blobs (plus the routes' rate-limit buckets and
-      // challenge tombstones). preview_id is REQUIRED: preview deployments
-      // must never read or write production vault blobs.
+      // challenge tombstones). Preview deployments bind the isolated
+      // preview namespace via env.preview below — `preview_id` is a
+      // Workers-config concept that Pages IGNORES (verified empirically:
+      // the dashboard-deployed config bound production for both envs).
       "binding": "VAULT_SYNC",
-      "id": "4f550842d84c45549c4d30a3cd3f10c3",
-      "preview_id": "97815021dedf4b3483669f99e6aa1347"
+      "id": "4f550842d84c45549c4d30a3cd3f10c3"
     }
-  ]
+  ],
+  // Pages per-environment override. NOTE: kv_namespaces is a
+  // non-inheritable key — this array REPLACES the top-level list for
+  // preview deployments wholesale, so every binding must be repeated here.
+  // Only VAULT_SYNC differs (isolated preview namespace: previews and
+  // staging.zap.cooking must never read or write production vault blobs);
+  // the other three deliberately keep their production ids — their
+  // preview-isolation status is a separate follow-up decision.
+  "env": {
+    "preview": {
+      "kv_namespaces": [
+        {
+          "binding": "SHORTLINKS",
+          "id": "2ad4aaf7011543b7b70c8c46a14766e1"
+        },
+        {
+          "binding": "GATED_CONTENT",
+          "id": "e373fff5cddb4db885eb4f027c307545"
+        },
+        {
+          "binding": "NOURISH_FLAGS",
+          "id": "62b1fc47ff274697923fc65e51592734"
+        },
+        {
+          "binding": "VAULT_SYNC",
+          "id": "97815021dedf4b3483669f99e6aa1347"
+        }
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## What

Fixes the vault-sync preview isolation that PR #507 claimed but never actually wired: `preview_id` is a **Workers**-config concept that Pages silently ignores. Verified empirically — `wrangler pages download config` showed the deployed dashboard config binding the **production** namespace (`4f550842…`) for **both** environments, so staging/preview vault-sync writes (rate-limit buckets, challenge tombstones, and any enrollment blobs) were landing in production KV.

## Mechanism

Replaced with the override Pages honors: `env.preview.kv_namespaces`. Since `kv_namespaces` is a **non-inheritable key**, the preview array replaces the top-level list wholesale — all four bindings are repeated verbatim, with only `VAULT_SYNC` differing:

| Binding | Production | Preview |
|---|---|---|
| SHORTLINKS | `2ad4aaf7…` | `2ad4aaf7…` (unchanged) |
| GATED_CONTENT | `e373fff5…` | `e373fff5…` (unchanged) |
| NOURISH_FLAGS | `62b1fc47…` | `62b1fc47…` (unchanged) |
| **VAULT_SYNC** | `4f550842…` | **`97815021…` (isolated)** |

Validated via `wrangler pages dev` startup: config parses, all four bindings resolve. 435/435 tests (config-only change).

## ⚠️ Flagged, deliberately NOT changed here (single concern)

**The other three namespaces have the same both-environments-share-production exposure** — confirmed by the dashboard config download: `SHORTLINKS`, `GATED_CONTENT`, and `NOURISH_FLAGS` are bound to their production namespaces in Preview too. That means preview/staging deployments can read and write production shortlinks, gated-content entries, and Nourish rate-limit/flag data today, and always could. Whether each warrants an isolated preview namespace (some may *want* shared data, e.g. shortlinks resolving on staging) is a per-binding product decision — follow-up, not this PR.

## After merge

Pull main into staging and redeploy (per plan). Post-redeploy verification of the isolation: enroll a test vault on staging, then check the namespaces — note that `wrangler kv key list/get` from this workstation's OAuth session returns empty for *everything* (including garbage IDs — unreliable tooling, see the investigation), so verify via the dashboard KV browser instead: the blob's `sha256(credentialId)` key should appear in `VAULT_SYNC_PREVIEW` (`97815021…`) and NOT in `VAULT_SYNC` (`4f550842…`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)