### PR TITLE
feat(cheffy): note review sats credits — server (Phase 5.1) [HOLD: merges with 5.2]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.612",
+  "version": "4.2.613",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.609",
+  "version": "4.2.610",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.610",
+  "version": "4.2.611",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.608",
+  "version": "4.2.609",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.611",
+  "version": "4.2.612",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/noteReviewCredits.server.test.ts
+++ b/src/lib/noteReviewCredits.server.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getCreditBalance,
+  spendCredit,
+  storeCreditInvoice,
+  getCreditInvoice,
+  creditInvoicePaid,
+  NOTE_REVIEW_CREDIT_SATS,
+  NOTE_REVIEW_CREDIT_BTC,
+  __resetNoteReviewCreditsForTests,
+  type CreditKV
+} from './noteReviewCredits.server';
+
+const PK = 'A'.repeat(64); // uppercase on purpose — keys must normalize
+
+function fakeKV(): CreditKV & { dump(): Map<string, string> } {
+  const map = new Map<string, string>();
+  return {
+    get: async (k: string) => map.get(k) ?? null,
+    put: async (k: string, v: string) => void map.set(k, v),
+    dump: () => map
+  };
+}
+
+describe('price constants', () => {
+  it('21 sats, BTC-denominated at 8 decimals', () => {
+    expect(NOTE_REVIEW_CREDIT_SATS).toBe(21);
+    expect(NOTE_REVIEW_CREDIT_BTC).toBe('0.00000021');
+    expect(Math.round(Number(NOTE_REVIEW_CREDIT_BTC) * 1e8)).toBe(21);
+  });
+});
+
+// Every behavior is tested against both backends: a fake KV (the
+// production path) and the in-memory dev fallback (kv = undefined).
+for (const backend of ['kv', 'memory'] as const) {
+  describe(`credit ledger (${backend})`, () => {
+    let kv: CreditKV;
+
+    beforeEach(() => {
+      __resetNoteReviewCreditsForTests();
+      kv = backend === 'kv' ? fakeKV() : undefined;
+    });
+
+    it('balance starts at zero and tolerates garbage values', async () => {
+      expect(await getCreditBalance(kv, PK)).toBe(0);
+      if (kv) {
+        await kv.put(`credit:note-review:${PK.toLowerCase()}`, 'not-a-number');
+        expect(await getCreditBalance(kv, PK)).toBe(0);
+      }
+    });
+
+    it('credits a paid invoice exactly once (idempotency mark)', async () => {
+      const first = await creditInvoicePaid(kv, 'rr-1', PK);
+      expect(first).toEqual({ credited: true, balance: 1 });
+      // Poll-spam: same invoice observed paid again.
+      const second = await creditInvoicePaid(kv, 'rr-1', PK);
+      expect(second).toEqual({ credited: false, balance: 1 });
+      // A different invoice credits normally.
+      expect(await creditInvoicePaid(kv, 'rr-2', PK)).toEqual({ credited: true, balance: 2 });
+    });
+
+    it('spends down and floors at zero', async () => {
+      await creditInvoicePaid(kv, 'rr-1', PK);
+      expect(await spendCredit(kv, PK)).toBe(0);
+      expect(await spendCredit(kv, PK)).toBe(0); // floor, never negative
+      expect(await getCreditBalance(kv, PK)).toBe(0);
+    });
+
+    it('stores invoice metadata bound to the lowercased pubkey', async () => {
+      const expiresAt = 1_800_000_000_000;
+      await storeCreditInvoice(kv, 'rr-9', PK, expiresAt);
+      const meta = await getCreditInvoice(kv, 'rr-9');
+      expect(meta).toMatchObject({
+        pubkey: PK.toLowerCase(),
+        receiveRequestId: 'rr-9',
+        expiresAt
+      });
+      expect(await getCreditInvoice(kv, 'rr-unknown')).toBeNull();
+    });
+
+    it('balance is pubkey-cased consistently (cross-device by key)', async () => {
+      await creditInvoicePaid(kv, 'rr-1', PK.toLowerCase());
+      expect(await getCreditBalance(kv, PK.toUpperCase())).toBe(1);
+    });
+  });
+}

--- a/src/lib/noteReviewCredits.server.ts
+++ b/src/lib/noteReviewCredits.server.ts
@@ -1,0 +1,150 @@
+/**
+ * Cheffy Note Review — sats credit ledger (server-side, GATED_CONTENT KV).
+ *
+ * Non-members buy drafts at 21 sats each (Phase 5, decision D2:
+ * payment-adjacent KV lives beside the membership invoice metadata in
+ * GATED_CONTENT, not NOURISH_FLAGS). Members never touch this ledger.
+ *
+ * KV key scheme (no collision with `inv:` / `invhash:` / promo keys):
+ *   credit:note-review:{pubkey}      → integer balance (no TTL — paid money)
+ *   nrcredit:inv:{receiveRequestId}  → CreditInvoiceMetadata JSON (TTL 2h)
+ *   nrcredit:done:{receiveRequestId} → '1' idempotency mark (TTL 7d)
+ *
+ * Concurrency: KV read-then-write is non-atomic. A raced double-spend or
+ * double-credit costs ~$0.002 of API budget — accepted and documented in
+ * the Phase 5 scope. The idempotency mark makes status-poll spam unable
+ * to double-credit in the common (serial) case.
+ *
+ * Dev fallback: in-memory Maps when no KV is bound, mirroring
+ * invoiceMetadataStore.server.ts, so local dev and tests work.
+ */
+
+export const NOTE_REVIEW_CREDIT_SATS = 21;
+export const NOTE_REVIEW_CREDIT_BTC = '0.00000021';
+/** Lightning invoice lifetime — an in-modal purchase, not a 24h bill. */
+export const CREDIT_INVOICE_EXPIRY_SECONDS = 600;
+
+const INVOICE_TTL_SECONDS = 7200; // metadata outlives the invoice comfortably
+const DONE_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+export interface CreditInvoiceMetadata {
+  pubkey: string;
+  receiveRequestId: string;
+  createdAt: number;
+  /** ms epoch — past this and unpaid, the client offers a fresh invoice. */
+  expiresAt: number;
+}
+
+export type CreditKV =
+  | {
+      get(key: string, type?: 'text' | 'json'): Promise<string | unknown | null>;
+      put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>;
+    }
+  | null
+  | undefined;
+
+const balanceKey = (pubkey: string) => `credit:note-review:${pubkey.toLowerCase()}`;
+const invoiceKey = (id: string) => `nrcredit:inv:${id}`;
+const doneKey = (id: string) => `nrcredit:done:${id}`;
+
+// ── Dev-only in-memory fallback ─────────────────────────────────────
+const memBalances = new Map<string, number>();
+const memInvoices = new Map<string, CreditInvoiceMetadata>();
+const memDone = new Set<string>();
+
+/** Test hook — clears the in-memory fallback between tests. */
+export function __resetNoteReviewCreditsForTests(): void {
+  memBalances.clear();
+  memInvoices.clear();
+  memDone.clear();
+}
+
+export async function getCreditBalance(kv: CreditKV, pubkey: string): Promise<number> {
+  if (!kv) return memBalances.get(balanceKey(pubkey)) ?? 0;
+  const raw = (await kv.get(balanceKey(pubkey))) as string | null;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 0;
+}
+
+async function setBalance(kv: CreditKV, pubkey: string, balance: number): Promise<void> {
+  const value = String(Math.max(0, balance));
+  if (!kv) {
+    memBalances.set(balanceKey(pubkey), Math.max(0, balance));
+    return;
+  }
+  await kv.put(balanceKey(pubkey), value); // no TTL — paid credits persist
+}
+
+/**
+ * Spend one credit. Call ONLY after a successful draft (success-only
+ * decrement is non-negotiable: nobody pays 21 sats for an error).
+ * Returns the balance after the spend.
+ */
+export async function spendCredit(kv: CreditKV, pubkey: string): Promise<number> {
+  const balance = await getCreditBalance(kv, pubkey);
+  const after = Math.max(0, balance - 1);
+  await setBalance(kv, pubkey, after);
+  return after;
+}
+
+export async function storeCreditInvoice(
+  kv: CreditKV,
+  receiveRequestId: string,
+  pubkey: string,
+  expiresAt: number
+): Promise<void> {
+  const entry: CreditInvoiceMetadata = {
+    pubkey: pubkey.toLowerCase(),
+    receiveRequestId,
+    createdAt: Date.now(),
+    expiresAt
+  };
+  if (!kv) {
+    memInvoices.set(invoiceKey(receiveRequestId), entry);
+    return;
+  }
+  await kv.put(invoiceKey(receiveRequestId), JSON.stringify(entry), {
+    expirationTtl: INVOICE_TTL_SECONDS
+  });
+}
+
+export async function getCreditInvoice(
+  kv: CreditKV,
+  receiveRequestId: string
+): Promise<CreditInvoiceMetadata | null> {
+  if (!kv) return memInvoices.get(invoiceKey(receiveRequestId)) ?? null;
+  const raw = (await kv.get(invoiceKey(receiveRequestId))) as string | null;
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as CreditInvoiceMetadata;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Credit a paid invoice exactly once (idempotency mark on the
+ * receive-request id — a status-poll storm can't double-credit).
+ * Returns whether this call performed the credit, plus the balance.
+ */
+export async function creditInvoicePaid(
+  kv: CreditKV,
+  receiveRequestId: string,
+  pubkey: string
+): Promise<{ credited: boolean; balance: number }> {
+  const alreadyDone = kv
+    ? ((await kv.get(doneKey(receiveRequestId))) as string | null) !== null
+    : memDone.has(doneKey(receiveRequestId));
+  if (alreadyDone) {
+    return { credited: false, balance: await getCreditBalance(kv, pubkey) };
+  }
+
+  if (kv) {
+    await kv.put(doneKey(receiveRequestId), '1', { expirationTtl: DONE_TTL_SECONDS });
+  } else {
+    memDone.add(doneKey(receiveRequestId));
+  }
+  const balance = (await getCreditBalance(kv, pubkey)) + 1;
+  await setBalance(kv, pubkey, balance);
+  return { credited: true, balance };
+}

--- a/src/lib/noteReviewCredits.server.ts
+++ b/src/lib/noteReviewCredits.server.ts
@@ -7,7 +7,7 @@
  *
  * KV key scheme (no collision with `inv:` / `invhash:` / promo keys):
  *   credit:note-review:{pubkey}      → integer balance (no TTL — paid money)
- *   nrcredit:inv:{receiveRequestId}  → CreditInvoiceMetadata JSON (TTL 2h)
+ *   nrcredit:inv:{receiveRequestId}  → CreditInvoiceMetadata JSON (TTL 48h)
  *   nrcredit:done:{receiveRequestId} → '1' idempotency mark (TTL 7d)
  *
  * Concurrency: KV read-then-write is non-atomic. A raced double-spend or
@@ -24,7 +24,12 @@ export const NOTE_REVIEW_CREDIT_BTC = '0.00000021';
 /** Lightning invoice lifetime — an in-modal purchase, not a 24h bill. */
 export const CREDIT_INVOICE_EXPIRY_SECONDS = 600;
 
-const INVOICE_TTL_SECONDS = 7200; // metadata outlives the invoice comfortably
+// The 600s invoice expiry bounds when a PAYMENT can happen; this TTL
+// only bounds how long a completed payment stays verifiable and
+// creditable. 48h so a payer who paid and closed the modal before the
+// poll observed COMPLETED can still be made whole (resume flow, next
+// modal open) — a short TTL here orphans real money.
+const INVOICE_TTL_SECONDS = 48 * 60 * 60;
 const DONE_TTL_SECONDS = 7 * 24 * 60 * 60;
 
 export interface CreditInvoiceMetadata {

--- a/src/lib/strikeService.expiry.test.ts
+++ b/src/lib/strikeService.expiry.test.ts
@@ -1,0 +1,45 @@
+/**
+ * createInvoice expiryInSeconds guard: only valid positive numbers
+ * reach Strike's receive-request body (0/NaN/negative/omitted → field
+ * absent, Strike's 24h default applies).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { env } from '$env/dynamic/private';
+import { createInvoice } from './strikeService.server';
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock);
+  env.STRIKE_API_KEY = 'test-key';
+  fetchMock.mockReset().mockResolvedValue({
+    ok: true,
+    json: async () => ({ receiveRequestId: 'rr', bolt11: { invoice: 'lnbc...' } })
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete env.STRIKE_API_KEY;
+});
+
+async function bolt11BodyFor(expiry?: number) {
+  await createInvoice('0.00000021', 'BTC', 'test', undefined, expiry);
+  return JSON.parse(fetchMock.mock.calls.at(-1)[1].body).bolt11;
+}
+
+describe('createInvoice expiryInSeconds', () => {
+  it('includes a valid positive expiry', async () => {
+    expect((await bolt11BodyFor(600)).expiryInSeconds).toBe(600);
+  });
+
+  it('omits the field when not provided (Strike default applies)', async () => {
+    expect('expiryInSeconds' in (await bolt11BodyFor())).toBe(false);
+  });
+
+  it('omits 0, NaN, and negatives', async () => {
+    for (const bad of [0, NaN, -60]) {
+      expect('expiryInSeconds' in (await bolt11BodyFor(bad)), String(bad)).toBe(false);
+    }
+  });
+});

--- a/src/lib/strikeService.server.ts
+++ b/src/lib/strikeService.server.ts
@@ -154,7 +154,14 @@ export async function createInvoice(
             currency: currency
           },
           description: description,
-          ...(expiryInSeconds ? { expiryInSeconds } : {})
+          // Include only a valid positive expiry — 0/NaN/negative never
+          // reach Strike (0 would be meaningless; omitted → Strike's
+          // 24h default applies).
+          ...(typeof expiryInSeconds === 'number' &&
+          Number.isFinite(expiryInSeconds) &&
+          expiryInSeconds > 0
+            ? { expiryInSeconds }
+            : {})
         }
       })
     },

--- a/src/lib/strikeService.server.ts
+++ b/src/lib/strikeService.server.ts
@@ -1,19 +1,19 @@
 /**
  * Strike API Service
- * 
+ *
  * Integration with Strike API for Lightning Network payments.
- * 
+ *
  * IMPORTANT: Strike API credentials are expected via environment variables:
  * - STRIKE_API_KEY: Your Strike API key
  * - STRIKE_API_BASE_URL: Base URL for Strike API (defaults to https://api.strike.me)
  * - STRIKE_WEBHOOK_SECRET: Secret for webhook signature verification
- * 
+ *
  * The keys are intentionally NOT hardcoded and must be set in your environment.
  * Example in .env file:
  *   STRIKE_API_KEY=your_api_key_here
  *   STRIKE_API_BASE_URL=https://api.strike.me
  *   STRIKE_WEBHOOK_SECRET=your_webhook_secret_here
- * 
+ *
  * NOTE: This file is server-only and uses SvelteKit's $env system.
  * Using dynamic/private so build doesn't fail when keys aren't set.
  */
@@ -22,150 +22,152 @@ import { env } from '$env/dynamic/private';
 
 // Types for Strike API
 export interface StrikeAmount {
-	amount: string;
-	currency: 'BTC' | 'USD' | 'EUR' | 'USDT' | 'GBP' | 'AUD';
+  amount: string;
+  currency: 'BTC' | 'USD' | 'EUR' | 'USDT' | 'GBP' | 'AUD';
 }
 
 export interface StrikeInvoice {
-	invoiceId: string;
-	amount: StrikeAmount;
-	currency: string;
-	state: 'UNPAID' | 'PENDING' | 'PAID' | 'CANCELLED';
-	created: string;
-	description?: string;
-	bolt11?: string;
+  invoiceId: string;
+  amount: StrikeAmount;
+  currency: string;
+  state: 'UNPAID' | 'PENDING' | 'PAID' | 'CANCELLED';
+  created: string;
+  description?: string;
+  bolt11?: string;
 }
 
 export interface ReceiveRequest {
-	receiveRequestId: string;
-	created: string;
-	targetCurrency?: string;
-	bolt11?: {
-		invoice: string;
-		requestedAmount?: StrikeAmount;
-		btcAmount?: string;
-		description?: string;
-		paymentHash?: string;
-		expires?: string;
-	};
+  receiveRequestId: string;
+  created: string;
+  targetCurrency?: string;
+  bolt11?: {
+    invoice: string;
+    requestedAmount?: StrikeAmount;
+    btcAmount?: string;
+    description?: string;
+    paymentHash?: string;
+    expires?: string;
+  };
 }
 
 export interface Receive {
-	receiveId: string;
-	state: 'PENDING' | 'COMPLETED' | 'FAILED';
-	amount?: StrikeAmount;
-	completed?: string;
+  receiveId: string;
+  state: 'PENDING' | 'COMPLETED' | 'FAILED';
+  amount?: StrikeAmount;
+  completed?: string;
 }
 
 export interface CreateInvoiceResponse {
-	receiveRequestId: string;
-	created: string;
-	invoice?: string; // BOLT11 invoice (top-level when bolt11 is requested)
-	paymentHash?: string; // Payment hash (top-level when bolt11 is requested)
-	expires?: string; // Expiration time as date-time string (top-level when bolt11 is requested)
-	requestedAmount?: StrikeAmount; // Requested amount details
-	btcAmount?: string; // Amount converted to BTC
-	description?: string; // Invoice description
-	descriptionHash?: string; // Description hash if provided
+  receiveRequestId: string;
+  created: string;
+  invoice?: string; // BOLT11 invoice (top-level when bolt11 is requested)
+  paymentHash?: string; // Payment hash (top-level when bolt11 is requested)
+  expires?: string; // Expiration time as date-time string (top-level when bolt11 is requested)
+  requestedAmount?: StrikeAmount; // Requested amount details
+  btcAmount?: string; // Amount converted to BTC
+  description?: string; // Invoice description
+  descriptionHash?: string; // Description hash if provided
 }
 
 export interface WebhookEvent {
-	eventType: string;
-	entityId: string;
-	changes?: Array<{
-		field: string;
-		oldValue: any;
-		newValue: any;
-	}>;
-	timestamp: string;
+  eventType: string;
+  entityId: string;
+  changes?: Array<{
+    field: string;
+    oldValue: any;
+    newValue: any;
+  }>;
+  timestamp: string;
 }
 
 /**
  * Get Strike API configuration from environment variables
  */
 function getStrikeConfig(platform?: any) {
-	const apiKey = platform?.env?.STRIKE_API_KEY || env.STRIKE_API_KEY;
-	const baseUrl = platform?.env?.STRIKE_API_BASE_URL || env.STRIKE_API_BASE_URL || 'https://api.strike.me';
-	const webhookSecret = platform?.env?.STRIKE_WEBHOOK_SECRET || env.STRIKE_WEBHOOK_SECRET;
+  const apiKey = platform?.env?.STRIKE_API_KEY || env.STRIKE_API_KEY;
+  const baseUrl =
+    platform?.env?.STRIKE_API_BASE_URL || env.STRIKE_API_BASE_URL || 'https://api.strike.me';
+  const webhookSecret = platform?.env?.STRIKE_WEBHOOK_SECRET || env.STRIKE_WEBHOOK_SECRET;
 
-	if (!apiKey) {
-		throw new Error(
-			'STRIKE_API_KEY environment variable is not set. ' +
-			'Please set it in your .env file or in your hosting provider\'s environment variables.'
-		);
-	}
+  if (!apiKey) {
+    throw new Error(
+      'STRIKE_API_KEY environment variable is not set. ' +
+        "Please set it in your .env file or in your hosting provider's environment variables."
+    );
+  }
 
-	return { apiKey, baseUrl, webhookSecret };
+  return { apiKey, baseUrl, webhookSecret };
 }
 
 /**
  * Make an authenticated request to Strike API
  */
 async function strikeRequest(
-	endpoint: string,
-	options: RequestInit = {},
-	platform?: any
+  endpoint: string,
+  options: RequestInit = {},
+  platform?: any
 ): Promise<Response> {
-	const { apiKey, baseUrl } = getStrikeConfig(platform);
-	const url = `${baseUrl.replace(/\/$/, '')}${endpoint}`;
+  const { apiKey, baseUrl } = getStrikeConfig(platform);
+  const url = `${baseUrl.replace(/\/$/, '')}${endpoint}`;
 
-	const response = await fetch(url, {
-		...options,
-		headers: {
-			'Authorization': `Bearer ${apiKey}`,
-			'Content-Type': 'application/json',
-			...options.headers,
-		},
-	});
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      ...options.headers
+    }
+  });
 
-	return response;
+  return response;
 }
 
 /**
  * Create a Lightning invoice
- * 
+ *
  * @param amount - Amount in the specified currency (as string, e.g., "10.50")
  * @param currency - Currency code (BTC, USD, EUR, USDT, GBP, AUD)
  * @param description - Invoice description (1-250 characters)
  * @param platform - Optional platform context for Cloudflare Workers
+ * @param expiryInSeconds - Optional Lightning invoice expiry (Strike defaults to 24h when omitted)
  * @returns Invoice details including BOLT11 invoice string
  */
 export async function createInvoice(
-	amount: string,
-	currency: StrikeAmount['currency'],
-	description: string,
-	platform?: any
+  amount: string,
+  currency: StrikeAmount['currency'],
+  description: string,
+  platform?: any,
+  expiryInSeconds?: number
 ): Promise<CreateInvoiceResponse> {
-	if (!description || description.length < 1 || description.length > 250) {
-		throw new Error('Description must be between 1 and 250 characters');
-	}
+  if (!description || description.length < 1 || description.length > 250) {
+    throw new Error('Description must be between 1 and 250 characters');
+  }
 
-	const response = await strikeRequest(
-		'/v1/receive-requests',
-		{
-			method: 'POST',
-			body: JSON.stringify({
-				bolt11: {
-					amount: {
-						amount: amount,
-						currency: currency,
-					},
-					description: description,
-				},
-			}),
-		},
-		platform
-	);
+  const response = await strikeRequest(
+    '/v1/receive-requests',
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        bolt11: {
+          amount: {
+            amount: amount,
+            currency: currency
+          },
+          description: description,
+          ...(expiryInSeconds ? { expiryInSeconds } : {})
+        }
+      })
+    },
+    platform
+  );
 
-	if (!response.ok) {
-		const errorText = await response.text();
-		throw new Error(
-			`Strike API error: ${response.status} ${response.statusText}. ${errorText}`
-		);
-	}
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Strike API error: ${response.status} ${response.statusText}. ${errorText}`);
+  }
 
-	const data = await response.json();
-	return data;
+  const data = await response.json();
+  return data;
 }
 
 /**
@@ -176,32 +178,30 @@ export async function createInvoice(
  * @returns Invoice details including current state
  */
 export async function checkInvoiceStatus(
-	invoiceId: string,
-	platform?: any
+  invoiceId: string,
+  platform?: any
 ): Promise<StrikeInvoice> {
-	if (!invoiceId) {
-		throw new Error('Invoice ID is required');
-	}
+  if (!invoiceId) {
+    throw new Error('Invoice ID is required');
+  }
 
-	const response = await strikeRequest(
-		`/v1/invoices/${invoiceId}`,
-		{
-			method: 'GET',
-		},
-		platform
-	);
+  const response = await strikeRequest(
+    `/v1/invoices/${invoiceId}`,
+    {
+      method: 'GET'
+    },
+    platform
+  );
 
-	if (!response.ok) {
-		if (response.status === 404) {
-			throw new Error(`Invoice not found: ${invoiceId}`);
-		}
-		const errorText = await response.text();
-		throw new Error(
-			`Strike API error: ${response.status} ${response.statusText}. ${errorText}`
-		);
-	}
+  if (!response.ok) {
+    if (response.status === 404) {
+      throw new Error(`Invoice not found: ${invoiceId}`);
+    }
+    const errorText = await response.text();
+    throw new Error(`Strike API error: ${response.status} ${response.statusText}. ${errorText}`);
+  }
 
-	return await response.json();
+  return await response.json();
 }
 
 /**
@@ -212,30 +212,28 @@ export async function checkInvoiceStatus(
  * @returns Receive request details
  */
 export async function getReceiveRequest(
-	receiveRequestId: string,
-	platform?: any
+  receiveRequestId: string,
+  platform?: any
 ): Promise<ReceiveRequest> {
-	if (!receiveRequestId) {
-		throw new Error('Receive request ID is required');
-	}
+  if (!receiveRequestId) {
+    throw new Error('Receive request ID is required');
+  }
 
-	const response = await strikeRequest(
-		`/v1/receive-requests/${receiveRequestId}`,
-		{ method: 'GET' },
-		platform
-	);
+  const response = await strikeRequest(
+    `/v1/receive-requests/${receiveRequestId}`,
+    { method: 'GET' },
+    platform
+  );
 
-	if (!response.ok) {
-		if (response.status === 404) {
-			throw new Error(`Receive request not found: ${receiveRequestId}`);
-		}
-		const errorText = await response.text();
-		throw new Error(
-			`Strike API error: ${response.status} ${response.statusText}. ${errorText}`
-		);
-	}
+  if (!response.ok) {
+    if (response.status === 404) {
+      throw new Error(`Receive request not found: ${receiveRequestId}`);
+    }
+    const errorText = await response.text();
+    throw new Error(`Strike API error: ${response.status} ${response.statusText}. ${errorText}`);
+  }
 
-	return await response.json();
+  return await response.json();
 }
 
 /**
@@ -246,172 +244,164 @@ export async function getReceiveRequest(
  * @returns Array of receives for the request
  */
 export async function getReceiveRequestReceives(
-	receiveRequestId: string,
-	platform?: any
+  receiveRequestId: string,
+  platform?: any
 ): Promise<Receive[]> {
-	if (!receiveRequestId) {
-		throw new Error('Receive request ID is required');
-	}
+  if (!receiveRequestId) {
+    throw new Error('Receive request ID is required');
+  }
 
-	const response = await strikeRequest(
-		`/v1/receive-requests/${receiveRequestId}/receives`,
-		{ method: 'GET' },
-		platform
-	);
+  const response = await strikeRequest(
+    `/v1/receive-requests/${receiveRequestId}/receives`,
+    { method: 'GET' },
+    platform
+  );
 
-	if (!response.ok) {
-		const errorText = await response.text();
-		throw new Error(
-			`Strike API error: ${response.status} ${response.statusText}. ${errorText}`
-		);
-	}
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Strike API error: ${response.status} ${response.statusText}. ${errorText}`);
+  }
 
-	const data = await response.json();
-	return Array.isArray(data) ? data : data.items || [];
+  const data = await response.json();
+  return Array.isArray(data) ? data : data.items || [];
 }
 
 /**
  * Validate and process webhook
- * 
+ *
  * @param payload - Raw webhook payload (string or object)
  * @param signature - Webhook signature from headers
  * @param platform - Optional platform context for Cloudflare Workers
  * @returns Parsed webhook event if valid, throws error if invalid
  */
 export async function handleWebhook(
-	payload: string | object,
-	signature: string,
-	platform?: any
+  payload: string | object,
+  signature: string,
+  platform?: any
 ): Promise<WebhookEvent> {
-	const { webhookSecret } = getStrikeConfig(platform);
+  const { webhookSecret } = getStrikeConfig(platform);
 
-	if (!webhookSecret) {
-		throw new Error(
-			'STRIKE_WEBHOOK_SECRET environment variable is not set. ' +
-			'Webhook signature verification requires this secret.'
-		);
-	}
+  if (!webhookSecret) {
+    throw new Error(
+      'STRIKE_WEBHOOK_SECRET environment variable is not set. ' +
+        'Webhook signature verification requires this secret.'
+    );
+  }
 
-	if (!signature) {
-		throw new Error('Webhook signature is required for verification');
-	}
+  if (!signature) {
+    throw new Error('Webhook signature is required for verification');
+  }
 
-	// Parse payload if it's a string
-	const payloadString = typeof payload === 'string' ? payload : JSON.stringify(payload);
-	const payloadObject = typeof payload === 'object' ? payload : JSON.parse(payloadString);
+  // Parse payload if it's a string
+  const payloadString = typeof payload === 'string' ? payload : JSON.stringify(payload);
+  const payloadObject = typeof payload === 'object' ? payload : JSON.parse(payloadString);
 
-	// Verify webhook signature
-	// Note: Strike API uses HMAC-SHA256 for webhook signatures
-	// The exact implementation may vary - consult Strike documentation for specifics
-	const isValid = await verifyWebhookSignature(
-		payloadString,
-		signature,
-		webhookSecret
-	);
+  // Verify webhook signature
+  // Note: Strike API uses HMAC-SHA256 for webhook signatures
+  // The exact implementation may vary - consult Strike documentation for specifics
+  const isValid = await verifyWebhookSignature(payloadString, signature, webhookSecret);
 
-	if (!isValid) {
-		throw new Error('Invalid webhook signature');
-	}
+  if (!isValid) {
+    throw new Error('Invalid webhook signature');
+  }
 
-	return payloadObject as WebhookEvent;
+  return payloadObject as WebhookEvent;
 }
 
 /**
  * Get current BTC/USD exchange rate from Strike API
- * 
+ *
  * @param platform - Optional platform context for Cloudflare Workers
  * @returns Current BTC price in USD
  */
 export async function getBtcUsdRate(platform?: any): Promise<number> {
-	const response = await strikeRequest(
-		'/v1/rates/ticker',
-		{
-			method: 'GET',
-		},
-		platform
-	);
+  const response = await strikeRequest(
+    '/v1/rates/ticker',
+    {
+      method: 'GET'
+    },
+    platform
+  );
 
-	if (!response.ok) {
-		const errorText = await response.text();
-		throw new Error(
-			`Strike API error: ${response.status} ${response.statusText}. ${errorText}`
-		);
-	}
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Strike API error: ${response.status} ${response.statusText}. ${errorText}`);
+  }
 
-	const rates = await response.json();
-	
-	// Strike returns an array of rate objects
-	// Find the BTC/USD pair
-	const btcUsdRate = rates.find((rate: any) => 
-		rate.sourceCurrency === 'BTC' && rate.targetCurrency === 'USD'
-	);
+  const rates = await response.json();
 
-	if (!btcUsdRate || !btcUsdRate.amount) {
-		throw new Error('BTC/USD rate not found in Strike response');
-	}
+  // Strike returns an array of rate objects
+  // Find the BTC/USD pair
+  const btcUsdRate = rates.find(
+    (rate: any) => rate.sourceCurrency === 'BTC' && rate.targetCurrency === 'USD'
+  );
 
-	return parseFloat(btcUsdRate.amount);
+  if (!btcUsdRate || !btcUsdRate.amount) {
+    throw new Error('BTC/USD rate not found in Strike response');
+  }
+
+  return parseFloat(btcUsdRate.amount);
 }
 
 /**
  * Check if Strike API is configured
- * 
+ *
  * @param platform - Optional platform context for Cloudflare Workers
  * @returns true if STRIKE_API_KEY is set
  */
 export function isStrikeConfigured(platform?: any): boolean {
-	const apiKey = platform?.env?.STRIKE_API_KEY || env.STRIKE_API_KEY;
-	return !!apiKey;
+  const apiKey = platform?.env?.STRIKE_API_KEY || env.STRIKE_API_KEY;
+  return !!apiKey;
 }
 
 /**
  * Verify webhook signature using HMAC-SHA256
- * 
+ *
  * @param payload - Raw payload string
  * @param signature - Signature from webhook headers
  * @param secret - Webhook secret
  * @returns true if signature is valid
  */
 async function verifyWebhookSignature(
-	payload: string,
-	signature: string,
-	secret: string
+  payload: string,
+  signature: string,
+  secret: string
 ): Promise<boolean> {
-	try {
-		const encoder = new TextEncoder();
-		const keyData = encoder.encode(secret);
-		const payloadData = encoder.encode(payload);
+  try {
+    const encoder = new TextEncoder();
+    const keyData = encoder.encode(secret);
+    const payloadData = encoder.encode(payload);
 
-		const cryptoKey = await crypto.subtle.importKey(
-			'raw',
-			keyData,
-			{ name: 'HMAC', hash: 'SHA-256' },
-			false,
-			['sign']
-		);
+    const cryptoKey = await crypto.subtle.importKey(
+      'raw',
+      keyData,
+      { name: 'HMAC', hash: 'SHA-256' },
+      false,
+      ['sign']
+    );
 
-		const expectedSignature = await crypto.subtle.sign('HMAC', cryptoKey, payloadData);
-		const expectedBytes = new Uint8Array(expectedSignature);
+    const expectedSignature = await crypto.subtle.sign('HMAC', cryptoKey, payloadData);
+    const expectedBytes = new Uint8Array(expectedSignature);
 
-		// Convert expected to hex for comparison with Strike's X-Webhook-Signature header
-		const expectedHex = Array.from(expectedBytes)
-			.map(b => b.toString(16).padStart(2, '0'))
-			.join('');
+    // Convert expected to hex for comparison with Strike's X-Webhook-Signature header
+    const expectedHex = Array.from(expectedBytes)
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
 
-		// Timing-safe comparison to prevent timing attacks
-		const a = encoder.encode(expectedHex.toLowerCase());
-		const b = encoder.encode(signature.toLowerCase());
-		if (a.byteLength !== b.byteLength) return false;
+    // Timing-safe comparison to prevent timing attacks
+    const a = encoder.encode(expectedHex.toLowerCase());
+    const b = encoder.encode(signature.toLowerCase());
+    if (a.byteLength !== b.byteLength) return false;
 
-		// Use subtle.verify as a timing-safe comparison (Web Crypto doesn't expose timingSafeEqual)
-		// Compare byte-by-byte with constant-time XOR
-		let result = 0;
-		for (let i = 0; i < a.byteLength; i++) {
-			result |= a[i] ^ b[i];
-		}
-		return result === 0;
-	} catch (error) {
-		console.error('Error verifying webhook signature:', error);
-		return false;
-	}
+    // Use subtle.verify as a timing-safe comparison (Web Crypto doesn't expose timingSafeEqual)
+    // Compare byte-by-byte with constant-time XOR
+    let result = 0;
+    for (let i = 0; i < a.byteLength; i++) {
+      result |= a[i] ^ b[i];
+    }
+    return result === 0;
+  } catch (error) {
+    console.error('Error verifying webhook signature:', error);
+    return false;
+  }
 }

--- a/src/routes/api/membership/strike-webhook/webhookNoopTolerance.test.ts
+++ b/src/routes/api/membership/strike-webhook/webhookNoopTolerance.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Regression guard for Phase 5 (Cheffy note-review credits): Strike
+ * webhooks are ACCOUNT-WIDE, so credit-purchase receive requests fire
+ * `receive-request.receive-completed` at this membership webhook too.
+ * Credit invoices live under `nrcredit:inv:` keys — invisible to this
+ * handler's `inv:` metadata lookup — so it must no-op with a 200 (never
+ * a retry-provoking error, never a member registration).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from './+server';
+
+const mocks = vi.hoisted(() => ({
+  handleWebhook: vi.fn(),
+  getReceiveRequestReceives: vi.fn(),
+  registerMember: vi.fn(),
+  getInvoiceMetadata: vi.fn()
+}));
+
+vi.mock('$lib/strikeService.server', () => ({
+  handleWebhook: mocks.handleWebhook,
+  getReceiveRequestReceives: mocks.getReceiveRequestReceives
+}));
+vi.mock('$lib/memberRegistration.server', () => ({ registerMember: mocks.registerMember }));
+vi.mock('$lib/invoiceMetadataStore.server', () => ({
+  getInvoiceMetadata: mocks.getInvoiceMetadata
+}));
+
+function makeEvent(payload: unknown) {
+  const request = new Request('https://zap.cooking/api/membership/strike-webhook', {
+    method: 'POST',
+    headers: { 'x-webhook-signature': 'sig' },
+    body: JSON.stringify(payload)
+  });
+  return { request, platform: { env: { MEMBERSHIP_ENABLED: 'true' } } } as never;
+}
+
+beforeEach(() => {
+  mocks.handleWebhook.mockReset().mockResolvedValue({});
+  mocks.getReceiveRequestReceives.mockReset().mockResolvedValue([]);
+  mocks.registerMember.mockReset();
+  // A note-review credit invoice: its metadata lives under nrcredit:inv:,
+  // so the membership store lookup finds nothing.
+  mocks.getInvoiceMetadata.mockReset().mockResolvedValue(null);
+});
+
+describe('membership strike-webhook tolerance of foreign receive requests', () => {
+  it('200-no-ops on a credit-purchase receive-completed (unknown to inv: metadata)', async () => {
+    const res = await POST(
+      makeEvent({
+        eventType: 'receive-request.receive-completed',
+        data: { entityId: 'rr-note-review-credit-123' }
+      })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.received).toBe(true);
+    expect(mocks.registerMember).not.toHaveBeenCalled();
+    // It never even needs the Strike API for an unknown invoice.
+    expect(mocks.getReceiveRequestReceives).not.toHaveBeenCalled();
+  });
+
+  it('200-acknowledges receive-pending without side effects', async () => {
+    const res = await POST(
+      makeEvent({
+        eventType: 'receive-request.receive-pending',
+        data: { entityId: 'rr-note-review-credit-123' }
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(mocks.registerMember).not.toHaveBeenCalled();
+  });
+});

--- a/src/routes/api/zappy/note-review/+server.ts
+++ b/src/routes/api/zappy/note-review/+server.ts
@@ -326,7 +326,13 @@ export const POST: RequestHandler = async ({ request, platform }) => {
     // IMAGE_UNREADABLE, and API failures all return before this line.
     let creditsRemaining: number | undefined;
     if (creditGranted) {
-      creditsRemaining = await spendCredit(platform?.env?.GATED_CONTENT, authPubkey);
+      try {
+        creditsRemaining = await spendCredit(platform?.env?.GATED_CONTENT, authPubkey);
+      } catch (err) {
+        // Fail open: the draft exists and the OpenAI call is already
+        // paid for — an uncharged draft beats a 500 that drops it.
+        console.error('[Note Review] spendCredit failed (fail-open, uncharged draft):', err);
+      }
     }
 
     // creditsRemaining is additive (credit-spending requests only) —

--- a/src/routes/api/zappy/note-review/+server.ts
+++ b/src/routes/api/zappy/note-review/+server.ts
@@ -17,15 +17,22 @@
  *   imageUrl: string,          // https image URL from the note (OpenAI fetches it — we never do)
  *   mode: "comment" | "recipe",
  *   noteText?: string,         // note content for context; untrusted, capped
- *   noteId?: string,           // event id hex, logging only
- *   experience?: true          // non-member preview request (HttpOnly cookie budget)
+ *   noteId?: string            // event id hex, logging only
  * }
+ * (A stale `experience: true` field from pre-Phase-5 clients is
+ * silently ignored — the preview system was removed for this endpoint.)
  *
  * Returns:
- *   { ok: true, output: string, mode: string, previewRemaining?: number }
- *   (previewRemaining only on preview-granted requests)
- *   { ok: false, error: string, code?: "NOT_MEMBER" | "PREVIEW_USED" |
+ *   { ok: true, output: string, mode: string, creditsRemaining?: number }
+ *   (creditsRemaining only when a purchased credit was spent)
+ *   { ok: false, error: string, code?: "NOT_MEMBER" |
  *     "MEMBERSHIP_UNAVAILABLE" | "RATE_LIMITED" | "NOT_FOOD" | "IMAGE_UNREADABLE" }
+ *
+ * Access (Phase 5): members draft free; non-members spend purchased
+ * 21-sat credits (GATED_CONTENT ledger, success-only decrement — an
+ * unreadable photo or API failure never consumes a paid credit).
+ * Zero credits → 403 NOT_MEMBER, which the client renders as the
+ * membership-or-sats payment card.
  *
  * DELIBERATE DEVIATION (decision D5, 2026-07): this endpoint fails
  * CLOSED when the membership service is unreachable (503
@@ -41,6 +48,7 @@ import { env } from '$env/dynamic/private';
 import { verifyNip98 } from '$lib/nip98.server';
 import { checkPerIpRateLimit } from '$lib/ipRateLimit.server';
 import { isImageUrl } from '$lib/imageUrls';
+import { getCreditBalance, spendCredit } from '$lib/noteReviewCredits.server';
 import {
   CHEFFY_VISION_MODEL,
   NOTE_REVIEW_COMMENT_INSTRUCTION,
@@ -64,14 +72,7 @@ const PER_DAY = 30;
 const COMMENT_MAX_TOKENS = 600;
 const RECIPE_MAX_TOKENS = 1200;
 
-// Non-member preview — same pattern as Cheffy chat (3 success-counted
-// turns per device via HttpOnly cookie) with a dedicated cookie so the
-// two features' budgets never collide.
-const EXPERIENCE_COOKIE = 'zapcooking_cheffy_note_review_experience_used';
-const EXPERIENCE_MAX_TURNS = 3;
-const EXPERIENCE_COOKIE_MAX_AGE = 60 * 60 * 24 * 180; // ~180 days
-
-export const POST: RequestHandler = async ({ request, platform, cookies, url }) => {
+export const POST: RequestHandler = async ({ request, platform }) => {
   try {
     const OPENAI_API_KEY = (platform?.env as any)?.OPENAI_API_KEY || env.OPENAI_API_KEY;
     if (!OPENAI_API_KEY) {
@@ -95,7 +96,6 @@ export const POST: RequestHandler = async ({ request, platform, cookies, url }) 
     }
 
     const { imageUrl, mode, noteText, noteId } = body ?? {};
-    const isExperience = body?.experience === true;
 
     if (mode !== 'comment' && mode !== 'recipe') {
       return json(
@@ -146,11 +146,10 @@ export const POST: RequestHandler = async ({ request, platform, cookies, url }) 
     }
     const authPubkey = verification.pubkey;
 
-    // Membership gate (Pro Kitchen) with the non-member preview path.
+    // Membership gate (Pro Kitchen) with the non-member credit path.
     // FAILS CLOSED on membership-service problems — see header comment
     // and issue #512 before "fixing" this to match the other endpoints.
-    let experienceGranted = false;
-    let experienceCount = 0;
+    let creditGranted = false;
     const MEMBERSHIP_ENABLED = platform?.env?.MEMBERSHIP_ENABLED || env.MEMBERSHIP_ENABLED;
     if (MEMBERSHIP_ENABLED?.toLowerCase() === 'true') {
       const API_SECRET = platform?.env?.RELAY_API_SECRET || env.RELAY_API_SECRET;
@@ -184,29 +183,21 @@ export const POST: RequestHandler = async ({ request, platform, cookies, url }) 
       }
 
       if (!isMember) {
-        if (!isExperience) {
+        // Purchased-credit path. Balance is read here but spent ONLY on
+        // a successful draft (bottom of the handler) — nobody pays 21
+        // sats for an error.
+        const balance = await getCreditBalance(platform?.env?.GATED_CONTENT, authPubkey);
+        if (balance <= 0) {
           return json(
             {
               ok: false,
               code: 'NOT_MEMBER',
-              error: 'Cheffy photo review is available to Pro Kitchen members.'
+              error: 'Cheffy photo review is available to Pro Kitchen members — or 21 sats a draft.'
             },
             { status: 403 }
           );
         }
-        const prior = parseInt(cookies.get(EXPERIENCE_COOKIE) || '0', 10);
-        experienceCount = Number.isFinite(prior) && prior > 0 ? prior : 0;
-        if (experienceCount >= EXPERIENCE_MAX_TURNS) {
-          return json(
-            {
-              ok: false,
-              code: 'PREVIEW_USED',
-              error: 'Unlock Pro Kitchen to keep asking Cheffy about dishes on the feed.'
-            },
-            { status: 429 }
-          );
-        }
-        experienceGranted = true;
+        creditGranted = true;
       }
     }
 
@@ -331,29 +322,20 @@ export const POST: RequestHandler = async ({ request, platform, cookies, url }) 
       );
     }
 
-    // Count a preview turn only on a successful draft (chat precedent:
-    // failures never burn the visitor's budget).
-    if (experienceGranted) {
-      const isHttps =
-        url.protocol === 'https:' || request.headers.get('x-forwarded-proto') === 'https';
-      cookies.set(EXPERIENCE_COOKIE, String(experienceCount + 1), {
-        path: '/',
-        httpOnly: true,
-        sameSite: 'lax',
-        secure: isHttps,
-        maxAge: EXPERIENCE_COOKIE_MAX_AGE
-      });
+    // Spend a purchased credit only on a successful draft — NOT_FOOD,
+    // IMAGE_UNREADABLE, and API failures all return before this line.
+    let creditsRemaining: number | undefined;
+    if (creditGranted) {
+      creditsRemaining = await spendCredit(platform?.env?.GATED_CONTENT, authPubkey);
     }
 
-    // previewRemaining is additive (preview requests only) — the client
-    // surfaces the remaining free-draft budget without a second call.
+    // creditsRemaining is additive (credit-spending requests only) —
+    // the client surfaces the remaining paid-draft balance.
     return json({
       ok: true,
       output: trimmed,
       mode,
-      ...(experienceGranted
-        ? { previewRemaining: Math.max(0, EXPERIENCE_MAX_TURNS - (experienceCount + 1)) }
-        : {})
+      ...(creditGranted ? { creditsRemaining } : {})
     });
   } catch (error: any) {
     console.error('[Note Review] Error:', error);

--- a/src/routes/api/zappy/note-review/credit-invoice/+server.ts
+++ b/src/routes/api/zappy/note-review/credit-invoice/+server.ts
@@ -15,6 +15,7 @@
  */
 
 import { json, type RequestHandler } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
 import { verifyNip98 } from '$lib/nip98.server';
 import { checkPerIpRateLimit } from '$lib/ipRateLimit.server';
 import { createInvoice, isStrikeConfigured } from '$lib/strikeService.server';
@@ -30,6 +31,23 @@ const PER_DAY = 20;
 
 export const POST: RequestHandler = async ({ request, platform }) => {
   try {
+    // Never sell credits while drafting is free: with membership gating
+    // off, note-review serves everyone at no charge, so a purchased
+    // credit would buy nothing. 409 — the request conflicts with the
+    // current access state, and a healthy client never sends it (the
+    // payment card only renders after a 403 NOT_MEMBER).
+    const MEMBERSHIP_ENABLED = platform?.env?.MEMBERSHIP_ENABLED || env.MEMBERSHIP_ENABLED;
+    if (MEMBERSHIP_ENABLED?.toLowerCase() !== 'true') {
+      return json(
+        {
+          ok: false,
+          code: 'CREDITS_NOT_NEEDED',
+          error: 'Drafting is currently free — no credits needed.'
+        },
+        { status: 409 }
+      );
+    }
+
     if (!isStrikeConfigured(platform)) {
       return json(
         { ok: false, error: 'Lightning payments are not available right now.' },

--- a/src/routes/api/zappy/note-review/credit-invoice/+server.ts
+++ b/src/routes/api/zappy/note-review/credit-invoice/+server.ts
@@ -135,6 +135,21 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 
     return json({ ok: true, invoiceId, bolt11, expiresAt });
   } catch (error: unknown) {
+    // Upstream Strike failures (auth rejection, 4xx/5xx) are a typed
+    // 502, not a bare 500 — the client shows a retry line and the real
+    // reason stays in the server log. strikeService throws with this
+    // exact message prefix for every non-ok Strike response.
+    if (error instanceof Error && error.message.startsWith('Strike API error')) {
+      console.error('[NR Credit Invoice] Strike rejected the request:', error.message);
+      return json(
+        {
+          ok: false,
+          code: 'STRIKE_ERROR',
+          error: 'Lightning payments are having trouble right now. Please try again shortly.'
+        },
+        { status: 502 }
+      );
+    }
     console.error('[NR Credit Invoice] Error:', error);
     return json(
       { ok: false, error: 'Could not create the invoice. Please try again.' },

--- a/src/routes/api/zappy/note-review/credit-invoice/+server.ts
+++ b/src/routes/api/zappy/note-review/credit-invoice/+server.ts
@@ -61,6 +61,11 @@ export const POST: RequestHandler = async ({ request, platform }) => {
     } catch {
       return json({ ok: false, error: 'Invalid request body' }, { status: 400 });
     }
+    // The expected body is `{}` — cap it before spending CPU on the
+    // NIP-98 payload hash.
+    if (bodyBytes.length > 1024) {
+      return json({ ok: false, error: 'Request body too large' }, { status: 413 });
+    }
 
     const verification = await verifyNip98(request, { bodyBytes });
     if (!verification.ok) {
@@ -72,6 +77,13 @@ export const POST: RequestHandler = async ({ request, platform }) => {
     // Per-pubkey cap (rate-limit buckets stay in NOURISH_FLAGS with the
     // rl: convention; the credit LEDGER lives in GATED_CONTENT).
     const rlKv = platform?.env?.NOURISH_FLAGS;
+    if (!rlKv) {
+      // checkPerIpRateLimit fails open silently — be loud so an
+      // unmetered invoice endpoint shows up in logs.
+      console.warn(
+        '[NR Credit Invoice] NOURISH_FLAGS KV not bound — invoice rate limiting is disabled'
+      );
+    }
     const rl = await checkPerIpRateLimit(rlKv, {
       ip: authPubkey,
       scope: 'note-review-invoice',

--- a/src/routes/api/zappy/note-review/credit-invoice/+server.ts
+++ b/src/routes/api/zappy/note-review/credit-invoice/+server.ts
@@ -1,0 +1,114 @@
+/**
+ * Cheffy Note Review — credit purchase invoice (Phase 5).
+ *
+ * POST /api/zappy/note-review/credit-invoice
+ * NIP-98 auth (body-hash bound; body is `{}` — the identity IS the
+ * correlation: the invoice is bound to the authed pubkey in KV, and
+ * credit-status only pays out to that same pubkey).
+ *
+ * Creates a Strike receive request for exactly 21 sats (BTC-denominated,
+ * 10-minute expiry) and stores {receiveRequestId → pubkey} metadata in
+ * GATED_CONTENT. Rate-limited per pubkey — invoice creation is free to
+ * us but spammable.
+ *
+ * Returns: { ok: true, invoiceId, bolt11, expiresAt }  (expiresAt: ms epoch)
+ */
+
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { verifyNip98 } from '$lib/nip98.server';
+import { checkPerIpRateLimit } from '$lib/ipRateLimit.server';
+import { createInvoice, isStrikeConfigured } from '$lib/strikeService.server';
+import {
+  NOTE_REVIEW_CREDIT_BTC,
+  NOTE_REVIEW_CREDIT_SATS,
+  CREDIT_INVOICE_EXPIRY_SECONDS,
+  storeCreditInvoice
+} from '$lib/noteReviewCredits.server';
+
+const PER_HOUR = 6;
+const PER_DAY = 20;
+
+export const POST: RequestHandler = async ({ request, platform }) => {
+  try {
+    if (!isStrikeConfigured(platform)) {
+      return json(
+        { ok: false, error: 'Lightning payments are not available right now.' },
+        { status: 503 }
+      );
+    }
+
+    let bodyBytes: Uint8Array;
+    try {
+      bodyBytes = new Uint8Array(await request.arrayBuffer());
+    } catch {
+      return json({ ok: false, error: 'Invalid request body' }, { status: 400 });
+    }
+
+    const verification = await verifyNip98(request, { bodyBytes });
+    if (!verification.ok) {
+      console.warn(`[NR Credit Invoice] NIP-98 rejected (${verification.reason})`);
+      return json({ ok: false, error: 'Authentication required' }, { status: 401 });
+    }
+    const authPubkey = verification.pubkey;
+
+    // Per-pubkey cap (rate-limit buckets stay in NOURISH_FLAGS with the
+    // rl: convention; the credit LEDGER lives in GATED_CONTENT).
+    const rlKv = platform?.env?.NOURISH_FLAGS;
+    const rl = await checkPerIpRateLimit(rlKv, {
+      ip: authPubkey,
+      scope: 'note-review-invoice',
+      perHour: PER_HOUR,
+      perDay: PER_DAY
+    });
+    if (rl.limited) {
+      return json(
+        {
+          ok: false,
+          code: 'RATE_LIMITED',
+          error: 'Too many invoices — give the last one a moment.',
+          retryAfter: rl.body.retryAfter
+        },
+        { status: 429 }
+      );
+    }
+
+    const strikeResponse = await createInvoice(
+      NOTE_REVIEW_CREDIT_BTC,
+      'BTC',
+      `Cheffy note review draft (${NOTE_REVIEW_CREDIT_SATS} sats) — zap.cooking`,
+      platform,
+      CREDIT_INVOICE_EXPIRY_SECONDS
+    );
+
+    // Strike nests the BOLT11 under bolt11; tolerate top-level for
+    // compatibility (same extraction as the membership flow).
+    const bolt11Data = (strikeResponse as { bolt11?: Record<string, unknown> }).bolt11;
+    const bolt11 = (bolt11Data?.invoice ?? (strikeResponse as { invoice?: string }).invoice) as
+      | string
+      | undefined;
+    const invoiceId = (strikeResponse as { receiveRequestId?: string }).receiveRequestId;
+    if (!bolt11 || !invoiceId) {
+      console.error('[NR Credit Invoice] Strike response missing invoice/id');
+      return json(
+        { ok: false, error: 'Could not create the invoice. Please try again.' },
+        { status: 502 }
+      );
+    }
+
+    const expiresString = (bolt11Data?.expires ??
+      (strikeResponse as { expires?: string }).expires) as string | undefined;
+    const expiresAt = expiresString
+      ? new Date(expiresString).getTime()
+      : Date.now() + CREDIT_INVOICE_EXPIRY_SECONDS * 1000;
+
+    await storeCreditInvoice(platform?.env?.GATED_CONTENT, invoiceId, authPubkey, expiresAt);
+
+    return json({ ok: true, invoiceId, bolt11, expiresAt });
+  } catch (error: unknown) {
+    console.error('[NR Credit Invoice] Error:', error);
+    return json(
+      { ok: false, error: 'Could not create the invoice. Please try again.' },
+      { status: 500 }
+    );
+  }
+};

--- a/src/routes/api/zappy/note-review/credit-invoice/creditInvoice.test.ts
+++ b/src/routes/api/zappy/note-review/credit-invoice/creditInvoice.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for POST /api/zappy/note-review/credit-invoice.
+ * Strike, NIP-98, and the rate limiter are mocked; the credit metadata
+ * store runs for real on its in-memory dev fallback.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  getCreditInvoice,
+  __resetNoteReviewCreditsForTests,
+  CREDIT_INVOICE_EXPIRY_SECONDS
+} from '$lib/noteReviewCredits.server';
+import { POST } from './+server';
+
+const mocks = vi.hoisted(() => ({
+  verifyNip98: vi.fn(),
+  checkPerIpRateLimit: vi.fn(),
+  createInvoice: vi.fn(),
+  isStrikeConfigured: vi.fn()
+}));
+
+vi.mock('$lib/nip98.server', () => ({ verifyNip98: mocks.verifyNip98 }));
+vi.mock('$lib/ipRateLimit.server', () => ({ checkPerIpRateLimit: mocks.checkPerIpRateLimit }));
+vi.mock('$lib/strikeService.server', () => ({
+  createInvoice: mocks.createInvoice,
+  isStrikeConfigured: mocks.isStrikeConfigured
+}));
+
+const PUBKEY = 'a'.repeat(64);
+
+function makeEvent() {
+  const request = new Request('https://zap.cooking/api/zappy/note-review/credit-invoice', {
+    method: 'POST',
+    body: '{}'
+  });
+  // GATED_CONTENT deliberately absent → credits lib uses its dev
+  // fallback, so stored metadata is observable via getCreditInvoice.
+  return { request, platform: { env: { NOURISH_FLAGS: { kv: true } } } } as never;
+}
+
+async function call() {
+  const res = await POST(makeEvent());
+  return { res, data: await res.json() };
+}
+
+beforeEach(() => {
+  __resetNoteReviewCreditsForTests();
+  mocks.verifyNip98.mockReset().mockResolvedValue({ ok: true, pubkey: PUBKEY });
+  mocks.checkPerIpRateLimit.mockReset().mockResolvedValue({ limited: false, ipHash: 'h' });
+  mocks.isStrikeConfigured.mockReset().mockReturnValue(true);
+  mocks.createInvoice.mockReset().mockResolvedValue({
+    receiveRequestId: 'rr-abc',
+    bolt11: {
+      invoice: 'lnbc210n1...',
+      paymentHash: 'ph',
+      expires: new Date(Date.now() + 600_000).toISOString()
+    }
+  });
+});
+
+describe('credit-invoice endpoint', () => {
+  it('503s when Strike is not configured', async () => {
+    mocks.isStrikeConfigured.mockReturnValue(false);
+    const { res } = await call();
+    expect(res.status).toBe(503);
+    expect(mocks.createInvoice).not.toHaveBeenCalled();
+  });
+
+  it('401s on NIP-98 failure without touching Strike', async () => {
+    mocks.verifyNip98.mockResolvedValue({ ok: false, reason: 'invalid-signature' });
+    const { res } = await call();
+    expect(res.status).toBe(401);
+    expect(mocks.createInvoice).not.toHaveBeenCalled();
+  });
+
+  it('rate-limits invoice creation per pubkey', async () => {
+    mocks.checkPerIpRateLimit.mockResolvedValue({
+      limited: true,
+      ipHash: 'h',
+      body: { error: 'rate_limited', retryAfter: 3600, scope: 'per-hour' }
+    });
+    const { res, data } = await call();
+    expect(res.status).toBe(429);
+    expect(data.code).toBe('RATE_LIMITED');
+    const [, params] = mocks.checkPerIpRateLimit.mock.calls[0];
+    expect(params).toEqual({ ip: PUBKEY, scope: 'note-review-invoice', perHour: 6, perDay: 20 });
+    expect(mocks.createInvoice).not.toHaveBeenCalled();
+  });
+
+  it('creates a 21-sat BTC invoice with the short expiry and binds it to the pubkey', async () => {
+    const { res, data } = await call();
+    expect(res.status).toBe(200);
+    // expect.stringMatching/anything don't typecheck under svelte-check
+    // (known repo limitation) — assert on the call args directly.
+    const [amount, currency, description, , expiry] = mocks.createInvoice.mock.calls[0];
+    expect(amount).toBe('0.00000021');
+    expect(currency).toBe('BTC');
+    expect(String(description)).toContain('Cheffy note review draft');
+    expect(expiry).toBe(CREDIT_INVOICE_EXPIRY_SECONDS);
+    expect(data).toMatchObject({ ok: true, invoiceId: 'rr-abc', bolt11: 'lnbc210n1...' });
+    expect(typeof data.expiresAt).toBe('number');
+
+    const meta = await getCreditInvoice(undefined, 'rr-abc');
+    expect(meta).toMatchObject({ pubkey: PUBKEY, receiveRequestId: 'rr-abc' });
+  });
+
+  it('502s when Strike omits the invoice or id', async () => {
+    mocks.createInvoice.mockResolvedValue({ bolt11: {} });
+    const { res } = await call();
+    expect(res.status).toBe(502);
+  });
+
+  it('500s when Strike throws', async () => {
+    mocks.createInvoice.mockRejectedValue(new Error('strike down'));
+    const { res } = await call();
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/routes/api/zappy/note-review/credit-invoice/creditInvoice.test.ts
+++ b/src/routes/api/zappy/note-review/credit-invoice/creditInvoice.test.ts
@@ -160,7 +160,25 @@ describe('credit-invoice endpoint', () => {
     expect(res.status).toBe(502);
   });
 
-  it('500s when Strike throws', async () => {
+  it('502s STRIKE_ERROR on upstream Strike rejections (e.g. auth), reason logged server-side', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mocks.createInvoice.mockRejectedValue(
+      new Error(
+        'Strike API error: 401 Unauthorized. {"data":{"code":"UNAUTHORIZED","message":"Invalid or unspecified identity."}}'
+      )
+    );
+    const { res, data } = await call();
+    expect(res.status).toBe(502);
+    expect(data.code).toBe('STRIKE_ERROR');
+    expect(data.error).not.toContain('Unauthorized'); // reason stays server-side
+    const logged = errSpy.mock.calls.some((c: unknown[]) =>
+      String(c[1] ?? c[0]).includes('401 Unauthorized')
+    );
+    expect(logged).toBe(true);
+    errSpy.mockRestore();
+  });
+
+  it('500s on non-Strike unexpected errors', async () => {
     mocks.createInvoice.mockRejectedValue(new Error('strike down'));
     const { res } = await call();
     expect(res.status).toBe(500);

--- a/src/routes/api/zappy/note-review/credit-invoice/creditInvoice.test.ts
+++ b/src/routes/api/zappy/note-review/credit-invoice/creditInvoice.test.ts
@@ -34,6 +34,17 @@ function makeEvent() {
   });
   // GATED_CONTENT deliberately absent → credits lib uses its dev
   // fallback, so stored metadata is observable via getCreditInvoice.
+  return {
+    request,
+    platform: { env: { MEMBERSHIP_ENABLED: 'true', NOURISH_FLAGS: { kv: true } } }
+  } as never;
+}
+
+function makeEventGatingOff() {
+  const request = new Request('https://zap.cooking/api/zappy/note-review/credit-invoice', {
+    method: 'POST',
+    body: '{}'
+  });
   return { request, platform: { env: { NOURISH_FLAGS: { kv: true } } } } as never;
 }
 
@@ -58,6 +69,15 @@ beforeEach(() => {
 });
 
 describe('credit-invoice endpoint', () => {
+  it('409s CREDITS_NOT_NEEDED while membership gating is off — never sell credits when drafting is free', async () => {
+    const res = await POST(makeEventGatingOff());
+    expect(res.status).toBe(409);
+    const data = await res.json();
+    expect(data.code).toBe('CREDITS_NOT_NEEDED');
+    expect(mocks.createInvoice).not.toHaveBeenCalled();
+    expect(mocks.verifyNip98).not.toHaveBeenCalled(); // refused before any work
+  });
+
   it('503s when Strike is not configured', async () => {
     mocks.isStrikeConfigured.mockReturnValue(false);
     const { res } = await call();

--- a/src/routes/api/zappy/note-review/credit-invoice/creditInvoice.test.ts
+++ b/src/routes/api/zappy/note-review/credit-invoice/creditInvoice.test.ts
@@ -78,6 +78,37 @@ describe('credit-invoice endpoint', () => {
     expect(mocks.verifyNip98).not.toHaveBeenCalled(); // refused before any work
   });
 
+  it('413s oversized bodies before hashing or auth', async () => {
+    const request = new Request('https://zap.cooking/api/zappy/note-review/credit-invoice', {
+      method: 'POST',
+      body: 'x'.repeat(4096)
+    });
+    const res = await POST({
+      request,
+      platform: { env: { MEMBERSHIP_ENABLED: 'true', NOURISH_FLAGS: { kv: true } } }
+    } as never);
+    expect(res.status).toBe(413);
+    expect(mocks.verifyNip98).not.toHaveBeenCalled();
+  });
+
+  it('warns loudly when the rate-limit KV binding is absent', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const request = new Request('https://zap.cooking/api/zappy/note-review/credit-invoice', {
+      method: 'POST',
+      body: '{}'
+    });
+    const res = await POST({
+      request,
+      platform: { env: { MEMBERSHIP_ENABLED: 'true' } }
+    } as never);
+    expect(res.status).toBe(200);
+    const warned = warnSpy.mock.calls.some((c: unknown[]) =>
+      String(c[0]).includes('NOURISH_FLAGS KV not bound')
+    );
+    expect(warned).toBe(true);
+    warnSpy.mockRestore();
+  });
+
   it('503s when Strike is not configured', async () => {
     mocks.isStrikeConfigured.mockReturnValue(false);
     const { res } = await call();

--- a/src/routes/api/zappy/note-review/credit-status/+server.ts
+++ b/src/routes/api/zappy/note-review/credit-status/+server.ts
@@ -1,0 +1,84 @@
+/**
+ * Cheffy Note Review — credit invoice status + idempotent crediting.
+ *
+ * GET /api/zappy/note-review/credit-status?id={receiveRequestId}
+ * NIP-98 auth (GET-style, no payload tag; the u tag matches because
+ * normalizeUrl strips query strings on both sides).
+ *
+ * Polled by the modal every few seconds while the payer sits on the
+ * invoice (D3: polling, mirroring the genesis flow — no new webhook).
+ * On the first observed COMPLETED receive, increments the pubkey's
+ * credit balance exactly once (idempotency mark on the invoice id —
+ * refresh spam can't double-credit).
+ *
+ * Returns: { ok: true, status: 'paid' | 'pending' | 'expired', balance }
+ */
+
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { verifyNip98 } from '$lib/nip98.server';
+import { getReceiveRequestReceives } from '$lib/strikeService.server';
+import {
+  getCreditInvoice,
+  creditInvoicePaid,
+  getCreditBalance
+} from '$lib/noteReviewCredits.server';
+
+export const GET: RequestHandler = async ({ request, url, platform }) => {
+  try {
+    const verification = await verifyNip98(request, {});
+    if (!verification.ok) {
+      console.warn(`[NR Credit Status] NIP-98 rejected (${verification.reason})`);
+      return json({ ok: false, error: 'Authentication required' }, { status: 401 });
+    }
+    const authPubkey = verification.pubkey;
+
+    const invoiceId = url.searchParams.get('id')?.trim();
+    if (!invoiceId) {
+      return json({ ok: false, error: 'id is required' }, { status: 400 });
+    }
+
+    const kv = platform?.env?.GATED_CONTENT;
+    const metadata = await getCreditInvoice(kv, invoiceId);
+    if (!metadata) {
+      // Unknown or TTL'd-out invoice — the client treats expired as
+      // "offer a fresh invoice"; no distinction leaked.
+      return json({
+        ok: true,
+        status: 'expired',
+        balance: await getCreditBalance(kv, authPubkey)
+      });
+    }
+    if (metadata.pubkey !== authPubkey.toLowerCase()) {
+      return json({ ok: false, error: 'Forbidden' }, { status: 403 });
+    }
+
+    // getReceiveRequestReceives returns a plain Receive[] (it unwraps
+    // Strike's items envelope itself).
+    let receives: Array<{ state?: string }> = [];
+    try {
+      receives = await getReceiveRequestReceives(invoiceId, platform);
+    } catch (err) {
+      console.error('[NR Credit Status] Strike lookup failed:', err);
+      return json(
+        { ok: false, error: 'Payment check hiccuped — trying again shortly.' },
+        { status: 503 }
+      );
+    }
+
+    const paid = receives.some((r) => r?.state === 'COMPLETED');
+    if (paid) {
+      const { balance } = await creditInvoicePaid(kv, invoiceId, authPubkey);
+      return json({ ok: true, status: 'paid', balance });
+    }
+
+    const status = Date.now() > metadata.expiresAt ? 'expired' : 'pending';
+    return json({
+      ok: true,
+      status,
+      balance: await getCreditBalance(kv, authPubkey)
+    });
+  } catch (error: unknown) {
+    console.error('[NR Credit Status] Error:', error);
+    return json({ ok: false, error: 'An unexpected error occurred' }, { status: 500 });
+  }
+};

--- a/src/routes/api/zappy/note-review/credit-status/creditStatus.test.ts
+++ b/src/routes/api/zappy/note-review/credit-status/creditStatus.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Unit tests for GET /api/zappy/note-review/credit-status.
+ * Strike and NIP-98 are mocked; the credit ledger runs for real on its
+ * in-memory dev fallback so idempotent crediting is exercised end to end.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  storeCreditInvoice,
+  getCreditBalance,
+  __resetNoteReviewCreditsForTests
+} from '$lib/noteReviewCredits.server';
+import { GET } from './+server';
+
+const mocks = vi.hoisted(() => ({
+  verifyNip98: vi.fn(),
+  getReceiveRequestReceives: vi.fn()
+}));
+
+vi.mock('$lib/nip98.server', () => ({ verifyNip98: mocks.verifyNip98 }));
+vi.mock('$lib/strikeService.server', () => ({
+  getReceiveRequestReceives: mocks.getReceiveRequestReceives
+}));
+
+const PUBKEY = 'a'.repeat(64);
+const OTHER = 'b'.repeat(64);
+const INVOICE = 'rr-xyz';
+
+function makeEvent(id: string | null) {
+  const url = new URL(
+    `https://zap.cooking/api/zappy/note-review/credit-status${id ? `?id=${id}` : ''}`
+  );
+  const request = new Request(url, { method: 'GET' });
+  return { request, url, platform: { env: {} } } as never;
+}
+
+async function call(id: string | null = INVOICE) {
+  const res = await GET(makeEvent(id));
+  return { res, data: await res.json() };
+}
+
+beforeEach(() => {
+  __resetNoteReviewCreditsForTests();
+  mocks.verifyNip98.mockReset().mockResolvedValue({ ok: true, pubkey: PUBKEY });
+  mocks.getReceiveRequestReceives.mockReset().mockResolvedValue([]);
+});
+
+describe('credit-status endpoint', () => {
+  it('401s on NIP-98 failure', async () => {
+    mocks.verifyNip98.mockResolvedValue({ ok: false, reason: 'stale-timestamp' });
+    const { res } = await call();
+    expect(res.status).toBe(401);
+  });
+
+  it('400s without an id', async () => {
+    const { res } = await call(null);
+    expect(res.status).toBe(400);
+  });
+
+  it('treats an unknown or TTL-expired invoice as expired', async () => {
+    const { res, data } = await call('rr-never-existed');
+    expect(res.status).toBe(200);
+    expect(data).toMatchObject({ ok: true, status: 'expired', balance: 0 });
+  });
+
+  it("403s when polling someone else's invoice", async () => {
+    await storeCreditInvoice(undefined, INVOICE, OTHER, Date.now() + 600_000);
+    const { res } = await call();
+    expect(res.status).toBe(403);
+  });
+
+  it('reports pending while unpaid and unexpired', async () => {
+    await storeCreditInvoice(undefined, INVOICE, PUBKEY, Date.now() + 600_000);
+    const { data } = await call();
+    expect(data).toMatchObject({ ok: true, status: 'pending', balance: 0 });
+  });
+
+  it('reports expired past the invoice deadline', async () => {
+    await storeCreditInvoice(undefined, INVOICE, PUBKEY, Date.now() - 1000);
+    const { data } = await call();
+    expect(data).toMatchObject({ ok: true, status: 'expired', balance: 0 });
+  });
+
+  it('credits exactly once on paid — poll spam cannot double-credit', async () => {
+    await storeCreditInvoice(undefined, INVOICE, PUBKEY, Date.now() + 600_000);
+    mocks.getReceiveRequestReceives.mockResolvedValue([
+      { state: 'PENDING' },
+      { state: 'COMPLETED' }
+    ]);
+
+    const first = await call();
+    expect(first.data).toMatchObject({ ok: true, status: 'paid', balance: 1 });
+
+    // Second, third… polls of the same paid invoice.
+    const second = await call();
+    expect(second.data).toMatchObject({ ok: true, status: 'paid', balance: 1 });
+    expect(await getCreditBalance(undefined, PUBKEY)).toBe(1);
+  });
+
+  it('a paid invoice past its display deadline still credits (payment won the race)', async () => {
+    await storeCreditInvoice(undefined, INVOICE, PUBKEY, Date.now() - 1000);
+    mocks.getReceiveRequestReceives.mockResolvedValue([{ state: 'COMPLETED' }]);
+    const { data } = await call();
+    expect(data).toMatchObject({ ok: true, status: 'paid', balance: 1 });
+  });
+
+  it('503s when Strike is unreachable, without crediting', async () => {
+    await storeCreditInvoice(undefined, INVOICE, PUBKEY, Date.now() + 600_000);
+    mocks.getReceiveRequestReceives.mockRejectedValue(new Error('down'));
+    const { res } = await call();
+    expect(res.status).toBe(503);
+    expect(await getCreditBalance(undefined, PUBKEY)).toBe(0);
+  });
+});

--- a/src/routes/api/zappy/note-review/noteReview.test.ts
+++ b/src/routes/api/zappy/note-review/noteReview.test.ts
@@ -198,6 +198,28 @@ describe('membership gate', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('fails open when the spend itself fails — the draft is never dropped', async () => {
+    mocks.hasActiveMembership.mockResolvedValue(false);
+    // KV that answers the gate read (balance 1) but explodes on the
+    // spend write: the paid-for draft must still be returned.
+    const flakyKv = {
+      get: vi.fn().mockResolvedValue('1'),
+      put: vi.fn().mockRejectedValue(new Error('KV write outage'))
+    };
+    const { res, data } = await call(validBody(), {
+      env: {
+        OPENAI_API_KEY: 'test-key',
+        MEMBERSHIP_ENABLED: 'true',
+        RELAY_API_SECRET: 'secret',
+        NOURISH_FLAGS: { kv: true },
+        GATED_CONTENT: flakyKv
+      }
+    });
+    expect(res.status).toBe(200);
+    expect(data.ok).toBe(true);
+    expect(data.creditsRemaining).toBeUndefined(); // uncharged draft, no claim made
+  });
+
   it('never spends a credit on a failed draft (NOT_FOOD)', async () => {
     mocks.hasActiveMembership.mockResolvedValue(false);
     await seedCredits(1);

--- a/src/routes/api/zappy/note-review/noteReview.test.ts
+++ b/src/routes/api/zappy/note-review/noteReview.test.ts
@@ -5,7 +5,8 @@
  * fetch) are mocked at the module boundary; the endpoint's own
  * validation, gating, and response-shaping logic runs for real —
  * including the D5 fail-CLOSED membership posture this endpoint
- * deliberately does not share with its siblings.
+ * deliberately does not share with its siblings. The credit ledger
+ * (Phase 5) runs for real on its in-memory dev fallback.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
@@ -13,7 +14,17 @@ import {
   NOTE_REVIEW_RECIPE_INSTRUCTION,
   CHEFFY_VISION_MODEL
 } from '$lib/cheffyPrompt.server';
+import {
+  creditInvoicePaid,
+  getCreditBalance,
+  __resetNoteReviewCreditsForTests
+} from '$lib/noteReviewCredits.server';
 import { POST } from './+server';
+
+/** Seed N purchased credits for PUBKEY via the real (idempotent) path. */
+async function seedCredits(n: number) {
+  for (let i = 0; i < n; i++) await creditInvoicePaid(undefined, `seed-${i}`, PUBKEY);
+}
 
 const mocks = vi.hoisted(() => ({
   verifyNip98: vi.fn(),
@@ -84,6 +95,7 @@ async function call(body: unknown, opts: EventOpts = {}) {
 }
 
 beforeEach(() => {
+  __resetNoteReviewCreditsForTests();
   vi.stubGlobal('fetch', fetchMock);
   mocks.verifyNip98.mockReset().mockResolvedValue({ ok: true, pubkey: PUBKEY });
   mocks.hasActiveMembership.mockReset().mockResolvedValue(true);
@@ -160,15 +172,25 @@ describe('NIP-98 auth', () => {
 });
 
 describe('membership gate', () => {
-  it('lets members through with full access', async () => {
+  it('lets members through with full access, never touching the credit ledger', async () => {
     const { res, data, setCookies } = await call(validBody());
     expect(res.status).toBe(200);
     expect(mocks.hasActiveMembership).toHaveBeenCalledWith(PUBKEY, 'secret');
-    expect(setCookies).toEqual([]); // members never touch the preview budget
-    expect(data.previewRemaining).toBeUndefined(); // additive field is preview-only
+    expect(setCookies).toEqual([]); // nothing sets cookies anymore
+    expect(data.creditsRemaining).toBeUndefined(); // additive field is credit-spends only
   });
 
-  it('403s NOT_MEMBER for a non-member without the experience flag', async () => {
+  it('spends a purchased credit on success and reports the remaining balance', async () => {
+    mocks.hasActiveMembership.mockResolvedValue(false);
+    await seedCredits(2);
+    const { res, data, setCookies } = await call(validBody());
+    expect(res.status).toBe(200);
+    expect(data.creditsRemaining).toBe(1);
+    expect(setCookies).toEqual([]); // the preview cookie is gone for good
+    expect(await getCreditBalance(undefined, PUBKEY)).toBe(1);
+  });
+
+  it('403s NOT_MEMBER at zero credits — the client renders this as the payment card', async () => {
     mocks.hasActiveMembership.mockResolvedValue(false);
     const { res, data } = await call(validBody());
     expect(res.status).toBe(403);
@@ -176,42 +198,38 @@ describe('membership gate', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('grants a preview turn, success-counts the cookie, and reports the remaining budget', async () => {
+  it('never spends a credit on a failed draft (NOT_FOOD)', async () => {
     mocks.hasActiveMembership.mockResolvedValue(false);
-    const { res, data, setCookies } = await call(validBody({ experience: true }));
-    expect(res.status).toBe(200);
-    expect(setCookies).toHaveLength(1);
-    expect(setCookies[0].name).toBe('zapcooking_cheffy_note_review_experience_used');
-    expect(setCookies[0].value).toBe('1');
-    expect(setCookies[0].opts.httpOnly).toBe(true);
-    expect(data.previewRemaining).toBe(2); // 3-turn budget, first just spent
-  });
-
-  it('reports zero remaining on the final preview turn', async () => {
-    mocks.hasActiveMembership.mockResolvedValue(false);
-    const { res, data } = await call(validBody({ experience: true }), {
-      cookies: { zapcooking_cheffy_note_review_experience_used: '2' }
-    });
-    expect(res.status).toBe(200);
-    expect(data.previewRemaining).toBe(0);
-  });
-
-  it('429s PREVIEW_USED once the preview budget is spent', async () => {
-    mocks.hasActiveMembership.mockResolvedValue(false);
-    const { res, data } = await call(validBody({ experience: true }), {
-      cookies: { zapcooking_cheffy_note_review_experience_used: '3' }
-    });
-    expect(res.status).toBe(429);
-    expect(data.code).toBe('PREVIEW_USED');
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  it('does not burn a preview turn on a failed draft', async () => {
-    mocks.hasActiveMembership.mockResolvedValue(false);
+    await seedCredits(1);
     fetchMock.mockResolvedValue(openaiOk('NOT_FOOD: A very photogenic cat.'));
-    const { res, setCookies } = await call(validBody({ experience: true }));
+    const { res } = await call(validBody());
     expect(res.status).toBe(422);
-    expect(setCookies).toEqual([]);
+    expect(await getCreditBalance(undefined, PUBKEY)).toBe(1); // still spendable
+  });
+
+  it('never spends a credit on an OpenAI failure', async () => {
+    mocks.hasActiveMembership.mockResolvedValue(false);
+    await seedCredits(1);
+    fetchMock.mockResolvedValue(openaiError(500, { code: 'server_error', message: 'boom' }));
+    const { res } = await call(validBody());
+    expect(res.status).toBe(500);
+    expect(await getCreditBalance(undefined, PUBKEY)).toBe(1);
+  });
+
+  it('silently ignores a stale experience flag from pre-Phase-5 clients', async () => {
+    mocks.hasActiveMembership.mockResolvedValue(false);
+    // Zero credits + the old flag → plain NOT_MEMBER, never PREVIEW_USED,
+    // never a cookie.
+    const zero = await call(validBody({ experience: true }));
+    expect(zero.res.status).toBe(403);
+    expect(zero.data.code).toBe('NOT_MEMBER');
+    expect(zero.setCookies).toEqual([]);
+    // With credits + the old flag → normal credit spend.
+    await seedCredits(1);
+    const spent = await call(validBody({ experience: true }));
+    expect(spent.res.status).toBe(200);
+    expect(spent.data.creditsRemaining).toBe(0);
+    expect(spent.data.previewRemaining).toBeUndefined();
   });
 
   it('fails CLOSED (503) on a membership-service outage — D5', async () => {


### PR DESCRIPTION
## ⚠️ Merge sequencing

**HOLD — do not merge until the 5.2 client PR is also approved.** Both merge the same day, this one first. Rationale: this PR removes the server preview path; until 5.2 ships the payment card, non-members would see a plain upsell with no way to pay. Old clients keep working through the window (`experience: true` is tolerantly ignored; regression-tested).

## Summary

Phase 5.1 of sats pay-per-use (v2 scope): non-members buy Cheffy note-review drafts at **21 sats each**; the preview system is **removed for this endpoint** (chat's experience preview untouched). Members unchanged.

- **Gate chain**: membership → credit balance → `403 NOT_MEMBER` (5.2 renders it as the payment card). Credits decrement **only on a successful draft** — `NOT_FOOD` / `IMAGE_UNREADABLE` / API failures never consume a paid credit.
- **Ledger** (`$lib/noteReviewCredits.server`, decision D2): `GATED_CONTENT` KV — `credit:note-review:{pubkey}` (no TTL, cross-device by key), `nrcredit:inv:{id}` (48h — long enough that a paid-then-closed-modal invoice stays creditable via the 5.2 resume flow), `nrcredit:done:{id}` idempotency mark (7d). Non-atomic read-then-write accepted per scope (~\$0.002 worst-case race).
- **`POST …/credit-invoice`**: NIP-98 + per-pubkey rate limit (6/hr, 20/day). Strike receive request, BTC-denominated `0.00000021`, 600s expiry (`createInvoice` gains a backwards-compatible `expiryInSeconds` param). Refuses with `409 CREDITS_NOT_NEEDED` while membership gating is off — never sells credits when drafting is free.
- **`GET …/credit-status?id=`**: NIP-98, pubkey-bound, polls Strike receives (D3: polling, genesis precedent — no new webhook). First observed `COMPLETED` credits exactly once; poll spam can't double-credit. A payment landing after the display deadline still credits.
- **Webhook tolerance**: regression test proves the account-wide membership strike-webhook 200-no-ops on credit receive requests (`nrcredit:inv:` keys are invisible to its `inv:` lookup).

## Test plan

- [x] 30 new unit tests: ledger on both backends, both endpoint matrices, gate ordering, success-only decrement, tolerant-ignore of stale `experience: true`, gating-off refusal, webhook no-op guard
- [x] Full suite green (34 files, 562 tests); `svelte-check` 0 errors
- [ ] 5.3 manual gate after both PRs merge: real 21-sat payment on preview, cross-device credit, member regression

Note: "Workers Builds" checks are expected to fail on this repo (known infra quirk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)