### PR TITLE
feat(cheffy): note photo review client — trigger + draft modal (Phase 2)

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -42,6 +42,16 @@ jobs:
             exit 1
           fi
 
+      - name: NOTE_REVIEW_POST_ENABLED must be false on main 🚫
+        run: |
+          if ! grep -q "export const NOTE_REVIEW_POST_ENABLED = false" src/lib/noteReview.ts; then
+            echo "::error file=src/lib/noteReview.ts::NOTE_REVIEW_POST_ENABLED is not false."
+            echo "The Post button ships dark until Phase 3 wires postComment()."
+            echo "Flip it in the Phase 3 PR that adds the publish path AND updates"
+            echo "this guard — a stray flip must not reach main."
+            exit 1
+          fi
+
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.603",
+  "version": "4.2.604",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.604",
+  "version": "4.2.605",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/CheffyNoteReview.svelte
+++ b/src/components/CheffyNoteReview.svelte
@@ -1,0 +1,330 @@
+<script lang="ts">
+  /**
+   * Cheffy Note Photo Review modal (Phase 2).
+   *
+   * Draft-only in this phase: the member picks a mode, Cheffy drafts a
+   * comment or recipe from the note's photo, and the member edits it in
+   * place. Posting is Phase 3 — the Post button ships dark behind
+   * NOTE_REVIEW_POST_ENABLED. Multi-image notes use the first image;
+   * the picker strip is Phase 4.
+   *
+   * All branching logic (phase transitions, error mapping, hedged
+   * copy) lives in $lib/noteReview so it stays unit-testable.
+   */
+  import type { NDKEvent } from '@nostr-dev-kit/ndk';
+  import { goto } from '$app/navigation';
+  import Modal from './Modal.svelte';
+  import CheffyAvatar from './CheffyAvatar.svelte';
+  import { ndk, userPublickey } from '$lib/nostr';
+  import { membershipStatusMap, queueMembershipLookup } from '$lib/stores/membershipStatus';
+  import { THINKING_LINES, COOKING_LINES, ERROR_LINES, pickLine } from '$lib/cheffy';
+  import {
+    requestNoteReview,
+    phaseForResult,
+    NOTE_REVIEW_POST_ENABLED,
+    type NoteReviewMode,
+    type NoteReviewPhase
+  } from '$lib/noteReview';
+
+  export let open = false;
+  export let event: NDKEvent;
+  export let imageUrls: string[] = [];
+
+  // Multi-image notes default to the first image (picker strip: Phase 4).
+  $: imageUrl = imageUrls[0] ?? '';
+
+  let phase: NoteReviewPhase = 'choose';
+  let mode: NoteReviewMode = 'comment';
+  let draft = '';
+  let message = '';
+  let loadingLine = '';
+  let errorLine = '';
+
+  $: signedIn = $userPublickey !== '';
+  $: normalizedPk = $userPublickey.trim().toLowerCase();
+  $: if ($userPublickey) queueMembershipLookup($userPublickey);
+  $: hasMembership = Boolean($membershipStatusMap[normalizedPk]?.active);
+
+  async function run(selected: NoteReviewMode) {
+    mode = selected;
+    phase = 'signing';
+    loadingLine = pickLine(selected === 'recipe' ? COOKING_LINES : THINKING_LINES, loadingLine);
+    const result = await requestNoteReview({
+      ndk: $ndk,
+      imageUrl,
+      noteText: event?.content,
+      mode: selected,
+      noteId: event?.id,
+      // Non-members go through the server-enforced preview budget.
+      experience: signedIn && !hasMembership,
+      onSigned: () => (phase = 'loading')
+    });
+    if (result.ok) draft = result.output;
+    const next = phaseForResult(result);
+    phase = next.phase;
+    message = next.message;
+    if (phase === 'error') errorLine = pickLine(ERROR_LINES, errorLine);
+  }
+
+  function reset() {
+    phase = 'choose';
+    draft = '';
+    message = '';
+  }
+
+  function signIn() {
+    open = false;
+    goto('/login?redirect=' + encodeURIComponent(window.location.pathname));
+  }
+
+  function viewMembership() {
+    open = false;
+    goto('/membership');
+  }
+</script>
+
+<Modal bind:open cleanup={reset}>
+  <div slot="title" class="nr-title">
+    <CheffyAvatar
+      size={28}
+      expression={phase === 'signing' || phase === 'loading' ? 'cooking' : 'happy'}
+      animate={phase === 'signing' || phase === 'loading'}
+    />
+    <span>Ask Cheffy about this dish</span>
+  </div>
+
+  <div class="nr-body">
+    {#if !signedIn}
+      <div class="nr-gate">
+        <CheffyAvatar size={72} expression="neutral" variant="character" />
+        <h2>Sign in to ask Cheffy</h2>
+        <p>Cheffy can draft a friendly reply or guess the recipe — you edit and sign it.</p>
+        <button type="button" class="nr-primary" on:click={signIn}>Sign in</button>
+      </div>
+    {:else if phase === 'choose'}
+      {#if imageUrl}
+        <img class="nr-thumb" src={imageUrl} alt="Dish from the note" loading="lazy" />
+      {/if}
+      <p class="nr-hint">What should Cheffy draft? You'll edit it before anything is posted.</p>
+      <div class="nr-choices">
+        <button type="button" class="nr-choice" on:click={() => run('comment')}>
+          <span class="nr-choice-title">Say something nice</span>
+          <span class="nr-choice-sub">A short, warm reply about the dish</span>
+        </button>
+        <button type="button" class="nr-choice" on:click={() => run('recipe')}>
+          <span class="nr-choice-title">Guess the recipe</span>
+          <span class="nr-choice-sub">Reverse-engineer it from the photo</span>
+        </button>
+      </div>
+    {:else if phase === 'signing'}
+      <div class="nr-wait">
+        <CheffyAvatar size={64} expression="thinking" variant="character" animate />
+        <p>Waiting for your signer to approve…</p>
+        <p class="nr-sub">Using a remote signer? This can take a few seconds.</p>
+      </div>
+    {:else if phase === 'loading'}
+      <div class="nr-wait">
+        <CheffyAvatar size={64} expression="cooking" variant="character" animate />
+        <p>{loadingLine}</p>
+      </div>
+    {:else if phase === 'draft'}
+      <p class="nr-hint">
+        Cheffy's draft — make it yours. {#if !NOTE_REVIEW_POST_ENABLED}Copy it into a reply for now;
+          one-tap posting is coming soon.{/if}
+      </p>
+      <textarea
+        class="nr-draft"
+        class:nr-draft-recipe={mode === 'recipe'}
+        bind:value={draft}
+        rows={mode === 'recipe' ? 16 : 5}
+        aria-label="Cheffy's draft"
+      ></textarea>
+      <div class="nr-actions">
+        <button type="button" class="nr-secondary" on:click={() => run(mode)}>Regenerate</button>
+        <button type="button" class="nr-ghost" on:click={reset}>Start over</button>
+        {#if NOTE_REVIEW_POST_ENABLED}
+          <!-- Phase 3 wires this to postComment(); flag-guarded until then. -->
+          <button type="button" class="nr-primary" disabled>Post reply</button>
+        {/if}
+      </div>
+    {:else if phase === 'dead-end'}
+      <div class="nr-wait">
+        <CheffyAvatar size={64} expression="concerned" variant="character" />
+        <p>{message}</p>
+        <button type="button" class="nr-ghost" on:click={reset}>Back</button>
+      </div>
+    {:else if phase === 'upsell'}
+      <div class="nr-gate">
+        <CheffyAvatar size={72} expression="neutral" variant="character" />
+        <h2>Cheffy photo review is a Pro Kitchen feature</h2>
+        <p>Get a drafted reply or a recipe guess for any dish photo on the feed.</p>
+        <button type="button" class="nr-primary" on:click={viewMembership}>View membership</button>
+      </div>
+    {:else if phase === 'preview-used'}
+      <div class="nr-gate">
+        <CheffyAvatar size={72} expression="happy" variant="character" />
+        <h2>Cheffy already gave your previews a look</h2>
+        <p>Unlock Pro Kitchen to keep asking Cheffy about dishes on the feed.</p>
+        <button type="button" class="nr-primary" on:click={viewMembership}>View membership</button>
+        <button type="button" class="nr-ghost" on:click={() => (open = false)}
+          >Keep exploring</button
+        >
+      </div>
+    {:else}
+      <div class="nr-wait">
+        <CheffyAvatar size={64} expression="concerned" variant="character" />
+        <p>{errorLine}</p>
+        {#if message}<p class="nr-sub">{message}</p>{/if}
+        <div class="nr-actions">
+          <button type="button" class="nr-secondary" on:click={() => run(mode)}>Try again</button>
+          <button type="button" class="nr-ghost" on:click={reset}>Back</button>
+        </div>
+      </div>
+    {/if}
+  </div>
+</Modal>
+
+<style>
+  .nr-title {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .nr-body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 4px 0;
+    max-width: 560px;
+  }
+
+  .nr-thumb {
+    width: 100%;
+    max-height: 220px;
+    object-fit: cover;
+    border-radius: 12px;
+  }
+
+  .nr-hint {
+    color: var(--color-text-secondary);
+    font-size: 0.9rem;
+  }
+
+  .nr-choices {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .nr-choice {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+    padding: 12px 16px;
+    min-height: 44px;
+    border: 1px solid var(--color-input-border);
+    border-radius: 12px;
+    background: transparent;
+    color: var(--color-text-primary);
+    text-align: left;
+    cursor: pointer;
+    transition:
+      border-color 0.15s ease,
+      background-color 0.15s ease;
+  }
+
+  .nr-choice:hover {
+    border-color: var(--color-primary);
+    background: color-mix(in srgb, var(--color-primary) 6%, transparent);
+  }
+
+  .nr-choice-title {
+    font-weight: 600;
+  }
+
+  .nr-choice-sub {
+    color: var(--color-text-secondary);
+    font-size: 0.85rem;
+  }
+
+  .nr-wait,
+  .nr-gate {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    text-align: center;
+    padding: 24px 16px;
+  }
+
+  .nr-gate p,
+  .nr-wait p {
+    max-width: 32ch;
+  }
+
+  .nr-gate p {
+    color: var(--color-text-secondary);
+  }
+
+  .nr-sub {
+    color: var(--color-text-secondary);
+    font-size: 0.85rem;
+  }
+
+  .nr-draft {
+    width: 100%;
+    padding: 12px;
+    border: 1px solid var(--color-input-border);
+    border-radius: 12px;
+    background: var(--color-bg-secondary);
+    color: var(--color-text-primary);
+    font-size: 0.95rem;
+    line-height: 1.45;
+    resize: vertical;
+  }
+
+  .nr-draft-recipe {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.85rem;
+  }
+
+  .nr-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .nr-primary,
+  .nr-secondary,
+  .nr-ghost {
+    min-height: 44px;
+    padding: 0 18px;
+    border-radius: 999px;
+    font-weight: 600;
+    cursor: pointer;
+    border: none;
+  }
+
+  .nr-primary {
+    background-color: var(--color-primary);
+    color: #fff;
+  }
+
+  .nr-primary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .nr-secondary {
+    background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+    color: var(--color-primary);
+  }
+
+  .nr-ghost {
+    background: transparent;
+    color: var(--color-text-secondary);
+  }
+</style>

--- a/src/components/CheffyNoteReviewTrigger.svelte
+++ b/src/components/CheffyNoteReviewTrigger.svelte
@@ -18,6 +18,7 @@
   export let size = 18;
 
   let open = false;
+  let imageUrls: string[] = [];
 
   $: imageUrls = extractImageUrls(event?.content || '');
 </script>

--- a/src/components/CheffyNoteReviewTrigger.svelte
+++ b/src/components/CheffyNoteReviewTrigger.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  /**
+   * "Ask Cheffy about this dish" entry point (Phase 2).
+   *
+   * Self-contained: owns image detection (renders nothing for imageless
+   * notes), owns the modal, and takes the caller's wrapper class so the
+   * two placements (NoteActionBar and FoodstrFeedOptimized's inline
+   * action row) stay one-line drops with no empty-wrapper ghosts.
+   */
+  import type { NDKEvent } from '@nostr-dev-kit/ndk';
+  import CheffyIcon from './icons/CheffyIcon.svelte';
+  import CheffyNoteReview from './CheffyNoteReview.svelte';
+  import { extractImageUrls } from '$lib/imageUrls';
+
+  export let event: NDKEvent;
+  /** Hover/padding wrapper class from the host action row. */
+  export let wrapClass = '';
+  export let size = 18;
+
+  let open = false;
+
+  $: imageUrls = extractImageUrls(event?.content || '');
+</script>
+
+{#if imageUrls.length > 0}
+  <div class={wrapClass}>
+    <button
+      type="button"
+      class="cheffy-trigger"
+      title="Ask Cheffy about this dish"
+      aria-label="Ask Cheffy about this dish"
+      on:click|stopPropagation|preventDefault={() => (open = true)}
+    >
+      <CheffyIcon {size} expression="happy" />
+    </button>
+  </div>
+
+  {#if open}
+    <CheffyNoteReview bind:open {event} {imageUrls} />
+  {/if}
+{/if}
+
+<style>
+  .cheffy-trigger {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    color: var(--color-text-secondary);
+  }
+</style>

--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -43,6 +43,7 @@
   import NoteTotalComments from './NoteTotalComments.svelte';
   import NoteTotalZaps from './NoteTotalZaps.svelte';
   import NoteRepost from './NoteRepost.svelte';
+  import CheffyNoteReviewTrigger from './CheffyNoteReviewTrigger.svelte';
   import CommentThread from './comments/CommentThread.svelte';
   import ZapModal from './ZapModal.svelte';
   import ShareModal from './ShareModal.svelte';
@@ -5296,6 +5297,12 @@
                     <div class="hover:bg-accent-gray rounded-full p-1.5 transition-colors">
                       <NoteRepost {event} />
                     </div>
+
+                    <!-- Renders nothing for imageless notes — the trigger owns detection. -->
+                    <CheffyNoteReviewTrigger
+                      {event}
+                      wrapClass="hover:bg-accent-gray rounded-full p-1.5 transition-colors"
+                    />
 
                     <div class="hover:bg-amber-50/50 rounded-full p-1 transition-colors">
                       <NoteTotalZaps

--- a/src/components/NoteActionBar.svelte
+++ b/src/components/NoteActionBar.svelte
@@ -4,6 +4,7 @@
   import NoteTotalComments from './NoteTotalComments.svelte';
   import NoteRepost from './NoteRepost.svelte';
   import NoteTotalZaps from './NoteTotalZaps.svelte';
+  import CheffyNoteReviewTrigger from './CheffyNoteReviewTrigger.svelte';
   import ZapModal from './ZapModal.svelte';
   import { ndk, userPublickey } from '$lib/nostr';
   import { fetchEngagement, optimisticZapUpdate, markSelfZapCompleted } from '$lib/engagementCache';
@@ -25,6 +26,9 @@
 
   /** Show the repost/quote button */
   export let showRepost: boolean = true;
+
+  /** Show the "Ask Cheffy about this dish" trigger (image-bearing notes only) */
+  export let showCheffy: boolean = true;
 
   let zapModalOpen = false;
 
@@ -103,6 +107,11 @@
       </div>
     {/if}
 
+    {#if showCheffy}
+      <!-- Renders nothing for imageless notes — the trigger owns detection. -->
+      <CheffyNoteReviewTrigger {event} wrapClass={iconWrapClass} />
+    {/if}
+
     <div class={zapWrapClass}>
       <NoteTotalZaps {event} onZapClick={openZapModal} />
     </div>
@@ -138,5 +147,4 @@
   .full .zap-pills-row {
     padding: 0;
   }
-
 </style>

--- a/src/components/NoteContent.svelte
+++ b/src/components/NoteContent.svelte
@@ -11,6 +11,7 @@
   import YouTubeEmbed from './YouTubeEmbed.svelte';
   import MediaCarousel from './MediaCarousel.svelte';
   import { processContentWithProfiles } from '$lib/contentProcessor';
+  import { isImageUrl, filterImageUrls } from '$lib/imageUrls';
   import MediaLightbox from './MediaLightbox.svelte';
   import LightningInvoiceCard from './LightningInvoiceCard.svelte';
 
@@ -40,38 +41,16 @@
     selectedImageIndex = 0;
   }
 
-  // Extract all image URLs from parsed content for navigation
-  function extractImageUrls(parts: any[]): string[] {
-    return parts
-      .filter((part) => part.type === 'url' && part.url && isImageUrl(part.url))
-      .map((part) => part.url);
-  }
+  // Image URLs from parsed content, deduplicated ($lib/imageUrls is the
+  // shared source of truth for detection). Dedup keeps the lightbox
+  // correct for notes that post the same image twice: every open site
+  // resolves its pane via allImageUrls.indexOf(url), so both rendered
+  // occurrences land on the single pane that shows that image.
+  $: allImageUrls = filterImageUrls(
+    finalParsedContent.filter((part: any) => part.type === 'url' && part.url).map((p: any) => p.url)
+  );
 
-  // Update allImageUrls when content changes
-  $: allImageUrls = extractImageUrls(finalParsedContent);
-
-  // Image extensions to detect
-  const IMAGE_EXTENSIONS = /\.(jpg|jpeg|png|gif|webp|svg|bmp|avif)(\?.*)?$/i;
   const VIDEO_EXTENSIONS = /\.(mp4|webm|mov|avi|mkv)(\?.*)?$/i;
-
-  function isImageUrl(url: string): boolean {
-    try {
-      const urlObj = new URL(url);
-      // Check extension
-      if (IMAGE_EXTENSIONS.test(urlObj.pathname)) return true;
-      // Check common image hosting patterns
-      if (urlObj.hostname.includes('image.nostr.build')) return true;
-      if (urlObj.hostname.includes('nostr.build') && urlObj.pathname.includes('/i/')) return true;
-      if (urlObj.hostname.includes('imgur.com')) return true;
-      if (urlObj.hostname.includes('imgproxy')) return true;
-      if (urlObj.hostname.includes('primal.b-cdn.net')) return true;
-      if (urlObj.hostname.includes('media.tenor.com')) return true;
-      if (urlObj.hostname.includes('i.ibb.co')) return true;
-      return false;
-    } catch {
-      return false;
-    }
-  }
 
   function isVideoUrl(url: string): boolean {
     try {

--- a/src/lib/imageUrls.test.ts
+++ b/src/lib/imageUrls.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isImageUrl, extractImageUrls } from './imageUrls';
+import { isImageUrl, extractImageUrls, filterImageUrls } from './imageUrls';
 
 describe('isImageUrl', () => {
   it('accepts extension-bearing image URLs', () => {
@@ -71,5 +71,39 @@ describe('extractImageUrls', () => {
   it('handles empty and image-free content', () => {
     expect(extractImageUrls('')).toEqual([]);
     expect(extractImageUrls('no links here')).toEqual([]);
+  });
+});
+
+describe('filterImageUrls', () => {
+  it('filters, dedupes, and preserves first-occurrence order', () => {
+    const A = 'https://example.com/a.jpg';
+    const B = 'https://example.com/b.png';
+    expect(filterImageUrls([A, 'https://example.com/page.html', B, A, ''])).toEqual([A, B]);
+  });
+
+  it('duplicate image URLs keep lightbox prev/next navigation correct after dedup', () => {
+    // Mirrors NoteContent.svelte's exact index math: allImageUrls feeds
+    // MediaLightbox positionally, and every open site resolves the pane
+    // via allImageUrls.indexOf(url) (clamped to 0). A note posting the
+    // same photo twice must not create a duplicate pane, and BOTH
+    // rendered occurrences must open the single pane that shows it.
+    const A = 'https://image.nostr.build/dish.jpg';
+    const B = 'https://example.com/plated.png';
+    const partsUrls = [A, A, B]; // note content: A appears twice
+
+    const allImageUrls = filterImageUrls(partsUrls);
+    expect(allImageUrls).toEqual([A, B]); // one pane per distinct image
+
+    // Clicking either rendered occurrence of A resolves to pane 0.
+    for (const clicked of [partsUrls[0], partsUrls[1]]) {
+      const index = allImageUrls.indexOf(clicked);
+      expect(index >= 0 ? index : 0).toBe(0);
+    }
+    // Clicking B resolves to pane 1; next from A is B, prev from B is A.
+    expect(allImageUrls.indexOf(B)).toBe(1);
+    expect(allImageUrls[allImageUrls.indexOf(A) + 1]).toBe(B);
+    expect(allImageUrls[allImageUrls.indexOf(B) - 1]).toBe(A);
+    // The counter shows the distinct-image count, not occurrence count.
+    expect(allImageUrls).toHaveLength(2);
   });
 });

--- a/src/lib/imageUrls.ts
+++ b/src/lib/imageUrls.ts
@@ -60,6 +60,25 @@ export function isImageUrl(url: string): boolean {
 }
 
 /**
+ * Filter candidate URLs down to image URLs, preserving first-occurrence
+ * order and deduplicating. Dedup is load-bearing for lightbox
+ * navigation: NoteContent resolves the pane index via
+ * `allImageUrls.indexOf(url)`, so every occurrence of a repeated URL
+ * must resolve to the single pane that renders it.
+ */
+export function filterImageUrls(urls: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const url of urls) {
+    if (url && !seen.has(url) && isImageUrl(url)) {
+      seen.add(url);
+      result.push(url);
+    }
+  }
+  return result;
+}
+
+/**
  * Extract image URLs from raw note content (kind-1 text), in order of
  * appearance, deduplicated. Works on the raw string — unlike
  * NoteContent's internal parts-based extraction, this needs no parser
@@ -67,15 +86,7 @@ export function isImageUrl(url: string): boolean {
  */
 export function extractImageUrls(content: string): string[] {
   if (!content) return [];
-  const seen = new Set<string>();
-  const result: string[] = [];
-  for (const raw of content.match(URL_REGEX) ?? []) {
-    // Strip punctuation that trails a URL embedded in prose.
-    const url = raw.replace(/[.,;:!?]+$/, '');
-    if (!seen.has(url) && isImageUrl(url)) {
-      seen.add(url);
-      result.push(url);
-    }
-  }
-  return result;
+  // Strip punctuation that trails a URL embedded in prose.
+  const candidates = (content.match(URL_REGEX) ?? []).map((raw) => raw.replace(/[.,;:!?]+$/, ''));
+  return filterImageUrls(candidates);
 }

--- a/src/lib/noteReview.test.ts
+++ b/src/lib/noteReview.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  phaseForResult,
+  requestNoteReview,
+  PHOTO_UNCLEAR_LINE,
+  SIGN_FAILED_LINE,
+  NOTE_REVIEW_POST_ENABLED,
+  NOTE_TEXT_MAX_CHARS
+} from './noteReview';
+import { extractImageUrls } from './imageUrls';
+
+describe('NOTE_REVIEW_POST_ENABLED', () => {
+  it('ships dark — posting is Phase 3', () => {
+    expect(NOTE_REVIEW_POST_ENABLED).toBe(false);
+  });
+});
+
+describe('phaseForResult — modal state machine', () => {
+  it('success → draft', () => {
+    expect(phaseForResult({ ok: true, output: 'Lovely crust!' })).toEqual({
+      phase: 'draft',
+      message: ''
+    });
+  });
+
+  it('NOT_MEMBER → upsell, PREVIEW_USED → preview-used', () => {
+    expect(phaseForResult({ ok: false, code: 'NOT_MEMBER' }).phase).toBe('upsell');
+    expect(phaseForResult({ ok: false, code: 'PREVIEW_USED' }).phase).toBe('preview-used');
+  });
+
+  it('NOT_FOOD hedges — never echoes the server line as a confident verdict', () => {
+    // The server line can be a confident "that's a cat" even when the
+    // real cause is a CDN fallback image for a dead link (Phase 1
+    // finding). The client must show the hedged line instead.
+    const { phase, message } = phaseForResult({
+      ok: false,
+      code: 'NOT_FOOD',
+      error: 'A very photogenic cat.'
+    });
+    expect(phase).toBe('dead-end');
+    expect(message).toBe(PHOTO_UNCLEAR_LINE);
+    expect(message).not.toContain('cat');
+    expect(message.toLowerCase()).not.toContain('not food');
+  });
+
+  it('IMAGE_UNREADABLE → same hedged dead-end', () => {
+    const { phase, message } = phaseForResult({ ok: false, code: 'IMAGE_UNREADABLE' });
+    expect(phase).toBe('dead-end');
+    expect(message).toBe(PHOTO_UNCLEAR_LINE);
+  });
+
+  it('SIGN_FAILED → error with signer-flavored copy', () => {
+    const { phase, message } = phaseForResult({ ok: false, code: 'SIGN_FAILED' });
+    expect(phase).toBe('error');
+    expect(message).toBe(SIGN_FAILED_LINE);
+  });
+
+  it('RATE_LIMITED and MEMBERSHIP_UNAVAILABLE surface the server line as a retryable error', () => {
+    for (const code of ['RATE_LIMITED', 'MEMBERSHIP_UNAVAILABLE']) {
+      const { phase, message } = phaseForResult({ ok: false, code, error: 'server says wait' });
+      expect(phase).toBe('error');
+      expect(message).toBe('server says wait');
+    }
+  });
+
+  it('unknown failures fall back to a generic retryable error', () => {
+    const { phase, message } = phaseForResult({ ok: false, code: 'NETWORK' });
+    expect(phase).toBe('error');
+    expect(message.length).toBeGreaterThan(0);
+  });
+});
+
+describe('requestNoteReview', () => {
+  const ndk = {} as never;
+  const base = {
+    ndk,
+    imageUrl: 'https://image.nostr.build/dish.jpg',
+    mode: 'comment' as const,
+    origin: 'https://zap.cooking'
+  };
+
+  function okFetch(payload: unknown = { ok: true, output: 'draft!' }, status = 200) {
+    return vi.fn().mockResolvedValue({
+      ok: status < 400,
+      status,
+      json: async () => payload
+    });
+  }
+
+  it('signs the exact body string it sends, against the endpoint URL', async () => {
+    const signHeader = vi.fn().mockResolvedValue('Nostr abc');
+    const fetchFn = okFetch();
+    await requestNoteReview({
+      ...base,
+      noteText: '  pasta night  ',
+      noteId: 'f'.repeat(64),
+      signHeader,
+      fetchFn
+    });
+    const signOpts = signHeader.mock.calls[0][1];
+    const fetchInit = fetchFn.mock.calls[0][1];
+    expect(signOpts.url).toBe('https://zap.cooking/api/zappy/note-review');
+    expect(signOpts.method).toBe('POST');
+    expect(signOpts.bodyString).toBe(fetchInit.body);
+    const body = JSON.parse(fetchInit.body);
+    expect(body.noteText).toBe('pasta night'); // trimmed
+    expect(body.experience).toBeUndefined(); // only sent when true
+    expect(fetchInit.headers.Authorization).toBe('Nostr abc');
+  });
+
+  it('caps noteText at the server limit', async () => {
+    const fetchFn = okFetch();
+    await requestNoteReview({
+      ...base,
+      noteText: 'y'.repeat(NOTE_TEXT_MAX_CHARS + 500),
+      signHeader: vi.fn().mockResolvedValue('Nostr abc'),
+      fetchFn
+    });
+    const body = JSON.parse(fetchFn.mock.calls[0][1].body);
+    expect(body.noteText).toHaveLength(NOTE_TEXT_MAX_CHARS);
+  });
+
+  it('includes experience: true for preview requests', async () => {
+    const fetchFn = okFetch();
+    await requestNoteReview({
+      ...base,
+      experience: true,
+      signHeader: vi.fn().mockResolvedValue('Nostr abc'),
+      fetchFn
+    });
+    expect(JSON.parse(fetchFn.mock.calls[0][1].body).experience).toBe(true);
+  });
+
+  it('calls onSigned after signing and before the fetch', async () => {
+    const order: string[] = [];
+    await requestNoteReview({
+      ...base,
+      onSigned: () => order.push('signed'),
+      signHeader: vi.fn().mockImplementation(async () => {
+        order.push('sign');
+        return 'Nostr abc';
+      }),
+      fetchFn: vi.fn().mockImplementation(async () => {
+        order.push('fetch');
+        return { ok: true, status: 200, json: async () => ({ ok: true, output: 'x' }) };
+      })
+    });
+    expect(order).toEqual(['sign', 'signed', 'fetch']);
+  });
+
+  it('maps a signer failure (e.g. not logged in, bunker rejected) to SIGN_FAILED without fetching', async () => {
+    const fetchFn = okFetch();
+    const result = await requestNoteReview({
+      ...base,
+      signHeader: vi.fn().mockRejectedValue(new Error('NIP-98 signing requires an NDK signer')),
+      fetchFn
+    });
+    expect(result).toMatchObject({ ok: false, code: 'SIGN_FAILED' });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('passes through server error codes', async () => {
+    const result = await requestNoteReview({
+      ...base,
+      signHeader: vi.fn().mockResolvedValue('Nostr abc'),
+      fetchFn: okFetch({ ok: false, code: 'PREVIEW_USED', error: 'spent' }, 429)
+    });
+    expect(result).toMatchObject({ ok: false, code: 'PREVIEW_USED', error: 'spent', status: 429 });
+  });
+
+  it('maps a thrown fetch to NETWORK', async () => {
+    const result = await requestNoteReview({
+      ...base,
+      signHeader: vi.fn().mockResolvedValue('Nostr abc'),
+      fetchFn: vi.fn().mockRejectedValue(new Error('offline'))
+    });
+    expect(result).toMatchObject({ ok: false, code: 'NETWORK' });
+  });
+});
+
+describe('trigger visibility gating (image detection)', () => {
+  // CheffyNoteReviewTrigger renders only when extractImageUrls finds
+  // at least one image in the note content — these mirror its gate.
+  it('image-bearing notes show the trigger', () => {
+    expect(extractImageUrls('dinner! https://image.nostr.build/abc.jpg').length).toBeGreaterThan(0);
+    expect(extractImageUrls('https://nostr.build/i/xyz look at this').length).toBeGreaterThan(0);
+  });
+
+  it('imageless notes hide the trigger', () => {
+    expect(extractImageUrls('just words tonight')).toHaveLength(0);
+    expect(extractImageUrls('a link https://zap.cooking/recipe/1 but no photo')).toHaveLength(0);
+    expect(extractImageUrls('video https://example.com/cooking.mp4')).toHaveLength(0);
+    expect(extractImageUrls('')).toHaveLength(0);
+  });
+});

--- a/src/lib/noteReview.ts
+++ b/src/lib/noteReview.ts
@@ -1,0 +1,165 @@
+/**
+ * Cheffy Note Photo Review — client logic (Phase 2).
+ *
+ * State machine and request plumbing for CheffyNoteReview.svelte, kept
+ * in a plain module so it is unit-testable (repo convention: logic in
+ * .ts, no Svelte component tests). The server contract lives at
+ * POST /api/zappy/note-review (NIP-98 auth, body-hash bound).
+ */
+
+import type NDK from '@nostr-dev-kit/ndk';
+import { signNip98AuthHeader } from './nip98';
+
+/**
+ * Ship-dark flag: the Post button in CheffyNoteReview renders only when
+ * this is true. Publish wiring (postComment) is Phase 3 — flipping this
+ * before Phase 3 lands shows a button that does nothing. Guarded by CI
+ * (flag-guard in checks.yaml) so a stray flip can't reach main.
+ */
+export const NOTE_REVIEW_POST_ENABLED = false;
+
+export type NoteReviewMode = 'comment' | 'recipe';
+
+export type NoteReviewPhase =
+  | 'choose' // mode selection
+  | 'signing' // waiting on the user's signer (NIP-46 round trips are slow)
+  | 'loading' // request in flight
+  | 'draft' // editable draft ready
+  | 'dead-end' // friendly stop — nothing postable (unclear/unreadable photo)
+  | 'upsell' // NOT_MEMBER — membership gate
+  | 'preview-used' // preview turns spent — conversion nudge
+  | 'error'; // retryable failure
+
+export type NoteReviewResult =
+  | { ok: true; output: string }
+  | { ok: false; code?: string; error?: string; status?: number };
+
+// Mirrors the server cap — a longer note just loses its tail.
+export const NOTE_TEXT_MAX_CHARS = 1000;
+
+/**
+ * Hedged dead-end copy. Phase 1 finding: the server's NOT_FOOD path also
+ * fires for CDN fallback images served in place of dead links (e.g.
+ * nostr.build never 404s), so the client must never confidently claim
+ * "that's not food" — and never echo the model's confident line.
+ */
+export const PHOTO_UNCLEAR_LINE =
+  "Cheffy couldn't get a good look at that photo. It might be a broken link — or just not clearly a dish.";
+
+export const SIGN_FAILED_LINE =
+  "Cheffy couldn't get your signer's autograph. Check your signer and try again.";
+
+const GENERIC_ERROR_LINE = 'Cheffy could not finish that one. Please try again.';
+
+/**
+ * Map a request result to the modal phase and its display message.
+ * Pure — this is the tested core of the modal's state machine.
+ */
+export function phaseForResult(result: NoteReviewResult): {
+  phase: NoteReviewPhase;
+  message: string;
+} {
+  if (result.ok) return { phase: 'draft', message: '' };
+  switch (result.code) {
+    case 'NOT_MEMBER':
+      return { phase: 'upsell', message: '' };
+    case 'PREVIEW_USED':
+      return { phase: 'preview-used', message: '' };
+    case 'NOT_FOOD':
+    case 'IMAGE_UNREADABLE':
+      // Deliberately ignore the server-provided line here — it can be a
+      // confident "that's a cat" while the truth is a dead link.
+      return { phase: 'dead-end', message: PHOTO_UNCLEAR_LINE };
+    case 'SIGN_FAILED':
+      return { phase: 'error', message: SIGN_FAILED_LINE };
+    default:
+      return { phase: 'error', message: result.error || GENERIC_ERROR_LINE };
+  }
+}
+
+export interface NoteReviewRequestOpts {
+  ndk: NDK;
+  imageUrl: string;
+  mode: NoteReviewMode;
+  /** Raw note content — trimmed and capped here, wrapped as untrusted context server-side. */
+  noteText?: string;
+  /** Event id hex, server logging only. */
+  noteId?: string;
+  /** Non-member preview request (server enforces the cookie budget). */
+  experience?: boolean;
+  /** Called once the NIP-98 header is signed, before the fetch — flips signing → loading. */
+  onSigned?: () => void;
+  /** Test injection points. */
+  signHeader?: typeof signNip98AuthHeader;
+  fetchFn?: typeof fetch;
+  origin?: string;
+}
+
+/**
+ * Sign and send a note-review request. Never throws — every failure
+ * mode comes back as a NoteReviewResult for phaseForResult to map.
+ */
+export async function requestNoteReview(opts: NoteReviewRequestOpts): Promise<NoteReviewResult> {
+  const {
+    ndk,
+    imageUrl,
+    mode,
+    noteId,
+    experience,
+    onSigned,
+    signHeader = signNip98AuthHeader,
+    fetchFn = fetch
+  } = opts;
+
+  const noteText = opts.noteText?.trim().slice(0, NOTE_TEXT_MAX_CHARS);
+  const body: Record<string, unknown> = { imageUrl, mode };
+  if (noteText) body.noteText = noteText;
+  if (noteId) body.noteId = noteId;
+  if (experience) body.experience = true;
+  // The signed payload hash and the fetch body must be the same string.
+  const bodyString = JSON.stringify(body);
+
+  const origin =
+    opts.origin ?? (typeof location !== 'undefined' ? location.origin : 'https://zap.cooking');
+
+  let authorization: string;
+  try {
+    authorization = await signHeader(ndk, {
+      method: 'POST',
+      url: `${origin}/api/zappy/note-review`,
+      bodyString
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'SIGN_FAILED',
+      error: err instanceof Error ? err.message : 'Signing failed'
+    };
+  }
+
+  onSigned?.();
+
+  try {
+    const resp = await fetchFn('/api/zappy/note-review', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: authorization },
+      body: bodyString
+    });
+    const data: Record<string, unknown> = await resp.json().catch(() => ({}));
+    if (resp.ok && data.ok === true && typeof data.output === 'string') {
+      return { ok: true, output: data.output };
+    }
+    return {
+      ok: false,
+      code: typeof data.code === 'string' ? data.code : undefined,
+      error: typeof data.error === 'string' ? data.error : undefined,
+      status: resp.status
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'NETWORK',
+      error: err instanceof Error ? err.message : 'Network error'
+    };
+  }
+}

--- a/src/lib/shareNoteImage.ts
+++ b/src/lib/shareNoteImage.ts
@@ -1,6 +1,6 @@
 /**
  * Share Note as Image
- * 
+ *
  * Generates shareable PNG images from Nostr notes using html2canvas
  */
 
@@ -10,32 +10,24 @@ import type { NDKEvent } from '@nostr-dev-kit/ndk';
 import { nip19 } from 'nostr-tools';
 import { sanitizeHTML } from '$lib/sanitize';
 
-// URL and image detection patterns
+// Image detection lives in $lib/imageUrls (shared source of truth).
+// Migration note: the shared isImageUrl is host-aware and anchors the
+// extension to the pathname (the old local copy matched '.jpg' anywhere
+// in the string), and the shared extractImageUrls dedupes — safe here
+// because only imageUrls[0] is ever rendered and stripImageUrls only
+// cares about a per-URL yes/no.
+import { isImageUrl, extractImageUrls } from '$lib/imageUrls';
+
+// URL pattern for stripping — kept local: stripImageUrls replaces over
+// the whole content string, which is a different job than extraction.
 const URL_REGEX = /(https?:\/\/[^\s]+)/g;
-const IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.avif', '.svg'];
-
-/**
- * Check if a URL is an image
- */
-function isImageUrl(url: string): boolean {
-  const lower = url.toLowerCase();
-  return IMAGE_EXTENSIONS.some((ext) => lower.includes(ext));
-}
-
-/**
- * Extract image URLs from content
- */
-function extractImageUrls(content: string): string[] {
-  const urls = content.match(URL_REGEX) || [];
-  return urls.filter((url) => isImageUrl(url));
-}
 
 /**
  * Remove image URLs from content
  */
 function stripImageUrls(content: string): string {
   return content
-    .replace(URL_REGEX, (url) => isImageUrl(url) ? '' : url)
+    .replace(URL_REGEX, (url) => (isImageUrl(url) ? '' : url))
     .replace(/\s+/g, ' ')
     .trim();
 }
@@ -68,7 +60,7 @@ export function decodeNostrReference(ref: string): string | null {
     // Remove the "nostr:" prefix
     const bech32 = ref.replace(/^nostr:/i, '');
     const decoded = nip19.decode(bech32);
-    
+
     if (decoded.type === 'note') {
       return decoded.data as string;
     } else if (decoded.type === 'nevent') {
@@ -98,10 +90,10 @@ export interface ReferencedNote {
  */
 function generateAvatarColor(pubkey: string): string {
   const hash = pubkey.split('').reduce((a, b) => {
-    a = ((a << 5) - a) + b.charCodeAt(0);
+    a = (a << 5) - a + b.charCodeAt(0);
     return a & a;
   }, 0);
-  
+
   const hue = Math.abs(hash) % 360;
   return `hsl(${hue}, 70%, 50%)`;
 }
@@ -138,7 +130,7 @@ export function generateImageFilename(event: NDKEvent): string {
     .filter((word) => word.length > 0)
     .join('-')
     .toLowerCase();
-  
+
   const prefix = words || 'note';
   return `zap-cooking-${prefix}-${event.id.substring(0, 8)}.png`;
 }
@@ -149,7 +141,7 @@ export function generateImageFilename(event: NDKEvent): string {
  */
 async function generateQRCode(url: string, size: number = 200): Promise<string | null> {
   if (!browser) return null;
-  
+
   try {
     // Try to use a QR code library if available, otherwise return null
     // For now, we'll skip QR code generation and add it later if needed
@@ -175,12 +167,12 @@ async function generateSafariImage(
 ): Promise<Blob | null> {
   const width = 540;
   const height = 540;
-  
+
   const canvas = document.createElement('canvas');
   canvas.width = width;
   canvas.height = height;
   const ctx = canvas.getContext('2d');
-  
+
   if (!ctx) {
     console.error('[ShareImage] Failed to get canvas context');
     return null;
@@ -188,7 +180,7 @@ async function generateSafariImage(
 
   // Polyfill for roundRect if not available (for older browsers)
   if (!ctx.roundRect) {
-    (ctx as any).roundRect = function(x: number, y: number, w: number, h: number, r: number) {
+    (ctx as any).roundRect = function (x: number, y: number, w: number, h: number, r: number) {
       if (w < 2 * r) r = w / 2;
       if (h < 2 * r) r = h / 2;
       this.beginPath();
@@ -229,7 +221,14 @@ async function generateSafariImage(
   ctx.fillRect(0, 0, width, height);
 
   // Add subtle glow effect
-  const radialGradient = ctx.createRadialGradient(width * 0.8, height * 0.2, 0, width * 0.8, height * 0.2, width);
+  const radialGradient = ctx.createRadialGradient(
+    width * 0.8,
+    height * 0.2,
+    0,
+    width * 0.8,
+    height * 0.2,
+    width
+  );
   radialGradient.addColorStop(0, 'rgba(251, 191, 36, 0.1)');
   radialGradient.addColorStop(1, 'transparent');
   ctx.fillStyle = radialGradient;
@@ -242,14 +241,14 @@ async function generateSafariImage(
   // Author section
   const authorPubkey = event.author?.hexpubkey || event.pubkey;
   const displayName = authorName || authorPubkey.substring(0, 12) + '...';
-  
+
   // Avatar
   const avatarSize = 36;
   const avatarX = padding;
   const avatarY = y;
   const avatarCenterX = avatarX + avatarSize / 2;
   const avatarCenterY = avatarY + avatarSize / 2;
-  
+
   // Try to load profile picture
   let pfpLoaded = false;
   if (authorPicture) {
@@ -266,10 +265,10 @@ async function generateSafariImage(
       pfpLoaded = true;
     }
   }
-  
+
   // Fallback to colored circle with initials
   if (!pfpLoaded) {
-    const avatarColor = `hsl(${Math.abs(authorPubkey.split('').reduce((a, b) => ((a << 5) - a) + b.charCodeAt(0), 0)) % 360}, 70%, 50%)`;
+    const avatarColor = `hsl(${Math.abs(authorPubkey.split('').reduce((a, b) => (a << 5) - a + b.charCodeAt(0), 0)) % 360}, 70%, 50%)`;
     ctx.fillStyle = avatarColor;
     ctx.beginPath();
     ctx.arc(avatarCenterX, avatarCenterY, avatarSize / 2, 0, Math.PI * 2);
@@ -316,7 +315,7 @@ async function generateSafariImage(
   const imageUrlRegex = /https?:\/\/[^\s]+\.(jpg|jpeg|png|gif|webp|avif)(\?[^\s]*)?/gi;
   const imageUrls = rawContent.match(imageUrlRegex) || [];
   const firstImageUrl = imageUrls.length > 0 ? imageUrls[0] : null;
-  
+
   // Load the first image if available
   let noteImage: HTMLImageElement | null = null;
   if (firstImageUrl) {
@@ -330,34 +329,38 @@ async function generateSafariImage(
     .replace(/https?:\/\/[^\s]+/gi, '🔗') // Replace other URLs with link emoji
     .replace(/\n\s*\n/g, '\n') // Collapse multiple newlines
     .trim();
-  
+
   const hasReferencedNote = referencedNoteContent && referencedNoteAuthor;
   const hasNoteImage = noteImage !== null;
-  
+
   // Adjust content length based on what we're showing
   let maxContentLength = 300;
   if (hasNoteImage && hasReferencedNote) maxContentLength = 100;
   else if (hasNoteImage) maxContentLength = 150;
   else if (hasReferencedNote) maxContentLength = 200;
-  
-  const displayContent = content.length > maxContentLength 
-    ? content.substring(0, maxContentLength) + '...' 
-    : content;
+
+  const displayContent =
+    content.length > maxContentLength ? content.substring(0, maxContentLength) + '...' : content;
 
   ctx.fillStyle = '#f3f4f6';
   ctx.font = '16px -apple-system, BlinkMacSystemFont, sans-serif';
-  
+
   // Define maxWidth for word wrapping
   const maxWidth = width - padding * 2;
-  
+
   // Word wrap helper
-  const wrapText = (text: string, maxY: number, fontSize: number = 16, color: string = '#f3f4f6') => {
+  const wrapText = (
+    text: string,
+    maxY: number,
+    fontSize: number = 16,
+    color: string = '#f3f4f6'
+  ) => {
     ctx.font = `${fontSize}px -apple-system, BlinkMacSystemFont, sans-serif`;
     ctx.fillStyle = color;
     const lineHeight = fontSize * 1.5;
     const words = text.split(' ');
     let line = '';
-    
+
     for (const word of words) {
       const testLine = line + word + ' ';
       const metrics = ctx.measureText(testLine);
@@ -375,28 +378,30 @@ async function generateSafariImage(
       y += lineHeight;
     }
   };
-  
+
   // Calculate available space for content vs image
   const footerHeight = 100; // engagement + branding
   const refNoteHeight = hasReferencedNote ? 90 : 0;
   const availableHeight = height - y - footerHeight - refNoteHeight - padding;
-  
+
   // Draw main content (limit height if we have an image)
-  const textMaxY = hasNoteImage ? y + Math.min(availableHeight * 0.3, 80) : height - footerHeight - refNoteHeight - 10;
+  const textMaxY = hasNoteImage
+    ? y + Math.min(availableHeight * 0.3, 80)
+    : height - footerHeight - refNoteHeight - 10;
   wrapText(displayContent, textMaxY);
-  
+
   // Draw note image if available
   if (noteImage) {
     y += 10;
-    
+
     // Calculate image dimensions to fit
     const imgMaxWidth = width - padding * 2;
     const imgMaxHeight = Math.min(availableHeight * 0.6, 180);
-    
+
     let imgWidth = noteImage.width;
     let imgHeight = noteImage.height;
     const imgAspect = imgWidth / imgHeight;
-    
+
     // Scale to fit
     if (imgWidth > imgMaxWidth) {
       imgWidth = imgMaxWidth;
@@ -406,10 +411,10 @@ async function generateSafariImage(
       imgHeight = imgMaxHeight;
       imgWidth = imgHeight * imgAspect;
     }
-    
+
     // Center horizontally
     const imgX = padding + (imgMaxWidth - imgWidth) / 2;
-    
+
     // Draw with rounded corners
     ctx.save();
     ctx.beginPath();
@@ -418,21 +423,21 @@ async function generateSafariImage(
     ctx.clip();
     ctx.drawImage(noteImage, imgX, y, imgWidth, imgHeight);
     ctx.restore();
-    
+
     // Add subtle border
     ctx.strokeStyle = 'rgba(255, 255, 255, 0.1)';
     ctx.lineWidth = 1;
     ctx.beginPath();
     ctx.roundRect(imgX, y, imgWidth, imgHeight, 8);
     ctx.stroke();
-    
+
     y += imgHeight + 10;
   }
-  
+
   // Draw referenced note if present
   if (hasReferencedNote && y < height - footerHeight - 10) {
     y += 5;
-    
+
     // Quote box background
     const quoteBoxY = y;
     const quoteBoxHeight = Math.min(80, height - y - footerHeight - 5);
@@ -443,9 +448,9 @@ async function generateSafariImage(
     ctx.roundRect(padding, quoteBoxY, width - padding * 2, quoteBoxHeight, 8);
     ctx.fill();
     ctx.stroke();
-    
+
     y = quoteBoxY + 12;
-    
+
     // Referenced note author
     ctx.fillStyle = '#9ca3af';
     ctx.font = 'bold 12px -apple-system, BlinkMacSystemFont, sans-serif';
@@ -453,32 +458,36 @@ async function generateSafariImage(
     ctx.textBaseline = 'top';
     ctx.fillText(`↩ ${referencedNoteAuthor}`, padding + 10, y);
     y += 18;
-    
+
     // Referenced note content (truncated)
-    const refContent = referencedNoteContent.length > 80 
-      ? referencedNoteContent.substring(0, 80) + '...'
-      : referencedNoteContent;
+    const refContent =
+      referencedNoteContent.length > 80
+        ? referencedNoteContent.substring(0, 80) + '...'
+        : referencedNoteContent;
     ctx.fillStyle = '#d1d5db';
     ctx.font = '13px -apple-system, BlinkMacSystemFont, sans-serif';
-    
+
     // Simple single-line truncation for quote
     const refMetrics = ctx.measureText(refContent);
     if (refMetrics.width > width - padding * 2 - 20) {
       let truncated = refContent;
-      while (ctx.measureText(truncated + '...').width > width - padding * 2 - 20 && truncated.length > 0) {
+      while (
+        ctx.measureText(truncated + '...').width > width - padding * 2 - 20 &&
+        truncated.length > 0
+      ) {
         truncated = truncated.slice(0, -1);
       }
       ctx.fillText(truncated + '...', padding + 10, y);
     } else {
       ctx.fillText(refContent, padding + 10, y);
     }
-    
+
     y = quoteBoxY + quoteBoxHeight + 5;
   }
 
   // Engagement metrics at bottom
   y = height - 100;
-  
+
   // Divider line
   ctx.strokeStyle = 'rgba(255, 255, 255, 0.15)';
   ctx.lineWidth = 1;
@@ -486,7 +495,7 @@ async function generateSafariImage(
   ctx.moveTo(padding, y);
   ctx.lineTo(width - padding, y);
   ctx.stroke();
-  
+
   y += 20;
 
   // Zaps
@@ -526,7 +535,7 @@ async function generateSafariImage(
   const iconSize = 36;
   const iconX = width - padding - iconSize;
   const iconY = height - padding - iconSize;
-  
+
   // Try to load the icon
   const iconImg = await loadImage('/icon.png', 2000);
   if (iconImg) {
@@ -560,8 +569,8 @@ async function generateSafariImage(
         // Fallback to toDataURL
         const dataUrl = canvas.toDataURL('image/png');
         fetch(dataUrl)
-          .then(res => res.blob())
-          .then(b => resolve(b))
+          .then((res) => res.blob())
+          .then((b) => resolve(b))
           .catch(() => resolve(null));
       }
     }, 'image/png');
@@ -576,7 +585,7 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number, errorMessage: st
     const timer = setTimeout(() => {
       reject(new Error(errorMessage));
     }, timeoutMs);
-    
+
     promise
       .then((result) => {
         clearTimeout(timer);
@@ -609,7 +618,15 @@ export async function generateNoteImage(
   // Wrap entire generation with a 15-second timeout
   try {
     return await withTimeout(
-      generateNoteImageInternal(event, engagementData, format, showQR, authorName, authorPicture, referencedNote),
+      generateNoteImageInternal(
+        event,
+        engagementData,
+        format,
+        showQR,
+        authorName,
+        authorPicture,
+        referencedNote
+      ),
       15000,
       'Image generation timed out. Please try again.'
     );
@@ -634,8 +651,8 @@ async function generateNoteImageInternal(
   // For Safari, use simple canvas drawing instead of html2canvas
   if (isSafari) {
     return generateSafariImage(
-      event, 
-      engagementData, 
+      event,
+      engagementData,
       authorName,
       authorPicture,
       referencedNote?.content,
@@ -650,8 +667,8 @@ async function generateNoteImageInternal(
     const imageUrls = isSafari ? [] : extractImageUrls(event.content || '');
 
     // Use smaller dimensions for Safari
-    const width = isSafari ? 540 : (format === 'square' ? 1080 : 1200);
-    const height = isSafari ? 540 : (format === 'square' ? 1080 : 675);
+    const width = isSafari ? 540 : format === 'square' ? 1080 : 1200;
+    const height = isSafari ? 540 : format === 'square' ? 1080 : 675;
 
     // Create a temporary container for the card
     container = document.createElement('div');
@@ -664,13 +681,13 @@ async function generateNoteImageInternal(
 
     // Create the HTML structure manually - skip all images on Safari
     const cardHTML = createNoteCardHTML(
-      event, 
-      engagementData, 
-      format, 
-      showQR, 
-      authorName, 
+      event,
+      engagementData,
+      format,
+      showQR,
+      authorName,
       isSafari ? undefined : authorPicture,
-      imageUrls, 
+      imageUrls,
       isSafari ? undefined : referencedNote,
       isSafari // skipAllImages flag for Safari
     );
@@ -683,7 +700,10 @@ async function generateNoteImageInternal(
     if (showQR) {
       const qrContainer = container.querySelector('#qr-code-container');
       if (qrContainer) {
-        const qrDataUrl = await generateQRCode(`https://zap.cooking/${nip19.noteEncode(event.id)}`, 120);
+        const qrDataUrl = await generateQRCode(
+          `https://zap.cooking/${nip19.noteEncode(event.id)}`,
+          120
+        );
         if (qrDataUrl) {
           qrContainer.innerHTML = `<img src="${qrDataUrl}" style="width: 100%; height: 100%;" />`;
         }
@@ -692,7 +712,7 @@ async function generateNoteImageInternal(
 
     // Generate canvas with Safari-specific options
     console.log('[ShareImage] Generating canvas with html2canvas...');
-    
+
     const canvas = await html2canvas(container, {
       width,
       height,
@@ -703,27 +723,31 @@ async function generateNoteImageInternal(
       logging: false,
       foreignObjectRendering: false,
       removeContainer: false,
-      imageTimeout: isSafari ? 0 : 15000,
+      imageTimeout: isSafari ? 0 : 15000
     });
 
     // Convert to blob - use toDataURL as fallback for Safari
     let blob: Blob | null = null;
-    
+
     // Try toBlob first (faster when it works)
     try {
       blob = await new Promise<Blob | null>((resolve, reject) => {
         const timeout = setTimeout(() => {
           reject(new Error('toBlob timeout'));
         }, 3000);
-        
-        canvas.toBlob((b) => {
-          clearTimeout(timeout);
-          if (b) {
-            resolve(b);
-          } else {
-            reject(new Error('toBlob returned null'));
-          }
-        }, 'image/png', 1.0);
+
+        canvas.toBlob(
+          (b) => {
+            clearTimeout(timeout);
+            if (b) {
+              resolve(b);
+            } else {
+              reject(new Error('toBlob returned null'));
+            }
+          },
+          'image/png',
+          1.0
+        );
       });
     } catch (e) {
       // Fallback to toDataURL (works better on Safari)
@@ -773,10 +797,11 @@ function createNoteCardHTML(
     const diffMs = now.getTime() - date.getTime();
     const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
     const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-    
+
     if (diffHours < 1) {
       const diffMins = Math.floor(diffMs / (1000 * 60));
-      timestamp = diffMins < 1 ? 'Just now' : `${diffMins} ${diffMins === 1 ? 'minute' : 'minutes'} ago`;
+      timestamp =
+        diffMins < 1 ? 'Just now' : `${diffMins} ${diffMins === 1 ? 'minute' : 'minutes'} ago`;
     } else if (diffHours < 24) {
       timestamp = `${diffHours} ${diffHours === 1 ? 'hour' : 'hours'} ago`;
     } else if (diffDays < 7) {
@@ -785,11 +810,11 @@ function createNoteCardHTML(
       timestamp = date.toLocaleDateString('en-US', {
         month: 'short',
         day: 'numeric',
-        year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined,
+        year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined
       });
     }
   }
-  
+
   const zapAmount = Math.floor(engagementData.zaps.totalAmount / 1000);
   const hasZaps = zapAmount > 0;
   const hasReactions = engagementData.reactions.count > 0;
@@ -801,29 +826,28 @@ function createNoteCardHTML(
 
   // Get author pubkey for avatar fallback
   const authorPubkey = event.author?.hexpubkey || event.pubkey;
-  
+
   // Get display name - don't truncate, show full name
-  const displayName = authorName || (() => {
-    try {
-      const npub = nip19.npubEncode(authorPubkey);
-      return npub.substring(0, 16) + '...';
-    } catch {
-      return authorPubkey.substring(0, 16) + '...';
-    }
-  })();
-  
+  const displayName =
+    authorName ||
+    (() => {
+      try {
+        const npub = nip19.npubEncode(authorPubkey);
+        return npub.substring(0, 16) + '...';
+      } catch {
+        return authorPubkey.substring(0, 16) + '...';
+      }
+    })();
+
   // Strip image URLs and nostr references from content
   let cleanContent = stripImageUrls(event.content || '');
   cleanContent = stripNostrReferences(cleanContent);
-  
+
   // Truncate content - shorter if we have images or referenced note to display
   const hasMedia = hasImages || hasReferencedNote;
-  const maxLength = hasMedia 
-    ? (format === 'square' ? 250 : 350)
-    : (format === 'square' ? 500 : 800);
-  const displayContent = cleanContent.length > maxLength
-    ? cleanContent.substring(0, maxLength) + '...'
-    : cleanContent;
+  const maxLength = hasMedia ? (format === 'square' ? 250 : 350) : format === 'square' ? 500 : 800;
+  const displayContent =
+    cleanContent.length > maxLength ? cleanContent.substring(0, maxLength) + '...' : cleanContent;
 
   // Format content - escape HTML, keep newlines as actual line breaks (using pre-wrap)
   const formattedContent = displayContent
@@ -831,21 +855,20 @@ function createNoteCardHTML(
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
   // Note: newlines are preserved by white-space: pre-wrap in CSS
-  
+
   // Format referenced note content if present
   let refNoteContent = '';
   let refNoteAuthor = '';
   if (referencedNote) {
-    const refContent = referencedNote.content.length > 200 
-      ? referencedNote.content.substring(0, 200) + '...'
-      : referencedNote.content;
-    refNoteContent = refContent
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;');
-    refNoteAuthor = referencedNote.authorName || referencedNote.authorPubkey.substring(0, 12) + '...';
+    const refContent =
+      referencedNote.content.length > 200
+        ? referencedNote.content.substring(0, 200) + '...'
+        : referencedNote.content;
+    refNoteContent = refContent.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    refNoteAuthor =
+      referencedNote.authorName || referencedNote.authorPubkey.substring(0, 12) + '...';
   }
-  
+
   // Get the origin for absolute URLs (needed for html2canvas to load images)
   const origin = browser ? window.location.origin : '';
 
@@ -883,7 +906,9 @@ function createNoteCardHTML(
         z-index: 1;
       ">
         <!-- Profile Picture -->
-        ${hasProfilePicture ? `
+        ${
+          hasProfilePicture
+            ? `
           <img 
             src="${authorPicture}" 
             crossorigin="anonymous"
@@ -910,7 +935,8 @@ function createNoteCardHTML(
             font-weight: bold;
             color: white;
           ">${getInitials(displayName)}</div>
-        ` : `
+        `
+            : `
           <div style="
             width: 72px;
             height: 72px;
@@ -924,7 +950,8 @@ function createNoteCardHTML(
             font-weight: bold;
             color: white;
           ">${getInitials(displayName)}</div>
-        `}
+        `
+        }
         <div style="flex: 1; min-width: 0;">
           <div style="font-size: 28px; font-weight: 600; margin-bottom: 4px; line-height: 1.3;">
             ${displayName}
@@ -936,7 +963,9 @@ function createNoteCardHTML(
       </div>
 
       <!-- Content -->
-      ${formattedContent ? `
+      ${
+        formattedContent
+          ? `
         <div style="
           font-size: ${hasImages ? '26px' : '32px'};
           line-height: 1.7;
@@ -950,10 +979,14 @@ function createNoteCardHTML(
           letter-spacing: 0.01em;
           ${hasImages ? 'max-height: 200px;' : 'flex: 1;'}
         ">${formattedContent}</div>
-      ` : ''}
+      `
+          : ''
+      }
 
       <!-- Image (first one only for now) -->
-      ${hasImages ? `
+      ${
+        hasImages
+          ? `
         <div style="
           flex: 1;
           display: flex;
@@ -977,10 +1010,14 @@ function createNoteCardHTML(
             onerror="this.style.display='none'"
           />
         </div>
-      ` : ''}
+      `
+          : ''
+      }
 
       <!-- Referenced/Quoted Note -->
-      ${hasReferencedNote && referencedNote ? `
+      ${
+        hasReferencedNote && referencedNote
+          ? `
         <div style="
           ${!hasImages ? 'flex: 1;' : ''}
           background: rgba(255, 255, 255, 0.05);
@@ -998,7 +1035,9 @@ function createNoteCardHTML(
             gap: 12px;
             margin-bottom: 12px;
           ">
-            ${referencedNote.authorPicture ? `
+            ${
+              referencedNote.authorPicture
+                ? `
               <img 
                 src="${referencedNote.authorPicture}" 
                 crossorigin="anonymous"
@@ -1010,7 +1049,8 @@ function createNoteCardHTML(
                 "
                 onerror="this.style.display='none'"
               />
-            ` : `
+            `
+                : `
               <div style="
                 width: 36px;
                 height: 36px;
@@ -1023,7 +1063,8 @@ function createNoteCardHTML(
                 font-weight: bold;
                 color: white;
               ">${getInitials(refNoteAuthor)}</div>
-            `}
+            `
+            }
             <div style="font-size: 18px; font-weight: 600; color: #e5e7eb;">
               ${refNoteAuthor}
             </div>
@@ -1037,7 +1078,9 @@ function createNoteCardHTML(
             word-wrap: break-word;
           ">${refNoteContent}</div>
         </div>
-      ` : ''}
+      `
+          : ''
+      }
 
       <!-- Engagement metrics - always show all three -->
       <div style="
@@ -1096,7 +1139,9 @@ function createNoteCardHTML(
             Found on zap.cooking ⚡
           </div>
         </div>
-        ${showLogo ? `
+        ${
+          showLogo
+            ? `
           <!-- Pan logo in bottom right -->
           <img 
             src="${origin}/icon.png" 
@@ -1108,14 +1153,16 @@ function createNoteCardHTML(
             "
             onerror="this.style.display='none'"
           />
-        ` : `
+        `
+            : `
           <!-- Text logo fallback for Safari -->
           <div style="
             font-size: 48px;
             font-weight: bold;
             color: #fbbf24;
           ">🍳</div>
-        `}
+        `
+        }
       </div>
     </div>
   `;
@@ -1170,10 +1217,7 @@ function waitForImages(container: HTMLElement, timeoutMs: number = 5000): Promis
 /**
  * Share or download the image
  */
-export async function shareNoteImage(
-  blob: Blob,
-  filename: string
-): Promise<boolean> {
+export async function shareNoteImage(blob: Blob, filename: string): Promise<boolean> {
   if (!browser) return false;
 
   try {
@@ -1183,7 +1227,7 @@ export async function shareNoteImage(
       if (navigator.canShare({ files: [file] })) {
         await navigator.share({
           files: [file],
-          title: 'Found on zap.cooking ⚡',
+          title: 'Found on zap.cooking ⚡'
         });
         return true;
       }

--- a/src/lib/shareNoteImage.ts
+++ b/src/lib/shareNoteImage.ts
@@ -27,7 +27,15 @@ const URL_REGEX = /(https?:\/\/[^\s]+)/g;
  */
 function stripImageUrls(content: string): string {
   return content
-    .replace(URL_REGEX, (url) => (isImageUrl(url) ? '' : url))
+    .replace(URL_REGEX, (match) => {
+      // URL_REGEX runs to the next whitespace, so a URL embedded in
+      // prose carries its trailing punctuation ("...a.jpg," / "...a.jpg)").
+      // The shared isImageUrl anchors the extension to the pathname, so
+      // test with the punctuation stripped — but drop the whole match,
+      // punctuation included, like the pre-migration behavior did.
+      const core = match.replace(/[.,;:!?)\]]+$/, '');
+      return isImageUrl(core) ? '' : match;
+    })
     .replace(/\s+/g, ' ')
     .trim();
 }


### PR DESCRIPTION
## Summary

Phase 2 of **Cheffy Note Photo Review** (server endpoint: #513): the client entry point and draft modal. **Draft-only** — the member picks comment or recipe mode, Cheffy drafts from the note's photo, the member edits in place. No posting: the Post button ships dark behind `NOTE_REVIEW_POST_ENABLED` with a new flag-guard CI step; publish wiring (postComment) is Phase 3.

### What's in here

- **`CheffyNoteReviewTrigger.svelte`** — self-contained "Ask Cheffy about this dish" entry point. Owns image detection via `$lib/imageUrls` (renders nothing for imageless notes) and the modal mount. Dual placement:
  - `NoteActionBar` — new `showCheffy` prop (default true), slotted between Repost and Zaps → thread views, polls, pack page
  - `FoodstrFeedOptimized` — one import + one instance in the existing inline action row; **no feed logic touched**
- **`CheffyNoteReview.svelte`** — modal on the house `Modal.svelte`: mode choice, NIP-98 **signing state** (NIP-46 bunker latency surfaced before the request even sends), loading lines from the `cheffy.ts` pools, editable draft, regenerate, sign-in / `NOT_MEMBER` upsell / `PREVIEW_USED` conversion branches, errors in Cheffy voice. Multi-image notes use the first image (picker strip: Phase 4).
- **`$lib/noteReview.ts`** — unit-testable state machine + request plumbing (signs the exact body string it sends, extract-recipe pattern). `NOT_FOOD`/`IMAGE_UNREADABLE` map to one **hedged** dead-end line — never a confident "that's not food" and never the server's line, since this path also covers CDN fallback images for dead links (Phase 1 finding).
- **Migration:** `NoteContent` + `shareNoteImage` now use `$lib/imageUrls`; new `filterImageUrls` dedupes while keeping `indexOf`-based lightbox navigation correct (explicit duplicate-URL prev/next test — dedup fixes a latent duplicate-pane bug). Accepted behavior change: `shareNoteImage` no longer treats URLs with `.jpg` only in a query string as images (documented at the import site). Deliberately not migrated: the feed's own loose `isImageUrl` copy (minimal-touch; follow-up ticket) and `shareNoteImage`'s Safari-path inline regexes.

## Test plan

- [x] 19 new unit tests: `phaseForResult` state machine (incl. hedge assertions), request signing/body/experience/error paths + `onSigned` ordering, trigger visibility gating, `filterImageUrls` + duplicate-URL lightbox navigation
- [x] Full suite green (30 files, 507 tests); `svelte-check` 0 errors
- [ ] Manual cross-device testing on the branch preview deployment (pre-merge gate)

Phase 3 (single PR, gated on the manual pass + this merge): flip `NOTE_REVIEW_POST_ENABLED`, wire Post → `postComment()`, update the flag-guard in the same PR.

Note: "Workers Builds" checks are expected to fail on this repo (known infra quirk — deploys go through Cloudflare Pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)