### PR TITLE
My Kitchen Phase 3 PR8: planner store

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.647",
+  "version": "4.2.648",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.646",
+  "version": "4.2.647",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/stores/plannerStore.test.ts
+++ b/src/lib/stores/plannerStore.test.ts
@@ -126,7 +126,7 @@ describe('debounced saves', () => {
 
     await vi.advanceTimersByTimeAsync(2000);
     expect(saveMealPlan).toHaveBeenCalledTimes(2);
-    const weeks = saveMealPlan.mock.calls.map((c) => c[0].week);
+    const weeks = saveMealPlan.mock.calls.map((c: unknown[]) => (c[0] as { week: string }).week);
     expect(new Set(weeks)).toEqual(new Set([W29, W30]));
   });
 });

--- a/src/lib/stores/plannerStore.test.ts
+++ b/src/lib/stores/plannerStore.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { writable, get } from 'svelte/store';
+import { createEmptyMealPlan } from '$lib/mealplan/schema';
+
+// ── Mocks (hoisted above imports by vitest) ──
+
+vi.mock('$app/environment', () => ({ browser: true }));
+
+vi.mock('$lib/nostr', async () => {
+  const { writable } = await import('svelte/store');
+  return { userPublickey: writable('a'.repeat(64)) };
+});
+
+vi.mock('$lib/services/plannerService', () => ({
+  fetchMealPlans: vi.fn(),
+  saveMealPlan: vi.fn(),
+  deleteMealPlan: vi.fn()
+}));
+
+import { userPublickey } from '$lib/nostr';
+import * as plannerService from '$lib/services/plannerService';
+import { plannerStore } from './plannerStore';
+
+const mockPubkey = userPublickey as unknown as ReturnType<typeof writable<string>>;
+const fetchMealPlans = vi.mocked(plannerService.fetchMealPlans);
+const saveMealPlan = vi.mocked(plannerService.saveMealPlan);
+const deleteMealPlan = vi.mocked(plannerService.deleteMealPlan);
+
+const W28 = '2026-W28';
+const W29 = '2026-W29';
+const W30 = '2026-W30';
+const W31 = '2026-W31';
+
+function okResult(weekId: string, overrides: Record<string, unknown> = {}) {
+  return {
+    status: 'ok',
+    weekId,
+    plan: createEmptyMealPlan(weekId),
+    readOnly: false,
+    event: null,
+    encryptionMethod: 'nip44',
+    ...overrides
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  fetchMealPlans.mockReset().mockResolvedValue(new Map());
+  saveMealPlan.mockReset().mockResolvedValue(null);
+  deleteMealPlan.mockReset().mockResolvedValue(null);
+  mockPubkey.set('a'.repeat(64));
+  plannerStore.clear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('prefetch batching and no-refetch', () => {
+  it('loads the visible week plus both neighbors in ONE service call', async () => {
+    await plannerStore.goToWeek(W29);
+    expect(fetchMealPlans).toHaveBeenCalledTimes(1);
+    expect(new Set(fetchMealPlans.mock.calls[0][0])).toEqual(new Set([W28, W29, W30]));
+  });
+
+  it('does not refetch already-loaded weeks on navigation', async () => {
+    await plannerStore.goToWeek(W29); // loads W28,W29,W30
+    fetchMealPlans.mockClear();
+
+    await plannerStore.nextWeek(); // W30 visible; only W31 missing
+    expect(fetchMealPlans).toHaveBeenCalledTimes(1);
+    expect(fetchMealPlans.mock.calls[0][0]).toEqual([W31]);
+
+    fetchMealPlans.mockClear();
+    await plannerStore.prevWeek(); // back to W29 — everything loaded
+    expect(fetchMealPlans).not.toHaveBeenCalled();
+  });
+
+  it('refresh() force-refetches the neighborhood', async () => {
+    await plannerStore.goToWeek(W29);
+    fetchMealPlans.mockClear();
+
+    await plannerStore.refresh();
+    expect(fetchMealPlans).toHaveBeenCalledTimes(1);
+    expect(new Set(fetchMealPlans.mock.calls[0][0])).toEqual(new Set([W28, W29, W30]));
+  });
+});
+
+describe('debounced saves', () => {
+  it('coalesces N mutations into one save', async () => {
+    await plannerStore.goToWeek(W29);
+
+    expect(plannerStore.setSlot(W29, 'mon', 'dinner', { type: 'text', text: 'Tacos' })).toBe(true);
+    plannerStore.setSlot(W29, 'tue', 'lunch', { type: 'text', text: 'Leftovers' });
+    plannerStore.setDayNotes(W29, 'mon', 'prep ahead');
+    plannerStore.setWeekNotes(W29, 'busy week');
+    plannerStore.clearSlot(W29, 'tue', 'lunch');
+
+    expect(saveMealPlan).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(saveMealPlan).toHaveBeenCalledTimes(1);
+    const savedPlan = saveMealPlan.mock.calls[0][0];
+    expect(savedPlan.days.mon.slots.dinner).toEqual({ type: 'text', text: 'Tacos' });
+    expect(savedPlan.days.mon.notes).toBe('prep ahead');
+    expect(savedPlan.notes).toBe('busy week');
+    expect(savedPlan.days.tue.slots.lunch).toBeUndefined();
+  });
+
+  it('saveNow flushes without waiting for the debounce', async () => {
+    await plannerStore.goToWeek(W29);
+    plannerStore.setSlot(W29, 'wed', 'breakfast', { type: 'recipe', a: '30023:pk:oats' });
+
+    await plannerStore.saveNow();
+    expect(saveMealPlan).toHaveBeenCalledTimes(1);
+
+    // Timer was cancelled — advancing does not double-save
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(saveMealPlan).toHaveBeenCalledTimes(1);
+  });
+
+  it('mutations on different weeks save independently', async () => {
+    await plannerStore.goToWeek(W29);
+    plannerStore.setSlot(W29, 'mon', 'dinner', { type: 'text', text: 'A' });
+    plannerStore.setSlot(W30, 'mon', 'dinner', { type: 'text', text: 'B' });
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(saveMealPlan).toHaveBeenCalledTimes(2);
+    const weeks = saveMealPlan.mock.calls.map((c) => c[0].week);
+    expect(new Set(weeks)).toEqual(new Set([W29, W30]));
+  });
+});
+
+describe('decrypt-failed preservation', () => {
+  it('keeps decrypt-failed distinct from empty and rejects mutations', async () => {
+    fetchMealPlans.mockResolvedValue(
+      new Map([[W29, { status: 'decrypt-failed', weekId: W29, event: null, error: 'denied' }]])
+    );
+
+    await plannerStore.goToWeek(W29);
+    const state = get(plannerStore);
+
+    expect(state.weeks[W29]).toEqual({ status: 'decrypt-failed', error: 'denied' });
+    // Neighbors had no events: loaded as empty editable plans, NOT decrypt-failed
+    expect(state.weeks[W28].status).toBe('ok');
+    expect(state.weeks[W30].status).toBe('ok');
+
+    expect(plannerStore.setSlot(W29, 'mon', 'dinner', { type: 'text', text: 'X' })).toBe(false);
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(saveMealPlan).not.toHaveBeenCalled();
+  });
+});
+
+describe('read-only enforcement', () => {
+  it('rejects mutations on schemaVersion > 1 weeks', async () => {
+    fetchMealPlans.mockResolvedValue(new Map([[W29, okResult(W29, { readOnly: true })]]));
+
+    await plannerStore.goToWeek(W29);
+    expect((get(plannerStore).weeks[W29] as any).readOnly).toBe(true);
+
+    expect(plannerStore.setSlot(W29, 'mon', 'dinner', { type: 'text', text: 'X' })).toBe(false);
+    expect(plannerStore.setWeekNotes(W29, 'nope')).toBe(false);
+    expect(plannerStore.clearSlot(W29, 'mon', 'dinner')).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(saveMealPlan).not.toHaveBeenCalled();
+  });
+
+  it('rejects mutations on not-yet-loaded weeks', () => {
+    expect(plannerStore.setSlot('2031-W02', 'mon', 'dinner', { type: 'text', text: 'X' })).toBe(
+      false
+    );
+  });
+});
+
+describe('logout clear', () => {
+  it('clears all state when the pubkey goes falsy', async () => {
+    plannerStore.init();
+    await plannerStore.goToWeek(W29);
+    plannerStore.setSlot(W29, 'mon', 'dinner', { type: 'text', text: 'Tacos' });
+    expect(Object.keys(get(plannerStore).weeks).length).toBeGreaterThan(0);
+
+    mockPubkey.set('');
+
+    const state = get(plannerStore);
+    expect(state.weeks).toEqual({});
+    expect(state.initialized).toBe(false);
+
+    // Pending save timer was cancelled by clear()
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(saveMealPlan).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteWeek', () => {
+  it('deletes via the service and resets to an empty editable week', async () => {
+    fetchMealPlans.mockResolvedValue(new Map([[W29, okResult(W29)]]));
+    await plannerStore.goToWeek(W29);
+    plannerStore.setSlot(W29, 'mon', 'dinner', { type: 'text', text: 'Tacos' });
+
+    await plannerStore.deleteWeek(W29);
+
+    expect(deleteMealPlan).toHaveBeenCalledWith(W29);
+    const weekState = get(plannerStore).weeks[W29];
+    expect(weekState.status).toBe('ok');
+    expect((weekState as any).plan.days).toEqual({});
+
+    // The pending mutation save was cancelled
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(saveMealPlan).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/stores/plannerStore.ts
+++ b/src/lib/stores/plannerStore.ts
@@ -1,0 +1,385 @@
+/**
+ * Meal Planner Store
+ *
+ * Reactive state over plannerService, on the groceryStore architecture:
+ * per-key (weekId) debounced saves, optimistic local mutations, and the
+ * userPublickey-watcher logout clear.
+ *
+ * Planner-specific behavior per docs/mealplan-contract.md and the
+ * Phase 3 findings:
+ * - Weeks carry the service's discriminated result end-to-end: an
+ *   'ok' week (possibly an empty plan) is NEVER conflated with a
+ *   'decrypt-failed' week — the UI must be able to render "couldn't
+ *   unlock this week".
+ * - Navigation loads the visible week plus both neighbors in ONE
+ *   multi-value #d fetch (the shared decrypt queue serializes signer
+ *   popups; batching avoids a popup per navigation step). Loaded
+ *   weeks are not refetched on navigation; refresh() force-refetches.
+ * - schemaVersion > 1 weeks are read-only: mutations are rejected at
+ *   the store level (mutators return false).
+ */
+
+import { writable, derived, get } from 'svelte/store';
+import { browser } from '$app/environment';
+import { userPublickey } from '$lib/nostr';
+import {
+  fetchMealPlans,
+  saveMealPlan,
+  deleteMealPlan,
+  type MealPlanFetchResult
+} from '$lib/services/plannerService';
+import { createEmptyMealPlan, type MealPlan, type MealPlanDay, type MealPlanDayKey, type MealSlot, type MealSlotKey } from '$lib/mealplan/schema';
+import { currentWeekId, isValidWeekId, nextWeekId, prevWeekId } from '$lib/mealplan/week';
+
+export type PlannerWeekState =
+  | { status: 'ok'; plan: MealPlan; readOnly: boolean }
+  | { status: 'decrypt-failed'; error: string };
+
+export interface PlannerStoreState {
+  /** Loaded weeks keyed by weekId. An absent key = not loaded yet. */
+  weeks: Record<string, PlannerWeekState>;
+  currentWeekId: string;
+  loading: boolean;
+  initialized: boolean;
+  error: string | null;
+  saving: boolean;
+  lastSaved: number | null;
+}
+
+const SAVE_DEBOUNCE_MS = 2000;
+
+function createPlannerStore() {
+  const { subscribe, set, update } = writable<PlannerStoreState>({
+    weeks: {},
+    currentWeekId: browser ? currentWeekId() : '1970-W01',
+    loading: false,
+    initialized: false,
+    error: null,
+    saving: false,
+    lastSaved: null
+  });
+
+  // Debounce timers for saves (keyed by weekId)
+  const saveTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const pendingSaves = new Set<string>();
+  let pubkeyUnsubscribe: (() => void) | null = null;
+
+  function scheduleSave(weekId: string): void {
+    const existingTimer = saveTimers.get(weekId);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+    }
+    const timer = setTimeout(async () => {
+      saveTimers.delete(weekId);
+      await performSave(weekId);
+    }, SAVE_DEBOUNCE_MS);
+    saveTimers.set(weekId, timer);
+  }
+
+  async function performSave(weekId: string): Promise<void> {
+    if (pendingSaves.has(weekId)) {
+      return;
+    }
+
+    pendingSaves.add(weekId);
+    update((s) => ({ ...s, saving: true }));
+
+    try {
+      // Read the LATEST week state (not a captured closure)
+      const weekState = get({ subscribe }).weeks[weekId];
+      if (weekState?.status === 'ok' && !weekState.readOnly) {
+        await saveMealPlan(weekState.plan);
+        update((s) => ({ ...s, lastSaved: Date.now(), error: null }));
+        console.log('[PlannerStore] Week saved:', weekId);
+      }
+    } catch (error) {
+      console.error('[PlannerStore] Failed to save week:', error);
+      update((s) => ({
+        ...s,
+        error: error instanceof Error ? error.message : 'Failed to save meal plan'
+      }));
+    } finally {
+      pendingSaves.delete(weekId);
+      if (pendingSaves.size === 0) {
+        update((s) => ({ ...s, saving: false }));
+      }
+    }
+  }
+
+  async function flushPendingSaves(): Promise<void> {
+    for (const [weekId, timer] of saveTimers) {
+      clearTimeout(timer);
+      saveTimers.delete(weekId);
+      await performSave(weekId);
+    }
+  }
+
+  function clearAllTimers(): void {
+    for (const timer of saveTimers.values()) {
+      clearTimeout(timer);
+    }
+    saveTimers.clear();
+  }
+
+  /** Fetch the given weeks in one multi-#d call, skipping loaded ones. */
+  async function loadWeeks(weekIds: string[], force = false): Promise<void> {
+    const state = get({ subscribe });
+    const targets = weekIds.filter(
+      (w) => isValidWeekId(w) && (force || state.weeks[w] === undefined)
+    );
+    if (targets.length === 0) return;
+
+    update((s) => ({ ...s, loading: true }));
+    try {
+      const results = await fetchMealPlans(targets);
+      update((s) => {
+        const weeks = { ...s.weeks };
+        for (const weekId of targets) {
+          weeks[weekId] = toWeekState(weekId, results.get(weekId));
+        }
+        return { ...s, weeks, error: null };
+      });
+    } catch (error) {
+      console.error('[PlannerStore] Failed to load weeks:', error);
+      update((s) => ({
+        ...s,
+        error: error instanceof Error ? error.message : 'Failed to load meal plans'
+      }));
+    } finally {
+      update((s) => ({ ...s, loading: false, initialized: true }));
+    }
+  }
+
+  function toWeekState(weekId: string, result: MealPlanFetchResult | undefined): PlannerWeekState {
+    if (!result) {
+      // Loaded, nothing on relays: an empty local plan, editable.
+      return { status: 'ok', plan: createEmptyMealPlan(weekId), readOnly: false };
+    }
+    if (result.status === 'decrypt-failed') {
+      // Contract: never collapse into "empty week".
+      return { status: 'decrypt-failed', error: result.error };
+    }
+    return { status: 'ok', plan: result.plan, readOnly: result.readOnly };
+  }
+
+  /** Visible week + both neighbors, one fetch. */
+  function neighborhood(weekId: string): string[] {
+    return [weekId, prevWeekId(weekId), nextWeekId(weekId)];
+  }
+
+  /**
+   * Guarded immutable mutation of an editable week's plan. Returns
+   * false (no state change, no save) when the week isn't loaded, is
+   * decrypt-failed, or is read-only.
+   */
+  function mutatePlan(weekId: string, mutate: (plan: MealPlan) => MealPlan): boolean {
+    const weekState = get({ subscribe }).weeks[weekId];
+    if (!weekState) {
+      console.warn('[PlannerStore] Mutation rejected — week not loaded:', weekId);
+      return false;
+    }
+    if (weekState.status === 'decrypt-failed') {
+      console.warn('[PlannerStore] Mutation rejected — week failed to decrypt:', weekId);
+      return false;
+    }
+    if (weekState.readOnly) {
+      console.warn('[PlannerStore] Mutation rejected — week is read-only (newer schema):', weekId);
+      return false;
+    }
+
+    update((s) => ({
+      ...s,
+      weeks: {
+        ...s.weeks,
+        [weekId]: { status: 'ok', plan: mutate(weekState.plan), readOnly: false }
+      }
+    }));
+    scheduleSave(weekId);
+    return true;
+  }
+
+  function withDay(
+    plan: MealPlan,
+    day: MealPlanDayKey,
+    mutateDay: (day: MealPlanDay) => MealPlanDay
+  ): MealPlan {
+    const existing = plan.days[day] || {};
+    return { ...plan, days: { ...plan.days, [day]: mutateDay(existing) } };
+  }
+
+  return {
+    subscribe,
+
+    /** Set up the logout watcher (mirrors groceryStore.init). */
+    init(): void {
+      if (!browser) return;
+      if (pubkeyUnsubscribe) {
+        pubkeyUnsubscribe();
+      }
+      pubkeyUnsubscribe = userPublickey.subscribe((pubkey) => {
+        if (!pubkey) {
+          this.clear();
+        }
+      });
+    },
+
+    /** Load the current week + neighbors (one multi-#d fetch). */
+    async load(): Promise<void> {
+      if (!browser || !get(userPublickey)) return;
+      await loadWeeks(neighborhood(get({ subscribe }).currentWeekId));
+    },
+
+    /** Force-refetch the current week + neighbors (pull-to-refresh). */
+    async refresh(): Promise<void> {
+      if (!browser || !get(userPublickey)) return;
+      await loadWeeks(neighborhood(get({ subscribe }).currentWeekId), true);
+    },
+
+    /** Navigate to a week; loads it (+ neighbors) unless already loaded. */
+    async goToWeek(weekId: string): Promise<void> {
+      if (!isValidWeekId(weekId)) {
+        console.warn('[PlannerStore] Invalid week id:', weekId);
+        return;
+      }
+      update((s) => ({ ...s, currentWeekId: weekId }));
+      await loadWeeks(neighborhood(weekId));
+    },
+
+    async nextWeek(): Promise<void> {
+      await this.goToWeek(nextWeekId(get({ subscribe }).currentWeekId));
+    },
+
+    async prevWeek(): Promise<void> {
+      await this.goToWeek(prevWeekId(get({ subscribe }).currentWeekId));
+    },
+
+    async goToCurrentWeek(): Promise<void> {
+      await this.goToWeek(currentWeekId());
+    },
+
+    // ── Mutations (PR9 API). All return false when rejected. ──
+
+    setSlot(weekId: string, day: MealPlanDayKey, slot: MealSlotKey, entry: MealSlot): boolean {
+      return mutatePlan(weekId, (plan) =>
+        withDay(plan, day, (d) => ({ ...d, slots: { ...d.slots, [slot]: entry } }))
+      );
+    },
+
+    clearSlot(weekId: string, day: MealPlanDayKey, slot: MealSlotKey): boolean {
+      return mutatePlan(weekId, (plan) =>
+        withDay(plan, day, (d) => {
+          const slots = { ...d.slots };
+          delete slots[slot];
+          return { ...d, slots };
+        })
+      );
+    },
+
+    setDayNotes(weekId: string, day: MealPlanDayKey, notes: string): boolean {
+      return mutatePlan(weekId, (plan) =>
+        withDay(plan, day, (d) => {
+          const next = { ...d };
+          if (notes) next.notes = notes;
+          else delete next.notes;
+          return next;
+        })
+      );
+    },
+
+    setWeekNotes(weekId: string, notes: string): boolean {
+      return mutatePlan(weekId, (plan) => {
+        const next = { ...plan };
+        if (notes) next.notes = notes;
+        else delete next.notes;
+        return next;
+      });
+    },
+
+    /** Delete a week's plan (kind-5) and reset it to an empty editable plan. */
+    async deleteWeek(weekId: string): Promise<void> {
+      const timer = saveTimers.get(weekId);
+      if (timer) {
+        clearTimeout(timer);
+        saveTimers.delete(weekId);
+      }
+
+      try {
+        await deleteMealPlan(weekId);
+        update((s) => ({
+          ...s,
+          weeks: {
+            ...s.weeks,
+            [weekId]: {
+              status: 'ok',
+              plan: createEmptyMealPlan(weekId),
+              readOnly: false
+            }
+          },
+          error: null
+        }));
+      } catch (error) {
+        console.error('[PlannerStore] Failed to delete week:', error);
+        update((s) => ({
+          ...s,
+          error: error instanceof Error ? error.message : 'Failed to delete meal plan'
+        }));
+      }
+    },
+
+    /** Flush all pending debounced saves immediately. */
+    async saveNow(): Promise<void> {
+      await flushPendingSaves();
+    },
+
+    clear(): void {
+      clearAllTimers();
+      pendingSaves.clear();
+      set({
+        weeks: {},
+        currentWeekId: browser ? currentWeekId() : '1970-W01',
+        loading: false,
+        initialized: false,
+        error: null,
+        saving: false,
+        lastSaved: null
+      });
+    },
+
+    destroy(): void {
+      clearAllTimers();
+      if (pubkeyUnsubscribe) {
+        pubkeyUnsubscribe();
+        pubkeyUnsubscribe = null;
+      }
+    }
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════
+// SINGLETON EXPORT
+// ═══════════════════════════════════════════════════════════════
+
+export const plannerStore = createPlannerStore();
+
+// Initialize on import (browser only)
+if (browser) {
+  plannerStore.init();
+}
+
+// ═══════════════════════════════════════════════════════════════
+// DERIVED STORES
+// ═══════════════════════════════════════════════════════════════
+
+export const plannerCurrentWeekId = derived(plannerStore, ($s) => $s.currentWeekId);
+export const plannerLoading = derived(plannerStore, ($s) => $s.loading);
+export const plannerSaving = derived(plannerStore, ($s) => $s.saving);
+export const plannerError = derived(plannerStore, ($s) => $s.error);
+export const plannerInitialized = derived(plannerStore, ($s) => $s.initialized);
+
+/** The visible week's state (undefined until loaded). */
+export const plannerCurrentWeek = derived(
+  plannerStore,
+  ($s): PlannerWeekState | undefined => $s.weeks[$s.currentWeekId]
+);
+
+export type { MealPlan, MealPlanDayKey, MealSlot, MealSlotKey } from '$lib/mealplan/schema';


### PR DESCRIPTION
Implements **Phase 3.1 (data layer, store half)** per the Phase 3 findings and [docs/mealplan-contract.md](https://github.com/zapcooking/frontend/blob/main/docs/mealplan-contract.md). Follows PR7 (#542). No UI — that's PR9.

## Changes — `src/lib/stores/plannerStore.ts` (+ tests)

Built on the groceryStore architecture, with the planner-specific behaviors from the findings:

- **State**: weeks keyed by weekId, each a discriminated `PlannerWeekState` — `{status:'ok', plan, readOnly}` or `{status:'decrypt-failed', error}`; absent key = not loaded. A loaded week with no relay event becomes an empty *editable* plan; **decrypt-failed is never collapsed into empty**, end-to-end from the service.
- **Debounced saves**: groceryStore's per-key infra copied (2s timers keyed by weekId, `pendingSaves` guard reading the *latest* state at fire time, `saveNow()` flush, all-timers clear).
- **Init/logout**: the `userPublickey`-watcher pattern — full `clear()` (including pending timers) when the pubkey goes falsy.
- **Week navigation**: `currentWeekId` from the PR7 helper; `goToWeek`/`nextWeek`/`prevWeek`/`goToCurrentWeek`. Every navigation loads the **visible week + both neighbors in ONE multi-value `#d` fetch** (the shared decrypt queue serializes signer popups — batching avoids a popup per step). Already-loaded weeks are never refetched on navigation; `refresh()` force-refetches for PR9's pull-to-refresh.
- **Mutation API for PR9**: `setSlot` (contract tagged union), `clearSlot`, `setDayNotes`, `setWeekNotes`, `deleteWeek` (kind-5 via service + reset to empty editable week + pending-save cancellation). All mutators return `false` on rejection.
- **Read-only enforcement**: `schemaVersion > 1` weeks render but reject every mutation at the store level, per contract rule 1.
- Derived stores: `plannerCurrentWeekId/Loading/Saving/Error/Initialized`, `plannerCurrentWeek`.

## Verification

- **11 new vitest cases pass** — exactly the required list: debounce coalescing (5 mutations → 1 save, payload asserted), `saveNow` flush without double-save, per-week save independence, decrypt-failed preserved through the store + mutation rejection + no save fired, read-only rejection across all mutators, not-loaded rejection, logout clear (state + timer cancellation), prefetch batching (one call, `{W28,W29,W30}`), no-refetch on revisit (navigate forward fetches only the new neighbor; navigate back fetches nothing), forced refresh, deleteWeek reset.
- **Full suite: 718/718.** Build passes (adapter-cloudflare).
- **Live relay verification (PR7 follow-up): PASS.** Node script against the default pool (damus, nos.lol, primal) with a throwaway key: published `mealplan-2026-W29` + `mealplan-2026-W30` (6/6 acks), then a fresh pool issued ONE `{kinds:[30078], authors:[pk], '#d':[W29,W30]}` REQ — **both events returned in the single query**. Test events cleaned up with NIP-09 deletes. (Session-based check not possible headlessly for encrypted content; this verifies the exact relay behavior the store depends on.)

## Notes / discoveries (not fixed here)

- No service/schema changes were needed — the PR7 API fit as designed.
- Inherited parity wart, now live for the planner too: the 2s debounce window has no `beforeunload` flush (grocery has the same). PR9's page `onDestroy → saveNow()` covers in-app navigation, not tab close.
- Store tests needed `vi.mock` factories with in-factory store creation (hoisting) — pattern now established for future store tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)