### PR TITLE
feat(nourish): Phase 2 — pantry macros, NIP-32 labels, rescore

### DIFF
--- a/NOURISH_MACROS_DISCOVERY.md
+++ b/NOURISH_MACROS_DISCOVERY.md
@@ -459,3 +459,34 @@ Discovery UI must degrade per 0.7 during the short backfill window.
 | 0.3 One vs two calls | **PASS** — **ONE call** (plan default; drift harness inconclusive, no objection) |
 
 **Phase 0 evidence complete — STOP.** Awaiting human review before any Phase 1 product code. (Publish-to-pantry remains a Phase 2 prerequisite when Phase 1 is approved.)
+
+---
+
+## Phase 2 backfill census (2026-07-10)
+
+Corpus rescore via `tmp/nourish-backfill/` (shared `runScoringPipeline`, rate-limited). Service pubkey registered as pantry member (Phase 0 §0.5 prerequisite). **Dry-run** locally — `NOTIFICATION_PRIVATE_KEY` not in `.dev.vars`; re-run with the key to publish from checkpoint (or post-merge admin bulk rescore).
+
+| | |
+|--|--:|
+| Corpus | 55 |
+| Scored | 52 |
+| Errors | 3 (2 recipe-not-found, 1 test ping) |
+| `estimate` | 45 |
+| `rough` | 7 |
+| macros omitted | 0 |
+
+| label | recipes |
+|-------|--------:|
+| `seedoil:free` | 41 |
+| `redmeat:free` | 32 |
+| `kcal:under800` | 31 |
+| `addedsugar:free` | 27 |
+| `kcal:under600` | 25 |
+| `carbs:under40` | 23 |
+| `protein:20plus` | 19 |
+| `carbs:under20` | 16 |
+| `protein:30plus` | 14 |
+| `kcal:under400` | 13 |
+| `protein:40plus` | 12 |
+
+Filter inventory is usable for Phase 3b — `seedoil:free` alone covers 41/52 scored recipes; high-protein chips have 12–19 matches.

--- a/NOURISH_MACROS_PLAN.md
+++ b/NOURISH_MACROS_PLAN.md
@@ -158,6 +158,10 @@ relabel pass via rescore, so they're chosen once, here):
 | kcal    | `kcal:under400`, `kcal:under600`, `kcal:under800`     | macros.perServing (cumulative downward: a 380-kcal recipe carries all three) |
 | carbs   | `carbs:under20`, `carbs:under40`           | macros.perServing |
 
+**Confidence gates threshold labels:** recipes with `macros.confidence === "rough"` emit NO macro-bucket labels (`protein:*`, `kcal:*`, `carbs:*`) — a filter must never serve a recipe whose estimate class says the number isn't trustworthy; flag labels (`seedoil:free` etc.) are independent of quantity confidence and still apply.
+
+**kcal-as-tag (0.5):** keep kcal only in content `macros` + bucket `l` tags — do **not** add a raw `nourish_kcal` numeric tag (NIP-01 can't range-query it; buckets already cover discovery).
+
 **Trick 2 — AND-composition is client-side.** A single filter's `#l`
 array is OR; two label conditions cannot be ANDed in one REQ. So
 "protein:30plus AND seedoil:free" = fetch on the more selective label,
@@ -293,12 +297,15 @@ verdict). Throwaway scripts allowed, not committed to src/.
 ## Phase 2 — Pantry events + labels + rescore (frontend PR 2)
 
 - `nourishPublisher.server.ts`: macros into event content; `L`/`l` label
-  tags per §3 (+ kcal-as-tag decision from 0.5). Additive; v1/v2
-  consumers unaffected.
+  tags per §3 (+ kcal-as-tag decision from 0.5: no raw `nourish_kcal`
+  tag). Additive; v1/v2/v3 consumers unaffected. Confidence `"rough"`
+  suppresses threshold labels (engine-side); flag labels still emit.
+  Publish targets include `wss://pantry.zap.cooking` with NIP-42 AUTH.
 - Rescore endpoint verified to carry macros + labels end-to-end (shared
-  engine should make this near-free — the PR proves it).
+  engine is not enough — the endpoint must pass them through; proven in
+  `nourishPublisher.server.test.ts`).
 - Execute the 0.8 backfill decision, rate-limited. This populates the
-  index.
+  index. Post-backfill label census reported in the PR.
 
 ## Phase 3 — Web UI: macros row + filtered discovery (frontend PR 3, split 3a/3b if large)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.631",
+  "version": "4.2.632",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/nourish/index.ts
+++ b/src/lib/nourish/index.ts
@@ -1,6 +1,7 @@
 export {
 	NOURISH_CACHE_VERSION,
 	NOURISH_PROMPT_VERSION,
+	NOURISH_LABEL_NAMESPACE,
 	NOURISH_WEIGHTS,
 	computeOverallScore,
 	type NourishRequest,

--- a/src/lib/nourish/macros.test.ts
+++ b/src/lib/nourish/macros.test.ts
@@ -419,6 +419,45 @@ describe('computeMacrosAndLabels', () => {
 		expect(omitReason).toBeTruthy();
 		expect(labels).toContain('seedoil:free');
 	});
+
+	it('rough confidence suppresses threshold labels but keeps flag labels', () => {
+		// High protein / low kcal would clear buckets if estimate — but bone_in → rough.
+		const { macros, labels } = computeMacrosAndLabels(
+			[
+				row(800, { kcal: 165, protein_g: 31, carbs_g: 0, fat_g: 3.6 }, {
+					seed_oil: 'no',
+					added_sugar: 'no',
+					red_meat: 'no',
+					bone_in: 'yes'
+				})
+			],
+			'2'
+		);
+		expect(macros?.confidence).toBe('rough');
+		expect(macros?.perServing.protein_g).toBeGreaterThanOrEqual(30);
+		expect(labels.some((l) => l.startsWith('protein:'))).toBe(false);
+		expect(labels.some((l) => l.startsWith('kcal:'))).toBe(false);
+		expect(labels.some((l) => l.startsWith('carbs:'))).toBe(false);
+		expect(labels).toContain('seedoil:free');
+		expect(labels).toContain('addedsugar:free');
+		expect(labels).toContain('redmeat:free');
+	});
+
+	it('estimate confidence still emits threshold labels', () => {
+		const { macros, labels } = computeMacrosAndLabels(
+			[
+				row(400, { kcal: 165, protein_g: 31, carbs_g: 0, fat_g: 3.6 }, {
+					seed_oil: 'no',
+					added_sugar: 'no',
+					red_meat: 'no'
+				})
+			],
+			'2'
+		);
+		expect(macros?.confidence).toBe('estimate');
+		expect(labels).toContain('protein:20plus');
+		expect(labels).toContain('protein:30plus');
+	});
 });
 
 describe('v3-shape scores still validate', () => {

--- a/src/lib/nourish/macros.ts
+++ b/src/lib/nourish/macros.ts
@@ -283,14 +283,21 @@ export function deriveThresholdLabels(
 
 /**
  * Full label set from a successful macro compute + raw ingredient flags.
+ *
+ * Confidence gate: `rough` suppresses threshold buckets (`protein:*`,
+ * `kcal:*`, `carbs:*`) so discovery filters never serve a recipe whose
+ * estimate class says the number isn't trustworthy. Flag labels
+ * (`seedoil:free` etc.) are independent of quantity confidence.
  */
 export function deriveNourishLabels(
 	macroResult: MacroComputeOk,
 	rawIngredients: unknown
 ): NourishLabel[] {
-	const labels: NourishLabel[] = [
-		...deriveThresholdLabels(macroResult.recipeTotals, macroResult.servings)
-	];
+	const labels: NourishLabel[] = [];
+
+	if (macroResult.macros.confidence !== 'rough') {
+		labels.push(...deriveThresholdLabels(macroResult.recipeTotals, macroResult.servings));
+	}
 
 	const seed = deriveFreeLabel(rawIngredients, 'seed_oil', 'seedoil:free');
 	const sugar = deriveFreeLabel(rawIngredients, 'added_sugar', 'addedsugar:free');

--- a/src/lib/nourish/nourishPublisher.server.test.ts
+++ b/src/lib/nourish/nourishPublisher.server.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Phase 2 — pantry event shape + label tags + rescore wiring.
+ *
+ * Pure builder tests (no network). Rescore round-trip proves the admin
+ * endpoint passes macros/labels into publishNourishEvent — the shared
+ * engine alone does not make that free.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildNourishEventParts, publishNourishEvent } from './nourishPublisher.server';
+import {
+	NOURISH_LABEL_NAMESPACE,
+	NOURISH_PROMPT_VERSION,
+	type NourishScores,
+	type NourishMacros,
+	type NourishLabel
+} from './types';
+import { generateSecretKey } from 'nostr-tools';
+
+function baseScores(): NourishScores {
+	return {
+		gut: { score: 7, label: 'Good', reason: 'r' },
+		protein: { score: 8, label: 'Good', reason: 'r' },
+		realFood: { score: 7, label: 'Good', reason: 'r' },
+		antiInflammatory: { score: 6, label: 'Moderate', reason: 'r' },
+		bloodSugar: { score: 6, label: 'Moderate', reason: 'r' },
+		immuneSupportive: { score: 6, label: 'Moderate', reason: 'r' },
+		brainHealth: { score: 6, label: 'Moderate', reason: 'r' },
+		heartHealth: { score: 6, label: 'Moderate', reason: 'r' },
+		overall: { score: 7, label: 'Good', reason: 'weighted' },
+		summary: 'A solid recipe.',
+		cacheVersion: '2.0'
+	};
+}
+
+const RECIPE_PUBKEY = 'a'.repeat(64);
+const RECIPE_DTAG = 'test-recipe';
+const CONTENT_HASH = 'b'.repeat(64);
+
+const sampleMacros: NourishMacros = {
+	perServing: { kcal: 420, protein_g: 32, carbs_g: 28, fat_g: 18 },
+	servingsUsed: 4,
+	servingsParsed: true,
+	confidence: 'estimate',
+	method: 'llm-per100g-v1'
+};
+
+const sampleLabels: NourishLabel[] = [
+	'protein:20plus',
+	'protein:30plus',
+	'kcal:under600',
+	'kcal:under800',
+	'carbs:under40',
+	'seedoil:free'
+];
+
+describe('buildNourishEventParts — additive event shape', () => {
+	it('emits macros in content and L/l tags per §3 bucket table', () => {
+		const { tags, content } = buildNourishEventParts({
+			recipePubkey: RECIPE_PUBKEY,
+			recipeDTag: RECIPE_DTAG,
+			contentHash: CONTENT_HASH,
+			scores: baseScores(),
+			improvements: ['use olive oil'],
+			ingredientSignals: [{ name: 'chicken', signals: ['protein'], contribution: 'protein' }],
+			macros: sampleMacros,
+			labels: sampleLabels,
+			createdAt: 1_700_000_000
+		});
+
+		expect(content.macros).toEqual(sampleMacros);
+		expect(content.labels).toEqual(sampleLabels);
+		expect(content.promptVersion).toBe(NOURISH_PROMPT_VERSION);
+		expect(content.createdAt).toBe(1_700_000_000);
+
+		expect(tags).toContainEqual(['L', NOURISH_LABEL_NAMESPACE]);
+		for (const label of sampleLabels) {
+			expect(tags).toContainEqual(['l', label, NOURISH_LABEL_NAMESPACE]);
+		}
+		// kcal-as-tag decision (0.5): no raw numeric kcal tag
+		expect(tags.some((t) => t[0] === 'nourish_kcal')).toBe(false);
+	});
+
+	it('v4 event missing macros (degraded-to-omitted) publishes with no macro tags', () => {
+		const { tags, content } = buildNourishEventParts({
+			recipePubkey: RECIPE_PUBKEY,
+			recipeDTag: RECIPE_DTAG,
+			contentHash: CONTENT_HASH,
+			scores: baseScores(),
+			improvements: [],
+			ingredientSignals: [],
+			labels: ['seedoil:free']
+		});
+
+		expect(content.macros).toBeUndefined();
+		expect(tags.some((t) => t[0] === 'nourish_kcal')).toBe(false);
+		expect(tags).toContainEqual(['L', NOURISH_LABEL_NAMESPACE]);
+		expect(tags).toContainEqual(['l', 'seedoil:free', NOURISH_LABEL_NAMESPACE]);
+	});
+
+	it('emits no L/l tags when labels are empty or omitted', () => {
+		const empty = buildNourishEventParts({
+			recipePubkey: RECIPE_PUBKEY,
+			recipeDTag: RECIPE_DTAG,
+			contentHash: CONTENT_HASH,
+			scores: baseScores(),
+			improvements: [],
+			ingredientSignals: [],
+			labels: []
+		});
+		expect(empty.tags.some((t) => t[0] === 'L' || t[0] === 'l')).toBe(false);
+		expect(empty.content.labels).toBeUndefined();
+
+		const omitted = buildNourishEventParts({
+			recipePubkey: RECIPE_PUBKEY,
+			recipeDTag: RECIPE_DTAG,
+			contentHash: CONTENT_HASH,
+			scores: baseScores(),
+			improvements: [],
+			ingredientSignals: []
+		});
+		expect(omitted.tags.some((t) => t[0] === 'L' || t[0] === 'l')).toBe(false);
+		expect(omitted.content.macros).toBeUndefined();
+	});
+
+	it('preserves v1/v2/v3 score fields so older consumers keep working', () => {
+		const { content, tags } = buildNourishEventParts({
+			recipePubkey: RECIPE_PUBKEY,
+			recipeDTag: RECIPE_DTAG,
+			contentHash: CONTENT_HASH,
+			scores: baseScores(),
+			improvements: ['x'],
+			ingredientSignals: [],
+			audienceScores: {
+				kidFriendly: { score: 8, label: 'Good', reason: 'mild' }
+			},
+			macros: sampleMacros,
+			labels: sampleLabels
+		});
+
+		expect(content.gut).toEqual(baseScores().gut);
+		expect(content.heartHealth).toEqual(baseScores().heartHealth);
+		expect(content.audience).toEqual({
+			kidFriendly: { score: 8, label: 'Good', reason: 'mild' }
+		});
+		expect(tags).toContainEqual(['audience_kidfriendly', '8']);
+		expect(tags).toContainEqual(['nourish_hearthealth', '6']);
+		expect(tags).toContainEqual(['prompt_version', NOURISH_PROMPT_VERSION]);
+	});
+
+	it('emits updated_at on rescore events', () => {
+		const { tags, content } = buildNourishEventParts({
+			recipePubkey: RECIPE_PUBKEY,
+			recipeDTag: RECIPE_DTAG,
+			contentHash: CONTENT_HASH,
+			scores: baseScores(),
+			improvements: [],
+			ingredientSignals: [],
+			macros: sampleMacros,
+			labels: sampleLabels,
+			updatedAt: 1_700_000_100
+		});
+		expect(tags).toContainEqual(['updated_at', '1700000100']);
+		expect(content.updatedAt).toBe(1_700_000_100);
+	});
+});
+
+describe('rescore round-trip — macros + labels reach the publisher', () => {
+	const publishMock = vi.fn(async () => true);
+	const pipelineMock = vi.fn();
+
+	beforeEach(() => {
+		publishMock.mockReset();
+		publishMock.mockResolvedValue(true);
+		pipelineMock.mockReset();
+		vi.resetModules();
+	});
+
+	it('admin rescore passes macros, confidence, and labels into publishNourishEvent', async () => {
+		const macros: NourishMacros = {
+			...sampleMacros,
+			confidence: 'estimate'
+		};
+		const labels: NourishLabel[] = ['protein:30plus', 'seedoil:free'];
+
+		pipelineMock.mockResolvedValue({
+			ok: true,
+			scores: baseScores(),
+			improvements: ['use less salt'],
+			ingredientSignals: [{ name: 'chicken', signals: ['protein'], contribution: 'protein' }],
+			audienceScores: {
+				kidFriendly: { score: 7, label: 'Good', reason: 'ok' }
+			},
+			macros,
+			labels
+		});
+
+		vi.doMock('$lib/nourish/scoringEngine.server', () => ({
+			runScoringPipeline: pipelineMock
+		}));
+		vi.doMock('$lib/nourish/nourishPublisher.server', () => ({
+			publishNourishEvent: publishMock
+		}));
+		vi.doMock('$lib/nip98.server', () => ({
+			verifyNip98: vi.fn(async () => ({ ok: true, pubkey: 'admin' }))
+		}));
+		vi.doMock('$lib/adminAuth', () => ({
+			ADMIN_PUBKEY: 'admin'
+		}));
+		vi.doMock('$env/dynamic/private', () => ({
+			env: {
+				OPENAI_API_KEY: 'sk-test',
+				NOTIFICATION_PRIVATE_KEY: '1'.repeat(64)
+			}
+		}));
+
+		const { POST } = await import('../../routes/api/admin/nourish/rescore/+server');
+
+		const body = {
+			recipePubkey: RECIPE_PUBKEY,
+			recipeDTag: RECIPE_DTAG,
+			title: 'Test Chicken',
+			ingredients: ['2 chicken breasts', 'salt'],
+			tags: ['dinner'],
+			servings: '4',
+			contentHash: CONTENT_HASH
+		};
+		const request = new Request('https://zap.cooking/api/admin/nourish/rescore', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: 'Nostr test'
+			},
+			body: JSON.stringify(body)
+		});
+
+		const response = await POST({
+			request,
+			platform: { env: {} }
+		} as any);
+
+		expect(response.status).toBe(200);
+		const json = await response.json();
+		expect(json.success).toBe(true);
+		expect(json.macros).toEqual(macros);
+		expect(json.labels).toEqual(labels);
+		expect(json.published).toBe(true);
+
+		expect(publishMock).toHaveBeenCalledTimes(1);
+		const publishArgs = publishMock.mock.calls[0][0];
+		expect(publishArgs.macros).toEqual(macros);
+		expect(publishArgs.labels).toEqual(labels);
+		expect(publishArgs.macros.confidence).toBe('estimate');
+		expect(publishArgs.updatedAt).toBeTypeOf('number');
+		expect(publishArgs.recipeDTag).toBe(RECIPE_DTAG);
+	});
+
+	it('rescore of a rough recipe still publishes macros + flag labels (no threshold tags upstream)', async () => {
+		const macros: NourishMacros = {
+			...sampleMacros,
+			confidence: 'rough'
+		};
+		const labels: NourishLabel[] = ['seedoil:free', 'addedsugar:free'];
+
+		pipelineMock.mockResolvedValue({
+			ok: true,
+			scores: baseScores(),
+			improvements: [],
+			ingredientSignals: [],
+			macros,
+			labels
+		});
+
+		vi.doMock('$lib/nourish/scoringEngine.server', () => ({
+			runScoringPipeline: pipelineMock
+		}));
+		vi.doMock('$lib/nourish/nourishPublisher.server', () => ({
+			publishNourishEvent: publishMock
+		}));
+		vi.doMock('$lib/nip98.server', () => ({
+			verifyNip98: vi.fn(async () => ({ ok: true, pubkey: 'admin' }))
+		}));
+		vi.doMock('$lib/adminAuth', () => ({
+			ADMIN_PUBKEY: 'admin'
+		}));
+		vi.doMock('$env/dynamic/private', () => ({
+			env: {
+				OPENAI_API_KEY: 'sk-test',
+				NOTIFICATION_PRIVATE_KEY: '1'.repeat(64)
+			}
+		}));
+
+		const { POST } = await import('../../routes/api/admin/nourish/rescore/+server');
+		const body = {
+			recipePubkey: RECIPE_PUBKEY,
+			recipeDTag: 'fried-chicken',
+			title: 'Fried Chicken',
+			ingredients: ['breaded chicken', 'oil for frying'],
+			tags: [],
+			servings: '4',
+			contentHash: CONTENT_HASH
+		};
+		const request = new Request('https://zap.cooking/api/admin/nourish/rescore', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: 'Nostr test'
+			},
+			body: JSON.stringify(body)
+		});
+
+		const response = await POST({ request, platform: { env: {} } as any });
+		expect(response.status).toBe(200);
+		const json = await response.json();
+		expect(json.macros.confidence).toBe('rough');
+		expect(json.labels).toEqual(labels);
+
+		const publishArgs = publishMock.mock.calls[0][0];
+		expect(publishArgs.macros.confidence).toBe('rough');
+		expect(publishArgs.labels).toEqual(labels);
+		expect(publishArgs.labels.some((l: string) => l.startsWith('protein:'))).toBe(false);
+
+		const parts = buildNourishEventParts({
+			recipePubkey: RECIPE_PUBKEY,
+			recipeDTag: 'fried-chicken',
+			contentHash: CONTENT_HASH,
+			scores: baseScores(),
+			improvements: [],
+			ingredientSignals: [],
+			macros,
+			labels
+		});
+		expect(parts.content.macros).toEqual(macros);
+		expect(parts.tags).toContainEqual(['l', 'seedoil:free', NOURISH_LABEL_NAMESPACE]);
+		expect(parts.tags.some((t) => t[0] === 'l' && String(t[1]).startsWith('protein:'))).toBe(
+			false
+		);
+	});
+});
+
+describe('publishNourishEvent — signs without throwing on omitted macros', () => {
+	it('builds a signed event when macros are omitted (degraded path)', async () => {
+		const OriginalWS = globalThis.WebSocket;
+		class FakeWS {
+			onopen: (() => void) | null = null;
+			onmessage: ((msg: MessageEvent) => void) | null = null;
+			onerror: (() => void) | null = null;
+			onclose: (() => void) | null = null;
+			constructor(_url: string) {
+				queueMicrotask(() => this.onopen?.());
+			}
+			send() {
+				queueMicrotask(() => this.onclose?.());
+			}
+			close() {}
+		}
+		// @ts-expect-error test stub
+		globalThis.WebSocket = FakeWS;
+
+		const sk = generateSecretKey();
+		const hex = Array.from(sk)
+			.map((b) => b.toString(16).padStart(2, '0'))
+			.join('');
+
+		const ok = await publishNourishEvent({
+			privateKey: hex,
+			recipePubkey: RECIPE_PUBKEY,
+			recipeDTag: RECIPE_DTAG,
+			contentHash: CONTENT_HASH,
+			scores: baseScores(),
+			improvements: [],
+			ingredientSignals: []
+		});
+		expect(ok).toBe(false);
+
+		globalThis.WebSocket = OriginalWS;
+	});
+});

--- a/src/lib/nourish/nourishPublisher.server.ts
+++ b/src/lib/nourish/nourishPublisher.server.ts
@@ -4,81 +4,309 @@
  * Signs and publishes Nourish analysis events (kind 30078) using
  * nostr-tools directly (not NDK). NDK's WebSocket handling doesn't
  * work reliably on Cloudflare Workers — direct WebSocket publish does.
+ *
+ * Phase 2: additive macros block in content + NIP-32 L/l self-labels.
+ * Public relays accept unsigned connections; pantry requires NIP-42 AUTH
+ * and an active membership for the service pubkey.
  */
 
-import { nip19, finalizeEvent } from 'nostr-tools';
+import { nip19, finalizeEvent, getPublicKey } from 'nostr-tools';
+import { makeAuthEvent } from 'nostr-tools/nip42';
 import {
-  NOURISH_CACHE_VERSION,
-  NOURISH_PROMPT_VERSION,
-  type NourishScores,
-  type AudienceScores,
-  type IngredientSignal
+	NOURISH_CACHE_VERSION,
+	NOURISH_PROMPT_VERSION,
+	NOURISH_LABEL_NAMESPACE,
+	type NourishScores,
+	type AudienceScores,
+	type IngredientSignal,
+	type NourishMacros,
+	type NourishLabel
 } from './types';
 import { buildNourishDTag } from './nourishRelay';
 
-const PUBLISH_RELAYS = ['wss://nos.lol', 'wss://relay.damus.io', 'wss://relay.primal.net'];
-const PUBLISH_TIMEOUT_MS = 5000;
+/** Public relays — no AUTH. Primary index store today (see Phase 0 §0.5). */
+const PUBLIC_PUBLISH_RELAYS = [
+	'wss://nos.lol',
+	'wss://relay.damus.io',
+	'wss://relay.primal.net'
+];
+
+/** Member relay — NIP-42 AUTH + active membership required to write. */
+const PANTRY_RELAY = 'wss://pantry.zap.cooking';
+
+const PUBLISH_RELAYS = [...PUBLIC_PUBLISH_RELAYS, PANTRY_RELAY];
+const PUBLISH_TIMEOUT_MS = 8000;
 
 /**
  * Resolve the private key from env var (supports both hex and nsec format).
  * Returns a Uint8Array for nostr-tools.
  */
 function resolvePrivateKey(raw: string): Uint8Array {
-  if (raw.startsWith('nsec1')) {
-    const decoded = nip19.decode(raw);
-    return decoded.data as Uint8Array;
-  }
-  if (/^[0-9a-fA-F]{64}$/.test(raw)) {
-    return Uint8Array.from(raw.match(/.{2}/g)!.map((b) => parseInt(b, 16)));
-  }
-  throw new Error('Invalid private key format — must be 64 hex chars or nsec');
+	if (raw.startsWith('nsec1')) {
+		const decoded = nip19.decode(raw);
+		return decoded.data as Uint8Array;
+	}
+	if (/^[0-9a-fA-F]{64}$/.test(raw)) {
+		return Uint8Array.from(raw.match(/.{2}/g)!.map((b) => parseInt(b, 16)));
+	}
+	throw new Error('Invalid private key format — must be 64 hex chars or nsec');
+}
+
+export interface NourishPublishInput {
+	recipePubkey: string;
+	recipeDTag: string;
+	contentHash: string;
+	scores: NourishScores;
+	improvements: string[];
+	ingredientSignals: IngredientSignal[];
+	audienceScores?: AudienceScores;
+	/**
+	 * Estimated per-serving macros (v4). Omitted when the engine degraded
+	 * to no macros — event publishes cleanly with no macro content/tags.
+	 */
+	macros?: NourishMacros;
+	/**
+	 * Derived discovery labels (v4). Empty / omitted → no L/l tags.
+	 * Threshold buckets are already confidence-gated upstream.
+	 */
+	labels?: NourishLabel[];
+	/**
+	 * Unix seconds. When set, emit an `updated_at` tag (and content-JSON
+	 * mirror) marking this event as a rescore rather than a first-time
+	 * score. Undefined → no tag emitted.
+	 */
+	updatedAt?: number;
+	/** Override created_at (tests). Defaults to now. */
+	createdAt?: number;
+}
+
+export interface NourishEventParts {
+	tags: string[][];
+	content: Record<string, unknown>;
+}
+
+/**
+ * Pure builder for kind-30078 tags + content JSON.
+ * Additive: v1/v2/v3 consumers ignore unknown keys/tags; a v4 event
+ * missing macros (degraded-to-omitted) publishes with no macro tags.
+ *
+ * kcal-as-tag (0.5): kcal lives in content `macros` + bucket `l` tags
+ * only — no raw `nourish_kcal` numeric tag.
+ */
+export function buildNourishEventParts(input: NourishPublishInput): NourishEventParts {
+	const {
+		recipePubkey,
+		recipeDTag,
+		contentHash,
+		scores,
+		improvements,
+		ingredientSignals,
+		audienceScores,
+		macros,
+		labels,
+		updatedAt,
+		createdAt: createdAtOverride
+	} = input;
+
+	const dTag = buildNourishDTag(recipePubkey, recipeDTag);
+	const createdAt = createdAtOverride ?? Math.floor(Date.now() / 1000);
+
+	const tags: string[][] = [
+		['d', dTag],
+		['client', 'zap.cooking'],
+		['a', `30023:${recipePubkey}:${recipeDTag}`],
+		['p', recipePubkey],
+		['nourish_version', NOURISH_CACHE_VERSION],
+		['content_hash', contentHash],
+		['prompt_version', NOURISH_PROMPT_VERSION],
+		['nourish_overall', String(scores.overall.score)],
+		['nourish_gut', String(scores.gut.score)],
+		['nourish_protein', String(scores.protein.score)],
+		['nourish_realfood', String(scores.realFood.score)],
+		// v2 Nourish dimensions — emitted on all events going forward.
+		// v1 events in the wild won't have them; parser defaults to 0.
+		['nourish_antiinflammatory', String(scores.antiInflammatory.score)],
+		['nourish_bloodsugar', String(scores.bloodSugar.score)],
+		['nourish_immunesupportive', String(scores.immuneSupportive.score)],
+		['nourish_brainhealth', String(scores.brainHealth.score)],
+		// v3 Nourish dimensions — heart health added in prompt v3.
+		['nourish_hearthealth', String(scores.heartHealth.score)]
+	];
+
+	// Audience tag prefix is distinct from nourish_* so future consumers
+	// can filter queries by namespace without pulling one when they want
+	// the other.
+	if (audienceScores) {
+		tags.push(['audience_kidfriendly', String(audienceScores.kidFriendly.score)]);
+	}
+	if (updatedAt !== undefined) {
+		tags.push(['updated_at', String(updatedAt)]);
+	}
+
+	// NIP-32 self-labels (Phase 2). Emit L once when any l is present.
+	if (labels && labels.length > 0) {
+		tags.push(['L', NOURISH_LABEL_NAMESPACE]);
+		for (const label of labels) {
+			tags.push(['l', label, NOURISH_LABEL_NAMESPACE]);
+		}
+	}
+
+	const content: Record<string, unknown> = {
+		gut: scores.gut,
+		protein: scores.protein,
+		realFood: scores.realFood,
+		antiInflammatory: scores.antiInflammatory,
+		bloodSugar: scores.bloodSugar,
+		immuneSupportive: scores.immuneSupportive,
+		brainHealth: scores.brainHealth,
+		heartHealth: scores.heartHealth,
+		overall: scores.overall,
+		summary: scores.summary,
+		improvements,
+		ingredient_signals: ingredientSignals,
+		cacheVersion: scores.cacheVersion,
+		...(audienceScores ? { audience: audienceScores } : {}),
+		// Macros — additive sibling. Absent when engine degraded to omitted.
+		...(macros ? { macros } : {}),
+		// Labels mirrored into content for self-describing payloads
+		// (tags are the indexed discovery surface).
+		...(labels && labels.length > 0 ? { labels } : {}),
+		promptVersion: NOURISH_PROMPT_VERSION,
+		contentHash,
+		createdAt,
+		...(updatedAt !== undefined ? { updatedAt } : {})
+	};
+
+	return { tags, content };
 }
 
 /**
  * Publish an event to a single relay via raw WebSocket.
- * Returns true if the relay accepted the event.
+ * When `privKeyBytes` is set, completes a NIP-42 AUTH handshake if the
+ * relay challenges (pantry) or returns auth-required on EVENT.
  */
-function publishToRelay(relayUrl: string, event: any): Promise<boolean> {
-  return new Promise((resolve) => {
-    try {
-      const WebSocket = globalThis.WebSocket;
-      const ws = new WebSocket(relayUrl);
-      let settled = false;
+function publishToRelay(
+	relayUrl: string,
+	event: { id: string; [k: string]: unknown },
+	privKeyBytes?: Uint8Array
+): Promise<boolean> {
+	return new Promise((resolve) => {
+		try {
+			const WebSocket = globalThis.WebSocket;
+			const ws = new WebSocket(relayUrl);
+			let settled = false;
+			let challenge: string | null = null;
+			let authed = false;
+			let eventSent = false;
+			let authEventId: string | null = null;
+			let pendingAuthRetry = false;
 
-      const timer = setTimeout(() => {
-        if (!settled) { settled = true; ws.close(); resolve(false); }
-      }, PUBLISH_TIMEOUT_MS);
+			const finish = (ok: boolean) => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timer);
+				try {
+					ws.close();
+				} catch {
+					/* ignore */
+				}
+				resolve(ok);
+			};
 
-      ws.onopen = () => {
-        if (settled) return;
-        try {
-          ws.send(JSON.stringify(['EVENT', event]));
-        } catch {
-          if (!settled) { settled = true; clearTimeout(timer); ws.close(); resolve(false); }
-        }
-      };
+			const timer = setTimeout(() => finish(false), PUBLISH_TIMEOUT_MS);
 
-      ws.onmessage = (msg: MessageEvent) => {
-        try {
-          const data = JSON.parse(typeof msg.data === 'string' ? msg.data : '');
-          if (data[0] === 'OK') {
-            const accepted = data[2] === true;
-            if (!settled) { settled = true; clearTimeout(timer); ws.close(); resolve(accepted); }
-          }
-        } catch {}
-      };
+			const sendEvent = () => {
+				if (settled) return;
+				eventSent = true;
+				try {
+					ws.send(JSON.stringify(['EVENT', event]));
+				} catch {
+					finish(false);
+				}
+			};
 
-      ws.onerror = () => {
-        if (!settled) { settled = true; clearTimeout(timer); try { ws.close(); } catch {} resolve(false); }
-      };
+			const sendAuth = (chal: string) => {
+				if (!privKeyBytes || settled || authEventId) return;
+				try {
+					const authEvent = finalizeEvent(makeAuthEvent(relayUrl, chal), privKeyBytes);
+					authEventId = authEvent.id;
+					ws.send(JSON.stringify(['AUTH', authEvent]));
+				} catch {
+					finish(false);
+				}
+			};
 
-      ws.onclose = () => {
-        if (!settled) { settled = true; clearTimeout(timer); resolve(false); }
-      };
-    } catch {
-      resolve(false);
-    }
-  });
+			ws.onopen = () => {
+				if (settled) return;
+				if (relayUrl === PANTRY_RELAY && privKeyBytes) {
+					// Wait briefly for a proactive AUTH challenge; then send
+					// EVENT (auth-required path retries after AUTH OK).
+					setTimeout(() => {
+						if (settled) return;
+						if (challenge && !authed) sendAuth(challenge);
+						if (!eventSent) sendEvent();
+					}, 400);
+				} else {
+					sendEvent();
+				}
+			};
+
+			ws.onmessage = (msg: MessageEvent) => {
+				try {
+					const data = JSON.parse(typeof msg.data === 'string' ? msg.data : '');
+					if (!Array.isArray(data) || data.length < 2) return;
+
+					if (data[0] === 'AUTH' && typeof data[1] === 'string') {
+						challenge = data[1];
+						if (privKeyBytes && !authed) sendAuth(challenge);
+						return;
+					}
+
+					if (data[0] === 'OK') {
+						const okId = data[1];
+						const accepted = data[2] === true;
+						const reason = typeof data[3] === 'string' ? data[3] : '';
+
+						if (authEventId && okId === authEventId) {
+							if (!accepted) {
+								finish(false);
+								return;
+							}
+							authed = true;
+							if (pendingAuthRetry || !eventSent) {
+								pendingAuthRetry = false;
+								sendEvent();
+							}
+							return;
+						}
+
+						if (okId === event.id) {
+							if (accepted) {
+								finish(true);
+								return;
+							}
+							if (/auth-required/i.test(reason) && privKeyBytes) {
+								pendingAuthRetry = true;
+								eventSent = false;
+								if (challenge) sendAuth(challenge);
+								return;
+							}
+							finish(false);
+						}
+					}
+				} catch {
+					/* ignore malformed frames */
+				}
+			};
+
+			ws.onerror = () => finish(false);
+			ws.onclose = () => {
+				if (!settled) finish(false);
+			};
+		} catch {
+			resolve(false);
+		}
+	});
 }
 
 /**
@@ -90,124 +318,55 @@ function publishToRelay(relayUrl: string, event: any): Promise<boolean> {
  * emitted, so those events don't trigger the badge.
  */
 export async function publishNourishEvent(opts: {
-  privateKey: string;
-  recipePubkey: string;
-  recipeDTag: string;
-  contentHash: string;
-  scores: NourishScores;
-  improvements: string[];
-  ingredientSignals: IngredientSignal[];
-  /**
-   * Audience scores (v2 events). When present, emit `audience_*`
-   * tags and an `audience` key in the content JSON. Omitted on v1
-   * events — downstream parsers treat missing `audience` as "no
-   * data" distinct from "score 0."
-   */
-  audienceScores?: AudienceScores;
-  /**
-   * Unix seconds. When set, emit an `updated_at` tag (and content-JSON
-   * mirror) marking this event as a rescore rather than a first-time
-   * score. Undefined → no tag emitted.
-   */
-  updatedAt?: number;
+	privateKey: string;
+	recipePubkey: string;
+	recipeDTag: string;
+	contentHash: string;
+	scores: NourishScores;
+	improvements: string[];
+	ingredientSignals: IngredientSignal[];
+	audienceScores?: AudienceScores;
+	macros?: NourishMacros;
+	labels?: NourishLabel[];
+	updatedAt?: number;
 }): Promise<boolean> {
-  const {
-    privateKey,
-    recipePubkey,
-    recipeDTag,
-    contentHash,
-    scores,
-    improvements,
-    ingredientSignals,
-    audienceScores,
-    updatedAt
-  } = opts;
+	const { privateKey, ...input } = opts;
 
-  try {
-    const privKeyBytes = resolvePrivateKey(privateKey);
-    const dTag = buildNourishDTag(recipePubkey, recipeDTag);
-    const createdAt = Math.floor(Date.now() / 1000);
+	try {
+		const privKeyBytes = resolvePrivateKey(privateKey);
+		// Sanity: signed events must come from the service key callers expect.
+		void getPublicKey(privKeyBytes);
 
-    const tags: string[][] = [
-      ['d', dTag],
-      ['client', 'zap.cooking'],
-      ['a', `30023:${recipePubkey}:${recipeDTag}`],
-      ['p', recipePubkey],
-      ['nourish_version', NOURISH_CACHE_VERSION],
-      ['content_hash', contentHash],
-      ['prompt_version', NOURISH_PROMPT_VERSION],
-      ['nourish_overall', String(scores.overall.score)],
-      ['nourish_gut', String(scores.gut.score)],
-      ['nourish_protein', String(scores.protein.score)],
-      ['nourish_realfood', String(scores.realFood.score)],
-      // v2 Nourish dimensions — emitted on all events going forward.
-      // v1 events in the wild won't have them; parser defaults to 0.
-      ['nourish_antiinflammatory', String(scores.antiInflammatory.score)],
-      ['nourish_bloodsugar', String(scores.bloodSugar.score)],
-      ['nourish_immunesupportive', String(scores.immuneSupportive.score)],
-      ['nourish_brainhealth', String(scores.brainHealth.score)],
-      // v3 Nourish dimensions — heart health added in prompt v3.
-      // v1/v2 events lack this; parser defaults to 0 with no UI penalty
-      // because the rescore banner prompts a fresh compute.
-      ['nourish_hearthealth', String(scores.heartHealth.score)]
-    ];
-    // Audience tag prefix is distinct from nourish_* so future consumers
-    // can filter queries by namespace (e.g. only Nourish, only Audience,
-    // or both) without pulling one when they want the other.
-    if (audienceScores) {
-      tags.push(['audience_kidfriendly', String(audienceScores.kidFriendly.score)]);
-    }
-    if (updatedAt !== undefined) {
-      tags.push(['updated_at', String(updatedAt)]);
-    }
+		const { tags, content } = buildNourishEventParts(input);
+		const createdAt =
+			typeof content.createdAt === 'number'
+				? content.createdAt
+				: Math.floor(Date.now() / 1000);
 
-    // Build and sign event using nostr-tools (works on CF Workers)
-    const event = finalizeEvent({
-      kind: 30078,
-      created_at: createdAt,
-      tags,
-      content: JSON.stringify({
-        gut: scores.gut,
-        protein: scores.protein,
-        realFood: scores.realFood,
-        // v2 Nourish dimensions — flat at root (preserves v1 parse path).
-        antiInflammatory: scores.antiInflammatory,
-        bloodSugar: scores.bloodSugar,
-        immuneSupportive: scores.immuneSupportive,
-        brainHealth: scores.brainHealth,
-        // v3 Nourish dimension — heart health.
-        heartHealth: scores.heartHealth,
-        overall: scores.overall,
-        summary: scores.summary,
-        improvements,
-        ingredient_signals: ingredientSignals,
-        cacheVersion: scores.cacheVersion,
-        // Audience — new root key, present only on v2 events. Keeping
-        // it at the root (rather than restructuring Nourish fields
-        // under a `nourish` key) preserves backward-compat for the
-        // relay parser's existing flat-shape assumptions.
-        ...(audienceScores ? { audience: audienceScores } : {}),
-        // Mirror identity fields into content so the payload is self-
-        // describing (tags already carry them; content duplication lets
-        // downstream consumers read either location).
-        promptVersion: NOURISH_PROMPT_VERSION,
-        contentHash,
-        createdAt,
-        ...(updatedAt !== undefined ? { updatedAt } : {})
-      })
-    }, privKeyBytes);
+		const event = finalizeEvent(
+			{
+				kind: 30078,
+				created_at: createdAt,
+				tags,
+				content: JSON.stringify(content)
+			},
+			privKeyBytes
+		);
 
-    // Publish to all relays in parallel
-    const results = await Promise.all(
-      PUBLISH_RELAYS.map((relay) => publishToRelay(relay, event))
-    );
+		const results = await Promise.all(
+			PUBLISH_RELAYS.map((relay) => publishToRelay(relay, event, privKeyBytes))
+		);
 
-    const successCount = results.filter(Boolean).length;
-    console.log(`[Nourish Publisher] Published to ${successCount}/${PUBLISH_RELAYS.length} relays for ${recipeDTag}`);
+		const successCount = results.filter(Boolean).length;
+		console.log(
+			`[Nourish Publisher] Published to ${successCount}/${PUBLISH_RELAYS.length} relays for ${input.recipeDTag}`
+		);
 
-    return successCount > 0;
-  } catch (err) {
-    console.error('[Nourish Publisher] Failed:', err);
-    return false;
-  }
+		// Success if ANY relay accepted — public relays remain the primary
+		// store; pantry may fail if membership/AUTH isn't ready yet.
+		return successCount > 0;
+	} catch (err) {
+		console.error('[Nourish Publisher] Failed:', err);
+		return false;
+	}
 }

--- a/src/lib/nourish/types.ts
+++ b/src/lib/nourish/types.ts
@@ -178,6 +178,12 @@ export interface NourishMacros {
 }
 
 /**
+ * NIP-32 self-label namespace on kind-30078 Nourish events (Phase 2).
+ * Distinct from the user-flag namespace `cooking.zap.nourish-flag`.
+ */
+export const NOURISH_LABEL_NAMESPACE = 'cooking.zap.nourish';
+
+/**
  * NIP-32-style label values derived server-side from macros + ingredient
  * flags. Namespace on the event is `cooking.zap.nourish` (Phase 2).
  */

--- a/src/routes/api/admin/nourish/rescore/+server.ts
+++ b/src/routes/api/admin/nourish/rescore/+server.ts
@@ -37,6 +37,9 @@
  *     scores: NourishScores,
  *     improvements: string[],
  *     ingredient_signals: IngredientSignal[],
+ *     audience_scores?: AudienceScores,
+ *     macros?: NourishMacros,          // v4 — omitted when degraded
+ *     labels: NourishLabel[],          // v4 — may be empty
  *     promptVersion: string,
  *     contentHash: string,
  *     createdAt: number,
@@ -150,10 +153,13 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 				{ status: pipelineResult.status }
 			);
 		}
-		const { scores, improvements, ingredientSignals, audienceScores } = pipelineResult;
+		const { scores, improvements, ingredientSignals, audienceScores, macros, labels } =
+			pipelineResult;
 
 		// Publish the new pantry event with the `updated_at` tag that
-		// drives the 24h "Updated" badge on the client.
+		// drives the 24h "Updated" badge on the client. Macros + labels
+		// ride the same event (Phase 2) — shared engine is not enough;
+		// this endpoint must pass them through explicitly.
 		const NOTIFICATION_PRIVATE_KEY =
 			(platform?.env as any)?.NOTIFICATION_PRIVATE_KEY || env.NOTIFICATION_PRIVATE_KEY;
 		if (!NOTIFICATION_PRIVATE_KEY) {
@@ -176,10 +182,12 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 				improvements,
 				ingredientSignals,
 				audienceScores,
+				macros,
+				labels,
 				updatedAt
 			});
 			console.log(
-				`[Nourish Rescore] publish ${published ? 'succeeded' : 'failed'} for ${recipeDTag.trim()}`
+				`[Nourish Rescore] publish ${published ? 'succeeded' : 'failed'} for ${recipeDTag.trim()} macros=${macros ? 'yes' : 'omitted'} labels=${labels.length}`
 			);
 		} catch (err) {
 			console.error('[Nourish Rescore] publish error:', err);
@@ -203,6 +211,8 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 			improvements,
 			ingredient_signals: ingredientSignals,
 			audience_scores: audienceScores,
+			...(macros ? { macros } : {}),
+			labels,
 			promptVersion: NOURISH_PROMPT_VERSION,
 			contentHash: contentHash.trim(),
 			createdAt: updatedAt,

--- a/src/routes/api/nourish/+server.ts
+++ b/src/routes/api/nourish/+server.ts
@@ -113,7 +113,9 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 						scores,
 						improvements,
 						ingredientSignals: ingredient_signals,
-						audienceScores
+						audienceScores,
+						macros,
+						labels
 					});
 					console.log(`[Nourish] Publish ${published ? 'succeeded' : 'failed'} for ${recipeDTag}`);
 				} catch (err) {


### PR DESCRIPTION
## Summary
- Publish v4 `macros` (+ confidence) into kind-30078 content and NIP-32 `L`/`l` labels (`cooking.zap.nourish`); no raw `nourish_kcal` tag (0.5). Additive — v1/v2/v3 consumers unaffected; degraded-to-omitted macros publish with no macro tags.
- **Confidence gates threshold labels:** `rough` suppresses `protein:*` / `kcal:*` / `carbs:*` so filters never serve untrustworthy numbers; flag labels (`seedoil:free` etc.) still emit. Recorded in plan §3.
- Wire compute + admin rescore through to the publisher (proven in tests — shared engine alone is not enough). Pantry added to publish targets with NIP-42 AUTH; service pubkey registered as pantry member.

## Backfill census (0.8)
Corpus rescore of 55 events (52 scored, 3 errors). **Dry-run** — `NOTIFICATION_PRIVATE_KEY` not in local `.dev.vars`, so events were not published yet. Re-run with the key to publish from checkpoint, or use admin bulk rescore post-merge.

| class | count |
|-------|------:|
| estimate | 45 |
| rough | 7 |
| macros omitted | 0 |

| label | recipes |
|-------|--------:|
| `seedoil:free` | 41 |
| `redmeat:free` | 32 |
| `kcal:under800` | 31 |
| `addedsugar:free` | 27 |
| `kcal:under600` | 25 |
| `carbs:under40` | 23 |
| `protein:20plus` | 19 |
| `carbs:under20` | 16 |
| `protein:30plus` | 14 |
| `kcal:under400` | 13 |
| `protein:40plus` | 12 |

Filter inventory looks healthy for Phase 3b (`seedoil:free` alone is 41/52).

Publish when keyed:
```bash
NOTIFICATION_PRIVATE_KEY=... pnpm exec vitest run --config tmp/nourish-backfill/vitest.config.ts
```

## Test plan
- [x] Unit: label emission per bucket table, rough-suppresses-threshold, flags survive rough, additive event shape, rescore round-trip (`macros.test.ts`, `nourishPublisher.server.test.ts`)
- [ ] With `NOTIFICATION_PRIVATE_KEY`: re-run backfill to publish v4 events to nos.lol + pantry
- [ ] Spot-check one rescored event on nos.lol for `macros` content + `L`/`l` tags
- [ ] Confirm v3 event still parses in web/Android (no UI changes in this PR)


Made with [Cursor](https://cursor.com)