### PR TITLE
feat(schedule): minutely cron sweep/broadcaster + e2e acceptance script (Phase 2, PR C)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.668",
+  "version": "4.2.670",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.670",
+  "version": "4.2.671",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.671",
+  "version": "4.2.672",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/scripts/schedule-test-post.ts
+++ b/scripts/schedule-test-post.ts
@@ -1,0 +1,133 @@
+/**
+ * Scheduled Posts — end-to-end acceptance script (spec §8).
+ *
+ * Signs a throwaway-key kind 1 with created_at = now + 180, schedules
+ * it via POST /api/schedule with a real NIP-98 header, polls GET until
+ * the row is 'sent', then confirms the event is fetchable by id on
+ * wss://pantry.zap.cooking. This is the acceptance gate for the whole
+ * backend (PRs A+B+C together).
+ *
+ * Prerequisites (must be live before this can pass):
+ *   - PR B routes deployed with the SCHEDULER_DB binding
+ *   - SCHEDULE_ENC_KEY secret set on the Pages project AND the cron
+ *     worker (same value in both)
+ *   - the cron worker deployed with the minutely trigger
+ *
+ * Usage:
+ *   npx tsx scripts/schedule-test-post.ts
+ *   SCHEDULE_TEST_BASE_URL=https://staging.zap.cooking npx tsx scripts/schedule-test-post.ts
+ *
+ * relay_mode is 'pantry' so the throwaway test post stays off the
+ * public relays. Exit 0 = full pipeline verified; exit 1 = failure
+ * (the failing stage is the last log line).
+ */
+
+import { finalizeEvent, generateSecretKey, getPublicKey, SimplePool } from 'nostr-tools';
+import { normalizeUrl, sha256Hex } from '../src/lib/nip98';
+
+const BASE_URL = process.env.SCHEDULE_TEST_BASE_URL ?? 'https://zap.cooking';
+const PANTRY_RELAY = 'wss://pantry.zap.cooking';
+const PUBLISH_LEAD_SECONDS = 180;
+const POLL_INTERVAL_MS = 30_000;
+const POLL_TIMEOUT_MS = 10 * 60_000;
+const RELAY_FETCH_TIMEOUT_MS = 15_000;
+
+const nowSec = () => Math.floor(Date.now() / 1000);
+const log = (stage: string, msg: string) => console.log(`[${stage}] ${msg}`);
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const sk = generateSecretKey();
+const pubkey = getPublicKey(sk);
+
+async function nip98Header(url: string, method: string, bodyString?: string): Promise<string> {
+  const tags: string[][] = [
+    ['u', normalizeUrl(url)],
+    ['method', method]
+  ];
+  if (bodyString !== undefined) {
+    tags.push(['payload', await sha256Hex(new TextEncoder().encode(bodyString))]);
+  }
+  const event = finalizeEvent({ kind: 27235, created_at: nowSec(), tags, content: '' }, sk);
+  return `Nostr ${Buffer.from(JSON.stringify(event)).toString('base64')}`;
+}
+
+async function main(): Promise<void> {
+  // ── 1/4: sign the future event ────────────────────────────────────
+  const publishAt = nowSec() + PUBLISH_LEAD_SECONDS;
+  const event = finalizeEvent(
+    {
+      kind: 1,
+      created_at: publishAt,
+      tags: [],
+      content: `zap.cooking scheduled-posts integration test — ${new Date().toISOString()}`
+    },
+    sk
+  );
+  log('1/4 sign', `throwaway pubkey ${pubkey}`);
+  log('1/4 sign', `event ${event.id}, publish_at ${publishAt} (${new Date(publishAt * 1000).toISOString()})`);
+
+  // ── 2/4: schedule it ──────────────────────────────────────────────
+  const scheduleUrl = `${BASE_URL}/api/schedule`;
+  const body = JSON.stringify({ event, relay_mode: 'pantry' });
+  const postRes = await fetch(scheduleUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: await nip98Header(scheduleUrl, 'POST', body)
+    },
+    body
+  });
+  const postData = (await postRes.json()) as Record<string, unknown>;
+  if (postRes.status !== 201) {
+    throw new Error(`POST /api/schedule returned ${postRes.status}: ${JSON.stringify(postData)}`);
+  }
+  log('2/4 schedule', `201 — ${JSON.stringify(postData)}`);
+
+  // ── 3/4: poll until the sweep broadcasts it ───────────────────────
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+  let status = 'pending';
+  while (Date.now() < deadline) {
+    await sleep(POLL_INTERVAL_MS);
+    const listRes = await fetch(scheduleUrl, {
+      headers: { Authorization: await nip98Header(scheduleUrl, 'GET') }
+    });
+    if (listRes.status !== 200) {
+      log('3/4 poll', `GET returned ${listRes.status} — retrying`);
+      continue;
+    }
+    const { items } = (await listRes.json()) as { items: { id: string; status: string; attempts: number; last_error: string | null }[] };
+    const item = items.find((i) => i.id === event.id);
+    if (!item) throw new Error('scheduled row disappeared from the list endpoint');
+    status = item.status;
+    log('3/4 poll', `status=${item.status} attempts=${item.attempts} last_error=${item.last_error ?? 'none'}`);
+    if (status === 'sent') break;
+    if (status === 'failed') throw new Error(`row failed terminally: ${item.last_error}`);
+  }
+  if (status !== 'sent') {
+    throw new Error(`timed out after ${POLL_TIMEOUT_MS / 60000} min — row still '${status}'`);
+  }
+  log('3/4 poll', 'row is sent — sweep broadcast it');
+
+  // ── 4/4: confirm on the pantry relay ──────────────────────────────
+  const pool = new SimplePool();
+  try {
+    const fetched = await Promise.race([
+      pool.get([PANTRY_RELAY], { ids: [event.id] }),
+      sleep(RELAY_FETCH_TIMEOUT_MS).then(() => null)
+    ]);
+    if (!fetched) throw new Error(`event ${event.id} not found on ${PANTRY_RELAY}`);
+    if (fetched.content !== event.content) throw new Error('relay returned a different event body');
+    log('4/4 relay', `event confirmed on ${PANTRY_RELAY}`);
+  } finally {
+    pool.close([PANTRY_RELAY]);
+  }
+
+  log('done', 'scheduled → swept → broadcast → fetchable. Full pipeline verified.');
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(`FAILED: ${err instanceof Error ? err.message : err}`);
+    process.exit(1);
+  });

--- a/scripts/schedule-test-post.ts
+++ b/scripts/schedule-test-post.ts
@@ -24,9 +24,16 @@
 
 import { finalizeEvent, generateSecretKey, getPublicKey, SimplePool } from 'nostr-tools';
 import { normalizeUrl, sha256Hex } from '../src/lib/nip98';
+import { standardRelays } from '../src/lib/consts';
 
 const BASE_URL = process.env.SCHEDULE_TEST_BASE_URL ?? 'https://zap.cooking';
 const PANTRY_RELAY = 'wss://pantry.zap.cooking';
+// SCHEDULE_TEST_RELAY_MODE=all schedules against the public relay list
+// instead of pantry — diagnostic mode for isolating pantry's write
+// posture from the worker's publish machinery. Default stays 'pantry'
+// so the routine acceptance run keeps test posts off public relays.
+const RELAY_MODE = process.env.SCHEDULE_TEST_RELAY_MODE === 'all' ? 'all' : 'pantry';
+const CONFIRM_RELAYS = RELAY_MODE === 'pantry' ? [PANTRY_RELAY] : [...standardRelays];
 const PUBLISH_LEAD_SECONDS = 180;
 const POLL_INTERVAL_MS = 30_000;
 const POLL_TIMEOUT_MS = 10 * 60_000;
@@ -68,7 +75,7 @@ async function main(): Promise<void> {
 
   // ── 2/4: schedule it ──────────────────────────────────────────────
   const scheduleUrl = `${BASE_URL}/api/schedule`;
-  const body = JSON.stringify({ event, relay_mode: 'pantry' });
+  const body = JSON.stringify({ event, relay_mode: RELAY_MODE });
   const postRes = await fetch(scheduleUrl, {
     method: 'POST',
     headers: {
@@ -81,7 +88,7 @@ async function main(): Promise<void> {
   if (postRes.status !== 201) {
     throw new Error(`POST /api/schedule returned ${postRes.status}: ${JSON.stringify(postData)}`);
   }
-  log('2/4 schedule', `201 — ${JSON.stringify(postData)}`);
+  log('2/4 schedule', `201 (relay_mode=${RELAY_MODE}) — ${JSON.stringify(postData)}`);
 
   // ── 3/4: poll until the sweep broadcasts it ───────────────────────
   const deadline = Date.now() + POLL_TIMEOUT_MS;
@@ -112,14 +119,14 @@ async function main(): Promise<void> {
   const pool = new SimplePool();
   try {
     const fetched = await Promise.race([
-      pool.get([PANTRY_RELAY], { ids: [event.id] }),
+      pool.get(CONFIRM_RELAYS, { ids: [event.id] }),
       sleep(RELAY_FETCH_TIMEOUT_MS).then(() => null)
     ]);
-    if (!fetched) throw new Error(`event ${event.id} not found on ${PANTRY_RELAY}`);
+    if (!fetched) throw new Error(`event ${event.id} not found on ${CONFIRM_RELAYS.join(', ')}`);
     if (fetched.content !== event.content) throw new Error('relay returned a different event body');
-    log('4/4 relay', `event confirmed on ${PANTRY_RELAY}`);
+    log('4/4 relay', `event confirmed via ${CONFIRM_RELAYS.length} relay(s) (${RELAY_MODE} mode)`);
   } finally {
-    pool.close([PANTRY_RELAY]);
+    pool.close(CONFIRM_RELAYS);
   }
 
   log('done', 'scheduled → swept → broadcast → fetchable. Full pipeline verified.');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
 		}
 	},
 	test: {
-		include: ['src/**/*.test.ts'],
+		include: ['src/**/*.test.ts', 'workers/**/*.test.ts'],
 		exclude: ['src/lib/clientTag.test.ts', 'src/lib/zapAmount.test.ts', 'node_modules/**']
 	}
 });

--- a/workers/cron/index.js
+++ b/workers/cron/index.js
@@ -1,13 +1,81 @@
-export default {
-  async scheduled(event, env, ctx) {
-    const response = await fetch('https://zap.cooking/api/cron/check-expiring-memberships', {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${env.CRON_SECRET}`
+/**
+ * zap-cooking-cron — two triggers, routed on event.cron:
+ *
+ *   "0 9 * * *"  daily membership-expiry check (pre-existing behavior)
+ *   "* * * * *"  scheduled-posts sweep/broadcast (spec §6)
+ *
+ * Anything that isn't the minutely cron falls through to the
+ * membership check, preserving the original worker's behavior for the
+ * daily trigger and for manual `wrangler triggers` invocations.
+ */
+
+import { SimplePool } from 'nostr-tools';
+import { sweepDueEvents } from './sweep';
+
+export const MINUTELY_CRON = '* * * * *';
+export const DAILY_CRON = '0 9 * * *';
+
+async function checkExpiringMemberships(env) {
+  const response = await fetch('https://zap.cooking/api/cron/check-expiring-memberships', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${env.CRON_SECRET}`
+    }
+  });
+
+  const result = await response.json();
+  console.log('Cron job result:', result);
+}
+
+async function runSweepTick(env) {
+  if (!env.SCHEDULER_DB || !env.SCHEDULE_ENC_KEY) {
+    console.error('[Sweep] SCHEDULER_DB / SCHEDULE_ENC_KEY not configured — skipping tick');
+    return;
+  }
+
+  // One pool per tick, closed in finally (spec §6.6). Workers supports
+  // outbound WebSockets, which is all SimplePool needs.
+  const pool = new SimplePool();
+  const openedRelays = new Set();
+  try {
+    const summary = await sweepDueEvents({
+      db: env.SCHEDULER_DB,
+      encKeyHex: env.SCHEDULE_ENC_KEY,
+      publish: async (event, relays) => {
+        relays.forEach((r) => openedRelays.add(r));
+        // pool.publish returns one promise per relay, fulfilled on OK.
+        const results = await Promise.allSettled(pool.publish(relays, event));
+        const okCount = results.filter((r) => r.status === 'fulfilled').length;
+        if (okCount === 0) {
+          const first = results.find((r) => r.status === 'rejected');
+          throw new Error(String(first?.reason ?? 'no relay accepted').slice(0, 500));
+        }
+        return okCount;
       }
     });
-    
-    const result = await response.json();
-    console.log('Cron job result:', result);
+    if (summary.due > 0) console.log('[Sweep]', JSON.stringify(summary));
+  } finally {
+    pool.close([...openedRelays]);
+  }
+}
+
+/**
+ * Trigger router, exported for tests: the minutely cron must never
+ * hit the membership endpoint and the daily cron must never run the
+ * sweep. `impl` is injectable so tests can assert exactly that.
+ */
+export async function dispatchScheduled(event, env, impl) {
+  if (event.cron === MINUTELY_CRON) {
+    return impl.sweep(env);
+  }
+  return impl.membership(env);
+}
+
+export default {
+  async scheduled(event, env, ctx) {
+    await dispatchScheduled(event, env, {
+      sweep: runSweepTick,
+      membership: checkExpiringMemberships
+    });
   }
 };

--- a/workers/cron/sweep.test.ts
+++ b/workers/cron/sweep.test.ts
@@ -1,0 +1,414 @@
+/**
+ * Unit tests for the scheduled-posts sweep (workers/cron/sweep.ts)
+ * and the cron trigger routing (workers/cron/index.js).
+ *
+ * The D1 fake implements exactly the five statements the sweep
+ * issues and throws on anything else. Its mutations are synchronous
+ * inside run()/all(), which mirrors D1's per-statement atomicity —
+ * that's what makes the concurrency test honest: two racing sweeps
+ * interleave at await boundaries but each claim is atomic.
+ *
+ * Crypto runs for real (rows are encrypted with the shared helper);
+ * relays never do — the publisher is injected and keeps a call log.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  sweepDueEvents,
+  relaysFor,
+  PANTRY_RELAY,
+  MAX_ATTEMPTS,
+  SWEEP_BATCH_LIMIT
+} from './sweep';
+import { dispatchScheduled, MINUTELY_CRON, DAILY_CRON } from './index';
+import { importScheduleKey, encryptScheduledEvent } from '../../src/lib/scheduleCrypto.server';
+import { standardRelays } from '../../src/lib/consts';
+
+const ENC_KEY = 'd'.repeat(64);
+const NOW = 1_800_000_000;
+const fixedClock = () => NOW;
+
+let key: CryptoKey;
+beforeAll(async () => {
+  key = await importScheduleKey(ENC_KEY);
+});
+
+// ── fake D1 ─────────────────────────────────────────────────────────
+
+interface Row {
+  id: string;
+  pubkey: string;
+  kind: number;
+  publish_at: number;
+  relay_mode: string;
+  ciphertext: string;
+  iv: string;
+  status: string;
+  attempts: number;
+  last_error: string | null;
+  created_at: number;
+  updated_at: number;
+  sent_at: number | null;
+}
+
+function fakeD1(rows: Row[]) {
+  return {
+    rows,
+    prepare(sql: string) {
+      return {
+        bind(...args: any[]) {
+          return {
+            async first() {
+              if (sql.startsWith('SELECT status')) {
+                const r = rows.find((r) => r.id === args[0]);
+                return r ? { status: r.status } : null;
+              }
+              throw new Error(`fakeD1: unexpected first(): ${sql}`);
+            },
+            async all() {
+              if (sql.includes('publish_at <= ?1')) {
+                const results = rows
+                  .filter((r) => r.status === 'pending' && r.publish_at <= args[0])
+                  .sort((a, b) => a.publish_at - b.publish_at)
+                  .slice(0, SWEEP_BATCH_LIMIT)
+                  .map(({ id, publish_at, relay_mode, ciphertext, iv }) => ({
+                    id,
+                    publish_at,
+                    relay_mode,
+                    ciphertext,
+                    iv
+                  }));
+                return { results };
+              }
+              throw new Error(`fakeD1: unexpected all(): ${sql}`);
+            },
+            async run() {
+              if (sql.includes("SET status = 'pending'") && sql.includes("'publishing'")) {
+                let changes = 0;
+                for (const r of rows) {
+                  if (r.status === 'publishing' && r.updated_at < args[1]) {
+                    r.status = 'pending';
+                    r.updated_at = args[0];
+                    changes++;
+                  }
+                }
+                return { meta: { changes } };
+              }
+              if (sql.includes("SET status = 'publishing'")) {
+                const r = rows.find((r) => r.id === args[0] && r.status === 'pending');
+                if (!r) return { meta: { changes: 0 } };
+                r.status = 'publishing';
+                r.updated_at = args[1];
+                return { meta: { changes: 1 } };
+              }
+              if (sql.includes("SET status = 'sent'")) {
+                const r = rows.find((r) => r.id === args[0]);
+                if (!r) return { meta: { changes: 0 } };
+                r.status = 'sent';
+                r.sent_at = args[1];
+                r.updated_at = args[1];
+                return { meta: { changes: 1 } };
+              }
+              if (sql.includes('attempts = attempts + 1')) {
+                const r = rows.find((r) => r.id === args[0]);
+                if (!r) return { meta: { changes: 0 } };
+                r.attempts += 1;
+                r.last_error = args[1];
+                r.updated_at = args[2];
+                r.status =
+                  r.attempts >= MAX_ATTEMPTS || args[2] > r.publish_at + 86400
+                    ? 'failed'
+                    : 'pending';
+                return { meta: { changes: 1 } };
+              }
+              throw new Error(`fakeD1: unexpected run(): ${sql}`);
+            }
+          };
+        }
+      };
+    }
+  };
+}
+
+type FakeDb = ReturnType<typeof fakeD1>;
+
+let seq = 0;
+/** Seed a row whose ciphertext really decrypts to a distinct event. */
+async function seedRow(rows: Row[], overrides: Partial<Row> = {}): Promise<Row & { eventId: string }> {
+  const eventId = `event-${++seq}`;
+  const { ciphertext, iv } = await encryptScheduledEvent(
+    key,
+    JSON.stringify({ id: eventId, kind: 1, content: `content ${seq}` })
+  );
+  const row: Row = {
+    id: seq.toString(16).padStart(64, '0'),
+    pubkey: 'p'.repeat(64),
+    kind: 1,
+    publish_at: NOW - 60,
+    relay_mode: 'all',
+    ciphertext,
+    iv,
+    status: 'pending',
+    attempts: 0,
+    last_error: null,
+    created_at: NOW - 3600,
+    updated_at: NOW - 3600,
+    sent_at: null,
+    ...overrides
+  };
+  rows.push(row);
+  return Object.assign(row, { eventId });
+}
+
+/** Injected publisher with a call log; okCount relays "accept". */
+function makePublisher(okCount = 1, delayMs = 0) {
+  const calls: { eventId: string; relays: string[] }[] = [];
+  const publish = async (event: any, relays: string[]) => {
+    if (delayMs > 0) await new Promise((r) => setTimeout(r, delayMs));
+    calls.push({ eventId: event.id, relays });
+    return okCount;
+  };
+  return { calls, publish };
+}
+
+function sweep(db: FakeDb, publish: any, clock: () => number = fixedClock) {
+  return sweepDueEvents({ db, encKeyHex: ENC_KEY, publish, clock });
+}
+
+// ── relay sets ──────────────────────────────────────────────────────
+
+describe('relaysFor', () => {
+  it("'pantry' broadcasts to the pantry relay only", () => {
+    expect(relaysFor('pantry')).toEqual([PANTRY_RELAY]);
+  });
+
+  it("'all' broadcasts to the app's default relay list (shared constant, not a mirror)", () => {
+    expect(relaysFor('all')).toBe(standardRelays);
+    expect(standardRelays.length).toBeGreaterThan(0);
+  });
+});
+
+// ── Gate A: concurrency ─────────────────────────────────────────────
+
+describe('concurrent sweeps', () => {
+  it('two sweeps racing over the same due rows broadcast every row exactly once', async () => {
+    const rows: Row[] = [];
+    const seeded = [];
+    for (let i = 0; i < 5; i++) seeded.push(await seedRow(rows));
+    const db = fakeD1(rows);
+
+    // Slow publisher forces interleaving: while sweep 1 awaits a
+    // publish, sweep 2 runs its select + claims.
+    const p1 = makePublisher(1, 5);
+    const p2 = makePublisher(1, 5);
+    const [s1, s2] = await Promise.all([sweep(db, p1.publish), sweep(db, p2.publish)]);
+
+    const allCalls = [...p1.calls, ...p2.calls];
+    const broadcastIds = allCalls.map((c) => c.eventId).sort();
+    expect(broadcastIds).toEqual(seeded.map((r) => r.eventId).sort()); // once each, none missing
+    expect(new Set(broadcastIds).size).toBe(5);
+    expect(rows.every((r) => r.status === 'sent')).toBe(true);
+    expect(s1.sent + s2.sent).toBe(5);
+    expect(s1.skipped + s2.skipped).toBeGreaterThan(0); // the loser actually raced
+  });
+});
+
+// ── Gate B: recovery ────────────────────────────────────────────────
+
+describe('stuck-claim recovery', () => {
+  it('re-claims and broadcasts a row stuck in publishing for 6 minutes; leaves a 2-minute-old claim alone', async () => {
+    const rows: Row[] = [];
+    const stale = await seedRow(rows, { status: 'publishing', updated_at: NOW - 360 });
+    const fresh = await seedRow(rows, { status: 'publishing', updated_at: NOW - 120 });
+    const db = fakeD1(rows);
+
+    const pub = makePublisher(1);
+    const summary = await sweep(db, pub.publish);
+
+    expect(summary.recovered).toBe(1);
+    expect(pub.calls.map((c) => c.eventId)).toEqual([stale.eventId]);
+    expect(stale.status).toBe('sent');
+    // The fresh claim belongs to a sweep that may still be alive.
+    expect(fresh.status).toBe('publishing');
+  });
+});
+
+// ── Gate C: cancel-vs-sweep race ────────────────────────────────────
+
+describe('cancel-vs-sweep race', () => {
+  it('a row cancelled between SELECT and claim is skipped and stays cancelled', async () => {
+    const rows: Row[] = [];
+    const row = await seedRow(rows);
+    const db = fakeD1(rows);
+
+    // Interpose on the due-select: the owner cancels right after the
+    // sweep has read the row but before it claims.
+    const origPrepare = db.prepare.bind(db);
+    db.prepare = (sql: string) => {
+      const stmt = origPrepare(sql);
+      if (!sql.includes('publish_at <= ?1')) return stmt;
+      return {
+        bind(...args: any[]) {
+          const bound = stmt.bind(...args);
+          return {
+            ...bound,
+            async all() {
+              const res = await bound.all();
+              row.status = 'cancelled';
+              return res;
+            }
+          };
+        }
+      };
+    };
+
+    const pub = makePublisher(1);
+    const summary = await sweep(db, pub.publish);
+
+    expect(summary.skipped).toBe(1);
+    expect(pub.calls).toEqual([]); // nothing broadcast
+    expect(row.status).toBe('cancelled');
+  });
+});
+
+// ── Gate D: terminal transitions ────────────────────────────────────
+
+describe('terminal failure transitions', () => {
+  it("the 10th failed attempt parks the row in 'failed'", async () => {
+    const rows: Row[] = [];
+    const row = await seedRow(rows, { attempts: MAX_ATTEMPTS - 1 });
+    const db = fakeD1(rows);
+
+    const pub = makePublisher(0); // zero relays accept
+    const summary = await sweep(db, pub.publish);
+
+    expect(row.status).toBe('failed');
+    expect(row.attempts).toBe(MAX_ATTEMPTS);
+    expect(row.last_error).toBe('no_relay_accepted');
+    expect(summary.failed).toBe(1);
+  });
+
+  it("a row past publish_at + 24h fails terminally even on attempt 1", async () => {
+    const rows: Row[] = [];
+    const row = await seedRow(rows, { publish_at: NOW - 86400 - 300, attempts: 0 });
+    const db = fakeD1(rows);
+
+    const pub = makePublisher(0);
+    await sweep(db, pub.publish);
+
+    expect(row.status).toBe('failed');
+    expect(row.attempts).toBe(1);
+  });
+
+  it("a mid-window failure goes back to 'pending' for the next tick", async () => {
+    const rows: Row[] = [];
+    const row = await seedRow(rows, { attempts: 3 });
+    const db = fakeD1(rows);
+
+    const pub = makePublisher(0);
+    const summary = await sweep(db, pub.publish);
+
+    expect(row.status).toBe('pending');
+    expect(row.attempts).toBe(4);
+    expect(summary.retried).toBe(1);
+  });
+
+  it("an undecryptable row records last_error='decrypt_failed' as a normal attempt (no hot loop)", async () => {
+    const rows: Row[] = [];
+    const row = await seedRow(rows);
+    // Valid base64, wrong bytes — GCM auth fails on decrypt.
+    row.ciphertext = btoa('not the real ciphertext');
+    const db = fakeD1(rows);
+
+    const pub = makePublisher(1);
+    const summary = await sweep(db, pub.publish);
+
+    expect(pub.calls).toEqual([]);
+    expect(row.status).toBe('pending');
+    expect(row.attempts).toBe(1);
+    expect(row.last_error).toBe('decrypt_failed');
+    expect(summary.retried).toBe(1);
+  });
+});
+
+// ── Gate E: partial relay success ───────────────────────────────────
+
+describe('partial relay success', () => {
+  it("1 OK out of 3 relays counts as 'sent'", async () => {
+    const rows: Row[] = [];
+    const row = await seedRow(rows);
+    const db = fakeD1(rows);
+
+    const pub = makePublisher(1); // 1 accept (the other 2 "failed")
+    const summary = await sweep(db, pub.publish);
+
+    expect(row.status).toBe('sent');
+    expect(row.sent_at).toBe(NOW);
+    expect(summary.sent).toBe(1);
+  });
+});
+
+// ── tick budget ─────────────────────────────────────────────────────
+
+describe('tick wall-clock budget', () => {
+  it('stops claiming once the budget is exhausted; unprocessed rows stay pending', async () => {
+    const rows: Row[] = [];
+    const first = await seedRow(rows, { publish_at: NOW - 120 });
+    const second = await seedRow(rows, { publish_at: NOW - 60 });
+    const db = fakeD1(rows);
+
+    // Clock advances 30 s on every publish — after the first row the
+    // 25 s budget is blown.
+    let t = NOW;
+    const clock = () => t;
+    const calls: string[] = [];
+    const publish = async (event: any) => {
+      calls.push(event.id);
+      t += 30;
+      return 1;
+    };
+
+    const summary = await sweep(db, publish, clock);
+
+    expect(calls).toEqual([first.eventId]);
+    expect(first.status).toBe('sent');
+    expect(second.status).toBe('pending'); // untouched — next tick's work
+    expect(summary.sent).toBe(1);
+  });
+});
+
+// ── Gate F: trigger routing ─────────────────────────────────────────
+
+describe('cron trigger routing', () => {
+  function spies() {
+    const calls: string[] = [];
+    return {
+      calls,
+      impl: {
+        sweep: async () => {
+          calls.push('sweep');
+        },
+        membership: async () => {
+          calls.push('membership');
+        }
+      }
+    };
+  }
+
+  it('the minutely trigger runs the sweep and never the membership check', async () => {
+    const { calls, impl } = spies();
+    await dispatchScheduled({ cron: MINUTELY_CRON }, {}, impl);
+    expect(calls).toEqual(['sweep']);
+  });
+
+  it('the daily trigger runs the membership check and never the sweep', async () => {
+    const { calls, impl } = spies();
+    await dispatchScheduled({ cron: DAILY_CRON }, {}, impl);
+    expect(calls).toEqual(['membership']);
+  });
+
+  it('an unknown cron falls through to the membership check (pre-split behavior)', async () => {
+    const { calls, impl } = spies();
+    await dispatchScheduled({ cron: '30 12 * * *' }, {}, impl);
+    expect(calls).toEqual(['membership']);
+  });
+});

--- a/workers/cron/sweep.ts
+++ b/workers/cron/sweep.ts
@@ -1,0 +1,207 @@
+/**
+ * Scheduled Posts — minutely sweep/broadcast logic (spec §6).
+ *
+ * Pure module: all effects arrive as injected dependencies (D1
+ * database, publisher function, clock) so vitest covers the claim /
+ * recovery / retry logic without relays or real D1. The worker entry
+ * (index.js) wires the real deps.
+ *
+ * LATE-BY-DESIGN: cron granularity is one minute, so publishes land
+ * 0–60 s after publish_at, and the broadcast event's created_at is
+ * therefore slightly in the past. That is normal, valid Nostr, and
+ * fine — do not "fix" it. Same for retries: relays accept past
+ * timestamps, so retrying within 24 h of publish_at is correct.
+ */
+
+import { importScheduleKey, decryptScheduledEvent } from '../../src/lib/scheduleCrypto.server';
+import { standardRelays } from '../../src/lib/consts';
+
+export const PANTRY_RELAY = 'wss://pantry.zap.cooking';
+
+/** Rows swept per tick. */
+export const SWEEP_BATCH_LIMIT = 20;
+/** A 'publishing' claim older than this is from a dead tick — recover it. */
+export const CLAIM_STALE_SECONDS = 300;
+/** Terminal failure: this many attempts, or… */
+export const MAX_ATTEMPTS = 10;
+/** …still unsent this long after publish_at. */
+export const RETRY_WINDOW_SECONDS = 86400;
+/** Wall-clock budget per tick (leave headroom under Workers' 30 s). */
+export const TICK_BUDGET_SECONDS = 25;
+
+/**
+ * Relay set per relay_mode. 'all' is the app's default relay list,
+ * imported directly from the frontend's src/lib/consts.ts — one
+ * source of truth, no mirror to drift.
+ */
+export function relaysFor(relayMode: string): string[] {
+  return relayMode === 'pantry' ? [PANTRY_RELAY] : standardRelays;
+}
+
+interface D1Like {
+  prepare(query: string): {
+    bind(...values: unknown[]): {
+      first<T = unknown>(): Promise<T | null>;
+      all<T = unknown>(): Promise<{ results: T[] }>;
+      run(): Promise<{ meta: { changes: number } }>;
+    };
+  };
+}
+
+interface DueRow {
+  id: string;
+  publish_at: number;
+  relay_mode: string;
+  ciphertext: string;
+  iv: string;
+}
+
+export interface SweepDeps {
+  db: D1Like;
+  /** 64-hex-char SCHEDULE_ENC_KEY — same secret the Pages API encrypts with. */
+  encKeyHex: string;
+  /**
+   * Broadcast one signed event to a relay set; resolves to the number
+   * of relays that accepted (OK true). ≥1 counts as sent.
+   */
+  publish: (event: unknown, relays: string[]) => Promise<number>;
+  /** Unix-seconds clock, injectable for tests. */
+  clock?: () => number;
+  budgetSeconds?: number;
+}
+
+export interface SweepSummary {
+  recovered: number;
+  due: number;
+  sent: number;
+  retried: number;
+  failed: number;
+  skipped: number;
+}
+
+export async function sweepDueEvents(deps: SweepDeps): Promise<SweepSummary> {
+  const { db, encKeyHex, publish } = deps;
+  const clock = deps.clock ?? (() => Math.floor(Date.now() / 1000));
+  const deadline = clock() + (deps.budgetSeconds ?? TICK_BUDGET_SECONDS);
+  const summary: SweepSummary = { recovered: 0, due: 0, sent: 0, retried: 0, failed: 0, skipped: 0 };
+
+  // 1. Recovery FIRST: claims from a tick that died mid-broadcast
+  // expire after 5 minutes and go back in the queue.
+  const now0 = clock();
+  const recovered = await db
+    .prepare(
+      "UPDATE scheduled_events SET status = 'pending', updated_at = ?1 WHERE status = 'publishing' AND updated_at < ?2"
+    )
+    .bind(now0, now0 - CLAIM_STALE_SECONDS)
+    .run();
+  summary.recovered = recovered.meta?.changes ?? 0;
+
+  // 2. Due rows, oldest first.
+  const { results: due } = await db
+    .prepare(
+      `SELECT id, publish_at, relay_mode, ciphertext, iv
+         FROM scheduled_events
+        WHERE status = 'pending' AND publish_at <= ?1
+        ORDER BY publish_at
+        LIMIT ${SWEEP_BATCH_LIMIT}`
+    )
+    .bind(clock())
+    .all<DueRow>();
+  summary.due = due.length;
+  if (due.length === 0) return summary;
+
+  const key = await importScheduleKey(encKeyHex);
+
+  for (const row of due) {
+    if (clock() > deadline) {
+      console.warn(`[Sweep] tick budget exhausted with ${summary.due - summary.skipped - summary.sent - summary.retried - summary.failed} rows left`);
+      break;
+    }
+
+    // 3. Atomic per-row claim. changes === 0 means another sweep took
+    // it or the owner cancelled it between our SELECT and now — skip
+    // silently. This check is the cancel-vs-sweep safety; never batch.
+    const claim = await db
+      .prepare(
+        "UPDATE scheduled_events SET status = 'publishing', updated_at = ?2 WHERE id = ?1 AND status = 'pending'"
+      )
+      .bind(row.id, clock())
+      .run();
+    if ((claim.meta?.changes ?? 0) !== 1) {
+      summary.skipped++;
+      continue;
+    }
+
+    // 4. Decrypt. Failure is a recorded attempt (last_error =
+    // 'decrypt_failed'), not a hot retry loop — the attempts cap and
+    // 24 h window will eventually park an undecryptable row in
+    // 'failed'.
+    let signedEvent: unknown;
+    try {
+      signedEvent = JSON.parse(await decryptScheduledEvent(key, row.ciphertext, row.iv));
+    } catch {
+      await recordFailedAttempt(db, row.id, 'decrypt_failed', clock(), summary);
+      continue;
+    }
+
+    // 5–6. Broadcast; ≥1 relay accepting means sent.
+    let okCount = 0;
+    let lastError = 'no_relay_accepted';
+    try {
+      okCount = await publish(signedEvent, relaysFor(row.relay_mode));
+    } catch (err) {
+      lastError = err instanceof Error ? err.message.slice(0, 500) : 'publish_error';
+    }
+
+    if (okCount >= 1) {
+      const now = clock();
+      await db
+        .prepare(
+          "UPDATE scheduled_events SET status = 'sent', sent_at = ?2, updated_at = ?2 WHERE id = ?1"
+        )
+        .bind(row.id, now)
+        .run();
+      summary.sent++;
+    } else {
+      await recordFailedAttempt(db, row.id, lastError, clock(), summary);
+    }
+  }
+
+  return summary;
+}
+
+/**
+ * 7. Failed attempt: attempts += 1 (SQL-side, so a competing sweep's
+ * increment between our read and write can't be lost), back to
+ * 'pending' for the next tick — unless the attempts cap or the 24 h
+ * retry window says the row is terminally 'failed'.
+ */
+async function recordFailedAttempt(
+  db: D1Like,
+  id: string,
+  lastError: string,
+  now: number,
+  summary: SweepSummary
+): Promise<void> {
+  await db
+    .prepare(
+      `UPDATE scheduled_events
+          SET attempts = attempts + 1,
+              last_error = ?2,
+              updated_at = ?3,
+              status = CASE
+                WHEN attempts + 1 >= ${MAX_ATTEMPTS} OR ?3 > publish_at + ${RETRY_WINDOW_SECONDS}
+                THEN 'failed' ELSE 'pending'
+              END
+        WHERE id = ?1`
+    )
+    .bind(id, lastError, now)
+    .run();
+
+  const after = await db
+    .prepare('SELECT status FROM scheduled_events WHERE id = ?1')
+    .bind(id)
+    .first<{ status: string }>();
+  if (after?.status === 'failed') summary.failed++;
+  else summary.retried++;
+}

--- a/workers/cron/wrangler.toml
+++ b/workers/cron/wrangler.toml
@@ -5,10 +5,14 @@ main = "index.js"
 # runs — a deploy without this pin lands a SECOND copy of this worker in
 # the wrong account (double cron fires, bindings to unreachable DBs).
 account_id = "2d2f9386809ef6f9cda581aa16dff31c"
-compatibility_date = "2024-01-01"
+# Bumped from 2024-01-01 for outbound-WebSocket client support
+# (SimplePool needs `new WebSocket()`); matches the Pages project date.
+compatibility_date = "2025-01-01"
 
 [triggers]
-crons = ["0 9 * * *"]
+# 09:00 daily = membership-expiry check; minutely = scheduled-posts
+# sweep. index.js routes on event.cron — keep both lists in sync.
+crons = ["0 9 * * *", "* * * * *"]
 
 # PRODUCTION scheduler DB, deliberately. This worker must NEVER bind
 # zapcooking-scheduler-preview: preview rows come from preview/staging

--- a/workers/cron/wrangler.toml
+++ b/workers/cron/wrangler.toml
@@ -8,6 +8,14 @@ account_id = "2d2f9386809ef6f9cda581aa16dff31c"
 # Bumped from 2024-01-01 for outbound-WebSocket client support
 # (SimplePool needs `new WebSocket()`); matches the Pages project date.
 compatibility_date = "2025-01-01"
+# This worker is cron-only — no HTTP surface to expose.
+workers_dev = false
+
+# Retain logs so post-hoc questions ("did the 09:00 tick run clean?",
+# "what did the sweep record?") are answerable from the CLI/dashboard
+# instead of requiring a live tail at the moment of failure.
+[observability]
+enabled = true
 
 [triggers]
 # 09:00 daily = membership-expiry check; minutely = scheduled-posts


### PR DESCRIPTION
Scheduled Posts Phase 2 — the sweep contract from spec §6 plus the §8 acceptance script. Closes out the backend stack (#566 → #568 → #567 → this).

## The sweep (`workers/cron/`)

- Second trigger `* * * * *` alongside the daily 09:00; `index.js` routes on `event.cron` via an exported `dispatchScheduled` with injectable implementations — tests assert the minutely trigger never hits the membership endpoint and vice versa, and unknown crons fall through to membership (pre-split behavior).
- `sweep.ts` is pure logic with injected db/publisher/clock. Tick order per spec: recover >5-min-stale `publishing` claims first; select due (limit 20, oldest first); claim each row atomically (`UPDATE … WHERE status='pending'`, `meta.changes === 1` — the cancel-vs-sweep safety); decrypt with the shared `scheduleCrypto` helper; broadcast; ≥1 relay OK → `sent`. Failed attempts increment SQL-side (`attempts = attempts + 1` with the terminal CASE in the same statement) so racing sweeps can't lose an increment; attempts ≥ 10 or 24 h past `publish_at` → `failed`. `decrypt_failed` is a recorded attempt, not a hot loop. 25 s tick budget; pool closed in `finally`. Publishes land 0–60 s after `publish_at` **by design** (cron granularity) — documented so nobody "fixes" it.
- `relay_mode='all'` imports `standardRelays` directly from `src/lib/consts.ts` (bundle-verified; no mirrored list to drift). `'pantry'` → `wss://pantry.zap.cooking` only.

## Tests (14 new; vitest include extended to `workers/**`)

The review gates: two racing sweeps broadcast every row exactly once (publisher call-log assertion, and the loser demonstrably skipped); 6-min-stale claim recovered while a 2-min claim is left alone; cancel between SELECT and claim → 0 changes, nothing broadcast, stays cancelled; 10th-attempt and 24 h-window terminal transitions; 1-of-3 relay OK = sent; trigger routing both directions. Full suite: 846 passing.

## Acceptance script + relay-mode flag

`scripts/schedule-test-post.ts` (spec §8): throwaway key, kind 1 at now+180, real NIP-98 header, POST → poll GET → confirm fetchable by id on the relay. `SCHEDULE_TEST_RELAY_MODE=all` switches to the public relay list (stage 4 then confirms via `standardRelays`); default stays `pantry` to keep test posts off public relays.

## Riders

`workers_dev = false` (cron-only worker, no HTTP surface) and `[observability] enabled` (retain logs — the pantry investigation needed a live tail because nothing was retained). Requires redeploying the cron worker after merge.

## Acceptance evidence

- **PASS (all mode, production):** scheduled → swept → broadcast → fetchable; D1 row `sent`, `attempts=0`, `sent_at = publish_at + 4 s`; event confirmed on the public relays.
- **Pantry mode blocked, fully diagnosed, fix in PR D:** (1) Pantry requires NIP-42 auth for writes (`OK false "auth-required"` confirmed at frame level) — and the keyless-by-design sweep can't sign a challenge, pending a policy/service-key decision; (2) a nostr-tools 2.16.2 bug in the Workers runtime: its inbound-frame queue yields via `MessageChannel`, which is undefined in workerd, so the queue dies after one frame — relays that preface the OK with an AUTH frame (khatru) always time out. Probe-verified: transport Workers→Pantry is healthy (101 in ~80 ms, AUTH+OK frames within ~120 ms, raw WebSocket). The 'all'-mode pass works because those relays send OK as the first frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)