### PR TITLE
My Kitchen Phase 3 PR7: mealplan contract + service

### DIFF
--- a/docs/mealplan-contract.md
+++ b/docs/mealplan-contract.md
@@ -1,0 +1,110 @@
+# Meal Plan Event Contract (v1)
+
+**This document is the frozen cross-platform contract.** The Android client ports against it
+verbatim — the `RecipeBookmarkRepository` ↔ `cookbookStore.ts` pairing is the model. Web
+implementation: `src/lib/mealplan/` + `src/lib/services/plannerService.ts`. Changes require a new
+`schemaVersion` and an update to this document in both repos.
+
+## Event envelope
+
+| Field | Value |
+|---|---|
+| kind | `30078` (NIP-78 application-specific data, addressable/replaceable per d-tag) |
+| d-tag | `mealplan-{isoWeekYear}-W{ww}` — e.g. `mealplan-2026-W29` |
+| tags | `['d', …]` and `['client', 'Zap Cooking']` — **nothing else** (see "No plaintext recipe tags") |
+| content | NIP-44 self-encrypted JSON payload (encrypted to the author's own pubkey) |
+| relays | The user's NIP-65 outbox write relays, falling back to the app's default pool. Never routed specially; no relay-side policy distinguishes `mealplan-` events (verified against members-relay filter policy). |
+
+### d-tag definition
+
+The week identifier is the **ISO 8601 week of the user's local wall-clock date**:
+
+- Weeks start **Monday**.
+- The year component is the **ISO week-numbering year** (`getISOWeekYear` semantics), NOT the
+  calendar year. Example: 2026 is a 53-week ISO year — Jan 1–3 2027 belong to `2026-W53`, and
+  Dec 29 2025 belongs to `2026-W01`.
+- The week number is zero-padded to two digits (`W%02d`): `W01`–`W52`/`W53`.
+- "Current week" is resolved from the device's local timezone. The same instant can fall in
+  different weeks on devices in different timezones; this is accepted — the plan follows the
+  user's wall clock.
+
+### No plaintext recipe tags (deviation from the grocery contract)
+
+Grocery lists expose linked recipes as plaintext `a` tags. Meal plans deliberately do **not**:
+a plaintext coordinate plus a week-stamped d-tag would tell any relay operator what the user is
+cooking and when, violating the hub's privacy posture ("readable by no one but the user").
+All recipe coordinates live only inside the encrypted payload. Nothing requires relay-side
+queryability: fetches are exact `#d` lookups and grocery generation runs client-side after
+decryption.
+
+### Replacement and deletion
+
+- Saving a week publishes a new event with the same d-tag; relays replace per NIP-01
+  addressable-event rules (newest `created_at` wins).
+- Deletion is NIP-09: kind `5` with an `a` tag `30078:{pubkey}:mealplan-{week}` (and an `e` tag
+  for the known event id when available).
+
+## Encrypted payload (schemaVersion 1)
+
+```json
+{
+  "schemaVersion": 1,
+  "week": "2026-W29",
+  "days": {
+    "mon": {
+      "slots": {
+        "breakfast": { "type": "recipe", "a": "30023:<pubkey>:<dTag>", "title": "Shakshuka" },
+        "lunch":     { "type": "text", "text": "Leftovers" },
+        "dinner":    { "type": "recipe", "a": "30023:<pubkey>:<dTag>" },
+        "snack":     { "type": "text", "text": "Fruit" }
+      },
+      "notes": "optional per-day note"
+    }
+  },
+  "notes": "optional per-week note",
+  "createdAt": 1789000000,
+  "updatedAt": 1789000123
+}
+```
+
+### Contract rules
+
+1. `schemaVersion` is required and is `1` for this contract. Readers encountering
+   `schemaVersion > 1` MUST treat the plan as **read-only** (render what they understand, never
+   write back), so newer clients can extend the schema without older clients destroying data.
+2. `week` mirrors the d-tag's week id (`{isoWeekYear}-W{ww}`) so the decrypted payload is
+   self-describing. On conflict the d-tag wins.
+3. `days` keys are `mon|tue|wed|thu|fri|sat|sun` (ISO order). Every day is optional; an absent
+   day means nothing planned.
+4. `slots` keys are exactly `breakfast|lunch|dinner|snack`. Every slot is optional.
+5. A slot entry is a tagged union:
+   - `{ "type": "recipe", "a": "<kind:pubkey:dTag>", "title": "<optional snapshot>" }` — `a` is a
+     kind-30023 coordinate. `title` is an optional denormalized display snapshot so grids render
+     offline; the coordinate stays authoritative and resolvers should refresh the title when the
+     recipe is available.
+   - `{ "type": "text", "text": "<free text>" }` — non-recipe entries ("Leftovers", "Eating out").
+     Text slots are skipped by grocery generation.
+6. `notes` (per-day and per-week) are optional free text.
+7. `createdAt` / `updatedAt` are unix seconds. `createdAt` is preserved across saves; `updatedAt`
+   is stamped on every save.
+8. **Readers MUST ignore unknown fields and writers MUST preserve them on round-trip** (parse →
+   edit known fields → re-serialize keeps unrecognized keys intact) within the same
+   `schemaVersion`.
+9. Invalid slot entries (unknown `type`, missing `a`/`text`) are dropped on read, never fatal;
+   a malformed payload as a whole reads as "no plan" but MUST be surfaced distinctly from an
+   empty week (see decrypt-failure rule below).
+
+### Decrypt failures are not empty weeks
+
+A fetch that finds an event but cannot decrypt or parse it MUST surface a distinguishable
+"decrypt failed" result, not silently report "no plan" — browser-extension and remote signers can
+deny decryption (the web client trips a session circuit breaker after repeated denials), and the
+UI must be able to say "couldn't unlock this week" instead of showing an empty grid.
+
+### NIP-46 durability caveat
+
+Remote (NIP-46) signers perform the NIP-44 encryption on the signer's side. Some remote signers
+have been observed producing ciphertext that a later session cannot decrypt. Matching the
+grocery contract, clients **write anyway** for NIP-46 users; this caveat is accepted and
+documented rather than blocked. If this policy changes it changes for grocery and meal plans
+together.

--- a/docs/my-kitchen-spec.md
+++ b/docs/my-kitchen-spec.md
@@ -82,7 +82,7 @@ Goal: grocery everywhere, fed by recipes.
 
 ## Phase 3 — Meal Planner (new feature, new data model)
 
-**Status: Not started**
+**Status: In progress**
 
 Goal: a week grid of planned meals referencing saved/published recipes; generates the grocery list.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.645",
+  "version": "4.2.646",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/mealplan/schema.test.ts
+++ b/src/lib/mealplan/schema.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateMealPlanPayload,
+  createEmptyMealPlan,
+  serializeMealPlan,
+  MEALPLAN_SCHEMA_VERSION,
+  type MealPlan
+} from './schema';
+
+const WEEK = '2026-W29';
+
+function validPayload(): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    week: WEEK,
+    days: {
+      mon: {
+        slots: {
+          breakfast: { type: 'recipe', a: '30023:abc:shakshuka', title: 'Shakshuka' },
+          lunch: { type: 'text', text: 'Leftovers' }
+        },
+        notes: 'prep the night before'
+      }
+    },
+    notes: 'light week',
+    createdAt: 1789000000,
+    updatedAt: 1789000123
+  };
+}
+
+describe('validateMealPlanPayload', () => {
+  it('accepts both tagged-union branches', () => {
+    const result = validateMealPlanPayload(validPayload(), WEEK);
+    expect(result).not.toBeNull();
+    const { plan, readOnly } = result!;
+    expect(readOnly).toBe(false);
+    expect(plan.days.mon?.slots?.breakfast).toEqual({
+      type: 'recipe',
+      a: '30023:abc:shakshuka',
+      title: 'Shakshuka'
+    });
+    expect(plan.days.mon?.slots?.lunch).toEqual({ type: 'text', text: 'Leftovers' });
+    expect(plan.days.mon?.notes).toBe('prep the night before');
+    expect(plan.notes).toBe('light week');
+    expect(plan.createdAt).toBe(1789000000);
+  });
+
+  it('round-trips: encode → validate → serialize preserves the payload', () => {
+    const original = validPayload();
+    const validated = validateMealPlanPayload(JSON.parse(JSON.stringify(original)), WEEK)!;
+    const roundTripped = JSON.parse(serializeMealPlan(validated.plan));
+    expect(roundTripped).toEqual(original);
+  });
+
+  it('preserves unknown fields at top, day, and slot level', () => {
+    const payload = validPayload();
+    payload.futureFeature = { some: 'data' };
+    (payload.days as any).mon.dayLevelExtra = 42;
+    (payload.days as any).mon.slots.breakfast.servings = 3;
+
+    const { plan } = validateMealPlanPayload(payload, WEEK)!;
+    const serialized = JSON.parse(serializeMealPlan(plan));
+    expect(serialized.futureFeature).toEqual({ some: 'data' });
+    expect(serialized.days.mon.dayLevelExtra).toBe(42);
+    expect(serialized.days.mon.slots.breakfast.servings).toBe(3);
+  });
+
+  it('flags schemaVersion > 1 as read-only without dropping content', () => {
+    const payload = validPayload();
+    payload.schemaVersion = 2;
+    const result = validateMealPlanPayload(payload, WEEK)!;
+    expect(result.readOnly).toBe(true);
+    expect(result.plan.schemaVersion).toBe(2);
+    expect(result.plan.days.mon?.slots?.breakfast).toBeDefined();
+  });
+
+  it('the d-tag week wins over a mismatched payload week', () => {
+    const payload = validPayload();
+    payload.week = '2020-W01';
+    const { plan } = validateMealPlanPayload(payload, WEEK)!;
+    expect(plan.week).toBe(WEEK);
+  });
+
+  it('drops invalid slot entries but keeps the rest of the day', () => {
+    const payload = validPayload();
+    (payload.days as any).mon.slots.dinner = { type: 'recipe' }; // missing a
+    (payload.days as any).mon.slots.snack = { type: 'mystery', x: 1 }; // unknown type
+    const { plan } = validateMealPlanPayload(payload, WEEK)!;
+    expect(plan.days.mon?.slots?.dinner).toBeUndefined();
+    expect(plan.days.mon?.slots?.snack).toBeUndefined();
+    expect(plan.days.mon?.slots?.breakfast).toBeDefined();
+    expect(plan.days.mon?.notes).toBe('prep the night before');
+  });
+
+  it('ignores unknown day keys and non-object days', () => {
+    const payload = validPayload();
+    (payload.days as any).funday = { slots: {} };
+    (payload.days as any).tue = 'not a day';
+    const { plan } = validateMealPlanPayload(payload, WEEK)!;
+    expect((plan.days as any).funday).toBeUndefined();
+    expect(plan.days.tue).toBeUndefined();
+  });
+
+  it('defensively defaults missing fields', () => {
+    const { plan, readOnly } = validateMealPlanPayload({}, WEEK)!;
+    expect(readOnly).toBe(false);
+    expect(plan.schemaVersion).toBe(1);
+    expect(plan.week).toBe(WEEK);
+    expect(plan.days).toEqual({});
+    expect(plan.createdAt).toBeGreaterThan(0);
+  });
+
+  it('rejects structurally unusable payloads', () => {
+    expect(validateMealPlanPayload(null, WEEK)).toBeNull();
+    expect(validateMealPlanPayload('a string', WEEK)).toBeNull();
+    expect(validateMealPlanPayload([1, 2], WEEK)).toBeNull();
+  });
+});
+
+describe('createEmptyMealPlan', () => {
+  it('creates a valid v1 skeleton', () => {
+    const plan: MealPlan = createEmptyMealPlan(WEEK);
+    expect(plan.schemaVersion).toBe(MEALPLAN_SCHEMA_VERSION);
+    expect(plan.week).toBe(WEEK);
+    expect(plan.days).toEqual({});
+    const validated = validateMealPlanPayload(JSON.parse(serializeMealPlan(plan)), WEEK);
+    expect(validated?.readOnly).toBe(false);
+  });
+});

--- a/src/lib/mealplan/schema.ts
+++ b/src/lib/mealplan/schema.ts
@@ -1,0 +1,137 @@
+/**
+ * Meal-plan payload schema (schemaVersion 1) — the decrypted JSON
+ * contract shared verbatim with Android. See docs/mealplan-contract.md;
+ * that document is frozen and this module implements it.
+ *
+ * Validation is defensive, mirroring decryptGroceryEvent's posture:
+ * invalid slot entries are dropped, unknown fields are PRESERVED on
+ * round-trip, and schemaVersion > 1 flags the plan read-only rather
+ * than failing.
+ */
+
+export const MEALPLAN_SCHEMA_VERSION = 1;
+
+export const DAY_KEYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as const;
+export type MealPlanDayKey = (typeof DAY_KEYS)[number];
+
+export const SLOT_KEYS = ['breakfast', 'lunch', 'dinner', 'snack'] as const;
+export type MealSlotKey = (typeof SLOT_KEYS)[number];
+
+export type MealSlot =
+  | { type: 'recipe'; a: string; title?: string; [key: string]: unknown }
+  | { type: 'text'; text: string; [key: string]: unknown };
+
+export interface MealPlanDay {
+  slots?: Partial<Record<MealSlotKey, MealSlot>>;
+  notes?: string;
+  [key: string]: unknown;
+}
+
+export interface MealPlan {
+  schemaVersion: number;
+  week: string;
+  days: Partial<Record<MealPlanDayKey, MealPlanDay>>;
+  notes?: string;
+  createdAt: number;
+  updatedAt: number;
+  [key: string]: unknown;
+}
+
+export interface ValidatedMealPlan {
+  plan: MealPlan;
+  /** True when schemaVersion > MEALPLAN_SCHEMA_VERSION — render, never write back. */
+  readOnly: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Validate one slot entry; null drops it (contract rule 9). */
+function validateSlot(raw: unknown): MealSlot | null {
+  if (!isRecord(raw)) return null;
+  if (raw.type === 'recipe' && typeof raw.a === 'string' && raw.a.length > 0) {
+    return raw as MealSlot;
+  }
+  if (raw.type === 'text' && typeof raw.text === 'string' && raw.text.length > 0) {
+    return raw as MealSlot;
+  }
+  return null;
+}
+
+function validateDay(raw: unknown): MealPlanDay | null {
+  if (!isRecord(raw)) return null;
+  // Preserve unknown day-level fields; rebuild only `slots` with the
+  // invalid entries dropped.
+  const day: MealPlanDay = { ...raw } as MealPlanDay;
+  if (raw.slots !== undefined) {
+    if (!isRecord(raw.slots)) {
+      delete day.slots;
+    } else {
+      const slots: Partial<Record<MealSlotKey, MealSlot>> = {};
+      for (const key of SLOT_KEYS) {
+        const slot = validateSlot(raw.slots[key]);
+        if (slot) slots[key] = slot;
+      }
+      day.slots = slots;
+    }
+  }
+  if (raw.notes !== undefined && typeof raw.notes !== 'string') {
+    delete day.notes;
+  }
+  return day;
+}
+
+/**
+ * Validate a decrypted payload against schemaVersion 1.
+ *
+ * Returns null only when the payload is structurally unusable (not an
+ * object). Unknown top-level fields are preserved; `weekId` (from the
+ * d-tag, which wins per contract rule 2) backfills a missing/mismatched
+ * `week`.
+ */
+export function validateMealPlanPayload(raw: unknown, weekId: string): ValidatedMealPlan | null {
+  if (!isRecord(raw)) return null;
+
+  const schemaVersion = typeof raw.schemaVersion === 'number' ? raw.schemaVersion : 1;
+  const readOnly = schemaVersion > MEALPLAN_SCHEMA_VERSION;
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const plan: MealPlan = {
+    ...raw,
+    schemaVersion,
+    week: weekId,
+    days: {},
+    createdAt: typeof raw.createdAt === 'number' ? raw.createdAt : nowSeconds,
+    updatedAt: typeof raw.updatedAt === 'number' ? raw.updatedAt : nowSeconds
+  } as MealPlan;
+
+  if (raw.notes !== undefined && typeof raw.notes !== 'string') {
+    delete plan.notes;
+  }
+
+  if (isRecord(raw.days)) {
+    for (const key of DAY_KEYS) {
+      const day = validateDay(raw.days[key]);
+      if (day) plan.days[key] = day;
+    }
+  }
+
+  return { plan, readOnly };
+}
+
+export function createEmptyMealPlan(weekId: string): MealPlan {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    schemaVersion: MEALPLAN_SCHEMA_VERSION,
+    week: weekId,
+    days: {},
+    createdAt: now,
+    updatedAt: now
+  };
+}
+
+/** Serialize for encryption — plain JSON keeps unknown fields intact. */
+export function serializeMealPlan(plan: MealPlan): string {
+  return JSON.stringify(plan);
+}

--- a/src/lib/mealplan/week.test.ts
+++ b/src/lib/mealplan/week.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import {
+  weekIdForDate,
+  weeksInISOYear,
+  parseWeekId,
+  isValidWeekId,
+  mondayOfWeek,
+  nextWeekId,
+  prevWeekId,
+  dTagForWeek,
+  weekIdFromDTag,
+  weekDisplayRange
+} from './week';
+
+describe('week ids across ISO year boundaries', () => {
+  it('2026 is a 53-week ISO year', () => {
+    expect(weeksInISOYear(2026)).toBe(53);
+    expect(weeksInISOYear(2025)).toBe(52);
+  });
+
+  it('Jan 1–3 2027 belong to 2026-W53', () => {
+    expect(weekIdForDate(new Date(2027, 0, 1))).toBe('2026-W53');
+    expect(weekIdForDate(new Date(2027, 0, 2))).toBe('2026-W53');
+    expect(weekIdForDate(new Date(2027, 0, 3))).toBe('2026-W53');
+    // Jan 4 2027 is a Monday — first day of 2027-W01
+    expect(weekIdForDate(new Date(2027, 0, 4))).toBe('2027-W01');
+  });
+
+  it('Dec 29 2025 belongs to 2026-W01', () => {
+    expect(weekIdForDate(new Date(2025, 11, 29))).toBe('2026-W01');
+    expect(weekIdForDate(new Date(2025, 11, 28))).toBe('2025-W52');
+  });
+
+  it('zero-pads single-digit weeks', () => {
+    expect(weekIdForDate(new Date(2026, 1, 2))).toBe('2026-W06');
+  });
+});
+
+describe('week arithmetic', () => {
+  it('crosses into and out of W53', () => {
+    expect(nextWeekId('2026-W53')).toBe('2027-W01');
+    expect(prevWeekId('2027-W01')).toBe('2026-W53');
+  });
+
+  it('crosses a 52-week year boundary', () => {
+    expect(prevWeekId('2026-W01')).toBe('2025-W52');
+    expect(nextWeekId('2025-W52')).toBe('2026-W01');
+  });
+
+  it('walks ordinary weeks', () => {
+    expect(nextWeekId('2026-W29')).toBe('2026-W30');
+    expect(prevWeekId('2026-W29')).toBe('2026-W28');
+  });
+
+  it('mondayOfWeek returns the ISO Monday', () => {
+    const monday = mondayOfWeek('2026-W29');
+    expect(monday.getDay()).toBe(1);
+    expect(weekIdForDate(monday)).toBe('2026-W29');
+  });
+});
+
+describe('d-tag round trip', () => {
+  it('encodes and decodes', () => {
+    expect(dTagForWeek('2026-W29')).toBe('mealplan-2026-W29');
+    expect(weekIdFromDTag('mealplan-2026-W29')).toBe('2026-W29');
+  });
+
+  it('rejects foreign or malformed d-tags', () => {
+    expect(weekIdFromDTag('grocery-abc123')).toBeNull();
+    expect(weekIdFromDTag('mealplan-2026-29')).toBeNull();
+    expect(weekIdFromDTag('mealplan-2026-W99')).toBeNull();
+  });
+});
+
+describe('validation', () => {
+  it('accepts real weeks and rejects out-of-range ones', () => {
+    expect(isValidWeekId('2026-W53')).toBe(true); // 53-week year
+    expect(isValidWeekId('2025-W53')).toBe(false); // 52-week year
+    expect(isValidWeekId('2026-W00')).toBe(false);
+    expect(isValidWeekId('2026-W54')).toBe(false);
+    expect(isValidWeekId('26-W05')).toBe(false);
+    expect(isValidWeekId('garbage')).toBe(false);
+    expect(parseWeekId('2026-W29')).toEqual({ year: 2026, week: 29 });
+  });
+});
+
+describe('display range', () => {
+  it('formats a same-month week', () => {
+    // 2026-W29: Mon Jul 13 – Sun Jul 19
+    expect(weekDisplayRange('2026-W29')).toBe('Week 29 (Jul 13–19)');
+  });
+
+  it('formats a cross-month week', () => {
+    // 2026-W27: Mon Jun 29 – Sun Jul 5
+    expect(weekDisplayRange('2026-W27')).toBe('Week 27 (Jun 29–Jul 5)');
+  });
+});

--- a/src/lib/mealplan/week.ts
+++ b/src/lib/mealplan/week.ts
@@ -1,0 +1,98 @@
+/**
+ * ISO-week identifiers for meal plans — the d-tag clock.
+ *
+ * A week id is `{isoWeekYear}-W{ww}` (e.g. "2026-W29"): ISO 8601 weeks,
+ * Monday start, week-numbering year (NOT calendar year — Jan 1–3 2027
+ * fall in 2026-W53), zero-padded week. Resolved from the device's local
+ * wall-clock date per docs/mealplan-contract.md.
+ */
+
+import {
+  addDays,
+  addWeeks,
+  format,
+  getISOWeek,
+  getISOWeekYear,
+  getISOWeeksInYear,
+  startOfISOWeek
+} from 'date-fns';
+
+export const MEALPLAN_D_TAG_PREFIX = 'mealplan-';
+
+const WEEK_ID_RE = /^(\d{4})-W(\d{2})$/;
+
+/** Week id for an arbitrary local date. */
+export function weekIdForDate(date: Date): string {
+  const year = getISOWeekYear(date);
+  const week = getISOWeek(date);
+  return `${year}-W${String(week).padStart(2, '0')}`;
+}
+
+/** Week id for "now" in the device's local timezone. */
+export function currentWeekId(): string {
+  return weekIdForDate(new Date());
+}
+
+/** Number of ISO weeks (52 or 53) in an ISO week-numbering year. */
+export function weeksInISOYear(isoYear: number): number {
+  // Jan 4 is always inside week 1 of its ISO year.
+  return getISOWeeksInYear(new Date(isoYear, 0, 4));
+}
+
+/** Parse a week id into its parts, or null if malformed/out of range. */
+export function parseWeekId(weekId: string): { year: number; week: number } | null {
+  const m = WEEK_ID_RE.exec(weekId);
+  if (!m) return null;
+  const year = Number(m[1]);
+  const week = Number(m[2]);
+  if (week < 1 || week > weeksInISOYear(year)) return null;
+  return { year, week };
+}
+
+export function isValidWeekId(weekId: string): boolean {
+  return parseWeekId(weekId) !== null;
+}
+
+/** The Monday (local midnight) that starts the given week. */
+export function mondayOfWeek(weekId: string): Date {
+  const parsed = parseWeekId(weekId);
+  if (!parsed) throw new Error(`Invalid week id: ${weekId}`);
+  // Jan 4 is always in W01 of its ISO year; walk forward from W01's Monday.
+  const w1Monday = startOfISOWeek(new Date(parsed.year, 0, 4));
+  return addWeeks(w1Monday, parsed.week - 1);
+}
+
+export function nextWeekId(weekId: string): string {
+  return weekIdForDate(addWeeks(mondayOfWeek(weekId), 1));
+}
+
+export function prevWeekId(weekId: string): string {
+  return weekIdForDate(addWeeks(mondayOfWeek(weekId), -1));
+}
+
+export function dTagForWeek(weekId: string): string {
+  return `${MEALPLAN_D_TAG_PREFIX}${weekId}`;
+}
+
+/** Inverse of dTagForWeek; null when the d-tag is not a valid mealplan tag. */
+export function weekIdFromDTag(dTag: string): string | null {
+  if (!dTag.startsWith(MEALPLAN_D_TAG_PREFIX)) return null;
+  const weekId = dTag.slice(MEALPLAN_D_TAG_PREFIX.length);
+  return isValidWeekId(weekId) ? weekId : null;
+}
+
+/**
+ * Human display range, e.g. "Week 29 (Jul 13–19)" or, across a month
+ * boundary, "Week 27 (Jun 29–Jul 5)".
+ */
+export function weekDisplayRange(weekId: string): string {
+  const parsed = parseWeekId(weekId);
+  if (!parsed) throw new Error(`Invalid week id: ${weekId}`);
+  const monday = mondayOfWeek(weekId);
+  const sunday = addDays(monday, 6);
+  const sameMonth = monday.getMonth() === sunday.getMonth();
+  const range = sameMonth
+    ? `${format(monday, 'MMM d')}–${format(sunday, 'd')}`
+    : `${format(monday, 'MMM d')}–${format(sunday, 'MMM d')}`;
+  return `Week ${parsed.week} (${range})`;
+}

--- a/src/lib/services/plannerService.ts
+++ b/src/lib/services/plannerService.ts
@@ -1,0 +1,281 @@
+/**
+ * Meal Planner Service
+ *
+ * Encrypted meal-plan storage on kind 30078 (NIP-78) with NIP-44
+ * self-encryption, mirroring groceryService's skeleton with two
+ * deliberate deviations per docs/mealplan-contract.md:
+ *
+ * - d-tags are deterministic (`mealplan-{isoWeek}`), so reads use exact
+ *   multi-value `#d` filters instead of grocery's fetch-all-and-filter.
+ * - NO plaintext recipe `a` tags on the event — coordinates live only
+ *   inside the encrypted payload (privacy posture: a plaintext
+ *   coordinate plus a week-stamped d-tag leaks what you're cooking).
+ *
+ * Decrypt failures are surfaced as distinguishable results, never as
+ * "no plan" — the UI must be able to render "couldn't unlock this
+ * week" (signer denials trip the shared decrypt circuit breaker).
+ */
+
+import { browser } from '$app/environment';
+import { get } from 'svelte/store';
+import { ndk, userPublickey, ndkReady } from '$lib/nostr';
+import { NDKEvent, NDKRelaySet, type NDKFilter } from '@nostr-dev-kit/ndk';
+import {
+  encrypt,
+  decrypt,
+  detectEncryptionMethod,
+  type EncryptionMethod
+} from '$lib/encryptionService';
+import { getOutboxRelays } from '$lib/relayListCache';
+import { CLIENT_TAG_IDENTIFIER } from '$lib/consts';
+import { dTagForWeek, weekIdFromDTag } from '$lib/mealplan/week';
+import {
+  serializeMealPlan,
+  validateMealPlanPayload,
+  type MealPlan
+} from '$lib/mealplan/schema';
+
+const MEALPLAN_KIND = 30078;
+const FETCH_TIMEOUT_MS = 10000;
+
+export type MealPlanFetchResult =
+  | {
+      status: 'ok';
+      weekId: string;
+      plan: MealPlan;
+      /** schemaVersion > 1: render, never write back (contract rule 1). */
+      readOnly: boolean;
+      event: NDKEvent;
+      encryptionMethod: EncryptionMethod;
+    }
+  | {
+      status: 'decrypt-failed';
+      weekId: string;
+      event: NDKEvent;
+      error: string;
+    };
+
+/**
+ * Fetch and decrypt meal plans for a set of week ids.
+ *
+ * Returns a Map keyed by weekId. An absent key means no plan exists for
+ * that week; a present key is either a decrypted plan or an explicit
+ * decrypt failure.
+ */
+export async function fetchMealPlans(weekIds: string[]): Promise<Map<string, MealPlanFetchResult>> {
+  const results = new Map<string, MealPlanFetchResult>();
+
+  if (!browser || weekIds.length === 0) {
+    return results;
+  }
+
+  const pubkey = get(userPublickey);
+  const ndkInstance = get(ndk);
+
+  if (!pubkey || !ndkInstance) {
+    console.warn('[PlannerService] Not logged in or NDK not available');
+    return results;
+  }
+
+  await ndkReady;
+
+  // Deterministic d-tags let us do exact multi-value #d matching —
+  // no fetch-all-and-filter (relays can't prefix-match d-tags).
+  const filter: NDKFilter = {
+    kinds: [MEALPLAN_KIND],
+    authors: [pubkey],
+    '#d': weekIds.map(dTagForWeek)
+  };
+
+  try {
+    const fetchPromise = ndkInstance.fetchEvents(filter, { closeOnEose: true });
+    const timeoutPromise = new Promise<Set<NDKEvent>>((resolve) => {
+      setTimeout(() => {
+        console.log('[PlannerService] Fetch timed out, returning empty set');
+        resolve(new Set());
+      }, FETCH_TIMEOUT_MS);
+    });
+
+    const events = await Promise.race([fetchPromise, timeoutPromise]);
+
+    // Replaceable events: relays can still hand back multiple versions
+    // of the same d-tag — keep the newest per week.
+    const newestByWeek = new Map<string, NDKEvent>();
+    for (const event of events) {
+      const dTag = event.tags.find((t) => t[0] === 'd')?.[1];
+      const weekId = dTag ? weekIdFromDTag(dTag) : null;
+      if (!weekId) continue;
+      const existing = newestByWeek.get(weekId);
+      if (existing && (existing.created_at || 0) >= (event.created_at || 0)) continue;
+      newestByWeek.set(weekId, event);
+    }
+
+    for (const [weekId, event] of newestByWeek) {
+      results.set(weekId, await decryptMealPlanEvent(weekId, event, pubkey));
+    }
+
+    return results;
+  } catch (error) {
+    console.error('[PlannerService] Failed to fetch meal plans:', error);
+    throw error;
+  }
+}
+
+/** Fetch a single week's plan. Null = no plan exists for that week. */
+export async function fetchMealPlan(weekId: string): Promise<MealPlanFetchResult | null> {
+  const results = await fetchMealPlans([weekId]);
+  return results.get(weekId) || null;
+}
+
+async function decryptMealPlanEvent(
+  weekId: string,
+  event: NDKEvent,
+  pubkey: string
+): Promise<MealPlanFetchResult> {
+  if (!event.content) {
+    return { status: 'decrypt-failed', weekId, event, error: 'Event missing content' };
+  }
+
+  try {
+    const method = detectEncryptionMethod(event.content);
+    const plaintext = await decrypt(pubkey, event.content, method);
+    const payload = JSON.parse(plaintext);
+
+    const validated = validateMealPlanPayload(payload, weekId);
+    if (!validated) {
+      return { status: 'decrypt-failed', weekId, event, error: 'Malformed meal plan payload' };
+    }
+
+    return {
+      status: 'ok',
+      weekId,
+      plan: validated.plan,
+      readOnly: validated.readOnly,
+      event,
+      encryptionMethod: method
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[PlannerService] Failed to decrypt/parse meal plan:', {
+      message,
+      weekId,
+      hasContent: !!event.content,
+      contentLength: event.content?.length || 0
+    });
+    return { status: 'decrypt-failed', weekId, event, error: message };
+  }
+}
+
+/**
+ * Save (create or replace) a week's meal plan.
+ *
+ * NIP-46 durability caveat applies (contract doc): remote signers may
+ * produce ciphertext a later session cannot decrypt; matching grocery,
+ * we write anyway.
+ */
+export async function saveMealPlan(plan: MealPlan): Promise<NDKEvent> {
+  if (!browser) {
+    throw new Error('Cannot save meal plan on server');
+  }
+
+  const pubkey = get(userPublickey);
+  const ndkInstance = get(ndk);
+
+  if (!pubkey) {
+    throw new Error('Not logged in');
+  }
+
+  if (!ndkInstance?.signer) {
+    throw new Error('No signer available. Please log in again.');
+  }
+
+  await ndkReady;
+
+  const now = Math.floor(Date.now() / 1000);
+  const planToSave: MealPlan = {
+    ...plan,
+    updatedAt: now,
+    createdAt: plan.createdAt || now
+  };
+
+  try {
+    const { ciphertext } = await encrypt(pubkey, serializeMealPlan(planToSave), 'nip44');
+
+    const event = new NDKEvent(ndkInstance);
+    event.kind = MEALPLAN_KIND;
+    event.content = ciphertext;
+    // Contract: d + client tags ONLY — recipe coordinates stay inside
+    // the encrypted payload.
+    event.tags = [
+      ['d', dTagForWeek(planToSave.week)],
+      ['client', CLIENT_TAG_IDENTIFIER]
+    ];
+
+    await event.sign();
+
+    const writeRelays = await getOutboxRelays(pubkey);
+
+    console.log(
+      '[PlannerService] Publishing meal plan...',
+      writeRelays.length > 0 ? `(${writeRelays.length} outbox relays)` : '(default relays)'
+    );
+
+    if (writeRelays.length > 0) {
+      const relaySet = NDKRelaySet.fromRelayUrls(writeRelays, ndkInstance);
+      await event.publish(relaySet);
+    } else {
+      await event.publish();
+    }
+
+    console.log('[PlannerService] Meal plan saved successfully');
+    return event;
+  } catch (error) {
+    console.error('[PlannerService] Failed to save meal plan:', error);
+    throw error;
+  }
+}
+
+/** Delete a week's plan via NIP-09 (kind 5). */
+export async function deleteMealPlan(weekId: string, eventId?: string): Promise<NDKEvent | null> {
+  if (!browser) {
+    return null;
+  }
+
+  const pubkey = get(userPublickey);
+  const ndkInstance = get(ndk);
+
+  if (!pubkey || !ndkInstance?.signer) {
+    throw new Error('Not logged in or no signer available');
+  }
+
+  await ndkReady;
+
+  try {
+    const deleteEvent = new NDKEvent(ndkInstance);
+    deleteEvent.kind = 5;
+    deleteEvent.content = 'Deleted meal plan';
+    deleteEvent.tags = [['a', `${MEALPLAN_KIND}:${pubkey}:${dTagForWeek(weekId)}`]];
+    if (eventId) {
+      deleteEvent.tags.push(['e', eventId]);
+    }
+
+    await deleteEvent.sign();
+
+    const writeRelays = await getOutboxRelays(pubkey);
+    if (writeRelays.length > 0) {
+      const relaySet = NDKRelaySet.fromRelayUrls(writeRelays, ndkInstance);
+      await deleteEvent.publish(relaySet);
+    } else {
+      await deleteEvent.publish();
+    }
+
+    console.log('[PlannerService] Meal plan deleted:', weekId);
+    return deleteEvent;
+  } catch (error) {
+    console.error('[PlannerService] Failed to delete meal plan:', error);
+    throw error;
+  }
+}
+
+export { createEmptyMealPlan } from '$lib/mealplan/schema';
+export type { MealPlan } from '$lib/mealplan/schema';


### PR DESCRIPTION
Implements **Phase 3.1 (data layer, service half)** of [docs/my-kitchen-spec.md](https://github.com/zapcooking/frontend/blob/main/docs/my-kitchen-spec.md) against the approved-and-frozen Phase 3 schema. Approved decisions applied: no plaintext a-tags, local-wall-clock ISO-week d-tags, slot tagged union with text entries, `schemaVersion: 1`, NIP-46 write-anyway with documented caveat.

## Changes

- **`docs/mealplan-contract.md`** — the frozen cross-platform contract (Android ports against it verbatim, per the `RecipeBookmarkRepository` ↔ `cookbookStore` model): envelope table, local-wall-clock ISO-week d-tag definition (`getISOWeekYear` semantics, Monday start, `W%02d`), full payload schema + contract rules (optional days/slots, unknown-field preservation, `schemaVersion > 1` → read-only), kind-5 deletion shape, decrypt-failure-≠-empty-week rule, NIP-46 durability caveat, and the no-plaintext-a-tags rationale.
- **`src/lib/mealplan/week.ts`** — ISO-week helpers on date-fns v3: `currentWeekId`, `weekIdForDate`, `dTagForWeek`/`weekIdFromDTag`, `parseWeekId`/`isValidWeekId` (range-checked against 52/53-week years), `prev`/`nextWeekId` via Monday-of-week arithmetic (correct across year boundaries incl. W53), `weekDisplayRange` ("Week 29 (Jul 13–19)", cross-month aware).
- **`src/lib/mealplan/schema.ts`** — payload types + `validateMealPlanPayload` (defensive: invalid slots dropped, unknown fields preserved at top/day/slot level, v>1 flagged read-only, d-tag week wins), `createEmptyMealPlan`, `serializeMealPlan`.
- **`src/lib/services/plannerService.ts`** — groceryService skeleton with the two approved deviations: exact multi-value `#d` fetch for a set of weekIds (deterministic d-tags make this possible; no fetch-all-and-filter) and **no plaintext recipe tags**. `fetchMealPlans` returns a Map with a discriminated result — `{status:'ok', plan, readOnly, …}` vs `{status:'decrypt-failed', error, …}` — so the store/UI can distinguish "couldn't unlock" from "no plan". Save: guards → `ndkReady` → NIP-44 self-encrypt → sign → outbox-or-default publish. Delete: kind-5 with the `30078:{pubkey}:{dTag}` coordinate.
- **Spec status**: Phase 3 → `In progress`.

## Verification

- **23 new vitest cases pass**: 2026-W53 year-boundary facts (Jan 1–3 2027 → `2026-W53`; Dec 29 2025 → `2026-W01`), W53↔W01 arithmetic both directions, 52-week-year boundary, zero-padding, weekId↔d-tag round-trip incl. rejection of foreign tags, display ranges (same-month + cross-month), payload round-trip with unknown-field preservation at all three levels, both union branches, v2 read-only flagging, invalid-slot dropping, malformed-payload rejection, empty-plan skeleton.
- **Full suite: 707/707 pass.** Build passes (adapter-cloudflare).

## Notes / discoveries (not fixed here)

- Nothing imports the new service yet — that's PR8 (store). The build compiling it confirms types only.
- Inherited grocery warts documented in the contract rather than diverging: the 2s-debounce/no-`beforeunload` loss window (will land with PR8's store) and the NIP-46 durability risk.
- `fetchMealPlans` relies on relays honoring multi-value `#d` filters — standard NIP-01; worth one live check when PR8 wires the store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)