### PR TITLE
test: extract cross-platform contract fixtures (parser, week, schema, generation)

### DIFF
--- a/docs/mealplan-contract.md
+++ b/docs/mealplan-contract.md
@@ -108,3 +108,28 @@ have been observed producing ciphertext that a later session cannot decrypt. Mat
 grocery contract, clients **write anyway** for NIP-46 users; this caveat is accepted and
 documented rather than blocked. If this policy changes it changes for grocery and meal plans
 together.
+
+## Cross-platform test fixtures
+
+Language-neutral JSON vectors under `src/test/fixtures/` are the **single source of truth** for
+parser / week / schema / grocery-generation behavior shared with Android. Web Vitest suites and
+Android JUnit suites both consume these files. **Fixture changes REQUIRE a matching Android
+update** — Android's copies under `app/src/test/resources/fixtures/` must checksum-match the
+hashes below. Unilateral edits on either side fail the Android checksum drift tests.
+
+| File | sha256 |
+|---|---|
+| `ingredient-parser.vectors.json` | `cc7e0ecae3ee8fac51e3ce46502fc758a30c9022b6a3f3765d49c42914b3ab81` |
+| `week.vectors.json` | `de5c75e648548f0fe38ebe021a03da17a1f3a977ec7b103642bbf0fd066faf30` |
+| `mealplan-schema.vectors.json` | `d8a34927d30a8a636bbc84ed3a384ee5f975d65827ae3302aceffb0239373e18` |
+| `grocery-generation.vectors.json` | `090faff2b486886c0c14fe83e3a4fe48f2b3de8ddff375f18f1e5c1d125508d0` |
+
+Notes:
+
+- `ingredient-parser.vectors.json` pins quirks (plural singularization `"2 cups"` → `"2 cup"`,
+  comma-suffix retention `"eggs, beaten"`) — they are the contract, not bugs to "fix" on one
+  platform.
+- `mealplan-schema.vectors.json` case `default-missing-fields` asserts `createdAt > 0` (wall
+  clock), not a fixed timestamp.
+- After editing any fixture file, recompute sha256 (`shasum -a 256`) and update this table **and**
+  the Android copies in the same change set (or a paired Android PR that lands immediately after).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.654",
+  "version": "4.2.655",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.653",
+  "version": "4.2.654",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/mealplan/groceryGeneration.test.ts
+++ b/src/lib/mealplan/groceryGeneration.test.ts
@@ -9,6 +9,7 @@ import {
 } from './groceryGeneration';
 import { createEmptyMealPlan, type MealPlan } from './schema';
 import type { ParsedIngredient } from '$lib/utils/ingredientParser';
+import fixtures from '../../test/fixtures/grocery-generation.vectors.json';
 
 function planWith(days: MealPlan['days']): MealPlan {
   return { ...createEmptyMealPlan('2026-W29'), days };
@@ -19,70 +20,34 @@ function ing(name: string, quantity: string): ParsedIngredient {
 }
 
 describe('collectWeekRecipeSlots', () => {
-  it('collects unique coordinates in day/slot order and counts text entries', () => {
-    const plan = planWith({
-      mon: {
-        slots: {
-          breakfast: { type: 'text', text: 'Coffee' },
-          dinner: { type: 'recipe', a: '30023:pk:curry' }
-        }
-      },
-      wed: {
-        slots: {
-          lunch: { type: 'recipe', a: '30023:pk:salad' },
-          dinner: { type: 'recipe', a: '30023:pk:curry' } // repeat
-        }
-      },
-      sun: { slots: { lunch: { type: 'text', text: 'Eating out' } } }
+  for (const v of fixtures.collectWeekRecipeSlots) {
+    it(v.id, () => {
+      const plan = planWith(v.days as MealPlan['days']);
+      expect(collectWeekRecipeSlots(plan)).toEqual(v.expected);
     });
-
-    const result = collectWeekRecipeSlots(plan);
-    expect(result.aTags).toEqual(['30023:pk:curry', '30023:pk:salad']);
-    expect(result.textCount).toBe(2);
-    expect(result.recipeSlotCount).toBe(3);
-  });
-
-  it('handles an empty week', () => {
-    expect(collectWeekRecipeSlots(planWith({}))).toEqual({
-      aTags: [],
-      textCount: 0,
-      recipeSlotCount: 0
-    });
-  });
+  }
 });
 
 describe('dedupeIngredients (approved v1: exact-match collapse, no merging)', () => {
-  it('collapses exact (name, quantity) duplicates keeping the first recipeId', () => {
-    const rows: GenerationRow[] = [
-      { ingredient: ing('olive oil', '2 tbsp'), recipeId: 'r1' },
-      { ingredient: ing('rice', '1 cup'), recipeId: 'r1' },
-      { ingredient: ing('olive oil', '2 tbsp'), recipeId: 'r2' } // exact dup
-    ];
-    const out = dedupeIngredients(rows);
-    expect(out).toHaveLength(2);
-    expect(out[0].recipeId).toBe('r1');
-  });
-
-  it('does NOT merge same name with different quantities', () => {
-    const rows: GenerationRow[] = [
-      { ingredient: ing('rice', '1 cup'), recipeId: 'r1' },
-      { ingredient: ing('rice', '2 cup'), recipeId: 'r2' }
-    ];
-    expect(dedupeIngredients(rows)).toHaveLength(2);
-  });
-
-  it('name match is case-insensitive, quantity verbatim', () => {
-    const rows: GenerationRow[] = [
-      { ingredient: ing('Olive Oil', '2 tbsp'), recipeId: 'r1' },
-      { ingredient: ing('olive oil', '2 tbsp'), recipeId: 'r2' },
-      { ingredient: ing('olive oil', '2 Tbsp'), recipeId: 'r3' } // quantity differs
-    ];
-    expect(dedupeIngredients(rows)).toHaveLength(2);
-  });
+  for (const v of fixtures.dedupeIngredients) {
+    it(v.id, () => {
+      const rows: GenerationRow[] = v.rows.map((r) => ({
+        ingredient: ing(r.name, r.quantity),
+        recipeId: r.recipeId
+      }));
+      const out = dedupeIngredients(rows);
+      expect(out).toHaveLength(v.expectedLength);
+      if (v.expectedFirstRecipeId) {
+        expect(out[0].recipeId).toBe(v.expectedFirstRecipeId);
+      }
+    });
+  }
 });
 
 describe('groceryListTitle', () => {
-  it('titles by week display range', () => {
-    expect(groceryListTitle('2026-W29')).toBe('Groceries — Week 29 (Jul 13–19)');
-  });
+  for (const v of fixtures.groceryListTitle) {
+    it(v.id, () => {
+      expect(groceryListTitle(v.weekId)).toBe(v.expected);
+    });
+  }
 });

--- a/src/lib/mealplan/schema.test.ts
+++ b/src/lib/mealplan/schema.test.ts
@@ -6,124 +6,124 @@ import {
   MEALPLAN_SCHEMA_VERSION,
   type MealPlan
 } from './schema';
+import fixtures from '../../test/fixtures/mealplan-schema.vectors.json';
 
-const WEEK = '2026-W29';
+const WEEK = fixtures.week;
 
-function validPayload(): Record<string, unknown> {
-  return {
-    schemaVersion: 1,
-    week: WEEK,
-    days: {
-      mon: {
-        slots: {
-          breakfast: { type: 'recipe', a: '30023:abc:shakshuka', title: 'Shakshuka' },
-          lunch: { type: 'text', text: 'Leftovers' }
-        },
-        notes: 'prep the night before'
-      }
-    },
-    notes: 'light week',
-    createdAt: 1789000000,
-    updatedAt: 1789000123
-  };
+function resolvePayload(ref: unknown): Record<string, unknown> | unknown {
+  if (ref === '$validPayload') {
+    return JSON.parse(JSON.stringify(fixtures.validPayload));
+  }
+  return ref;
 }
 
-describe('validateMealPlanPayload', () => {
-  it('accepts both tagged-union branches', () => {
-    const result = validateMealPlanPayload(validPayload(), WEEK);
-    expect(result).not.toBeNull();
-    const { plan, readOnly } = result!;
-    expect(readOnly).toBe(false);
-    expect(plan.days.mon?.slots?.breakfast).toEqual({
-      type: 'recipe',
-      a: '30023:abc:shakshuka',
-      title: 'Shakshuka'
+function applyOverrides(
+  payload: Record<string, unknown>,
+  overrides?: Record<string, unknown>
+): Record<string, unknown> {
+  if (!overrides) return payload;
+  return { ...payload, ...overrides };
+}
+
+describe('validateMealPlanPayload (fixture-driven)', () => {
+  for (const c of fixtures.cases) {
+    it(c.id, () => {
+      switch (c.kind) {
+        case 'validate': {
+          const base = resolvePayload(c.payload) as Record<string, unknown>;
+          const payload = applyOverrides(base, c.overrides as Record<string, unknown> | undefined);
+          const result = validateMealPlanPayload(payload, WEEK);
+          expect(result).not.toBeNull();
+          const { plan, readOnly } = result!;
+          const exp = c.expected as Record<string, unknown>;
+          if ('readOnly' in exp) expect(readOnly).toBe(exp.readOnly);
+          if ('schemaVersion' in exp) expect(plan.schemaVersion).toBe(exp.schemaVersion);
+          if ('week' in exp) expect(plan.week).toBe(exp.week);
+          if ('breakfast' in exp) expect(plan.days.mon?.slots?.breakfast).toEqual(exp.breakfast);
+          if ('lunch' in exp) expect(plan.days.mon?.slots?.lunch).toEqual(exp.lunch);
+          if ('dayNotes' in exp) expect(plan.days.mon?.notes).toBe(exp.dayNotes);
+          if ('weekNotes' in exp) expect(plan.notes).toBe(exp.weekNotes);
+          if ('createdAt' in exp) expect(plan.createdAt).toBe(exp.createdAt);
+          if (exp.breakfastPresent) expect(plan.days.mon?.slots?.breakfast).toBeDefined();
+          break;
+        }
+        case 'roundTrip': {
+          const original = resolvePayload(c.payload) as Record<string, unknown>;
+          const validated = validateMealPlanPayload(
+            JSON.parse(JSON.stringify(original)),
+            WEEK
+          )!;
+          const roundTripped = JSON.parse(serializeMealPlan(validated.plan));
+          expect(roundTripped).toEqual(original);
+          break;
+        }
+        case 'unknownFields': {
+          const payload = resolvePayload(c.payload) as Record<string, unknown>;
+          const inject = c.inject as {
+            top: Record<string, unknown>;
+            day: Record<string, unknown>;
+            slot: Record<string, unknown>;
+          };
+          Object.assign(payload, inject.top);
+          Object.assign((payload.days as any).mon, inject.day);
+          Object.assign((payload.days as any).mon.slots.breakfast, inject.slot);
+          const { plan } = validateMealPlanPayload(payload, WEEK)!;
+          const serialized = JSON.parse(serializeMealPlan(plan));
+          const exp = c.expected as Record<string, unknown>;
+          expect(serialized.futureFeature).toEqual(exp.futureFeature);
+          expect(serialized.days.mon.dayLevelExtra).toBe(exp.dayLevelExtra);
+          expect(serialized.days.mon.slots.breakfast.servings).toBe(exp.servings);
+          break;
+        }
+        case 'dropInvalidSlots': {
+          const payload = resolvePayload(c.payload) as Record<string, unknown>;
+          Object.assign((payload.days as any).mon.slots, c.injectSlots);
+          const { plan } = validateMealPlanPayload(payload, WEEK)!;
+          const exp = c.expected as Record<string, unknown>;
+          if (exp.dinnerAbsent) expect(plan.days.mon?.slots?.dinner).toBeUndefined();
+          if (exp.snackAbsent) expect(plan.days.mon?.slots?.snack).toBeUndefined();
+          if (exp.breakfastPresent) expect(plan.days.mon?.slots?.breakfast).toBeDefined();
+          if ('dayNotes' in exp) expect(plan.days.mon?.notes).toBe(exp.dayNotes);
+          break;
+        }
+        case 'ignoreUnknownDays': {
+          const payload = resolvePayload(c.payload) as Record<string, unknown>;
+          Object.assign(payload.days as object, c.injectDays);
+          const { plan } = validateMealPlanPayload(payload, WEEK)!;
+          expect((plan.days as any).funday).toBeUndefined();
+          expect(plan.days.tue).toBeUndefined();
+          break;
+        }
+        case 'defaults': {
+          const result = validateMealPlanPayload(c.payload as Record<string, unknown>, WEEK)!;
+          const exp = c.expected as Record<string, unknown>;
+          expect(result.readOnly).toBe(exp.readOnly);
+          expect(result.plan.schemaVersion).toBe(exp.schemaVersion);
+          expect(result.plan.week).toBe(exp.week);
+          expect(result.plan.days).toEqual(exp.days);
+          if (exp.createdAtPositive) expect(result.plan.createdAt).toBeGreaterThan(0);
+          break;
+        }
+        case 'reject': {
+          for (const p of c.payloads as unknown[]) {
+            expect(validateMealPlanPayload(p, WEEK)).toBeNull();
+          }
+          break;
+        }
+        case 'createEmpty': {
+          const plan: MealPlan = createEmptyMealPlan(WEEK);
+          const exp = c.expected as Record<string, unknown>;
+          expect(plan.schemaVersion).toBe(MEALPLAN_SCHEMA_VERSION);
+          expect(plan.schemaVersion).toBe(exp.schemaVersion);
+          expect(plan.week).toBe(exp.week);
+          expect(plan.days).toEqual(exp.days);
+          const validated = validateMealPlanPayload(JSON.parse(serializeMealPlan(plan)), WEEK);
+          expect(validated?.readOnly).toBe(exp.readOnly);
+          break;
+        }
+        default:
+          throw new Error(`unknown case kind: ${(c as { kind: string }).kind}`);
+      }
     });
-    expect(plan.days.mon?.slots?.lunch).toEqual({ type: 'text', text: 'Leftovers' });
-    expect(plan.days.mon?.notes).toBe('prep the night before');
-    expect(plan.notes).toBe('light week');
-    expect(plan.createdAt).toBe(1789000000);
-  });
-
-  it('round-trips: encode → validate → serialize preserves the payload', () => {
-    const original = validPayload();
-    const validated = validateMealPlanPayload(JSON.parse(JSON.stringify(original)), WEEK)!;
-    const roundTripped = JSON.parse(serializeMealPlan(validated.plan));
-    expect(roundTripped).toEqual(original);
-  });
-
-  it('preserves unknown fields at top, day, and slot level', () => {
-    const payload = validPayload();
-    payload.futureFeature = { some: 'data' };
-    (payload.days as any).mon.dayLevelExtra = 42;
-    (payload.days as any).mon.slots.breakfast.servings = 3;
-
-    const { plan } = validateMealPlanPayload(payload, WEEK)!;
-    const serialized = JSON.parse(serializeMealPlan(plan));
-    expect(serialized.futureFeature).toEqual({ some: 'data' });
-    expect(serialized.days.mon.dayLevelExtra).toBe(42);
-    expect(serialized.days.mon.slots.breakfast.servings).toBe(3);
-  });
-
-  it('flags schemaVersion > 1 as read-only without dropping content', () => {
-    const payload = validPayload();
-    payload.schemaVersion = 2;
-    const result = validateMealPlanPayload(payload, WEEK)!;
-    expect(result.readOnly).toBe(true);
-    expect(result.plan.schemaVersion).toBe(2);
-    expect(result.plan.days.mon?.slots?.breakfast).toBeDefined();
-  });
-
-  it('the d-tag week wins over a mismatched payload week', () => {
-    const payload = validPayload();
-    payload.week = '2020-W01';
-    const { plan } = validateMealPlanPayload(payload, WEEK)!;
-    expect(plan.week).toBe(WEEK);
-  });
-
-  it('drops invalid slot entries but keeps the rest of the day', () => {
-    const payload = validPayload();
-    (payload.days as any).mon.slots.dinner = { type: 'recipe' }; // missing a
-    (payload.days as any).mon.slots.snack = { type: 'mystery', x: 1 }; // unknown type
-    const { plan } = validateMealPlanPayload(payload, WEEK)!;
-    expect(plan.days.mon?.slots?.dinner).toBeUndefined();
-    expect(plan.days.mon?.slots?.snack).toBeUndefined();
-    expect(plan.days.mon?.slots?.breakfast).toBeDefined();
-    expect(plan.days.mon?.notes).toBe('prep the night before');
-  });
-
-  it('ignores unknown day keys and non-object days', () => {
-    const payload = validPayload();
-    (payload.days as any).funday = { slots: {} };
-    (payload.days as any).tue = 'not a day';
-    const { plan } = validateMealPlanPayload(payload, WEEK)!;
-    expect((plan.days as any).funday).toBeUndefined();
-    expect(plan.days.tue).toBeUndefined();
-  });
-
-  it('defensively defaults missing fields', () => {
-    const { plan, readOnly } = validateMealPlanPayload({}, WEEK)!;
-    expect(readOnly).toBe(false);
-    expect(plan.schemaVersion).toBe(1);
-    expect(plan.week).toBe(WEEK);
-    expect(plan.days).toEqual({});
-    expect(plan.createdAt).toBeGreaterThan(0);
-  });
-
-  it('rejects structurally unusable payloads', () => {
-    expect(validateMealPlanPayload(null, WEEK)).toBeNull();
-    expect(validateMealPlanPayload('a string', WEEK)).toBeNull();
-    expect(validateMealPlanPayload([1, 2], WEEK)).toBeNull();
-  });
-});
-
-describe('createEmptyMealPlan', () => {
-  it('creates a valid v1 skeleton', () => {
-    const plan: MealPlan = createEmptyMealPlan(WEEK);
-    expect(plan.schemaVersion).toBe(MEALPLAN_SCHEMA_VERSION);
-    expect(plan.week).toBe(WEEK);
-    expect(plan.days).toEqual({});
-    const validated = validateMealPlanPayload(JSON.parse(serializeMealPlan(plan)), WEEK);
-    expect(validated?.readOnly).toBe(false);
-  });
+  }
 });

--- a/src/lib/mealplan/week.test.ts
+++ b/src/lib/mealplan/week.test.ts
@@ -61,7 +61,7 @@ describe('d-tag round trip', () => {
   }
   for (const v of fixtures.weekIdFromDTagReject) {
     it(v.id, () => {
-      expect(weekIdFromDTag(v.input)).toBeNull();
+      expect(weekIdFromDTag(v.input)).toBe(v.expected);
     });
   }
 });

--- a/src/lib/mealplan/week.test.ts
+++ b/src/lib/mealplan/week.test.ts
@@ -11,87 +11,78 @@ import {
   weekIdFromDTag,
   weekDisplayRange
 } from './week';
+import fixtures from '../../test/fixtures/week.vectors.json';
+
+/** Local calendar date from fixture {y,m,d} (m is 1-indexed). */
+function localDate(d: { y: number; m: number; d: number }): Date {
+  return new Date(d.y, d.m - 1, d.d);
+}
 
 describe('week ids across ISO year boundaries', () => {
-  it('2026 is a 53-week ISO year', () => {
-    expect(weeksInISOYear(2026)).toBe(53);
-    expect(weeksInISOYear(2025)).toBe(52);
-  });
+  for (const v of fixtures.weeksInISOYear) {
+    it(v.id, () => {
+      expect(weeksInISOYear(v.year)).toBe(v.expected);
+    });
+  }
 
-  it('Jan 1–3 2027 belong to 2026-W53', () => {
-    expect(weekIdForDate(new Date(2027, 0, 1))).toBe('2026-W53');
-    expect(weekIdForDate(new Date(2027, 0, 2))).toBe('2026-W53');
-    expect(weekIdForDate(new Date(2027, 0, 3))).toBe('2026-W53');
-    // Jan 4 2027 is a Monday — first day of 2027-W01
-    expect(weekIdForDate(new Date(2027, 0, 4))).toBe('2027-W01');
-  });
-
-  it('Dec 29 2025 belongs to 2026-W01', () => {
-    expect(weekIdForDate(new Date(2025, 11, 29))).toBe('2026-W01');
-    expect(weekIdForDate(new Date(2025, 11, 28))).toBe('2025-W52');
-  });
-
-  it('zero-pads single-digit weeks', () => {
-    expect(weekIdForDate(new Date(2026, 1, 2))).toBe('2026-W06');
-  });
+  for (const v of fixtures.weekIdForDate) {
+    it(v.id, () => {
+      expect(weekIdForDate(localDate(v.date))).toBe(v.expected);
+    });
+  }
 });
 
 describe('week arithmetic', () => {
-  it('crosses into and out of W53', () => {
-    expect(nextWeekId('2026-W53')).toBe('2027-W01');
-    expect(prevWeekId('2027-W01')).toBe('2026-W53');
-  });
-
-  it('crosses a 52-week year boundary', () => {
-    expect(prevWeekId('2026-W01')).toBe('2025-W52');
-    expect(nextWeekId('2025-W52')).toBe('2026-W01');
-  });
-
-  it('walks ordinary weeks', () => {
-    expect(nextWeekId('2026-W29')).toBe('2026-W30');
-    expect(prevWeekId('2026-W29')).toBe('2026-W28');
-  });
-
-  it('mondayOfWeek returns the ISO Monday', () => {
-    const monday = mondayOfWeek('2026-W29');
-    expect(monday.getDay()).toBe(1);
-    expect(weekIdForDate(monday)).toBe('2026-W29');
-  });
+  for (const v of fixtures.nextWeekId) {
+    it(`next:${v.id}`, () => {
+      expect(nextWeekId(v.input)).toBe(v.expected);
+    });
+  }
+  for (const v of fixtures.prevWeekId) {
+    it(`prev:${v.id}`, () => {
+      expect(prevWeekId(v.input)).toBe(v.expected);
+    });
+  }
+  for (const v of fixtures.mondayOfWeek) {
+    it(v.id, () => {
+      const monday = mondayOfWeek(v.input);
+      expect(monday.getDay()).toBe(v.expectedDayOfWeek);
+      expect(weekIdForDate(monday)).toBe(v.expectedWeekId);
+    });
+  }
 });
 
 describe('d-tag round trip', () => {
-  it('encodes and decodes', () => {
-    expect(dTagForWeek('2026-W29')).toBe('mealplan-2026-W29');
-    expect(weekIdFromDTag('mealplan-2026-W29')).toBe('2026-W29');
-  });
-
-  it('rejects foreign or malformed d-tags', () => {
-    expect(weekIdFromDTag('grocery-abc123')).toBeNull();
-    expect(weekIdFromDTag('mealplan-2026-29')).toBeNull();
-    expect(weekIdFromDTag('mealplan-2026-W99')).toBeNull();
-  });
+  for (const v of fixtures.dTagRoundTrip) {
+    it(v.id, () => {
+      expect(dTagForWeek(v.weekId)).toBe(v.dTag);
+      expect(weekIdFromDTag(v.dTag)).toBe(v.weekId);
+    });
+  }
+  for (const v of fixtures.weekIdFromDTagReject) {
+    it(v.id, () => {
+      expect(weekIdFromDTag(v.input)).toBeNull();
+    });
+  }
 });
 
 describe('validation', () => {
-  it('accepts real weeks and rejects out-of-range ones', () => {
-    expect(isValidWeekId('2026-W53')).toBe(true); // 53-week year
-    expect(isValidWeekId('2025-W53')).toBe(false); // 52-week year
-    expect(isValidWeekId('2026-W00')).toBe(false);
-    expect(isValidWeekId('2026-W54')).toBe(false);
-    expect(isValidWeekId('26-W05')).toBe(false);
-    expect(isValidWeekId('garbage')).toBe(false);
-    expect(parseWeekId('2026-W29')).toEqual({ year: 2026, week: 29 });
-  });
+  for (const v of fixtures.isValidWeekId) {
+    it(v.id, () => {
+      expect(isValidWeekId(v.input)).toBe(v.expected);
+    });
+  }
+  for (const v of fixtures.parseWeekId) {
+    it(v.id, () => {
+      expect(parseWeekId(v.input)).toEqual(v.expected);
+    });
+  }
 });
 
 describe('display range', () => {
-  it('formats a same-month week', () => {
-    // 2026-W29: Mon Jul 13 – Sun Jul 19
-    expect(weekDisplayRange('2026-W29')).toBe('Week 29 (Jul 13–19)');
-  });
-
-  it('formats a cross-month week', () => {
-    // 2026-W27: Mon Jun 29 – Sun Jul 5
-    expect(weekDisplayRange('2026-W27')).toBe('Week 27 (Jun 29–Jul 5)');
-  });
+  for (const v of fixtures.weekDisplayRange) {
+    it(v.id, () => {
+      expect(weekDisplayRange(v.input)).toBe(v.expected);
+    });
+  }
 });

--- a/src/lib/utils/ingredientParser.test.ts
+++ b/src/lib/utils/ingredientParser.test.ts
@@ -9,126 +9,43 @@ import {
   parseIngredientsFromRecipe,
   normalizeFraction
 } from './ingredientParser';
+import fixtures from '../../test/fixtures/ingredient-parser.vectors.json';
 
 /**
- * First tests for the ingredient parser (it shipped untested — Phase 3
- * findings). These pin the parser's ACTUAL current behavior so the
- * grocery-generation feature has a stable base; behavioral oddities are
- * documented inline and filed rather than fixed here.
+ * Fixture-driven ingredient parser tests. Expectations live in
+ * src/test/fixtures/ingredient-parser.vectors.json (cross-platform contract).
+ * Quirks (plural singularization, comma-suffix retention) ARE the contract.
  */
 
 describe('parseIngredient', () => {
-  it('parses number + unit + name', () => {
-    const p = parseIngredient('2 cups flour');
-    // NOTE (quirk, filed): the unit alternation matches the singular
-    // form first and `s?` eats the plural — "cups" comes back as "cup".
-    expect(p.quantity).toBe('2 cup');
-    expect(p.name).toBe('flour');
-    expect(p.category).toBe('pantry');
-    expect(p.originalText).toBe('2 cups flour');
-  });
-
-  it('parses ASCII fractions', () => {
-    const p = parseIngredient('1/2 teaspoon salt');
-    expect(p.quantity).toBe('1/2 teaspoon');
-    expect(p.name).toBe('salt');
-  });
-
-  it('parses mixed numbers', () => {
-    const p = parseIngredient('1 1/2 cups sugar');
-    expect(p.quantity).toBe('1 1/2 cup');
-    expect(p.name).toBe('sugar');
-  });
-
-  it('parses unicode fractions', () => {
-    const p = parseIngredient('½ cup sugar');
-    expect(p.quantity).toBe('½ cup');
-    expect(p.name).toBe('sugar');
-  });
-
-  it('parses unitless quantities', () => {
-    const p = parseIngredient('2 onions, diced');
-    expect(p.quantity).toBe('2');
-    expect(p.name).toBe('onions');
-  });
-
-  it('keeps unquantified items whole', () => {
-    const p = parseIngredient('salt and pepper to taste');
-    expect(p.quantity).toBe('');
-    expect(p.name).toBe('salt and pepper to taste');
-  });
-
-  it('treats size words as units ("3 large eggs")', () => {
-    const p = parseIngredient('3 large eggs');
-    expect(p.quantity).toBe('3 large');
-    expect(p.name).toBe('eggs');
-    expect(p.category).toBe('protein');
-  });
-
-  it('strips parenthetical prep notes', () => {
-    const p = parseIngredient('2 cups flour (sifted)');
-    expect(p.name).toBe('flour');
-  });
-
-  it('strips known comma-prep suffixes but keeps unknown ones', () => {
-    expect(parseIngredient('2 carrots, chopped').name).toBe('carrots');
-    // "beaten" is not in the prep-word list — the suffix stays (quirk, filed)
-    expect(parseIngredient('3 large eggs, beaten').name).toBe('eggs, beaten');
-  });
-
-  it('drops leading articles from names', () => {
-    const p = parseIngredient('1 an onion');
-    expect(p.name).toBe('onion');
-  });
+  for (const vector of fixtures.parseIngredient) {
+    it(vector.id, () => {
+      const p = parseIngredient(vector.input);
+      expect(p).toEqual(vector.expected);
+    });
+  }
 });
 
 describe('extractIngredientsFromRecipe', () => {
-  const MD = `## Chef's notes
-
-Great dish.
-
-## Ingredients
-
-- 2 cups flour
-* 1 cup milk
-1. 3 eggs
-
-**For the sauce**
-
-- 1 jar tomato sauce
-plain line ingredient
-
-## Directions
-
-1. Mix.
-`;
-
-  it('extracts bullets, stars, numbered and plain lines; skips bold subheads', () => {
-    expect(extractIngredientsFromRecipe(MD)).toEqual([
-      '2 cups flour',
-      '1 cup milk',
-      '3 eggs',
-      '1 jar tomato sauce',
-      'plain line ingredient'
-    ]);
-  });
-
-  it('returns empty for content without an Ingredients section', () => {
-    expect(extractIngredientsFromRecipe('## Directions\n\n1. Cook.')).toEqual([]);
-  });
+  for (const vector of fixtures.extractIngredientsFromRecipe) {
+    it(vector.id, () => {
+      expect(extractIngredientsFromRecipe(vector.input)).toEqual(vector.expected);
+    });
+  }
 });
 
 describe('parseIngredientsFromRecipe', () => {
-  it('extracts and parses in one pass', () => {
-    const parsed = parseIngredientsFromRecipe('## Ingredients\n\n- 2 cups flour\n- 1/2 tsp salt\n');
-    expect(parsed).toHaveLength(2);
-    expect(parsed[0].name).toBe('flour');
-    expect(parsed[1].quantity).toBe('1/2 tsp');
-  });
+  for (const vector of fixtures.parseIngredientsFromRecipe) {
+    it(vector.id, () => {
+      expect(parseIngredientsFromRecipe(vector.input)).toEqual(vector.expected);
+    });
+  }
 });
 
 describe('normalizeFraction', () => {
-  it('converts unicode fractions to ASCII', () => {
-    expect(normalizeFraction('½ cup and ¾ tsp')).toBe('1/2 cup and 3/4 tsp');
-  });
+  for (const vector of fixtures.normalizeFraction) {
+    it(vector.id, () => {
+      expect(normalizeFraction(vector.input)).toBe(vector.expected);
+    });
+  }
 });

--- a/src/test/fixtures/grocery-generation.vectors.json
+++ b/src/test/fixtures/grocery-generation.vectors.json
@@ -1,0 +1,77 @@
+{
+  "description": "Cross-platform grocery-generation contract vectors. Source: src/lib/mealplan/groceryGeneration.test.ts.",
+  "collectWeekRecipeSlots": [
+    {
+      "id": "unique-coords-day-slot-order",
+      "days": {
+        "mon": {
+          "slots": {
+            "breakfast": { "type": "text", "text": "Coffee" },
+            "dinner": { "type": "recipe", "a": "30023:pk:curry" }
+          }
+        },
+        "wed": {
+          "slots": {
+            "lunch": { "type": "recipe", "a": "30023:pk:salad" },
+            "dinner": { "type": "recipe", "a": "30023:pk:curry" }
+          }
+        },
+        "sun": {
+          "slots": {
+            "lunch": { "type": "text", "text": "Eating out" }
+          }
+        }
+      },
+      "expected": {
+        "aTags": ["30023:pk:curry", "30023:pk:salad"],
+        "textCount": 2,
+        "recipeSlotCount": 3
+      }
+    },
+    {
+      "id": "empty-week",
+      "days": {},
+      "expected": {
+        "aTags": [],
+        "textCount": 0,
+        "recipeSlotCount": 0
+      }
+    }
+  ],
+  "dedupeIngredients": [
+    {
+      "id": "exact-dup-first-recipeId-wins",
+      "rows": [
+        { "name": "olive oil", "quantity": "2 tbsp", "recipeId": "r1" },
+        { "name": "rice", "quantity": "1 cup", "recipeId": "r1" },
+        { "name": "olive oil", "quantity": "2 tbsp", "recipeId": "r2" }
+      ],
+      "expectedLength": 2,
+      "expectedFirstRecipeId": "r1"
+    },
+    {
+      "id": "no-merge-different-quantities",
+      "rows": [
+        { "name": "rice", "quantity": "1 cup", "recipeId": "r1" },
+        { "name": "rice", "quantity": "2 cup", "recipeId": "r2" }
+      ],
+      "expectedLength": 2
+    },
+    {
+      "id": "case-insensitive-name-verbatim-quantity",
+      "rows": [
+        { "name": "Olive Oil", "quantity": "2 tbsp", "recipeId": "r1" },
+        { "name": "olive oil", "quantity": "2 tbsp", "recipeId": "r2" },
+        { "name": "olive oil", "quantity": "2 Tbsp", "recipeId": "r3" }
+      ],
+      "expectedLength": 2
+    }
+  ],
+  "groceryListTitle": [
+    {
+      "id": "week-29",
+      "weekId": "2026-W29",
+      "expected": "Groceries — Week 29 (Jul 13–19)"
+    }
+  ]
+}

--- a/src/test/fixtures/ingredient-parser.vectors.json
+++ b/src/test/fixtures/ingredient-parser.vectors.json
@@ -1,0 +1,163 @@
+{
+  "description": "Cross-platform ingredient-parser contract vectors. Source: src/lib/utils/ingredientParser.test.ts. Quirks (plural singularization, comma-suffix retention) ARE the contract — do not \"fix\" them unilaterally.",
+  "parseIngredient": [
+    {
+      "id": "number-unit-name",
+      "input": "2 cups flour",
+      "expected": {
+        "quantity": "2 cup",
+        "name": "flour",
+        "category": "pantry",
+        "originalText": "2 cups flour"
+      },
+      "notes": "quirk: unit alternation matches singular first; s? eats the plural"
+    },
+    {
+      "id": "ascii-fraction",
+      "input": "1/2 teaspoon salt",
+      "expected": {
+        "quantity": "1/2 teaspoon",
+        "name": "salt",
+        "category": "pantry",
+        "originalText": "1/2 teaspoon salt"
+      }
+    },
+    {
+      "id": "mixed-number",
+      "input": "1 1/2 cups sugar",
+      "expected": {
+        "quantity": "1 1/2 cup",
+        "name": "sugar",
+        "category": "pantry",
+        "originalText": "1 1/2 cups sugar"
+      }
+    },
+    {
+      "id": "unicode-fraction",
+      "input": "½ cup sugar",
+      "expected": {
+        "quantity": "½ cup",
+        "name": "sugar",
+        "category": "pantry",
+        "originalText": "½ cup sugar"
+      }
+    },
+    {
+      "id": "unitless-quantity",
+      "input": "2 onions, diced",
+      "expected": {
+        "quantity": "2",
+        "name": "onions",
+        "category": "produce",
+        "originalText": "2 onions, diced"
+      }
+    },
+    {
+      "id": "unquantified",
+      "input": "salt and pepper to taste",
+      "expected": {
+        "quantity": "",
+        "name": "salt and pepper to taste",
+        "category": "produce",
+        "originalText": "salt and pepper to taste"
+      },
+      "notes": "category quirks with keyword order: 'pepper' hits produce before pantry 'salt'"
+    },
+    {
+      "id": "size-word-unit",
+      "input": "3 large eggs",
+      "expected": {
+        "quantity": "3 large",
+        "name": "eggs",
+        "category": "protein",
+        "originalText": "3 large eggs"
+      }
+    },
+    {
+      "id": "strip-parenthetical",
+      "input": "2 cups flour (sifted)",
+      "expected": {
+        "quantity": "2 cup",
+        "name": "flour",
+        "category": "pantry",
+        "originalText": "2 cups flour (sifted)"
+      }
+    },
+    {
+      "id": "comma-prep-known",
+      "input": "2 carrots, chopped",
+      "expected": {
+        "quantity": "2",
+        "name": "carrots",
+        "category": "produce",
+        "originalText": "2 carrots, chopped"
+      }
+    },
+    {
+      "id": "comma-prep-unknown-retained",
+      "input": "3 large eggs, beaten",
+      "expected": {
+        "quantity": "3 large",
+        "name": "eggs, beaten",
+        "category": "protein",
+        "originalText": "3 large eggs, beaten"
+      },
+      "notes": "quirk: 'beaten' is not in the prep-word list — suffix stays"
+    },
+    {
+      "id": "drop-leading-article",
+      "input": "1 an onion",
+      "expected": {
+        "quantity": "1",
+        "name": "onion",
+        "category": "produce",
+        "originalText": "1 an onion"
+      }
+    }
+  ],
+  "extractIngredientsFromRecipe": [
+    {
+      "id": "extract-bullets-stars-numbered-plain",
+      "input": "## Chef's notes\n\nGreat dish.\n\n## Ingredients\n\n- 2 cups flour\n* 1 cup milk\n1. 3 eggs\n\n**For the sauce**\n\n- 1 jar tomato sauce\nplain line ingredient\n\n## Directions\n\n1. Mix.\n",
+      "expected": [
+        "2 cups flour",
+        "1 cup milk",
+        "3 eggs",
+        "1 jar tomato sauce",
+        "plain line ingredient"
+      ]
+    },
+    {
+      "id": "extract-no-section",
+      "input": "## Directions\n\n1. Cook.",
+      "expected": []
+    }
+  ],
+  "parseIngredientsFromRecipe": [
+    {
+      "id": "extract-and-parse",
+      "input": "## Ingredients\n\n- 2 cups flour\n- 1/2 tsp salt\n",
+      "expected": [
+        {
+          "quantity": "2 cup",
+          "name": "flour",
+          "category": "pantry",
+          "originalText": "2 cups flour"
+        },
+        {
+          "quantity": "1/2 tsp",
+          "name": "salt",
+          "category": "pantry",
+          "originalText": "1/2 tsp salt"
+        }
+      ]
+    }
+  ],
+  "normalizeFraction": [
+    {
+      "id": "unicode-to-ascii",
+      "input": "½ cup and ¾ tsp",
+      "expected": "1/2 cup and 3/4 tsp"
+    }
+  ]
+}

--- a/src/test/fixtures/mealplan-schema.vectors.json
+++ b/src/test/fixtures/mealplan-schema.vectors.json
@@ -1,0 +1,130 @@
+{
+  "description": "Cross-platform meal-plan schema contract vectors. Source: src/lib/mealplan/schema.test.ts. WEEK is always 2026-W29 unless noted.",
+  "week": "2026-W29",
+  "validPayload": {
+    "schemaVersion": 1,
+    "week": "2026-W29",
+    "days": {
+      "mon": {
+        "slots": {
+          "breakfast": { "type": "recipe", "a": "30023:abc:shakshuka", "title": "Shakshuka" },
+          "lunch": { "type": "text", "text": "Leftovers" }
+        },
+        "notes": "prep the night before"
+      }
+    },
+    "notes": "light week",
+    "createdAt": 1789000000,
+    "updatedAt": 1789000123
+  },
+  "cases": [
+    {
+      "id": "accept-union-branches",
+      "kind": "validate",
+      "payload": "$validPayload",
+      "expected": {
+        "readOnly": false,
+        "breakfast": { "type": "recipe", "a": "30023:abc:shakshuka", "title": "Shakshuka" },
+        "lunch": { "type": "text", "text": "Leftovers" },
+        "dayNotes": "prep the night before",
+        "weekNotes": "light week",
+        "createdAt": 1789000000
+      }
+    },
+    {
+      "id": "round-trip",
+      "kind": "roundTrip",
+      "payload": "$validPayload"
+    },
+    {
+      "id": "preserve-unknown-fields",
+      "kind": "unknownFields",
+      "payload": "$validPayload",
+      "inject": {
+        "top": { "futureFeature": { "some": "data" } },
+        "day": { "dayLevelExtra": 42 },
+        "slot": { "servings": 3 }
+      },
+      "expected": {
+        "futureFeature": { "some": "data" },
+        "dayLevelExtra": 42,
+        "servings": 3
+      }
+    },
+    {
+      "id": "schema-v2-readonly",
+      "kind": "validate",
+      "payload": "$validPayload",
+      "overrides": { "schemaVersion": 2 },
+      "expected": {
+        "readOnly": true,
+        "schemaVersion": 2,
+        "breakfastPresent": true
+      }
+    },
+    {
+      "id": "dtag-week-wins",
+      "kind": "validate",
+      "payload": "$validPayload",
+      "overrides": { "week": "2020-W01" },
+      "expected": { "week": "2026-W29" }
+    },
+    {
+      "id": "drop-invalid-slots",
+      "kind": "dropInvalidSlots",
+      "payload": "$validPayload",
+      "injectSlots": {
+        "dinner": { "type": "recipe" },
+        "snack": { "type": "mystery", "x": 1 }
+      },
+      "expected": {
+        "dinnerAbsent": true,
+        "snackAbsent": true,
+        "breakfastPresent": true,
+        "dayNotes": "prep the night before"
+      }
+    },
+    {
+      "id": "ignore-unknown-day-keys",
+      "kind": "ignoreUnknownDays",
+      "payload": "$validPayload",
+      "injectDays": {
+        "funday": { "slots": {} },
+        "tue": "not a day"
+      },
+      "expected": {
+        "fundayAbsent": true,
+        "tueAbsent": true
+      }
+    },
+    {
+      "id": "default-missing-fields",
+      "kind": "defaults",
+      "payload": {},
+      "expected": {
+        "readOnly": false,
+        "schemaVersion": 1,
+        "week": "2026-W29",
+        "days": {},
+        "createdAtPositive": true
+      },
+      "notes": "createdAt is wall-clock; assert presence/positivity, not a fixed value"
+    },
+    {
+      "id": "reject-unusable",
+      "kind": "reject",
+      "payloads": [null, "a string", [1, 2]]
+    },
+    {
+      "id": "create-empty-skeleton",
+      "kind": "createEmpty",
+      "expected": {
+        "schemaVersion": 1,
+        "week": "2026-W29",
+        "days": {},
+        "readOnly": false
+      }
+    }
+  ],
+  "notRepresentableAsData": []
+}

--- a/src/test/fixtures/week.vectors.json
+++ b/src/test/fixtures/week.vectors.json
@@ -1,0 +1,61 @@
+{
+  "description": "Cross-platform ISO-week contract vectors. Source: src/lib/mealplan/week.test.ts. Dates use calendar {y,m,d} with m 1-indexed.",
+  "weeksInISOYear": [
+    { "id": "2026-is-53", "year": 2026, "expected": 53 },
+    { "id": "2025-is-52", "year": 2025, "expected": 52 }
+  ],
+  "weekIdForDate": [
+    { "id": "jan1-2027", "date": { "y": 2027, "m": 1, "d": 1 }, "expected": "2026-W53" },
+    { "id": "jan2-2027", "date": { "y": 2027, "m": 1, "d": 2 }, "expected": "2026-W53" },
+    { "id": "jan3-2027", "date": { "y": 2027, "m": 1, "d": 3 }, "expected": "2026-W53" },
+    { "id": "jan4-2027", "date": { "y": 2027, "m": 1, "d": 4 }, "expected": "2027-W01" },
+    { "id": "dec29-2025", "date": { "y": 2025, "m": 12, "d": 29 }, "expected": "2026-W01" },
+    { "id": "dec28-2025", "date": { "y": 2025, "m": 12, "d": 28 }, "expected": "2025-W52" },
+    { "id": "zero-pad", "date": { "y": 2026, "m": 2, "d": 2 }, "expected": "2026-W06" }
+  ],
+  "nextWeekId": [
+    { "id": "w53-to-w01", "input": "2026-W53", "expected": "2027-W01" },
+    { "id": "w52-to-w01", "input": "2025-W52", "expected": "2026-W01" },
+    { "id": "ordinary", "input": "2026-W29", "expected": "2026-W30" }
+  ],
+  "prevWeekId": [
+    { "id": "w01-to-w53", "input": "2027-W01", "expected": "2026-W53" },
+    { "id": "w01-to-w52", "input": "2026-W01", "expected": "2025-W52" },
+    { "id": "ordinary", "input": "2026-W29", "expected": "2026-W28" }
+  ],
+  "mondayOfWeek": [
+    {
+      "id": "w29-monday",
+      "input": "2026-W29",
+      "expectedDayOfWeek": 1,
+      "expectedWeekId": "2026-W29"
+    }
+  ],
+  "dTagRoundTrip": [
+    {
+      "id": "encode-decode",
+      "weekId": "2026-W29",
+      "dTag": "mealplan-2026-W29"
+    }
+  ],
+  "weekIdFromDTagReject": [
+    { "id": "foreign-prefix", "input": "grocery-abc123", "expected": null },
+    { "id": "missing-W", "input": "mealplan-2026-29", "expected": null },
+    { "id": "invalid-week", "input": "mealplan-2026-W99", "expected": null }
+  ],
+  "isValidWeekId": [
+    { "id": "real-w53", "input": "2026-W53", "expected": true },
+    { "id": "invalid-w53-on-52-year", "input": "2025-W53", "expected": false },
+    { "id": "w00", "input": "2026-W00", "expected": false },
+    { "id": "w54", "input": "2026-W54", "expected": false },
+    { "id": "short-year", "input": "26-W05", "expected": false },
+    { "id": "garbage", "input": "garbage", "expected": false }
+  ],
+  "parseWeekId": [
+    { "id": "w29", "input": "2026-W29", "expected": { "year": 2026, "week": 29 } }
+  ],
+  "weekDisplayRange": [
+    { "id": "same-month", "input": "2026-W29", "expected": "Week 29 (Jul 13–19)" },
+    { "id": "cross-month", "input": "2026-W27", "expected": "Week 27 (Jun 29–Jul 5)" }
+  ]
+}


### PR DESCRIPTION
## Summary

* Extract language-neutral JSON fixtures under `src/test/fixtures/` (vault fixture home): `ingredient-parser.vectors.json` (15 cases including pinned quirks), `week.vectors.json` (W53/year-boundary set), `mealplan-schema.vectors.json`, `grocery-generation.vectors.json` (dedupe + title).
* Rewrite Vitest suites to **consume** the fixtures — no expectation lives only inline. Coverage identical; suite green (60 tests across the four files).
* Document fixture file list + sha256 checksums and the paired-update rule in `docs/mealplan-contract.md`.

## Test plan

* [x] `pnpm exec vitest run src/lib/utils/ingredientParser.test.ts src/lib/mealplan/week.test.ts src/lib/mealplan/schema.test.ts src/lib/mealplan/groceryGeneration.test.ts` — 60/60 green
* [ ] Copilot review + triage

## Notes

* Quirks are contract: `"2 cups"` → `"2 cup"`, `"eggs, beaten"` retains suffix.
* Android Part B copies these at the recorded checksums.


Made with [Cursor](https://cursor.com)