### PR TITLE
feat(nourish): Phase 3a — macros row on the Nourish card

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.632",
+  "version": "4.2.633",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.633",
+  "version": "4.2.634",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/nourish/NourishModal.svelte
+++ b/src/components/nourish/NourishModal.svelte
@@ -15,8 +15,9 @@
 	import { ingredientStore } from '$lib/nourish/ingredientStore';
 	import { computeContentHash, queryNourishEvent } from '$lib/nourish/nourishRelay';
 	import { resolveScore, purgeMemory, type ResolveResult } from '$lib/nourish/scoreResolver';
-	import type { NourishScores } from '$lib/nourish/types';
+	import type { NourishScores, NourishMacros } from '$lib/nourish/types';
 	import { NOURISH_PROMPT_VERSION } from '$lib/nourish/types';
+	import { parseMacrosBlock } from '$lib/nourish/macrosDisplay';
 	import type { FlagTarget } from '$lib/nourish/flagSubmit';
 	import { onMount, onDestroy } from 'svelte';
 	import NourishResult from './NourishResult.svelte';
@@ -40,6 +41,8 @@
 		: null;
 
 	let scores: NourishScores | null = null;
+	/** v4 macros — undefined on v3 / degraded; NourishResult omits the row. */
+	let macros: NourishMacros | undefined = undefined;
 	let improvements: string[] = [];
 	let loading = false;
 	let checking = false;
@@ -112,6 +115,7 @@
 		pantryTimeout = false;
 		attemptCount = 0;
 		fetched = false;
+		macros = undefined;
 		resolvedPromptVersion = NOURISH_PROMPT_VERSION;
 		resolvedUpdatedAt = undefined;
 	}
@@ -152,6 +156,7 @@
 
 		if (result.status === 'hit') {
 			scores = result.entry.scores;
+			macros = result.entry.macros;
 			improvements = [];
 			buildImprovements(result.entry.scores, result.entry.improvements);
 			analyzedAt = result.entry.createdAt;
@@ -237,6 +242,7 @@
 			if (!data.success) { error = data.error || 'Failed to analyze recipe.'; return; }
 
 			scores = data.scores;
+			macros = parseMacrosBlock(data.macros);
 			analyzedAt = data.createdAt ?? Math.floor(Date.now() / 1000);
 			resolvedPromptVersion = data.promptVersion ?? NOURISH_PROMPT_VERSION;
 			const writeKey = toCacheKey(recipePubkey, recipeDTag);
@@ -247,6 +253,7 @@
 					{
 						contentHash,
 						createdAt: data.createdAt,
+						macros,
 						improvements: data.improvements,
 						ingredientSignals: data.ingredient_signals
 					}
@@ -269,7 +276,7 @@
 		improvements = mergeImprovements(generateSuggestions(s), llm || []);
 	}
 
-	function retry() { scores = null; analyzeRecipe(); }
+	function retry() { scores = null; macros = undefined; analyzeRecipe(); }
 
 	// Refresh the stale banner's score without unconditionally burning
 	// an LLM call. Flow:
@@ -285,6 +292,7 @@
 	// Closes drift source #5 (refresh button unconditionally computes).
 	async function reanalyze() {
 		scores = null;
+		macros = undefined;
 		stale = false;
 
 		const { recipePubkey, recipeDTag } = getRecipeCoordinates();
@@ -306,6 +314,7 @@
 				// LLM call. Write-through so subsequent mounts skip the
 				// pantry query.
 				scores = pantry.result.scores;
+				macros = pantry.result.macros;
 				analyzedAt = pantry.result.createdAt;
 				resolvedPromptVersion = pantry.result.promptVersion;
 				resolvedUpdatedAt = pantry.result.updatedAt;
@@ -317,6 +326,7 @@
 						contentHash: pantry.result.contentHash,
 						createdAt: pantry.result.createdAt,
 						updatedAt: pantry.result.updatedAt,
+						macros: pantry.result.macros,
 						improvements: pantry.result.improvements,
 						ingredientSignals: pantry.result.ingredientSignals
 					}
@@ -416,6 +426,7 @@
 			// the user sees the card update in place, not disappear and
 			// come back.
 			scores = data.scores;
+			macros = parseMacrosBlock(data.macros);
 			analyzedAt = data.createdAt ?? Math.floor(Date.now() / 1000);
 			resolvedPromptVersion = data.promptVersion ?? NOURISH_PROMPT_VERSION;
 			// Rescore via /api/nourish doesn't carry the admin `updated_at`
@@ -433,6 +444,7 @@
 					{
 						contentHash,
 						createdAt: data.createdAt,
+						macros,
 						improvements: data.improvements,
 						ingredientSignals: data.ingredient_signals
 					}
@@ -515,6 +527,7 @@
 
 		<NourishResult
 			{scores}
+			{macros}
 			{improvements}
 			{flagTarget}
 			promptVersion={resolvedPromptVersion}

--- a/src/components/nourish/NourishResult.svelte
+++ b/src/components/nourish/NourishResult.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   /**
-   * NourishResult — strengths-focused result presentation (v3, 8 dims).
+   * NourishResult — strengths-focused result presentation (v3+, 8 dims).
    *
    * Shared between the /nourish page and the NourishModal on recipe pages.
    * Leads with what the food brings, never with what it lacks. The card is
@@ -8,7 +8,9 @@
    * warning (no amber, no red, no letter grade, no composite number).
    *
    * Prompt v3 added Heart-healthy as the 8th dimension and rebalanced the
-   * overall composite weights. Members see a rescore CTA via the
+   * overall composite weights. Prompt v4 adds an optional macros row
+   * (kcal / protein / carbs / fat per serving) — absent on v3 data so the
+   * card renders exactly as before. Members see a rescore CTA via the
    * `rescoreVariant` prop — 'upgrade' for out-of-version scores,
    * 'refresh' for current-version scores, null for non-members / contexts
    * without a persistent recipe.
@@ -19,10 +21,16 @@
   import ArrowUpIcon from 'phosphor-svelte/lib/ArrowUp';
   import SparkleIcon from 'phosphor-svelte/lib/Sparkle';
   import ArrowClockwiseIcon from 'phosphor-svelte/lib/ArrowClockwise';
-  import type { NourishScores, IngredientSignal } from '$lib/nourish/types';
+  import type { NourishScores, NourishMacros, IngredientSignal } from '$lib/nourish/types';
+  import { macrosRowView } from '$lib/nourish/macrosDisplay';
   import type { FlagTarget, NourishDimension } from '$lib/nourish/flagSubmit';
 
   export let scores: NourishScores;
+  /**
+   * Estimated per-serving macros (v4). Absent on v3 / degraded scores —
+   * the card renders exactly as today (no empty row, no placeholder).
+   */
+  export let macros: NourishMacros | undefined = undefined;
   export let quickTake: string = '';
   export let improvements: string[] = [];
   export let ingredientSignals: IngredientSignal[] = [];
@@ -202,6 +210,10 @@
 
   $: strengths = topStrengths(scores);
 
+  // Macros row — null when absent (v3 / degraded). Confidence + servings
+  // copy live in macrosDisplay so the states stay unit-testable.
+  $: macrosView = macrosRowView(macros);
+
   // ─── Upgrade dimension inference ───────────────────────────────────
   // Improvements come from the LLM as plain strings, untagged. Rather
   // than re-engineering the scoring prompt, we infer the target
@@ -310,6 +322,37 @@
             {tag}
           </span>
         {/each}
+      </div>
+    </div>
+  {/if}
+
+  <!-- Macros row (v4) — per-serving kcal / P / C / F. Absent block
+       (v3 or engine omit) skips this entirely — today's card exactly.
+       `rough` gets muted treatment; copy from macrosRowView. -->
+  {#if macrosView}
+    <div
+      class="nr-macros"
+      class:nr-macros-rough={macrosView.tone === 'rough'}
+      aria-label={macrosView.label}
+    >
+      <p class="nr-macros-label">{macrosView.label}</p>
+      <div class="nr-macros-figures">
+        <div class="nr-macro">
+          <span class="nr-macro-value">{macrosView.kcal}</span>
+          <span class="nr-macro-unit">kcal</span>
+        </div>
+        <div class="nr-macro">
+          <span class="nr-macro-value">{macrosView.protein_g}</span>
+          <span class="nr-macro-unit">g protein</span>
+        </div>
+        <div class="nr-macro">
+          <span class="nr-macro-value">{macrosView.carbs_g}</span>
+          <span class="nr-macro-unit">g carbs</span>
+        </div>
+        <div class="nr-macro">
+          <span class="nr-macro-value">{macrosView.fat_g}</span>
+          <span class="nr-macro-unit">g fat</span>
+        </div>
       </div>
     </div>
   {/if}
@@ -517,6 +560,63 @@
     background: rgba(34, 197, 94, 0.1);
     color: #22c55e;
     white-space: nowrap;
+  }
+
+  /* Macros row — compact four-figure strip. `rough` is muted/hedged so
+     the honesty label isn't just an asterisk on otherwise-confident
+     numbers (~13% of the corpus lands here). */
+  .nr-macros {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    padding: 0.45rem 0.15rem 0.15rem;
+  }
+  .nr-macros-label {
+    margin: 0;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-secondary);
+    opacity: 0.6;
+  }
+  .nr-macros-figures {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.35rem;
+  }
+  .nr-macro {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.05rem;
+    min-width: 0;
+  }
+  .nr-macro-value {
+    font-size: 0.95rem;
+    font-weight: 600;
+    line-height: 1.15;
+    color: var(--color-text-primary);
+    font-variant-numeric: tabular-nums;
+  }
+  .nr-macro-unit {
+    font-size: 0.625rem;
+    line-height: 1.2;
+    color: var(--color-text-secondary);
+    opacity: 0.75;
+  }
+  .nr-macros-rough {
+    opacity: 0.72;
+  }
+  .nr-macros-rough .nr-macros-label {
+    text-transform: none;
+    letter-spacing: 0.01em;
+    font-weight: 500;
+    font-style: italic;
+    opacity: 0.85;
+  }
+  .nr-macros-rough .nr-macro-value {
+    font-weight: 500;
   }
 
   /* 2-col tile grid — auto-rows so one expanded tile lets its row grow

--- a/src/lib/nourish/cache.ts
+++ b/src/lib/nourish/cache.ts
@@ -1,5 +1,10 @@
 import { browser } from '$app/environment';
-import { NOURISH_CACHE_VERSION, type NourishScores, type AudienceScores } from './types';
+import {
+	NOURISH_CACHE_VERSION,
+	type NourishScores,
+	type AudienceScores,
+	type NourishMacros
+} from './types';
 
 const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
@@ -38,6 +43,11 @@ interface CacheEntry {
 	 * call.
 	 */
 	audienceScores?: AudienceScores;
+	/**
+	 * Estimated per-serving macros (v4). Undefined on v3 / degraded
+	 * entries — Phase 3a card omits the macros row when absent.
+	 */
+	macros?: NourishMacros;
 	improvements?: string[];
 	ingredientSignals?: import('./types').IngredientSignal[];
 }
@@ -92,6 +102,7 @@ export function setNourishScores(
 		createdAt?: number;
 		updatedAt?: number;
 		audienceScores?: AudienceScores;
+		macros?: NourishMacros;
 		improvements?: string[];
 		ingredientSignals?: import('./types').IngredientSignal[];
 	}
@@ -108,6 +119,7 @@ export function setNourishScores(
 			createdAt: extra?.createdAt,
 			updatedAt: extra?.updatedAt,
 			audienceScores: extra?.audienceScores,
+			macros: extra?.macros,
 			improvements: extra?.improvements,
 			ingredientSignals: extra?.ingredientSignals
 		};

--- a/src/lib/nourish/index.ts
+++ b/src/lib/nourish/index.ts
@@ -37,3 +37,6 @@ export {
 	roundMacros,
 	macroDerivedKcal
 } from './macros';
+
+export { macrosRowView, parseMacrosBlock, honestFigures } from './macrosDisplay';
+export type { MacrosRowView, MacrosRowTone } from './macrosDisplay';

--- a/src/lib/nourish/macrosDisplay.test.ts
+++ b/src/lib/nourish/macrosDisplay.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Phase 3a — macros row render logic.
+ *
+ * Covers present / absent / rough / unparsed-servings / malformed states.
+ * Layout (muted rough treatment, row spacing) is not unit-testable here —
+ * eyeball those on device/browser: estimate row, rough row (~13% of
+ * corpus), and the unparsed-servings label length on a narrow card.
+ */
+import { describe, it, expect } from 'vitest';
+import { honestFigures, macrosRowView, parseMacrosBlock } from './macrosDisplay';
+import type { NourishMacros } from './types';
+
+const baseMacros = (over: Partial<NourishMacros> = {}): NourishMacros => ({
+	perServing: { kcal: 420, protein_g: 32, carbs_g: 28, fat_g: 18 },
+	servingsUsed: 4,
+	servingsParsed: true,
+	confidence: 'estimate',
+	method: 'llm-per100g-v1',
+	...over
+});
+
+describe('macrosRowView — present / absent', () => {
+	it('returns null when macros are absent (v3 / degraded) — no row', () => {
+		expect(macrosRowView(undefined)).toBeNull();
+		expect(macrosRowView(null)).toBeNull();
+	});
+
+	it('returns a view when macros are present', () => {
+		const view = macrosRowView(baseMacros());
+		expect(view).not.toBeNull();
+		expect(view!.kcal).toBe(420);
+		expect(view!.protein_g).toBe(32);
+		expect(view!.carbs_g).toBe(28);
+		expect(view!.fat_g).toBe(18);
+		expect(view!.label).toBe('Estimated per serving');
+		expect(view!.tone).toBe('estimate');
+	});
+});
+
+describe('macrosRowView — confidence copy', () => {
+	it('estimate → "Estimated per serving"', () => {
+		const view = macrosRowView(baseMacros({ confidence: 'estimate' }));
+		expect(view!.label).toBe('Estimated per serving');
+		expect(view!.tone).toBe('estimate');
+	});
+
+	it('rough → "Rough estimate" with rough tone (honesty framing)', () => {
+		// Breaded+fried / bone-in: as-written diverges from as-consumed —
+		// we'd rather tell you than guess (discovery rough-class rationale).
+		const view = macrosRowView(baseMacros({ confidence: 'rough' }));
+		expect(view!.label).toBe('Rough estimate');
+		expect(view!.tone).toBe('rough');
+	});
+});
+
+describe('macrosRowView — servingsParsed: false (0.4)', () => {
+	it('estimate + unparsed → discloses assumed servings', () => {
+		const view = macrosRowView(
+			baseMacros({ servingsParsed: false, servingsUsed: 4 })
+		);
+		expect(view!.label).toBe('Estimated per serving (servings assumed: 4)');
+		expect(view!.tone).toBe('estimate');
+	});
+
+	it('rough + unparsed → Rough estimate + assumed servings', () => {
+		const view = macrosRowView(
+			baseMacros({
+				confidence: 'rough',
+				servingsParsed: false,
+				servingsUsed: 4
+			})
+		);
+		expect(view!.label).toBe('Rough estimate (servings assumed: 4)');
+		expect(view!.tone).toBe('rough');
+	});
+});
+
+describe('honestFigures — no false precision', () => {
+	it('coerces to whole numbers; never emits decimals', () => {
+		const figs = honestFigures({
+			kcal: 420.4,
+			protein_g: 32.7,
+			carbs_g: 28.2,
+			fat_g: 18.9
+		});
+		expect(figs).toEqual({
+			kcal: 420,
+			protein_g: 33,
+			carbs_g: 28,
+			fat_g: 19
+		});
+		for (const n of Object.values(figs)) {
+			expect(Number.isInteger(n)).toBe(true);
+		}
+	});
+
+	it('does not re-round kcal to a finer precision than the server', () => {
+		// Server already rounded to nearest 10; UI must not invent .0 or
+		// locale-formatted decimals that look more precise.
+		const figs = honestFigures({
+			kcal: 420,
+			protein_g: 32,
+			carbs_g: 28,
+			fat_g: 18
+		});
+		expect(String(figs.kcal)).toBe('420');
+		expect(String(figs.protein_g)).toBe('32');
+	});
+});
+
+describe('parseMacrosBlock — degrade to absent on garbage', () => {
+	it('accepts a well-formed v4 block', () => {
+		const parsed = parseMacrosBlock(baseMacros());
+		expect(parsed).toEqual(baseMacros());
+	});
+
+	it('returns undefined for missing / non-object / incomplete perServing', () => {
+		expect(parseMacrosBlock(undefined)).toBeUndefined();
+		expect(parseMacrosBlock(null)).toBeUndefined();
+		expect(parseMacrosBlock('nope')).toBeUndefined();
+		expect(parseMacrosBlock({ perServing: { kcal: 100 } })).toBeUndefined();
+	});
+
+	it('returns undefined for invalid confidence or servingsParsed', () => {
+		expect(
+			parseMacrosBlock({
+				...baseMacros(),
+				confidence: 'high'
+			})
+		).toBeUndefined();
+		expect(
+			parseMacrosBlock({
+				...baseMacros(),
+				servingsParsed: 'yes'
+			})
+		).toBeUndefined();
+	});
+
+	it('accepts rough confidence', () => {
+		const parsed = parseMacrosBlock(baseMacros({ confidence: 'rough' }));
+		expect(parsed?.confidence).toBe('rough');
+	});
+});
+
+describe('eyeball checklist (not automated)', () => {
+	it('documents layout states that need a device/browser pass', () => {
+		// These are intentional documentation assertions — layout isn't
+		// unit-testable without a Svelte harness.
+		const states = [
+			'estimate row — normal weight, four figures aligned',
+			'rough row — muted/hedged treatment (~13% of corpus)',
+			'unparsed-servings label — wraps cleanly on narrow modal',
+			'absent macros — card identical to pre-3a (no empty row)'
+		];
+		expect(states).toHaveLength(4);
+	});
+});

--- a/src/lib/nourish/macrosDisplay.ts
+++ b/src/lib/nourish/macrosDisplay.ts
@@ -1,0 +1,128 @@
+/**
+ * Macros row display helpers (Phase 3a).
+ *
+ * Pure render logic for the Nourish card macros row — label copy,
+ * confidence tone, and honest-precision figure formatting. Kept out of
+ * the Svelte component so the present / absent / rough / unparsed-
+ * servings states are unit-testable (this repo has no Svelte component
+ * harness — see vitest.config.ts / cheffyLauncherRelocation.test.ts).
+ *
+ * Layout (spacing, muted visual weight on `rough`) is not unit-testable;
+ * those states need a device/browser eyeball.
+ */
+
+import type { NourishMacroPerServing, NourishMacros } from './types';
+
+/** Visual treatment for the row — `rough` is muted/hedged in the card. */
+export type MacrosRowTone = 'estimate' | 'rough';
+
+/**
+ * Resolved view model for the macros row. `null` means "do not render"
+ * (v3 event, degraded omit, or malformed block) — today's card exactly.
+ */
+export interface MacrosRowView {
+	label: string;
+	tone: MacrosRowTone;
+	/** Whole numbers only — never decimals. */
+	kcal: number;
+	protein_g: number;
+	carbs_g: number;
+	fat_g: number;
+}
+
+/**
+ * Lenient parse of a pantry/API macros block. Returns undefined when the
+ * shape is unusable so the UI degrades to "no row" rather than shipping
+ * garbage figures. Does not re-round beyond integer display coercion —
+ * server already applied honest rounding.
+ */
+export function parseMacrosBlock(raw: unknown): NourishMacros | undefined {
+	if (!raw || typeof raw !== 'object') return undefined;
+	const m = raw as Record<string, unknown>;
+	const ps = m.perServing;
+	if (!ps || typeof ps !== 'object') return undefined;
+	const p = ps as Record<string, unknown>;
+
+	const kcal = asNonNegNumber(p.kcal);
+	const protein_g = asNonNegNumber(p.protein_g);
+	const carbs_g = asNonNegNumber(p.carbs_g);
+	const fat_g = asNonNegNumber(p.fat_g);
+	if (kcal === null || protein_g === null || carbs_g === null || fat_g === null) {
+		return undefined;
+	}
+
+	const servingsUsed = asPositiveNumber(m.servingsUsed);
+	if (servingsUsed === null) return undefined;
+	if (typeof m.servingsParsed !== 'boolean') return undefined;
+
+	const confidence = m.confidence;
+	if (confidence !== 'estimate' && confidence !== 'rough') return undefined;
+
+	const method = m.method === 'llm-per100g-v1' ? m.method : 'llm-per100g-v1';
+
+	return {
+		perServing: { kcal, protein_g, carbs_g, fat_g },
+		servingsUsed,
+		servingsParsed: m.servingsParsed,
+		confidence,
+		method
+	};
+}
+
+/**
+ * Build the macros row view, or `null` when the block is absent/unusable.
+ *
+ * Label discipline (plan §3a + discovery §0.4 + rough-class honesty):
+ *   - estimate + parsed → "Estimated per serving"
+ *   - rough + parsed → "Rough estimate"
+ *   - servingsParsed false → append "(servings assumed: N)" — never silent
+ *     about the fallback (N is servingsUsed, always 4 from the engine today)
+ */
+export function macrosRowView(
+	macros: NourishMacros | null | undefined
+): MacrosRowView | null {
+	if (!macros?.perServing) return null;
+
+	const figures = honestFigures(macros.perServing);
+	const tone: MacrosRowTone = macros.confidence === 'rough' ? 'rough' : 'estimate';
+	const base = tone === 'rough' ? 'Rough estimate' : 'Estimated per serving';
+	const label =
+		macros.servingsParsed === false
+			? `${base} (servings assumed: ${macros.servingsUsed})`
+			: base;
+
+	return {
+		label,
+		tone,
+		...figures
+	};
+}
+
+/**
+ * Honest precision at the render boundary: whole numbers only.
+ * kcal is already rounded to 10s server-side — we never reformat to look
+ * more precise (no decimals, no false trailing zeros).
+ */
+export function honestFigures(per: NourishMacroPerServing): {
+	kcal: number;
+	protein_g: number;
+	carbs_g: number;
+	fat_g: number;
+} {
+	return {
+		kcal: Math.round(per.kcal),
+		protein_g: Math.round(per.protein_g),
+		carbs_g: Math.round(per.carbs_g),
+		fat_g: Math.round(per.fat_g)
+	};
+}
+
+function asNonNegNumber(v: unknown): number | null {
+	if (typeof v !== 'number' || !Number.isFinite(v) || v < 0) return null;
+	return v;
+}
+
+function asPositiveNumber(v: unknown): number | null {
+	if (typeof v !== 'number' || !Number.isFinite(v) || v <= 0) return null;
+	return v;
+}

--- a/src/lib/nourish/nourishPublisher.server.test.ts
+++ b/src/lib/nourish/nourishPublisher.server.test.ts
@@ -309,7 +309,10 @@ describe('rescore round-trip — macros + labels reach the publisher', () => {
 			body: JSON.stringify(body)
 		});
 
-		const response = await POST({ request, platform: { env: {} } as any });
+		const response = await POST({
+			request,
+			platform: { env: {} }
+		} as any);
 		expect(response.status).toBe(200);
 		const json = await response.json();
 		expect(json.macros.confidence).toBe('rough');

--- a/src/lib/nourish/nourishPublisher.server.ts
+++ b/src/lib/nourish/nourishPublisher.server.ts
@@ -187,7 +187,9 @@ export function buildNourishEventParts(input: NourishPublishInput): NourishEvent
  */
 function publishToRelay(
 	relayUrl: string,
-	event: { id: string; [k: string]: unknown },
+	// `finalizeEvent` returns VerifiedEvent (no string index signature) —
+	// only `id` is read; the full object is JSON-serialized for EVENT.
+	event: { id: string },
 	privKeyBytes?: Uint8Array
 ): Promise<boolean> {
 	return new Promise((resolve) => {

--- a/src/lib/nourish/nourishRelay.ts
+++ b/src/lib/nourish/nourishRelay.ts
@@ -18,6 +18,7 @@ import {
   type NourishRelayResult,
   type IngredientSignal
 } from './types';
+import { parseMacrosBlock } from './macrosDisplay';
 export type { NourishRelayResult } from './types';
 
 const PANTRY_RELAY = 'wss://pantry.zap.cooking';
@@ -266,6 +267,10 @@ export function parseNourishEvent(event: NDKEvent): NourishRelayResult | null {
       ? content.ingredient_signals.filter((i: any) => i && typeof i.name === 'string')
       : [];
 
+    // Macros (v4) — additive. v3 events and degrade-to-omitted payloads
+    // leave this undefined so the card renders exactly as today.
+    const macros = parseMacrosBlock(content.macros);
+
     // Extract metadata from tags. Untagged legacy events surface as
     // 'unknown' so the admin rescore-candidates view can triage them,
     // rather than being silently mislabelled as v1.
@@ -288,6 +293,7 @@ export function parseNourishEvent(event: NDKEvent): NourishRelayResult | null {
       improvements,
       ingredientSignals,
       audienceScores,
+      ...(macros ? { macros } : {}),
       contentHash,
       promptVersion,
       nourishVersion,

--- a/src/lib/nourish/scoreResolver.ts
+++ b/src/lib/nourish/scoreResolver.ts
@@ -28,7 +28,12 @@
 import type NDK from '@nostr-dev-kit/ndk';
 import { getNourishCache, setNourishScores, type NourishCacheKey } from './cache';
 import { queryNourishEvent } from './nourishRelay';
-import type { AudienceScores, NourishScores, IngredientSignal } from './types';
+import type {
+  AudienceScores,
+  NourishScores,
+  NourishMacros,
+  IngredientSignal
+} from './types';
 
 // ─── Public types ────────────────────────────────────────────
 
@@ -47,6 +52,11 @@ export interface ResolvedEntry {
    * expansion). Background mode — no UI consumer reads this yet.
    */
   audienceScores?: AudienceScores;
+  /**
+   * Estimated per-serving macros (v4). Undefined on v3 / degraded
+   * entries — Phase 3a card omits the row when absent.
+   */
+  macros?: NourishMacros;
   improvements?: string[];
   ingredientSignals?: IngredientSignal[];
   promptVersion: string;
@@ -247,6 +257,7 @@ function writeThrough(requestedKey: NourishCacheKey, winner: Candidate): void {
       createdAt: winner.entry.createdAt,
       updatedAt: winner.entry.updatedAt,
       audienceScores: winner.entry.audienceScores,
+      macros: winner.entry.macros,
       improvements: winner.entry.improvements,
       ingredientSignals: winner.entry.ingredientSignals
     });
@@ -266,6 +277,7 @@ function l3EntryToResolved(
     createdAt: l3.createdAt ?? Math.floor(l3.timestamp / 1000),
     updatedAt: l3.updatedAt,
     audienceScores: l3.audienceScores,
+    macros: l3.macros,
     improvements: l3.improvements,
     ingredientSignals: l3.ingredientSignals,
     // Prefer the entry's stored promptVersion over the caller's hint.
@@ -342,6 +354,7 @@ async function doResolve(ndk: NDK, key: NourishCacheKey): Promise<ResolveResult>
         createdAt: l4.result.createdAt,
         updatedAt: l4.result.updatedAt,
         audienceScores: l4.result.audienceScores,
+        macros: l4.result.macros,
         improvements: l4.result.improvements,
         ingredientSignals: l4.result.ingredientSignals,
         promptVersion: l4.result.promptVersion

--- a/src/lib/nourish/types.ts
+++ b/src/lib/nourish/types.ts
@@ -23,6 +23,11 @@ export interface NourishRelayResult {
    * no UI renders this yet; PR 3 Phase 2 #1d decision).
    */
   audienceScores?: AudienceScores;
+  /**
+   * Estimated per-serving macros (prompt v4). Undefined on v3 events and
+   * when the engine degraded to omitted. Surfaced by Phase 3a UI.
+   */
+  macros?: NourishMacros;
   contentHash: string;
   promptVersion: string;
   nourishVersion: string;


### PR DESCRIPTION
## Summary
- Adds a per-serving macros row (kcal / protein / carbs / fat) to `NourishResult`, plumbed from pantry parse → cache/resolver → modal.
- Confidence is a first-class design state: **Estimated per serving** vs muted **Rough estimate**; `servingsParsed: false` discloses `(servings assumed: N)`.
- Absent/malformed macros (v3 or engine omit) leave today's card unchanged — no empty row or placeholder. UI-only; no engine, publisher, or discovery changes.

## Test plan
- [ ] Unit: `npx vitest run src/lib/nourish/macrosDisplay.test.ts` (present / absent / rough / unparsed / honest precision / malformed)
- [ ] Open a v3 (no macros) recipe Nourish card — identical to pre-3a
- [ ] Open a v4 `estimate` recipe — row shows "Estimated per serving" + four whole-number figures
- [ ] Open a v4 `rough` recipe (~13% of corpus, e.g. breaded+fried or bone-in) — "Rough estimate" with muted treatment
- [ ] Unparsed servings path — label includes `(servings assumed: 4)`
- [ ] **Eyeball (layout not unit-testable):** estimate vs rough visual weight; long unparsed label on narrow modal; no empty gap when macros absent


Made with [Cursor](https://cursor.com)