### PR TITLE
docs(my-kitchen): mark Phases 1–3 shipped (web + Android)

### DIFF
--- a/docs/my-kitchen-spec.md
+++ b/docs/my-kitchen-spec.md
@@ -51,7 +51,7 @@ Goal: both platforms present the same thing under the same name before adding an
 
 ## Phase 1 — Hub Shell & IA
 
-**Status: Shipped (web)**
+**Status: Shipped (web + Android)**
 
 Goal: a hub landing surface with room for the future sections, without building them yet.
 
@@ -65,7 +65,7 @@ Goal: a hub landing surface with room for the future sections, without building 
 
 ## Phase 2 — Grocery Parity (Android) + Hub Integration
 
-**Status: Not started**
+**Status: Shipped**
 
 Goal: grocery everywhere, fed by recipes.
 
@@ -82,7 +82,7 @@ Goal: grocery everywhere, fed by recipes.
 
 ## Phase 3 — Meal Planner (new feature, new data model)
 
-**Status: In progress**
+**Status: Shipped (web + Android; 3.5 remains open)**
 
 Goal: a week grid of planned meals referencing saved/published recipes; generates the grocery list.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.656",
+  "version": "4.2.657",
   "private": true,
   "scripts": {
     "dev": "vite dev",


### PR DESCRIPTION
## Summary
- Flip `docs/my-kitchen-spec.md` status lines after Android arc PR 11 (generate grocery from week) lands the Android half of Phase 3.3/3.4.
- Phase 1 → Shipped (web + Android); Phase 2 → Shipped; Phase 3 → Shipped (web + Android; 3.5 remains open).

## Test plan
- [ ] Spec status lines match shipped reality on both platforms
- [ ] No other docs/content changes in this PR


Made with [Cursor](https://cursor.com)