### PR TITLE
feat(security): nsec paste guard — block secret-key pastes outside login

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.655",
+  "version": "4.2.656",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/LoginFormIOS.svelte
+++ b/src/components/LoginFormIOS.svelte
@@ -421,6 +421,7 @@
         placeholder="nsec1..."
         class="input block w-full sm:text-sm p-3"
         disabled={authState.isLoading}
+        data-nsec-field
       />
       {#if nsecError}
         <div class="text-sm" style="color: var(--color-danger, #ef4444)">{nsecError}</div>

--- a/src/components/LoginOverlay.svelte
+++ b/src/components/LoginOverlay.svelte
@@ -849,6 +849,7 @@
           placeholder="nsec1..."
           class="input block w-full sm:text-sm p-3"
           disabled={authState.isLoading}
+          data-nsec-field
         />
         {#if nsecError}
           <div class="text-sm" style="color: var(--color-danger, #ef4444)">{nsecError}</div>

--- a/src/lib/nsecPasteGuard.ts
+++ b/src/lib/nsecPasteGuard.ts
@@ -1,0 +1,83 @@
+/**
+ * nsec paste guard.
+ *
+ * A secret key (nsec) should only ever be pasted into the login/key-import
+ * field. Pasting one anywhere else — the note composer, a profile bio, a
+ * wallet send note, a relay URL, … — is almost always a slip that leaks the
+ * key into the wrong box. This blocks those pastes before they land.
+ *
+ * Mirrors the same-named guard already shipped in the native apps
+ * (zap_cooking_android / wisp / wisp-ios) and sidecar: a single capture-phase
+ * `paste` listener on the document that scans the clipboard for an nsec and
+ * cancels the paste (with a toast) unless the target is an allowed field.
+ *
+ * Two opt-out mechanisms, both defaulting to safe:
+ *   1. The target input is marked with `data-nsec-field` (the login/import
+ *      field). This is the primary, declarative mechanism — no global state
+ *      to remember to reset.
+ *   2. The `nsecPasteAllowed` store is true (a programmatic, screen-level
+ *      escape hatch, matching the native flag).
+ *
+ * Install once at startup via `installNsecPasteGuard()` (called from the root
+ * layout's onMount). Idempotent.
+ */
+import { writable } from 'svelte/store';
+import { showToast } from './toast';
+
+// Canonical nsec is `nsec1` + exactly 58 bech32 chars, but we accept 20+ so a
+// partially-selected / truncated key is still caught. Case-insensitive.
+const NSEC_RE = /nsec1[a-z0-9]{20,}/i;
+
+/** True while a screen that intentionally accepts nsec input is on screen. */
+export const nsecPasteAllowed = writable(false);
+
+/** Marker attribute placed on the one input where an nsec belongs. */
+const ALLOWED_ATTR = 'data-nsec-field';
+
+let installed = false;
+
+export function containsNsec(text: string): boolean {
+  return NSEC_RE.test(text);
+}
+
+function isAllowedTarget(target: EventTarget | null, storeAllowed: boolean): boolean {
+  if (storeAllowed) return true;
+  if (target instanceof HTMLElement) return !!target.closest(`[${ALLOWED_ATTR}]`);
+  return false;
+}
+
+const WARNING_MESSAGE =
+  'Paste blocked — your nsec is your private key. Only paste it into the login field to sign in.';
+
+/**
+ * Install the global capture-phase paste listener. Safe to call more than
+ * once (e.g. across HMR / layout remounts).
+ */
+export function installNsecPasteGuard(): void {
+  if (installed || typeof document === 'undefined') return;
+  installed = true;
+
+  let storeAllowed = false;
+  nsecPasteAllowed.subscribe((v) => (storeAllowed = v));
+
+  document.addEventListener(
+    'paste',
+    (e) => {
+      if (e.defaultPrevented) return;
+      let text = '';
+      try {
+        const cd = (e as ClipboardEvent).clipboardData;
+        text = cd ? cd.getData('text') : '';
+      } catch {
+        return;
+      }
+      if (!containsNsec(text)) return;
+      if (isAllowedTarget(e.target, storeAllowed)) return;
+      // Block the paste and surface why.
+      e.preventDefault();
+      e.stopPropagation();
+      showToast('error', WARNING_MESSAGE, 4500);
+    },
+    true // capture: beat any field-level handlers
+  );
+}

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -33,6 +33,10 @@ export const toasts = writable<ToastMessage[]>([]);
 
 /**
  * Fire a toast. Returns the id so callers can dismiss early if needed.
+ *
+ * Only one toast is shown at a time: a new toast replaces any currently
+ * visible. This keeps a rapid burst (e.g. repeated blocked pastes) from
+ * stacking a column of identical messages.
  */
 export function showToast(
   variant: ToastVariant,
@@ -41,7 +45,7 @@ export function showToast(
   link?: ToastLink
 ): string {
   const id = `toast-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  toasts.update((list) => [...list, { id, variant, message, durationMs, link }]);
+  toasts.set([{ id, variant, message, durationMs, link }]);
   if (durationMs > 0) {
     setTimeout(() => dismissToast(id), durationMs);
   }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -30,6 +30,7 @@
   import { clearUnwrapCache } from '$lib/nip17';
   import { stopGroupSubscription, clearGroups } from '$lib/stores/groups';
   import { preconnectPantry } from '$lib/nip29';
+  import { installNsecPasteGuard } from '$lib/nsecPasteGuard';
   import type { LayoutData } from './$types';
   import ErrorBoundary from '../components/ErrorBoundary.svelte';
   import OfflineIndicator from '../components/OfflineIndicator.svelte';
@@ -327,6 +328,9 @@
 
   onMount(async () => {
     try {
+      // Block accidental nsec pastes everywhere except the login/key-import
+      // field (the one place a secret key belongs). Idempotent.
+      installNsecPasteGuard();
       // Detect platform first (iOS, Android, or web)
       detectPlatform();
 


### PR DESCRIPTION
## Summary

Pasting an nsec anywhere except the login/key-import field is almost always a slip that leaks the private key into the wrong box (note composer, profile bio, wallet send note, relay URL, …). This blocks those pastes before they land — porting the same-named guard already shipped in **zap_cooking_android / wisp / wisp-ios** and **sidecar**.

## Changes

- **New `src/lib/nsecPasteGuard.ts`** — a single capture-phase `paste` listener on `document` that scans the clipboard for an nsec (`/nsec1[a-z0-9]{20,}/i` — accepts 20+ chars so truncated/partial keys are still caught) and cancels the paste with a toast unless the target is allowed. Two opt-out mechanisms, both defaulting safe:
  - The target is within `[data-nsec-field]` — declarative, can't be forgotten (primary).
  - The `nsecPasteAllowed` store flag is true — programmatic, screen-level escape hatch (matches the native flag).
  - `installNsecPasteGuard()` is idempotent (HMR-safe).
- **Wired in the root layout's `onMount`** so it covers the whole app from first load.
- **`data-nsec-field` on the two login inputs** (`LoginOverlay.svelte`, `LoginFormIOS.svelte`) — the only places a secret key belongs.
- **`toast.ts`** — only one toast on screen at a time (a new toast replaces any visible), so a rapid burst of blocked pastes doesn't stack a column of identical messages.

## Testing

- `pnpm run check` — 0 errors
- Drove the guard in a headless browser against the dev server, simulating real `paste` events with clipboard data:
  - **Plain field** → paste cancelled, field stays empty, "Paste blocked" toast shown ✅
  - **`data-nsec-field` input** → paste goes through, nsec lands ✅

🧄 Minced with [Claude Code](https://claude.com/claude-code)