### PR TITLE
feat(schedule): D1 migration + encryption-at-rest module for scheduled posts (Phase 1, PR A)

### DIFF
--- a/migrations/scheduler/0001_create_scheduled_events.sql
+++ b/migrations/scheduler/0001_create_scheduled_events.sql
@@ -1,0 +1,28 @@
+-- Migration 0001 — scheduled_events table for the Scheduled Posts feature.
+--
+-- Database: zapcooking-scheduler (D1). Applied with:
+--   wrangler d1 migrations apply zapcooking-scheduler --remote
+-- The D1 bindings (`SCHEDULER_DB` in wrangler.jsonc and
+-- workers/cron/wrangler.toml, with migrations_dir pointed here) land in
+-- the follow-up API-routes PR; this file is checked in first so the
+-- schema is reviewable alongside the crypto/auth modules it serves.
+
+CREATE TABLE scheduled_events (
+  id            TEXT PRIMARY KEY,      -- the Nostr event id (64-char hex)
+  pubkey        TEXT NOT NULL,         -- author pubkey (hex), must match NIP-98 auth
+  kind          INTEGER NOT NULL,      -- allowlist: 1, 1068, 6969, 30023, 35000
+  publish_at    INTEGER NOT NULL,      -- unix seconds; MUST equal event.created_at
+  relay_mode    TEXT NOT NULL,         -- 'all' | 'pantry'
+  ciphertext    TEXT NOT NULL,         -- base64(AES-256-GCM(full signed event JSON))
+  iv            TEXT NOT NULL,         -- base64, 12 random bytes per row
+  status        TEXT NOT NULL DEFAULT 'pending',
+                -- 'pending' | 'publishing' | 'sent' | 'failed' | 'cancelled'
+  attempts      INTEGER NOT NULL DEFAULT 0,
+  last_error    TEXT,
+  created_at    INTEGER NOT NULL,      -- row creation (unix seconds)
+  updated_at    INTEGER NOT NULL,
+  sent_at       INTEGER
+);
+
+CREATE INDEX idx_sched_due    ON scheduled_events (status, publish_at);
+CREATE INDEX idx_sched_pubkey ON scheduled_events (pubkey, status);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.665",
+  "version": "4.2.666",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/nip98.server.test.ts
+++ b/src/lib/nip98.server.test.ts
@@ -188,6 +188,16 @@ describe('verifyNip98', () => {
     expect(result).toEqual({ ok: false, reason: 'payload-mismatch' });
   });
 
+  it('rejects missing payload tag when bodyBytes provided', async () => {
+    const body = JSON.stringify({ type: 'text', textData: 'hello' });
+    const bodyBytes = new TextEncoder().encode(body);
+    const event = await buildSignedAuthEvent({});
+    const request = makeRequest({ body, authorization: encodeAuthHeader(event) });
+
+    const result = await verifyNip98(request, { bodyBytes });
+    expect(result).toEqual({ ok: false, reason: 'missing-payload-tag' });
+  });
+
   it('rejects expectedPubkey mismatch when the param is provided', async () => {
     const otherSk = generateSecretKey();
     const body = '{}';

--- a/src/lib/scheduleCrypto.server.test.ts
+++ b/src/lib/scheduleCrypto.server.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { finalizeEvent, generateSecretKey } from 'nostr-tools';
+import {
+  importScheduleKey,
+  encryptScheduledEvent,
+  decryptScheduledEvent
+} from './scheduleCrypto.server';
+
+const HEX_KEY = 'a'.repeat(64);
+
+function signedEventJson(): string {
+  const event = finalizeEvent(
+    {
+      kind: 1,
+      created_at: Math.floor(Date.now() / 1000) + 3600,
+      tags: [],
+      content: 'scheduled test post'
+    },
+    generateSecretKey()
+  );
+  return JSON.stringify(event);
+}
+
+/** Flip one bit in the middle of a base64 payload's decoded bytes. */
+function tamper(base64: string): string {
+  const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+  bytes[Math.floor(bytes.length / 2)] ^= 0x01;
+  return btoa(String.fromCharCode(...bytes));
+}
+
+describe('scheduleCrypto', () => {
+  it('round-trips a signed event JSON string', async () => {
+    const key = await importScheduleKey(HEX_KEY);
+    const plaintext = signedEventJson();
+
+    const { ciphertext, iv } = await encryptScheduledEvent(key, plaintext);
+    const decrypted = await decryptScheduledEvent(key, ciphertext, iv);
+
+    expect(decrypted).toBe(plaintext);
+    expect(JSON.parse(decrypted).content).toBe('scheduled test post');
+  });
+
+  it('generates a fresh IV per encryption (same plaintext, distinct outputs)', async () => {
+    const key = await importScheduleKey(HEX_KEY);
+    const plaintext = signedEventJson();
+
+    const a = await encryptScheduledEvent(key, plaintext);
+    const b = await encryptScheduledEvent(key, plaintext);
+
+    expect(a.iv).not.toBe(b.iv);
+    expect(a.ciphertext).not.toBe(b.ciphertext);
+    expect(atob(a.iv)).toHaveLength(12);
+  });
+
+  it('fails GCM auth on tampered ciphertext', async () => {
+    const key = await importScheduleKey(HEX_KEY);
+    const { ciphertext, iv } = await encryptScheduledEvent(key, signedEventJson());
+
+    await expect(decryptScheduledEvent(key, tamper(ciphertext), iv)).rejects.toThrow();
+  });
+
+  it('fails GCM auth on tampered IV', async () => {
+    const key = await importScheduleKey(HEX_KEY);
+    const { ciphertext, iv } = await encryptScheduledEvent(key, signedEventJson());
+
+    await expect(decryptScheduledEvent(key, ciphertext, tamper(iv))).rejects.toThrow();
+  });
+
+  it('fails decryption under a different key', async () => {
+    const keyA = await importScheduleKey(HEX_KEY);
+    const keyB = await importScheduleKey('b'.repeat(64));
+    const { ciphertext, iv } = await encryptScheduledEvent(keyA, signedEventJson());
+
+    await expect(decryptScheduledEvent(keyB, ciphertext, iv)).rejects.toThrow();
+  });
+
+  it('rejects malformed keys (wrong length, non-hex)', async () => {
+    await expect(importScheduleKey('a'.repeat(63))).rejects.toThrow(/64 hex/);
+    await expect(importScheduleKey('a'.repeat(65))).rejects.toThrow(/64 hex/);
+    await expect(importScheduleKey('g'.repeat(64))).rejects.toThrow(/64 hex/);
+    await expect(importScheduleKey('')).rejects.toThrow(/64 hex/);
+  });
+});

--- a/src/lib/scheduleCrypto.server.ts
+++ b/src/lib/scheduleCrypto.server.ts
@@ -1,0 +1,92 @@
+/**
+ * Scheduled Posts — encryption-at-rest helpers.
+ *
+ * Signed events awaiting publish are stored in D1 as
+ * AES-256-GCM ciphertext (base64) with a per-row random 12-byte IV.
+ *
+ * Honest threat model: this protects DB exports and backups from
+ * casual exposure. It does NOT protect against the server operator —
+ * the broadcast path necessarily holds SCHEDULE_ENC_KEY to decrypt
+ * and publish. Don't oversell this property in user-facing copy.
+ *
+ * Pure module: the key arrives as a parameter (routes read
+ * SCHEDULE_ENC_KEY from env; the cron worker reads its own secret),
+ * so the identical code runs in Pages functions, the cron worker,
+ * and vitest with no env plumbing. Uses only WebCrypto
+ * (`crypto.subtle`), which behaves identically in all three.
+ */
+
+const IV_BYTES = 12;
+
+/**
+ * Import the 64-hex-char (32-byte) SCHEDULE_ENC_KEY into a CryptoKey.
+ * Throws on malformed keys so a misconfigured secret fails loudly at
+ * startup rather than producing undecryptable rows.
+ */
+export async function importScheduleKey(hexKey: string): Promise<CryptoKey> {
+  if (!/^[0-9a-fA-F]{64}$/.test(hexKey)) {
+    throw new Error('SCHEDULE_ENC_KEY must be exactly 64 hex characters (32 bytes)');
+  }
+  const raw = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) {
+    raw[i] = parseInt(hexKey.slice(i * 2, i * 2 + 2), 16);
+  }
+  return crypto.subtle.importKey('raw', raw, { name: 'AES-GCM' }, false, [
+    'encrypt',
+    'decrypt'
+  ]);
+}
+
+/**
+ * Encrypt a serialized signed event. Returns base64 ciphertext and
+ * base64 IV, matching the `ciphertext` / `iv` columns of
+ * `scheduled_events`. A fresh random IV is generated per call —
+ * never reuse an IV under GCM.
+ */
+export async function encryptScheduledEvent(
+  key: CryptoKey,
+  plaintext: string
+): Promise<{ ciphertext: string; iv: string }> {
+  const iv = crypto.getRandomValues(new Uint8Array(IV_BYTES));
+  const encrypted = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    new TextEncoder().encode(plaintext)
+  );
+  return {
+    ciphertext: bytesToBase64(new Uint8Array(encrypted)),
+    iv: bytesToBase64(iv)
+  };
+}
+
+/**
+ * Decrypt a row back to the signed-event JSON string. GCM's auth tag
+ * makes any tampering (ciphertext or IV) throw rather than return
+ * garbage — callers should let that propagate and mark the row
+ * failed, not retry.
+ */
+export async function decryptScheduledEvent(
+  key: CryptoKey,
+  ciphertext: string,
+  iv: string
+): Promise<string> {
+  const decrypted = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: base64ToBytes(iv) },
+    key,
+    base64ToBytes(ciphertext)
+  );
+  return new TextDecoder().decode(decrypted);
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary);
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}


### PR DESCRIPTION
Phase 1 groundwork for Scheduled Posts (spec §§2–3). No routes yet — those land in PR B (stacked on this branch).

## What's here

- **`migrations/scheduler/0001_create_scheduled_events.sql`** — the `scheduled_events` table per spec §2: event id as PRIMARY KEY (natural idempotency — the same signed event can't be scheduled twice), no plaintext content columns, `(status, publish_at)` index for the Phase 2 due-sweep and `(pubkey, status)` for owner queries. Already applied to the `zapcooking-scheduler` D1 database.
- **`src/lib/scheduleCrypto.server.ts`** — AES-256-GCM via WebCrypto, per-row random 12-byte IV, base64 ciphertext/IV matching the table columns. The key arrives as a parameter (no env read inside the module) so the identical code runs in Pages functions, the cron worker, and vitest. Comments state the honest threat model: protects DB exports/backups, **not** the server operator, who necessarily holds the key to broadcast.
- **Tests** — crypto round-trip, per-call IV freshness, tampered ciphertext/IV fail GCM auth, wrong-key decryption fails, malformed-key rejection; plus one new NIP-98 verifier test (missing `payload` tag with a body present).

## Deviation from spec, for review

The spec asks for a new `src/lib/server/nip98.ts`; instead we **reuse the existing `src/lib/nip98.server.ts`**, which already implements every §4 check (kind 27235, id+sig verification, ±60 s skew, `u`/`method` tag binding, mandatory `payload` hash when a body is present) with matching threat model and tests. The spec's check #7 (payload event's pubkey must equal the auth pubkey) is a route-level check and ships in PR B. The crypto module lives at `src/lib/scheduleCrypto.server.ts` (repo `*.server.ts` convention) rather than the spec's suggested `src/lib/server/` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)