### PR TITLE
feat(cheffy): pay credit invoices through the in-app wallet when configured

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.617",
+  "version": "4.2.618",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.614",
+  "version": "4.2.615",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.615",
+  "version": "4.2.616",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.616",
+  "version": "4.2.617",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/CheffyNoteReview.svelte
+++ b/src/components/CheffyNoteReview.svelte
@@ -22,6 +22,7 @@
   import { THINKING_LINES, COOKING_LINES, ERROR_LINES, pickLine } from '$lib/cheffy';
   import { onDestroy } from 'svelte';
   import { lightningService } from '$lib/lightningService';
+  import { activeWallet, sendPayment } from '$lib/wallet';
   import {
     requestNoteReview,
     phaseForResult,
@@ -35,6 +36,8 @@
     requestCreditInvoice,
     checkCreditStatus,
     pollActionForStatus,
+    executeCreditPayment,
+    isInAppWalletKind,
     storePendingInvoice,
     clearPendingInvoice,
     resumePendingInvoice,
@@ -77,6 +80,15 @@
   let payError = '';
   let pollTimer: ReturnType<typeof setInterval> | null = null;
   let resumeCheckedForOpen = false;
+  // In-app payment failed/timed out — offer the bc modal with the SAME
+  // invoice (a BOLT11 settles exactly once; no double-payment guard
+  // needed, the poll credits whichever attempt lands).
+  let inAppPayFailed = false;
+  let currentBolt11 = '';
+
+  // productPayment.ts pattern, verbatim semantics: NWC/Spark pay
+  // inline; everyone else gets the bitcoin-connect modal.
+  $: hasInAppWallet = isInAppWalletKind($activeWallet?.kind);
 
   $: signedIn = $userPublickey !== '';
   $: normalizedPk = $userPublickey.trim().toLowerCase();
@@ -184,58 +196,97 @@
       storePendingInvoice({ invoiceId, bolt11, expiresAt: created.expiresAt });
     }
 
+    currentBolt11 = bolt11;
+    inAppPayFailed = false;
     let setPaidHandle: { setPaid: (r: { preimage: string }) => void } | null = null;
-    try {
-      setPaidHandle = await lightningService.launchPayment({
-        invoice: bolt11,
-        onPaid: () => {
-          // Wallet says paid — the server poll below stays authoritative.
-        },
+
+    function beginPolling(id: string) {
+      stopPolling();
+      let pollInFlight = false; // 3s ticks must never overlap a slow check
+      pollTimer = setInterval(async () => {
+        if (pollInFlight) return;
+        pollInFlight = true;
+        try {
+          const status = await checkCreditStatus({ ndk: $ndk, invoiceId: id });
+          if (!status.ok) return; // transient — keep polling until expiry
+          const { action } = pollActionForStatus(status.status);
+          if (action === 'continue') return;
+          stopPolling();
+          if (action === 'credited') {
+            clearPendingInvoice();
+            creditBalance = status.balance;
+            setPaidHandle?.setPaid({ preimage: 'strike-confirmed' });
+            // Straight into drafting — they paid for this draft.
+            void run(mode);
+          } else {
+            clearPendingInvoice();
+            if (phase === 'paying') {
+              phase = 'upsell';
+              payError = 'That invoice expired — grab a fresh one below.';
+            }
+          }
+        } finally {
+          pollInFlight = false;
+        }
+      }, 3000);
+    }
+
+    async function launchExternal(invoiceToPay: string) {
+      try {
+        setPaidHandle = await lightningService.launchPayment({
+          invoice: invoiceToPay,
+          onPaid: () => {
+            // Wallet says paid — the server poll stays authoritative.
+          },
+          onCancelled: () => {
+            // Modal closed. Keep the pending invoice stored — if they paid
+            // right before closing, resolve-or-resume credits them.
+            stopPolling();
+            if (phase === 'paying') phase = 'upsell';
+          }
+        });
+      } catch (err) {
+        // No wallet UI ever appeared — don't strand the user on a timer.
+        // The stored invoice stays put: the next tap reuses it.
+        console.error('[NoteReview] payment modal failed:', err);
+        stopPolling();
+        phase = 'upsell';
+        payError = "Couldn't open the payment window. Tap again to retry the same invoice.";
+      }
+    }
+
+    // The poll starts FIRST on every path (inside executeCreditPayment);
+    // wallet-side success is advisory — the poll is the sole crediting
+    // authority regardless of how the sats travel.
+    const path = await executeCreditPayment(bolt11, {
+      hasInAppWallet,
+      sendPayment: (b) =>
+        sendPayment(b, { amount: CREDIT_PRICE_SATS, description: 'Cheffy note review draft' }),
+      launchExternal,
+      startPoll: () => beginPolling(invoiceId)
+    });
+    if (path === 'in-app-failed' && phase === 'paying') {
+      // Fallback affordance: re-present the SAME bolt11 in the bc modal.
+      inAppPayFailed = true;
+    }
+  }
+
+  function openFallbackModal() {
+    // Same invoice, never a fresh mint — a BOLT11 settles exactly once,
+    // so even a race with a slow in-app payment cannot double-charge.
+    inAppPayFailed = false;
+    void lightningService
+      .launchPayment({
+        invoice: currentBolt11,
+        onPaid: () => {},
         onCancelled: () => {
-          // Modal closed. Keep the pending invoice stored — if they paid
-          // right before closing, resolve-or-resume credits them.
           stopPolling();
           if (phase === 'paying') phase = 'upsell';
         }
+      })
+      .catch(() => {
+        inAppPayFailed = true;
       });
-    } catch (err) {
-      // No wallet UI ever appeared — don't strand the user on a timer.
-      // The stored invoice stays put: the next tap reuses it.
-      console.error('[NoteReview] payment modal failed:', err);
-      stopPolling();
-      phase = 'upsell';
-      payError = "Couldn't open the payment window. Tap again to retry the same invoice.";
-      return;
-    }
-
-    stopPolling();
-    let pollInFlight = false; // 3s ticks must never overlap a slow check
-    pollTimer = setInterval(async () => {
-      if (pollInFlight) return;
-      pollInFlight = true;
-      try {
-        const status = await checkCreditStatus({ ndk: $ndk, invoiceId });
-        if (!status.ok) return; // transient — keep polling until expiry
-        const { action } = pollActionForStatus(status.status);
-        if (action === 'continue') return;
-        stopPolling();
-        if (action === 'credited') {
-          clearPendingInvoice();
-          creditBalance = status.balance;
-          setPaidHandle?.setPaid({ preimage: 'strike-confirmed' });
-          // Straight into drafting — they paid for this draft.
-          void run(mode);
-        } else {
-          clearPendingInvoice();
-          if (phase === 'paying') {
-            phase = 'upsell';
-            payError = 'That invoice expired — grab a fresh one below.';
-          }
-        }
-      } finally {
-        pollInFlight = false;
-      }
-    }, 3000);
   }
 
   function handlePublishOutcome(outcome: PublishOutcome) {
@@ -295,6 +346,8 @@
     selectedImageIndex = 0;
     payError = '';
     resumeAck = false;
+    inAppPayFailed = false;
+    currentBolt11 = '';
     stopPolling();
   }
 
@@ -477,9 +530,20 @@
       <div class="nr-wait">
         <CheffyAvatar size={64} expression="excited" variant="character" animate />
         <p>Waiting for your {CREDIT_PRICE_SATS} sats…</p>
-        <p class="nr-sub">
-          Pay the invoice in the wallet window — drafting starts the moment it lands.
-        </p>
+        {#if inAppPayFailed}
+          <p class="nr-sub">
+            Your wallet didn't answer. The invoice is still good — pay it another way.
+          </p>
+          <button type="button" class="nr-secondary" on:click={openFallbackModal}>
+            Open payment window
+          </button>
+        {:else if hasInAppWallet}
+          <p class="nr-sub">Paying from your wallet — drafting starts the moment it lands.</p>
+        {:else}
+          <p class="nr-sub">
+            Pay the invoice in the wallet window — drafting starts the moment it lands.
+          </p>
+        {/if}
         <button
           type="button"
           class="nr-ghost"

--- a/src/components/CheffyNoteReview.svelte
+++ b/src/components/CheffyNoteReview.svelte
@@ -85,6 +85,11 @@
   // needed, the poll credits whichever attempt lands).
   let inAppPayFailed = false;
   let currentBolt11 = '';
+  // bc modal success-flip handle — shared by the primary external path
+  // AND the fallback modal, so the poll's confirmation can flip
+  // whichever modal is actually open (late-settle: fallback showing →
+  // poll confirms → modal flips to success, then drafting starts).
+  let paymentModalHandle: { setPaid: (r: { preimage: string }) => void } | null = null;
 
   // productPayment.ts pattern, verbatim semantics: NWC/Spark pay
   // inline; everyone else gets the bitcoin-connect modal.
@@ -198,7 +203,7 @@
 
     currentBolt11 = bolt11;
     inAppPayFailed = false;
-    let setPaidHandle: { setPaid: (r: { preimage: string }) => void } | null = null;
+    paymentModalHandle = null;
 
     function beginPolling(id: string) {
       stopPolling();
@@ -215,7 +220,7 @@
           if (action === 'credited') {
             clearPendingInvoice();
             creditBalance = status.balance;
-            setPaidHandle?.setPaid({ preimage: 'strike-confirmed' });
+            paymentModalHandle?.setPaid({ preimage: 'strike-confirmed' });
             // Straight into drafting — they paid for this draft.
             void run(mode);
           } else {
@@ -233,7 +238,7 @@
 
     async function launchExternal(invoiceToPay: string) {
       try {
-        setPaidHandle = await lightningService.launchPayment({
+        paymentModalHandle = await lightningService.launchPayment({
           invoice: invoiceToPay,
           onPaid: () => {
             // Wallet says paid — the server poll stays authoritative.
@@ -283,6 +288,10 @@
           stopPolling();
           if (phase === 'paying') phase = 'upsell';
         }
+      })
+      .then((handle) => {
+        // The poll's confirmation must be able to flip THIS modal too.
+        paymentModalHandle = handle;
       })
       .catch(() => {
         inAppPayFailed = true;
@@ -348,6 +357,7 @@
     resumeAck = false;
     inAppPayFailed = false;
     currentBolt11 = '';
+    paymentModalHandle = null;
     stopPolling();
   }
 

--- a/src/lib/noteReview.test.ts
+++ b/src/lib/noteReview.test.ts
@@ -838,3 +838,95 @@ describe('preview-system removal completeness', () => {
     });
   }
 });
+
+// ---------------------------------------------------------------------------
+// Credit payment routing (in-app wallet first, bc fallback)
+// ---------------------------------------------------------------------------
+
+import { isInAppWalletKind, executeCreditPayment } from './noteReview';
+
+describe('isInAppWalletKind — productPayment.ts semantics', () => {
+  it('kind 3 (NWC) and kind 4 (Spark) are in-app; WebLN and walletless are not', () => {
+    expect(isInAppWalletKind(3)).toBe(true);
+    expect(isInAppWalletKind(4)).toBe(true);
+    expect(isInAppWalletKind(1)).toBe(false); // WebLN → bc modal handles it natively
+    expect(isInAppWalletKind(undefined)).toBe(false);
+  });
+});
+
+describe('executeCreditPayment — routing and poll authority', () => {
+  const BOLT11 = 'lnbc210n1testinvoice';
+
+  function io(overrides: Partial<Parameters<typeof executeCreditPayment>[1]> = {}) {
+    return {
+      hasInAppWallet: true,
+      sendPayment: vi.fn().mockResolvedValue({ success: true }),
+      launchExternal: vi.fn().mockResolvedValue(undefined),
+      startPoll: vi.fn(),
+      ...overrides
+    };
+  }
+
+  it('kind-3/4 wallet routes inline through sendPayment, never opening the modal', async () => {
+    const deps = io();
+    const path = await executeCreditPayment(BOLT11, deps);
+    expect(path).toBe('in-app');
+    expect(deps.sendPayment).toHaveBeenCalledWith(BOLT11);
+    expect(deps.launchExternal).not.toHaveBeenCalled();
+  });
+
+  it('no in-app wallet routes to the bitcoin-connect modal', async () => {
+    const deps = io({ hasInAppWallet: false });
+    const path = await executeCreditPayment(BOLT11, deps);
+    expect(path).toBe('external');
+    expect(deps.launchExternal).toHaveBeenCalledWith(BOLT11);
+    expect(deps.sendPayment).not.toHaveBeenCalled();
+  });
+
+  it('in-app failure returns the fallback path WITHOUT auto-opening the modal (affordance, user-invoked, same invoice)', async () => {
+    const deps = io({
+      sendPayment: vi.fn().mockResolvedValue({ success: false, error: 'no route' })
+    });
+    const path = await executeCreditPayment(BOLT11, deps);
+    expect(path).toBe('in-app-failed');
+    expect(deps.launchExternal).not.toHaveBeenCalled();
+  });
+
+  it('in-app throw and in-app timeout both fall back', async () => {
+    const threw = io({ sendPayment: vi.fn().mockRejectedValue(new Error('nwc relay down')) });
+    expect(await executeCreditPayment(BOLT11, threw)).toBe('in-app-failed');
+
+    const hung = io({
+      sendPayment: vi.fn().mockReturnValue(new Promise(() => {})),
+      inAppTimeoutMs: 20
+    });
+    expect(await executeCreditPayment(BOLT11, hung)).toBe('in-app-failed');
+  });
+
+  it('THE POLL STARTS FIRST ON EVERY PATH — wallet signals stay advisory, the poll is the sole crediting authority', async () => {
+    // in-app success: poll started before sendPayment resolves
+    const order: string[] = [];
+    const success = io({
+      startPoll: vi.fn(() => order.push('poll')),
+      sendPayment: vi.fn(async () => {
+        order.push('send');
+        return { success: true };
+      })
+    });
+    await executeCreditPayment(BOLT11, success);
+    expect(order).toEqual(['poll', 'send']);
+
+    // external path
+    const ext = io({ hasInAppWallet: false });
+    await executeCreditPayment(BOLT11, ext);
+    expect(ext.startPoll).toHaveBeenCalledTimes(1);
+
+    // failure path — the poll keeps running so a slow settle still credits
+    const fail = io({ sendPayment: vi.fn().mockResolvedValue({ success: false }) });
+    await executeCreditPayment(BOLT11, fail);
+    expect(fail.startPoll).toHaveBeenCalledTimes(1);
+
+    // And there is nothing else success COULD do: the io surface has no
+    // crediting hook — executeCreditPayment can only start the poll.
+  });
+});

--- a/src/lib/noteReview.test.ts
+++ b/src/lib/noteReview.test.ts
@@ -5,7 +5,9 @@ import {
   DEAD_END_LINES,
   SIGN_FAILED_LINE,
   NOTE_REVIEW_POST_ENABLED,
-  NOTE_TEXT_MAX_CHARS
+  NOTE_TEXT_MAX_CHARS,
+  isInAppWalletKind,
+  executeCreditPayment
 } from './noteReview';
 import { extractImageUrls } from './imageUrls';
 
@@ -843,8 +845,6 @@ describe('preview-system removal completeness', () => {
 // Credit payment routing (in-app wallet first, bc fallback)
 // ---------------------------------------------------------------------------
 
-import { isInAppWalletKind, executeCreditPayment } from './noteReview';
-
 describe('isInAppWalletKind — productPayment.ts semantics', () => {
   it('kind 3 (NWC) and kind 4 (Spark) are in-app; WebLN and walletless are not', () => {
     expect(isInAppWalletKind(3)).toBe(true);
@@ -901,6 +901,17 @@ describe('executeCreditPayment — routing and poll authority', () => {
       inAppTimeoutMs: 20
     });
     expect(await executeCreditPayment(BOLT11, hung)).toBe('in-app-failed');
+  });
+
+  it('clears the losing race timer after a fast in-app settle', async () => {
+    vi.useFakeTimers();
+    try {
+      const deps = io();
+      await executeCreditPayment(BOLT11, deps);
+      expect(vi.getTimerCount()).toBe(0); // no 30s straggler
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('THE POLL STARTS FIRST ON EVERY PATH — wallet signals stay advisory, the poll is the sole crediting authority', async () => {

--- a/src/lib/noteReview.ts
+++ b/src/lib/noteReview.ts
@@ -643,18 +643,25 @@ export async function executeCreditPayment(
     return 'external';
   }
 
+  const timeoutMs = io.inAppTimeoutMs ?? IN_APP_PAY_TIMEOUT_MS;
+  let timer: ReturnType<typeof setTimeout> | undefined;
   try {
-    const timeoutMs = io.inAppTimeoutMs ?? IN_APP_PAY_TIMEOUT_MS;
     const result = await Promise.race([
       io.sendPayment(bolt11),
-      new Promise<{ success: false; error: string }>((resolve) =>
-        setTimeout(() => resolve({ success: false, error: 'in-app payment timed out' }), timeoutMs)
-      )
+      new Promise<{ success: false; error: string }>((resolve) => {
+        timer = setTimeout(
+          () => resolve({ success: false, error: 'in-app payment timed out' }),
+          timeoutMs
+        );
+      })
     ]);
     // Success here is ADVISORY — the poll does the crediting either way.
     // A late settle after the timeout is also fine: the poll observes it.
     return result.success ? 'in-app' : 'in-app-failed';
   } catch {
     return 'in-app-failed';
+  } finally {
+    // Don't leave the losing timer pending after a fast settle.
+    clearTimeout(timer);
   }
 }

--- a/src/lib/noteReview.ts
+++ b/src/lib/noteReview.ts
@@ -591,3 +591,70 @@ export async function resumePendingInvoice(opts: CreditApiOpts): Promise<ResumeO
   }
   return { outcome: 'pending', invoice: pending };
 }
+
+// ---------------------------------------------------------------------------
+// Credit payment routing — in-app wallet first, bitcoin-connect fallback
+// ---------------------------------------------------------------------------
+
+/**
+ * Mirrors productPayment.ts's hasInAppWallet: NWC (kind 3) and Spark
+ * (kind 4) pay inline through the app's own wallet; WebLN (kind 1) and
+ * walletless users go through the bitcoin-connect modal, which handles
+ * WebLN natively.
+ */
+export function isInAppWalletKind(kind: number | undefined): boolean {
+  return kind === 3 || kind === 4;
+}
+
+export type CreditPaymentPath = 'in-app' | 'external' | 'in-app-failed';
+
+export interface CreditPaymentIo {
+  hasInAppWallet: boolean;
+  /** walletManager.sendPayment wrapper — the app's own wallet. */
+  sendPayment: (bolt11: string) => Promise<{ success: boolean; error?: string }>;
+  /** lightningService.launchPayment wrapper — the bitcoin-connect modal. */
+  launchExternal: (bolt11: string) => Promise<void>;
+  /** Begins the 3s credit-status poll. */
+  startPoll: () => void;
+  /** In-app payment deadline before the fallback affordance shows. */
+  inAppTimeoutMs?: number;
+}
+
+const IN_APP_PAY_TIMEOUT_MS = 30_000;
+
+/**
+ * Route one credit-invoice payment. THE POLL STARTS FIRST, ON EVERY
+ * PATH — wallet-side success signals (in-app result, bc onPaid) are
+ * advisory only; the server credit-status poll is the sole crediting
+ * authority. An in-app failure/timeout returns 'in-app-failed' WITHOUT
+ * opening the modal — the caller renders a fallback affordance that
+ * re-presents the SAME bolt11 (never mint a second; double payment is
+ * protocol-impossible since a BOLT11 settles exactly once, so the
+ * fallback needs no guard).
+ */
+export async function executeCreditPayment(
+  bolt11: string,
+  io: CreditPaymentIo
+): Promise<CreditPaymentPath> {
+  io.startPoll();
+
+  if (!io.hasInAppWallet) {
+    await io.launchExternal(bolt11);
+    return 'external';
+  }
+
+  try {
+    const timeoutMs = io.inAppTimeoutMs ?? IN_APP_PAY_TIMEOUT_MS;
+    const result = await Promise.race([
+      io.sendPayment(bolt11),
+      new Promise<{ success: false; error: string }>((resolve) =>
+        setTimeout(() => resolve({ success: false, error: 'in-app payment timed out' }), timeoutMs)
+      )
+    ]);
+    // Success here is ADVISORY — the poll does the crediting either way.
+    // A late settle after the timeout is also fine: the poll observes it.
+    return result.success ? 'in-app' : 'in-app-failed';
+  } catch {
+    return 'in-app-failed';
+  }
+}


### PR DESCRIPTION
## Summary

Live-testing finding: the app's own wallet system (NWC/Spark configured in settings) and bitcoin-connect are fully siloed — an NWC user tapping "⚡ 21 sats" got a cold connect-a-wallet modal. The credit purchase now copies the `productPayment.ts` pattern verbatim:

- **`hasInAppWallet` (kind 3 NWC | kind 4 Spark) → `sendPayment(bolt11)` inline** in the existing paying phase
- **Everyone else → `lightningService.launchPayment`** exactly as before (WebLN users deliberately stay on the bc modal, which speaks WebLN natively — same semantics as productPayment)
- **In-app failure/throw/30s-timeout → user-invoked fallback affordance** re-presenting the SAME bolt11 in the bc modal. Never a second mint; double payment is protocol-impossible (a BOLT11 settles exactly once), so the fallback needs no guard
- **The poll starts FIRST on every path** — `executeCreditPayment`'s io surface has no crediting hook by design; wallet-side success signals (in-app result, bc `onPaid`) stay advisory and the 3s `credit-status` poll remains the sole crediting authority
- **Late-settle handled cleanly**: the bc modal's `setPaid` handle is shared across the primary and fallback launch sites, so a poll-confirmed payment flips whichever modal is open to success before drafting starts (fallback copy is replaced, never stranded)

## Test plan

- [x] 6 new unit tests: kind-3/4 route inline, walletless routes to bc with the invoice, in-app failure returns the affordance path without auto-opening the modal, throw + hung-payment timeout fallbacks, and poll-starts-first ordering asserted on every path
- [x] Full suite green (35 files, 592 tests); `svelte-check` 0 errors
- [ ] Manual pass on the branch preview: NWC-configured non-member taps "⚡ 21 sats" → wallet pays inline → drafting starts; fallback affordance → QR pay → modal flips to success

Follow-up filed: #523 — membership checkouts have the identical gap (conversion-funnel fix, same pattern, three pages).

Note: "Workers Builds" checks are expected to fail on this repo (known infra quirk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)