### PR TITLE
fix(recipes): hide 19 known dev/e2e test recipes from /recipes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.656",
+  "version": "4.2.657",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.658",
+  "version": "4.2.659",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.657",
+  "version": "4.2.658",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -63,11 +63,11 @@ export const HIDDEN_RECIPE_COORDINATES: ReadonlySet<string> = new Set([
 
 /** True when a recipe coordinate is on the permanent /recipes hide list. */
 export function isHiddenRecipeCoordinate(
-  kind: number,
-  pubkey: string,
+  kind: number | undefined | null,
+  pubkey: string | undefined | null,
   dTag: string | undefined | null
 ): boolean {
-  if (!pubkey || !dTag) return false;
+  if (kind == null || !pubkey || !dTag) return false;
   return HIDDEN_RECIPE_COORDINATES.has(`${kind}:${pubkey}:${dTag}`);
 }
 

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -32,6 +32,45 @@ export const RECIPE_TAG_PREFIX_NEW = 'zapcooking';
 export const RECIPE_TAG_PREFIX_LEGACY = 'nostrcooking';
 export const RECIPE_TAGS = [RECIPE_TAG_PREFIX_NEW, RECIPE_TAG_PREFIX_LEGACY]; // For filtering (supports both)
 
+/**
+ * Dev / e2e test recipes that should never surface on /recipes.
+ * Coordinates are NIP-01 addressable keys `kind:pubkey:d-tag` (not event ids),
+ * so later replaceable revisions stay hidden too.
+ *
+ * Source naddrs (19): zc-pr11 / pr10 / pr11-ghost / pr10-zero-parse* / e2e-*.
+ */
+export const HIDDEN_RECIPE_COORDINATES: ReadonlySet<string> = new Set([
+  '30023:8b739c62ed2a9b76c2836a18a6bc9a480b6f8d902b8f702083dfae20bf6b15b9:zc-pr11-test-bravo',
+  '30023:8b739c62ed2a9b76c2836a18a6bc9a480b6f8d902b8f702083dfae20bf6b15b9:zc-pr11-test-alpha',
+  '30023:8b739c62ed2a9b76c2836a18a6bc9a480b6f8d902b8f702083dfae20bf6b15b9:pr10-pancakes',
+  '30023:a22a71c97b536902adb2b15f3e56014d2a2a2adc0c2d99f3996081455cc4ea92:pr11-ghost-recipe',
+  '30023:a22a71c97b536902adb2b15f3e56014d2a2a2adc0c2d99f3996081455cc4ea92:pr10-zero-parse2',
+  '30023:a22a71c97b536902adb2b15f3e56014d2a2a2adc0c2d99f3996081455cc4ea92:pr10-zero-parse',
+  '30023:772e4f7ffd63a09748eb231e40e4dbd772fe997b8748c194f6204cfd8e4c933f:e2e-salad',
+  '30023:772e4f7ffd63a09748eb231e40e4dbd772fe997b8748c194f6204cfd8e4c933f:e2e-toast',
+  '30023:772e4f7ffd63a09748eb231e40e4dbd772fe997b8748c194f6204cfd8e4c933f:e2e-curry',
+  '30023:783f7c04246e161314bd33853b20aecd3b027e3ef9c9783ec3d973365a2f269c:e2e-salad',
+  '30023:bcaa6d25a3cac844c4631e082f62917fb6c8e3b80a3a05c87a65444310f04921:e2e-salad',
+  '30023:434b9310a45d05d97c1d45354fb4a9857bf181db3194e107402c6cb002164c9a:e2e-salad',
+  '30023:434b9310a45d05d97c1d45354fb4a9857bf181db3194e107402c6cb002164c9a:e2e-curry',
+  '30023:f74290982a8cce6b8f869f3c33f5f9844bcbaf9ad22909904aae6f04efce69f4:e2e-curry',
+  '30023:5a866ed1f65d68aec7c1879f810eff389ec15bfccf685b303df040d072f50864:e2e-curry',
+  '30023:f62cdccd2c958cdd9726351cbc0e804ab9e32c47f6c62d649b0aaa23f9651f0d:e2e-salad',
+  '30023:f62cdccd2c958cdd9726351cbc0e804ab9e32c47f6c62d649b0aaa23f9651f0d:e2e-curry',
+  '30023:dd7e9c53ae4509aba878370c7285395e5d61b98e8eabdb33afa4deb6b6f68c13:e2e-salad',
+  '30023:dd7e9c53ae4509aba878370c7285395e5d61b98e8eabdb33afa4deb6b6f68c13:e2e-curry'
+]);
+
+/** True when a recipe coordinate is on the permanent /recipes hide list. */
+export function isHiddenRecipeCoordinate(
+  kind: number,
+  pubkey: string,
+  dTag: string | undefined | null
+): boolean {
+  if (!pubkey || !dTag) return false;
+  return HIDDEN_RECIPE_COORDINATES.has(`${kind}:${pubkey}:${dTag}`);
+}
+
 // Gated/Premium recipe kind (addressable event in 30000-39999 range)
 // Using 35000 to differentiate from regular recipes (30023)
 export const GATED_RECIPE_KIND = 35000;

--- a/src/routes/recipes/+page.svelte
+++ b/src/routes/recipes/+page.svelte
@@ -6,8 +6,14 @@
   import PullToRefresh from '../../components/PullToRefresh.svelte';
   import { validateMarkdownTemplate } from '$lib/parser';
   import type { PageData } from './$types';
-  import { RECIPE_TAGS } from '$lib/consts';
+  import { RECIPE_TAGS, isHiddenRecipeCoordinate } from '$lib/consts';
   import { feedCacheService } from '$lib/feedCache';
+
+  function isDisplayableRecipe(event: NDKEvent): boolean {
+    const dTag = event.tags.find((t) => t[0] === 'd')?.[1];
+    if (isHiddenRecipeCoordinate(event.kind, event.pubkey, dTag)) return false;
+    return validateMarkdownTemplate(event.content) !== null;
+  }
 
   export const data: PageData = {} as PageData;
 
@@ -115,8 +121,8 @@
             if (getCurrentRelayGeneration() !== startGeneration) {
               console.log('🚫 Relay changed during cache fetch, ignoring cached data');
             } else {
-              // Filter cached events for valid recipes
-              events = cached.filter(e => validateMarkdownTemplate(e.content) !== null);
+              // Filter cached events for valid (non-hidden) recipes
+              events = cached.filter(isDisplayableRecipe);
               loaded = true;
               console.log(`⚡ Cache hit: ${events.length} recipes in ${(performance.now() - perfStart).toFixed(0)}ms`);
               return;
@@ -144,7 +150,7 @@
           return;
         }
         
-        if (validateMarkdownTemplate(event.content) !== null) {
+        if (isDisplayableRecipe(event)) {
           fetchedEvents.push(event);
           events = [...fetchedEvents];
 
@@ -256,7 +262,7 @@
         }
         if (seen.has(event.id)) return;
         seen.add(event.id);
-        if (validateMarkdownTemplate(event.content) !== null) {
+        if (isDisplayableRecipe(event)) {
           newEvents.push(event);
         }
       });


### PR DESCRIPTION
## Summary
- Add a 19-entry `HIDDEN_RECIPE_COORDINATES` blocklist (NIP-01 `kind:pubkey:d-tag`) for known PR/e2e throwaway recipes
- Filter them out of `/recipes` on cache hit, live subscription, and pagination so they no longer appear on the public feed
- Coordinates (not event ids) so later replaceable revisions stay hidden too

## Test plan
- [ ] Open https://zap.cooking/recipes after deploy — none of the listed naddrs' titles (ZC PR11 Test *, PR10 *, PR11 Ghost, PR10 Zero Parse *, e2e-*) appear in Recent
- [ ] Confirm real recipes still load and paginate
- [ ] Pull-to-refresh still works; hidden coords do not reappear from cache


Made with [Cursor](https://cursor.com)