### PR TITLE
feat(pantry): add "New Recipes by Week" chart to /pantry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.660",
+  "version": "4.2.661",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/routes/api/pantry/recipes-by-week/+server.ts
+++ b/src/routes/api/pantry/recipes-by-week/+server.ts
@@ -1,0 +1,40 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+
+/**
+ * Server-side proxy for the member relay's weekly new-recipe stats.
+ *
+ * The relay endpoint is auth-gated and expects an `Authorization: Bearer
+ * <secret>` header. The secret (RELAY_API_SECRET) must never reach the
+ * browser, so this route holds it server-side and passes the relay's JSON
+ * straight through. Mirrors the pattern in src/routes/api/membership/+server.ts.
+ */
+export const GET: RequestHandler = async ({ platform }) => {
+  const apiSecret = platform?.env?.RELAY_API_SECRET || env.RELAY_API_SECRET;
+
+  if (!apiSecret) {
+    console.error(
+      '[api/pantry/recipes-by-week] RELAY_API_SECRET not configured — refusing to fetch stats'
+    );
+    return json({ error: 'recipe stats unavailable' }, { status: 503 });
+  }
+
+  try {
+    const res = await fetch('https://pantry.zap.cooking/api/stats/recipes-by-week', {
+      headers: {
+        Authorization: `Bearer ${apiSecret}`
+      }
+    });
+
+    if (!res.ok) {
+      console.error('[api/pantry/recipes-by-week] relay returned', res.status);
+      return json({ error: 'recipe stats unavailable' }, { status: 502 });
+    }
+
+    const data = await res.json();
+    return json(data);
+  } catch (error) {
+    console.error('[api/pantry/recipes-by-week] fetch failed', error);
+    return json({ error: 'recipe stats unavailable' }, { status: 502 });
+  }
+};

--- a/src/routes/pantry/+page.svelte
+++ b/src/routes/pantry/+page.svelte
@@ -9,6 +9,43 @@
 
   const PANTRY_RELAY = 'wss://pantry.zap.cooking';
 
+  // Weekly new-recipe stats (fetched via the server-side proxy so the relay
+  // secret never reaches the browser).
+  interface RecipeWeek {
+    week_start: string;
+    count: number;
+  }
+  let recipeWeeks: RecipeWeek[] = [];
+  let recipeWeeksMax = 0;
+  let recipeWeeksLoading = false;
+  let recipeWeeksError = false;
+  let recipeWeeksLoaded = false;
+
+  async function loadRecipesByWeek() {
+    if (recipeWeeksLoaded || recipeWeeksLoading) return;
+
+    recipeWeeksLoading = true;
+    recipeWeeksError = false;
+    try {
+      const res = await fetch('/api/pantry/recipes-by-week');
+      if (!res.ok) throw new Error(`stats request failed: ${res.status}`);
+      const data = await res.json();
+      recipeWeeks = Array.isArray(data?.weeks) ? data.weeks : [];
+      recipeWeeksMax = recipeWeeks.reduce((m, w) => Math.max(m, w.count), 0);
+      recipeWeeksLoaded = true;
+    } catch (err) {
+      console.error('Failed to load recipes-by-week:', err);
+      recipeWeeksError = true;
+    } finally {
+      recipeWeeksLoading = false;
+    }
+  }
+
+  // Load the chart once membership is confirmed.
+  $: if (hasActiveMembership) {
+    loadRecipesByWeek();
+  }
+
   // Check membership status
   async function checkMembership() {
     if (!$userPublickey || checkingMembership) return;
@@ -160,6 +197,43 @@
           </ul>
         </div>
       </div>
+    </section>
+
+    <!-- New Recipes by Week Section -->
+    <section class="rounded-xl shadow-sm p-5 md:p-6 transition-all duration-300" style="border: 1px solid var(--color-input-border); background-color: var(--color-bg-secondary)">
+      <h2 class="text-2xl font-bold mb-4 flex items-center gap-2" style="color: var(--color-text-primary)">
+        <span>📈</span>
+        <span>New Recipes by Week</span>
+      </h2>
+
+      {#if recipeWeeksLoading}
+        <p class="text-sm" style="color: var(--color-text-secondary)">Loading…</p>
+      {:else if recipeWeeksError}
+        <p class="text-sm" style="color: var(--color-text-secondary)">
+          Recipe stats are unavailable right now. Please check back later.
+        </p>
+      {:else if !recipeWeeks.length || recipeWeeksMax === 0}
+        <p class="text-sm" style="color: var(--color-text-secondary)">
+          No new recipes recorded yet.
+        </p>
+      {:else}
+        <div class="flex items-end gap-1 h-40">
+          {#each recipeWeeks as week (week.week_start)}
+            <div class="flex flex-1 flex-col items-center justify-end h-full">
+              <div class="text-[10px] mb-1" style="color: var(--color-text-secondary)">{week.count}</div>
+              <div
+                class="w-full rounded-t transition-all duration-300"
+                style="height: {recipeWeeksMax ? Math.max(2, (week.count / recipeWeeksMax) * 100) : 2}%; background-color: {week.count === 0 ? 'var(--color-input-border)' : 'var(--color-primary)'};"
+                title="{week.week_start}: {week.count} recipes"
+              ></div>
+              <div class="text-[9px] mt-1" style="color: var(--color-text-secondary)">{week.week_start.slice(5)}</div>
+            </div>
+          {/each}
+        </div>
+        <p class="text-xs mt-4" style="color: var(--color-text-secondary)">
+          Recipes added to the Pantry each week. The July spike reflects a one-time import of existing recipes.
+        </p>
+      {/if}
     </section>
 
     <!-- Browse Content Section -->


### PR DESCRIPTION
## Summary
Adds a members-only **New Recipes by Week** card to the `/pantry` page, backed by a server-side proxy so the relay API secret never reaches the browser. Single-concern change.

## Changes
- **New proxy route** `src/routes/api/pantry/recipes-by-week/+server.ts` (GET): fetches the auth-gated relay endpoint `https://pantry.zap.cooking/api/stats/recipes-by-week` with the `Authorization: Bearer <RELAY_API_SECRET>` header (same env var + read pattern as `src/routes/api/membership/+server.ts`), and passes the JSON straight through. On failure returns a clean `{ error }` with `502`/`503` — no secret or internal detail leaked.
- **Pantry page** `src/routes/pantry/+page.svelte`: fetches the local proxy once membership is confirmed and renders a lightweight pure-CSS bar chart (one bar per week, height proportional to count, count above, `MM-DD` label below, `title` tooltip — no chart library). Handles loading, error, and empty/all-zero states. Card matches the sibling cards' styling.
- Caption notes the July spike reflects a one-time recipe import.

## Secret handling
The `RELAY_API_SECRET` is read server-side only (`platform?.env?.RELAY_API_SECRET || env.RELAY_API_SECRET`); the browser only ever calls the local `/api/pantry/recipes-by-week` proxy.

## Verification
- `npm run check` (svelte-check / typecheck): **0 errors**, no warnings from the new files.
- Did **not** run the full `vite build` or a live browser session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)