### PR TITLE
feat(cheffy): note review sats payment card + credit flow — client (Phase 5.2) [HOLD: merges after #521]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.609",
+  "version": "4.2.610",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.608",
+  "version": "4.2.609",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/CheffyNoteReview.svelte
+++ b/src/components/CheffyNoteReview.svelte
@@ -20,6 +20,8 @@
   import { ndk, userPublickey } from '$lib/nostr';
   import { membershipStatusMap, queueMembershipLookup } from '$lib/stores/membershipStatus';
   import { THINKING_LINES, COOKING_LINES, ERROR_LINES, pickLine } from '$lib/cheffy';
+  import { onDestroy } from 'svelte';
+  import { lightningService } from '$lib/lightningService';
   import {
     requestNoteReview,
     phaseForResult,
@@ -30,7 +32,16 @@
     loadDisclosurePref,
     shouldSeedDisclosureFromPref,
     saveDisclosurePref,
+    requestCreditInvoice,
+    checkCreditStatus,
+    pollActionForStatus,
+    storePendingInvoice,
+    clearPendingInvoice,
+    resumePendingInvoice,
     DISCLOSURE_FOOTER,
+    CREDIT_PRICE_SATS,
+    CREDITS_CROSS_DEVICE_LINE,
+    PAYMENT_CARD_EXAMPLE_DRAFT,
     NOTE_REVIEW_POST_ENABLED,
     type NoteReviewMode,
     type NoteReviewPhase,
@@ -59,9 +70,13 @@
   // Disclosure footer toggle — per-mode preference, applied at publish
   // time only (never part of the editable draft).
   let disclosureOn = false;
-  // Remaining free drafts, from the server's additive previewRemaining
-  // field (preview-granted requests only).
-  let previewRemaining: number | null = null;
+  // Paid-draft balance: from creditsRemaining on spends, credit-status
+  // polls, and the resume flow. null until any signal arrives.
+  let creditBalance: number | null = null;
+  let resumeAck = false; // "payment received" banner after a resume credit
+  let payError = '';
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+  let resumeCheckedForOpen = false;
 
   $: signedIn = $userPublickey !== '';
   $: normalizedPk = $userPublickey.trim().toLowerCase();
@@ -81,13 +96,11 @@
       noteText: event?.content,
       mode: selected,
       noteId: event?.id,
-      // Non-members go through the server-enforced preview budget.
-      experience: signedIn && !hasMembership,
       onSigned: () => (phase = 'loading')
     });
     if (result.ok) {
       draft = result.output;
-      previewRemaining = result.previewRemaining ?? null;
+      if (typeof result.creditsRemaining === 'number') creditBalance = result.creditsRemaining;
     }
     const next = phaseForResult(result);
     phase = next.phase;
@@ -98,6 +111,85 @@
   function toggleDisclosure() {
     disclosureOn = !disclosureOn;
     saveDisclosurePref(mode, disclosureOn);
+  }
+
+  function stopPolling() {
+    if (pollTimer) clearInterval(pollTimer);
+    pollTimer = null;
+  }
+
+  onDestroy(stopPolling);
+
+  // One-shot resume per modal open: a paid-but-unobserved invoice from a
+  // previous session gets credited here (server metadata lives 48h).
+  $: if (open && signedIn && !resumeCheckedForOpen) {
+    resumeCheckedForOpen = true;
+    void resumePendingInvoice({ ndk: $ndk }).then((r) => {
+      if (r.outcome === 'paid') {
+        creditBalance = r.balance;
+        resumeAck = true;
+      }
+      // expired → cleared silently inside the helper; pending/absent → nothing.
+    });
+  }
+  $: if (!open) {
+    resumeCheckedForOpen = false;
+    stopPolling();
+  }
+
+  async function startPayment() {
+    payError = '';
+    phase = 'paying';
+    const invoice = await requestCreditInvoice({ ndk: $ndk });
+    if (!invoice.ok) {
+      phase = 'upsell';
+      payError =
+        invoice.code === 'RATE_LIMITED'
+          ? (invoice.error ?? 'Too many invoices — give the last one a moment.')
+          : 'Could not set up the payment. Please try again.';
+      return;
+    }
+    storePendingInvoice(invoice.invoiceId);
+
+    let setPaidHandle: { setPaid: (r: { preimage: string }) => void } | null = null;
+    try {
+      setPaidHandle = await lightningService.launchPayment({
+        invoice: invoice.bolt11,
+        onPaid: () => {
+          // Wallet says paid — the server poll below stays authoritative.
+        },
+        onCancelled: () => {
+          // Modal closed. Keep the pending invoice stored — if they paid
+          // right before closing, the resume flow credits them.
+          stopPolling();
+          if (phase === 'paying') phase = 'upsell';
+        }
+      });
+    } catch (err) {
+      console.error('[NoteReview] payment modal failed:', err);
+    }
+
+    stopPolling();
+    pollTimer = setInterval(async () => {
+      const status = await checkCreditStatus({ ndk: $ndk, invoiceId: invoice.invoiceId });
+      if (!status.ok) return; // transient — keep polling until expiry
+      const { action } = pollActionForStatus(status.status);
+      if (action === 'continue') return;
+      stopPolling();
+      if (action === 'credited') {
+        clearPendingInvoice();
+        creditBalance = status.balance;
+        setPaidHandle?.setPaid({ preimage: 'strike-confirmed' });
+        // Straight into drafting — they paid for this draft.
+        void run(mode);
+      } else {
+        clearPendingInvoice();
+        if (phase === 'paying') {
+          phase = 'upsell';
+          payError = 'That invoice expired — grab a fresh one below.';
+        }
+      }
+    }, 3000);
   }
 
   function handlePublishOutcome(outcome: PublishOutcome) {
@@ -155,7 +247,9 @@
     noteLink = '';
     timeoutSignedEvent = null;
     selectedImageIndex = 0;
-    previewRemaining = null;
+    payError = '';
+    resumeAck = false;
+    stopPolling();
   }
 
   function signIn() {
@@ -206,6 +300,14 @@
           {/each}
         </div>
       {/if}
+      {#if resumeAck}
+        <p class="nr-resume-ack">
+          ⚡ Payment received — you have {creditBalance === 1
+            ? '1 draft'
+            : `${creditBalance} drafts`}.
+          {CREDITS_CROSS_DEVICE_LINE}
+        </p>
+      {/if}
       <p class="nr-hint">What should Cheffy draft? You'll edit it before anything is posted.</p>
       <div class="nr-choices">
         <button type="button" class="nr-choice" on:click={() => run('comment')}>
@@ -232,9 +334,9 @@
       {@const posting = phase === 'posting'}
       <div class="nr-draft-head">
         <p class="nr-hint">Cheffy's draft — make it yours, then post it as your own reply.</p>
-        {#if previewRemaining !== null}
-          <span class="nr-preview-chip">
-            {previewRemaining === 1 ? '1 free draft left' : `${previewRemaining} free drafts left`}
+        {#if creditBalance !== null}
+          <span class="nr-credit-chip" title={CREDITS_CROSS_DEVICE_LINE}>
+            ⚡ {creditBalance === 1 ? '1 draft' : `${creditBalance} drafts`}
           </span>
         {/if}
       </div>
@@ -308,21 +410,40 @@
         <button type="button" class="nr-ghost" on:click={reset}>Back</button>
       </div>
     {:else if phase === 'upsell'}
+      <!-- Payment card: membership stays visually primary; sats is the
+           impulse lane. -->
       <div class="nr-gate">
         <CheffyAvatar size={72} expression="neutral" variant="character" />
         <h2>Cheffy photo review is a Pro Kitchen feature</h2>
         <p>Get a drafted reply or a recipe guess for any dish photo on the feed.</p>
+        <div class="nr-example">
+          <span class="nr-example-label">The kind of reply Cheffy drafts:</span>
+          <p class="nr-example-text">"{PAYMENT_CARD_EXAMPLE_DRAFT}"</p>
+        </div>
+        {#if payError}<p class="nr-post-error">{payError}</p>{/if}
         <button type="button" class="nr-primary" on:click={viewMembership}>View membership</button>
+        <button type="button" class="nr-secondary" on:click={startPayment}>
+          ⚡ {CREDIT_PRICE_SATS} sats for one draft
+        </button>
+        <p class="nr-sub">{CREDITS_CROSS_DEVICE_LINE}</p>
       </div>
-    {:else if phase === 'preview-used'}
-      <div class="nr-gate">
-        <CheffyAvatar size={72} expression="happy" variant="character" />
-        <h2>Cheffy already gave your previews a look</h2>
-        <p>Unlock Pro Kitchen to keep asking Cheffy about dishes on the feed.</p>
-        <button type="button" class="nr-primary" on:click={viewMembership}>View membership</button>
-        <button type="button" class="nr-ghost" on:click={() => (open = false)}
-          >Keep exploring</button
+    {:else if phase === 'paying'}
+      <div class="nr-wait">
+        <CheffyAvatar size={64} expression="excited" variant="character" animate />
+        <p>Waiting for your {CREDIT_PRICE_SATS} sats…</p>
+        <p class="nr-sub">
+          Pay the invoice in the wallet window — drafting starts the moment it lands.
+        </p>
+        <button
+          type="button"
+          class="nr-ghost"
+          on:click={() => {
+            stopPolling();
+            phase = 'upsell';
+          }}
         >
+          Back
+        </button>
       </div>
     {:else}
       <div class="nr-wait">
@@ -473,7 +594,7 @@
     flex-wrap: wrap;
   }
 
-  .nr-preview-chip {
+  .nr-credit-chip {
     flex: 0 0 auto;
     font-size: 0.75rem;
     font-weight: 600;
@@ -481,6 +602,39 @@
     border-radius: 999px;
     color: var(--color-primary);
     background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+  }
+
+  .nr-example {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 10px 14px;
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--color-primary) 6%, transparent);
+    max-width: 40ch;
+  }
+
+  .nr-example-label {
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--color-text-secondary);
+  }
+
+  .nr-example-text {
+    font-size: 0.9rem;
+    font-style: italic;
+    color: var(--color-text-primary);
+    margin: 0;
+  }
+
+  .nr-resume-ack {
+    font-size: 0.88rem;
+    padding: 8px 12px;
+    border-radius: 8px;
+    color: var(--color-primary);
+    background: color-mix(in srgb, var(--color-primary) 10%, transparent);
   }
 
   .nr-disclosure {

--- a/src/components/CheffyNoteReview.svelte
+++ b/src/components/CheffyNoteReview.svelte
@@ -140,54 +140,100 @@
   async function startPayment() {
     payError = '';
     phase = 'paying';
-    const invoice = await requestCreditInvoice({ ndk: $ndk });
-    if (!invoice.ok) {
-      phase = 'upsell';
-      payError =
-        invoice.code === 'RATE_LIMITED'
-          ? (invoice.error ?? 'Too many invoices — give the last one a moment.')
-          : 'Could not set up the payment. Please try again.';
+
+    // Resolve any outstanding invoice BEFORE minting a new one — an
+    // overwrite would orphan a just-paid invoice's credit client-side.
+    let invoiceId = '';
+    let bolt11 = '';
+    const prior = await resumePendingInvoice({ ndk: $ndk });
+    if (prior.outcome === 'paid') {
+      // They already paid the earlier invoice — no new charge, straight
+      // into drafting.
+      creditBalance = prior.balance;
+      void run(mode);
       return;
     }
-    storePendingInvoice(invoice.invoiceId);
+    if (
+      prior.outcome === 'pending' &&
+      prior.invoice.bolt11 &&
+      (prior.invoice.expiresAt ?? 0) > Date.now() + 30_000
+    ) {
+      // Still-live unpaid invoice: reuse it rather than minting another.
+      invoiceId = prior.invoice.invoiceId;
+      bolt11 = prior.invoice.bolt11;
+    } else if (prior.outcome === 'pending' && !prior.invoice.bolt11) {
+      // Legacy/opaque pending id we can't display and can't confirm
+      // settled — never overwrite a possibly-paid invoice.
+      phase = 'upsell';
+      payError = 'Still checking an earlier payment — try again in a moment.';
+      return;
+    }
+
+    if (!invoiceId) {
+      const created = await requestCreditInvoice({ ndk: $ndk });
+      if (!created.ok) {
+        phase = 'upsell';
+        payError =
+          created.code === 'RATE_LIMITED'
+            ? (created.error ?? 'Too many invoices — give the last one a moment.')
+            : 'Could not set up the payment. Please try again.';
+        return;
+      }
+      invoiceId = created.invoiceId;
+      bolt11 = created.bolt11;
+      storePendingInvoice({ invoiceId, bolt11, expiresAt: created.expiresAt });
+    }
 
     let setPaidHandle: { setPaid: (r: { preimage: string }) => void } | null = null;
     try {
       setPaidHandle = await lightningService.launchPayment({
-        invoice: invoice.bolt11,
+        invoice: bolt11,
         onPaid: () => {
           // Wallet says paid — the server poll below stays authoritative.
         },
         onCancelled: () => {
           // Modal closed. Keep the pending invoice stored — if they paid
-          // right before closing, the resume flow credits them.
+          // right before closing, resolve-or-resume credits them.
           stopPolling();
           if (phase === 'paying') phase = 'upsell';
         }
       });
     } catch (err) {
+      // No wallet UI ever appeared — don't strand the user on a timer.
+      // The stored invoice stays put: the next tap reuses it.
       console.error('[NoteReview] payment modal failed:', err);
+      stopPolling();
+      phase = 'upsell';
+      payError = "Couldn't open the payment window. Tap again to retry the same invoice.";
+      return;
     }
 
     stopPolling();
+    let pollInFlight = false; // 3s ticks must never overlap a slow check
     pollTimer = setInterval(async () => {
-      const status = await checkCreditStatus({ ndk: $ndk, invoiceId: invoice.invoiceId });
-      if (!status.ok) return; // transient — keep polling until expiry
-      const { action } = pollActionForStatus(status.status);
-      if (action === 'continue') return;
-      stopPolling();
-      if (action === 'credited') {
-        clearPendingInvoice();
-        creditBalance = status.balance;
-        setPaidHandle?.setPaid({ preimage: 'strike-confirmed' });
-        // Straight into drafting — they paid for this draft.
-        void run(mode);
-      } else {
-        clearPendingInvoice();
-        if (phase === 'paying') {
-          phase = 'upsell';
-          payError = 'That invoice expired — grab a fresh one below.';
+      if (pollInFlight) return;
+      pollInFlight = true;
+      try {
+        const status = await checkCreditStatus({ ndk: $ndk, invoiceId });
+        if (!status.ok) return; // transient — keep polling until expiry
+        const { action } = pollActionForStatus(status.status);
+        if (action === 'continue') return;
+        stopPolling();
+        if (action === 'credited') {
+          clearPendingInvoice();
+          creditBalance = status.balance;
+          setPaidHandle?.setPaid({ preimage: 'strike-confirmed' });
+          // Straight into drafting — they paid for this draft.
+          void run(mode);
+        } else {
+          clearPendingInvoice();
+          if (phase === 'paying') {
+            phase = 'upsell';
+            payError = 'That invoice expired — grab a fresh one below.';
+          }
         }
+      } finally {
+        pollInFlight = false;
       }
     }, 3000);
   }

--- a/src/lib/noteReview.test.ts
+++ b/src/lib/noteReview.test.ts
@@ -36,9 +36,8 @@ describe('phaseForResult — modal state machine', () => {
     });
   });
 
-  it('NOT_MEMBER → upsell, PREVIEW_USED → preview-used', () => {
+  it('NOT_MEMBER → upsell (the payment card)', () => {
     expect(phaseForResult({ ok: false, code: 'NOT_MEMBER' }).phase).toBe('upsell');
-    expect(phaseForResult({ ok: false, code: 'PREVIEW_USED' }).phase).toBe('preview-used');
   });
 
   it('NOT_FOOD hedges — never echoes the server line as a confident verdict', () => {
@@ -133,15 +132,16 @@ describe('requestNoteReview', () => {
     expect(body.noteText).toHaveLength(NOTE_TEXT_MAX_CHARS);
   });
 
-  it('includes experience: true for preview requests', async () => {
+  it('never sends an experience field (preview system removed in Phase 5)', async () => {
     const fetchFn = okFetch();
     await requestNoteReview({
       ...base,
-      experience: true,
+      noteText: 'hi',
       signHeader: vi.fn().mockResolvedValue('Nostr abc'),
       fetchFn
     });
-    expect(JSON.parse(fetchFn.mock.calls[0][1].body).experience).toBe(true);
+    const body = JSON.parse(fetchFn.mock.calls[0][1].body);
+    expect('experience' in body).toBe(false);
   });
 
   it('calls onSigned after signing and before the fetch', async () => {
@@ -260,7 +260,7 @@ describe('canPost — double-post guard', () => {
       'posted',
       'dead-end',
       'upsell',
-      'preview-used',
+      'paying',
       'error'
     ];
     for (const phase of blocked) expect(canPost(phase), phase).toBe(false);
@@ -570,8 +570,8 @@ describe('footer in the built event per toggle state', () => {
   });
 });
 
-describe('previewRemaining passthrough', () => {
-  it('surfaces the additive server field on success', async () => {
+describe('creditsRemaining passthrough', () => {
+  it('surfaces the additive server field on credit spends', async () => {
     const result = await requestNoteReview({
       ndk: {} as never,
       imageUrl: 'https://image.nostr.build/dish.jpg',
@@ -581,10 +581,10 @@ describe('previewRemaining passthrough', () => {
       fetchFn: vi.fn().mockResolvedValue({
         ok: true,
         status: 200,
-        json: async () => ({ ok: true, output: 'draft!', previewRemaining: 2 })
+        json: async () => ({ ok: true, output: 'draft!', creditsRemaining: 1 })
       }) as never
     });
-    expect(result).toMatchObject({ ok: true, previewRemaining: 2 });
+    expect(result).toMatchObject({ ok: true, creditsRemaining: 1 });
   });
 
   it('is absent for member responses', async () => {
@@ -601,7 +601,7 @@ describe('previewRemaining passthrough', () => {
       }) as never
     });
     expect(result.ok).toBe(true);
-    if (result.ok) expect(result.previewRemaining).toBeUndefined();
+    if (result.ok) expect(result.creditsRemaining).toBeUndefined();
   });
 });
 
@@ -615,4 +615,200 @@ describe('shouldSeedDisclosureFromPref', () => {
       expect(shouldSeedDisclosureFromPref(phase), phase).toBe(false);
     }
   });
+});
+
+// ---------------------------------------------------------------------------
+// Credit purchase (Phase 5)
+// ---------------------------------------------------------------------------
+
+import { readFileSync } from 'node:fs';
+import {
+  requestCreditInvoice,
+  checkCreditStatus,
+  pollActionForStatus,
+  storePendingInvoice,
+  loadPendingInvoice,
+  clearPendingInvoice,
+  resumePendingInvoice,
+  CREDIT_PRICE_SATS,
+  PAYMENT_CARD_EXAMPLE_DRAFT,
+  CREDITS_CROSS_DEVICE_LINE
+} from './noteReview';
+
+function fakeStorageGlobal() {
+  const map = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => void map.set(k, v),
+    removeItem: (k: string) => void map.delete(k),
+    clear: () => map.clear(),
+    key: () => null,
+    get length() {
+      return map.size;
+    }
+  } as Storage);
+  return map;
+}
+
+describe('payment card constants', () => {
+  it('prices one draft at 21 sats and hedges nothing about cross-device credits', () => {
+    expect(CREDIT_PRICE_SATS).toBe(21);
+    expect(CREDITS_CROSS_DEVICE_LINE.toLowerCase()).toContain('any device');
+  });
+
+  it('example draft is comment-mode length: a short, specific, warm reply', () => {
+    expect(PAYMENT_CARD_EXAMPLE_DRAFT.length).toBeGreaterThan(40);
+    expect(PAYMENT_CARD_EXAMPLE_DRAFT.length).toBeLessThan(300);
+    expect(PAYMENT_CARD_EXAMPLE_DRAFT).not.toContain('## Ingredients'); // not a recipe
+  });
+});
+
+describe('requestCreditInvoice', () => {
+  const base = { ndk: {} as never, origin: 'https://zap.cooking' };
+
+  it('signs the empty body against the credit-invoice URL and returns the invoice', async () => {
+    const signHeader = vi.fn().mockResolvedValue('Nostr abc');
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, invoiceId: 'rr-1', bolt11: 'lnbc...', expiresAt: 123 })
+    });
+    const result = await requestCreditInvoice({ ...base, signHeader, fetchFn } as never);
+    expect(result).toEqual({ ok: true, invoiceId: 'rr-1', bolt11: 'lnbc...', expiresAt: 123 });
+    const signOpts = signHeader.mock.calls[0][1];
+    expect(signOpts.url).toBe('https://zap.cooking/api/zappy/note-review/credit-invoice');
+    expect(signOpts.bodyString).toBe(fetchFn.mock.calls[0][1].body);
+  });
+
+  it('maps signer failure and server errors to typed results', async () => {
+    const signFail = await requestCreditInvoice({
+      ...base,
+      signHeader: vi.fn().mockRejectedValue(new Error('no signer')),
+      fetchFn: vi.fn()
+    } as never);
+    expect(signFail).toMatchObject({ ok: false, code: 'SIGN_FAILED' });
+
+    const rateLimited = await requestCreditInvoice({
+      ...base,
+      signHeader: vi.fn().mockResolvedValue('Nostr abc'),
+      fetchFn: vi.fn().mockResolvedValue({
+        ok: false,
+        status: 429,
+        json: async () => ({ ok: false, code: 'RATE_LIMITED', error: 'slow down' })
+      })
+    } as never);
+    expect(rateLimited).toMatchObject({ ok: false, code: 'RATE_LIMITED' });
+  });
+});
+
+describe('checkCreditStatus', () => {
+  it('signs the query-free URL (normalizeUrl strips queries) but fetches with the id', async () => {
+    const signHeader = vi.fn().mockResolvedValue('Nostr abc');
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, status: 'pending', balance: 0 })
+    });
+    const result = await checkCreditStatus({
+      ndk: {} as never,
+      origin: 'https://zap.cooking',
+      invoiceId: 'rr-1',
+      signHeader,
+      fetchFn
+    } as never);
+    expect(result).toEqual({ ok: true, status: 'pending', balance: 0 });
+    expect(signHeader.mock.calls[0][1].url).toBe(
+      'https://zap.cooking/api/zappy/note-review/credit-status'
+    );
+    expect(fetchFn.mock.calls[0][0]).toBe('/api/zappy/note-review/credit-status?id=rr-1');
+  });
+});
+
+describe('pollActionForStatus — polling state machine', () => {
+  it('paid → credited, expired → expired, pending → continue', () => {
+    expect(pollActionForStatus('paid')).toEqual({ action: 'credited' });
+    expect(pollActionForStatus('expired')).toEqual({ action: 'expired' });
+    expect(pollActionForStatus('pending')).toEqual({ action: 'continue' });
+  });
+});
+
+describe('pending-invoice resume flow', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  function resumeWith(status: 'paid' | 'pending' | 'expired' | 'fail', balance = 1) {
+    const fetchFn =
+      status === 'fail'
+        ? vi.fn().mockRejectedValue(new Error('offline'))
+        : vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({ ok: true, status, balance })
+          });
+    return resumePendingInvoice({
+      ndk: {} as never,
+      origin: 'https://zap.cooking',
+      signHeader: vi.fn().mockResolvedValue('Nostr abc'),
+      fetchFn
+    } as never);
+  }
+
+  it('absent: no stored invoice → no network call, outcome absent', async () => {
+    fakeStorageGlobal();
+    expect(await resumeWith('paid')).toEqual({ outcome: 'absent' });
+  });
+
+  it('paid: credits acknowledged and the stored id is cleared', async () => {
+    fakeStorageGlobal();
+    storePendingInvoice('rr-9');
+    expect(await resumeWith('paid', 3)).toEqual({ outcome: 'paid', balance: 3 });
+    expect(loadPendingInvoice()).toBeNull(); // cleared — can't double-acknowledge
+  });
+
+  it('expired: cleared silently', async () => {
+    fakeStorageGlobal();
+    storePendingInvoice('rr-9');
+    expect(await resumeWith('expired')).toEqual({ outcome: 'expired' });
+    expect(loadPendingInvoice()).toBeNull();
+  });
+
+  it('pending: kept for the next open', async () => {
+    fakeStorageGlobal();
+    storePendingInvoice('rr-9');
+    expect(await resumeWith('pending')).toEqual({ outcome: 'pending' });
+    expect(loadPendingInvoice()).toBe('rr-9');
+  });
+
+  it('check failure: NEVER clears a potentially-paid invoice', async () => {
+    fakeStorageGlobal();
+    storePendingInvoice('rr-9');
+    expect(await resumeWith('fail')).toEqual({ outcome: 'pending' });
+    expect(loadPendingInvoice()).toBe('rr-9');
+  });
+
+  it('storage helpers are SSR/private-mode safe', () => {
+    // No localStorage stubbed at all here.
+    expect(() => storePendingInvoice('rr-1')).not.toThrow();
+    expect(loadPendingInvoice()).toBeNull();
+    expect(() => clearPendingInvoice()).not.toThrow();
+  });
+});
+
+describe('preview-system removal completeness', () => {
+  // Chat's experience preview (cheffyChat.ts, /api/zappy) is untouched
+  // by design; these files must carry no trace of the note-review one.
+  const FORBIDDEN = [/PREVIEW_USED/, /previewRemaining/, /'preview-used'/, /\bexperience\b/i];
+  const FILES = [
+    'src/lib/noteReview.ts',
+    'src/components/CheffyNoteReview.svelte',
+    'src/components/CheffyNoteReviewTrigger.svelte'
+  ];
+
+  for (const file of FILES) {
+    it(`${file} carries no preview/experience symbols`, () => {
+      const source = readFileSync(file, 'utf8');
+      for (const pattern of FORBIDDEN) {
+        expect(pattern.test(source), `${pattern} found in ${file}`).toBe(false);
+      }
+    });
+  }
 });

--- a/src/lib/noteReview.test.ts
+++ b/src/lib/noteReview.test.ts
@@ -724,6 +724,23 @@ describe('checkCreditStatus', () => {
   });
 });
 
+describe('checkCreditStatus status validation', () => {
+  it('rejects unknown status strings instead of polling forever on garbage', async () => {
+    const result = await checkCreditStatus({
+      ndk: {} as never,
+      origin: 'https://zap.cooking',
+      invoiceId: 'rr-1',
+      signHeader: vi.fn().mockResolvedValue('Nostr abc'),
+      fetchFn: vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, status: 'PROCESSING', balance: 0 })
+      })
+    } as never);
+    expect(result.ok).toBe(false);
+  });
+});
+
 describe('pollActionForStatus — polling state machine', () => {
   it('paid → credited, expired → expired, pending → continue', () => {
     expect(pollActionForStatus('paid')).toEqual({ action: 'credited' });
@@ -759,35 +776,44 @@ describe('pending-invoice resume flow', () => {
 
   it('paid: credits acknowledged and the stored id is cleared', async () => {
     fakeStorageGlobal();
-    storePendingInvoice('rr-9');
+    storePendingInvoice({ invoiceId: 'rr-9', bolt11: 'lnbc...', expiresAt: 1 });
     expect(await resumeWith('paid', 3)).toEqual({ outcome: 'paid', balance: 3 });
     expect(loadPendingInvoice()).toBeNull(); // cleared — can't double-acknowledge
   });
 
   it('expired: cleared silently', async () => {
     fakeStorageGlobal();
-    storePendingInvoice('rr-9');
+    storePendingInvoice({ invoiceId: 'rr-9', bolt11: 'lnbc...', expiresAt: 1 });
     expect(await resumeWith('expired')).toEqual({ outcome: 'expired' });
     expect(loadPendingInvoice()).toBeNull();
   });
 
-  it('pending: kept for the next open', async () => {
+  it('pending: kept for the next open, and the outcome carries the invoice for reuse', async () => {
     fakeStorageGlobal();
-    storePendingInvoice('rr-9');
-    expect(await resumeWith('pending')).toEqual({ outcome: 'pending' });
-    expect(loadPendingInvoice()).toBe('rr-9');
+    const invoice = { invoiceId: 'rr-9', bolt11: 'lnbc...', expiresAt: 9_999_999_999_999 };
+    storePendingInvoice(invoice);
+    expect(await resumeWith('pending')).toEqual({ outcome: 'pending', invoice });
+    expect(loadPendingInvoice()).toEqual(invoice);
   });
 
   it('check failure: NEVER clears a potentially-paid invoice', async () => {
     fakeStorageGlobal();
-    storePendingInvoice('rr-9');
-    expect(await resumeWith('fail')).toEqual({ outcome: 'pending' });
-    expect(loadPendingInvoice()).toBe('rr-9');
+    const invoice = { invoiceId: 'rr-9', bolt11: 'lnbc...', expiresAt: 1 };
+    storePendingInvoice(invoice);
+    expect(await resumeWith('fail')).toEqual({ outcome: 'pending', invoice });
+    expect(loadPendingInvoice()).toEqual(invoice);
+  });
+
+  it('tolerates the legacy bare-string storage format', async () => {
+    const map = fakeStorageGlobal();
+    map.set('zapcooking_note_review_pending_invoice', 'rr-legacy');
+    expect(loadPendingInvoice()).toEqual({ invoiceId: 'rr-legacy' });
+    expect(await resumeWith('paid', 2)).toEqual({ outcome: 'paid', balance: 2 });
   });
 
   it('storage helpers are SSR/private-mode safe', () => {
     // No localStorage stubbed at all here.
-    expect(() => storePendingInvoice('rr-1')).not.toThrow();
+    expect(() => storePendingInvoice({ invoiceId: 'rr-1' })).not.toThrow();
     expect(loadPendingInvoice()).toBeNull();
     expect(() => clearPendingInvoice()).not.toThrow();
   });

--- a/src/lib/noteReview.ts
+++ b/src/lib/noteReview.ts
@@ -34,8 +34,8 @@ export type NoteReviewPhase =
   | 'post-timeout' // signed but relay round-trip timed out — retry without re-signing
   | 'posted' // published — success state with a link to the reply
   | 'dead-end' // friendly stop — nothing postable (unclear/unreadable photo)
-  | 'upsell' // NOT_MEMBER — membership gate
-  | 'preview-used' // preview turns spent — conversion nudge
+  | 'upsell' // NOT_MEMBER — the membership-or-sats payment card
+  | 'paying' // 21-sat invoice active: Alby modal open, status polling
   | 'error'; // retryable failure
 
 /** The only phase a publish may start from — the double-post guard. */
@@ -44,7 +44,7 @@ export function canPost(phase: NoteReviewPhase): boolean {
 }
 
 export type NoteReviewResult =
-  | { ok: true; output: string; previewRemaining?: number }
+  | { ok: true; output: string; creditsRemaining?: number }
   | { ok: false; code?: string; error?: string; status?: number };
 
 // Mirrors the server cap — a longer note just loses its tail.
@@ -82,8 +82,6 @@ export function phaseForResult(result: NoteReviewResult): {
   switch (result.code) {
     case 'NOT_MEMBER':
       return { phase: 'upsell', message: '' };
-    case 'PREVIEW_USED':
-      return { phase: 'preview-used', message: '' };
     case 'NOT_FOOD':
     case 'IMAGE_UNREADABLE':
       // Deliberately ignore the server-provided line here — it can be a
@@ -104,8 +102,6 @@ export interface NoteReviewRequestOpts {
   noteText?: string;
   /** Event id hex, server logging only. */
   noteId?: string;
-  /** Non-member preview request (server enforces the cookie budget). */
-  experience?: boolean;
   /** Called once the NIP-98 header is signed, before the fetch — flips signing → loading. */
   onSigned?: () => void;
   /** Test injection points. */
@@ -124,7 +120,6 @@ export async function requestNoteReview(opts: NoteReviewRequestOpts): Promise<No
     imageUrl,
     mode,
     noteId,
-    experience,
     onSigned,
     signHeader = signNip98AuthHeader,
     fetchFn = fetch
@@ -134,7 +129,6 @@ export async function requestNoteReview(opts: NoteReviewRequestOpts): Promise<No
   const body: Record<string, unknown> = { imageUrl, mode };
   if (noteText) body.noteText = noteText;
   if (noteId) body.noteId = noteId;
-  if (experience) body.experience = true;
   // The signed payload hash and the fetch body must be the same string.
   const bodyString = JSON.stringify(body);
 
@@ -169,9 +163,9 @@ export async function requestNoteReview(opts: NoteReviewRequestOpts): Promise<No
       return {
         ok: true,
         output: data.output,
-        // Additive server field on preview-granted requests only.
-        ...(typeof data.previewRemaining === 'number'
-          ? { previewRemaining: data.previewRemaining }
+        // Additive server field on credit-spending requests only.
+        ...(typeof data.creditsRemaining === 'number'
+          ? { creditsRemaining: data.creditsRemaining }
           : {})
       };
     }
@@ -385,4 +379,193 @@ export function saveDisclosurePref(mode: NoteReviewMode, on: boolean): void {
     // Storage unavailable (private mode) — the toggle still works for
     // the session; it just won't be remembered.
   }
+}
+
+// ---------------------------------------------------------------------------
+// Credit purchase (Phase 5) — 21 sats per draft for non-members
+// ---------------------------------------------------------------------------
+
+export const CREDIT_PRICE_SATS = 21;
+
+/** Chip + card copy: credits follow the key, not the device. */
+export const CREDITS_CROSS_DEVICE_LINE = 'Tied to your Nostr key — works on any device.';
+
+/**
+ * Static example shown on the payment card (D5) so first-timers see
+ * output quality before the 21-sat ask. Comment-mode length, hardcoded.
+ */
+export const PAYMENT_CARD_EXAMPLE_DRAFT =
+  "That crust has the kind of golden edge you only get from a properly hot pan — and the basil on top says you weren't rushing. Beautiful work.";
+
+export type CreditInvoiceResult =
+  | { ok: true; invoiceId: string; bolt11: string; expiresAt: number }
+  | { ok: false; code?: string; error?: string };
+
+export type CreditStatusResult =
+  | { ok: true; status: 'paid' | 'pending' | 'expired'; balance: number }
+  | { ok: false; code?: string; error?: string };
+
+interface CreditApiOpts {
+  ndk: NDK;
+  signHeader?: typeof signNip98AuthHeader;
+  fetchFn?: typeof fetch;
+  origin?: string;
+}
+
+function apiOrigin(origin?: string): string {
+  return origin ?? (typeof location !== 'undefined' ? location.origin : 'https://zap.cooking');
+}
+
+/** Buy one draft: create a 21-sat invoice bound to the signed-in key. */
+export async function requestCreditInvoice(opts: CreditApiOpts): Promise<CreditInvoiceResult> {
+  const { ndk, signHeader = signNip98AuthHeader, fetchFn = fetch } = opts;
+  const bodyString = '{}';
+  let authorization: string;
+  try {
+    authorization = await signHeader(ndk, {
+      method: 'POST',
+      url: `${apiOrigin(opts.origin)}/api/zappy/note-review/credit-invoice`,
+      bodyString
+    });
+  } catch (err) {
+    return { ok: false, code: 'SIGN_FAILED', error: err instanceof Error ? err.message : '' };
+  }
+  try {
+    const resp = await fetchFn('/api/zappy/note-review/credit-invoice', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: authorization },
+      body: bodyString
+    });
+    const data: Record<string, unknown> = await resp.json().catch(() => ({}));
+    if (
+      resp.ok &&
+      data.ok === true &&
+      typeof data.invoiceId === 'string' &&
+      typeof data.bolt11 === 'string'
+    ) {
+      return {
+        ok: true,
+        invoiceId: data.invoiceId,
+        bolt11: data.bolt11,
+        expiresAt: typeof data.expiresAt === 'number' ? data.expiresAt : 0
+      };
+    }
+    return {
+      ok: false,
+      code: typeof data.code === 'string' ? data.code : undefined,
+      error: typeof data.error === 'string' ? data.error : undefined
+    };
+  } catch (err) {
+    return { ok: false, code: 'NETWORK', error: err instanceof Error ? err.message : '' };
+  }
+}
+
+/**
+ * Poll one invoice. The NIP-98 u-tag is signed without the query string
+ * — normalizeUrl strips it on both sides, so signature and URL match.
+ */
+export async function checkCreditStatus(
+  opts: CreditApiOpts & { invoiceId: string }
+): Promise<CreditStatusResult> {
+  const { ndk, invoiceId, signHeader = signNip98AuthHeader, fetchFn = fetch } = opts;
+  let authorization: string;
+  try {
+    authorization = await signHeader(ndk, {
+      method: 'GET',
+      url: `${apiOrigin(opts.origin)}/api/zappy/note-review/credit-status`
+    });
+  } catch (err) {
+    return { ok: false, code: 'SIGN_FAILED', error: err instanceof Error ? err.message : '' };
+  }
+  try {
+    const resp = await fetchFn(
+      `/api/zappy/note-review/credit-status?id=${encodeURIComponent(invoiceId)}`,
+      { method: 'GET', headers: { Authorization: authorization } }
+    );
+    const data: Record<string, unknown> = await resp.json().catch(() => ({}));
+    if (resp.ok && data.ok === true && typeof data.status === 'string') {
+      return {
+        ok: true,
+        status: data.status as 'paid' | 'pending' | 'expired',
+        balance: typeof data.balance === 'number' ? data.balance : 0
+      };
+    }
+    return {
+      ok: false,
+      code: typeof data.code === 'string' ? data.code : undefined,
+      error: typeof data.error === 'string' ? data.error : undefined
+    };
+  } catch (err) {
+    return { ok: false, code: 'NETWORK', error: err instanceof Error ? err.message : '' };
+  }
+}
+
+/** What the 3s poll loop does with each status observation. */
+export function pollActionForStatus(status: 'paid' | 'pending' | 'expired'): {
+  action: 'credited' | 'expired' | 'continue';
+} {
+  if (status === 'paid') return { action: 'credited' };
+  if (status === 'expired') return { action: 'expired' };
+  return { action: 'continue' };
+}
+
+// ── Pending-invoice persistence (resume flow) ────────────────────────
+// If the payer closes the modal between paying and the poll observing
+// COMPLETED, the invoice id survives here; the next modal open polls it
+// once and credits them (server metadata stays creditable for 48h).
+
+const PENDING_INVOICE_KEY = 'zapcooking_note_review_pending_invoice';
+
+export function storePendingInvoice(invoiceId: string): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(PENDING_INVOICE_KEY, invoiceId);
+  } catch {
+    // Private mode — resume just won't work across closes this session.
+  }
+}
+
+export function loadPendingInvoice(): string | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    return localStorage.getItem(PENDING_INVOICE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingInvoice(): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.removeItem(PENDING_INVOICE_KEY);
+  } catch {
+    // Nothing to clean if storage is unavailable.
+  }
+}
+
+export type ResumeOutcome =
+  | { outcome: 'absent' }
+  | { outcome: 'paid'; balance: number }
+  | { outcome: 'pending' }
+  | { outcome: 'expired' };
+
+/**
+ * One-shot resume check on modal open. paid → cleared + acknowledged;
+ * expired → cleared silently; pending → kept for the next open;
+ * check failure → kept (never destroys a potentially-paid invoice).
+ */
+export async function resumePendingInvoice(opts: CreditApiOpts): Promise<ResumeOutcome> {
+  const invoiceId = loadPendingInvoice();
+  if (!invoiceId) return { outcome: 'absent' };
+  const result = await checkCreditStatus({ ...opts, invoiceId });
+  if (!result.ok) return { outcome: 'pending' }; // transient — keep and retry next open
+  if (result.status === 'paid') {
+    clearPendingInvoice();
+    return { outcome: 'paid', balance: result.balance };
+  }
+  if (result.status === 'expired') {
+    clearPendingInvoice();
+    return { outcome: 'expired' };
+  }
+  return { outcome: 'pending' };
 }

--- a/src/lib/noteReview.ts
+++ b/src/lib/noteReview.ts
@@ -483,10 +483,14 @@ export async function checkCreditStatus(
       { method: 'GET', headers: { Authorization: authorization } }
     );
     const data: Record<string, unknown> = await resp.json().catch(() => ({}));
-    if (resp.ok && data.ok === true && typeof data.status === 'string') {
+    if (
+      resp.ok &&
+      data.ok === true &&
+      (data.status === 'paid' || data.status === 'pending' || data.status === 'expired')
+    ) {
       return {
         ok: true,
-        status: data.status as 'paid' | 'pending' | 'expired',
+        status: data.status,
         balance: typeof data.balance === 'number' ? data.balance : 0
       };
     }
@@ -516,19 +520,37 @@ export function pollActionForStatus(status: 'paid' | 'pending' | 'expired'): {
 
 const PENDING_INVOICE_KEY = 'zapcooking_note_review_pending_invoice';
 
-export function storePendingInvoice(invoiceId: string): void {
+export interface PendingInvoice {
+  invoiceId: string;
+  /** Present since the object format — lets a live invoice be REUSED
+   * instead of overwritten by a fresh purchase (an overwrite would
+   * orphan a just-paid invoice's credit client-side). */
+  bolt11?: string;
+  expiresAt?: number;
+}
+
+export function storePendingInvoice(invoice: PendingInvoice): void {
   if (typeof localStorage === 'undefined') return;
   try {
-    localStorage.setItem(PENDING_INVOICE_KEY, invoiceId);
+    localStorage.setItem(PENDING_INVOICE_KEY, JSON.stringify(invoice));
   } catch {
     // Private mode — resume just won't work across closes this session.
   }
 }
 
-export function loadPendingInvoice(): string | null {
+export function loadPendingInvoice(): PendingInvoice | null {
   if (typeof localStorage === 'undefined') return null;
   try {
-    return localStorage.getItem(PENDING_INVOICE_KEY);
+    const raw = localStorage.getItem(PENDING_INVOICE_KEY);
+    if (!raw) return null;
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed.invoiceId === 'string') return parsed as PendingInvoice;
+    } catch {
+      // Legacy bare-string format from the first 5.2 iteration.
+      return { invoiceId: raw };
+    }
+    return null;
   } catch {
     return null;
   }
@@ -546,7 +568,7 @@ export function clearPendingInvoice(): void {
 export type ResumeOutcome =
   | { outcome: 'absent' }
   | { outcome: 'paid'; balance: number }
-  | { outcome: 'pending' }
+  | { outcome: 'pending'; invoice: PendingInvoice }
   | { outcome: 'expired' };
 
 /**
@@ -555,10 +577,10 @@ export type ResumeOutcome =
  * check failure → kept (never destroys a potentially-paid invoice).
  */
 export async function resumePendingInvoice(opts: CreditApiOpts): Promise<ResumeOutcome> {
-  const invoiceId = loadPendingInvoice();
-  if (!invoiceId) return { outcome: 'absent' };
-  const result = await checkCreditStatus({ ...opts, invoiceId });
-  if (!result.ok) return { outcome: 'pending' }; // transient — keep and retry next open
+  const pending = loadPendingInvoice();
+  if (!pending) return { outcome: 'absent' };
+  const result = await checkCreditStatus({ ...opts, invoiceId: pending.invoiceId });
+  if (!result.ok) return { outcome: 'pending', invoice: pending }; // transient — keep, retry next open
   if (result.status === 'paid') {
     clearPendingInvoice();
     return { outcome: 'paid', balance: result.balance };
@@ -567,5 +589,5 @@ export async function resumePendingInvoice(opts: CreditApiOpts): Promise<ResumeO
     clearPendingInvoice();
     return { outcome: 'expired' };
   }
-  return { outcome: 'pending' };
+  return { outcome: 'pending', invoice: pending };
 }


### PR DESCRIPTION
## ⚠️ Merge sequencing

**HOLD — nothing merges until the 5.3 manual gate passes on the integration preview (real sats).** Then same-day: #521 (server) first, this PR second. Expect a trivial `package.json` version-line conflict on the second merge; the hook re-stamps.

## Summary

Phase 5.2 of sats pay-per-use: the client side of 21-sats-per-draft for non-members. Pairs with #521 (server endpoints + ledger); this PR touches only client files — no overlap.

- **Payment card** (replaces the plain NOT_MEMBER upsell): membership CTA primary, "⚡ 21 sats for one draft" secondary, hardcoded example draft (D5) so first-timers see output quality before the ask, cross-device credits footnote
- **Invoice flow**: Alby bitcoin-connect modal via the house `lightningService.launchPayment` (QR/copy/WebLN — no hand-rolled invoice UI, per ratified 5.0 amendment); 3s `credit-status` polling with keep-waiting semantics; **the server poll is authoritative** over the wallet's `onPaid`; paid → modal flips via `setPaid` and drafting starts immediately in the mode already chosen
- **Balance chip** "⚡ N drafts" driven by `creditsRemaining` / status polls / resume, with tied-to-your-key copy
- **Pending-invoice resume**: invoice id persisted on creation, polled once per modal open — paid → credited with acknowledgment, expired → cleared silently, pending or check-failure → kept (a potentially-paid invoice is never destroyed client-side; pairs with #521's 48h metadata TTL)
- **Preview UI fully removed** (chip, PREVIEW_USED phase, `experience` send, `previewRemaining` field) with an fs-scan removal-completeness test; chat's own experience system untouched

## Test plan

- [x] 15 net-new unit tests: payment-card constants, invoice/status client signing shapes, polling state machine, all four resume branches + never-clear-on-failure, `creditsRemaining` passthrough, removal-completeness scan
- [x] Branch suite green (548 tests); `svelte-check` 0 errors
- [ ] 5.3 manual gate on the integration preview: real 21-sat Strike payment, cross-device credit, expired-invoice flow, member regression

Note: "Workers Builds" checks are expected to fail on this repo (known infra quirk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)