### PR TITLE
My Kitchen Phase 0 PR3: Published tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.641",
+  "version": "4.2.642",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/myRecipesPack.test.ts
+++ b/src/lib/myRecipesPack.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { fetchMyAuthoredRecipeEvents, fetchMyAuthoredRecipes } from './myRecipesPack';
+
+const PUBKEY = 'a'.repeat(64);
+
+const VALID_MARKDOWN = `## Ingredients
+
+- 1 cup flour
+
+## Directions
+
+1. Mix well.
+`;
+
+function recipeEvent(opts: {
+  dTag?: string;
+  createdAt: number;
+  title?: string;
+  image?: string;
+  content?: string;
+}) {
+  const tags: string[][] = [];
+  if (opts.dTag) tags.push(['d', opts.dTag]);
+  if (opts.title) tags.push(['title', opts.title]);
+  if (opts.image) tags.push(['image', opts.image]);
+  tags.push(['t', 'zapcooking']);
+  return {
+    pubkey: PUBKEY,
+    created_at: opts.createdAt,
+    content: opts.content ?? VALID_MARKDOWN,
+    tags
+  } as any;
+}
+
+/**
+ * Minimal NDK stand-in: subscribe() returns a handler registry and
+ * delivers the given events (then eose) on a microtask, mirroring the
+ * async arrival the real implementation sees.
+ */
+function fakeNdk(events: any[]) {
+  return {
+    subscribe: () => {
+      const handlers: Record<string, (arg?: any) => void> = {};
+      queueMicrotask(() => {
+        for (const e of events) handlers['event']?.(e);
+        handlers['eose']?.();
+      });
+      return {
+        on(name: string, cb: (arg?: any) => void) {
+          handlers[name] = cb;
+        },
+        stop() {}
+      };
+    }
+  } as any;
+}
+
+describe('fetchMyAuthoredRecipeEvents', () => {
+  it('dedupes a revised recipe by coordinate, keeping the newest version', async () => {
+    const original = recipeEvent({ dTag: 'tacos', createdAt: 100, title: 'Tacos v1' });
+    const revision = recipeEvent({ dTag: 'tacos', createdAt: 200, title: 'Tacos v2' });
+
+    // Old-then-new arrival
+    let result = await fetchMyAuthoredRecipeEvents(fakeNdk([original, revision]), PUBKEY);
+    expect(result).toHaveLength(1);
+    expect(result[0].created_at).toBe(200);
+
+    // New-then-old arrival (relay order is not guaranteed)
+    result = await fetchMyAuthoredRecipeEvents(fakeNdk([revision, original]), PUBKEY);
+    expect(result).toHaveLength(1);
+    expect(result[0].created_at).toBe(200);
+  });
+
+  it('filters events whose content fails recipe validation', async () => {
+    const valid = recipeEvent({ dTag: 'soup', createdAt: 100 });
+    const invalid = recipeEvent({ dTag: 'not-a-recipe', createdAt: 200, content: 'just some text' });
+
+    const result = await fetchMyAuthoredRecipeEvents(fakeNdk([valid, invalid]), PUBKEY);
+    expect(result).toHaveLength(1);
+    expect(result[0].tags.find((t: string[]) => t[0] === 'd')?.[1]).toBe('soup');
+  });
+
+  it('skips events without a d tag', async () => {
+    const noDTag = recipeEvent({ createdAt: 100 });
+    const result = await fetchMyAuthoredRecipeEvents(fakeNdk([noDTag]), PUBKEY);
+    expect(result).toHaveLength(0);
+  });
+
+  it('sorts newest-first', async () => {
+    const older = recipeEvent({ dTag: 'older', createdAt: 100 });
+    const newer = recipeEvent({ dTag: 'newer', createdAt: 300 });
+    const middle = recipeEvent({ dTag: 'middle', createdAt: 200 });
+
+    const result = await fetchMyAuthoredRecipeEvents(fakeNdk([older, newer, middle]), PUBKEY);
+    expect(result.map((e) => e.created_at)).toEqual([300, 200, 100]);
+  });
+});
+
+describe('fetchMyAuthoredRecipes (share-pack projection)', () => {
+  it('projects events into the pack shape with coordinate a-tags', async () => {
+    const event = recipeEvent({
+      dTag: 'pasta',
+      createdAt: 150,
+      title: ' Pasta Night ',
+      image: 'https://example.com/pasta.jpg'
+    });
+
+    const result = await fetchMyAuthoredRecipes(fakeNdk([event]), PUBKEY);
+    expect(result).toEqual([
+      {
+        aTag: `30023:${PUBKEY}:pasta`,
+        title: 'Pasta Night',
+        image: 'https://example.com/pasta.jpg',
+        createdAt: 150
+      }
+    ]);
+  });
+
+  it('falls back to the d-tag when there is no title tag', async () => {
+    const event = recipeEvent({ dTag: 'untitled-dish', createdAt: 100 });
+    const result = await fetchMyAuthoredRecipes(fakeNdk([event]), PUBKEY);
+    expect(result[0].title).toBe('untitled-dish');
+    expect(result[0].image).toBeUndefined();
+  });
+});

--- a/src/lib/myRecipesPack.ts
+++ b/src/lib/myRecipesPack.ts
@@ -43,17 +43,16 @@ const MAX_RECIPES = 500;
 const SUBSCRIPTION_TIMEOUT_MS = 10_000;
 
 /**
- * Fetch every recipe authored by `pubkey` and return them in a shape
- * suitable for the share-pack flow. Resolves with an empty array if
- * the user hasn't authored any recipes (the caller surfaces an empty
- * state rather than treating this as an error).
+ * Fetch every recipe authored by `pubkey` as full NDKEvents, validated
+ * and deduped by addressable coordinate, sorted newest-first. Resolves
+ * with an empty array if the user hasn't authored any recipes.
  *
- * Implementation mirrors the user-profile recipes-tab pattern in
- * `routes/user/[slug]/+page.svelte`: subscribe with the standard
- * RECIPE_TAGS filter, validate content via `parseMarkdownForEditing`'s
- * looser sibling, dedupe by a-tag, sort newest-first.
+ * This is the single implementation of the authored-recipes query —
+ * the same filter Android's Published sub-tab uses. The share-pack
+ * flow consumes it via `fetchMyAuthoredRecipes` below; the My Kitchen
+ * Published tab consumes the events directly for card rendering.
  */
-export async function fetchMyAuthoredRecipes(ndk: NDK, pubkey: string): Promise<MyRecipeForPack[]> {
+export async function fetchMyAuthoredRecipeEvents(ndk: NDK, pubkey: string): Promise<NDKEvent[]> {
   if (!ndk) throw new Error('NDK not initialized');
   if (!pubkey) throw new Error('Pubkey required');
 
@@ -68,7 +67,7 @@ export async function fetchMyAuthoredRecipes(ndk: NDK, pubkey: string): Promise<
   // created_at) keeps only the latest version. NDK delivers events as
   // they arrive — when two come in for the same address we keep
   // whichever has the higher created_at.
-  const byATag = new Map<string, MyRecipeForPack>();
+  const byATag = new Map<string, NDKEvent>();
 
   await new Promise<void>((resolve) => {
     const subscription = ndk.subscribe(filter, { closeOnEose: true });
@@ -86,23 +85,19 @@ export async function fetchMyAuthoredRecipes(ndk: NDK, pubkey: string): Promise<
       // validateMarkdownTemplate returns MarkdownTemplate | string —
       // it never returns null. A string return is an error message
       // describing what's wrong with the markdown. Filter on that
-      // shape so malformed events stay out of the pack. (The wider
-      // codebase uses an `!= null` check that's always true; we
-      // don't fix it here to keep this PR scoped, but we use the
-      // correct check for new code.)
+      // shape so malformed events stay out. (The wider codebase uses
+      // an `!= null` check that's always true; we don't fix it here
+      // to keep this scoped, but we use the correct check for new
+      // code.)
       const validation = validateMarkdownTemplate(event.content);
       if (typeof validation === 'string') return;
       const dTag = event.tags.find((t) => t[0] === 'd')?.[1];
       if (!dTag) return;
       const aTag = `${RECIPE_KIND}:${pubkey}:${dTag}`;
       const existing = byATag.get(aTag);
-      const createdAt = event.created_at || 0;
-      if (existing && existing.createdAt >= createdAt) return;
+      if (existing && (existing.created_at || 0) >= (event.created_at || 0)) return;
 
-      const title = event.tags.find((t) => t[0] === 'title')?.[1]?.trim() || dTag;
-      const image = event.tags.find((t) => t[0] === 'image')?.[1] || undefined;
-
-      byATag.set(aTag, { aTag, title, image, createdAt });
+      byATag.set(aTag, event);
     });
 
     subscription.on('eose', () => {
@@ -116,5 +111,27 @@ export async function fetchMyAuthoredRecipes(ndk: NDK, pubkey: string): Promise<
     });
   });
 
-  return Array.from(byATag.values()).sort((a, b) => b.createdAt - a.createdAt);
+  return Array.from(byATag.values()).sort((a, b) => (b.created_at || 0) - (a.created_at || 0));
+}
+
+/**
+ * Fetch every recipe authored by `pubkey` and return them in a shape
+ * suitable for the share-pack flow. Resolves with an empty array if
+ * the user hasn't authored any recipes (the caller surfaces an empty
+ * state rather than treating this as an error).
+ *
+ * Thin projection over `fetchMyAuthoredRecipeEvents` — just what the
+ * modal preview + publish path need.
+ */
+export async function fetchMyAuthoredRecipes(ndk: NDK, pubkey: string): Promise<MyRecipeForPack[]> {
+  const events = await fetchMyAuthoredRecipeEvents(ndk, pubkey);
+  return events.map((event) => {
+    const dTag = event.tags.find((t) => t[0] === 'd')?.[1] || '';
+    return {
+      aTag: `${RECIPE_KIND}:${pubkey}:${dTag}`,
+      title: event.tags.find((t) => t[0] === 'title')?.[1]?.trim() || dTag,
+      image: event.tags.find((t) => t[0] === 'image')?.[1] || undefined,
+      createdAt: event.created_at || 0
+    };
+  });
 }

--- a/src/routes/my-kitchen/+page.svelte
+++ b/src/routes/my-kitchen/+page.svelte
@@ -46,9 +46,12 @@
   import { writable, type Writable, get } from 'svelte/store';
   import { clickOutside } from '$lib/clickOutside';
   import PullToRefresh from '../../components/PullToRefresh.svelte';
+  import ShareMyRecipesAction from '../../components/ShareMyRecipesAction.svelte';
+  import { fetchMyAuthoredRecipeEvents } from '$lib/myRecipesPack';
+  import { validateMarkdownTemplate } from '$lib/parser';
 
   // ===== View / sort / filter state (synced with URL query params) =====
-  type ViewMode = 'packs' | 'feed';
+  type ViewMode = 'packs' | 'feed' | 'published';
   type SortMode = 'recent-added' | 'recent-updated' | 'az';
 
   let viewMode: ViewMode = 'packs';
@@ -118,6 +121,7 @@
     const v = params.get('view');
     let view: ViewMode = 'packs';
     if (v === 'feed') view = 'feed';
+    else if (v === 'published') view = 'published';
     else if (v === 'packs' || v === 'grid') view = 'packs'; // legacy 'grid' alias
     const s = params.get('sort');
     const sort: SortMode =
@@ -173,6 +177,7 @@
       await cookbookStore.load();
       await loadCoverImages();
       await updateCachedRecipeCount();
+      if (publishedRequested) await loadPublishedRecipes();
     } finally {
       pullToRefreshEl?.complete();
     }
@@ -832,6 +837,52 @@
     }
     return { title, summary, image, link };
   }
+
+  // ===== Published tab (author-scoped kind-30023, same filter as Android's Published sub-tab) =====
+  let publishedEvents: NDKEvent[] = [];
+  let publishedLoading = false;
+  let publishedLoaded = false;
+  // Lazy: no authored-recipes query until the tab is first opened
+  // (mirrors Android's CookbookViewModel.requestMyRecipes()).
+  let publishedRequested = false;
+
+  async function loadPublishedRecipes() {
+    if (!$userPublickey) return;
+    publishedLoading = true;
+    try {
+      if ($isOnline && $ndk) {
+        const events = await fetchMyAuthoredRecipeEvents($ndk, $userPublickey);
+        publishedEvents = events;
+        // Cache for offline reuse (same store the feed view reads from).
+        // Fire-and-forget: cache writes must not block or fail the tab.
+        for (const e of events) {
+          offlineStorage.saveRecipeFromEvent(e).catch(() => {});
+        }
+      } else {
+        // Offline fallback: whatever authored recipes are already in the
+        // recipe cache (populated by prior visits / feed browsing). Apply
+        // the same validity check as the live path.
+        const cached = await offlineStorage.getAllRecipes();
+        publishedEvents = cached
+          .filter((c: any) => c.authorPubkey === $userPublickey)
+          .map((c: any) => buildFakeEventFromCache(c))
+          .filter((e: NDKEvent) => typeof validateMarkdownTemplate(e.content) !== 'string')
+          .sort((a: NDKEvent, b: NDKEvent) => (b.created_at || 0) - (a.created_at || 0));
+      }
+    } catch (err) {
+      console.warn('[My Kitchen published] Failed to load authored recipes', err);
+    } finally {
+      publishedLoading = false;
+      publishedLoaded = true;
+    }
+  }
+
+  // First open of the tab (including ?view=published deep links, which
+  // hydrate viewMode from the URL) triggers the one-time load.
+  $: if (viewMode === 'published' && !publishedRequested && $userPublickey) {
+    publishedRequested = true;
+    loadPublishedRecipes();
+  }
 </script>
 
 <svelte:head>
@@ -1295,6 +1346,24 @@
               <span class="text-xs opacity-80">·&nbsp;{totalUniqueSaved}</span>
             {/if}
           </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={viewMode === 'published'}
+            on:click={() => setView('published')}
+            class="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors {viewMode ===
+            'published'
+              ? 'bg-gradient-to-r from-orange-500 to-amber-500 text-white shadow-sm'
+              : ''}"
+            style={viewMode === 'published' ? '' : 'color: var(--color-text-secondary);'}
+            title="Recipes you've published"
+          >
+            <PencilSimpleIcon size={16} weight={viewMode === 'published' ? 'fill' : 'regular'} />
+            <span>Published</span>
+            {#if publishedLoaded && publishedEvents.length > 0}
+              <span class="text-xs opacity-80">·&nbsp;{publishedEvents.length}</span>
+            {/if}
+          </button>
         </div>
 
         <!-- Sort + Filter (feed only) -->
@@ -1402,6 +1471,11 @@
                 </div>
               {/if}
             </div>
+          </div>
+        {:else if viewMode === 'published'}
+          <!-- Published-tab companion action -->
+          <div class="flex items-center gap-2 flex-wrap">
+            <ShareMyRecipesAction pubkey={$userPublickey} />
           </div>
         {/if}
       </div>
@@ -1526,6 +1600,83 @@
               </div>
             {/each}
           {/if}
+        </div>
+      {/if}
+    {:else if viewMode === 'published'}
+      <!-- Published view: recipes authored by the signed-in user -->
+      {#if publishedLoading && !publishedLoaded}
+        <div class="grid gap-4 sm:gap-5 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+          {#each Array(3) as _}
+            <div
+              class="rounded-2xl overflow-hidden animate-pulse"
+              style="background-color: var(--color-input-bg);"
+            >
+              <div class="w-full aspect-[4/3]" style="background-color: var(--color-accent-gray);"></div>
+              <div class="p-3 sm:p-4 flex flex-col gap-2">
+                <div
+                  class="h-4 w-3/4 rounded"
+                  style="background-color: var(--color-accent-gray);"
+                ></div>
+                <div
+                  class="h-3 w-1/2 rounded"
+                  style="background-color: var(--color-accent-gray);"
+                ></div>
+              </div>
+            </div>
+          {/each}
+        </div>
+      {:else if publishedEvents.length === 0}
+        <div class="flex flex-col items-center justify-center py-12 px-4">
+          <div
+            class="w-16 h-16 rounded-full bg-gradient-to-br from-orange-100 to-amber-100 dark:from-orange-900/30 dark:to-amber-900/30 flex items-center justify-center mb-4"
+          >
+            <PencilSimpleIcon size={32} weight="regular" class="text-orange-500" />
+          </div>
+          <h3 class="text-lg font-medium mb-2" style="color: var(--color-text-primary)">
+            No published recipes yet
+          </h3>
+          <p class="text-caption text-center max-w-sm mb-4">
+            Recipes you publish on Zap.cooking will show up here.
+          </p>
+          <a
+            href="/create"
+            class="flex items-center gap-2 px-5 py-2.5 bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 text-white rounded-full font-medium transition-all"
+          >
+            <PlusIcon size={18} weight="bold" />
+            Create a Recipe
+          </a>
+        </div>
+      {:else}
+        <!-- Big-card grid, same layout as the feed view -->
+        <div class="grid gap-4 sm:gap-5 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+          {#each publishedEvents as e (e.id || feedCardData(e).link)}
+            {@const card = feedCardData(e)}
+            {#if card.link}
+              <a
+                href={card.link}
+                class="group flex flex-col rounded-2xl overflow-hidden transition-transform duration-200 hover:scale-[1.01] hover:shadow-xl"
+                style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+              >
+                <div class="relative w-full aspect-[4/3] overflow-hidden feed-card-image-wrap">
+                  <div
+                    use:lazyLoad={{ url: card.image }}
+                    class="absolute inset-0 feed-card-image group-hover:scale-105 transition-transform duration-700 ease-in-out"
+                  ></div>
+                </div>
+                <div class="p-3 sm:p-4 flex flex-col gap-1">
+                  <h3
+                    class="text-base sm:text-lg font-semibold leading-snug line-clamp-2"
+                    style="color: var(--color-text-primary);"
+                  >
+                    {card.title}
+                  </h3>
+                  {#if card.summary}
+                    <p class="text-sm text-caption line-clamp-2">{card.summary}</p>
+                  {/if}
+                </div>
+              </a>
+            {/if}
+          {/each}
         </div>
       {/if}
     {:else}


### PR DESCRIPTION
Implements **Phase 0.2** of [docs/my-kitchen-spec.md](https://github.com/zapcooking/frontend/blob/main/docs/my-kitchen-spec.md) per the Phase 0 investigation findings (Area 3). Branched off main after PR1 (#536); independent of PR2 (#537).

## What

A third **Published** pill on My Kitchen's existing URL-synced view toggle (`?view=published`), showing the signed-in user's authored kind-30023 recipes — mirroring Android's Saved/Published IA.

## Design decisions (per findings + scope)

- **Renderer needed full NDKEvents**, so I added `fetchMyAuthoredRecipeEvents(ndk, pubkey): Promise<NDKEvent[]>` in `myRecipesPack.ts` and refactored `fetchMyAuthoredRecipes` into a thin projection over it. The filter/validation/dedupe logic — `{ authors: [pubkey], kinds: [30023], '#t': RECIPE_TAGS, limit: 500 }`, `typeof validateMarkdownTemplate(content) === 'string'` → reject, coordinate-dedupe keeping newest — now has exactly one implementation, shared by the share-pack flow and the tab. This is the same filter Android's `Nip23RecipeFormat.authorFeedFilter` uses.
- **Rendering** reuses the page's own `feedCardData` big-card grid (findings recommendation: visual consistency within the hub), including the feed view's skeleton style.
- **Lazy load**: no authored-recipes query fires until the tab is first opened — the load is triggered only by a `viewMode === 'published'` reactive guard (which also covers `?view=published` deep links, since view state hydrates from the URL) and, after first open, pull-to-refresh. Mirrors Android's `CookbookViewModel.requestMyRecipes()`.
- **Cache**: strict cache-first à la `ensureFeedEvents` doesn't fit here — membership in the authored set isn't known offline. Instead: network-first with write-through to `offlineStorage.saveRecipeFromEvent`, plus an offline fallback that filters the recipe cache by `authorPubkey` with the same validity check.
- **Empty state** with a Create-a-Recipe CTA to `/create`; **`ShareMyRecipesAction`** mounted as the tab's companion action in the toolbar (where the Feed view shows its share button).
- **Signed-out**: inherits the page's existing gate (`onMount` → `goto('/login')`); no additional gating needed.

## Verification

- `pnpm vitest run src/lib/myRecipesPack.test.ts` — **6/6 pass** (new file): coordinate dedupe keeps the newest revision in *both* arrival orders, invalid-content filtering, missing-d-tag skip, newest-first sort, pack-projection shape
- `pnpm run build` passes (adapter-cloudflare)
- Deep link `/my-kitchen?view=published` returns 200; `view=published` is accepted by `readParams` and the reactive guard fires on hydrate
- Lazy load confirmed by call-site audit: `fetchMyAuthoredRecipeEvents` is reachable only via the first-open guard and post-first-open refresh
- Not exercised: full signed-in click-through (needs a real session with authored recipes) — worth a quick manual pass on preview

## Discoveries (noted, not fixed — out of scope)

- **Pre-existing:** with zero collections, the page shows the global empty state regardless of `?view=` — so `?view=published` (like `?view=feed` today) is unreachable until `ensureDefaultList()` creates the default list on mount. Transient in practice; flagging for completeness.
- **Merge note:** PR2 (#537) edits adjacent lines in the same toolbar block (aria-label, Share button copy) — whichever merges second may need a trivial rebase.
- Profile page's no-op validation check remains untouched per scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)