### PR TITLE
Passkey-first signup (Phase 3 — gated off)

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -33,6 +33,15 @@ jobs:
             exit 1
           fi
 
+      - name: PASSKEY_SIGNUP_ENABLED must be false on main 🚫
+        run: |
+          if ! grep -q "export const PASSKEY_SIGNUP_ENABLED = false" src/lib/passkeySync.ts; then
+            echo "::error file=src/lib/passkeySync.ts::PASSKEY_SIGNUP_ENABLED is not false."
+            echo "Launch flips SIGNUP and SYNC together in one deliberate PR that"
+            echo "updates this guard (R3 ruling). A stray flip must not reach main."
+            exit 1
+          fi
+
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/docs/passkey-vault-manual-tests.md
+++ b/docs/passkey-vault-manual-tests.md
@@ -84,6 +84,20 @@ not data loss.
 | P2-11 | Enrollment with the network blocked (devtools offline after page load) | Enrollment still succeeds locally; sync retries silently on next unlock (verify with devtools online: PUT fires during unlock, single prompt) | ☐ |
 | P2-12 | Conflict-replace (different account's nsec over a synced vault) | Local record replaced after confirm; NO vault-sync network call; original owner's other devices still sign in (R4) | ☐ |
 
+## Phase 3 — passkey-first signup (requires PASSKEY_SIGNUP_ENABLED + PASSKEY_SYNC_ENABLED = true build)
+
+| # | Steps | Expected | Status |
+|---|-------|----------|--------|
+| P3-1 | Full signup, Safari desktop: Create Profile → Secure your account (sync checked) → two biometric prompts → backup (download) → profile → land. **Then immediately "Sign in with passkey" on the paired iPhone.** | The launch-story demo end to end: signed up with a fingerprint, signed in on the phone with a face. No plaintext key in desktop localStorage at any point (verify devtools). Backup banner reads "Passkey created… this key is your account". | ☐ |
+| P3-2 | Same on Chrome desktop → Android phone (GPM) | Same | ☐ |
+| P3-3 | Skip path: tap "Skip for now" | Remainder of signup is byte-identical to today (plaintext path); Settings enrollment still offered later | ☐ |
+| P3-4 | Cancel the biometric sheet mid-step | Stays on the step, no error banner; retry works; skip still available | ☐ |
+| P3-5 | Failure recovery: provider without PRF (e.g. security key selected) | Friendly error + orphan-passkey note as a separate line; continue → account created on plaintext path | ☐ |
+| P3-6 | Unsupported browser (e.g. Firefox ESR) or preview origin | Secure step never renders — flow identical to today, not a disabled step | ☐ |
+| P3-7 | Conflict at signup: browser holds another account's vault → Create Profile | "Replace saved login?" dialog BEFORE the secure step; confirm → local record replaced (no network call), step proceeds; cancel → step skipped, plaintext signup | ☐ |
+| P3-8 | Sync checkbox unchecked at signup | Enrolled locally, zero /api/vault-sync traffic (devtools network) | ☐ |
+| P3-9 | Abandon the modal right after enrolling (before backup) | User lands logged in (passkey session); Settings shows enrolled vault; nsec reveal available for backup | ☐ |
+
 ## Non-regression
 
 | # | Steps | Expected | Chrome desktop | Android Chrome |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.596",
+  "version": "4.2.597",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/LoginOverlay.svelte
+++ b/src/components/LoginOverlay.svelte
@@ -14,8 +14,12 @@
   import {
     detectSupport,
     getVaultRecord,
+    deleteVaultRecord,
     isCeremonyCancelled,
-    type VaultRecord
+    PrfUnsupportedError,
+    PasskeyVaultError,
+    type VaultRecord,
+    type VaultSupport
   } from '$lib/passkeyVault';
   import { onMount, onDestroy, tick } from 'svelte';
   import { env as publicEnv } from '$env/dynamic/public';
@@ -32,7 +36,12 @@
     type GoogleSession
   } from '$lib/googleBackup/googleBackupFlow';
   import { isValidPin } from '$lib/googleBackup/googleBackupCrypto';
-  import { PASSKEY_SYNC_ENABLED, shouldOfferSyncSignIn } from '$lib/passkeySync';
+  import {
+    PASSKEY_SYNC_ENABLED,
+    PASSKEY_SIGNUP_ENABLED,
+    shouldOfferSyncSignIn,
+    shouldOfferSignupEnrollment
+  } from '$lib/passkeySync';
 
   let authManager: any = null;
   let authState: AuthState = {
@@ -128,6 +137,17 @@
   // unsupported origin (e.g. an old preview build's localStorage) must not
   // offer an unlock that can no longer bind to the real rp id.
   let vaultSupported = false;
+  // Full detection level — the signup step needs 'full' (PRF confirmed
+  // plausible), stricter than the unlock card's !== 'none'.
+  let vaultSupportLevel: VaultSupport = 'none';
+
+  // "Secure your account" signup step (Phase 3, behind PASSKEY_SIGNUP_ENABLED).
+  let securePending = false; // step renders between generate and backup
+  let secureEnrolled = false; // switches the backup banner copy
+  let secureBusy = false;
+  let secureError = '';
+  let secureOrphanNote = false;
+  let secureSyncOn = true; // R1: default ON
 
   // Vault conflict confirmation: signing in with a key that differs from the
   // enrolled vault's account requires an explicit "replace" confirmation
@@ -213,8 +233,11 @@
   onMount(() => {
     try {
       vaultRecord = getVaultRecord();
-      if (vaultRecord || PASSKEY_SYNC_ENABLED) {
-        detectSupport().then((s) => (vaultSupported = s !== 'none'));
+      if (vaultRecord || PASSKEY_SYNC_ENABLED || PASSKEY_SIGNUP_ENABLED) {
+        detectSupport().then((s) => {
+          vaultSupported = s !== 'none';
+          vaultSupportLevel = s;
+        });
       }
       if (vaultRecord) {
         try {
@@ -490,6 +513,70 @@
     generatedKeys = authManager.generateKeyPair();
     backupStep = 1;
     backupDownloaded = false;
+    secureEnrolled = false;
+    secureError = '';
+    secureOrphanNote = false;
+    secureSyncOn = true;
+
+    // "Secure your account" step eligibility (Phase 3). Ineligible →
+    // securePending stays false and the rendered flow is byte-identical to
+    // today (R4: the step is absent, never disabled).
+    securePending = shouldOfferSignupEnrollment({
+      flagEnabled: PASSKEY_SIGNUP_ENABLED,
+      support: vaultSupportLevel
+    });
+
+    // Conflict pre-check (§3 ruling): a fresh keypair can never own an
+    // existing record, so any record here is a FOREIGN vault. Surface the
+    // existing replace dialog BEFORE the secure step — enrolling first
+    // would silently overwrite it. Confirm → local-only delete (never a
+    // network call — R4 Phase 2) and the step proceeds; cancel → the step
+    // is skipped and signup continues on today's plaintext path.
+    if (securePending && getVaultRecord()) {
+      securePending = false;
+      raiseVaultConflict(
+        'This browser has a saved login for another account. Creating a new profile will ' +
+          "remove that saved login — make sure the other account's key is backed up first.",
+        async () => {
+          deleteVaultRecord();
+          securePending = true;
+        }
+      );
+    }
+  }
+
+  async function secureWithPasskey() {
+    if (!authManager || !generatedKeys) return;
+    secureBusy = true;
+    secureError = '';
+    secureOrphanNote = false;
+    try {
+      const privateKeyHex = Array.from(generatedKeys.privateKey)
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+      await authManager.enrollAtSignup(privateKeyHex, generatedKeys.publicKey, {
+        sync: secureSyncOn
+      });
+      secureEnrolled = true;
+      securePending = false; // advance to the backup step
+    } catch (error: any) {
+      if (isCeremonyCancelled(error)) {
+        // Dismissed sheet: stay on the step silently; skip link remains.
+      } else {
+        secureOrphanNote = error instanceof PasskeyVaultError && error.orphanPasskeyLikely;
+        secureError =
+          error instanceof PrfUnsupportedError
+            ? "Your password manager doesn't support this feature yet. Nothing was changed — " +
+              'continue below and your account will work normally.'
+            : error?.message || 'Could not set up the passkey. Nothing was changed.';
+      }
+    } finally {
+      secureBusy = false;
+    }
+  }
+
+  function skipSecureStep() {
+    securePending = false;
   }
 
   function downloadKeysBackup() {
@@ -612,6 +699,12 @@
     nsecModal = false;
     generateModal = false;
     bunkerModal = false;
+    securePending = false;
+    secureEnrolled = false;
+    secureBusy = false;
+    secureError = '';
+    secureOrphanNote = false;
+    secureSyncOn = true;
     nip46UniversalModal = false;
     googleModal = false;
     googleStep = 'signin';
@@ -1067,7 +1160,11 @@
         </div>
       {:else}
         <h2 class="login-modal-title">
-          {backupStep === 2 ? 'Add a display name and bio (optional)' : '🔐 Save your backup key'}
+          {securePending
+            ? '🔐 Secure your account'
+            : backupStep === 2
+              ? 'Add a display name and bio (optional)'
+              : '🔐 Save your backup key'}
         </h2>
       {/if}
       <div class="flex flex-col gap-4">
@@ -1088,11 +1185,72 @@
               <p class="text-xs text-caption text-center mt-2">Takes less than 10 seconds</p>
             </div>
           </div>
+        {:else if securePending}
+          <!-- Phase 3 "Secure your account" step. Renders only when
+               PASSKEY_SIGNUP_ENABLED and detectSupport() === 'full'; skip
+               continues into today's flow unchanged. -->
+          <div class="space-y-4">
+            <p class="text-sm text-caption">
+              Protect your new account with a passkey — Face ID, Touch ID, or your device screen
+              lock. You'll sign in with a tap instead of a key, on this device and your other
+              devices through your password manager.
+            </p>
+            <p class="text-sm text-caption">
+              <strong style="color: var(--color-text-primary)">A passkey is not a backup.</strong>
+              You'll save your account key in the next step — keep both.
+            </p>
+
+            {#if PASSKEY_SYNC_ENABLED}
+              <label class="flex items-start gap-2 cursor-pointer">
+                <input type="checkbox" bind:checked={secureSyncOn} disabled={secureBusy} class="mt-0.5" />
+                <span class="text-xs text-caption">
+                  <span class="font-medium" style="color: var(--color-text-primary)">
+                    Sign in on other devices.
+                  </span>
+                  Stores an encrypted copy of your key on Zap Cooking's servers — only your passkey
+                  can unlock it. You can turn this off any time in Settings.
+                </span>
+              </label>
+            {/if}
+
+            {#if secureError}
+              <div class="signin-error" role="alert">
+                <p>{secureError}</p>
+                {#if secureOrphanNote}
+                  <p class="mt-1">
+                    (A passkey may have been created in your password manager; it's safe to delete.)
+                  </p>
+                {/if}
+              </div>
+            {/if}
+
+            <div>
+              <Button on:click={secureWithPasskey} primary={true} disabled={secureBusy} class="w-full">
+                {secureBusy ? 'Waiting for passkey…' : 'Set up passkey'}
+              </Button>
+              <button
+                type="button"
+                class="block mx-auto mt-3 text-xs text-caption hover:opacity-80 underline"
+                on:click={skipSecureStep}
+                disabled={secureBusy}
+              >
+                Skip for now — you can turn this on later in Settings
+              </button>
+            </div>
+          </div>
         {:else}
           <div class="space-y-4">
             {#if backupStep === 1}
               <div class="bg-green-50 border border-green-200 rounded-lg p-3">
-                <p class="text-sm text-green-700">✓ Your profile has been created. Save your backup key below to recover it later.</p>
+                <p class="text-sm text-green-700">
+                  {#if secureEnrolled}
+                    ✓ Passkey created. Now save your account key — the passkey signs you in, but
+                    <strong>this key is your account</strong>, and it's the only way back in if you
+                    ever lose access to your passkeys.
+                  {:else}
+                    ✓ Your profile has been created. Save your backup key below to recover it later.
+                  {/if}
+                </p>
               </div>
             {/if}
             {#if backupStep === 1}

--- a/src/lib/authManager.signup.test.ts
+++ b/src/lib/authManager.signup.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import fixture from '../test/fixtures/vault-v1.json';
+
+/**
+ * Phase 3 passkey-first signup: enrollAtSignup composes enrollPasskey →
+ * authenticateWithPrivateKey (same-pubkey ADOPTION) → uploadVault. Flags
+ * forced ON via partial module mock (everything else real); authenticator
+ * and fetch mocked; crypto real against the frozen vault-v1 vectors.
+ *
+ * The headline pin (§2 ruling): the plaintext private key is NEVER written
+ * to localStorage at any instant during the happy path — asserted with a
+ * setItem SPY over the whole flow, not just absence at the end.
+ */
+
+vi.mock('$app/environment', () => ({ browser: true }));
+
+vi.mock('./passkeySync', async (importOriginal: () => Promise<unknown>) => {
+  const real = (await importOriginal()) as Record<string, unknown>;
+  return { ...real, PASSKEY_SYNC_ENABLED: true, PASSKEY_SIGNUP_ENABLED: true };
+});
+
+vi.mock('@nostr-dev-kit/ndk', async () => {
+  const { getPublicKey } = await import('nostr-tools');
+  const toBytes = (hex: string) =>
+    Uint8Array.from(hex.match(/.{2}/g)!.map((b: string) => parseInt(b, 16)));
+  class NDKPrivateKeySigner {
+    privateKey: string;
+    constructor(pk: string) {
+      this.privateKey = pk;
+    }
+    async user() {
+      const pubkey = getPublicKey(toBytes(this.privateKey));
+      return { pubkey, hexpubkey: pubkey };
+    }
+  }
+  class NDKNip46Signer {}
+  class NDKNip07Signer {}
+  class NDKRelaySet {
+    static fromRelayUrls() {
+      return {};
+    }
+  }
+  return {
+    NDKPrivateKeySigner,
+    NDKNip46Signer,
+    NDKNip07Signer,
+    NDKRelaySet,
+    NDKSubscriptionCacheUsage: { ONLY_RELAY: 'ONLY_RELAY' }
+  };
+});
+
+import { AuthManager, VaultConflictError } from './authManager';
+import { VAULT_STORAGE_KEY, type VaultRecord } from './passkeyVault';
+import { SYNC_ENABLED_KEY } from './passkeySync';
+import { hexToBytes, bytesToB64 } from './passkeyVaultCrypto';
+
+const NSEC = fixture.nsecHex;
+const PUBKEY = fixture.pubkeyHex;
+const CRED_ID = fixture.credentialIdB64url;
+const PK_KEY = 'nostrcooking_privateKey';
+const FOREIGN_PUBKEY = 'ab'.repeat(32);
+
+function fakeCredential(ext: { prfResult?: Uint8Array; prfEnabled?: boolean } = {}) {
+  const raw = Uint8Array.from(atob(CRED_ID.replace(/-/g, '+').replace(/_/g, '/') + '=='), (c) =>
+    c.charCodeAt(0)
+  );
+  return {
+    id: CRED_ID,
+    rawId: raw.buffer,
+    type: 'public-key',
+    response: {
+      signature: new Uint8Array([1]).buffer,
+      authenticatorData: new Uint8Array([2]).buffer,
+      clientDataJSON: new Uint8Array([3]).buffer,
+      getPublicKey: () => new Uint8Array([9, 9]).buffer,
+      getPublicKeyAlgorithm: () => -7
+    },
+    getClientExtensionResults: () => {
+      if (ext.prfResult) return { prf: { results: { first: ext.prfResult.slice().buffer } } };
+      if (ext.prfEnabled !== undefined) return { prf: { enabled: ext.prfEnabled } };
+      return {};
+    }
+  };
+}
+
+function foreignRecord(): VaultRecord {
+  return {
+    version: 1,
+    pubkey: FOREIGN_PUBKEY,
+    nsecCiphertext: fixture.expectedNsecCiphertextB64,
+    createdAt: 1,
+    keys: [
+      {
+        credentialId: 'Zm9yZWlnbi1jcmVk',
+        wrappedDek: fixture.expectedWrappedDekB64,
+        dekIv: bytesToB64(hexToBytes(fixture.dekIvHex)),
+        addedAt: 1
+      }
+    ]
+  };
+}
+
+let store: Map<string, string>;
+let setItemKeys: string[];
+let fetchMock: ReturnType<typeof vi.fn>;
+let credentials: { create: ReturnType<typeof vi.fn>; get: ReturnType<typeof vi.fn> };
+let ndk: { signer: any; activeUser: any };
+
+const json = (status: number, body: unknown) => new Response(JSON.stringify(body), { status });
+const flush = () => new Promise((r) => setTimeout(r, 10));
+
+function happyAuthenticator() {
+  credentials.create.mockResolvedValue(fakeCredential({ prfEnabled: true }));
+  credentials.get.mockResolvedValue(
+    fakeCredential({ prfResult: hexToBytes(fixture.prfOutputHex) })
+  );
+}
+
+function acceptingServer() {
+  fetchMock.mockImplementation(async (url: string) =>
+    String(url).endsWith('/challenge')
+      ? json(200, { challenge: 'c2VydmVyLWNoYWxsZW5nZQ', expiresAt: Date.now() + 120000 })
+      : json(200, { ok: true })
+  );
+}
+
+beforeEach(() => {
+  store = new Map();
+  setItemKeys = [];
+  (globalThis as any).localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => {
+      setItemKeys.push(k); // the spy: records EVERY write, not just final state
+      store.set(k, String(v));
+    },
+    removeItem: (k: string) => store.delete(k),
+    clear: () => store.clear()
+  };
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+  credentials = { create: vi.fn(), get: vi.fn() };
+  vi.stubGlobal('navigator', { credentials });
+  vi.stubGlobal('window', {
+    isSecureContext: true,
+    PublicKeyCredential: function PublicKeyCredential() {}
+  });
+  ndk = { signer: null, activeUser: null };
+});
+
+describe('enrollAtSignup — happy path', () => {
+  it('never writes the plaintext key at ANY instant (setItem spy), session passkey, blob uploaded', async () => {
+    acceptingServer();
+    happyAuthenticator();
+    const am = new AuthManager(ndk);
+
+    await am.enrollAtSignup(NSEC, PUBKEY, { sync: true });
+    await flush();
+
+    // The §2 pin: no write of nostrcooking_privateKey EVER happened.
+    expect(setItemKeys).not.toContain(PK_KEY);
+
+    const state = am.getState();
+    expect(state.isAuthenticated).toBe(true);
+    expect(state.authMethod).toBe('passkey'); // adoption branch, not privateKey
+    expect(state.publicKey).toBe(PUBKEY);
+    expect(ndk.signer?.privateKey).toBe(NSEC);
+    expect(JSON.parse(store.get(VAULT_STORAGE_KEY)!).pubkey).toBe(PUBKEY);
+    expect(store.get(SYNC_ENABLED_KEY)).toBe('1');
+
+    // Two-prompt budget; TOFU PUT rode the verify-get assertion.
+    expect(credentials.create).toHaveBeenCalledTimes(1);
+    expect(credentials.get).toHaveBeenCalledTimes(1);
+    const puts = fetchMock.mock.calls.filter(([, init]: any) => init?.method === 'PUT');
+    expect(puts).toHaveLength(1);
+    expect(JSON.parse(puts[0][1].body).assertion.credentialId).toBe(CRED_ID);
+  });
+
+  it('a later re-auth with the same key (useGeneratedKeys shape) stays plaintext-free', async () => {
+    acceptingServer();
+    happyAuthenticator();
+    const am = new AuthManager(ndk);
+    await am.enrollAtSignup(NSEC, PUBKEY, { sync: true });
+
+    // useGeneratedKeys calls authenticateWithPrivateKey again at activation.
+    await am.authenticateWithPrivateKey(NSEC);
+
+    expect(setItemKeys).not.toContain(PK_KEY);
+    expect(am.getState().authMethod).toBe('passkey');
+  });
+
+  it('sync unchecked → zero network calls, sync recorded off', async () => {
+    happyAuthenticator();
+    const am = new AuthManager(ndk);
+    await am.enrollAtSignup(NSEC, PUBKEY, { sync: false });
+    await flush();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(store.get(SYNC_ENABLED_KEY)).toBe('0');
+    expect(setItemKeys).not.toContain(PK_KEY);
+    expect(am.getState().authMethod).toBe('passkey');
+  });
+});
+
+describe('enrollAtSignup — failure is non-destructive', () => {
+  it('PRF failure → nothing persisted, not authenticated; plaintext path still works after', async () => {
+    acceptingServer();
+    credentials.create.mockResolvedValue(fakeCredential({ prfEnabled: true }));
+    credentials.get.mockResolvedValue(fakeCredential({})); // no PRF on verify-get
+    const am = new AuthManager(ndk);
+
+    await expect(am.enrollAtSignup(NSEC, PUBKEY, { sync: true })).rejects.toThrow();
+
+    expect(am.getState().isAuthenticated).toBe(false);
+    expect(store.get(VAULT_STORAGE_KEY)).toBeUndefined();
+    expect(store.get(PK_KEY)).toBeUndefined();
+
+    // The skip path (today's signup) still activates the account.
+    await am.authenticateWithPrivateKey(NSEC);
+    expect(am.getState().isAuthenticated).toBe(true);
+    expect(am.getState().authMethod).toBe('privateKey');
+    expect(store.get(PK_KEY)).toBe(NSEC);
+  });
+
+  it('user cancel on create → nothing persisted, no error state beyond the rejection', async () => {
+    credentials.create.mockRejectedValue(new DOMException('cancelled', 'NotAllowedError'));
+    const am = new AuthManager(ndk);
+    await expect(am.enrollAtSignup(NSEC, PUBKEY, { sync: false })).rejects.toThrow();
+    expect(store.size).toBe(0);
+    expect(am.getState().isAuthenticated).toBe(false);
+  });
+});
+
+describe('enrollAtSignup — foreign-vault guard (defense-in-depth)', () => {
+  it('refuses with VaultConflictError before any ceremony; record intact', async () => {
+    store.set(VAULT_STORAGE_KEY, JSON.stringify(foreignRecord()));
+    const am = new AuthManager(ndk);
+
+    await expect(am.enrollAtSignup(NSEC, PUBKEY, { sync: true })).rejects.toThrow(
+      VaultConflictError
+    );
+
+    expect(credentials.create).not.toHaveBeenCalled();
+    expect(credentials.get).not.toHaveBeenCalled();
+    expect(JSON.parse(store.get(VAULT_STORAGE_KEY)!).pubkey).toBe(FOREIGN_PUBKEY);
+  });
+
+  it('after the UI replace flow deletes the record, enrollment proceeds', async () => {
+    store.set(VAULT_STORAGE_KEY, JSON.stringify(foreignRecord()));
+    acceptingServer();
+    happyAuthenticator();
+    const am = new AuthManager(ndk);
+
+    // What the conflict dialog's confirm does (local-only, no network).
+    store.delete(VAULT_STORAGE_KEY);
+    const callsBefore = fetchMock.mock.calls.length;
+
+    await am.enrollAtSignup(NSEC, PUBKEY, { sync: false });
+    expect(am.getState().authMethod).toBe('passkey');
+    expect(fetchMock.mock.calls.length).toBe(callsBefore); // replace made no network call
+  });
+});

--- a/src/lib/authManager.ts
+++ b/src/lib/authManager.ts
@@ -24,6 +24,7 @@ import {
 import { hexToBytes } from './passkeyVaultCrypto';
 import {
   PASSKEY_SYNC_ENABLED,
+  PASSKEY_SIGNUP_ENABLED,
   isSyncEnabled,
   setSyncEnabled,
   isUploadPending,
@@ -1613,6 +1614,68 @@ export class AuthManager {
       }
       // No syncable entry (provider without getPublicKey): sync simply
       // cannot happen for this credential — nothing to retry.
+    } else if (opts?.sync === false) {
+      setSyncEnabled(false);
+    }
+  }
+
+  // Passkey-first signup (Phase 3): enroll a JUST-GENERATED key, then start
+  // the session through the same-pubkey ADOPTION branch of
+  // authenticateWithPrivateKey — the plaintext key is never written to
+  // storage at any instant (pinned by test with a setItem spy). Composition
+  // of three merged primitives: enrollPasskey → authenticate(adopts) →
+  // uploadVault. Two prompts total; with opts.sync the verify-get carries
+  // the TOFU PUT assertion (Phase 2 pattern).
+  //
+  // Failure at any point is non-destructive: nothing persisted, no session
+  // — the caller (signup UI) lets the user retry, or skip into today's
+  // plaintext path, which still works unchanged.
+  async enrollAtSignup(
+    privkeyHex: string,
+    pubkey: string,
+    opts?: { sync?: boolean }
+  ): Promise<void> {
+    if (!browser) throw new Error('Browser environment required');
+    if (!PASSKEY_SIGNUP_ENABLED) throw new Error('Passkey signup is not enabled');
+
+    // Defense-in-depth (same philosophy as removeVault's guard): a fresh
+    // keypair can never own an existing record, so any record here is a
+    // FOREIGN vault — enrolling would silently overwrite it. The signup UI
+    // pre-empts this with the conflict dialog; the method refuses
+    // independently in case that gating ever regresses.
+    const existing = getVaultRecord();
+    if (existing && existing.pubkey !== pubkey) {
+      throw new VaultConflictError(existing.pubkey);
+    }
+
+    let label = 'Zap Cooking';
+    try {
+      label = `Zap Cooking · ${nip19.npubEncode(pubkey).slice(0, 13)}…`;
+    } catch {
+      /* keep default */
+    }
+
+    const wantSync = PASSKEY_SYNC_ENABLED && opts?.sync === true;
+    const serverChallenge = wantSync ? await fetchChallengeSafe() : null;
+
+    const { record, assertion } = await enrollPasskey(
+      privkeyHex,
+      pubkey,
+      label,
+      serverChallenge ? { serverChallenge } : undefined
+    );
+
+    // Record exists for this pubkey now — this authenticates via adoption:
+    // authMethod 'passkey', plaintext never persisted.
+    await this.authenticateWithPrivateKey(privkeyHex);
+
+    if (wantSync) {
+      setSyncEnabled(true);
+      if (serverChallenge && assertion && syncableKeyEntry(record)) {
+        void uploadVault(record, assertion);
+      } else if (syncableKeyEntry(record)) {
+        setUploadPending(true);
+      }
     } else if (opts?.sync === false) {
       setSyncEnabled(false);
     }

--- a/src/lib/passkeySync.test.ts
+++ b/src/lib/passkeySync.test.ts
@@ -16,6 +16,7 @@ import {
   fetchChallengeSafe,
   syncableKeyEntry,
   shouldOfferSyncSignIn,
+  shouldOfferSignupEnrollment,
   isUploadPending,
   setUploadPending,
   SyncSignInError,
@@ -248,6 +249,13 @@ describe('helpers', () => {
     const badAlg = fixtureRecord();
     (badAlg.keys[0] as any).alg = -8;
     expect(syncableKeyEntry(badAlg)).toBeNull();
+  });
+
+  it('shouldOfferSignupEnrollment: flag AND full support only (step absent, never disabled)', () => {
+    expect(shouldOfferSignupEnrollment({ flagEnabled: true, support: 'full' })).toBe(true);
+    expect(shouldOfferSignupEnrollment({ flagEnabled: false, support: 'full' })).toBe(false);
+    expect(shouldOfferSignupEnrollment({ flagEnabled: true, support: 'no-prf' })).toBe(false);
+    expect(shouldOfferSignupEnrollment({ flagEnabled: true, support: 'none' })).toBe(false);
   });
 
   it('shouldOfferSyncSignIn matrix', () => {

--- a/src/lib/passkeySync.ts
+++ b/src/lib/passkeySync.ts
@@ -42,6 +42,14 @@ import { getPublicKey } from 'nostr-tools';
  */
 export const PASSKEY_SYNC_ENABLED = false;
 
+/**
+ * Phase 3 gate: passkey enrollment offered inside account creation
+ * ("Secure your account" step). Launch-coupled with PASSKEY_SYNC_ENABLED —
+ * the launch PR flips BOTH together and updates the CI flag-guard in the
+ * same change (R3 ruling). Guarded on main by .github/workflows/checks.yaml.
+ */
+export const PASSKEY_SIGNUP_ENABLED = false;
+
 /** '1' = user opted in (R1 default-ON at enrollment); '0' = explicitly off.
  * ABSENT = off — pre-Phase-2 enrollments must never surprise-upload. */
 export const SYNC_ENABLED_KEY = 'nostrcooking_vault_sync_enabled';
@@ -278,6 +286,19 @@ export async function signInWithPasskey(): Promise<SyncSignInResult> {
   } finally {
     zeroize(kek, dek, prfOutput);
   }
+}
+
+/**
+ * Predicate for the signup "Secure your account" step (unit-tested).
+ * 'full' only: signup must never render a step that the enrollment
+ * ceremony would immediately fail — unsupported browsers get today's
+ * signup byte-identical (R4: absent, not disabled).
+ */
+export function shouldOfferSignupEnrollment(ctx: {
+  flagEnabled: boolean;
+  support: 'full' | 'no-prf' | 'none';
+}): boolean {
+  return ctx.flagEnabled && ctx.support === 'full';
 }
 
 /** Predicate for the LoginOverlay button (unit-tested). */

--- a/src/lib/passkeyVault.test.ts
+++ b/src/lib/passkeyVault.test.ts
@@ -187,6 +187,28 @@ describe('enrollPasskey', () => {
     expect(getVaultRecord()).toBeNull();
   });
 
+  it('tags orphanPasskeyLikely ONLY on failures after create() completed', async () => {
+    // Before create: no credential exists, no orphan possible.
+    let pre: unknown;
+    await enrollPasskey('11'.repeat(32), fixture.pubkeyHex, 'Test').catch((e) => (pre = e));
+    expect((pre as PrfUnsupportedError).orphanPasskeyLikely).toBeFalsy();
+
+    // After create, PRF missing on verify-get: a provider-side credential
+    // may exist — the UI's "safe to delete" note keys off this flag.
+    credentials.create.mockResolvedValue(fakeCredential(NEW_CRED_ID, { prfEnabled: true }));
+    credentials.get.mockResolvedValue(fakeCredential(NEW_CRED_ID, {}));
+    let post: unknown;
+    await enrollPasskey(fixture.nsecHex, fixture.pubkeyHex, 'Test').catch((e) => (post = e));
+    expect(post).toBeInstanceOf(PrfUnsupportedError);
+    expect((post as PrfUnsupportedError).orphanPasskeyLikely).toBe(true);
+
+    // create() itself reporting prf disabled: credential was created.
+    credentials.create.mockResolvedValue(fakeCredential(NEW_CRED_ID, { prfEnabled: false }));
+    let created: unknown;
+    await enrollPasskey(fixture.nsecHex, fixture.pubkeyHex, 'Test').catch((e) => (created = e));
+    expect((created as PrfUnsupportedError).orphanPasskeyLikely).toBe(true);
+  });
+
   it('captures SPKI/alg into the key entry when the provider exposes getPublicKey', async () => {
     const spkiBytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
     credentials.create.mockResolvedValue(

--- a/src/lib/passkeyVault.ts
+++ b/src/lib/passkeyVault.ts
@@ -73,7 +73,15 @@ export interface VaultRecord {
   keys: VaultKeyEntry[];
 }
 
-export class PasskeyVaultError extends Error {}
+export class PasskeyVaultError extends Error {
+  /**
+   * True when the failure happened AFTER create() completed: a credential
+   * may exist in the user's provider even though nothing was persisted on
+   * our side. UI copy shows the "safe to delete" orphan note only when
+   * this is set (we cannot delete authenticator-side credentials).
+   */
+  orphanPasskeyLikely = false;
+}
 /** Authenticator/provider has no usable PRF — enrollment must not proceed. */
 export class PrfUnsupportedError extends PasskeyVaultError {}
 /** Post-enroll round-trip verification failed — nothing was persisted. */
@@ -356,9 +364,16 @@ export async function enrollPasskey(
   })) as PublicKeyCredential | null;
   if (!created) throw new PasskeyVaultError('Passkey creation returned no credential');
 
+  // Everything past this point fails with orphanPasskeyLikely: the
+  // credential exists provider-side even though we persist nothing.
+  const tagOrphan = (e: unknown): never => {
+    if (e instanceof PasskeyVaultError) e.orphanPasskeyLikely = true;
+    throw e;
+  };
+
   const createExt = (created.getClientExtensionResults() as any)?.prf;
   if (createExt && createExt.enabled === false) {
-    throw new PrfUnsupportedError('Passkey provider reported PRF unsupported on create()');
+    tagOrphan(new PrfUnsupportedError('Passkey provider reported PRF unsupported on create()'));
   }
 
   // Capture the credential public key for vault-sync (SPKI DER — no CBOR
@@ -381,7 +396,9 @@ export async function enrollPasskey(
   // Verify-on-get: derive the KEK from a real assertion, never from create().
   // With opts.serverChallenge this same prompt also produces the TOFU PUT
   // assertion — enrollment must never grow a third ceremony.
-  const { credentialId, prfOutput, assertion } = await assertWithPrf([created.id], opts);
+  const { credentialId, prfOutput, assertion } = await assertWithPrf([created.id], opts).catch(
+    tagOrphan
+  );
 
   const kek = deriveKek(prfOutput);
   const dek = generateDek();
@@ -415,10 +432,13 @@ export async function enrollPasskey(
     saveVaultRecord(record);
     return { record, assertion };
   } catch (e) {
-    if (e instanceof PasskeyVaultError) throw e;
-    throw new EnrollVerifyError(
-      `Vault verification failed: ${e instanceof Error ? e.message : String(e)}`
+    if (e instanceof PasskeyVaultError) tagOrphan(e);
+    tagOrphan(
+      new EnrollVerifyError(
+        `Vault verification failed: ${e instanceof Error ? e.message : String(e)}`
+      )
     );
+    throw e; // unreachable — tagOrphan always throws; keeps TS control-flow happy
   } finally {
     zeroize(kek, dek, verifyDek, prfOutput);
   }


### PR DESCRIPTION
## What

The launch story wired into account creation: a new "Secure your account" step between key generation and the existing mandatory backup gate (R1 ruling b). **Ships dark** behind `PASSKEY_SIGNUP_ENABLED = false`; skip or ineligibility yields today's signup **byte-identical** (step absent, never disabled — R4).

## Flow

Create Profile → **Secure your account** (primary "Set up passkey", R1 sync opt-in default ON, de-emphasized "Skip for now" link) → existing download-gated backup step (banner gains the "this key is your account" line when enrolled) → profile → activate.

- **No plaintext at any instant** (§2 ruling): `enrollAtSignup` composes three merged primitives — `enrollPasskey` → `authenticateWithPrivateKey` (same-pubkey **adoption**) → `uploadVault`. Pinned by a **setItem spy over the whole happy path**, not end-state absence.
- **Two prompts total**, TOFU PUT rides the verify-get assertion (Phase 2 pattern), asserted `create ×1 / get ×1`.
- **Conflict at signup** (§3): any existing record is foreign to a fresh keypair — the existing replace dialog fires **before** the step (confirm = local-only delete, zero network — asserted; cancel = step skipped). `enrollAtSignup` independently refuses foreign records (defense-in-depth, `removeVault`-guard philosophy).
- **Failure recovery**: enrollment failure persists nothing; the plaintext path still activates the account (tested). Cancelled sheet = silent stay-on-step. Bonus property: abandoning the modal *after* enrolling now lands the user logged in with a persisted vault — strictly safer than today's abandon-at-backup, which loses the keys.
- Copy per the Gate 2 verdict (4 changes applied verbatim, incl. "account key" vocabulary and the split provider-failure error).

## ⚠️ One file beyond the Gate 2 list, flagged

`passkeyVault.ts` gained `PasskeyVaultError.orphanPasskeyLikely` (tagged on failures **after** `create()` completed) — forced by copy ruling 3, which renders the orphan-passkey note *only when a credential may actually exist provider-side*. Additive; pre/post-create tagging is unit-tested.

## Flags & guard (R3)

`PASSKEY_SIGNUP_ENABLED` sits beside `PASSKEY_SYNC_ENABLED` in `passkeySync.ts`; the CI `flag-guard` now checks both on main. Launch = one PR flipping SIGNUP+SYNC together and updating the guard.

## Testing

**444/444** (9 new): setItem-spy plaintext pin; idempotent re-auth at activation; sync-unchecked → zero network; PRF-failure → recovery into plaintext path; cancel-on-create; foreign-vault refusal with no ceremony; replace-then-proceed with no network; eligibility-predicate matrix; orphan-tagging pre- vs post-create. All 435 pre-existing tests unchanged and passing; Capacitor paths untouched (step lives in the overlay's web branch). svelte-check 0 errors; production build clean.

Manual checklist: 9 new Phase 3 cases in `docs/passkey-vault-manual-tests.md`, headlined by the launch-story demo — desktop signup with a fingerprint, immediate sign-in on the paired phone with a face (P3-1 Safari/iCloud, P3-2 Chrome/GPM).

Known-ignorable: "Workers Builds" checks fail as always.

🤖 Generated with [Claude Code](https://claude.com/claude-code)