### PR TITLE
My Kitchen Phase 1 PR6: remove top-level Grocery nav

### DIFF
--- a/docs/my-kitchen-spec.md
+++ b/docs/my-kitchen-spec.md
@@ -51,7 +51,7 @@ Goal: both platforms present the same thing under the same name before adding an
 
 ## Phase 1 — Hub Shell & IA
 
-**Status: In progress**
+**Status: Shipped (web)**
 
 Goal: a hub landing surface with room for the future sections, without building them yet.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.644",
+  "version": "4.2.645",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/DesktopSideNav.svelte
+++ b/src/components/DesktopSideNav.svelte
@@ -14,7 +14,6 @@
 
   import NewspaperIcon from 'phosphor-svelte/lib/Newspaper';
   import CookbookIcon from 'phosphor-svelte/lib/BookOpen';
-  import ShoppingCartIcon from 'phosphor-svelte/lib/ShoppingCart';
   import WalletIcon from 'phosphor-svelte/lib/Wallet';
   import CrownSimpleIcon from 'phosphor-svelte/lib/CrownSimple';
   import HandshakeIcon from 'phosphor-svelte/lib/Handshake';
@@ -101,12 +100,6 @@
       label: 'My Kitchen',
       icon: CookbookIcon,
       match: (p) => p.startsWith('/my-kitchen')
-    },
-    {
-      href: '/my-kitchen/grocery',
-      label: 'Grocery Lists',
-      icon: ShoppingCartIcon,
-      match: (p) => p.startsWith('/my-kitchen/grocery')
     },
     {
       href: '/wallet',

--- a/src/components/MobileNavDrawer.svelte
+++ b/src/components/MobileNavDrawer.svelte
@@ -14,7 +14,6 @@
   import EnvelopeSimpleIcon from 'phosphor-svelte/lib/EnvelopeSimple';
   import ClockCounterClockwiseIcon from 'phosphor-svelte/lib/ClockCounterClockwise';
   import CookbookIcon from 'phosphor-svelte/lib/BookOpen';
-  import ShoppingCartIcon from 'phosphor-svelte/lib/ShoppingCart';
   import WalletIcon from 'phosphor-svelte/lib/Wallet';
   import LeafIcon from 'phosphor-svelte/lib/Leaf';
   import CrownSimpleIcon from 'phosphor-svelte/lib/CrownSimple';
@@ -50,7 +49,6 @@
 
   const kitchenItems: NavItem[] = [
     { href: '/my-kitchen', label: 'My Kitchen', icon: CookbookIcon, match: (p) => p.startsWith('/my-kitchen') },
-    { href: '/my-kitchen/grocery', label: 'Grocery Lists', icon: ShoppingCartIcon, match: (p) => p.startsWith('/my-kitchen/grocery') },
     { href: '/wallet', label: 'Wallet', icon: WalletIcon, match: () => $walletModalOpen, badge: 'wallet' },
     { href: '/nourish', label: 'Nourish', icon: LeafIcon, match: (p) => p.startsWith('/nourish') },
     { href: '/membership', label: 'Membership', icon: CrownSimpleIcon, match: (p) => p.startsWith('/membership') },

--- a/src/components/UserSidePanel.svelte
+++ b/src/components/UserSidePanel.svelte
@@ -12,7 +12,6 @@
   import MeasuringCupIcon from './icons/MeasuringCupIcon.svelte';
   import TimerIcon from 'phosphor-svelte/lib/Timer';
   import CalculatorIcon from 'phosphor-svelte/lib/Calculator';
-  import ShoppingCartIcon from 'phosphor-svelte/lib/ShoppingCart';
   import FloppyDiskIcon from 'phosphor-svelte/lib/FloppyDisk';
   import WalletIcon from 'phosphor-svelte/lib/Wallet';
   import SparkleIcon from 'phosphor-svelte/lib/Sparkle';
@@ -316,16 +315,6 @@
             >
               <CookbookIcon size={22} />
               <span class="font-medium">My Kitchen</span>
-            </button>
-          </li>
-          <li>
-            <button
-              on:click={() => navigate('/my-kitchen/grocery')}
-              class="w-full flex items-center gap-4 px-4 py-3 rounded-xl hover:bg-opacity-50 transition-colors cursor-pointer"
-              style="color: var(--color-text-primary);"
-            >
-              <ShoppingCartIcon size={22} />
-              <span class="font-medium">Grocery Lists</span>
             </button>
           </li>
           <li>


### PR DESCRIPTION
Completes **Phase 1** of [docs/my-kitchen-spec.md](https://github.com/zapcooking/frontend/blob/main/docs/my-kitchen-spec.md) (findings Area 5): the top-level nav collapses to the single **My Kitchen** entry. Follows #539/#540.

## Changes

- Removed the Grocery Lists entries from `DesktopSideNav` (kitchen group), `MobileNavDrawer`, and `UserSidePanel`, plus their now-unused `ShoppingCartIcon` imports.
- The My Kitchen entry needs **no `match()` change** — its existing `startsWith('/my-kitchen')` covers all hub children (verified in the Phase 1 findings and live below).
- Spec status: Phase 1 → `Shipped (web)`.

## Verification (dev server)

- Grocery remains reachable via My Kitchen → Grocery section (`SectionNav` entry from PR5, untouched)
- `/grocery` → single-hop 301 → `/my-kitchen/grocery`; landing page highlights exactly **My Kitchen** in the top nav + **Grocery** in the section nav — the transitional dual-highlight noted in #540 is resolved
- `grep '/grocery'` across `src/components/` (excluding the `grocery/` component dir): zero references
- `BottomNav` untouched (never had these entries)
- Build passes (adapter-cloudflare)

🤖 Generated with [Claude Code](https://claude.com/claude-code)