### PR TITLE
feat(cheffy): note photo review polish batch (Phase 4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.606",
+  "version": "4.2.607",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.607",
+  "version": "4.2.608",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/CheffyNoteReview.svelte
+++ b/src/components/CheffyNoteReview.svelte
@@ -26,6 +26,10 @@
     publishNoteReviewReply,
     retryPublishSignedEvent,
     canPost,
+    withDisclosureFooter,
+    loadDisclosurePref,
+    saveDisclosurePref,
+    DISCLOSURE_FOOTER,
     NOTE_REVIEW_POST_ENABLED,
     type NoteReviewMode,
     type NoteReviewPhase,
@@ -36,8 +40,11 @@
   export let event: NDKEvent;
   export let imageUrls: string[] = [];
 
-  // Multi-image notes default to the first image (picker strip: Phase 4).
-  $: imageUrl = imageUrls[0] ?? '';
+  // Multi-image picker: defaults to the first image; selection persists
+  // across Regenerate (only reset() clears it). One imageUrl per server
+  // call — the picker is purely client-side selection.
+  let selectedImageIndex = 0;
+  $: imageUrl = imageUrls[selectedImageIndex] ?? imageUrls[0] ?? '';
 
   let phase: NoteReviewPhase = 'choose';
   let mode: NoteReviewMode = 'comment';
@@ -48,6 +55,12 @@
   let postError = '';
   let noteLink = '';
   let timeoutSignedEvent: NDKEvent | null = null;
+  // Disclosure footer toggle — per-mode preference, applied at publish
+  // time only (never part of the editable draft).
+  let disclosureOn = false;
+  // Remaining free drafts, from the server's additive previewRemaining
+  // field (preview-granted requests only).
+  let previewRemaining: number | null = null;
 
   $: signedIn = $userPublickey !== '';
   $: normalizedPk = $userPublickey.trim().toLowerCase();
@@ -56,6 +69,7 @@
 
   async function run(selected: NoteReviewMode) {
     mode = selected;
+    disclosureOn = loadDisclosurePref(selected);
     phase = 'signing';
     loadingLine = pickLine(selected === 'recipe' ? COOKING_LINES : THINKING_LINES, loadingLine);
     const result = await requestNoteReview({
@@ -68,11 +82,19 @@
       experience: signedIn && !hasMembership,
       onSigned: () => (phase = 'loading')
     });
-    if (result.ok) draft = result.output;
+    if (result.ok) {
+      draft = result.output;
+      previewRemaining = result.previewRemaining ?? null;
+    }
     const next = phaseForResult(result);
     phase = next.phase;
     message = next.message;
     if (phase === 'error') errorLine = pickLine(ERROR_LINES, errorLine);
+  }
+
+  function toggleDisclosure() {
+    disclosureOn = !disclosureOn;
+    saveDisclosurePref(mode, disclosureOn);
   }
 
   function handlePublishOutcome(outcome: PublishOutcome) {
@@ -98,7 +120,13 @@
     postError = '';
     phase = 'posting';
     handlePublishOutcome(
-      await publishNoteReviewReply({ ndk: $ndk, parentEvent: event, content: draft })
+      await publishNoteReviewReply({
+        ndk: $ndk,
+        parentEvent: event,
+        // Footer joins the content only here, at publish time — the
+        // textarea's value (draft) never contains it.
+        content: withDisclosureFooter(draft, disclosureOn)
+      })
     );
   }
 
@@ -123,6 +151,8 @@
     postError = '';
     noteLink = '';
     timeoutSignedEvent = null;
+    selectedImageIndex = 0;
+    previewRemaining = null;
   }
 
   function signIn() {
@@ -158,6 +188,21 @@
       {#if imageUrl}
         <img class="nr-thumb" src={imageUrl} alt="Dish from the note" loading="lazy" />
       {/if}
+      {#if imageUrls.length > 1}
+        <div class="nr-picker" role="group" aria-label="Choose which photo Cheffy looks at">
+          {#each imageUrls as url, i (url)}
+            <button
+              type="button"
+              class="nr-picker-thumb"
+              class:nr-picker-selected={i === selectedImageIndex}
+              aria-pressed={i === selectedImageIndex}
+              on:click={() => (selectedImageIndex = i)}
+            >
+              <img src={url} alt="Photo {i + 1} of {imageUrls.length}" loading="lazy" />
+            </button>
+          {/each}
+        </div>
+      {/if}
       <p class="nr-hint">What should Cheffy draft? You'll edit it before anything is posted.</p>
       <div class="nr-choices">
         <button type="button" class="nr-choice" on:click={() => run('comment')}>
@@ -182,7 +227,14 @@
       </div>
     {:else if phase === 'draft' || phase === 'posting'}
       {@const posting = phase === 'posting'}
-      <p class="nr-hint">Cheffy's draft — make it yours, then post it as your own reply.</p>
+      <div class="nr-draft-head">
+        <p class="nr-hint">Cheffy's draft — make it yours, then post it as your own reply.</p>
+        {#if previewRemaining !== null}
+          <span class="nr-preview-chip">
+            {previewRemaining === 1 ? '1 free draft left' : `${previewRemaining} free drafts left`}
+          </span>
+        {/if}
+      </div>
       <textarea
         class="nr-draft"
         class:nr-draft-recipe={mode === 'recipe'}
@@ -191,6 +243,21 @@
         aria-label="Cheffy's draft"
         disabled={posting}
       ></textarea>
+      <label class="nr-disclosure">
+        <input
+          type="checkbox"
+          checked={disclosureOn}
+          on:change={toggleDisclosure}
+          disabled={posting}
+        />
+        <span>Add a small "via Cheffy" note</span>
+      </label>
+      {#if disclosureOn}
+        <!-- Publish-time footer preview — never part of the textarea. -->
+        <div class="nr-footer-preview" aria-label="Footer added when posting">
+          {DISCLOSURE_FOOTER}
+        </div>
+      {/if}
       {#if postError}
         <p class="nr-post-error">{postError}</p>
       {/if}
@@ -363,6 +430,77 @@
     padding: 8px 12px;
     border-radius: 8px;
     background: color-mix(in srgb, var(--color-primary) 8%, transparent);
+  }
+
+  .nr-picker {
+    display: flex;
+    gap: 8px;
+    overflow-x: auto;
+    padding-bottom: 4px;
+  }
+
+  .nr-picker-thumb {
+    flex: 0 0 auto;
+    width: 56px;
+    height: 56px;
+    padding: 0;
+    border: 2px solid transparent;
+    border-radius: 10px;
+    overflow: hidden;
+    background: none;
+    cursor: pointer;
+  }
+
+  .nr-picker-thumb img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+
+  .nr-picker-selected {
+    border-color: var(--color-primary);
+  }
+
+  .nr-draft-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .nr-preview-chip {
+    flex: 0 0 auto;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 3px 10px;
+    border-radius: 999px;
+    color: var(--color-primary);
+    background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+  }
+
+  .nr-disclosure {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.85rem;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .nr-disclosure input {
+    accent-color: var(--color-primary);
+  }
+
+  .nr-footer-preview {
+    font-size: 0.85rem;
+    color: var(--color-text-secondary);
+    padding: 6px 12px;
+    border-radius: 8px;
+    border: 1px dashed var(--color-input-border);
+    width: fit-content;
   }
 
   .nr-draft {

--- a/src/components/CheffyNoteReview.svelte
+++ b/src/components/CheffyNoteReview.svelte
@@ -28,6 +28,7 @@
     canPost,
     withDisclosureFooter,
     loadDisclosurePref,
+    shouldSeedDisclosureFromPref,
     saveDisclosurePref,
     DISCLOSURE_FOOTER,
     NOTE_REVIEW_POST_ENABLED,
@@ -69,7 +70,9 @@
 
   async function run(selected: NoteReviewMode) {
     mode = selected;
-    disclosureOn = loadDisclosurePref(selected);
+    // Seed the toggle from the stored pref only on initial mode
+    // selection; Regenerate / try-again keep the in-session toggle.
+    if (shouldSeedDisclosureFromPref(phase)) disclosureOn = loadDisclosurePref(selected);
     phase = 'signing';
     loadingLine = pickLine(selected === 'recipe' ? COOKING_LINES : THINKING_LINES, loadingLine);
     const result = await requestNoteReview({

--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -101,7 +101,7 @@
   import {
     fetchFeedFromPrimal,
     fetchGlobalFromPrimal,
-    fetchContactListFromPrimal,
+    fetchContactListFromPrimal
   } from '$lib/primalCache';
 
   // Membership checking for member feed
@@ -455,7 +455,12 @@
   const RELAY_POOLS = {
     recipes: ['wss://nos.lol', 'wss://relay.damus.io'], // General relays with recipe content
     fallback: ['wss://relay.primal.net', 'wss://nostr.wine', 'wss://antiprimal.net'], // Fast general relays for broader discovery
-    discovery: ['wss://nostr.wine', 'wss://relay.primal.net', 'wss://purplepag.es', 'wss://antiprimal.net'], // Additional relays for discovery
+    discovery: [
+      'wss://nostr.wine',
+      'wss://relay.primal.net',
+      'wss://purplepag.es',
+      'wss://antiprimal.net'
+    ], // Additional relays for discovery
     profiles: ['wss://purplepag.es'], // Profile metadata (356ms, specialized for kind:0)
     members: ['wss://pantry.zap.cooking'] // Private member relay (The Pantry)
   };
@@ -704,7 +709,9 @@
         ) {
           // Fix C: Single-fire per intersection — reset after rAF
           sentinelFiredThisFrame = true;
-          requestAnimationFrame(() => { if (!isDestroyed) sentinelFiredThisFrame = false; });
+          requestAnimationFrame(() => {
+            if (!isDestroyed) sentinelFiredThisFrame = false;
+          });
           loadMore();
         }
       },
@@ -931,7 +938,10 @@
   // Click anywhere on a feed card (except on a link, button, or while
   // selecting text) to open the single-note view.
   function gotoNoteFromCard(e: MouseEvent, ev: NDKEvent) {
-    if (e.target instanceof Element && e.target.closest('a, button, input, textarea, [role="button"]')) {
+    if (
+      e.target instanceof Element &&
+      e.target.closest('a, button, input, textarea, [role="button"]')
+    ) {
       return;
     }
     if (typeof window !== 'undefined' && window.getSelection()?.toString()) return;
@@ -1363,11 +1373,7 @@
       const staleKeys: string[] = [];
       for (let i = 0; i < localStorage.length; i++) {
         const k = localStorage.key(i);
-        if (
-          k &&
-          k.startsWith(INSTANT_CACHE_LEGACY_PREFIX) &&
-          !k.startsWith(INSTANT_CACHE_PREFIX)
-        ) {
+        if (k && k.startsWith(INSTANT_CACHE_LEGACY_PREFIX) && !k.startsWith(INSTANT_CACHE_PREFIX)) {
           staleKeys.push(k);
         }
       }
@@ -2056,7 +2062,9 @@
         // Start Primal fetch (non-blocking)
         const primalPromise = (async (): Promise<NDKEvent[] | null> => {
           try {
-            const primalFollows = (primalPrefetch ? await primalPrefetch : null) || await fetchContactListFromPrimal($userPublickey);
+            const primalFollows =
+              (primalPrefetch ? await primalPrefetch : null) ||
+              (await fetchContactListFromPrimal($userPublickey));
             primalPrefetch = null; // Consumed
 
             if (!primalFollows || primalFollows.length === 0) return null;
@@ -2093,11 +2101,7 @@
           };
         }
 
-        const outboxPromise = fetchFollowingEvents(
-          $ndk,
-          $userPublickey,
-          outboxOptions
-        );
+        const outboxPromise = fetchFollowingEvents($ndk, $userPublickey, outboxOptions);
 
         // Race: use whichever resolves with good data first
         const primalResult = await Promise.race([
@@ -2187,9 +2191,10 @@
         const repliesPrimalPromise = (async (): Promise<NDKEvent[] | null> => {
           try {
             // Use already-cached follow list instead of re-fetching from Primal
-            const follows = followedPubkeysForRealtime.length > 0
-              ? followedPubkeysForRealtime
-              : await fetchContactListFromPrimal($userPublickey);
+            const follows =
+              followedPubkeysForRealtime.length > 0
+                ? followedPubkeysForRealtime
+                : await fetchContactListFromPrimal($userPublickey);
 
             if (!follows || follows.length === 0) return null;
 
@@ -2427,7 +2432,10 @@
       }
 
       // Start relay pool fetch immediately (runs in parallel with Primal)
-      const relayPoolPromise = fetchFromRelays(hashtagFilter, [...RELAY_POOLS.recipes, ...RELAY_POOLS.fallback]);
+      const relayPoolPromise = fetchFromRelays(hashtagFilter, [
+        ...RELAY_POOLS.recipes,
+        ...RELAY_POOLS.fallback
+      ]);
 
       // Start Primal fetch concurrently (only for community global, not profile views)
       let primalGlobalResult: NDKEvent[] | null = null;
@@ -2436,10 +2444,12 @@
           // Race: Primal vs relay pools — use whichever finishes with good data first
           const primalPromise = (async (): Promise<NDKEvent[] | null> => {
             try {
-              const result = primalPrefetch ? await primalPrefetch : await fetchGlobalFromPrimal($ndk, {
-                limit: 200,
-                since: sevenDaysAgo()
-              });
+              const result = primalPrefetch
+                ? await primalPrefetch
+                : await fetchGlobalFromPrimal($ndk, {
+                    limit: 200,
+                    since: sevenDaysAgo()
+                  });
               primalPrefetch = null;
               if (!result) return null;
               const { events: primalEvents } = result;
@@ -2527,12 +2537,11 @@
       // freshness gap (e.g., newest is 3+ hours old while unhashtagged food posts
       // exist from minutes ago).
       if (!authorPubkey) {
-        const newestHashtagTime = hashtagEvents.length > 0
-          ? Math.max(...hashtagEvents.map((e) => e.created_at || 0))
-          : 0;
+        const newestHashtagTime =
+          hashtagEvents.length > 0 ? Math.max(...hashtagEvents.map((e) => e.created_at || 0)) : 0;
         const THIRTY_MINUTES = 30 * 60;
         const now = Math.floor(Date.now() / 1000);
-        const resultsAreStale = newestHashtagTime > 0 && (now - newestHashtagTime) > THIRTY_MINUTES;
+        const resultsAreStale = newestHashtagTime > 0 && now - newestHashtagTime > THIRTY_MINUTES;
 
         if (hashtagEvents.length < 30 || resultsAreStale) {
           try {
@@ -2875,7 +2884,10 @@
     } else if (filterMode !== 'members') {
       // Global feed: always apply food filter
       // Profile view: respect the foodFilterEnabled toggle (matches initial load)
-      if (authorPubkey ? (foodFilterEnabled && !shouldIncludeEvent(event)) : !shouldIncludeEvent(event)) return;
+      if (
+        authorPubkey ? foodFilterEnabled && !shouldIncludeEvent(event) : !shouldIncludeEvent(event)
+      )
+        return;
     }
     // Members mode: no food filter
 
@@ -3062,9 +3074,10 @@
         if (!$userPublickey) return;
 
         // Reuse cached follow list — avoid redundant Primal call
-        const follows = followedPubkeysForRealtime.length > 0
-          ? followedPubkeysForRealtime
-          : await fetchContactListFromPrimal($userPublickey);
+        const follows =
+          followedPubkeysForRealtime.length > 0
+            ? followedPubkeysForRealtime
+            : await fetchContactListFromPrimal($userPublickey);
 
         if (filterMode !== startMode) return;
         if (follows.length === 0) return;
@@ -3319,9 +3332,7 @@
 
       if (validNew.length > 0) {
         validNew.forEach((e) => seenEventIds.add(e.id));
-        events = [...validNew, ...events].sort(
-          (a, b) => getEventSortTime(b) - getEventSortTime(a)
-        );
+        events = [...validNew, ...events].sort((a, b) => getEventSortTime(b) - getEventSortTime(a));
         lastEventTime = Math.max(lastEventTime, ...validNew.map(getEventSortTime));
         await cacheEvents();
       }
@@ -4676,7 +4687,13 @@
   // either way. Letting the batch run for everyone warms/populates the
   // engagement store first, so subsequent per-card fetchEngagement calls can
   // see already-fetched fresh data and no-op instead of fanning out.
-  $: if (typeof window !== 'undefined' && $ndk && events.length > 0 && !loading && renderedNotes.size > 0) {
+  $: if (
+    typeof window !== 'undefined' &&
+    $ndk &&
+    events.length > 0 &&
+    !loading &&
+    renderedNotes.size > 0
+  ) {
     // Clear any pending preload
     if (engagementPreloadTimeout) {
       clearTimeout(engagementPreloadTimeout);
@@ -4684,7 +4701,9 @@
 
     // Only preload engagement for items near the viewport (in renderedNotes)
     engagementPreloadTimeout = setTimeout(async () => {
-      const allEventIds = events.map((e) => e.id).filter((id): id is string => Boolean(id) && renderedNotes.has(id));
+      const allEventIds = events
+        .map((e) => e.id)
+        .filter((id): id is string => Boolean(id) && renderedNotes.has(id));
 
       // Filter to only fetch events that aren't already fresh
       // Cached data loads instantly via getEngagementStore, so only preload if missing/stale
@@ -4723,12 +4742,7 @@
   // VISIBILITY UPDATE: When items become visible, ensure they're fresh.
   // Same anon-friendly rationale as the preload reactive above — batching
   // benefits everyone, not just logged-in users.
-  $: if (
-    typeof window !== 'undefined' &&
-    $ndk &&
-    visibleNotes.size > 0 &&
-    events.length > 0
-  ) {
+  $: if (typeof window !== 'undefined' && $ndk && visibleNotes.size > 0 && events.length > 0) {
     // Debounce batch fetching to avoid too many calls
     if (engagementBatchTimeout) {
       clearTimeout(engagementBatchTimeout);
@@ -4942,398 +4956,408 @@
           <div
             use:renderZoneAction={event.id}
             class="feed-post-wrapper"
-            style="{!renderedNotes.has(event.id) && measuredHeights.has(event.id) ? `height: ${measuredHeights.get(event.id)}px;` : ''}"
+            style={!renderedNotes.has(event.id) && measuredHeights.has(event.id)
+              ? `height: ${measuredHeights.get(event.id)}px;`
+              : ''}
           >
-          {#if renderedNotes.has(event.id)}
-          <!-- Get engagement info - always check cache, subscribe only when visible -->
-          {@const isVisible = visibleNotes.has(event.id)}
-          {@const engagementInfo = getEngagementRenderInfo(event.id, isVisible)}
-          <!-- Glow/animation disabled on community feed to reduce bandwidth -->
-          <!-- {@const isZapAnimating = zapAnimatingNotes.has(event.id)} -->
-          <!-- {@const zapGlowTier = engagementInfo.zapGlowTier} -->
-          {@const engagementStoreValue = get(getEngagementStore(event.id))}
-          {@const engagementData = {
-            zaps: {
-              totalAmount: engagementStoreValue.zaps.totalAmount,
-              count: engagementStoreValue.zaps.count
-            },
-            reactions: { count: engagementStoreValue.reactions.count },
-            comments: { count: engagementStoreValue.comments.count }
-          }}
-          <!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->
-          <article
-            class="w-full cursor-pointer"
-            on:click={(e) => gotoNoteFromCard(e, event)}
-            role="link"
-            tabindex="0"
-            on:keydown|self={(e) => {
-              if (e.key === 'Enter') {
-                const href = noteHrefFromEventId(event.id);
-                if (href) goto(href);
-              }
-            }}
-          >
-            {#if getRepostedBy(event)}
-              {@const reposterPubkey = getRepostedBy(event) || ''}
-              <a
-                href="/user/{nip19.npubEncode(reposterPubkey)}"
-                class="flex items-center gap-1.5 text-xs mb-3 px-2 sm:px-0 hover:opacity-80 transition-opacity"
-                style="color: var(--color-caption)"
-                on:click|stopPropagation
+            {#if renderedNotes.has(event.id)}
+              <!-- Get engagement info - always check cache, subscribe only when visible -->
+              {@const isVisible = visibleNotes.has(event.id)}
+              {@const engagementInfo = getEngagementRenderInfo(event.id, isVisible)}
+              <!-- Glow/animation disabled on community feed to reduce bandwidth -->
+              <!-- {@const isZapAnimating = zapAnimatingNotes.has(event.id)} -->
+              <!-- {@const zapGlowTier = engagementInfo.zapGlowTier} -->
+              {@const engagementStoreValue = get(getEngagementStore(event.id))}
+              {@const engagementData = {
+                zaps: {
+                  totalAmount: engagementStoreValue.zaps.totalAmount,
+                  count: engagementStoreValue.zaps.count
+                },
+                reactions: { count: engagementStoreValue.reactions.count },
+                comments: { count: engagementStoreValue.comments.count }
+              }}
+              <!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->
+              <article
+                class="w-full cursor-pointer"
+                on:click={(e) => gotoNoteFromCard(e, event)}
+                role="link"
+                tabindex="0"
+                on:keydown|self={(e) => {
+                  if (e.key === 'Enter') {
+                    const href = noteHrefFromEventId(event.id);
+                    if (href) goto(href);
+                  }
+                }}
               >
-                <svg
-                  class="w-3.5 h-3.5"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-                  />
-                </svg>
-                <span>Reposted by</span>
-                <!--
+                {#if getRepostedBy(event)}
+                  {@const reposterPubkey = getRepostedBy(event) || ''}
+                  <a
+                    href="/user/{nip19.npubEncode(reposterPubkey)}"
+                    class="flex items-center gap-1.5 text-xs mb-3 px-2 sm:px-0 hover:opacity-80 transition-opacity"
+                    style="color: var(--color-caption)"
+                    on:click|stopPropagation
+                  >
+                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                      />
+                    </svg>
+                    <span>Reposted by</span>
+                    <!--
                   Use CustomName (renders <span>) here, not AuthorName which
                   renders a <button>. Nesting <button> inside <a> is invalid
                   HTML and breaks keyboard / screen-reader behavior.
                 -->
-                <CustomName pubkey={reposterPubkey} className="text-xs font-medium" />
-              </a>
-            {/if}
-
-            <!-- User header with avatar and name -->
-            <div class="flex items-center justify-between mb-3 px-2 sm:px-0">
-              <div class="flex items-center space-x-3 flex-1 min-w-0">
-                {#if !hideAvatar}
-                  <a
-                    href="/user/{nip19.npubEncode(event.author?.hexpubkey || event.pubkey)}"
-                    class="flex-shrink-0 cursor-pointer"
-                    on:click|stopPropagation={() => goto(`/user/${nip19.npubEncode(event.author?.hexpubkey || event.pubkey)}`)}
-                  >
-                    <Avatar
-                      pubkey={event.author?.hexpubkey || event.pubkey}
-                      size={40}
-                    />
+                    <CustomName pubkey={reposterPubkey} className="text-xs font-medium" />
                   </a>
                 {/if}
 
-                <div class="flex items-center space-x-2 flex-wrap min-w-0">
-                  {#if !hideAuthorName}
-                    <!-- truncate + min-w-0 lets a long display name shrink with an
+                <!-- User header with avatar and name -->
+                <div class="flex items-center justify-between mb-3 px-2 sm:px-0">
+                  <div class="flex items-center space-x-3 flex-1 min-w-0">
+                    {#if !hideAvatar}
+                      <a
+                        href="/user/{nip19.npubEncode(event.author?.hexpubkey || event.pubkey)}"
+                        class="flex-shrink-0 cursor-pointer"
+                        on:click|stopPropagation={() =>
+                          goto(
+                            `/user/${nip19.npubEncode(event.author?.hexpubkey || event.pubkey)}`
+                          )}
+                      >
+                        <Avatar pubkey={event.author?.hexpubkey || event.pubkey} size={40} />
+                      </a>
+                    {/if}
+
+                    <div class="flex items-center space-x-2 flex-wrap min-w-0">
+                      {#if !hideAuthorName}
+                        <!-- truncate + min-w-0 lets a long display name shrink with an
                          ellipsis instead of pushing the timestamp onto a new line
                          (or worse, splitting "about 3 hours ago" mid-phrase). -->
-                    <AuthorName {event} className="font-semibold text-sm truncate min-w-0" />
-                    <span class="text-sm flex-shrink-0" style="color: var(--color-caption)">·</span>
-                  {/if}
-                  <span class="text-sm whitespace-nowrap flex-shrink-0" style="color: var(--color-caption)">
-                    {event.created_at ? formatTimeAgo(event.created_at) : 'Unknown time'}
-                  </span>
-                  <ClientAttribution tags={event.tags} enableEnrichment={false} />
-                </div>
-              </div>
-
-              <!-- Post actions menu (top right) -->
-              <div class="flex-shrink-0 ml-2">
-                <PostActionsMenu
-                  {event}
-                  {engagementData}
-                  on:copy={(e) => {
-                    selectedEvent = event;
-                    handlePostCopy(e);
-                  }}
-                  on:share={(e) => {
-                    selectedEvent = event;
-                    handlePostShare(e, event);
-                  }}
-                  on:downloadImage={handleDownloadImage}
-                />
-              </div>
-            </div>
-
-            <!-- Main content area - full width below header -->
-            <div class="px-2 sm:px-0">
-              <!-- Reply context (orange bracket at top for replies) -->
-              {#if isReply(event)}
-                {@const parentNoteId = getParentNoteId(event)}
-                {#if parentNoteId}
-                  {@const parentHref = noteHrefFromEventId(parentNoteId)}
-                  {#if parentHref}
-                    {#await resolveReplyContext(parentNoteId)}
-                      <!-- Loading state -->
-                      <div class="parent-quote-embed mb-3">
-                        <div class="parent-quote-loading">
-                          <div class="w-4 h-4 bg-accent-gray rounded-full animate-pulse"></div>
-                          <div class="h-3 bg-accent-gray rounded w-20 animate-pulse"></div>
-                        </div>
-                      </div>
-                    {:then context}
-                      <!-- Always-visible embedded parent quote -->
-                      <a
-                        href={parentHref}
-                        class="parent-quote-embed mb-3 block hover:opacity-90 transition-opacity"
-                        on:click|stopPropagation
+                        <AuthorName {event} className="font-semibold text-sm truncate min-w-0" />
+                        <span class="text-sm flex-shrink-0" style="color: var(--color-caption)"
+                          >·</span
+                        >
+                      {/if}
+                      <span
+                        class="text-sm whitespace-nowrap flex-shrink-0"
+                        style="color: var(--color-caption)"
                       >
-                        <div class="parent-quote-header">
-                          {#if context.authorPubkey}
-                            <Avatar pubkey={context.authorPubkey} size={16} />
-                          {/if}
-                          <span class="parent-quote-author">
-                            {#if context.error === 'deleted'}
-                              <span class="italic">deleted note</span>
-                            {:else if context.error === 'Failed to load'}
-                              a note
-                            {:else}
-                              {context.authorName.startsWith('npub')
-                                ? context.authorName.substring(0, 12) + '...'
-                                : context.authorName}
-                            {/if}
-                          </span>
-                        </div>
-                        {#if context.notePreview && !context.error}
-                          <p class="parent-quote-content">{context.notePreview}</p>
-                        {/if}
-                        {#if context.previewImage && !context.error}
-                          <img
-                            src={getOptimizedImageUrl(context.previewImage)}
-                            class="parent-quote-image"
-                            loading="lazy"
-                            alt=""
-                          />
-                        {/if}
-                        <span class="parent-quote-link"> View full thread → </span>
-                      </a>
-                    {:catch}
-                      <!-- Fallback - simple link -->
-                      <a href={parentHref} class="parent-quote-embed mb-3 block">
-                        <div class="parent-quote-header">
-                          <svg
-                            class="w-4 h-4"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                              stroke-width="2"
-                              d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"
-                            />
-                          </svg>
-                          <span class="parent-quote-author">Replying to a note</span>
-                        </div>
-                      </a>
-                    {/await}
-                  {:else}
-                    <div class="parent-quote-embed mb-3">
-                      <div class="parent-quote-header">
-                        <span class="parent-quote-author">Replying to a note</span>
-                      </div>
+                        {event.created_at ? formatTimeAgo(event.created_at) : 'Unknown time'}
+                      </span>
+                      <ClientAttribution tags={event.tags} enableEnrichment={false} />
                     </div>
-                  {/if}
-                {/if}
-              {/if}
-
-              <!-- Content - strip quoted note reference if present to avoid bubble embed -->
-              {#if event.kind === 1068}
-                <PollDisplay {event} />
-              {:else if hasQuotedNote(event)}
-                {@const cleanContent = getContentWithoutMedia(
-                  getContentWithoutQuote(event.content)
-                )}
-                {#if cleanContent}
-                  <div
-                    class="text-sm leading-relaxed mb-3"
-                    style="color: var(--color-text-primary)"
-                  >
-                    <NoteContent content={cleanContent} />
                   </div>
-                {/if}
-              {:else if getContentWithoutMedia(event.content)}
-                {@const cleanContent = getContentWithoutMedia(event.content)}
-                <div class="text-sm leading-relaxed mb-3" style="color: var(--color-text-primary)">
-                  <NoteContent content={cleanContent} />
-                </div>
-              {/if}
 
-              <!-- Quoted note embed (appears below user's content) -->
-              {#if hasQuotedNote(event)}
-                {@const quotedNoteId = getQuotedNoteId(event)}
-                {#if quotedNoteId}
-                  {@const quotedHref = noteHrefFromEventId(quotedNoteId)}
-                  {#if quotedHref}
-                    {#await resolveReplyContext(quotedNoteId)}
-                      <!-- Loading state -->
-                      <div class="parent-quote-embed mb-3">
-                        <div class="parent-quote-loading">
-                          <div class="w-4 h-4 bg-accent-gray rounded-full animate-pulse"></div>
-                          <div class="h-3 bg-accent-gray rounded w-20 animate-pulse"></div>
-                        </div>
-                      </div>
-                    {:then context}
-                      <!-- Quoted note with orange bracket style -->
-                      <a
-                        href={quotedHref}
-                        class="parent-quote-embed mb-3 block hover:opacity-90 transition-opacity"
-                        on:click|stopPropagation
-                      >
-                        <div class="parent-quote-header">
-                          {#if context.authorPubkey}
-                            <Avatar pubkey={context.authorPubkey} size={16} />
-                          {/if}
-                          <span class="parent-quote-author">
-                            {#if context.error === 'deleted'}
-                              <span class="italic">deleted note</span>
-                            {:else if context.error === 'Failed to load'}
-                              a note
-                            {:else}
-                              {context.authorName.startsWith('npub')
-                                ? context.authorName.substring(0, 12) + '...'
-                                : context.authorName}
-                            {/if}
-                          </span>
-                        </div>
-                        {#if context.notePreview && !context.error}
-                          <p class="parent-quote-content">{context.notePreview}</p>
-                        {/if}
-                        {#if context.previewImage && !context.error}
-                          <img
-                            src={getOptimizedImageUrl(context.previewImage)}
-                            class="parent-quote-image"
-                            loading="lazy"
-                            alt=""
-                          />
-                        {/if}
-                        <span class="parent-quote-link"> View quoted note → </span>
-                      </a>
-                    {:catch}
-                      <!-- Fallback - simple link -->
-                      <a href={quotedHref} class="parent-quote-embed mb-3 block">
-                        <div class="parent-quote-header">
-                          <svg
-                            class="w-4 h-4"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
+                  <!-- Post actions menu (top right) -->
+                  <div class="flex-shrink-0 ml-2">
+                    <PostActionsMenu
+                      {event}
+                      {engagementData}
+                      on:copy={(e) => {
+                        selectedEvent = event;
+                        handlePostCopy(e);
+                      }}
+                      on:share={(e) => {
+                        selectedEvent = event;
+                        handlePostShare(e, event);
+                      }}
+                      on:downloadImage={handleDownloadImage}
+                    />
+                  </div>
+                </div>
+
+                <!-- Main content area - full width below header -->
+                <div class="px-2 sm:px-0">
+                  <!-- Reply context (orange bracket at top for replies) -->
+                  {#if isReply(event)}
+                    {@const parentNoteId = getParentNoteId(event)}
+                    {#if parentNoteId}
+                      {@const parentHref = noteHrefFromEventId(parentNoteId)}
+                      {#if parentHref}
+                        {#await resolveReplyContext(parentNoteId)}
+                          <!-- Loading state -->
+                          <div class="parent-quote-embed mb-3">
+                            <div class="parent-quote-loading">
+                              <div class="w-4 h-4 bg-accent-gray rounded-full animate-pulse"></div>
+                              <div class="h-3 bg-accent-gray rounded w-20 animate-pulse"></div>
+                            </div>
+                          </div>
+                        {:then context}
+                          <!-- Always-visible embedded parent quote -->
+                          <a
+                            href={parentHref}
+                            class="parent-quote-embed mb-3 block hover:opacity-90 transition-opacity"
+                            on:click|stopPropagation
                           >
-                            <path
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                              stroke-width="2"
-                              d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"
-                            />
-                          </svg>
-                          <span class="parent-quote-author">Quoting a note</span>
+                            <div class="parent-quote-header">
+                              {#if context.authorPubkey}
+                                <Avatar pubkey={context.authorPubkey} size={16} />
+                              {/if}
+                              <span class="parent-quote-author">
+                                {#if context.error === 'deleted'}
+                                  <span class="italic">deleted note</span>
+                                {:else if context.error === 'Failed to load'}
+                                  a note
+                                {:else}
+                                  {context.authorName.startsWith('npub')
+                                    ? context.authorName.substring(0, 12) + '...'
+                                    : context.authorName}
+                                {/if}
+                              </span>
+                            </div>
+                            {#if context.notePreview && !context.error}
+                              <p class="parent-quote-content">{context.notePreview}</p>
+                            {/if}
+                            {#if context.previewImage && !context.error}
+                              <img
+                                src={getOptimizedImageUrl(context.previewImage)}
+                                class="parent-quote-image"
+                                loading="lazy"
+                                alt=""
+                              />
+                            {/if}
+                            <span class="parent-quote-link"> View full thread → </span>
+                          </a>
+                        {:catch}
+                          <!-- Fallback - simple link -->
+                          <a href={parentHref} class="parent-quote-embed mb-3 block">
+                            <div class="parent-quote-header">
+                              <svg
+                                class="w-4 h-4"
+                                fill="none"
+                                stroke="currentColor"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"
+                                />
+                              </svg>
+                              <span class="parent-quote-author">Replying to a note</span>
+                            </div>
+                          </a>
+                        {/await}
+                      {:else}
+                        <div class="parent-quote-embed mb-3">
+                          <div class="parent-quote-header">
+                            <span class="parent-quote-author">Replying to a note</span>
+                          </div>
                         </div>
-                      </a>
-                    {/await}
-                  {:else}
-                    <div class="parent-quote-embed mb-3">
-                      <div class="parent-quote-header">
-                        <span class="parent-quote-author">Quoting a note</span>
+                      {/if}
+                    {/if}
+                  {/if}
+
+                  <!-- Content - strip quoted note reference if present to avoid bubble embed -->
+                  {#if event.kind === 1068}
+                    <PollDisplay {event} />
+                  {:else if hasQuotedNote(event)}
+                    {@const cleanContent = getContentWithoutMedia(
+                      getContentWithoutQuote(event.content)
+                    )}
+                    {#if cleanContent}
+                      <div
+                        class="text-sm leading-relaxed mb-3"
+                        style="color: var(--color-text-primary)"
+                      >
+                        <NoteContent content={cleanContent} />
                       </div>
+                    {/if}
+                  {:else if getContentWithoutMedia(event.content)}
+                    {@const cleanContent = getContentWithoutMedia(event.content)}
+                    <div
+                      class="text-sm leading-relaxed mb-3"
+                      style="color: var(--color-text-primary)"
+                    >
+                      <NoteContent content={cleanContent} />
                     </div>
                   {/if}
-                {/if}
-              {/if}
 
-              {#if getImageUrlsCached(event).length > 0}
-                {@const mediaUrls = getImageUrlsCached(event)}
+                  <!-- Quoted note embed (appears below user's content) -->
+                  {#if hasQuotedNote(event)}
+                    {@const quotedNoteId = getQuotedNoteId(event)}
+                    {#if quotedNoteId}
+                      {@const quotedHref = noteHrefFromEventId(quotedNoteId)}
+                      {#if quotedHref}
+                        {#await resolveReplyContext(quotedNoteId)}
+                          <!-- Loading state -->
+                          <div class="parent-quote-embed mb-3">
+                            <div class="parent-quote-loading">
+                              <div class="w-4 h-4 bg-accent-gray rounded-full animate-pulse"></div>
+                              <div class="h-3 bg-accent-gray rounded w-20 animate-pulse"></div>
+                            </div>
+                          </div>
+                        {:then context}
+                          <!-- Quoted note with orange bracket style -->
+                          <a
+                            href={quotedHref}
+                            class="parent-quote-embed mb-3 block hover:opacity-90 transition-opacity"
+                            on:click|stopPropagation
+                          >
+                            <div class="parent-quote-header">
+                              {#if context.authorPubkey}
+                                <Avatar pubkey={context.authorPubkey} size={16} />
+                              {/if}
+                              <span class="parent-quote-author">
+                                {#if context.error === 'deleted'}
+                                  <span class="italic">deleted note</span>
+                                {:else if context.error === 'Failed to load'}
+                                  a note
+                                {:else}
+                                  {context.authorName.startsWith('npub')
+                                    ? context.authorName.substring(0, 12) + '...'
+                                    : context.authorName}
+                                {/if}
+                              </span>
+                            </div>
+                            {#if context.notePreview && !context.error}
+                              <p class="parent-quote-content">{context.notePreview}</p>
+                            {/if}
+                            {#if context.previewImage && !context.error}
+                              <img
+                                src={getOptimizedImageUrl(context.previewImage)}
+                                class="parent-quote-image"
+                                loading="lazy"
+                                alt=""
+                              />
+                            {/if}
+                            <span class="parent-quote-link"> View quoted note → </span>
+                          </a>
+                        {:catch}
+                          <!-- Fallback - simple link -->
+                          <a href={quotedHref} class="parent-quote-embed mb-3 block">
+                            <div class="parent-quote-header">
+                              <svg
+                                class="w-4 h-4"
+                                fill="none"
+                                stroke="currentColor"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"
+                                />
+                              </svg>
+                              <span class="parent-quote-author">Quoting a note</span>
+                            </div>
+                          </a>
+                        {/await}
+                      {:else}
+                        <div class="parent-quote-embed mb-3">
+                          <div class="parent-quote-header">
+                            <span class="parent-quote-author">Quoting a note</span>
+                          </div>
+                        </div>
+                      {/if}
+                    {/if}
+                  {/if}
 
-                <!-- Swipeable gallery: peeking 4:5 tiles with a count
+                  {#if getImageUrlsCached(event).length > 0}
+                    {@const mediaUrls = getImageUrlsCached(event)}
+
+                    <!-- Swipeable gallery: peeking 4:5 tiles with a count
                      badge; single media shrink-wraps to the photo.
                      The lightbox only renders images, so it gets an
                      images-only list (videos play inline in their
                      tiles) with the index remapped accordingly. -->
-                <div class="mb-3">
-                  <MediaCarousel
-                    items={mediaUrls}
-                    optimizeUrl={getOptimizedImageUrl}
-                    onItemClick={(url) => {
-                      const imageUrls = mediaUrls.filter((u) => isImageUrl(u));
-                      const imageIndex = imageUrls.indexOf(url);
-                      openImageModal(url, imageUrls, imageIndex >= 0 ? imageIndex : 0);
-                    }}
-                  />
-                </div>
-              {/if}
+                    <div class="mb-3">
+                      <MediaCarousel
+                        items={mediaUrls}
+                        optimizeUrl={getOptimizedImageUrl}
+                        onItemClick={(url) => {
+                          const imageUrls = mediaUrls.filter((u) => isImageUrl(u));
+                          const imageIndex = imageUrls.indexOf(url);
+                          openImageModal(url, imageUrls, imageIndex >= 0 ? imageIndex : 0);
+                        }}
+                      />
+                    </div>
+                  {/if}
 
-              <!-- Reaction pills row -->
-              {#if visibleNotes.has(event.id)}
-                <div class="px-2 sm:px-0">
-                  <NoteReactionPills {event} />
-                </div>
-              {/if}
-
-              <!-- Zap pills row: above action icons to avoid cutoff on the right -->
-              {#if visibleNotes.has(event.id)}
-                <div class="px-2 sm:px-0">
-                  <NoteTotalZaps
-                    {event}
-                    onZapClick={() => openZapModal(event)}
-                    showPills={true}
-                    onlyPills={true}
-                    maxPills={10}
-                  />
-                </div>
-              {/if}
-
-              <div
-                class="flex items-center justify-between flex-wrap gap-2 px-2 sm:px-0 py-1"
-                use:lazyLoadAction={event.id}
-              >
-                <div class="flex items-center space-x-1 flex-shrink-0">
+                  <!-- Reaction pills row -->
                   {#if visibleNotes.has(event.id)}
-                    <div class="hover:bg-accent-gray rounded-full p-1.5 transition-colors">
-                      <NoteTotalLikes {event} />
+                    <div class="px-2 sm:px-0">
+                      <NoteReactionPills {event} />
                     </div>
+                  {/if}
 
-                    <div class="hover:bg-accent-gray rounded-full p-1.5 transition-colors">
-                      <NoteTotalComments {event} />
-                    </div>
-
-                    <div class="hover:bg-accent-gray rounded-full p-1.5 transition-colors">
-                      <NoteRepost {event} />
-                    </div>
-
-                    <!-- Renders nothing for imageless notes — the trigger owns detection. -->
-                    <CheffyNoteReviewTrigger
-                      {event}
-                      wrapClass="hover:bg-accent-gray rounded-full p-1.5 transition-colors"
-                    />
-
-                    <div class="hover:bg-amber-50/50 rounded-full p-1 transition-colors">
+                  <!-- Zap pills row: above action icons to avoid cutoff on the right -->
+                  {#if visibleNotes.has(event.id)}
+                    <div class="px-2 sm:px-0">
                       <NoteTotalZaps
                         {event}
                         onZapClick={() => openZapModal(event)}
-                        showPills={false}
+                        showPills={true}
+                        onlyPills={true}
+                        maxPills={10}
                       />
                     </div>
-                  {:else}
-                    <span class="text-caption p-1.5 opacity-40">♡</span>
-                    <span class="text-caption p-1.5 opacity-40">💬</span>
-                    <span class="text-caption p-1.5 opacity-40">🔁</span>
-                    <span class="text-caption p-1.5 opacity-40">⚡</span>
                   {/if}
-                </div>
-              </div>
 
-              <div class="px-2 sm:px-0">
-                {#if visibleNotes.has(event.id)}
-                  <CommentThread variant="feed" {event} />
-                {/if}
+                  <div
+                    class="flex items-center justify-between flex-wrap gap-2 px-2 sm:px-0 py-1"
+                    use:lazyLoadAction={event.id}
+                  >
+                    <div class="flex items-center space-x-1 flex-shrink-0">
+                      {#if visibleNotes.has(event.id)}
+                        <div class="hover:bg-accent-gray rounded-full p-1.5 transition-colors">
+                          <NoteTotalLikes {event} />
+                        </div>
+
+                        <div class="hover:bg-accent-gray rounded-full p-1.5 transition-colors">
+                          <NoteTotalComments {event} />
+                        </div>
+
+                        <div class="hover:bg-accent-gray rounded-full p-1.5 transition-colors">
+                          <NoteRepost {event} />
+                        </div>
+
+                        <div class="hover:bg-amber-50/50 rounded-full p-1 transition-colors">
+                          <NoteTotalZaps
+                            {event}
+                            onZapClick={() => openZapModal(event)}
+                            showPills={false}
+                          />
+                        </div>
+                      {:else}
+                        <span class="text-caption p-1.5 opacity-40">♡</span>
+                        <span class="text-caption p-1.5 opacity-40">💬</span>
+                        <span class="text-caption p-1.5 opacity-40">🔁</span>
+                        <span class="text-caption p-1.5 opacity-40">⚡</span>
+                      {/if}
+                    </div>
+
+                    {#if visibleNotes.has(event.id)}
+                      <!-- Bottom-right of the card. ml-auto keeps it
+                       right-aligned even when the narrow mobile content
+                       column wraps it onto its own line (column width
+                       < action cluster + trigger at ~390px). Renders
+                       nothing for imageless notes — the trigger owns
+                       detection. -->
+                      <CheffyNoteReviewTrigger
+                        {event}
+                        wrapClass="ml-auto hover:bg-accent-gray rounded-full p-1.5 transition-colors"
+                      />
+                    {/if}
+                  </div>
+
+                  <div class="px-2 sm:px-0">
+                    {#if visibleNotes.has(event.id)}
+                      <CommentThread variant="feed" {event} />
+                    {/if}
+                  </div>
+                </div>
+              </article>
+            {:else}
+              <div style="min-height: 380px;">
+                <FeedPostSkeleton />
               </div>
-            </div>
-          </article>
-          {:else}
-            <div
-              style="min-height: 380px;"
-            >
-              <FeedPostSkeleton />
-            </div>
-          {/if}
+            {/if}
           </div>
         {/each}
 

--- a/src/components/NoteActionBar.svelte
+++ b/src/components/NoteActionBar.svelte
@@ -107,14 +107,15 @@
       </div>
     {/if}
 
-    {#if showCheffy}
-      <!-- Renders nothing for imageless notes — the trigger owns detection. -->
-      <CheffyNoteReviewTrigger {event} wrapClass={iconWrapClass} />
-    {/if}
-
     <div class={zapWrapClass}>
       <NoteTotalZaps {event} onZapClick={openZapModal} />
     </div>
+
+    {#if showCheffy}
+      <!-- Bottom-right of the card (ml-auto). Renders nothing for
+           imageless notes — the trigger owns detection. -->
+      <CheffyNoteReviewTrigger {event} wrapClass={`${iconWrapClass} ml-auto`} />
+    {/if}
   </div>
 </div>
 

--- a/src/lib/noteReview.test.ts
+++ b/src/lib/noteReview.test.ts
@@ -464,6 +464,7 @@ import { afterEach } from 'vitest';
 import {
   withDisclosureFooter,
   loadDisclosurePref,
+  shouldSeedDisclosureFromPref,
   saveDisclosurePref,
   DISCLOSURE_FOOTER,
   DISCLOSURE_DEFAULTS
@@ -601,5 +602,17 @@ describe('previewRemaining passthrough', () => {
     });
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.previewRemaining).toBeUndefined();
+  });
+});
+
+describe('shouldSeedDisclosureFromPref', () => {
+  it('seeds only on initial mode selection — Regenerate/try-again keep the in-session toggle', () => {
+    expect(shouldSeedDisclosureFromPref('choose')).toBe(true);
+    // Regenerate runs from 'draft', try-again from 'error' — an
+    // in-session toggle must survive both even when localStorage
+    // cannot persist it (private mode).
+    for (const phase of ['draft', 'error', 'posting', 'dead-end'] as NoteReviewPhase[]) {
+      expect(shouldSeedDisclosureFromPref(phase), phase).toBe(false);
+    }
   });
 });

--- a/src/lib/noteReview.test.ts
+++ b/src/lib/noteReview.test.ts
@@ -455,3 +455,151 @@ describe('client tag on the built event (real postComment)', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Disclosure footer + preview count (Phase 4)
+// ---------------------------------------------------------------------------
+
+import { afterEach } from 'vitest';
+import {
+  withDisclosureFooter,
+  loadDisclosurePref,
+  saveDisclosurePref,
+  DISCLOSURE_FOOTER,
+  DISCLOSURE_DEFAULTS
+} from './noteReview';
+
+describe('withDisclosureFooter', () => {
+  it('appends the exact footer on its own line after one blank line', () => {
+    expect(withDisclosureFooter('Lovely crust!', true)).toBe(
+      'Lovely crust!\n\n⚡🍳 via Cheffy · zap.cooking'
+    );
+    expect(DISCLOSURE_FOOTER).toBe('⚡🍳 via Cheffy · zap.cooking');
+  });
+
+  it('returns the draft untouched when the toggle is off', () => {
+    const draft = 'My own words, no footer.';
+    expect(withDisclosureFooter(draft, false)).toBe(draft);
+  });
+
+  it('normalizes trailing whitespace so exactly one blank line separates the footer', () => {
+    expect(withDisclosureFooter('Great sear!\n\n\n', true)).toBe(
+      'Great sear!\n\n⚡🍳 via Cheffy · zap.cooking'
+    );
+  });
+
+  it('never mutates the draft itself — the textarea value stays footer-free', () => {
+    const draft = 'Editable draft';
+    withDisclosureFooter(draft, true);
+    expect(draft).toBe('Editable draft');
+    expect(withDisclosureFooter(draft, true).startsWith(draft)).toBe(true);
+  });
+});
+
+describe('disclosure per-mode preference', () => {
+  function fakeStorage() {
+    const map = new Map<string, string>();
+    return {
+      getItem: (k: string) => map.get(k) ?? null,
+      setItem: (k: string, v: string) => void map.set(k, v),
+      removeItem: (k: string) => void map.delete(k),
+      clear: () => map.clear(),
+      key: () => null,
+      get length() {
+        return map.size;
+      }
+    } as Storage;
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('defaults: ON for recipe, OFF for comment', () => {
+    vi.stubGlobal('localStorage', fakeStorage());
+    expect(DISCLOSURE_DEFAULTS).toEqual({ comment: false, recipe: true });
+    expect(loadDisclosurePref('recipe')).toBe(true);
+    expect(loadDisclosurePref('comment')).toBe(false);
+  });
+
+  it('persists each mode independently', () => {
+    vi.stubGlobal('localStorage', fakeStorage());
+    saveDisclosurePref('recipe', false);
+    saveDisclosurePref('comment', true);
+    expect(loadDisclosurePref('recipe')).toBe(false);
+    expect(loadDisclosurePref('comment')).toBe(true);
+    // Flipping one mode leaves the other alone.
+    saveDisclosurePref('recipe', true);
+    expect(loadDisclosurePref('comment')).toBe(true);
+  });
+
+  it('falls back to defaults without localStorage (SSR/private mode)', () => {
+    expect(loadDisclosurePref('recipe')).toBe(DISCLOSURE_DEFAULTS.recipe);
+    expect(loadDisclosurePref('comment')).toBe(DISCLOSURE_DEFAULTS.comment);
+    expect(() => saveDisclosurePref('recipe', true)).not.toThrow();
+  });
+});
+
+describe('footer in the built event per toggle state', () => {
+  const ndk = {} as never;
+  const parentEvent = { id: 'c'.repeat(64), pubkey: 'd'.repeat(64), kind: 1 } as never;
+
+  async function publishedContent(draft: string, disclosureOn: boolean): Promise<string> {
+    const postCommentFn = vi
+      .fn()
+      .mockResolvedValue({ event: fakeSignedEvent(), publishedRelays: [] });
+    await publishNoteReviewReply({
+      ndk,
+      parentEvent,
+      content: withDisclosureFooter(draft, disclosureOn),
+      postCommentFn: postCommentFn as never
+    });
+    return postCommentFn.mock.calls[0][1].content;
+  }
+
+  it('toggle on → footer present in the published content', async () => {
+    const content = await publishedContent('Those crispy edges!', true);
+    expect(content).toBe('Those crispy edges!\n\n⚡🍳 via Cheffy · zap.cooking');
+  });
+
+  it('toggle off → footer absent', async () => {
+    const content = await publishedContent('Those crispy edges!', false);
+    expect(content).toBe('Those crispy edges!');
+    expect(content).not.toContain(DISCLOSURE_FOOTER);
+  });
+});
+
+describe('previewRemaining passthrough', () => {
+  it('surfaces the additive server field on success', async () => {
+    const result = await requestNoteReview({
+      ndk: {} as never,
+      imageUrl: 'https://image.nostr.build/dish.jpg',
+      mode: 'comment',
+      origin: 'https://zap.cooking',
+      signHeader: vi.fn().mockResolvedValue('Nostr abc') as never,
+      fetchFn: vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, output: 'draft!', previewRemaining: 2 })
+      }) as never
+    });
+    expect(result).toMatchObject({ ok: true, previewRemaining: 2 });
+  });
+
+  it('is absent for member responses', async () => {
+    const result = await requestNoteReview({
+      ndk: {} as never,
+      imageUrl: 'https://image.nostr.build/dish.jpg',
+      mode: 'comment',
+      origin: 'https://zap.cooking',
+      signHeader: vi.fn().mockResolvedValue('Nostr abc') as never,
+      fetchFn: vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, output: 'draft!' })
+      }) as never
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.previewRemaining).toBeUndefined();
+  });
+});

--- a/src/lib/noteReview.ts
+++ b/src/lib/noteReview.ts
@@ -356,6 +356,17 @@ export const DISCLOSURE_DEFAULTS: Record<NoteReviewMode, boolean> = {
   recipe: true
 };
 
+/**
+ * The stored preference seeds the toggle only on the initial mode
+ * selection (from the choose phase). Regenerate / try-again re-runs
+ * must preserve the member's in-session toggle — reloading would reset
+ * it to the default wherever localStorage can't persist (private
+ * mode), and the live toggle state is the fresher signal anyway.
+ */
+export function shouldSeedDisclosureFromPref(phase: NoteReviewPhase): boolean {
+  return phase === 'choose';
+}
+
 export function loadDisclosurePref(mode: NoteReviewMode): boolean {
   if (typeof localStorage === 'undefined') return DISCLOSURE_DEFAULTS[mode];
   try {

--- a/src/lib/noteReview.ts
+++ b/src/lib/noteReview.ts
@@ -44,7 +44,7 @@ export function canPost(phase: NoteReviewPhase): boolean {
 }
 
 export type NoteReviewResult =
-  | { ok: true; output: string }
+  | { ok: true; output: string; previewRemaining?: number }
   | { ok: false; code?: string; error?: string; status?: number };
 
 // Mirrors the server cap — a longer note just loses its tail.
@@ -166,7 +166,14 @@ export async function requestNoteReview(opts: NoteReviewRequestOpts): Promise<No
     });
     const data: Record<string, unknown> = await resp.json().catch(() => ({}));
     if (resp.ok && data.ok === true && typeof data.output === 'string') {
-      return { ok: true, output: data.output };
+      return {
+        ok: true,
+        output: data.output,
+        // Additive server field on preview-granted requests only.
+        ...(typeof data.previewRemaining === 'number'
+          ? { previewRemaining: data.previewRemaining }
+          : {})
+      };
     }
     return {
       ok: false,
@@ -311,5 +318,60 @@ export async function retryPublishSignedEvent(opts: RetryPublishOpts): Promise<P
     // Still no relay ack — keep the signed event so the member can try
     // again or safely close (it may have landed regardless).
     return { ok: false, code: 'publish-timeout', message: POST_TIMEOUT_LINE, signedEvent };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Disclosure footer (Phase 4) — optional "via Cheffy" attribution
+// ---------------------------------------------------------------------------
+
+/**
+ * Appended at publish time when the member's toggle is on — NEVER
+ * embedded in the editable textarea (the modal shows it as a separate
+ * non-editable preview). Exact string is part of the product spec.
+ */
+export const DISCLOSURE_FOOTER = '⚡🍳 via Cheffy · zap.cooking';
+
+/**
+ * Build the publish content: the member's draft, untouched, plus the
+ * footer on its own line after one blank line when the toggle is on.
+ * Trailing whitespace on the draft is normalized so the footer never
+ * drifts more than one blank line away.
+ */
+export function withDisclosureFooter(draft: string, on: boolean): string {
+  if (!on) return draft;
+  return `${draft.replace(/\s+$/, '')}\n\n${DISCLOSURE_FOOTER}`;
+}
+
+// Per-mode preference, house pattern: zapcooking_* localStorage keys.
+// Defaults differ by mode: a recipe is Cheffy's structured work product
+// (attribution on), a comment is the member's own voice (off).
+const DISCLOSURE_PREF_KEYS: Record<NoteReviewMode, string> = {
+  comment: 'zapcooking_note_review_disclosure_comment',
+  recipe: 'zapcooking_note_review_disclosure_recipe'
+};
+
+export const DISCLOSURE_DEFAULTS: Record<NoteReviewMode, boolean> = {
+  comment: false,
+  recipe: true
+};
+
+export function loadDisclosurePref(mode: NoteReviewMode): boolean {
+  if (typeof localStorage === 'undefined') return DISCLOSURE_DEFAULTS[mode];
+  try {
+    const raw = localStorage.getItem(DISCLOSURE_PREF_KEYS[mode]);
+    return raw === null ? DISCLOSURE_DEFAULTS[mode] : raw === '1';
+  } catch {
+    return DISCLOSURE_DEFAULTS[mode];
+  }
+}
+
+export function saveDisclosurePref(mode: NoteReviewMode, on: boolean): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(DISCLOSURE_PREF_KEYS[mode], on ? '1' : '0');
+  } catch {
+    // Storage unavailable (private mode) — the toggle still works for
+    // the session; it just won't be remembered.
   }
 }

--- a/src/routes/api/zappy/note-review/+server.ts
+++ b/src/routes/api/zappy/note-review/+server.ts
@@ -22,7 +22,8 @@
  * }
  *
  * Returns:
- *   { ok: true, output: string, mode: string }
+ *   { ok: true, output: string, mode: string, previewRemaining?: number }
+ *   (previewRemaining only on preview-granted requests)
  *   { ok: false, error: string, code?: "NOT_MEMBER" | "PREVIEW_USED" |
  *     "MEMBERSHIP_UNAVAILABLE" | "RATE_LIMITED" | "NOT_FOOD" | "IMAGE_UNREADABLE" }
  *
@@ -344,7 +345,16 @@ export const POST: RequestHandler = async ({ request, platform, cookies, url }) 
       });
     }
 
-    return json({ ok: true, output: trimmed, mode });
+    // previewRemaining is additive (preview requests only) — the client
+    // surfaces the remaining free-draft budget without a second call.
+    return json({
+      ok: true,
+      output: trimmed,
+      mode,
+      ...(experienceGranted
+        ? { previewRemaining: Math.max(0, EXPERIENCE_MAX_TURNS - (experienceCount + 1)) }
+        : {})
+    });
   } catch (error: any) {
     console.error('[Note Review] Error:', error);
     return json(

--- a/src/routes/api/zappy/note-review/noteReview.test.ts
+++ b/src/routes/api/zappy/note-review/noteReview.test.ts
@@ -161,10 +161,11 @@ describe('NIP-98 auth', () => {
 
 describe('membership gate', () => {
   it('lets members through with full access', async () => {
-    const { res, setCookies } = await call(validBody());
+    const { res, data, setCookies } = await call(validBody());
     expect(res.status).toBe(200);
     expect(mocks.hasActiveMembership).toHaveBeenCalledWith(PUBKEY, 'secret');
     expect(setCookies).toEqual([]); // members never touch the preview budget
+    expect(data.previewRemaining).toBeUndefined(); // additive field is preview-only
   });
 
   it('403s NOT_MEMBER for a non-member without the experience flag', async () => {
@@ -175,14 +176,24 @@ describe('membership gate', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('grants a preview turn and success-counts the cookie', async () => {
+  it('grants a preview turn, success-counts the cookie, and reports the remaining budget', async () => {
     mocks.hasActiveMembership.mockResolvedValue(false);
-    const { res, setCookies } = await call(validBody({ experience: true }));
+    const { res, data, setCookies } = await call(validBody({ experience: true }));
     expect(res.status).toBe(200);
     expect(setCookies).toHaveLength(1);
     expect(setCookies[0].name).toBe('zapcooking_cheffy_note_review_experience_used');
     expect(setCookies[0].value).toBe('1');
     expect(setCookies[0].opts.httpOnly).toBe(true);
+    expect(data.previewRemaining).toBe(2); // 3-turn budget, first just spent
+  });
+
+  it('reports zero remaining on the final preview turn', async () => {
+    mocks.hasActiveMembership.mockResolvedValue(false);
+    const { res, data } = await call(validBody({ experience: true }), {
+      cookies: { zapcooking_cheffy_note_review_experience_used: '2' }
+    });
+    expect(res.status).toBe(200);
+    expect(data.previewRemaining).toBe(0);
   });
 
   it('429s PREVIEW_USED once the preview budget is spent', async () => {

--- a/src/routes/membership/+page.svelte
+++ b/src/routes/membership/+page.svelte
@@ -850,6 +850,14 @@
                   </div>
                 </li>
                 <li>
+                  <span class="feature-icon">📸</span>
+                  <div class="feature-content">
+                    <span class="feature-text"
+                      >Cheffy photo review - draft a reply or recipe from any dish photo on the feed</span
+                    >
+                  </div>
+                </li>
+                <li>
                   <span class="feature-icon">✨</span>
                   <div class="feature-content">
                     <span class="feature-text">Sous Chef features</span>


### PR DESCRIPTION
## Summary

Phase 4 polish for the now-live Cheffy Note Photo Review (#513 → #516 → #518): disclosure footer, trigger relocation, multi-image picker, preview-count chip, membership bullet. Server change is one **additive** response field; no behavior changes to existing flows.

### What's in here

- **Disclosure footer toggle** — `⚡🍳 via Cheffy · zap.cooking` appended at publish time only (never part of the editable textarea; a non-editable dashed preview shows below it when on). Per-mode preference via the house `zapcooking_*` localStorage pattern; defaults: recipe ON, comment OFF.
- **Trigger relocated to the card's bottom-right** on both surfaces, position-only: `ml-auto` after zaps in `NoteActionBar`; right side of the feed's existing `justify-between` row. Gate screenshots caught a 390px wrap (feed content column is 270px — narrower than cluster 248px + trigger 30px), fixed with `ml-auto` on the wrapper so the wrapped line right-aligns on its own row, fully clear of the zap tap-target. Screenshot sheet with measurements: [Phase 4 gate artifact](https://claude.ai/code/artifact/5a32a5c1-95a7-4718-8b19-232487087232)
- **Multi-image picker** — thumbnail strip for notes with 2+ distinct images (`filterImageUrls` order), tap to select, selection persists across Regenerate. Server untouched — one `imageUrl` per call.
- **Preview-count chip** — additive `previewRemaining` field on preview-granted responses (Android-friendly: pure addition to the response shape), surfaced as an "N free drafts left" chip in the draft phase.
- **Membership page** — Cheffy photo review bullet under Kitchen Tools, matching the existing register.

## Test plan

- [x] 12 new unit tests: footer present/absent in published content per toggle state, exact footer format + draft immutability, per-mode pref defaults/persistence/SSR fallback, `previewRemaining` passthrough + server assertions (2 → 0 → absent-for-members)
- [x] Full suite green (30 files, 532 tests); `svelte-check` 0 errors
- [x] Placement verified visually at 1280px and 390px on both surfaces (see artifact)
- [ ] Manual pass on the branch preview (pre-merge gate)

Note: "Workers Builds" checks are expected to fail on this repo (known infra quirk — deploys go through Cloudflare Pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)