### PR TITLE
My Kitchen Phase 1 PR5: grocery move into hub

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.643",
+  "version": "4.2.644",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/DesktopSideNav.svelte
+++ b/src/components/DesktopSideNav.svelte
@@ -103,10 +103,10 @@
       match: (p) => p.startsWith('/my-kitchen')
     },
     {
-      href: '/grocery',
+      href: '/my-kitchen/grocery',
       label: 'Grocery Lists',
       icon: ShoppingCartIcon,
-      match: (p) => p.startsWith('/grocery')
+      match: (p) => p.startsWith('/my-kitchen/grocery')
     },
     {
       href: '/wallet',

--- a/src/components/MobileNavDrawer.svelte
+++ b/src/components/MobileNavDrawer.svelte
@@ -50,7 +50,7 @@
 
   const kitchenItems: NavItem[] = [
     { href: '/my-kitchen', label: 'My Kitchen', icon: CookbookIcon, match: (p) => p.startsWith('/my-kitchen') },
-    { href: '/grocery', label: 'Grocery Lists', icon: ShoppingCartIcon, match: (p) => p.startsWith('/grocery') },
+    { href: '/my-kitchen/grocery', label: 'Grocery Lists', icon: ShoppingCartIcon, match: (p) => p.startsWith('/my-kitchen/grocery') },
     { href: '/wallet', label: 'Wallet', icon: WalletIcon, match: () => $walletModalOpen, badge: 'wallet' },
     { href: '/nourish', label: 'Nourish', icon: LeafIcon, match: (p) => p.startsWith('/nourish') },
     { href: '/membership', label: 'Membership', icon: CrownSimpleIcon, match: (p) => p.startsWith('/membership') },

--- a/src/components/UserSidePanel.svelte
+++ b/src/components/UserSidePanel.svelte
@@ -320,7 +320,7 @@
           </li>
           <li>
             <button
-              on:click={() => navigate('/grocery')}
+              on:click={() => navigate('/my-kitchen/grocery')}
               class="w-full flex items-center gap-4 px-4 py-3 rounded-xl hover:bg-opacity-50 transition-colors cursor-pointer"
               style="color: var(--color-text-primary);"
             >

--- a/src/components/grocery/GroceryListCard.svelte
+++ b/src/components/grocery/GroceryListCard.svelte
@@ -19,7 +19,7 @@
 </script>
 
 <a
-  href="/grocery/{list.id}"
+  href="/my-kitchen/grocery/{list.id}"
   class="group block p-4 rounded-2xl transition-all duration-200 hover:scale-[1.02] hover:shadow-lg"
   style="background-color: var(--color-bg-secondary); border: 1px solid var(--color-input-border);"
 >

--- a/src/routes/grocery/+page.server.ts
+++ b/src/routes/grocery/+page.server.ts
@@ -1,0 +1,7 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async () => {
+  // Grocery lives inside the My Kitchen hub now — redirect for backward compatibility
+  throw redirect(301, '/my-kitchen/grocery');
+};

--- a/src/routes/grocery/[id]/+page.server.ts
+++ b/src/routes/grocery/[id]/+page.server.ts
@@ -1,0 +1,7 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ params }) => {
+  // Grocery lives inside the My Kitchen hub now — redirect old list links, preserving the id
+  throw redirect(301, `/my-kitchen/grocery/${params.id}`);
+};

--- a/src/routes/my-kitchen/+layout.svelte
+++ b/src/routes/my-kitchen/+layout.svelte
@@ -7,6 +7,7 @@
    */
   import SectionNav from '../../components/SectionNav.svelte';
   import BookOpenIcon from 'phosphor-svelte/lib/BookOpen';
+  import ShoppingCartIcon from 'phosphor-svelte/lib/ShoppingCart';
   import CalendarBlankIcon from 'phosphor-svelte/lib/CalendarBlank';
   import LeafIcon from 'phosphor-svelte/lib/Leaf';
 
@@ -15,9 +16,16 @@
       href: '/my-kitchen',
       label: 'Recipes',
       icon: BookOpenIcon,
-      // Exact match: child routes (planner, nourish, grocery in PR5)
-      // must not false-highlight the index section.
+      // Exact match: child routes (grocery, planner, nourish) must not
+      // false-highlight the index section.
       match: (p: string) => p === '/my-kitchen'
+    },
+    {
+      href: '/my-kitchen/grocery',
+      label: 'Grocery',
+      icon: ShoppingCartIcon,
+      // startsWith so the /my-kitchen/grocery/[id] detail keeps the tab active
+      match: (p: string) => p.startsWith('/my-kitchen/grocery')
     },
     {
       href: '/my-kitchen/planner',

--- a/src/routes/my-kitchen/grocery/+page.svelte
+++ b/src/routes/my-kitchen/grocery/+page.svelte
@@ -11,9 +11,9 @@
   } from '$lib/stores/groceryStore';
   import PlusIcon from 'phosphor-svelte/lib/Plus';
   import ShoppingCartIcon from 'phosphor-svelte/lib/ShoppingCart';
-  import PanLoader from '../../components/PanLoader.svelte';
-  import GroceryListCard from '../../components/grocery/GroceryListCard.svelte';
-  import PullToRefresh from '../../components/PullToRefresh.svelte';
+  import PanLoader from '../../../components/PanLoader.svelte';
+  import GroceryListCard from '../../../components/grocery/GroceryListCard.svelte';
+  import PullToRefresh from '../../../components/PullToRefresh.svelte';
 
   // Pull-to-refresh ref
   let pullToRefreshEl: PullToRefresh;
@@ -52,7 +52,7 @@
     try {
       const newList = await groceryStore.addList('Shopping List');
       // Navigate to the new list
-      goto(`/grocery/${newList.id}`);
+      goto(`/my-kitchen/grocery/${newList.id}`);
     } catch (error) {
       console.error('Failed to create list:', error);
     } finally {

--- a/src/routes/my-kitchen/grocery/[id]/+page.svelte
+++ b/src/routes/my-kitchen/grocery/[id]/+page.svelte
@@ -18,11 +18,11 @@
   import PencilSimpleIcon from 'phosphor-svelte/lib/PencilSimple';
   import FloppyDiskIcon from 'phosphor-svelte/lib/FloppyDisk';
   import CircleNotchIcon from 'phosphor-svelte/lib/CircleNotch';
-  import PanLoader from '../../../components/PanLoader.svelte';
-  import Modal from '../../../components/Modal.svelte';
-  import Button from '../../../components/Button.svelte';
-  import SortableGroceryCategory from '../../../components/grocery/SortableGroceryCategory.svelte';
-  import AddItemForm from '../../../components/grocery/AddItemForm.svelte';
+  import PanLoader from '../../../../components/PanLoader.svelte';
+  import Modal from '../../../../components/Modal.svelte';
+  import Button from '../../../../components/Button.svelte';
+  import SortableGroceryCategory from '../../../../components/grocery/SortableGroceryCategory.svelte';
+  import AddItemForm from '../../../../components/grocery/AddItemForm.svelte';
 
   // Get list ID from URL params
   $: listId = $page.params.id as string;
@@ -109,7 +109,7 @@
     try {
       const success = await groceryStore.deleteList(listId);
       if (success) {
-        goto('/grocery');
+        goto('/my-kitchen/grocery');
       }
     } catch (error) {
       console.error('Failed to delete list:', error);
@@ -162,7 +162,7 @@
       <!-- Back link and actions -->
       <div class="flex items-center justify-between">
         <a 
-          href="/grocery" 
+          href="/my-kitchen/grocery" 
           class="flex items-center gap-2 text-sm font-medium transition-colors hover:opacity-80"
           style="color: var(--color-text-secondary)"
         >


### PR DESCRIPTION
Implements the grocery move from the approved Phase 1 findings (Area 3): `/grocery` → `/my-kitchen/grocery` with param-preserving 301s, Bucket B untouched.

> **Stacked on #539** (base: `feat/my-kitchen-hub-shell`) — PR4 was not yet merged at implementation time, and this PR needs its layout + SectionNav. GitHub will retarget the base to `main` automatically when #539 merges. Deviation from the "branch off main after PR4 is merged" instruction, flagged deliberately rather than merging #539 myself.

## Changes

- **`git mv`** both grocery pages under `src/routes/my-kitchen/grocery/` (94–95% renames, history preserved). Fixed their relative `../../components/...` imports for the new depth — a mechanical consequence of the move the findings inventory didn't list.
- **301 stubs**: `/grocery` → `/my-kitchen/grocery`; `/grocery/[id]` → `/my-kitchen/grocery/{id}` (opaque-id passthrough, Phase 0 `[naddr]` pattern; neither page reads query params).
- **8 Bucket A refs updated**: DesktopSideNav + MobileNavDrawer (href + `startsWith` match — **entries kept**, removal is PR6), UserSidePanel `navigate()`, GroceryListCard href, three in-page refs in the moved files.
- **SectionNav**: Grocery added between Recipes and Planner, `startsWith('/my-kitchen/grocery')` so the `[id]` detail keeps the tab active. Detail stays **inside** the hub layout per findings (no `+page@` escape).

## Bucket B — zero changes (verified: `git diff src/lib/` is empty)

Grep survivors, all protocol/storage-bound by design: `GROCERY_D_TAG_PREFIX = 'grocery-'` (Nostr d-tag prefix — coincidentally shares the old route's name; must never change), `GROCERY_KIND = 30078`, NIP-44 encryption path, `client` tag, `generateListId()`, relay selection (`groceryService.ts:59-89` et al).

## Verification

| Check | Result |
|---|---|
| `/grocery`, `/grocery/{id}` | single-hop 301 → hub equivalents, id passthrough ✅ |
| `/my-kitchen/grocery` + `[id]` detail | render inside hub layout, Grocery section active on both ✅ |
| Top-level Grocery nav entries | still present, now pointing at hub route ✅ |
| Build | ✅ adapter-cloudflare |
| **CRUD click-through** (headless Chrome, seeded throwaway-key session) | Signed-in index renders in hub with section nav ✅; create-list wiring fires but the awaited relay publish never settles for a fresh key, blocking the downstream add/check/delete steps. **Control experiment: identical hang on pre-move `origin/main` `/grocery`** — pre-existing behavior, not a move regression. Store/service have a zero-line diff. Full CRUD needs a member-key pass on the preview deploy. |

## Discoveries (noted, not fixed)

- **Fresh-account "New List" hangs indefinitely** (`groceryStore.addList` awaits `saveGroceryList`; outbox resolver finds no write relays for a key with no kind-10002 relay list — "No relays found for filter"). Reproduced identically on main. Recommend filing as a bug: new users' first grocery action can hang with the button stuck on "Creating…".
- **Transitional dual-highlight until PR6**: DesktopSideNav highlights both "My Kitchen" (`startsWith('/my-kitchen')`) and "Grocery Lists" (`startsWith('/my-kitchen/grocery')`) on grocery pages. Resolves when PR6 removes the Grocery entry.
- **Repo tooling**: `pnpm install`'s hook-install step (`cp` to `.git/hooks`) fails inside git worktrees, where `.git` is a file — `--ignore-scripts` + manual `svelte-kit sync` works around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)