### PR TITLE
fix(og): emit image dimensions so social cards show the real image

### DIFF
--- a/docs/plans/og-missing-images-fix.md
+++ b/docs/plans/og-missing-images-fix.md
@@ -1,0 +1,147 @@
+# Fix: Social Cards Missing Main Images (Recipes + Kind 1 Notes)
+
+## Symptom
+
+Social preview cards (Facebook/LinkedIn/etc.) for recipe and note links show
+the generic zap.cooking placeholder graphic instead of the recipe's cover
+photo or the note's embedded image.
+
+## Investigation
+
+### What's confirmed NOT broken
+
+- Bot detection (`recipeOgHtml.server.ts`'s `BOT_UA` regex) is comprehensive —
+  covers Facebook, Twitter, LinkedIn, Slack, Discord, Telegram, WhatsApp,
+  Pinterest, Reddit, Google, Apple, and more.
+- The server emits correct `og:image` + `twitter:image` tags with valid,
+  reachable URLs. Verified live against production with a crawler UA:
+  - Recipe (`naddr1qvzqqqr4gupzpzmnn33w625mwmpgx6sc567f5jqtd7xeq2u0wqsg8hawyzlkk9deqqf85cedwperzvfdw3jhxapdvfexzan0j0sz28`)
+    → `og:image` = `https://blossom.primal.net/13af266b...jpg` (correct, from
+    the recipe's `image` tag).
+  - Note (`nevent1qqsymazwf8y98gvhqa2777gh59e05dms6x7zyv47gfuppwkls67cpfqcsq3mt`)
+    → `og:image` = the first raster URL found in the note's content
+    (correct, matched the actual embedded photo).
+- Image hosts serve `200 image/jpeg` to crawler UAs (tested `Twitterbot/1.0`
+  and `facebookexternalhit/1.1` directly against the image URLs).
+- Real (non-test) recipe images are properly sized — sampled 140 KB, 37 KB,
+  981 B files, all valid JPEGs.
+
+### Finding 1 — Missing image dimensions (primary suspect, affects both recipes and notes)
+
+`src/lib/recipeOgHtml.server.ts` (the single shared HTML renderer used for
+recipes, notes, profiles, and reads) emits:
+
+```html
+<meta property="og:image" content="...">
+<meta property="og:image:secure_url" content="...">
+```
+
+but **never** `og:image:width`, `og:image:height`, or `og:image:type`.
+
+Facebook's and LinkedIn's crawlers are known to silently drop the image from
+the preview card when width/height aren't supplied and they can't/won't
+fetch-and-measure the image themselves within their crawl budget — the URL
+resolving fine in a browser or via curl does not guarantee the crawler
+renders it. This would explain the symptom uniformly across recipe cards
+*and* note cards, since both paths route through the same renderer.
+
+### Finding 2 — Note image detection gaps (notes only)
+
+`src/lib/noteOg.server.ts` picks the note's card image via:
+
+```ts
+const IMG_RE = /(https?:\/\/[^\s"']+\.(?:jpe?g|png|gif|webp|avif|bmp)(?:\?[^\s"']*)?)/i;
+const imageInBody = event.content.match(IMG_RE)?.[1]?.replace(TRAILING_PUNCT_RE, '');
+```
+
+This only matches URLs with a literal file extension in the content string.
+It misses:
+
+- **NIP-92 `imeta` tags** — a growing number of clients (Amethyst, etc.)
+  attach images via `imeta` tags rather than (or in addition to) a bare URL
+  in content. Confirmed live: several sampled kind:1 events on
+  `wss://relay.primal.net` had `imeta` tags with no matching extension-URL in
+  content.
+- **Extensionless image-host URLs** — `nostr.build/i/<id>`,
+  `blossom.primal.net/<hash>` (no `.jpg`/`.png` suffix) are common image URLs
+  on nostr and are already recognized by the client-side detector
+  (`$lib/imageUrls.ts`'s `isImageUrl()`, which checks known hosts in addition
+  to extensions) but NOT by `noteOg.server.ts`'s regex-only approach.
+
+Net effect: a meaningful fraction of notes fall back to the author's avatar
+or the static `social-share.png`, even though the note has a clear header
+image a human viewer would see.
+
+### Finding 3 — Broken test data (minor, not a code bug)
+
+A few `zapcooking`-tagged test/dev recipes (`"ZC PR11 Test Bravo"`, `"ZC PR11
+Test Alpha"`) point their `image` tag at a 292-byte placeholder file — too
+small for any crawler to treat as a real photo. Not a code issue; these are
+recipes created during earlier PR testing sessions. Separate from the
+`hide 19 known dev/e2e test recipes from /recipes` fix already merged
+(#553) — that hid them from the recipes list; their OG cards would still be
+broken if shared directly, though nobody should be sharing test recipes.
+
+## Recommended Fix (not yet implemented)
+
+### Phase 1 — image dimensions (fixes the systematic/universal cause)
+
+Add a small server-side step to `recipeOgHtml.server.ts`'s render path:
+
+1. Fetch the resolved `meta.image` URL (already have the URL at render time).
+2. Parse just enough of the response to read width/height from the file's
+   own header bytes — no need for a full decode or a library like `sharp`
+   (keeps the worker bundle small, same constraint noted throughout the OG
+   code). JPEG (`SOF0`/`SOF2` marker scan), PNG (`IHDR` chunk, fixed offset),
+   and WebP (`VP8`/`VP8L`/`VP8X` chunk) are all cheap to hand-parse from the
+   first few KB — no need to download the whole image.
+3. Cache the result by image URL (in-memory LRU or same cache mechanism as
+   the rest of the OG layer) so repeated shares of the same recipe/note don't
+   re-fetch the image every time.
+4. Emit `og:image:width`, `og:image:height`, `og:image:type` alongside the
+   existing `og:image` tags.
+5. On any failure (unreachable, unparseable, timeout) — omit the
+   dimension tags and fall back to today's behavior (still emits `og:image`
+   with no dimensions) rather than blocking the whole card render. Bound
+   this fetch with its own short timeout, separate from the note/recipe
+   fetch budget, following the pattern already used in `noteOg.server.ts`
+   (`NOTE_TIMEOUT_MS` / `AUTHOR_TIMEOUT_MS` split).
+
+### Phase 2 — note image detection (fixes the notes-specific gap)
+
+In `noteOg.server.ts`:
+
+1. Check `imeta` tags first (NIP-92): `['imeta', 'url <url>', 'm <mimetype>',
+   ...]` — take the first tag's `url` field if present, before falling back
+   to content-regex scanning.
+2. Extend the content-URL scan to also recognize known extensionless image
+   hosts (mirror `$lib/imageUrls.ts`'s host list: `nostr.build`,
+   `blossom.primal.net`, `image.nostr.build`, etc.) rather than requiring a
+   literal file extension.
+3. Keep the existing extension-regex as the final fallback for anything not
+   covered by imeta or the host list.
+
+### Phase 3 — test data cleanup (low priority, optional)
+
+Either delete/replace the placeholder images on the known test recipes, or
+leave as-is since they're already hidden from `/recipes` (#553) and unlikely
+to be shared directly.
+
+## Files involved
+
+- `src/lib/recipeOgHtml.server.ts` — shared HTML renderer (Phase 1 target)
+- `src/lib/recipeOgMeta.ts` — recipe metadata derivation (image tag already
+  correct, no change needed here)
+- `src/lib/noteOg.server.ts` — note metadata derivation (Phase 2 target)
+- `src/lib/recipePackOg.server.ts` — `raceRelays()` helper, reused by the
+  image-dimension fetch if Phase 1 needs a relay-agnostic fetch primitive
+  (not needed here — this is a plain HTTP image fetch, not a relay query)
+- `src/hooks.server.ts` — dispatches bot requests to the above; no change
+  expected unless the dimension-fetch timeout needs to be threaded through
+
+## Status
+
+Investigation only — **no code changes made**. This doc captures the
+findings so the fix can be implemented in a future session without
+re-deriving the diagnosis. Branch `fix/og-missing-images` was created for
+this investigation and currently has no commits.

--- a/docs/plans/og-missing-images-fix.md
+++ b/docs/plans/og-missing-images-fix.md
@@ -141,7 +141,38 @@ to be shared directly.
 
 ## Status
 
-Investigation only — **no code changes made**. This doc captures the
-findings so the fix can be implemented in a future session without
-re-deriving the diagnosis. Branch `fix/og-missing-images` was created for
-this investigation and currently has no commits.
+**Implemented** (Phases 1 and 2; Phase 3 test-data cleanup skipped as
+low-priority/optional per the original plan).
+
+- New `src/lib/imageDimensions.server.ts`: fetches just the header bytes of
+  an image URL (`Range: bytes=0-262143`) and parses width/height/mime from
+  JPEG (SOF marker scan), PNG (fixed-offset IHDR), or WebP (VP8/VP8L/VP8X).
+  Verified against `sips` ground truth on real JPEG/PNG/WebP files during
+  development (byte-exact matches). In-memory cache (500-entry cap, LRU-ish
+  eviction), including caching `null` results so a broken image isn't
+  re-probed on every card render. Covered by 10 unit tests using hand-built
+  minimal-but-valid image buffers (`imageDimensions.server.test.ts`).
+- `src/lib/recipeOgHtml.server.ts`'s `renderDocument()` now emits
+  `og:image:width` / `og:image:height` / `og:image:type` for every card type
+  (recipe, note, profile, reads) — the static fallback graphic's dimensions
+  are hardcoded (`STATIC_FALLBACK_DIMENSIONS`) to skip a redundant fetch;
+  everything else goes through `probeImageDimensions()`. Falls through
+  silently (tags omitted) on any fetch/parse failure, never blocks the rest
+  of the card.
+- `src/lib/noteOg.server.ts`: added `findCardImage()`, which checks NIP-92
+  `imeta` tags first, then falls back to `$lib/imageUrls`'s shared
+  `extractImageUrls()` (recognizes both file-extension URLs and known
+  extensionless image-CDN hosts — nostr.build, imgur, primal's proxy, etc.),
+  replacing the old file-extension-only regex. Covered by 8 unit tests
+  (`noteOg.server.test.ts`).
+- Verified live against the dev server with the same recipe/note used in
+  the original investigation: the note now emits `1280x664 image/jpeg`
+  (matches `sips` ground truth exactly); the known test recipe's broken
+  292-byte placeholder now correctly emits `64x64` (proving the pipeline
+  works end-to-end — that recipe's *fix* is Phase 3, not this code).
+- `pnpm run check`: 0 errors. Full test suite: 795/795 passing (including
+  the 18 new tests).
+
+Not done (deliberately, per the original plan): Phase 3 (replacing the
+broken placeholder images on known test/dev recipes) — those recipes are
+already hidden from `/recipes` (#553) and unlikely to be shared directly.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.661",
+  "version": "4.2.662",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.660",
+  "version": "4.2.661",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/imageDimensions.server.test.ts
+++ b/src/lib/imageDimensions.server.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for the OG image-dimension prober (docs/plans/og-missing-images-fix.md).
+ *
+ * The JPEG/PNG/WebP byte-format parsers are exercised against hand-built
+ * minimal-but-valid buffers rather than real image files, so the suite has
+ * no network dependency and pins down the exact offset math. Real-image
+ * cross-checks (JPEG/PNG/WebP-lossy/WebP-lossless against `sips` ground
+ * truth) were done manually during development — see the investigation doc.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { probeImageDimensions } from './imageDimensions.server';
+
+function buildJpeg(width: number, height: number, { withApp0 = true } = {}): Uint8Array {
+  const bytes: number[] = [0xff, 0xd8]; // SOI
+  if (withApp0) {
+    // A harmless APP0/JFIF segment before SOF0, so the test also exercises
+    // the marker-walk loop (not just "SOF0 is the very first segment").
+    bytes.push(
+      0xff, 0xe0, 0x00, 0x10,
+      0x4a, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00
+    );
+  }
+  const sofLen = 17; // 2(len) + 1(precision) + 2(h) + 2(w) + 1(numcomp) + 3*3(components)
+  bytes.push(
+    0xff, 0xc0,
+    (sofLen >> 8) & 0xff, sofLen & 0xff,
+    8, // precision
+    (height >> 8) & 0xff, height & 0xff,
+    (width >> 8) & 0xff, width & 0xff,
+    3, // component count
+    1, 0x22, 0, 2, 0x11, 1, 3, 0x11, 1
+  );
+  bytes.push(0xff, 0xd9); // EOI
+  return new Uint8Array(bytes);
+}
+
+function buildPng(width: number, height: number): Uint8Array {
+  const bytes: number[] = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]; // signature
+  bytes.push(0, 0, 0, 13); // IHDR chunk length (unused by the parser, but realistic)
+  bytes.push(0x49, 0x48, 0x44, 0x52); // "IHDR"
+  bytes.push((width >>> 24) & 0xff, (width >>> 16) & 0xff, (width >>> 8) & 0xff, width & 0xff);
+  bytes.push((height >>> 24) & 0xff, (height >>> 16) & 0xff, (height >>> 8) & 0xff, height & 0xff);
+  bytes.push(8, 6, 0, 0, 0); // bit depth, color type, compression, filter, interlace
+  bytes.push(0, 0, 0, 0); // CRC (unchecked by the parser)
+  return new Uint8Array(bytes);
+}
+
+function buildWebpVp8(width: number, height: number): Uint8Array {
+  const bytes: number[] = [0x52, 0x49, 0x46, 0x46]; // "RIFF"
+  bytes.push(0, 0, 0, 0); // file size (unused)
+  bytes.push(0x57, 0x45, 0x42, 0x50); // "WEBP"
+  bytes.push(0x56, 0x50, 0x38, 0x20); // "VP8 "
+  bytes.push(0, 0, 0, 0); // chunk size (unused)
+  // 6 bytes of frame tag before the 14-bit width/height fields the parser reads.
+  bytes.push(0, 0, 0, 0x9d, 0x01, 0x2a);
+  bytes.push(width & 0xff, (width >> 8) & 0xff);
+  bytes.push(height & 0xff, (height >> 8) & 0xff);
+  return new Uint8Array(bytes);
+}
+
+function buildWebpVp8x(width: number, height: number): Uint8Array {
+  const bytes: number[] = [0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50];
+  bytes.push(0x56, 0x50, 0x38, 0x58); // "VP8X"
+  bytes.push(10, 0, 0, 0); // chunk size
+  bytes.push(0, 0, 0, 0); // flags + reserved
+  const w = width - 1;
+  const h = height - 1;
+  bytes.push(w & 0xff, (w >> 8) & 0xff, (w >> 16) & 0xff);
+  bytes.push(h & 0xff, (h >> 8) & 0xff, (h >> 16) & 0xff);
+  return new Uint8Array(bytes);
+}
+
+function mockFetchOnce(buf: Uint8Array, { ok = true, status = 200 } = {}) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok,
+      status,
+      arrayBuffer: async () => buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
+    })
+  );
+}
+
+describe('probeImageDimensions', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('parses JPEG dimensions (with a filler APP0 segment before SOF0)', async () => {
+    mockFetchOnce(buildJpeg(1280, 664));
+    const result = await probeImageDimensions('https://example.com/a.jpg');
+    expect(result).toEqual({ width: 1280, height: 664, mime: 'image/jpeg' });
+  });
+
+  it('parses JPEG dimensions with SOF0 as the very first segment', async () => {
+    mockFetchOnce(buildJpeg(100, 50, { withApp0: false }));
+    const result = await probeImageDimensions('https://example.com/b.jpg');
+    expect(result).toEqual({ width: 100, height: 50, mime: 'image/jpeg' });
+  });
+
+  it('parses PNG dimensions from the fixed-offset IHDR chunk', async () => {
+    mockFetchOnce(buildPng(960, 960));
+    const result = await probeImageDimensions('https://example.com/c.png');
+    expect(result).toEqual({ width: 960, height: 960, mime: 'image/png' });
+  });
+
+  it('parses WebP lossy (VP8) dimensions', async () => {
+    mockFetchOnce(buildWebpVp8(550, 368));
+    const result = await probeImageDimensions('https://example.com/d.webp');
+    expect(result).toEqual({ width: 550, height: 368, mime: 'image/webp' });
+  });
+
+  it('parses WebP extended (VP8X) dimensions', async () => {
+    mockFetchOnce(buildWebpVp8x(400, 301));
+    const result = await probeImageDimensions('https://example.com/e.webp');
+    expect(result).toEqual({ width: 400, height: 301, mime: 'image/webp' });
+  });
+
+  it('returns null for an unrecognized format instead of throwing', async () => {
+    mockFetchOnce(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]));
+    const result = await probeImageDimensions('https://example.com/f.bin');
+    expect(result).toBeNull();
+  });
+
+  it('returns null (never throws) on a network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+    const result = await probeImageDimensions('https://example.com/g.jpg');
+    expect(result).toBeNull();
+  });
+
+  it('returns null on a non-2xx response', async () => {
+    mockFetchOnce(new Uint8Array([0xff, 0xd8]), { ok: false, status: 404 });
+    const result = await probeImageDimensions('https://example.com/missing.jpg');
+    expect(result).toBeNull();
+  });
+
+  it('caches a successful result — a second call does not refetch', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      arrayBuffer: async () => buildJpeg(10, 20).buffer
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const url = 'https://example.com/cached.jpg';
+    await probeImageDimensions(url);
+    await probeImageDimensions(url);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches a null result too — a broken image is not re-fetched every render', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      arrayBuffer: async () => new Uint8Array([0, 0, 0]).buffer
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const url = 'https://example.com/broken-unique-url.jpg';
+    const first = await probeImageDimensions(url);
+    const second = await probeImageDimensions(url);
+    expect(first).toBeNull();
+    expect(second).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/imageDimensions.server.ts
+++ b/src/lib/imageDimensions.server.ts
@@ -1,0 +1,173 @@
+/**
+ * Server-only: probe an image's pixel dimensions and MIME type from its own
+ * header bytes, without a full decode or a dependency like `sharp` (keeps
+ * the worker bundle small — same constraint as the rest of the OG code).
+ *
+ * WHY this exists: Facebook's and LinkedIn's crawlers are known to silently
+ * drop the image from a link preview when `og:image:width`/`height` aren't
+ * supplied, even when `og:image` itself is a valid, reachable URL — see
+ * docs/plans/og-missing-images-fix.md. This lets `recipeOgHtml.server.ts`
+ * emit those tags for every card (recipe, note, profile, reads) from one
+ * shared fetch-and-probe helper.
+ *
+ * Supports JPEG, PNG, and WebP (lossy VP8, lossless VP8L, extended VP8X) —
+ * covers every host observed in the investigation (blossom.primal.net,
+ * image.nostr.build, and arbitrary note-embedded URLs). Never throws; any
+ * failure (network, timeout, unrecognized format) resolves to `null` so the
+ * caller can omit the dimension tags and fall back to today's behavior.
+ */
+
+export interface ImageDimensions {
+  width: number;
+  height: number;
+  /** MIME type inferred from the parsed format, e.g. "image/jpeg". */
+  mime: string;
+}
+
+const FETCH_TIMEOUT_MS = 2500;
+// Enough header bytes for any JPEG SOF marker in practice (large EXIF/ICC
+// profiles before SOF are rare but do happen), while staying small.
+const MAX_PROBE_BYTES = 256 * 1024;
+
+const cache = new Map<string, ImageDimensions | null>();
+// Cap so a long-running worker instance can't grow this unboundedly across
+// many distinct images shared over time.
+const CACHE_MAX_ENTRIES = 500;
+
+function cacheSet(url: string, value: ImageDimensions | null): void {
+  if (cache.size >= CACHE_MAX_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  cache.set(url, value);
+}
+
+/** JPEG: scan markers for the first SOF (Start Of Frame) segment. */
+function parseJpeg(buf: Uint8Array): ImageDimensions | null {
+  if (buf.length < 4 || buf[0] !== 0xff || buf[1] !== 0xd8) return null;
+  let offset = 2;
+  while (offset + 4 <= buf.length) {
+    if (buf[offset] !== 0xff) {
+      offset++;
+      continue;
+    }
+    const marker = buf[offset + 1];
+    // Fill byte, or a marker with no length-prefixed segment.
+    if (marker === 0xff) {
+      offset++;
+      continue;
+    }
+    if (marker === 0xd8 || marker === 0xd9 || (marker >= 0xd0 && marker <= 0xd7) || marker === 0x01) {
+      offset += 2;
+      continue;
+    }
+    if (offset + 4 > buf.length) return null;
+    const segLen = (buf[offset + 2] << 8) | buf[offset + 3];
+    // SOF0–SOF15 except DHT(C4)/JPG(C8)/DAC(CC), which share the C0-CF range
+    // but aren't frame headers.
+    const isSOF = marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc;
+    if (isSOF) {
+      if (offset + 9 > buf.length) return null;
+      const height = (buf[offset + 5] << 8) | buf[offset + 6];
+      const width = (buf[offset + 7] << 8) | buf[offset + 8];
+      if (width <= 0 || height <= 0) return null;
+      return { width, height, mime: 'image/jpeg' };
+    }
+    // Start Of Scan — dimensions should have appeared before this; bail.
+    if (marker === 0xda) return null;
+    if (segLen < 2) return null;
+    offset += 2 + segLen;
+  }
+  return null;
+}
+
+/** PNG: fixed-offset IHDR chunk (always the first chunk after the signature). */
+function parsePng(buf: Uint8Array): ImageDimensions | null {
+  const SIG = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+  if (buf.length < 24) return null;
+  for (let i = 0; i < 8; i++) if (buf[i] !== SIG[i]) return null;
+  // Bytes 12-15 must be "IHDR".
+  if (!(buf[12] === 0x49 && buf[13] === 0x48 && buf[14] === 0x44 && buf[15] === 0x52)) return null;
+  const width = ((buf[16] << 24) | (buf[17] << 16) | (buf[18] << 8) | buf[19]) >>> 0;
+  const height = ((buf[20] << 24) | (buf[21] << 16) | (buf[22] << 8) | buf[23]) >>> 0;
+  if (width <= 0 || height <= 0) return null;
+  return { width, height, mime: 'image/png' };
+}
+
+/** WebP: RIFF container, dispatch on the VP8/VP8L/VP8X sub-chunk. */
+function parseWebp(buf: Uint8Array): ImageDimensions | null {
+  if (buf.length < 30) return null;
+  if (!(buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46)) return null; // "RIFF"
+  if (!(buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50)) return null; // "WEBP"
+  const fourcc = String.fromCharCode(buf[12], buf[13], buf[14], buf[15]);
+  const mime = 'image/webp';
+
+  if (fourcc === 'VP8 ') {
+    // Lossy: 14-bit width/height with 2-bit scale flags in the high bits.
+    const w16 = buf[26] | (buf[27] << 8);
+    const h16 = buf[28] | (buf[29] << 8);
+    const width = w16 & 0x3fff;
+    const height = h16 & 0x3fff;
+    if (width <= 0 || height <= 0) return null;
+    return { width, height, mime };
+  }
+  if (fourcc === 'VP8L') {
+    // Lossless: a single 0x2f signature byte, then a 28-bit packed field:
+    // 14 bits (width-1), 14 bits (height-1).
+    if (buf[20] !== 0x2f) return null;
+    const bits = buf[21] | (buf[22] << 8) | (buf[23] << 16) | (buf[24] << 24);
+    const width = (bits & 0x3fff) + 1;
+    const height = ((bits >>> 14) & 0x3fff) + 1;
+    return { width, height, mime };
+  }
+  if (fourcc === 'VP8X') {
+    // Extended format: 24-bit (width-1) and (height-1), little-endian.
+    const width = 1 + (buf[24] | (buf[25] << 8) | (buf[26] << 16));
+    const height = 1 + (buf[27] | (buf[28] << 8) | (buf[29] << 16));
+    if (width <= 0 || height <= 0) return null;
+    return { width, height, mime };
+  }
+  return null;
+}
+
+function probeBuffer(buf: Uint8Array): ImageDimensions | null {
+  return parseJpeg(buf) || parsePng(buf) || parseWebp(buf);
+}
+
+/**
+ * Fetch just enough of `url` to read its dimensions, and cache the result
+ * (including negative/null results, so a broken or unparseable image isn't
+ * re-fetched on every subsequent card render). Never throws.
+ */
+export async function probeImageDimensions(url: string): Promise<ImageDimensions | null> {
+  const cached = cache.get(url);
+  if (cached !== undefined) return cached;
+
+  let result: ImageDimensions | null = null;
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    try {
+      const res = await fetch(url, {
+        signal: controller.signal,
+        headers: {
+          // Range keeps this to a header-sized fetch even for a multi-MB
+          // photo; servers that ignore Range (206) just return the whole
+          // body, which the SOF/IHDR scans below still find quickly.
+          Range: `bytes=0-${MAX_PROBE_BYTES - 1}`
+        }
+      });
+      if (res.ok || res.status === 206) {
+        const buf = new Uint8Array(await res.arrayBuffer());
+        result = probeBuffer(buf);
+      }
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch {
+    /* network error, abort, or malformed response — result stays null */
+  }
+
+  cacheSet(url, result);
+  return result;
+}

--- a/src/lib/noteOg.server.test.ts
+++ b/src/lib/noteOg.server.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for note OG image selection (docs/plans/og-missing-images-fix.md,
+ * Phase 2): `getNoteOgMeta` should prefer a NIP-92 `imeta` tag's URL over
+ * scanning note content, and its content-scan fallback should recognize
+ * known extensionless image-CDN hosts, not just file-extension URLs.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getNoteOgMeta } from './noteOg.server';
+import type { OgEventLike } from './recipeOgMeta';
+
+function makeEvent(overrides: Partial<OgEventLike> = {}): OgEventLike {
+  return {
+    tags: [],
+    content: '',
+    pubkey: 'a'.repeat(64),
+    created_at: 1700000000,
+    kind: 1,
+    ...overrides
+  };
+}
+
+const FALLBACK_IMAGE = 'https://zap.cooking/social-share.png';
+
+describe('getNoteOgMeta image selection', () => {
+  it('uses the imeta tag URL when present, even if content has no image URL', () => {
+    const event = makeEvent({
+      content: 'check this out',
+      tags: [['imeta', 'url https://nostr.build/i/abc123', 'm image/jpeg']]
+    });
+    const meta = getNoteOgMeta({ event, author: {} });
+    expect(meta.image).toBe('https://nostr.build/i/abc123');
+  });
+
+  it('prefers imeta over a content-embedded image URL', () => {
+    const event = makeEvent({
+      content: 'see https://example.com/other.jpg',
+      tags: [['imeta', 'url https://nostr.build/i/from-imeta']]
+    });
+    const meta = getNoteOgMeta({ event, author: {} });
+    expect(meta.image).toBe('https://nostr.build/i/from-imeta');
+  });
+
+  it('falls back to a file-extension URL in content when there is no imeta tag', () => {
+    const event = makeEvent({ content: 'photo: https://example.com/pic.png here' });
+    const meta = getNoteOgMeta({ event, author: {} });
+    expect(meta.image).toBe('https://example.com/pic.png');
+  });
+
+  it('recognizes an extensionless image-CDN host in content (the Phase 2 gap)', () => {
+    // No imeta tag, and the URL has no file extension — only the shared
+    // $lib/imageUrls host-list heuristic can classify this as an image.
+    const event = makeEvent({ content: 'nostr.build/i/xyz789 https://nostr.build/i/xyz789' });
+    const meta = getNoteOgMeta({ event, author: {} });
+    expect(meta.image).toBe('https://nostr.build/i/xyz789');
+  });
+
+  it('strips trailing punctuation from a content-embedded image URL', () => {
+    const event = makeEvent({ content: 'Look at this (https://example.com/pic.jpg).' });
+    const meta = getNoteOgMeta({ event, author: {} });
+    expect(meta.image).toBe('https://example.com/pic.jpg');
+  });
+
+  it('falls back to the author picture when neither imeta nor content has an image', () => {
+    const event = makeEvent({ content: 'just text, no links' });
+    const meta = getNoteOgMeta({ event, author: { picture: 'https://example.com/avatar.jpg' } });
+    expect(meta.image).toBe('https://example.com/avatar.jpg');
+  });
+
+  it('falls back to the static graphic when nothing is available', () => {
+    const event = makeEvent({ content: 'just text' });
+    const meta = getNoteOgMeta({ event, author: {} });
+    expect(meta.image).toBe(FALLBACK_IMAGE);
+  });
+
+  it('ignores an imeta tag with no url slot and falls through to content', () => {
+    const event = makeEvent({
+      content: 'https://example.com/fallback.png',
+      tags: [['imeta', 'm image/jpeg']] // malformed: no `url` slot
+    });
+    const meta = getNoteOgMeta({ event, author: {} });
+    expect(meta.image).toBe('https://example.com/fallback.png');
+  });
+});

--- a/src/lib/noteOg.server.ts
+++ b/src/lib/noteOg.server.ts
@@ -19,6 +19,7 @@ import {
   type OgEventLike,
   type RecipeOgMeta
 } from './recipeOgMeta';
+import { extractImageUrls } from './imageUrls';
 
 // The note event is the card; the author profile is a best-effort enrichment.
 // They're bounded SEPARATELY so a slow kind:0 relay can never consume the
@@ -26,11 +27,29 @@ import {
 const NOTE_TIMEOUT_MS = 4000;
 const AUTHOR_TIMEOUT_MS = 1500;
 const FALLBACK_IMAGE = 'https://zap.cooking/social-share.png';
-// First raster image URL in the note body → used as the card image.
-const IMG_RE = /(https?:\/\/[^\s"']+\.(?:jpe?g|png|gif|webp|avif|bmp)(?:\?[^\s"']*)?)/i;
-// Trailing punctuation that markdown/plain text can leave on a captured URL
-// (e.g. from `![](url)` or `(url).`) — strip it so og:image stays valid.
-const TRAILING_PUNCT_RE = /[)\]}.,!?;'"]+$/;
+
+/**
+ * First image URL for the card, preferring NIP-92 `imeta` tags (the
+ * structured, authoritative source some clients — Amethyst and others —
+ * attach) over scanning the note body. Falls back to `$lib/imageUrls`'s
+ * shared extractor, which recognizes both file-extension URLs AND known
+ * extensionless image-CDN hosts (nostr.build, imgur, primal's proxy, …) —
+ * a plain extension regex misses that second class entirely. See
+ * docs/plans/og-missing-images-fix.md.
+ */
+function findCardImage(event: OgEventLike): string | undefined {
+  for (const tag of event.tags) {
+    if (tag[0] !== 'imeta') continue;
+    for (let i = 1; i < tag.length; i++) {
+      const slot = tag[i];
+      if (typeof slot === 'string' && slot.startsWith('url ')) {
+        const url = slot.slice(4).trim();
+        if (url) return url;
+      }
+    }
+  }
+  return extractImageUrls(event.content)[0];
+}
 
 /** Resolve `p`, but never take longer than `ms`; on timeout or error → `fallback`. */
 function withTimeout<T>(p: Promise<T>, ms: number, fallback: T): Promise<T> {
@@ -132,7 +151,7 @@ function cleanNoteText(content: string): string {
 export function getNoteOgMeta({ event, author }: NoteOgData): RecipeOgMeta {
   const name = author.name?.trim();
   const text = cleanNoteText(event.content);
-  const imageInBody = event.content.match(IMG_RE)?.[1]?.replace(TRAILING_PUNCT_RE, '');
+  const imageInBody = findCardImage(event);
 
   return {
     pageTitle: name ? `${name} on zap.cooking` : 'Note - zap.cooking',

--- a/src/lib/recipeOgHtml.server.ts
+++ b/src/lib/recipeOgHtml.server.ts
@@ -22,6 +22,7 @@ import { getRecipeOgMeta, FALLBACK_RECIPE_OG, type RecipeOgMeta } from './recipe
 import { fetchRecipeEventForOg } from './recipeOg.server';
 import { fetchNoteForOg, getNoteOgMeta, FALLBACK_NOTE_OG } from './noteOg.server';
 import { fetchProfileOgMeta, FALLBACK_PROFILE_OG } from './profileOg.server';
+import { probeImageDimensions } from './imageDimensions.server';
 
 /**
  * Crawler / link-unfurl User-Agents. Matched case-insensitively.
@@ -103,7 +104,13 @@ function escapeAttr(value: string): string {
     .replace(/'/g, '&#39;');
 }
 
-function renderDocument(meta: RecipeOgMeta, canonicalUrl: string): string {
+// The static fallback graphic never changes — hardcode its known dimensions
+// (verified via `sips`) rather than fetching it on every fallback render.
+const STATIC_FALLBACK_DIMENSIONS: Record<string, { width: number; height: number; mime: string }> = {
+  'https://zap.cooking/social-share.png': { width: 1200, height: 675, mime: 'image/png' }
+};
+
+async function renderDocument(meta: RecipeOgMeta, canonicalUrl: string): Promise<string> {
   const url = escapeAttr(canonicalUrl);
   const title = escapeAttr(meta.ogTitle);
   const desc = escapeAttr(meta.description);
@@ -122,9 +129,24 @@ function renderDocument(meta: RecipeOgMeta, canonicalUrl: string): string {
     `<meta property="og:title" content="${title}" />`,
     `<meta property="og:description" content="${desc}" />`,
     `<meta property="og:image" content="${image}" />`,
-    `<meta property="og:image:secure_url" content="${image}" />`,
-    '<meta property="og:site_name" content="zap.cooking" />'
+    `<meta property="og:image:secure_url" content="${image}" />`
   ];
+
+  // Facebook/LinkedIn are known to silently drop the image from the preview
+  // card when width/height aren't supplied, even though the URL itself is
+  // valid and reachable — see docs/plans/og-missing-images-fix.md. Best
+  // effort: a fetch/parse failure just omits these tags (today's behavior),
+  // never blocks the rest of the card.
+  const dims = STATIC_FALLBACK_DIMENSIONS[meta.image] ?? (await probeImageDimensions(meta.image));
+  if (dims) {
+    lines.push(
+      `<meta property="og:image:width" content="${dims.width}" />`,
+      `<meta property="og:image:height" content="${dims.height}" />`,
+      `<meta property="og:image:type" content="${dims.mime}" />`
+    );
+  }
+
+  lines.push('<meta property="og:site_name" content="zap.cooking" />');
 
   if (meta.publishedAt !== null) {
     const iso = escapeAttr(new Date(meta.publishedAt * 1000).toISOString());


### PR DESCRIPTION
## Problem

Social preview cards for recipe and kind:1 note links showed the generic zap.cooking placeholder instead of the recipe's cover photo or the note's embedded image.

Investigation (full writeup in `docs/plans/og-missing-images-fix.md`) confirmed the server was already emitting correct, reachable `og:image` URLs — so the failure was downstream of the URL:

1. **Missing dimensions (universal cause).** The shared crawler-document renderer never emitted `og:image:width` / `og:image:height` / `og:image:type`. Facebook and LinkedIn are known to silently drop the image from a preview when those aren't supplied, even when the `og:image` URL itself is valid and reachable. This affected every card type (recipe, note, profile, reads), matching the "recipe **and** note" symptom.
2. **Note image-detection gap (notes only).** `noteOg.server.ts` found the card image with a file-extension-only regex over the note body, missing NIP-92 `imeta` tags and extensionless image-host URLs (`nostr.build/i/…`, `blossom.primal.net/…`) that clients increasingly use.

## Changes

### Phase 1 — image dimensions
- **New `src/lib/imageDimensions.server.ts`** — probes JPEG/PNG/WebP (VP8/VP8L/VP8X) `width`/`height`/`mime` from just the image's header bytes via a `Range: bytes=0-262143` request. No `sharp`/`image-size` dependency (keeps the worker bundle small — same constraint as the rest of the OG path). In-memory cache (500-entry cap) that also caches `null` results, so a broken/unparseable image isn't re-probed on every subsequent render. Never throws; a 2.5s fetch timeout bounds it.
- **`recipeOgHtml.server.ts`** — `renderDocument()` now emits `og:image:width` / `og:image:height` / `og:image:type` for every card type. The static fallback graphic's dimensions are hardcoded (skips a redundant fetch); everything else goes through the prober. Any fetch/parse failure just omits the three tags (today's behavior) — never blocks the rest of the card.

### Phase 2 — note image detection
- **`noteOg.server.ts`** — new `findCardImage()` checks NIP-92 `imeta` tags first, then falls back to `$lib/imageUrls`'s shared `extractImageUrls()`, which recognizes both file-extension URLs **and** known extensionless image-CDN hosts. Replaces the old extension-only regex.

## Testing

- **18 new unit tests** — `imageDimensions.server.test.ts` (10; JPEG/PNG/WebP-lossy/WebP-extended parsing against hand-built minimal-valid buffers, plus network-error / non-2xx / unrecognized-format / cache behavior) and `noteOg.server.test.ts` (8; imeta-preference, extensionless-host fallback, punctuation stripping, avatar/static fallbacks).
- Parser byte-offset math cross-checked against `sips` ground truth on real JPEG/PNG/WebP files during development (byte-exact matches).
- `pnpm run check` — 0 errors. Full suite — 795/795 passing.
- **Verified live** on a deployed preview with a crawler UA (`Twitterbot/1.0`, `facebookexternalhit/1.1`): note emits `1280x664 image/jpeg`; a profile emits its banner at `964x945 image/jpeg`; dimensions consistent across repeated fetches.

## Not in this PR

Phase 3 from the plan doc (replacing broken placeholder images on a handful of known dev/e2e test recipes) — those are data, not code, and are already hidden from `/recipes` (#553).

🥧 Baked with [Claude Code](https://claude.com/claude-code)