### PR TITLE
feat(recipes): green stock-ticker trend for new recipes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.662",
+  "version": "4.2.663",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/routes/recipes/+page.svelte
+++ b/src/routes/recipes/+page.svelte
@@ -48,15 +48,47 @@
   let recipeWeeksLoaded = false;
   let recipeWeeksError = false;
 
-  // Sum the two most-recent Monday-start UTC weeks → the pill number. A
-  // single-week window reads as empty early in the week (few recipes yet);
-  // a rolling 2-week window stays meaningful. slice(-2) safely handles a
-  // series shorter than 2 elements.
-  $: recentCount = recipeWeeks.slice(-2).reduce((sum, w) => sum + w.count, 0);
-  // Show only on a clean, non-empty series AND when the window actually has
-  // new recipes — a "0" pill isn't worth showing. Failing silent is correct
-  // for a nice-to-have signal.
-  $: showStatsPill =
+  // Hero number = new recipes over the last 3 weeks (rolling window). A
+  // shorter window reads as empty early in the week (few recipes yet); a
+  // 3-week window stays meaningful. slice(-3) safely handles a series
+  // shorter than 3 elements.
+  $: recentCount = recipeWeeks.slice(-3).reduce((sum, w) => sum + w.count, 0);
+
+  // Single brand-consistent green for the whole ticker (number, arrow,
+  // line, dot). The theme has no green token, so define one local constant.
+  const TREND_GREEN = '#16a34a';
+
+  // Sparkline geometry: a thin polyline over the 12-week series, y-scaled to
+  // the series max (Math.max guard vs. div-by-0), with a dot on the last
+  // point to anchor "now" and a faint gradient fill underneath.
+  const SPARK_W = 112;
+  const SPARK_H = 24;
+  const SPARK_PAD = 3;
+  $: sparkMax = Math.max(recipeWeeksMax, 1);
+  $: sparkX = (i: number) =>
+    recipeWeeks.length <= 1
+      ? SPARK_W / 2
+      : SPARK_PAD + (i / (recipeWeeks.length - 1)) * (SPARK_W - SPARK_PAD * 2);
+  $: sparkY = (count: number) =>
+    SPARK_PAD + (1 - count / sparkMax) * (SPARK_H - SPARK_PAD * 2);
+  $: sparkPoints = recipeWeeks
+    .map((w, i) => `${sparkX(i).toFixed(1)},${sparkY(w.count).toFixed(1)}`)
+    .join(' ');
+  // Close the polyline down to the baseline on both ends for the fill area.
+  $: sparkAreaPoints = recipeWeeks.length
+    ? `${sparkPoints} ${sparkX(recipeWeeks.length - 1).toFixed(1)},${SPARK_H} ${sparkX(0).toFixed(1)},${SPARK_H}`
+    : '';
+  $: sparkLastPoint = recipeWeeks.length
+    ? {
+        x: sparkX(recipeWeeks.length - 1).toFixed(1),
+        y: sparkY(recipeWeeks[recipeWeeks.length - 1].count).toFixed(1)
+      }
+    : null;
+
+  // Show only on a clean, non-empty series AND when this week actually has
+  // new recipes. Loading / error / empty / all-zero all fall through to
+  // hidden — failing silent is correct for a nice-to-have signal.
+  $: showTrend =
     recipeWeeksLoaded && !recipeWeeksError && recipeWeeks.length > 0 && recentCount > 0;
 
   async function loadRecipesByWeek() {
@@ -498,47 +530,48 @@
       </a>
     </div>
 
-    <!-- "New recipes" pill: glanceable 2-week stat + inline sparkline.
-         Hidden until the stats land (loading = render nothing) and hidden
-         on any error/empty/all-zero result. Never blocks the feed. -->
-    {#if showStatsPill}
-      <div class="flex">
-        <span
-          class="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium"
-          style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border); color: var(--color-text-primary)"
-          title="New recipes added to the Pantry in the last 2 weeks (bars are weekly, UTC)"
-        >
-          <span aria-hidden="true">🆕</span>
-          <span>{recentCount} new recipes</span>
-          <!-- Inline sparkline: one thin bar per week over the 12-week
-               series, height scaled to the series max. The last two bars
-               (the counted window) are highlighted. No axes/labels. -->
-          <svg
-            class="shrink-0"
-            width="90"
-            height="20"
-            viewBox="0 0 90 20"
-            preserveAspectRatio="none"
-            role="img"
-            aria-label="New recipes per week over the last {recipeWeeks.length} weeks"
-          >
-            {#each recipeWeeks as week, i (week.week_start)}
-              {@const barHeight = recipeWeeksMax
-                ? Math.max(1, (week.count / recipeWeeksMax) * 18)
-                : 1}
-              {@const inWindow = i >= recipeWeeks.length - 2}
-              <rect
-                x={i * 7.5 + 1}
-                y={20 - barHeight}
-                width="5.5"
-                height={barHeight}
-                rx="1"
-                fill={inWindow ? 'var(--color-primary)' : 'var(--color-text-secondary)'}
-                opacity={inWindow ? '1' : '0.55'}
-              />
-            {/each}
-          </svg>
+    <!-- Quiet stock-ticker-style "new this week" trend. No container/card:
+         a green hero number + up-arrow, a muted label, and a thin green
+         sparkline anchored with a dot on the latest week. Hidden while
+         loading and on any error/empty/all-zero result. Never blocks the
+         feed. -->
+    {#if showTrend}
+      <div
+        class="flex items-baseline gap-2.5 pt-1"
+        title="New recipes added to the Pantry over the last 3 weeks (line is weekly, UTC)"
+      >
+        <span class="text-2xl font-semibold leading-none" style="color: {TREND_GREEN}">
+          <span aria-hidden="true">↑</span>{recentCount}
         </span>
+        <span class="text-xs" style="color: var(--color-text-secondary)">new recently</span>
+        <svg
+          class="shrink-0 self-center"
+          width={SPARK_W}
+          height={SPARK_H}
+          viewBox="0 0 {SPARK_W} {SPARK_H}"
+          fill="none"
+          role="img"
+          aria-label="New recipes per week over the last {recipeWeeks.length} weeks"
+        >
+          <defs>
+            <linearGradient id="recipesTrendFill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color={TREND_GREEN} stop-opacity="0.16" />
+              <stop offset="100%" stop-color={TREND_GREEN} stop-opacity="0" />
+            </linearGradient>
+          </defs>
+          <polygon points={sparkAreaPoints} fill="url(#recipesTrendFill)" stroke="none" />
+          <polyline
+            points={sparkPoints}
+            fill="none"
+            stroke={TREND_GREEN}
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          {#if sparkLastPoint}
+            <circle cx={sparkLastPoint.x} cy={sparkLastPoint.y} r="2.5" fill={TREND_GREEN} />
+          {/if}
+        </svg>
       </div>
     {/if}
 


### PR DESCRIPTION
## What

Adds a quiet, **containerless stock-ticker-style trend** to the `/recipes` header — replacing the earlier orange pill/bar-cluster concept. Three baseline-aligned elements, left to right:

1. **Hero number** — green `↑ N`, large/bold. `N` = rolling **last-3-weeks** new-recipe count.
2. **Label** — `new recently`, small and muted (exact window in the tooltip).
3. **Trend line** — a thin green **polyline** (1.5px) over the 12-week series, ~112×24px, with a faint green gradient fill underneath and a filled dot on the latest week to anchor "now". Y-scaled to the series max with a `Math.max` guard.

Single brand green (`#16a34a`) throughout — no conditional red/down, no orange accent, no card/border/background.

## Data

Reuses the existing `/api/pantry/recipes-by-week` server-side proxy (12-week `{ weeks: [{week_start, count}] }`). **No relay, endpoint, or proxy changes.** Series is currently clean (fresh `created_at` bucketing, max ~8, no spike).

## Isolation & states

- Fetch is fire-and-forget in `onMount`, after the feed load — it can never block or fail the feed.
- **Loading:** renders nothing. **Error / empty / all-zero:** hidden entirely (fail-silent).

## Scope

Frontend-only, single-concern — one file: `src/routes/recipes/+page.svelte`. No changes to feed loading, pagination, filters, the proxy, or the relay.

## Verification

`npm run check` (typecheck) passes — 0 errors, no new warnings. Not verified in a live browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)