### PR TITLE
fix: quorum readiness for the NDK connection pool

### DIFF
--- a/docs/ndk-readiness-discovery.md
+++ b/docs/ndk-readiness-discovery.md
@@ -1,0 +1,126 @@
+# NDK Readiness Discovery — `ndkReady` fires too early
+
+Investigation of cold-session fetch misses and publish under-delivery. **Status: PR A (quorum readiness, §6a / §7.1) implemented — see the Addendum at the bottom. PR B (cookbookStore repair) and PR C (workaround cleanup) pending.** Sections 1–8 describe the pre-fix state as investigated.
+
+Date: 2026-07-13. NDK version: 2.10.0 (semantics below verified against the installed source, not docs).
+
+---
+
+## 1. What "ready" means today
+
+`ndkReady` (`src/lib/nostr.ts:258`) resolves after `connectWithRetry` → `connectionManager.connectWithCircuitBreaker()` (`src/lib/connectionManager.ts:346`), which is:
+
+1. `await ndk.connect()` — **not a barrier**: `NDKRelayConnectivity.connect()` returns when the WebSocket object is *created*, not when it opens. `NDK.connect` wraps pool connects in `Promise.allSettled`, so it never rejects either.
+2. `await waitForFirstRelay(3000)` (`connectionManager.ts:367`) — polls every 50 ms until **one** relay socket is OPEN, or gives up at 3 s and resolves anyway.
+3. On total failure, `ndkReadyResolve()` is still called ("resolve anyway so components don't hang", `nostr.ts:478`).
+
+So `await ndkReady` ⇒ "at most one of five relays is known connected, possibly zero."
+
+Every other readiness primitive is the **same signal**, not a stronger one:
+
+- `ndkConnected` store — set `true` at the same moment (`nostr.ts:286`).
+- `isNdkReady()` — `get(ndkConnected)`. **Zero live callers** (dead import in `profileCache.ts:5`).
+- `ensureNdkConnected(timeoutMs=6000)` (`nostr.ts:512`) — awaits `ndkReady`, then polls `ndkConnected`; since `ndkConnected` flips true at first-relay, it adds nothing on the happy path.
+- `switchRelays` (members/discovery modes) funnels through the same `connectWithRetry`, so relay-mode switches have first-relay semantics too.
+
+Default pool (`src/lib/consts.ts`): damus, nos.lol, purplepag.es, primal, nostr.wine. Note **purplepag.es is a profiles-only relay** — if it wins the connect race, a "ready" pool serves zero recipe/list events. Outbox model is enabled in all modes with a separate outbox pool (purplepag.es, nos.lol).
+
+## 2. Why early fetches miss data (NDK 2.10.0 mechanics)
+
+The REQ itself is *not* the problem — NDK queues per-relay subscriptions until the relay is ready (`NDKRelaySubscription.execute`: status → WAITING, fires on the relay `ready` event) and a pool monitor replays filters to relays that connect later.
+
+The loss happens at **EOSE aggregation** (`NDKSubscription.eoseReceived`, dist `index.mjs:3355-3403`):
+
+- "Seen all EOSEs" is checked against the sub's target relay set, but the fallback heuristic computes over **currently-connected** relays only: once ≥2 connected relays have EOSE'd and they are ≥50 % of connected-with-filters relays, EOSE fires within a shrinking ≤1 s window.
+- `fetchEvents` uses `closeOnEose: true`; at EOSE the sub **stops and removes the pool monitor**, so relays that connect afterwards never receive the REQ.
+- Cold-start worked example: relays A, B connect at 400 ms, C/D/E at 1–3 s. Fetch at "ready" targets all five, gets EOSE from A+B (2/2 connected = 100 %) → resolves immediately with only A+B's events. C/D/E's copies are lost. If the user's lists live only on C, the fetch returns empty **successfully**.
+
+With authors-scoped filters (outbox path, e.g. My Kitchen's kind-30001 fetch by own pubkey), relay selection *prefers currently-connected relays* (`chooseRelayCombinationForPubkeys` seeds `preferredRelays` from `pool.connectedRelays()`), compounding the bias toward the early-connected subset on a cold NIP-65 cache.
+
+## 3. Publish side
+
+Materially safer than fetch, with two real gaps:
+
+- **NDK buffers per-relay**: `NDKRelayPublisher.publish` registers `once("connect")` for unconnected relays and delivers when the socket opens, bounded by the publish timeout (default 2500 ms). Slow-but-alive relays usually get the event.
+- **But success = 1 relay**: `NDKRelaySet.publish(event, timeoutMs, requiredRelayCount = 1)` resolves as long as one relay OKs. Under-connected publishes silently deliver to a subset; only zero acceptances throws `NDKPublishError("Not enough relays received the event")` — the error seen from `ensureDefaultList`.
+- `publishQueue.attemptPublish` (`src/lib/publishQueue.ts:498`) is the robust path: `ensureNdkConnected(5000)`, best-effort force-connect of target relays, 10 s timeout, IndexedDB retry queue on failure. **Many call sites bypass it** with bare `event.publish()` (cookbookStore throughout, recipePack, comments, marketplace, profileBackup, …) and get single-shot semantics with no retry.
+
+Conclusion: a warm-pool readiness gate fixes most of the publish exposure via NDK's own buffering; the remaining publish risk is per-call-site (`requiredRelayCount`, queue bypass), not a readiness-primitive problem.
+
+## 4. Symptom traces
+
+### 4a. My Kitchen empty flash — CONFIRMED, and worse than the premise
+
+`cookbookStore.load()` (`src/lib/stores/cookbookStore.ts:284-333`): cold session → IndexedDB empty → skips the cache branch → fires `this.refreshFromNostr()` **unawaited** and resolves with `lists: []`. `refreshFromNostr` (`:338`) **never awaits any readiness signal at all** — it subscribes `closeOnEose: true` against whatever is connected the instant the page mounts. Early empty EOSE → `set({ lists: [], loading: false, initialized: true })` → `my-kitchen/+page.svelte:1494` renders "Start Your Kitchen". The sub is closed, so late relays can't heal it.
+
+### 4b. `ensureDefaultList` — CONFIRMED, plus a data hazard
+
+`cookbookStore.ts:534-610`: gates the publish on `isCurrentlyOnline()` (navigator.onLine — wrong signal), no readiness await, no signer check. In the cold window, zero relays accept within timeout → the caught `NDKPublishError`, op queued.
+
+**Worse**: the "does a default list exist" check reads `state.lists` (`:537`), which on cold start is empty *because refreshFromNostr hasn't returned yet*. It then publishes a **fresh empty kind-30001 replaceable event** with the same `d` tag (`nostrcooking-bookmarks`) that can supersede the user's real "Saved" list on relays that were never queried. This is a correctness bug independent of the error message.
+
+### 4c. PR10 picker workaround — CONFIRMED as compensation
+
+`RecipePickerModal.svelte:139-147`: on empty store, `await cookbookStore.load()` then explicitly `await cookbookStore.refreshFromNostr()` — exactly compensating 4a's unawaited refresh. Still racy (refreshFromNostr awaits nothing), so it narrows but does not close the window. Removable once the store is fixed.
+
+**Premise correction**: no e2e reproduces the cold race. The repo (both worktrees) has vitest only — no Playwright/e2e config; searches for cold/race tests found nothing. The "reproduced in PR10 e2e" premise doesn't match what's on disk; the mechanism above is proven from source instead. A deterministic repro should be added with the fix (staggered-connect fake pool in vitest, and/or dev-mode connect-delay harness).
+
+## 5. Consumer inventory (summary)
+
+Full table in the investigation transcript; shape of the estate:
+
+- **~30 guarded await sites** across 25 files (`ndkReady` or `ensureNdkConnected`): feed (`FoodstrFeedOptimized` ×4), profileCache, memories, publishQueue, timer/autoZap settings, relayListCache, nip37 drafts (×6), groceryService (×4), spark (×6), wallet/nwc/nwcBackup (×10), routes: settings, boost, explore, packs (×3), recipes, polls, nourish/explore. All inherit first-relay semantics; **all get stronger semantics for free if the primitive is fixed.**
+- **~60 unguarded files** call `fetchEvents`/`fetchEvent`/`publish` with no readiness gate (cookbookStore, savedPacksStore, nip17, nostrBackup, marketplace, many `[slug]` routes…) — they survive on warm SPA navigation. First-action-after-launch on those routes is exposed regardless; the primitive fix narrows their window too (anything indirectly downstream of a guarded mount), but per-file audits are follow-up work, not part of the core fix.
+- **Existing workarounds that acknowledge the race** (candidates for later simplification):
+  - `WalletPanel.svelte:316-321` — retry ladder `[3000, 8000, 14000]` ms, comment: "ndkReady fires on the FIRST relay WebSocket open…"
+  - `nwcBackup.ts:252-256` — live subscription instead of `fetchEvents` "so NDK automatically forwards it to relays that connect after this call"
+  - `RecipePickerModal.svelte:139-147` — forced awaited refresh (4c)
+  - packs/recipes/polls/explore route comments — cold-load gates + fetch timeout races
+- **Dead code found**: `isNdkReady` (no callers), `ndkReady` import in `kitchen/+page.svelte` (unused — that page's fetches are effectively unguarded).
+
+## 6. Fix options assessed
+
+**(a) Quorum readiness — RECOMMENDED.** Replace `waitForFirstRelay` with a quorum wait inside `connectWithCircuitBreaker`; `ndkReady`/`ndkConnected`/`ensureNdkConnected` keep their exact APIs and never-hang contract.
+
+Proposed semantics (M = pool size):
+- resolve immediately when **all M** relays are connected;
+- else when `connected ≥ max(2, ceil(0.6·M))`, clamped to M (so members mode, M=1, keeps today's behavior);
+- hard cap ~4 s, resolve anyway (preserve never-hang).
+
+Built on public NDK API (`pool.stats()` / `relay:connect`), same polling pattern as today. One file changes; ~30 guarded call sites are upgraded with zero churn. This is the fix Android should port against.
+
+**(b) Per-call minimum-connections guard.** Correct in principle but requires touching every call site, and there's no central fetch helper to hook — 60+ unguarded files would still be unguarded. Rejected as the primary fix; the quorum gate gives the same protection at one chokepoint.
+
+**(c) Retry-on-empty.** Papers over fetches, does nothing for publishes or the `ensureDefaultList` replaceable-overwrite hazard, and adds latency exactly when the pool is healthy-but-slow. Rejected (existing per-fetch timeout races stay as backstops).
+
+**(d) NDK-idiomatic.** NDK has no N-of-M primitive. Its own internal idiom (`setActiveUser`) is `pool.once("connect")`, where the pool `connect` event = *all* relays connected, or ≥1 at `timeoutMs` **iff a timeout was passed to `connect()`** (the app passes none). All-or-timeout burns the full timeout whenever any one public relay is down — a common state. Quorum with an all-connected early exit strictly dominates; it *is* the idiomatic building blocks, composed better.
+
+Non-goal honesty: quorum shrinks the miss window from "1 relay" to "≥60 % of pool, usually all," but the EOSE heuristic can still drop a straggler that connects post-quorum. If a specific critical read needs 100 %, the `nwcBackup` live-sub pattern is the right per-call tool — deliberately not generalized in the core PR.
+
+## 7. PR plan (single-concern)
+
+1. **PR A — the readiness fix** (`connectionManager.ts` + touchpoint in `nostr.ts`): quorum wait as in 6(a); vitest for quorum math with a staggered-connect fake pool (this doubles as the deterministic repro: assert the old first-relay predicate would have resolved before quorum). No consumer changes. Log line with time-to-quorum + connected count for field verification.
+2. **PR B — cookbookStore cold-session correctness**: `refreshFromNostr` awaits readiness; `load()` awaits the network refresh when the offline cache is empty (keeps cache-first fast path when warm); `ensureDefaultList` gates on relay connectivity instead of `navigator.onLine` **and only creates after a completed refresh confirms absence** (closes the replaceable-overwrite hazard). Remove `RecipePickerModal.svelte:139-147`.
+3. **PR C — follow-up simplifications** (optional, after A+B soak): shrink WalletPanel retry ladder, delete dead `isNdkReady`/kitchen imports, re-audit route-level `ensureNdkConnected` comments. Keep per-fetch timeout races and the nwcBackup live-sub (still-valid backstops).
+
+Android ports against A+B semantics, not against the workarounds.
+
+## 8. Risks
+
+- **Cold-start latency**: first fetch waits for quorum instead of first relay — typically +100–500 ms, bounded at ~4 s if 2+ relays are down (today: 3 s bound). Feed impact is blunted by the existing Primal-HTTP overlap (`FoodstrFeedOptimized.svelte:2003`).
+- **One-relay pool modes** (members): quorum clamps to 1 — behavior unchanged by design; verify the clamp in tests.
+- **Relay-set switching**: `switchRelays` reuses `connectWithRetry`, so switches also wait for quorum — slightly slower switch UX, same bound.
+- **Not a total fix**: post-quorum stragglers can still be missed by `closeOnEose` fetches (see §6 non-goal); unguarded call sites (§5) remain a separate cleanup track.
+- **Publish under-delivery** to relays that take >2.5 s to connect persists at bare `event.publish()` sites (NDK per-relay buffer timeout); acceptable post-quorum since the pool is warm, revisit only if OK-verification telemetry says otherwise.
+
+---
+
+## Addendum — PR A implementation notes (2026-07-13)
+
+**Shipped** in `connectionManager.ts` (+ one comment in `nostr.ts`): `waitForFirstRelay` replaced by `waitForRelayQuorum` inside `connectWithCircuitBreaker`, with `relayQuorumTarget(M) = min(M, max(2, ceil(0.6·M)))`, a 4 s never-hang cap, and a `✅ Relay quorum reached: X/M in Yms` log line for field verification. `ndkReady` / `ndkConnected` / `ensureNdkConnected` APIs unchanged; every consumer file byte-identical.
+
+**New discovery, fixed here because quorum counting depends on it**: the manager's pool checks used `relay.connectivity?.status === 1 // 1 = OPEN` — a stale enum from pre-2.x NDK. In NDK 2.10, `1 = DISCONNECTED` and `CONNECTED = 5` (through `AUTHENTICATED = 8`). Consequence of the old constant: `getPoolConnectedRelays()` and the heartbeat counted *disconnected* relays as connected, so the old first-relay gate could resolve on a relay **failure** (a relay that flipped back to DISCONNECTED), making pre-fix `ndkReady` weaker than even §1 described. Both sites now use `status >= NDKRelayStatus.CONNECTED` (≥ so relays mid-NIP-42 auth count). Side effect: `getConnectedRelays()` (settings UI, relaySelector, queryBatcher) now reports truthfully.
+
+**Deterministic repro** (the missing piece flagged in §4c): `src/lib/connectionManager.test.ts` — staggered-connect fake pool; the repro test shows a closeOnEose-style fetch gated on first-relay semantics missing an event that lives only on the 3rd-connecting relay, while the quorum gate catches it. Also covers quorum math for M=1/2/3/5/10, the all-connected fast path, mid-auth counting, and the 4 s cap on total failure.
+
+**Measured cold-start cost** (Node harness driving the real NDK 2.10 pool against the 5 standard relays, 3 runs): first relay 271–372 ms, quorum 3/5 at 572–694 ms, all 5 at 601–951 ms → **added readiness latency ≈ 290–320 ms**, within the predicted 100–500 ms band. Worst case remains the 4 s cap when 3+ relays are down (previously a 3 s cap that could pass with zero live relays).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.651",
+  "version": "4.2.652",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/connectionManager.test.ts
+++ b/src/lib/connectionManager.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NDKRelayStatus } from '@nostr-dev-kit/ndk';
+import type NDK from '@nostr-dev-kit/ndk';
+import { ConnectionManager, relayQuorumTarget } from './connectionManager';
+
+/**
+ * Quorum readiness tests with a staggered-connect fake pool.
+ *
+ * The repro test at the bottom is the deterministic reproduction of the
+ * cold-session fetch miss described in docs/ndk-readiness-discovery.md:
+ * a closeOnEose-style fetch only sees events from relays connected at
+ * gate-resolution time (NDK 2.10's EOSE heuristic counts only currently-
+ * connected relays and the subscription stops at EOSE), so a first-relay
+ * gate misses events that live on later-connecting relays.
+ */
+
+interface FakeRelay {
+  url: string;
+  status: NDKRelayStatus;
+}
+
+class FakePool {
+  relays = new Map<string, FakeRelay>();
+  private listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+  on(event: string, cb: (...args: unknown[]) => void) {
+    if (!this.listeners.has(event)) this.listeners.set(event, new Set());
+    this.listeners.get(event)!.add(cb);
+  }
+
+  emit(event: string, ...args: unknown[]) {
+    for (const cb of this.listeners.get(event) ?? []) cb(...args);
+  }
+}
+
+function makeFakeNdk(relayUrls: string[]): { ndk: NDK; pool: FakePool } {
+  const pool = new FakePool();
+  for (const url of relayUrls) {
+    pool.relays.set(url, { url, status: NDKRelayStatus.DISCONNECTED });
+  }
+  const ndk = {
+    explicitRelayUrls: relayUrls,
+    pool
+  } as unknown as NDK;
+  return { ndk, pool };
+}
+
+function connectRelay(pool: FakePool, url: string) {
+  const relay = pool.relays.get(url)!;
+  relay.status = NDKRelayStatus.CONNECTED;
+  pool.emit('relay:connect', relay);
+}
+
+function urls(n: number): string[] {
+  return Array.from({ length: n }, (_, i) => `wss://relay${i + 1}.test`);
+}
+
+/**
+ * The OLD readiness predicate, reimplemented verbatim in spirit: poll until
+ * ANY single relay is connected. Kept here (not in the manager) purely so the
+ * repro test can contrast old vs new semantics on the same timeline.
+ */
+function waitForFirstRelayLegacy(pool: FakePool, timeoutMs = 3000): Promise<void> {
+  return new Promise((resolve) => {
+    const startTime = Date.now();
+    const interval = setInterval(() => {
+      const anyConnected = Array.from(pool.relays.values()).some(
+        (r) => r.status >= NDKRelayStatus.CONNECTED
+      );
+      if (anyConnected || Date.now() - startTime > timeoutMs) {
+        clearInterval(interval);
+        resolve();
+      }
+    }, 50);
+  });
+}
+
+describe('relayQuorumTarget', () => {
+  it('clamps to 1 for a single-relay pool (members mode unchanged)', () => {
+    expect(relayQuorumTarget(1)).toBe(1);
+  });
+
+  it('requires both relays of a 2-relay pool', () => {
+    expect(relayQuorumTarget(2)).toBe(2);
+  });
+
+  it('requires 2 of 3', () => {
+    expect(relayQuorumTarget(3)).toBe(2);
+  });
+
+  it('requires 3 of 5 (standard pool)', () => {
+    expect(relayQuorumTarget(5)).toBe(3);
+  });
+
+  it('scales at 60% for larger pools', () => {
+    expect(relayQuorumTarget(10)).toBe(6);
+  });
+
+  it('never exceeds the pool size', () => {
+    for (let m = 1; m <= 12; m++) {
+      expect(relayQuorumTarget(m)).toBeLessThanOrEqual(m);
+    }
+  });
+});
+
+describe('ConnectionManager.waitForRelayQuorum', () => {
+  let manager: ConnectionManager | null = null;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    manager?.destroy();
+    manager = null;
+    vi.useRealTimers();
+  });
+
+  it('M=5: resolves at the 3rd connect, not the 1st', async () => {
+    const { ndk, pool } = makeFakeNdk(urls(5));
+    manager = new ConnectionManager(ndk);
+
+    const resolved = vi.fn();
+    const wait = manager.waitForRelayQuorum(4000).then(resolved);
+
+    setTimeout(() => connectRelay(pool, 'wss://relay1.test'), 100);
+    setTimeout(() => connectRelay(pool, 'wss://relay2.test'), 800);
+    setTimeout(() => connectRelay(pool, 'wss://relay3.test'), 1500);
+
+    await vi.advanceTimersByTimeAsync(200);
+    expect(resolved).not.toHaveBeenCalled(); // 1/5 — old semantics would have resolved here
+
+    await vi.advanceTimersByTimeAsync(700); // t=900, 2/5
+    expect(resolved).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(700); // t=1600, 3/5 = quorum
+    expect(resolved).toHaveBeenCalled();
+    await wait;
+  });
+
+  it('M=5: all-connected before the call resolves immediately', async () => {
+    const { ndk, pool } = makeFakeNdk(urls(5));
+    manager = new ConnectionManager(ndk);
+    for (const url of urls(5)) connectRelay(pool, url);
+
+    const resolved = vi.fn();
+    const wait = manager.waitForRelayQuorum(4000).then(resolved);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toHaveBeenCalled();
+    await wait;
+  });
+
+  it('M=2: quorum is both relays — 1 of 2 is not ready', async () => {
+    const { ndk, pool } = makeFakeNdk(urls(2));
+    manager = new ConnectionManager(ndk);
+
+    const resolved = vi.fn();
+    const wait = manager.waitForRelayQuorum(4000).then(resolved);
+
+    setTimeout(() => connectRelay(pool, 'wss://relay1.test'), 100);
+    setTimeout(() => connectRelay(pool, 'wss://relay2.test'), 1000);
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(resolved).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(600); // t=1100, 2/2
+    expect(resolved).toHaveBeenCalled();
+    await wait;
+  });
+
+  it('M=1 (members mode): resolves on the single relay, waits until it connects', async () => {
+    const { ndk, pool } = makeFakeNdk(urls(1));
+    manager = new ConnectionManager(ndk);
+
+    const resolved = vi.fn();
+    const wait = manager.waitForRelayQuorum(4000).then(resolved);
+
+    await vi.advanceTimersByTimeAsync(300);
+    expect(resolved).not.toHaveBeenCalled();
+
+    connectRelay(pool, 'wss://relay1.test');
+    await vi.advanceTimersByTimeAsync(100);
+    expect(resolved).toHaveBeenCalled();
+    await wait;
+  });
+
+  it('counts relays past CONNECTED (mid-NIP-42 auth) toward quorum', async () => {
+    const { ndk, pool } = makeFakeNdk(urls(1));
+    manager = new ConnectionManager(ndk);
+
+    pool.relays.get('wss://relay1.test')!.status = NDKRelayStatus.AUTHENTICATED;
+
+    const resolved = vi.fn();
+    const wait = manager.waitForRelayQuorum(4000).then(resolved);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toHaveBeenCalled();
+    await wait;
+  });
+
+  it('never hangs: resolves at the cap when no relay ever connects', async () => {
+    const { ndk } = makeFakeNdk(urls(5));
+    manager = new ConnectionManager(ndk);
+
+    const resolved = vi.fn();
+    const wait = manager.waitForRelayQuorum(4000).then(resolved);
+
+    await vi.advanceTimersByTimeAsync(3900);
+    expect(resolved).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(300); // past the 4s cap
+    expect(resolved).toHaveBeenCalled();
+    await wait;
+  });
+
+  it('deterministic repro: first-relay gate misses late-relay events, quorum gate does not', async () => {
+    const { ndk, pool } = makeFakeNdk(urls(5));
+    manager = new ConnectionManager(ndk);
+
+    // The target event lives ONLY on relay3, which connects late.
+    const eventsByRelay: Record<string, string[]> = {
+      'wss://relay1.test': ['e-common'],
+      'wss://relay2.test': ['e-common'],
+      'wss://relay3.test': ['e-common', 'e-target'],
+      'wss://relay4.test': [],
+      'wss://relay5.test': []
+    };
+
+    // Models fetchEvents(closeOnEose): the result set is whatever the relays
+    // connected at gate-resolution time hold — EOSE fires over the connected
+    // subset and the subscription stops, so later connects deliver nothing.
+    const fetchSnapshot = (): string[] => {
+      const seen = new Set<string>();
+      for (const relay of pool.relays.values()) {
+        if (relay.status >= NDKRelayStatus.CONNECTED) {
+          for (const id of eventsByRelay[relay.url]) seen.add(id);
+        }
+      }
+      return [...seen];
+    };
+
+    setTimeout(() => connectRelay(pool, 'wss://relay1.test'), 100);
+    setTimeout(() => connectRelay(pool, 'wss://relay2.test'), 1200);
+    setTimeout(() => connectRelay(pool, 'wss://relay3.test'), 1500);
+    setTimeout(() => connectRelay(pool, 'wss://relay4.test'), 2000);
+    // relay5 never connects
+
+    let oldResult: string[] | null = null;
+    let newResult: string[] | null = null;
+    const oldGate = waitForFirstRelayLegacy(pool).then(() => {
+      oldResult = fetchSnapshot();
+    });
+    const newGate = manager.waitForRelayQuorum(4000).then(() => {
+      newResult = fetchSnapshot();
+    });
+
+    await vi.advanceTimersByTimeAsync(2500);
+    await Promise.all([oldGate, newGate]);
+
+    // OLD semantics: gate opened on relay1 alone — the fetch misses e-target.
+    expect(oldResult).toContain('e-common');
+    expect(oldResult).not.toContain('e-target');
+
+    // NEW semantics: gate opened at 3-of-5 (relay3 included) — e-target found.
+    expect(newResult).toContain('e-target');
+  });
+});

--- a/src/lib/connectionManager.ts
+++ b/src/lib/connectionManager.ts
@@ -1,5 +1,15 @@
 import type NDK from '@nostr-dev-kit/ndk';
-import { NDKRelaySet } from '@nostr-dev-kit/ndk';
+import { NDKRelaySet, NDKRelayStatus } from '@nostr-dev-kit/ndk';
+
+/**
+ * Number of connected relays that counts as "ready" for a pool of `total` relays.
+ * All-connected always qualifies (the target is never above `total`); otherwise
+ * max(2, ceil(fraction·total)), clamped to `total` so a single-relay pool
+ * (members mode) still waits for its one relay rather than an impossible 2.
+ */
+export function relayQuorumTarget(total: number, fraction = 0.6): number {
+  return Math.min(total, Math.max(2, Math.ceil(fraction * total)));
+}
 
 export interface RelayHealth {
   status: 'connected' | 'disconnected' | 'degraded' | 'circuit-open';
@@ -42,6 +52,8 @@ export class ConnectionManager {
   private readonly CIRCUIT_BREAKER_TIMEOUT = 30000; // 30 seconds
   private readonly HEARTBEAT_INTERVAL = 30000; // 30 seconds
   private readonly MAX_RESPONSE_TIME = 5000; // 5 seconds for degraded status
+  private readonly QUORUM_FRACTION = 0.6;
+  private readonly QUORUM_TIMEOUT_MS = 4000;
 
   constructor(ndk: NDK) {
     this.ndkRef = ndk;
@@ -291,9 +303,10 @@ export class ConnectionManager {
         const health = this.relayHealth.get(url);
         if (!health) return;
         
-        // Check if relay is still connected via the pool
+        // Check if relay is still connected via the pool (see enum note in
+        // getPoolConnectedRelays — the old `=== 1` matched DISCONNECTED)
         const relayInstance = this.ndkRef.pool.relays.get(url);
-        const isConnected = relayInstance?.connectivity?.status === 1; // 1 = OPEN
+        const isConnected = relayInstance !== undefined && relayInstance.status >= NDKRelayStatus.CONNECTED;
         
         if (isConnected) {
           health.lastSeen = Date.now();
@@ -351,9 +364,11 @@ export class ConnectionManager {
     try {
       await this.ndkRef.connect();
       console.log('✅ NDK.connect() completed');
-      
-      // Wait for at least one relay WebSocket to be connected (fast - typically <500ms)
-      await this.waitForFirstRelay(3000); // Reduced timeout since we're not waiting for health checks
+
+      // Wait for a quorum of relay WebSockets, not just the first one.
+      // A first-relay gate let cold-start fetches race a mostly-unconnected
+      // pool (see docs/ndk-readiness-discovery.md).
+      await this.waitForRelayQuorum(this.QUORUM_TIMEOUT_MS);
     } catch (error) {
       console.error('❌ NDK connection failed:', error);
       throw error;
@@ -361,26 +376,63 @@ export class ConnectionManager {
   }
 
   /**
-   * Wait for at least one relay WebSocket to be connected (with timeout)
-   * This is fast - just waits for WebSocket open, not health check
+   * Count connected relays against the pool's target size.
+   * Counts from the NDK pool (authoritative WebSocket status); falls back to
+   * the health-tracking map for the total only while the pool is unpopulated,
+   * so an empty pool never reads as a trivially-satisfied quorum of 0.
    */
-  async waitForFirstRelay(timeoutMs: number = 3000): Promise<void> {
-    // Check if already connected (via relay:connect event)
-    if (this.getConnectedRelays().length > 0) {
-      console.log('✅ Relay already connected');
+  private getQuorumCounts(): { connected: number; total: number } {
+    let connected = 0;
+    let total = 0;
+    try {
+      for (const relay of this.ndkRef.pool.relays.values()) {
+        total++;
+        // >= CONNECTED so relays mid-NIP-42 auth (AUTH_REQUESTED..AUTHENTICATED) count
+        if (relay.status >= NDKRelayStatus.CONNECTED) {
+          connected++;
+        }
+      }
+    } catch (e) {
+      // Pool might not be ready yet
+    }
+    if (total === 0) {
+      total = this.relayHealth.size;
+    }
+    return { connected, total };
+  }
+
+  /**
+   * Wait for a quorum of relay WebSockets to be connected (with timeout).
+   * Resolves as soon as connected >= relayQuorumTarget(total) — which is
+   * satisfied immediately when all relays connect — and resolves anyway at
+   * the timeout so callers never hang (same contract as the old first-relay
+   * wait, and as ndkReady has always guaranteed).
+   */
+  async waitForRelayQuorum(timeoutMs: number = this.QUORUM_TIMEOUT_MS): Promise<void> {
+    const startTime = Date.now();
+
+    const quorumReached = (): boolean => {
+      const { connected, total } = this.getQuorumCounts();
+      if (total === 0) return false;
+      return connected >= relayQuorumTarget(total, this.QUORUM_FRACTION);
+    };
+
+    const logOutcome = (reached: boolean) => {
+      const { connected, total } = this.getQuorumCounts();
+      const elapsed = Date.now() - startTime;
+      if (reached) {
+        console.log(`✅ Relay quorum reached: ${connected}/${total} connected in ${elapsed}ms`);
+      } else {
+        console.warn(`⚠️ Timeout waiting for relay quorum (${connected}/${total} connected after ${elapsed}ms), proceeding anyway`);
+      }
+    };
+
+    if (quorumReached()) {
+      logOutcome(true);
       return;
     }
 
-    // Also check NDK pool directly for connected relays
-    const poolConnected = this.getPoolConnectedRelays();
-    if (poolConnected.length > 0) {
-      console.log(`✅ Relay connected (from pool): ${poolConnected[0]}`);
-      return;
-    }
-    
     return new Promise((resolve) => {
-      const startTime = Date.now();
-      
       // Poll frequently for fast response
       const checkInterval = setInterval(() => {
         // Bail if destroyed
@@ -389,22 +441,18 @@ export class ConnectionManager {
           resolve();
           return;
         }
-        
-        const connected = this.getConnectedRelays();
-        const poolRelays = this.getPoolConnectedRelays();
-        
-        if (connected.length > 0 || poolRelays.length > 0) {
+
+        if (quorumReached()) {
           clearInterval(checkInterval);
-          const firstRelay = connected[0] || poolRelays[0];
-          console.log(`✅ First relay connected: ${firstRelay}`);
+          logOutcome(true);
           resolve();
           return;
         }
-        
+
         // Check timeout
         if (Date.now() - startTime > timeoutMs) {
           clearInterval(checkInterval);
-          console.warn('⚠️ Timeout waiting for relay connections, proceeding anyway');
+          logOutcome(false);
           resolve();
           return;
         }
@@ -419,8 +467,10 @@ export class ConnectionManager {
     const connected: string[] = [];
     try {
       for (const [url, relay] of this.ndkRef.pool.relays) {
-        // Check if relay WebSocket is open
-        if (relay.connectivity?.status === 1) { // 1 = OPEN
+        // Check if relay WebSocket is open. NOTE: in NDK 2.10 the status enum
+        // is DISCONNECTED=1, CONNECTED=5..AUTHENTICATED=8 — the old `=== 1`
+        // check here dated from a pre-2.x enum and matched DISCONNECTED.
+        if (relay.status >= NDKRelayStatus.CONNECTED) {
           connected.push(url);
         }
       }

--- a/src/lib/nostr.ts
+++ b/src/lib/nostr.ts
@@ -279,7 +279,7 @@ async function connectWithRetry(ndkInstance: NDK, maxRetries = 3): Promise<void>
       // Create new connection manager for this NDK instance
       const connectionManager = createConnectionManager(ndkInstance);
       
-      // Use connection manager's circuit breaker logic (waits for first relay)
+      // Use connection manager's circuit breaker logic (waits for a relay quorum)
       await connectionManager.connectWithCircuitBreaker();
       
       // Mark as connected - relays are now ready


### PR DESCRIPTION
## What

`ndkReady` (and everything downstream of it: `ndkConnected`, `ensureNdkConnected`) resolved on the **first** relay WebSocket open, so first-action-after-launch fetches raced a mostly-unconnected pool and publishes under-delivered. Full investigation: [docs/ndk-readiness-discovery.md](../blob/fix/ndk-quorum-readiness/docs/ndk-readiness-discovery.md) (moved into `docs/` as part of this PR, with an implementation addendum).

This PR replaces `waitForFirstRelay` inside `connectWithCircuitBreaker` with `waitForRelayQuorum`:

- ready at `min(M, max(2, ceil(0.6·M)))` connected relays — 3-of-5 for the standard pool, all-connected resolves immediately, M=1 (members mode) unchanged;
- hard 4s cap that resolves anyway, preserving the never-hang contract;
- `✅ Relay quorum reached: X/M in Yms` log line for field verification.

**Zero call-site churn** — that's the point of this option: `ndkReady` / `ndkConnected` / `ensureNdkConnected` keep their exact public APIs and flip at the new, stronger moment. Verified by diff: only `connectionManager.ts` changed materially; `nostr.ts` is a one-line comment; every consumer file (~30 guarded await sites across 25 files) is byte-identical to main.

## What this enables (PR B lands the consumer repairs)

Three confirmed symptoms trace to the first-relay gate; this PR is the substrate for fixing them, and PR B (cookbookStore) does the consumer-side repairs:

1. **My Kitchen empty flash** — cold-session `refreshFromNostr` EOSE'd against an under-connected pool and cached `lists: []`.
2. **`ensureDefaultList` overwrite hazard** — publish-before-connected error, plus creating a fresh empty kind-30001 that can supersede the user's real Saved list.
3. **Recipe picker workaround** (`RecipePickerModal.svelte:139-147`) — compensates for the unawaited cold refresh; removable in PR B.

## Discovery fixed here (load-bearing), discoveries noted (not fixed)

- **Fixed**: the manager's pool checks used `relay.connectivity?.status === 1 // 1 = OPEN` — a stale pre-2.x enum. In NDK 2.10, `1 = DISCONNECTED`, `CONNECTED = 5..AUTHENTICATED = 8`, so the old gate could count a **failed** relay as connected and `ndkReady` could resolve on a relay failure. Quorum counting depends on correct counting, so both sites now use `status >= NDKRelayStatus.CONNECTED`. Side effect: `getConnectedRelays()` (settings UI, relaySelector, queryBatcher) now reports truthfully.
- **Noted for PR B/C, untouched**: cookbookStore/ensureDefaultList, picker workaround, WalletPanel retry ladder, dead `isNdkReady` + unused `ndkReady` import in `kitchen/+page.svelte`, bare `event.publish()` sites (`requiredRelayCount = 1` semantics unchanged).

## Tests

`src/lib/connectionManager.test.ts` — staggered-connect fake pool (13 tests):
- quorum math M=1/2/3/5/10 incl. the all-connected fast path and mid-NIP-42-auth relays counting;
- 4s cap resolves on total failure (never hangs);
- **deterministic repro** the discovery doc lacked: a closeOnEose-style fetch gated on OLD (first-relay) semantics misses an event that lives only on the 3rd-connecting relay; gated on NEW (quorum) semantics it's found.

## Verification

- Full suite: **753/753 pass** (48 files); `svelte-check`: **0 errors** (142 pre-existing warnings, none in touched files).
- Consumers verified unchanged by `git diff origin/main --name-only`: only `connectionManager.ts`, `nostr.ts` (comment), the new test, the moved doc, and the hook's `package.json` version bump.
- **Cold-start timing, measured** (Node harness driving the real NDK 2.10 pool against the 5 standard relays, 3 runs): first relay 271–372ms → quorum 3/5 at 572–694ms → **~290–320ms added before first fetch**, inside the predicted 100–500ms band; all 5 relays connected by ~1s in every run. With relays down, readiness is bounded at 4s (the old 3s cap could pass with zero live relays).

Single-concern: no consumer changes, no publish-semantics changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)