### PR TITLE
My Kitchen Phase 0 PR2: display-string rename

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.641",
+  "version": "4.2.642",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/DesktopSideNav.svelte
+++ b/src/components/DesktopSideNav.svelte
@@ -98,7 +98,7 @@
   const kitchen: NavItem[] = [
     {
       href: '/my-kitchen',
-      label: 'Cookbook',
+      label: 'My Kitchen',
       icon: CookbookIcon,
       match: (p) => p.startsWith('/my-kitchen')
     },

--- a/src/components/MobileNavDrawer.svelte
+++ b/src/components/MobileNavDrawer.svelte
@@ -49,7 +49,7 @@
   ];
 
   const kitchenItems: NavItem[] = [
-    { href: '/my-kitchen', label: 'Cookbook', icon: CookbookIcon, match: (p) => p.startsWith('/my-kitchen') },
+    { href: '/my-kitchen', label: 'My Kitchen', icon: CookbookIcon, match: (p) => p.startsWith('/my-kitchen') },
     { href: '/grocery', label: 'Grocery Lists', icon: ShoppingCartIcon, match: (p) => p.startsWith('/grocery') },
     { href: '/wallet', label: 'Wallet', icon: WalletIcon, match: () => $walletModalOpen, badge: 'wallet' },
     { href: '/nourish', label: 'Nourish', icon: LeafIcon, match: (p) => p.startsWith('/nourish') },

--- a/src/components/SaveButton.svelte
+++ b/src/components/SaveButton.svelte
@@ -395,7 +395,7 @@
       disabled={loading}
       class="flex items-center justify-center rounded-full transition duration-200 touch-none select-none {sizeClasses} {variantClasses} {showText ? 'px-4 gap-2' : ''}"
       aria-label={isSaved ? 'Recipe saved' : 'Save recipe'}
-      title={isSaved ? 'Recipe saved (hold for options)' : 'Save to cookbook (hold for options)'}
+      title={isSaved ? 'Recipe saved (hold for options)' : 'Save to My Kitchen (hold for options)'}
     >
       {#if loading}
         <div class="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin"></div>

--- a/src/components/UserSidePanel.svelte
+++ b/src/components/UserSidePanel.svelte
@@ -315,7 +315,7 @@
               style="color: var(--color-text-primary);"
             >
               <CookbookIcon size={22} />
-              <span class="font-medium">Cookbook</span>
+              <span class="font-medium">My Kitchen</span>
             </button>
           </li>
           <li>

--- a/src/routes/my-kitchen/+page.svelte
+++ b/src/routes/my-kitchen/+page.svelte
@@ -70,7 +70,7 @@
     if (totalUniqueSaved === 0) return;
     sharePackSource = { type: 'cookbook' };
     sharePackATags = aggregatedRecipes.map((r) => r.aTag);
-    sharePackTitle = 'My Zap Cooking Cookbook';
+    sharePackTitle = 'My Zap Cooking Kitchen';
     sharePackDescription = '';
     sharePackImage = savedCollection ? coverImages.get(savedCollection.id) : undefined;
     sharePackOpen = true;
@@ -835,7 +835,7 @@
 </script>
 
 <svelte:head>
-  <title>My Cookbook - zap.cooking</title>
+  <title>My Kitchen - zap.cooking</title>
   <meta name="description" content="Your saved recipes and collections on zap.cooking" />
 </svelte:head>
 
@@ -982,7 +982,7 @@
   {#if selectedList}
     {#await loadRecipeEvents(selectedList) then recipeEvents}
       <div class="flex flex-col gap-4">
-        <p class="text-sm text-caption">Select a recipe to use as your cookbook cover</p>
+        <p class="text-sm text-caption">Select a recipe to use as your collection cover</p>
 
         {#if recipeEvents.length === 0}
           <p class="text-caption text-center py-8">
@@ -1075,7 +1075,7 @@
         <div class="flex-1">
           <p class="text-sm font-medium" style="color: var(--color-text-primary)">You're offline</p>
           <p class="text-xs text-caption">
-            Your cookbooks are saved locally. Changes will sync when you're back online.
+            Your collections are saved locally. Changes will sync when you're back online.
           </p>
         </div>
       </div>
@@ -1088,7 +1088,7 @@
           <p class="text-sm font-medium" style="color: var(--color-text-primary)">
             Syncing changes...
           </p>
-          <p class="text-xs text-caption">Your cookbooks are being updated.</p>
+          <p class="text-xs text-caption">Your collections are being updated.</p>
         </div>
       </div>
     {:else if $cookbookSyncStatus === 'pending' && $cookbookPendingOps > 0}
@@ -1121,7 +1121,7 @@
           <BookmarkIcon size={24} weight="fill" class="text-white" />
         </div>
         <div>
-          <h1 class="text-2xl font-bold" style="color: var(--color-text-primary)">My Cookbook</h1>
+          <h1 class="text-2xl font-bold" style="color: var(--color-text-primary)">My Kitchen</h1>
           <p class="text-sm text-caption">Your saved recipes & collections</p>
         </div>
       </div>
@@ -1201,7 +1201,7 @@
             class="flex items-center gap-1.5 pl-4 pr-3 py-1.5 bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 text-white rounded-full font-medium transition-all text-sm"
             aria-haspopup="true"
             aria-expanded={createMenuOpen}
-            aria-label="Add to cookbook"
+            aria-label="Add to My Kitchen"
           >
             <PlusIcon size={18} weight="bold" />
             <span class="hidden sm:inline">Add</span>
@@ -1259,7 +1259,7 @@
           class="inline-flex p-0.5 rounded-full"
           style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
           role="tablist"
-          aria-label="Cookbook view"
+          aria-label="My Kitchen view"
         >
           <button
             type="button"
@@ -1307,10 +1307,10 @@
               class="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
               style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
               title="Share your saved recipes as a Recipe Pack"
-              aria-label="Share cookbook as Recipe Pack"
+              aria-label="Share My Kitchen as Recipe Pack"
             >
               <ShareNetworkIcon size={16} />
-              <span>Share Cookbook</span>
+              <span>Share My Kitchen</span>
             </button>
 
             <!-- Sort dropdown -->
@@ -1426,10 +1426,10 @@
           <BookmarkIcon size={40} weight="regular" class="text-orange-500" />
         </div>
         <h2 class="text-xl font-semibold mb-2" style="color: var(--color-text-primary)">
-          Start Your Cookbook
+          Start Your Kitchen
         </h2>
         <p class="text-caption text-center max-w-md mb-6">
-          Save recipes you love and organize them into collections. Your cookbook is private to you.
+          Save recipes you love and organize them into collections. Your kitchen is private to you.
         </p>
         <div class="flex gap-3">
           <button

--- a/src/routes/my-kitchen/[naddr]/+page.svelte
+++ b/src/routes/my-kitchen/[naddr]/+page.svelte
@@ -812,7 +812,7 @@
   
   <div class="flex flex-col gap-4">
     <p class="text-sm text-caption">
-      Select a recipe to use as your cookbook cover
+      Select a recipe to use as your collection cover
     </p>
     
     {#if events.length === 0}
@@ -913,7 +913,7 @@
       <a
         href="/my-kitchen"
         class="absolute top-4 left-4 w-10 h-10 flex items-center justify-center rounded-full bg-black/35 hover:bg-black/55 text-white transition-colors backdrop-blur-sm"
-        aria-label="Back to cookbook"
+        aria-label="Back to My Kitchen"
       >
         <ArrowLeftIcon size={20} weight="bold" />
       </a>
@@ -1070,7 +1070,7 @@
           You're offline
         </h3>
         <p class="text-caption text-center max-w-sm mb-4">
-          This cookbook has {cachedRecipeCount} {cachedRecipeCount === 1 ? 'recipe' : 'recipes'} saved, 
+          This collection has {cachedRecipeCount} {cachedRecipeCount === 1 ? 'recipe' : 'recipes'} saved, 
           but recipe details require an internet connection to view.
         </p>
         <p class="text-caption text-center text-sm">
@@ -1142,7 +1142,7 @@
       class="flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 text-white rounded-full font-medium transition-all"
     >
       <ArrowLeftIcon size={18} />
-      Back to Cookbook
+      Back to My Kitchen
     </a>
   </div>
 {/if}

--- a/src/routes/pack/[naddr]/+page.svelte
+++ b/src/routes/pack/[naddr]/+page.svelte
@@ -217,7 +217,7 @@
   async function importPack() {
     if (isImporting) return;
     if (!$userPublickey) {
-      showToast('info', 'Sign in to save this Recipe Pack to your cookbook.');
+      showToast('info', 'Sign in to save this Recipe Pack to My Kitchen.');
       goto('/login');
       return;
     }
@@ -237,7 +237,7 @@
       }
       const defaultList = await cookbookStore.ensureDefaultList();
       if (!defaultList) {
-        showToast('error', 'Could not access your cookbook. Try again.');
+        showToast('error', 'Could not access My Kitchen. Try again.');
         return;
       }
 
@@ -254,9 +254,9 @@
       const { added, skipped, failed } = result;
 
       if (added === 0 && skipped > 0) {
-        showToast('info', 'Already in your cookbook.');
+        showToast('info', 'Already in My Kitchen.');
       } else if (added > 0 && skipped === 0) {
-        showToast('success', `Added ${added} ${added === 1 ? 'recipe' : 'recipes'} to your cookbook.`);
+        showToast('success', `Added ${added} ${added === 1 ? 'recipe' : 'recipes'} to My Kitchen.`);
       } else if (added > 0 && skipped > 0) {
         showToast('success', `Added ${added}, skipped ${skipped} already saved.`);
       } else if (failed > 0) {
@@ -451,14 +451,14 @@
     </h1>
     <p class="text-caption text-center max-w-md mb-4">
       This pack may have been deleted, or your relays don't have it yet. Try again later, or browse
-      your cookbook.
+      My Kitchen.
     </p>
     <a
       href="/my-kitchen"
       class="flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 text-white rounded-full font-medium transition-all"
     >
       <ArrowLeftIcon size={18} />
-      Go to Cookbook
+      Go to My Kitchen
     </a>
   </div>
 {:else}
@@ -472,7 +472,7 @@
         class="inline-flex items-center gap-1.5 text-sm text-caption hover:text-primary transition-colors"
       >
         <ArrowLeftIcon size={16} />
-        <span>Cookbook</span>
+        <span>My Kitchen</span>
       </a>
     </div>
 
@@ -593,7 +593,7 @@
           style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
         >
           <BookmarkIcon size={16} />
-          Open your cookbook
+          Open My Kitchen
         </a>
         <!-- Delete (NIP-09 deletion request). Secondary destructive
              styling so the action is reachable but not the focal CTA;
@@ -614,7 +614,7 @@
           style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
         >
           <CheckCircleIcon size={16} weight="fill" class="text-green-500" />
-          Saved in your cookbook
+          Saved in My Kitchen
         </span>
       {:else}
         <button
@@ -627,7 +627,7 @@
             <span>Saving {importProgress.current}/{importProgress.total}…</span>
           {:else}
             <BookmarkIcon size={16} weight="fill" />
-            <span>Save Pack to Cookbook</span>
+            <span>Save Pack to My Kitchen</span>
           {/if}
         </button>
       {/if}

--- a/src/routes/packs/+page.svelte
+++ b/src/routes/packs/+page.svelte
@@ -547,7 +547,7 @@
         {tab === 'discover'
           ? "We couldn't find any Recipe Packs on the connected relays. Check back soon."
           : tab === 'mine'
-            ? 'Open a collection in your cookbook and tap "Share Pack" to publish your first one.'
+            ? 'Open a collection in My Kitchen and tap "Share Pack" to publish your first one.'
             : 'Tap the bookmark icon on a pack to save it here.'}
       </p>
       <a
@@ -555,7 +555,7 @@
         class="flex items-center px-4 py-2 rounded-full font-medium text-sm transition-colors"
         style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
       >
-        Open Cookbook
+        Open My Kitchen
       </a>
     </div>
   {:else}


### PR DESCRIPTION
Implements the display-string portion of **Phase 0.1** of [docs/my-kitchen-spec.md](https://github.com/zapcooking/frontend/blob/main/docs/my-kitchen-spec.md), per the Phase 0 investigation findings (Area 1, Bucket A). Copy only — zero logic changes, zero Bucket B changes. Follows PR1 (#536).

## Every string, old → new

### Nav
| File | Old | New |
|---|---|---|
| `DesktopSideNav.svelte` | `Cookbook` (label) | `My Kitchen` |
| `MobileNavDrawer.svelte` | `Cookbook` (label) | `My Kitchen` |
| `UserSidePanel.svelte` | `Cookbook` (link) | `My Kitchen` |

### `my-kitchen/+page.svelte`
| Old | New |
|---|---|
| `<title>My Cookbook - zap.cooking</title>` | `<title>My Kitchen - zap.cooking</title>` |
| H1 `My Cookbook` | `My Kitchen` |
| `My Zap Cooking Cookbook` (default share-pack title) | `My Zap Cooking Kitchen` |
| `Select a recipe to use as your cookbook cover` | `…your collection cover` |
| `Your cookbooks are saved locally. …` | `Your collections are saved locally. …` |
| `Your cookbooks are being updated.` | `Your collections are being updated.` |
| aria `Add to cookbook` | `Add to My Kitchen` |
| aria `Cookbook view` | `My Kitchen view` |
| aria `Share cookbook as Recipe Pack` | `Share My Kitchen as Recipe Pack` |
| `Share Cookbook` (button) | `Share My Kitchen` |
| `Start Your Cookbook` (empty state) | `Start Your Kitchen` |
| `…Your cookbook is private to you.` | `…Your kitchen is private to you.` |

### `my-kitchen/[naddr]/+page.svelte`
| Old | New |
|---|---|
| `Back to Cookbook` | `Back to My Kitchen` |
| aria `Back to cookbook` | `Back to My Kitchen` |
| `Select a recipe to use as your cookbook cover` | `…your collection cover` |
| `This cookbook has {n} recipe(s) saved, …` | `This collection has {n} recipe(s) saved, …` |

### `SaveButton.svelte`
| Old | New |
|---|---|
| `Save to cookbook (hold for options)` | `Save to My Kitchen (hold for options)` |

### `pack/[naddr]/+page.svelte`
| Old | New |
|---|---|
| `Sign in to save this Recipe Pack to your cookbook.` | `…to My Kitchen.` |
| `Could not access your cookbook. Try again.` | `Could not access My Kitchen. Try again.` |
| `Already in your cookbook.` | `Already in My Kitchen.` |
| `Added {n} recipe(s) to your cookbook.` | `…to My Kitchen.` |
| `…Try again later, or browse your cookbook.` | `…Try again later, or browse My Kitchen.` |
| `Go to Cookbook` | `Go to My Kitchen` |
| `Cookbook` (back link) | `My Kitchen` |
| `Open your cookbook` | `Open My Kitchen` |
| `Saved in your cookbook` | `Saved in My Kitchen` |
| `Save Pack to Cookbook` | `Save Pack to My Kitchen` |

### `packs/+page.svelte`
| Old | New |
|---|---|
| `Open a collection in your cookbook and tap "Share Pack"…` | `Open a collection in My Kitchen and tap "Share Pack"…` |
| `Open Cookbook` | `Open My Kitchen` |

Copy judgment calls: "cookbook(s)" meaning *a collection* became **collection(s)** (cover picker, offline banners, offline detail copy) rather than a forced "My Kitchen"; possessive "your cookbook" became the proper noun "My Kitchen".

## Surviving "cookbook" strings — all on the findings exclusion list

- **Export flow (PDF artifact sense):** all of `ExportCookbookModal.svelte` (51 occurrences, zero diff — verified), plus its entry points on the pack page: `Export as Cookbook` button and `Export this pack as a printable cookbook PDF` tooltip
- **Admin promo labels:** `admin/+page.svelte` "Cookbook promos" tile; `admin/promos/+page.svelte` scope labels + `COOKBOOK_PROMOS_DISABLED` help text
- **Terms page:** generic "cookbooks and food-related publications"
- **Not user-facing:** code comments, `[Cookbook]` console-log tags, `type: 'cookbook'` RecipePackSource discriminator (Bucket B), `CookbookIcon`/module/store identifiers

## Verification

- `pnpm run build` passes (adapter-cloudflare)
- Case-insensitive survivor grep across `src/**/*.svelte`: every remaining occurrence classified above

Out-of-scope note: the PDF export flow's "cookbook" terminology is now the only user-facing use of the word — if the product later wants that artifact renamed (e.g. "recipe book"), it should be its own copy decision, not part of Phase 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)