### PR TITLE
feat(cheffy): note photo review publish path (Phase 3) — LAUNCHES POSTING ON MERGE

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -42,13 +42,13 @@ jobs:
             exit 1
           fi
 
-      - name: NOTE_REVIEW_POST_ENABLED must be false on main 🚫
+      - name: NOTE_REVIEW_POST_ENABLED must be true on main 🚫
         run: |
-          if ! grep -q "export const NOTE_REVIEW_POST_ENABLED = false" src/lib/noteReview.ts; then
-            echo "::error file=src/lib/noteReview.ts::NOTE_REVIEW_POST_ENABLED is not false."
-            echo "The Post button ships dark until Phase 3 wires postComment()."
-            echo "Flip it in the Phase 3 PR that adds the publish path AND updates"
-            echo "this guard — a stray flip must not reach main."
+          if ! grep -q "export const NOTE_REVIEW_POST_ENABLED = true" src/lib/noteReview.ts; then
+            echo "::error file=src/lib/noteReview.ts::NOTE_REVIEW_POST_ENABLED is not true."
+            echo "Posting launched in Phase 3 (flag flipped with the postComment"
+            echo "wiring). An un-flip silently dark-ships the Post button — if you"
+            echo "mean to kill the publish path, update this guard in the same PR."
             exit 1
           fi
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.605",
+  "version": "4.2.606",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/CheffyNoteReview.svelte
+++ b/src/components/CheffyNoteReview.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
   /**
-   * Cheffy Note Photo Review modal (Phase 2).
+   * Cheffy Note Photo Review modal.
    *
-   * Draft-only in this phase: the member picks a mode, Cheffy drafts a
-   * comment or recipe from the note's photo, and the member edits it in
-   * place. Posting is Phase 3 — the Post button ships dark behind
-   * NOTE_REVIEW_POST_ENABLED. Multi-image notes use the first image;
-   * the picker strip is Phase 4.
+   * The member picks a mode, Cheffy drafts a comment or recipe from the
+   * note's photo, the member edits in place, then posts it as their own
+   * NIP-10 reply via postComment() (D1: mandatory edit-before-post, no
+   * auto-publish). Publish failures keep the draft; a publish timeout
+   * keeps the SIGNED event so retry never asks the signer twice.
+   * Multi-image notes use the first image; the picker strip is Phase 4.
    *
    * All branching logic (phase transitions, error mapping, hedged
-   * copy) lives in $lib/noteReview so it stays unit-testable.
+   * copy, publish outcomes) lives in $lib/noteReview so it stays
+   * unit-testable.
    */
   import type { NDKEvent } from '@nostr-dev-kit/ndk';
   import { goto } from '$app/navigation';
@@ -21,9 +23,13 @@
   import {
     requestNoteReview,
     phaseForResult,
+    publishNoteReviewReply,
+    retryPublishSignedEvent,
+    canPost,
     NOTE_REVIEW_POST_ENABLED,
     type NoteReviewMode,
-    type NoteReviewPhase
+    type NoteReviewPhase,
+    type PublishOutcome
   } from '$lib/noteReview';
 
   export let open = false;
@@ -39,6 +45,9 @@
   let message = '';
   let loadingLine = '';
   let errorLine = '';
+  let postError = '';
+  let noteLink = '';
+  let timeoutSignedEvent: NDKEvent | null = null;
 
   $: signedIn = $userPublickey !== '';
   $: normalizedPk = $userPublickey.trim().toLowerCase();
@@ -66,10 +75,54 @@
     if (phase === 'error') errorLine = pickLine(ERROR_LINES, errorLine);
   }
 
+  function handlePublishOutcome(outcome: PublishOutcome) {
+    if (outcome.ok) {
+      noteLink = outcome.noteLink;
+      phase = 'posted';
+      return;
+    }
+    if (outcome.code === 'publish-timeout') {
+      timeoutSignedEvent = outcome.signedEvent;
+      message = outcome.message;
+      phase = 'post-timeout';
+      return;
+    }
+    // Draft is preserved — the member's edits are never lost to a
+    // publish failure.
+    postError = outcome.message;
+    phase = 'draft';
+  }
+
+  async function post() {
+    if (!canPost(phase)) return; // double-click guard (with the disabled attr)
+    postError = '';
+    phase = 'posting';
+    handlePublishOutcome(
+      await publishNoteReviewReply({ ndk: $ndk, parentEvent: event, content: draft })
+    );
+  }
+
+  async function retryPost() {
+    if (!timeoutSignedEvent) return;
+    phase = 'posting';
+    handlePublishOutcome(
+      await retryPublishSignedEvent({ ndk: $ndk, signedEvent: timeoutSignedEvent })
+    );
+  }
+
+  function viewReply() {
+    const target = noteLink;
+    open = false;
+    goto(target);
+  }
+
   function reset() {
     phase = 'choose';
     draft = '';
     message = '';
+    postError = '';
+    noteLink = '';
+    timeoutSignedEvent = null;
   }
 
   function signIn() {
@@ -127,25 +180,56 @@
         <CheffyAvatar size={64} expression="cooking" variant="character" animate />
         <p>{loadingLine}</p>
       </div>
-    {:else if phase === 'draft'}
-      <p class="nr-hint">
-        Cheffy's draft — make it yours. {#if !NOTE_REVIEW_POST_ENABLED}Copy it into a reply for now;
-          one-tap posting is coming soon.{/if}
-      </p>
+    {:else if phase === 'draft' || phase === 'posting'}
+      {@const posting = phase === 'posting'}
+      <p class="nr-hint">Cheffy's draft — make it yours, then post it as your own reply.</p>
       <textarea
         class="nr-draft"
         class:nr-draft-recipe={mode === 'recipe'}
         bind:value={draft}
         rows={mode === 'recipe' ? 16 : 5}
         aria-label="Cheffy's draft"
+        disabled={posting}
       ></textarea>
+      {#if postError}
+        <p class="nr-post-error">{postError}</p>
+      {/if}
       <div class="nr-actions">
-        <button type="button" class="nr-secondary" on:click={() => run(mode)}>Regenerate</button>
-        <button type="button" class="nr-ghost" on:click={reset}>Start over</button>
+        <button type="button" class="nr-secondary" on:click={() => run(mode)} disabled={posting}>
+          Regenerate
+        </button>
+        <button type="button" class="nr-ghost" on:click={reset} disabled={posting}>
+          Start over
+        </button>
         {#if NOTE_REVIEW_POST_ENABLED}
-          <!-- Phase 3 wires this to postComment(); flag-guarded until then. -->
-          <button type="button" class="nr-primary" disabled>Post reply</button>
+          <button
+            type="button"
+            class="nr-primary"
+            on:click={post}
+            disabled={posting || !draft.trim()}
+          >
+            {posting ? 'Posting…' : 'Post reply'}
+          </button>
         {/if}
+      </div>
+    {:else if phase === 'post-timeout'}
+      <div class="nr-wait">
+        <CheffyAvatar size={64} expression="thinking" variant="character" />
+        <p>{message}</p>
+        <div class="nr-actions">
+          <button type="button" class="nr-primary" on:click={retryPost}>Give it another push</button
+          >
+          <button type="button" class="nr-ghost" on:click={() => (open = false)}>Close</button>
+        </div>
+      </div>
+    {:else if phase === 'posted'}
+      <div class="nr-wait">
+        <CheffyAvatar size={64} expression="excited" variant="character" />
+        <p>Posted! Cheffy tips his toque to you.</p>
+        <div class="nr-actions">
+          <button type="button" class="nr-primary" on:click={viewReply}>View your reply</button>
+          <button type="button" class="nr-ghost" on:click={() => (open = false)}>Done</button>
+        </div>
       </div>
     {:else if phase === 'dead-end'}
       <div class="nr-wait">
@@ -271,6 +355,14 @@
   .nr-sub {
     color: var(--color-text-secondary);
     font-size: 0.85rem;
+  }
+
+  .nr-post-error {
+    color: var(--color-text-secondary);
+    font-size: 0.9rem;
+    padding: 8px 12px;
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--color-primary) 8%, transparent);
   }
 
   .nr-draft {

--- a/src/lib/noteReview.test.ts
+++ b/src/lib/noteReview.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   phaseForResult,
   requestNoteReview,
-  PHOTO_UNCLEAR_LINE,
+  DEAD_END_LINES,
   SIGN_FAILED_LINE,
   NOTE_REVIEW_POST_ENABLED,
   NOTE_TEXT_MAX_CHARS
@@ -10,8 +10,21 @@ import {
 import { extractImageUrls } from './imageUrls';
 
 describe('NOTE_REVIEW_POST_ENABLED', () => {
-  it('ships dark — posting is Phase 3', () => {
-    expect(NOTE_REVIEW_POST_ENABLED).toBe(false);
+  it('is live — posting shipped in Phase 3', () => {
+    expect(NOTE_REVIEW_POST_ENABLED).toBe(true);
+  });
+});
+
+describe('DEAD_END_LINES pool', () => {
+  it('every line hedges — no confident "not food" verdict anywhere in the pool', () => {
+    expect(DEAD_END_LINES.length).toBeGreaterThanOrEqual(3);
+    for (const line of DEAD_END_LINES) {
+      expect(line.toLowerCase()).not.toContain('not food');
+      expect(line.toLowerCase()).not.toContain("isn't food");
+      // Stay in the "couldn't get a good look" register: hedged, about
+      // the photo/visibility, not a verdict on the subject.
+      expect(line).toMatch(/couldn't|can't|may|might/i);
+    }
   });
 });
 
@@ -31,22 +44,22 @@ describe('phaseForResult — modal state machine', () => {
   it('NOT_FOOD hedges — never echoes the server line as a confident verdict', () => {
     // The server line can be a confident "that's a cat" even when the
     // real cause is a CDN fallback image for a dead link (Phase 1
-    // finding). The client must show the hedged line instead.
+    // finding). The client must show a hedged pool line instead.
     const { phase, message } = phaseForResult({
       ok: false,
       code: 'NOT_FOOD',
       error: 'A very photogenic cat.'
     });
     expect(phase).toBe('dead-end');
-    expect(message).toBe(PHOTO_UNCLEAR_LINE);
+    expect(DEAD_END_LINES).toContain(message);
     expect(message).not.toContain('cat');
     expect(message.toLowerCase()).not.toContain('not food');
   });
 
-  it('IMAGE_UNREADABLE → same hedged dead-end', () => {
+  it('IMAGE_UNREADABLE → same hedged dead-end pool', () => {
     const { phase, message } = phaseForResult({ ok: false, code: 'IMAGE_UNREADABLE' });
     expect(phase).toBe('dead-end');
-    expect(message).toBe(PHOTO_UNCLEAR_LINE);
+    expect(DEAD_END_LINES).toContain(message);
   });
 
   it('SIGN_FAILED → error with signer-flavored copy', () => {
@@ -191,5 +204,254 @@ describe('trigger visibility gating (image detection)', () => {
     expect(extractImageUrls('a link https://zap.cooking/recipe/1 but no photo')).toHaveLength(0);
     expect(extractImageUrls('video https://example.com/cooking.mp4')).toHaveLength(0);
     expect(extractImageUrls('')).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Publish path (Phase 3)
+// ---------------------------------------------------------------------------
+
+vi.mock('$lib/nip65Routing', () => ({
+  buildInboxAwareRelaySet: vi.fn(async () => undefined)
+}));
+
+// postComment → tagUtils imports $lib/nostr, which pulls $app/environment
+// and the Dexie cache adapter — neither loads under the node test env.
+// buildNip22CommentTags never touches these stores, so a light stub is
+// safe and keeps the client-tag test running the REAL tag builder.
+vi.mock('$lib/nostr', async () => {
+  const { writable } = await import('svelte/store');
+  return {
+    ndk: writable({}),
+    ndkConnected: writable(false),
+    userPublickey: writable('')
+  };
+});
+
+import { NDKEvent } from '@nostr-dev-kit/ndk';
+import {
+  canPost,
+  publishNoteReviewReply,
+  retryPublishSignedEvent,
+  noteLinkFor,
+  POST_TIMEOUT_LINE,
+  PUBLISH_FAILED_LINE,
+  type NoteReviewPhase
+} from './noteReview';
+import { PostCommentError } from './comments/postComment';
+import { CLIENT_TAG_IDENTIFIER } from './consts';
+
+const HEX_ID = 'e'.repeat(64);
+const HEX_PK = 'a'.repeat(64);
+
+function fakeSignedEvent(): NDKEvent {
+  return { id: HEX_ID, pubkey: HEX_PK, kind: 1, publish: vi.fn() } as unknown as NDKEvent;
+}
+
+describe('canPost — double-post guard', () => {
+  it('allows posting only from the draft phase', () => {
+    expect(canPost('draft')).toBe(true);
+    const blocked: NoteReviewPhase[] = [
+      'choose',
+      'signing',
+      'loading',
+      'posting',
+      'post-timeout',
+      'posted',
+      'dead-end',
+      'upsell',
+      'preview-used',
+      'error'
+    ];
+    for (const phase of blocked) expect(canPost(phase), phase).toBe(false);
+  });
+});
+
+describe('noteLinkFor', () => {
+  it('builds a thread-view link with nevent (author + kind hints)', () => {
+    const link = noteLinkFor(fakeSignedEvent());
+    expect(link.startsWith('/nevent1')).toBe(true);
+  });
+});
+
+describe('publishNoteReviewReply — outcome mapping', () => {
+  const ndk = {} as never;
+  const parentEvent = { id: 'c'.repeat(64), pubkey: 'd'.repeat(64), kind: 1 } as never;
+
+  function failingPostComment(err: unknown) {
+    return vi.fn().mockRejectedValue(err) as never;
+  }
+
+  it('success → ok with the published event and a thread link', async () => {
+    const event = fakeSignedEvent();
+    const outcome = await publishNoteReviewReply({
+      ndk,
+      parentEvent,
+      content: 'lovely crust!',
+      postCommentFn: vi.fn().mockResolvedValue({ event, publishedRelays: ['wss://r'] }) as never
+    });
+    expect(outcome).toMatchObject({ ok: true, event });
+    if (outcome.ok) expect(outcome.noteLink.startsWith('/nevent1')).toBe(true);
+  });
+
+  it('sign-failed → signer-flavored message, draft preserved by caller', async () => {
+    const outcome = await publishNoteReviewReply({
+      ndk,
+      parentEvent,
+      content: 'x',
+      postCommentFn: failingPostComment(new PostCommentError('sign-failed', 'nope'))
+    });
+    expect(outcome).toMatchObject({ ok: false, code: 'sign-failed', message: SIGN_FAILED_LINE });
+  });
+
+  it('publish-timeout with signedEvent → recovery outcome carrying the signed event', async () => {
+    const signed = fakeSignedEvent();
+    const outcome = await publishNoteReviewReply({
+      ndk,
+      parentEvent,
+      content: 'x',
+      postCommentFn: failingPostComment(
+        new PostCommentError('publish-timeout', 'slow relays', { signedEvent: signed })
+      )
+    });
+    expect(outcome).toMatchObject({
+      ok: false,
+      code: 'publish-timeout',
+      message: POST_TIMEOUT_LINE
+    });
+    if (!outcome.ok && outcome.code === 'publish-timeout') {
+      expect(outcome.signedEvent).toBe(signed);
+    }
+  });
+
+  it('publish-timeout WITHOUT signedEvent degrades to plain publish-failed', async () => {
+    const outcome = await publishNoteReviewReply({
+      ndk,
+      parentEvent,
+      content: 'x',
+      postCommentFn: failingPostComment(new PostCommentError('publish-timeout', 'slow'))
+    });
+    expect(outcome).toMatchObject({
+      ok: false,
+      code: 'publish-failed',
+      message: PUBLISH_FAILED_LINE
+    });
+  });
+
+  it('publish-failed and invalid-parent map to their Cheffy-voice messages', async () => {
+    const failed = await publishNoteReviewReply({
+      ndk,
+      parentEvent,
+      content: 'x',
+      postCommentFn: failingPostComment(new PostCommentError('publish-failed', 'rejected'))
+    });
+    expect(failed).toMatchObject({ ok: false, code: 'publish-failed' });
+
+    const invalid = await publishNoteReviewReply({
+      ndk,
+      parentEvent,
+      content: 'x',
+      postCommentFn: failingPostComment(new PostCommentError('invalid-parent', 'bad parent'))
+    });
+    expect(invalid).toMatchObject({ ok: false, code: 'invalid-parent' });
+  });
+
+  it('non-PostCommentError throws map to unknown', async () => {
+    const outcome = await publishNoteReviewReply({
+      ndk,
+      parentEvent,
+      content: 'x',
+      postCommentFn: failingPostComment(new Error('boom'))
+    });
+    expect(outcome).toMatchObject({ ok: false, code: 'unknown', message: 'boom' });
+  });
+});
+
+describe('retryPublishSignedEvent — timeout recovery', () => {
+  const ndk = {} as never;
+
+  it('re-publishes the already-signed event (no re-sign) and succeeds', async () => {
+    const signed = fakeSignedEvent();
+    (signed.publish as ReturnType<typeof vi.fn>).mockResolvedValue(new Set());
+    const buildRelaySetFn = vi.fn(async () => undefined) as never;
+    const outcome = await retryPublishSignedEvent({ ndk, signedEvent: signed, buildRelaySetFn });
+    expect(outcome).toMatchObject({ ok: true, event: signed });
+    expect(buildRelaySetFn).toHaveBeenCalledWith({ event: signed, ndk });
+    expect(signed.publish).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the signed event when the retry fails, so the member can push again', async () => {
+    const signed = fakeSignedEvent();
+    (signed.publish as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('still down'));
+    const outcome = await retryPublishSignedEvent({
+      ndk,
+      signedEvent: signed,
+      buildRelaySetFn: vi.fn(async () => undefined) as never
+    });
+    expect(outcome).toMatchObject({ ok: false, code: 'publish-timeout' });
+    if (!outcome.ok && outcome.code === 'publish-timeout') {
+      expect(outcome.signedEvent).toBe(signed);
+    }
+  });
+
+  it('times out a hung retry and keeps the signed event', async () => {
+    const signed = fakeSignedEvent();
+    (signed.publish as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+    const outcome = await retryPublishSignedEvent({
+      ndk,
+      signedEvent: signed,
+      timeoutMs: 20,
+      buildRelaySetFn: vi.fn(async () => undefined) as never
+    });
+    expect(outcome).toMatchObject({ ok: false, code: 'publish-timeout' });
+  });
+});
+
+describe('client tag on the built event (real postComment)', () => {
+  it('published replies carry the NIP-89 client tag and NIP-10 parent reference', async () => {
+    const signSpy = vi.spyOn(NDKEvent.prototype, 'sign').mockImplementation(async function (
+      this: NDKEvent
+    ) {
+      this.id = HEX_ID;
+      this.sig = 'f'.repeat(128);
+      this.pubkey = HEX_PK;
+      return this.sig;
+    });
+    const publishSpy = vi
+      .spyOn(NDKEvent.prototype, 'publish')
+      .mockResolvedValue(new Set() as never);
+
+    try {
+      // parentEvent.author (used by postComment's rootInput) calls
+      // ndk.getUser — the only NDK surface this test needs.
+      const mockNdk = {
+        getUser: (opts: { pubkey: string }) => ({ pubkey: opts.pubkey })
+      } as never;
+      const parentEvent = new NDKEvent(mockNdk as never);
+      parentEvent.kind = 1;
+      parentEvent.id = 'c'.repeat(64);
+      parentEvent.pubkey = 'd'.repeat(64);
+      parentEvent.tags = [];
+
+      // Default postCommentFn — the REAL postComment builds the event.
+      const outcome = await publishNoteReviewReply({
+        ndk: mockNdk,
+        parentEvent,
+        content: 'Those crispy edges are a feature.'
+      });
+
+      expect(outcome.ok).toBe(true);
+      if (outcome.ok) {
+        expect(outcome.event.kind).toBe(1); // plain NIP-10 reply to a kind-1 note
+        expect(outcome.event.tags).toContainEqual(['client', CLIENT_TAG_IDENTIFIER]);
+        const eTag = outcome.event.tags.find((t) => t[0] === 'e' && t[1] === parentEvent.id);
+        expect(eTag).toBeDefined();
+        const pTag = outcome.event.tags.find((t) => t[0] === 'p' && t[1] === parentEvent.pubkey);
+        expect(pTag).toBeDefined();
+      }
+    } finally {
+      signSpy.mockRestore();
+      publishSpy.mockRestore();
+    }
   });
 });

--- a/src/lib/noteReview.ts
+++ b/src/lib/noteReview.ts
@@ -8,15 +8,20 @@
  */
 
 import type NDK from '@nostr-dev-kit/ndk';
+import type { NDKEvent } from '@nostr-dev-kit/ndk';
+import { nip19 } from 'nostr-tools';
 import { signNip98AuthHeader } from './nip98';
+import { pickLine } from './cheffy';
+import { postComment, PostCommentError } from './comments/postComment';
+import { buildInboxAwareRelaySet } from './nip65Routing';
 
 /**
- * Ship-dark flag: the Post button in CheffyNoteReview renders only when
- * this is true. Publish wiring (postComment) is Phase 3 — flipping this
- * before Phase 3 lands shows a button that does nothing. Guarded by CI
- * (flag-guard in checks.yaml) so a stray flip can't reach main.
+ * Post-button flag, flipped ON in Phase 3 alongside the postComment()
+ * wiring. Kept (rather than deleted) as the kill switch for the publish
+ * path; the flag-guard in checks.yaml now asserts it stays true so an
+ * accidental un-flip can't silently dark-ship posting either.
  */
-export const NOTE_REVIEW_POST_ENABLED = false;
+export const NOTE_REVIEW_POST_ENABLED = true;
 
 export type NoteReviewMode = 'comment' | 'recipe';
 
@@ -25,10 +30,18 @@ export type NoteReviewPhase =
   | 'signing' // waiting on the user's signer (NIP-46 round trips are slow)
   | 'loading' // request in flight
   | 'draft' // editable draft ready
+  | 'posting' // publish in flight — Post disabled, no double-post
+  | 'post-timeout' // signed but relay round-trip timed out — retry without re-signing
+  | 'posted' // published — success state with a link to the reply
   | 'dead-end' // friendly stop — nothing postable (unclear/unreadable photo)
   | 'upsell' // NOT_MEMBER — membership gate
   | 'preview-used' // preview turns spent — conversion nudge
   | 'error'; // retryable failure
+
+/** The only phase a publish may start from — the double-post guard. */
+export function canPost(phase: NoteReviewPhase): boolean {
+  return phase === 'draft';
+}
 
 export type NoteReviewResult =
   | { ok: true; output: string }
@@ -38,13 +51,19 @@ export type NoteReviewResult =
 export const NOTE_TEXT_MAX_CHARS = 1000;
 
 /**
- * Hedged dead-end copy. Phase 1 finding: the server's NOT_FOOD path also
- * fires for CDN fallback images served in place of dead links (e.g.
- * nostr.build never 404s), so the client must never confidently claim
- * "that's not food" — and never echo the model's confident line.
+ * Hedged dead-end copy pool. Phase 1 finding: the server's NOT_FOOD path
+ * also fires for CDN fallback images served in place of dead links
+ * (e.g. nostr.build never 404s), so every line here must stay in the
+ * "couldn't get a good look" register — never a confident "that's not
+ * food", and the model's line is never echoed. Rotated via pickLine so
+ * regenerate attempts don't repeat the same dead-end verbatim.
  */
-export const PHOTO_UNCLEAR_LINE =
-  "Cheffy couldn't get a good look at that photo. It might be a broken link — or just not clearly a dish.";
+export const DEAD_END_LINES = [
+  "Cheffy couldn't get a good look at that photo. It might be a broken link — or just not clearly a dish.",
+  "That photo's playing hard to get — Cheffy can't quite make out a dish in it.",
+  "Cheffy squinted, but couldn't spot a dish in there. The photo may not have come through.",
+  "Hmm — Cheffy couldn't see this one clearly. The link may be stale, or the dish is camera-shy."
+];
 
 export const SIGN_FAILED_LINE =
   "Cheffy couldn't get your signer's autograph. Check your signer and try again.";
@@ -69,7 +88,7 @@ export function phaseForResult(result: NoteReviewResult): {
     case 'IMAGE_UNREADABLE':
       // Deliberately ignore the server-provided line here — it can be a
       // confident "that's a cat" while the truth is a dead link.
-      return { phase: 'dead-end', message: PHOTO_UNCLEAR_LINE };
+      return { phase: 'dead-end', message: pickLine(DEAD_END_LINES) };
     case 'SIGN_FAILED':
       return { phase: 'error', message: SIGN_FAILED_LINE };
     default:
@@ -161,5 +180,136 @@ export async function requestNoteReview(opts: NoteReviewRequestOpts): Promise<No
       code: 'NETWORK',
       error: err instanceof Error ? err.message : 'Network error'
     };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Publish path (Phase 3) — Post → postComment() with the kind-1 parent
+// ---------------------------------------------------------------------------
+
+export const POST_TIMEOUT_LINE =
+  "The relays are taking their time. Your reply is signed and may already be out there — give it another push, and Cheffy won't ask your signer twice.";
+
+export const PUBLISH_FAILED_LINE =
+  "The relays didn't take that one. Your draft is safe — give it another go.";
+
+export type PublishOutcome =
+  | { ok: true; event: NDKEvent; noteLink: string }
+  | { ok: false; code: 'publish-timeout'; message: string; signedEvent: NDKEvent }
+  | {
+      ok: false;
+      code: 'sign-failed' | 'publish-failed' | 'invalid-parent' | 'unknown';
+      message: string;
+    };
+
+/**
+ * Thread-view link for a published reply. House pattern: nevent with
+ * author + kind hints, falling back to a bare note1 encoding.
+ */
+export function noteLinkFor(event: NDKEvent): string {
+  try {
+    return '/' + nip19.neventEncode({ id: event.id, author: event.pubkey, kind: event.kind ?? 1 });
+  } catch {
+    return '/' + nip19.noteEncode(event.id);
+  }
+}
+
+export interface PublishNoteReviewOpts {
+  ndk: NDK;
+  /** The kind-1 note being replied to. */
+  parentEvent: NDKEvent;
+  /** The member-edited draft (D1: never raw model output on auto-pilot). */
+  content: string;
+  /** Test injection. */
+  postCommentFn?: typeof postComment;
+}
+
+/**
+ * Publish the edited draft as a NIP-10 reply, signed by the member.
+ * postComment owns tagging (NIP-10 via buildNip22CommentTags), the
+ * NIP-89 client tag, inbox-aware relay routing, and signing. Never
+ * throws — every PostCommentError code maps to a typed outcome so the
+ * modal can branch in Cheffy voice, including the publish-timeout
+ * signed-event recovery path.
+ */
+export async function publishNoteReviewReply(opts: PublishNoteReviewOpts): Promise<PublishOutcome> {
+  const { ndk, parentEvent, content, postCommentFn = postComment } = opts;
+  try {
+    const { event } = await postCommentFn(ndk, {
+      parentEvent,
+      content,
+      signingStrategy: 'explicit-with-timeout'
+    });
+    return { ok: true, event, noteLink: noteLinkFor(event) };
+  } catch (err) {
+    if (err instanceof PostCommentError) {
+      switch (err.code) {
+        case 'sign-failed':
+          return { ok: false, code: 'sign-failed', message: SIGN_FAILED_LINE };
+        case 'publish-timeout':
+          if (err.signedEvent) {
+            return {
+              ok: false,
+              code: 'publish-timeout',
+              message: POST_TIMEOUT_LINE,
+              signedEvent: err.signedEvent
+            };
+          }
+          return { ok: false, code: 'publish-failed', message: PUBLISH_FAILED_LINE };
+        case 'publish-failed':
+          return { ok: false, code: 'publish-failed', message: PUBLISH_FAILED_LINE };
+        case 'invalid-parent':
+          return {
+            ok: false,
+            code: 'invalid-parent',
+            message: "Cheffy lost track of the note you're replying to. Close and try again."
+          };
+      }
+    }
+    return {
+      ok: false,
+      code: 'unknown',
+      message: err instanceof Error ? err.message : PUBLISH_FAILED_LINE
+    };
+  }
+}
+
+const RETRY_PUBLISH_TIMEOUT_MS = 15_000;
+
+export interface RetryPublishOpts {
+  ndk: NDK;
+  /** The already-signed event from a publish-timeout outcome. */
+  signedEvent: NDKEvent;
+  timeoutMs?: number;
+  /** Test injection. */
+  buildRelaySetFn?: typeof buildInboxAwareRelaySet;
+}
+
+/**
+ * Recovery path for publish-timeout: re-publish the ALREADY-SIGNED
+ * event (same id, no second signer round trip) to the inbox-aware
+ * relay set. Relays deduplicate by event id, so if the first attempt
+ * actually landed this is a harmless no-op.
+ */
+export async function retryPublishSignedEvent(opts: RetryPublishOpts): Promise<PublishOutcome> {
+  const {
+    ndk,
+    signedEvent,
+    timeoutMs = RETRY_PUBLISH_TIMEOUT_MS,
+    buildRelaySetFn = buildInboxAwareRelaySet
+  } = opts;
+  try {
+    const relaySet = await buildRelaySetFn({ event: signedEvent, ndk });
+    await Promise.race([
+      signedEvent.publish(relaySet ?? undefined),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('publish retry timed out')), timeoutMs)
+      )
+    ]);
+    return { ok: true, event: signedEvent, noteLink: noteLinkFor(signedEvent) };
+  } catch {
+    // Still no relay ack — keep the signed event so the member can try
+    // again or safely close (it may have landed regardless).
+    return { ok: false, code: 'publish-timeout', message: POST_TIMEOUT_LINE, signedEvent };
   }
 }


### PR DESCRIPTION
## ⚡ Launch note

**Merging this PR launches Cheffy Note Photo Review posting for members** — `NOTE_REVIEW_POST_ENABLED` ships `true` (kept as the publish kill switch; the flag-guard CI step now asserts it stays true so an accidental un-flip can't silently dark-ship posting). Membership-page copy follows in Phase 4.

## Summary

Phase 3 of Cheffy Note Photo Review (#513 server, #516 client draft modal): the member-edited draft now publishes as a **NIP-10 reply signed by the member** via `postComment()` with the kind-1 parent. D1 holds: mandatory edit-before-post, no auto-publish, no bot identity.

### What's in here

- **Full typed-error handling in Cheffy voice** — `publishNoteReviewReply` maps every `PostCommentError` code (`sign-failed`, `publish-timeout`, `publish-failed`, `invalid-parent`) to a typed outcome; publish failures return to the draft **with the member's edits preserved**.
- **Publish-timeout signed-event recovery** — first consumer of `postComment`'s `signedEvent` capability: on timeout the already-signed event is held and "Give it another push" re-publishes it **as-is** (same event id, inbox-aware relay set, no second signer round trip; relays dedupe by id so a landed first attempt makes retry a harmless no-op). Follow-up filed for ReplyComposer to adopt the same pattern.
- **NIP-89 client tag confirmed by test** — an integration test runs the real `postComment` (only sign/publish/relay-routing stubbed) and asserts `['client', 'Zap Cooking']` plus the NIP-10 `e`/`p` tags on the built event.
- **Post-publish UX** — success state with a **View your reply** link (house `nevent` encoding with author+kind hints), clean modal close resets all state, and double-post protection (disabled button during publish + `canPost()` phase guard).
- **`DEAD_END_LINES` pool** (didn't land in #516) — rotating hedged dead-end copy via `pickLine`; tests assert pool membership and the pool-wide invariants (never "not food", never the server's line). *The four lines are open to copy review on this PR — wording changes are copy-only commits.*

## Test plan

- [x] 13 new unit tests: publish outcome mapping for every error code (incl. timeout-without-signedEvent degradation), retry success/failure/hung branches, `canPost` double-post guard across all phases, real-`postComment` client-tag + NIP-10 tag integration test
- [x] Full suite green (30 files, 520 tests); `svelte-check` 0 errors
- [ ] Manual cross-device pass on the branch preview, including NIP-10 threading spot-check in Damus/Amethyst (pre-merge gate)

Note: "Workers Builds" checks are expected to fail on this repo (known infra quirk — deploys go through Cloudflare Pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)