### PR TITLE
fix(schedule): raw-WebSocket publisher — excise nostr-tools from the sweep's publish path (PR D)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.672",
+  "version": "4.2.673",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/scripts/debug/pantry-probe/index.js
+++ b/scripts/debug/pantry-probe/index.js
@@ -1,0 +1,248 @@
+/**
+ * pantry-probe — relay-transport diagnostic worker (REFERENCE COPY).
+ *
+ * Kept as the reference implementation behind workers/cron/publisher.ts
+ * and for future relay transport debugging. Deploy manually only while
+ * investigating (wrangler deploy -c scripts/debug/pantry-probe/wrangler.toml,
+ * org account), trigger via its workers.dev URL, and DELETE the worker
+ * when done — it is not part of any deployed surface.
+ *
+ * July 2026 findings this probe produced: Workers→pantry transport is
+ * healthy at the frame level; pantry rejects unauthenticated writes
+ * with OK-false "auth-required" (NIP-42); and nostr-tools 2.16.2's
+ * inbound queue dies after one frame in workerd (yieldThread needs
+ * MessageChannel, which is undefined) — see the runtime check below.
+ *
+ * Observes, from inside the Workers runtime, exactly where the
+ * conversation to wss://pantry.zap.cooking stalls, vs a control relay
+ * (wss://nos.lol). Raw WebSocket handling on purpose — no SimplePool —
+ * we want frame-level truth with millisecond timings.
+ *
+ * Per relay:
+ *   1. NIP-11 HTTPS GET (Accept: application/nostr+json) — isolates
+ *      TCP+TLS+HTTP reachability from WebSocket concerns.
+ *   2a. fetch(url, {Upgrade: websocket}) — explicit 101 semantics.
+ *   2b. new WebSocket(url) — the exact mechanism nostr-tools uses in
+ *       the sweep worker. All subsequent stages ride this socket.
+ *   3. Record EVERY inbound frame verbatim (truncated 400 chars) with
+ *      ms offsets. khatru with auth sends ["AUTH", challenge] on
+ *      connect — whether that frame arrives is the key observation.
+ *   4. +1s: send ["REQ","probe",{"kinds":[1],"limit":1}].
+ *   5. +5s: send a valid signed throwaway EVENT; watch for OK.
+ *   Plus close codes/reasons and any exceptions.
+ */
+
+import { finalizeEvent, generateSecretKey } from 'nostr-tools/pure';
+
+const OPEN_TIMEOUT_MS = 8_000;
+const TAIL_CAPTURE_MS = 10_000;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function probeNip11(httpUrl) {
+  const s = {};
+  const t0 = Date.now();
+  try {
+    const res = await fetch(httpUrl, {
+      headers: { Accept: 'application/nostr+json' },
+      signal: AbortSignal.timeout(8000)
+    });
+    const body = await res.text();
+    s.status = res.status;
+    s.ms = Date.now() - t0;
+    s.body = body.slice(0, 300);
+  } catch (e) {
+    s.error = String(e);
+    s.ms = Date.now() - t0;
+  }
+  return s;
+}
+
+async function probeFetchUpgrade(httpUrl) {
+  const s = {};
+  const t0 = Date.now();
+  try {
+    const res = await fetch(httpUrl, {
+      headers: { Upgrade: 'websocket' },
+      signal: AbortSignal.timeout(8000)
+    });
+    s.status = res.status;
+    s.ms = Date.now() - t0;
+    s.gotWebSocket = !!res.webSocket;
+    if (res.webSocket) {
+      try {
+        res.webSocket.accept();
+        res.webSocket.close(1000, 'probe upgrade check done');
+      } catch (e) {
+        s.closeError = String(e);
+      }
+    }
+  } catch (e) {
+    s.error = String(e);
+    s.ms = Date.now() - t0;
+  }
+  return s;
+}
+
+async function probeWebSocket(wsUrl, signedEvent) {
+  const s = { mechanism: 'new WebSocket(url)', frames: [], exceptions: [] };
+  const t0 = Date.now();
+  let ws;
+  try {
+    ws = new WebSocket(wsUrl);
+  } catch (e) {
+    s.constructError = String(e);
+    return s;
+  }
+
+  const opened = new Promise((resolve) => {
+    ws.addEventListener('open', () => {
+      s.openMs = Date.now() - t0;
+      resolve(true);
+    });
+  });
+  ws.addEventListener('message', (ev) => {
+    s.frames.push({ tMs: Date.now() - t0, data: String(ev.data).slice(0, 400) });
+  });
+  ws.addEventListener('close', (ev) => {
+    s.close = { tMs: Date.now() - t0, code: ev.code, reason: String(ev.reason).slice(0, 200) };
+  });
+  ws.addEventListener('error', (ev) => {
+    s.exceptions.push({ tMs: Date.now() - t0, error: String(ev?.message ?? ev) });
+  });
+
+  const didOpen = await Promise.race([opened, sleep(OPEN_TIMEOUT_MS).then(() => false)]);
+  if (!didOpen) {
+    s.openTimedOutAfterMs = OPEN_TIMEOUT_MS;
+    try { ws.close(); } catch {}
+    await sleep(200);
+    return s;
+  }
+
+  await sleep(1000);
+  try {
+    ws.send(JSON.stringify(['REQ', 'probe', { kinds: [1], limit: 1 }]));
+    s.reqSentAtMs = Date.now() - t0;
+  } catch (e) {
+    s.exceptions.push({ tMs: Date.now() - t0, error: 'REQ send: ' + String(e) });
+  }
+
+  await sleep(4000);
+  try {
+    ws.send(JSON.stringify(['EVENT', signedEvent]));
+    s.eventSentAtMs = Date.now() - t0;
+  } catch (e) {
+    s.exceptions.push({ tMs: Date.now() - t0, error: 'EVENT send: ' + String(e) });
+  }
+
+  await sleep(TAIL_CAPTURE_MS);
+  try { ws.close(1000, 'probe done'); } catch {}
+  await sleep(300);
+  return s;
+}
+
+/**
+ * Mimics the sweep's exact conversation shape: EVENT sent immediately
+ * on open, no prior REQ — and handlers wired via on* property setters
+ * (what nostr-tools' AbstractRelay does) instead of addEventListener.
+ */
+async function probeEventFirst(wsUrl, signedEvent) {
+  const s = { mechanism: 'new WebSocket(url) + on* setters, EVENT immediately on open', frames: [], exceptions: [] };
+  const t0 = Date.now();
+  let ws;
+  try {
+    ws = new WebSocket(wsUrl);
+  } catch (e) {
+    s.constructError = String(e);
+    return s;
+  }
+  const opened = new Promise((resolve) => {
+    ws.onopen = () => {
+      s.openMs = Date.now() - t0;
+      try {
+        ws.send('["EVENT",' + JSON.stringify(signedEvent) + ']');
+        s.eventSentAtMs = Date.now() - t0;
+      } catch (e) {
+        s.exceptions.push({ tMs: Date.now() - t0, error: 'EVENT send: ' + String(e) });
+      }
+      resolve(true);
+    };
+  });
+  ws.onmessage = (ev) => {
+    s.frames.push({ tMs: Date.now() - t0, data: String(ev.data).slice(0, 400) });
+  };
+  ws.onclose = (ev) => {
+    s.close = { tMs: Date.now() - t0, code: ev.code, reason: String(ev.reason).slice(0, 200) };
+  };
+  ws.onerror = (ev) => {
+    s.exceptions.push({ tMs: Date.now() - t0, error: String(ev?.message ?? ev) });
+  };
+  const didOpen = await Promise.race([opened, sleep(OPEN_TIMEOUT_MS).then(() => false)]);
+  if (!didOpen) {
+    s.openTimedOutAfterMs = OPEN_TIMEOUT_MS;
+    try { ws.close(); } catch {}
+    await sleep(200);
+    return s;
+  }
+  await sleep(TAIL_CAPTURE_MS);
+  try { ws.close(1000, 'probe done'); } catch {}
+  await sleep(300);
+  return s;
+}
+
+async function probeRelay(wsUrl) {
+  const httpUrl = wsUrl.replace('wss://', 'https://');
+  const sk = generateSecretKey();
+  const signedEvent = finalizeEvent(
+    {
+      kind: 1,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [],
+      content: `pantry-probe transport diagnostic — ${new Date().toISOString()}`
+    },
+    sk
+  );
+  const eventFirstSigned = finalizeEvent(
+    {
+      kind: 1,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [],
+      content: `pantry-probe event-first diagnostic — ${new Date().toISOString()}`
+    },
+    generateSecretKey()
+  );
+  return {
+    relay: wsUrl,
+    probeEventId: signedEvent.id,
+    eventFirstEventId: eventFirstSigned.id,
+    nip11: await probeNip11(httpUrl),
+    fetchUpgrade: await probeFetchUpgrade(httpUrl),
+    webSocket: await probeWebSocket(wsUrl, signedEvent),
+    webSocketEventFirst: await probeEventFirst(wsUrl, eventFirstSigned)
+  };
+}
+
+export default {
+  async fetch() {
+    let messageChannelCheck;
+    try {
+      const ch = new MessageChannel();
+      ch.port1.close();
+      messageChannelCheck = 'available';
+    } catch (e) {
+      messageChannelCheck = 'THROWS: ' + String(e);
+    }
+    const report = {
+      probe: 'pantry-probe',
+      startedAt: new Date().toISOString(),
+      runtime: {
+        typeofMessageChannel: typeof MessageChannel,
+        messageChannelConstruct: messageChannelCheck
+      },
+      results: [await probeRelay('wss://pantry.zap.cooking'), await probeRelay('wss://nos.lol')]
+    };
+    return new Response(JSON.stringify(report, null, 2), {
+      headers: { 'content-type': 'application/json' }
+    });
+  }
+};

--- a/scripts/debug/pantry-probe/wrangler.toml
+++ b/scripts/debug/pantry-probe/wrangler.toml
@@ -1,0 +1,7 @@
+# SCRATCH DIAGNOSTIC WORKER — delete after the pantry transport
+# investigation. Pre-authorized 2026-07-23; no bindings, no secrets.
+name = "pantry-probe"
+main = "index.js"
+account_id = "2d2f9386809ef6f9cda581aa16dff31c"
+compatibility_date = "2025-01-01"
+workers_dev = true

--- a/workers/cron/index.js
+++ b/workers/cron/index.js
@@ -9,8 +9,8 @@
  * daily trigger and for manual `wrangler triggers` invocations.
  */
 
-import { SimplePool } from 'nostr-tools';
 import { sweepDueEvents } from './sweep';
+import { publishEventRaw } from './publisher';
 
 export const MINUTELY_CRON = '* * * * *';
 export const DAILY_CRON = '0 9 * * *';
@@ -33,30 +33,20 @@ async function runSweepTick(env) {
     return;
   }
 
-  // One pool per tick, closed in finally (spec §6.6). Workers supports
-  // outbound WebSockets, which is all SimplePool needs.
-  const pool = new SimplePool();
-  const openedRelays = new Set();
-  try {
-    const summary = await sweepDueEvents({
-      db: env.SCHEDULER_DB,
-      encKeyHex: env.SCHEDULE_ENC_KEY,
-      publish: async (event, relays) => {
-        relays.forEach((r) => openedRelays.add(r));
-        // pool.publish returns one promise per relay, fulfilled on OK.
-        const results = await Promise.allSettled(pool.publish(relays, event));
-        const okCount = results.filter((r) => r.status === 'fulfilled').length;
-        if (okCount === 0) {
-          const first = results.find((r) => r.status === 'rejected');
-          throw new Error(String(first?.reason ?? 'no relay accepted').slice(0, 500));
-        }
-        return okCount;
-      }
-    });
-    if (summary.due > 0) console.log('[Sweep]', JSON.stringify(summary));
-  } finally {
-    pool.close([...openedRelays]);
-  }
+  // Raw-WebSocket publisher (publisher.ts) — NOT nostr-tools. Its
+  // inbound-frame queue relies on MessageChannel, which is undefined
+  // in the Workers runtime, so it drops every frame after the first;
+  // relays that preface OK with AUTH (pantry/khatru) always "timed
+  // out". publishEventRaw awaits the id-matched OK per relay, closes
+  // sockets in every path, and throws the first relay's verbatim
+  // failure reason when nothing accepts — which sweep.ts records as
+  // last_error.
+  const summary = await sweepDueEvents({
+    db: env.SCHEDULER_DB,
+    encKeyHex: env.SCHEDULE_ENC_KEY,
+    publish: (event, relays) => publishEventRaw(event, relays)
+  });
+  if (summary.due > 0) console.log('[Sweep]', JSON.stringify(summary));
 }
 
 /**

--- a/workers/cron/publisher.test.ts
+++ b/workers/cron/publisher.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for the raw-WebSocket publisher (workers/cron/publisher.ts).
+ *
+ * Each test scripts an exact inbound frame sequence against a fake
+ * socket. The mandatory case is AUTH-then-OK — the sequence that
+ * killed nostr-tools in the Workers runtime (its frame queue yields
+ * via MessageChannel, undefined in workerd, so frame #2 was never
+ * processed). The publisher must survive ANY frame noise and settle
+ * only on the OK matching the published event's id.
+ */
+import { describe, it, expect } from 'vitest';
+import { publishToRelay, publishEventRaw, type WebSocketLike } from './publisher';
+
+const EVENT = { id: 'e'.repeat(64), kind: 1, content: 'scheduled', sig: 's'.repeat(128) };
+const OTHER_ID = 'f'.repeat(64);
+const AUTH_REASON = 'auth-required: please authenticate with NIP-42';
+
+/**
+ * Scripted fake socket. `script` frames are delivered (async, one
+ * task apart — distinct WebSocket messages) after the publisher sends
+ * its EVENT, mirroring real relay behavior.
+ */
+class FakeWS implements WebSocketLike {
+  sent: string[] = [];
+  closed: { code?: number; reason?: string } | null = null;
+  private listeners = new Map<string, ((ev: any) => void)[]>();
+
+  constructor(
+    public url: string,
+    private script: { framesOnSend?: unknown[]; neverOpen?: boolean; errorOnOpen?: boolean } = {}
+  ) {
+    if (!script.neverOpen) {
+      setTimeout(() => {
+        if (script.errorOnOpen) this.emit('error', { message: 'boom' });
+        else this.emit('open', {});
+      }, 0);
+    }
+  }
+
+  addEventListener(type: string, fn: (ev: any) => void) {
+    const arr = this.listeners.get(type) ?? [];
+    arr.push(fn);
+    this.listeners.set(type, arr);
+  }
+
+  emit(type: string, ev: any) {
+    for (const fn of this.listeners.get(type) ?? []) fn(ev);
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+    let delay = 0;
+    for (const frame of this.script.framesOnSend ?? []) {
+      setTimeout(() => this.emit('message', { data: typeof frame === 'string' ? frame : JSON.stringify(frame) }), ++delay);
+    }
+  }
+
+  close(code?: number, reason?: string) {
+    this.closed = { code, reason };
+  }
+}
+
+function factoryFor(sockets: Record<string, FakeWS>) {
+  return (url: string) => {
+    if (!sockets[url]) throw new Error(`no fake socket scripted for ${url}`);
+    return sockets[url];
+  };
+}
+
+const okTrue = ['OK', EVENT.id, true, ''];
+const okFalseAuth = ['OK', EVENT.id, false, AUTH_REASON];
+const authFrame = ['AUTH', '25b1ca23eebb683f'];
+
+describe('publishToRelay frame handling', () => {
+  async function run(frames: unknown[], timeoutMs = 500) {
+    const ws = new FakeWS('wss://r', { framesOnSend: frames });
+    const result = publishToRelay('wss://r', EVENT, timeoutMs, () => ws);
+    return { ws, result };
+  }
+
+  it('AUTH-then-OK: survives the exact sequence that broke nostr-tools in workerd', async () => {
+    const { ws, result } = await run([authFrame, okTrue]);
+    await expect(result).resolves.toBe('');
+    expect(ws.sent).toEqual([`["EVENT",${JSON.stringify(EVENT)}]`]);
+    expect(ws.closed?.code).toBe(1000);
+  });
+
+  it('OK as the first frame still resolves (the framing-luck case)', async () => {
+    const { result } = await run([okTrue]);
+    await expect(result).resolves.toBe('');
+  });
+
+  it('OK false rejects with the relay reason verbatim', async () => {
+    const { ws, result } = await run([authFrame, okFalseAuth]);
+    await expect(result).rejects.toThrow(AUTH_REASON);
+    expect(ws.closed?.code).toBe(1000); // clean close on rejection path too
+  });
+
+  it('ignores unrelated frames interleaved before the matching OK', async () => {
+    const { result } = await run([
+      authFrame,
+      ['EVENT', 'sub1', { id: OTHER_ID, kind: 1, content: 'noise' }],
+      ['EOSE', 'sub1'],
+      ['NOTICE', 'rate limit soon'],
+      'this is not json {',
+      ['OK', OTHER_ID, false, 'someone else got rejected'],
+      42,
+      okTrue
+    ]);
+    await expect(result).resolves.toBe('');
+  });
+
+  it('no OK at all → per-relay timeout with a descriptive error, socket closed', async () => {
+    const ws = new FakeWS('wss://r', { framesOnSend: [authFrame] }); // AUTH only, OK never comes
+    const result = publishToRelay('wss://r', EVENT, 60, () => ws);
+    await expect(result).rejects.toThrow(/publish timed out awaiting OK/);
+    expect(ws.closed).not.toBeNull();
+  });
+
+  it('connection that never opens times out rather than hanging', async () => {
+    const ws = new FakeWS('wss://r', { neverOpen: true });
+    const result = publishToRelay('wss://r', EVENT, 60, () => ws);
+    await expect(result).rejects.toThrow(/publish timed out/);
+  });
+
+  it('connection error rejects promptly', async () => {
+    const ws = new FakeWS('wss://r', { errorOnOpen: true });
+    const result = publishToRelay('wss://r', EVENT, 500, () => ws);
+    await expect(result).rejects.toThrow(/connection error/);
+  });
+});
+
+describe('publishEventRaw across a relay set', () => {
+  it('multi-relay partial success: 1 OK true + 1 OK false + 1 timeout = sent (returns 1)', async () => {
+    const sockets = {
+      'wss://a': new FakeWS('wss://a', { framesOnSend: [authFrame, okTrue] }),
+      'wss://b': new FakeWS('wss://b', { framesOnSend: [okFalseAuth] }),
+      'wss://c': new FakeWS('wss://c', { framesOnSend: [] }) // opens, never OKs
+    };
+    const okCount = await publishEventRaw(EVENT, ['wss://a', 'wss://b', 'wss://c'], {
+      timeoutMs: 80,
+      wsFactory: factoryFor(sockets)
+    });
+    expect(okCount).toBe(1);
+    // Every socket closed regardless of outcome.
+    expect(Object.values(sockets).every((s) => s.closed !== null)).toBe(true);
+  });
+
+  it('all relays fail → throws the FIRST relay’s verbatim reason (what sweep stores as last_error)', async () => {
+    const sockets = {
+      'wss://a': new FakeWS('wss://a', { framesOnSend: [authFrame, okFalseAuth] }),
+      'wss://b': new FakeWS('wss://b', { framesOnSend: [] })
+    };
+    await expect(
+      publishEventRaw(EVENT, ['wss://a', 'wss://b'], { timeoutMs: 80, wsFactory: factoryFor(sockets) })
+    ).rejects.toThrow(AUTH_REASON);
+  });
+
+  it('all relays accept → count equals relay set size', async () => {
+    const sockets = {
+      'wss://a': new FakeWS('wss://a', { framesOnSend: [okTrue] }),
+      'wss://b': new FakeWS('wss://b', { framesOnSend: [authFrame, okTrue] })
+    };
+    const okCount = await publishEventRaw(EVENT, ['wss://a', 'wss://b'], {
+      timeoutMs: 200,
+      wsFactory: factoryFor(sockets)
+    });
+    expect(okCount).toBe(2);
+  });
+});

--- a/workers/cron/publisher.ts
+++ b/workers/cron/publisher.ts
@@ -1,0 +1,151 @@
+/**
+ * Raw-WebSocket Nostr event publisher for the sweep worker.
+ *
+ * Replaces nostr-tools' SimplePool on the PUBLISH path only. Why:
+ * nostr-tools 2.16.2 processes inbound relay frames through a queue
+ * that yields between messages via `new MessageChannel()` —
+ * undefined in the Workers runtime — so the queue dies after the
+ * FIRST frame. Relays that preface their OK with another frame (e.g.
+ * khatru's ["AUTH", challenge] on pantry) therefore always "time out"
+ * even though the OK arrives milliseconds later. Diagnosed 2026-07-23
+ * with the frame-level probe now preserved at scripts/debug/pantry-probe/.
+ *
+ * Design (mirrors the probe's proven event-first sequence):
+ * - one connection per relay, all relays raced concurrently;
+ * - EVENT sent immediately on open;
+ * - resolve/reject ONLY on the OK frame matching this event's id;
+ * - AUTH frames are deliberately ignored — the sweep holds no keys by
+ *   design and cannot answer a NIP-42 challenge;
+ * - every other frame (EVENT, EOSE, NOTICE, unparseable junk, OKs for
+ *   other ids) is ignored WITHOUT killing the connection — that
+ *   fragility is the exact bug this module excises;
+ * - OK false rejects with the relay's verbatim reason so the sweep
+ *   records e.g. "auth-required: please authenticate with NIP-42" as
+ *   last_error instead of a misleading timeout;
+ * - per-relay timeout (default 10 s) keeps the worst case well inside
+ *   the sweep's 25 s tick budget;
+ * - the socket is closed in every path.
+ */
+
+export const PER_RELAY_TIMEOUT_MS = 10_000;
+
+interface SignedEventLike {
+  id: string;
+  [key: string]: unknown;
+}
+
+/** Minimal surface of a client WebSocket — injectable for tests. */
+export interface WebSocketLike {
+  addEventListener(type: string, listener: (ev: any) => void): void;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+}
+
+export type WebSocketFactory = (url: string) => WebSocketLike;
+
+export interface PublishOptions {
+  timeoutMs?: number;
+  /** Tests inject a scripted fake; production uses `new WebSocket(url)`. */
+  wsFactory?: WebSocketFactory;
+}
+
+/**
+ * Publish one signed event to one relay. Resolves with the OK
+ * message's reason field (usually '') on OK true; rejects with the
+ * relay's verbatim reason on OK false, or a descriptive error on
+ * timeout / connection failure.
+ */
+export function publishToRelay(
+  url: string,
+  event: SignedEventLike,
+  timeoutMs: number,
+  wsFactory: WebSocketFactory
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let ws: WebSocketLike;
+    try {
+      ws = wsFactory(url);
+    } catch (err) {
+      reject(new Error(`websocket construct failed (${url}): ${String(err)}`));
+      return;
+    }
+
+    let settled = false;
+    const timer = setTimeout(() => {
+      finish(() => reject(new Error(`publish timed out awaiting OK (${url})`)));
+    }, timeoutMs);
+    const finish = (settle: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        ws.close(1000, 'publish settled');
+      } catch {
+        /* already closed */
+      }
+      settle();
+    };
+
+    ws.addEventListener('open', () => {
+      try {
+        ws.send(`["EVENT",${JSON.stringify(event)}]`);
+      } catch (err) {
+        finish(() => reject(new Error(`send failed (${url}): ${String(err)}`)));
+      }
+    });
+
+    ws.addEventListener('message', (ev: { data: unknown }) => {
+      let frame: unknown;
+      try {
+        frame = JSON.parse(String(ev.data));
+      } catch {
+        return; // junk frame — ignore, keep waiting for our OK
+      }
+      if (!Array.isArray(frame) || frame[0] !== 'OK' || frame[1] !== event.id) {
+        return; // AUTH / EVENT / EOSE / NOTICE / someone else's OK — ignore
+      }
+      const reason = String(frame[3] ?? '');
+      if (frame[2] === true) finish(() => resolve(reason));
+      else finish(() => reject(new Error(reason || 'rejected without reason')));
+    });
+
+    ws.addEventListener('close', (ev: { code?: number; reason?: string }) => {
+      finish(() =>
+        reject(new Error(`connection closed before OK (${url}, code ${ev?.code ?? '?'})`))
+      );
+    });
+
+    ws.addEventListener('error', () => {
+      finish(() => reject(new Error(`connection error (${url})`)));
+    });
+  });
+}
+
+/**
+ * Publish to a relay set concurrently. Resolves with the number of
+ * relays that accepted (≥1 — the sweep's "sent" criterion). When ALL
+ * relays fail, throws with the first relay's verbatim failure reason,
+ * which the sweep stores as last_error.
+ */
+export async function publishEventRaw(
+  event: SignedEventLike,
+  relays: string[],
+  opts: PublishOptions = {}
+): Promise<number> {
+  const timeoutMs = opts.timeoutMs ?? PER_RELAY_TIMEOUT_MS;
+  const wsFactory = opts.wsFactory ?? ((url: string) => new WebSocket(url) as WebSocketLike);
+
+  const results = await Promise.allSettled(
+    relays.map((url) => publishToRelay(url, event, timeoutMs, wsFactory))
+  );
+  const okCount = results.filter((r) => r.status === 'fulfilled').length;
+  if (okCount === 0) {
+    const first = results.find((r) => r.status === 'rejected') as
+      | PromiseRejectedResult
+      | undefined;
+    const reason =
+      first?.reason instanceof Error ? first.reason.message : String(first?.reason ?? 'no relay accepted');
+    throw new Error(reason.slice(0, 500));
+  }
+  return okCount;
+}


### PR DESCRIPTION
Fixes the diagnosed worker→pantry publish failure. Root cause (probe-verified, 2026-07-23): nostr-tools 2.16.2 processes inbound relay frames through a queue whose `yieldThread()` constructs a `MessageChannel` — **undefined in the Workers runtime** — so the queue dies after the first frame. Relays that preface their OK with `["AUTH", challenge]` (khatru/pantry) always surfaced as `publish timed out` even though the OK arrived ~50 ms later; the earlier `relay_mode='all'` pass worked only because those relays send OK as frame #1.

## What changed

- **`workers/cron/publisher.ts`** (new): raw-WebSocket publish path built from the probe's proven event-first sequence. One connection per relay, raced concurrently; EVENT sent immediately on open; settles **only** on the OK frame matching the event id; per-relay 10 s timeout inside the sweep's 25 s tick budget; OK-false rejects with the relay's **verbatim** reason (so pantry now records `auth-required: please authenticate with NIP-42` as `last_error` instead of a misleading timeout); AUTH frames deliberately ignored (the keyless-by-design worker cannot answer NIP-42); all other frames — EVENT/EOSE/NOTICE/junk/foreign OKs — ignored without dying, which is the exact fragility being excised; sockets closed in every path.
- **`workers/cron/index.js`**: publish dep now `publishEventRaw`; SimplePool removed. `sweep.ts` untouched — same injected contract. Worker bundle shrinks **237 KiB → 8.5 KiB** (nostr-tools out entirely).
- **`scripts/debug/pantry-probe/`**: the frame-level diagnostic worker committed as the reference implementation (manual deploy only while debugging; delete the worker after use).

## Tests

10 new, driving scripted frame sequences against fake sockets — mandatorily including **AUTH-then-OK** (the sequence that killed nostr-tools in workerd), plus OK-first, OK-false-verbatim-reason, unrelated/junk frames interleaved, no-OK timeout, never-opens, connection-error, multi-relay partial success (1 OK + 1 reject + 1 timeout = sent), all-fail first-reason propagation, and all-accept. Full suite: **856 passing**.

## After merge

One cron-worker deploy from main (org-pinned, explicit `-c workers/cron/wrangler.toml` — also picks up PR C's `workers_dev=false` + observability riders), then the all-mode acceptance run re-certifies the feature deterministically. Pantry mode remains blocked on the NIP-42 policy decision (relay-side allowlist / service key / drop pantry mode) — separate from this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)