### PR TITLE
feat(relays): publish recipes to pantry.zap.cooking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.638",
+  "version": "4.2.639",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/publishQueue.ts
+++ b/src/lib/publishQueue.ts
@@ -31,7 +31,19 @@ const STALE_ITEM_AGE = 30 * 60 * 1000; // 30 minutes - auto-cleanup stale items
 // NIP-65 inbox routing — shared helper handles the kind:10002 lookup
 // + capping. See $lib/nip65Routing for the algorithm details.
 import { unionInboxRelayUrls } from '$lib/nip65Routing';
+import { normalizeRelayUrl } from '$lib/relayListCache';
 import { PANTRY_RELAY_URL } from '$lib/nostr';
+
+/**
+ * Kinds mirrored to pantry.zap.cooking on every `'all'`-mode publish.
+ *
+ * Only kind 30023: pantry's write policy exempts KindRecipe (30023) from
+ * NIP-42 auth, so unauthed publishes land. Kind 35000 (gated/premium)
+ * falls through to auth + membership gates and would be silently rejected
+ * for most users — follow-up once authed 35000 writes + client auth during
+ * publish are confirmed. Dashboard recipe count is 30023-only anyway.
+ */
+const PANTRY_MIRROR_KINDS = new Set([30023]);
 
 /**
  * Represents a pending publish operation
@@ -472,6 +484,8 @@ class PublishQueueManager {
    *
    * Relay set construction:
    *   1. Base URLs from `relayMode` (pantry / all)
+   *   1b. For kind:30023 on `'all'` mode, union pantry.zap.cooking so the
+   *       live recipe-count dashboard stays current (see PANTRY_MIRROR_KINDS)
    *   2. NIP-65 augmentation: for every non-self pubkey in the event's `p`
    *      tags, add their published *read* (inbox) relays. This is what
    *      makes replies / mentions / reactions / zaps reach the recipient.
@@ -510,7 +524,22 @@ class PublishQueueManager {
     console.log(`[PublishQueue] Event ID: ${event.id}`);
 
     // 1. Base URLs from relay mode (user's intent takes precedence).
-    const baseUrls = this.getBaseRelayUrls(relayMode, ndkInstance);
+    let baseUrls = this.getBaseRelayUrls(relayMode, ndkInstance);
+
+    // 1b. Mirror kind:30023 recipes to pantry so the live recipe-count
+    //     dashboard stays current. Pool usually omits pantry (it is not
+    //     in standardRelays). Dedup both sides via normalizeRelayUrl so
+    //     trailing-slash / casing variants don't double-add.
+    if (
+      relayMode === 'all' &&
+      event.kind != null &&
+      PANTRY_MIRROR_KINDS.has(event.kind)
+    ) {
+      const pantryKey = normalizeRelayUrl(PANTRY_RELAY_URL);
+      if (!baseUrls.some((u) => normalizeRelayUrl(u) === pantryKey)) {
+        baseUrls = [...baseUrls, PANTRY_RELAY_URL];
+      }
+    }
 
     // 2. Union with NIP-65 recipient inbox relays. Capped at the helper's
     //    MAX_PUBLISH_RELAYS so a heavily p-tagged post stays bounded.

--- a/src/routes/souschef/+page.svelte
+++ b/src/routes/souschef/+page.svelte
@@ -11,6 +11,7 @@
   import { recipeTags, RECIPE_TAG_PREFIX_NEW, type recipeTagSimple } from '$lib/consts';
   import { createMarkdown, validateMarkdownTemplate } from '$lib/parser';
   import { addClientTagToEvent } from '$lib/nip89';
+  import { publishQueue } from '$lib/publishQueue';
   import { nip19 } from 'nostr-tools';
   import {
     ANON_IMPORT_HANDOFF_KEY,
@@ -71,6 +72,7 @@
   // Publishing state
   let isPublishing = false;
   let publishError = '';
+  let publishInfo = '';
 
   // Extraction state
   let isExtracting = false;
@@ -514,6 +516,7 @@
 
     isPublishing = true;
     publishError = '';
+    publishInfo = '';
 
     try {
       // Format ingredients/directions into markdown strings
@@ -571,22 +574,35 @@
 
       addClientTagToEvent(event);
 
-      // Publish with timeout
-      let publishTimeoutId: ReturnType<typeof setTimeout> | undefined;
-      const publishTimeout: Promise<never> = new Promise((_, reject) => {
-        publishTimeoutId = setTimeout(
-          () => reject(new Error('Publish timed out after 15 seconds')),
-          15000
-        );
-      });
-      await Promise.race([event.publish(), publishTimeout]);
-      if (publishTimeoutId !== undefined) {
-        clearTimeout(publishTimeoutId);
+      // Publish via publishQueue (same path as /create).
+      //
+      // Deliberate behavior change vs bare event.publish(): NDK's outbox
+      // model routes writes to the author's NIP-65 write relays. The queue
+      // fans out to the pool (+ pantry for kind 30023) and persists an
+      // IndexedDB retry if relays flake — more reliable for imports.
+      const publishResult = await publishQueue.publishWithRetry(event, 'all');
+      if (!publishResult.success && !publishResult.queued) {
+        throw new Error(publishResult.error || 'Publish failed');
+      }
+
+      // Queued for retry — surface honestly and stay put. The recipe may
+      // not be fetchable yet (same honesty as /create's queued message;
+      // we skip redirect so /recipe/<naddr> doesn't 404).
+      if (publishResult.queued) {
+        publishInfo =
+          'Publish queued. Your recipe will be published as soon as relays are reachable.';
+        isPublishing = false;
+        return;
+      }
+
+      const recipePubkey = event.pubkey || $userPublickey;
+      if (!recipePubkey) {
+        throw new Error('Unable to determine author pubkey for recipe address');
       }
 
       const naddr = nip19.naddrEncode({
         identifier: title.toLowerCase().replaceAll(' ', '-'),
-        pubkey: event.pubkey,
+        pubkey: recipePubkey,
         kind: 30023
       });
 
@@ -895,6 +911,13 @@
             <div class="flex items-start gap-3 p-4 rounded-xl bg-red-500/10 border border-red-500/20">
               <WarningIcon size={20} class="text-red-500 flex-shrink-0 mt-0.5" />
               <p class="text-sm text-red-500">{publishError}</p>
+            </div>
+          {/if}
+
+          {#if publishInfo}
+            <div class="flex items-start gap-3 p-4 rounded-xl bg-green-500/10 border border-green-500/20">
+              <CheckCircleIcon size={20} class="text-green-500 flex-shrink-0 mt-0.5" />
+              <p class="text-sm text-green-600 dark:text-green-400">{publishInfo}</p>
             </div>
           {/if}
 


### PR DESCRIPTION
## Summary
- Live recipe-count dashboard on pantry drifts stale because create/edit/import never wrote kind 30023 to `wss://pantry.zap.cooking` (pool is seeded from `standardRelays`, which omits pantry).
- `publishQueue` `'all'` mode now unions pantry into base URLs for **kind 30023 only** (`PANTRY_MIRROR_KINDS`), after `getBaseRelayUrls` and before the NIP-65 inbox union. Covers create, edit, and fork without widening general read traffic.
- Sous Chef switched from bare `event.publish()` (NIP-65 outbox + timeout race) to `publishQueue.publishWithRetry(event, 'all')`, including honest queued-state handling. This is a deliberate behavior change that makes imports more reliable (pool fan-out + IndexedDB retry vs outbox-only publish).

## What was deliberately not changed
- **`standardRelays`** — adding pantry there would hit general reads, backups, counts, settings defaults, etc. Kind-gated publish-path union is the narrow fix.
- **`articleOutbox`**, **`RELAY_SETS`**, Nourish, membership, wallet paths.

## Kind 35000 follow-up
Pantry's write policy exempts only kind 30023 from NIP-42 auth (`KindRecipe` in `rejectEventPolicy`). Kind 35000 falls through to auth + membership gates, so unauthed gated-recipe mirrors would be silently rejected. Gated-recipes-on-pantry needs a separate change (confirm authed 35000 writes + client auth during publish). Dashboard counts 30023 only.

## Failure semantics
Unchanged: publish succeeds when ≥1 relay confirms (`publishedRelays.size`). Pantry being down does not block a successful multi-relay publish.

## Test plan
- [ ] Publish a free (kind 30023) recipe from `/create` on staging/prod
- [ ] Confirm Pantry Admin recipe count ticks up by 1 (e.g. 483 → 484)
- [ ] Optionally REQ `wss://pantry.zap.cooking` for the event id / pubkey + kind 30023
- [ ] Publish via Sous Chef import and confirm it lands on pantry the same way
- [ ] (Optional) Confirm a gated 35000 publish does **not** attempt to rely on pantry landing


Made with [Cursor](https://cursor.com)