### PR TITLE
Restructure /membership as single Cook+ AI-tools pitch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.675",
+  "version": "4.2.676",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.674",
+  "version": "4.2.675",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.673",
+  "version": "4.2.674",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/app.html
+++ b/src/app.html
@@ -22,19 +22,20 @@
       html:not(.dark) .logo-dark { display: none !important; }
     </style>
 
-    <!-- Override fetch BEFORE anything else loads to intercept __data.json requests in static builds -->
+    <!-- Override fetch BEFORE anything else loads to intercept __data.json
+         requests in packaged Capacitor/static builds. Do NOT treat bare
+         localhost as static — Vite/Wrangler local servers need real data. -->
     <script>
       (function () {
-        // Check if this is a static/Capacitor build (localhost or capacitor protocol)
-        var isStaticBuild =
-          window.location.hostname === 'localhost' ||
-          window.location.hostname === '127.0.0.1' ||
-          window.location.protocol === 'file:' ||
-          window.location.protocol === 'capacitor:';
+        var protocol = window.location.protocol;
+        var isPackagedStatic =
+          protocol === 'file:' ||
+          protocol === 'capacitor:' ||
+          typeof window.Capacitor !== 'undefined';
 
-        if (!isStaticBuild) return;
+        if (!isPackagedStatic) return;
 
-        console.log('[app.html] Setting up early fetch interceptor for static build');
+        console.log('[app.html] Setting up early fetch interceptor for packaged static build');
 
         var originalFetch = window.fetch;
         window.fetch = function (input, init) {

--- a/src/components/CheffyMessenger.svelte
+++ b/src/components/CheffyMessenger.svelte
@@ -486,7 +486,7 @@
       <!-- Membership gate -->
       <div class="cheffy-gate">
         <CheffyAvatar size={72} expression="neutral" variant="character" />
-        <h2>Cheffy is a Pro Kitchen feature</h2>
+        <h2>Cheffy comes with Cook+</h2>
         <p>Ask cooking questions, use what you have, fix a mistake, or turn an idea into dinner.</p>
         <button
           type="button"
@@ -573,20 +573,20 @@
         {#if inExperience && $cheffyConversion}
           <!-- Soft conversion card — shown once the preview turns are
                spent (or when the experience was already used): invites the
-               visitor to create a free kitchen or unlock Kitchen+. Never a
+               visitor to create a free kitchen or unlock Cook+. Never a
                paywall — this is the gentle next step. -->
           <div class="conversion" role="group" aria-label="Keep cooking with Cheffy">
             <CheffyAvatar size={44} expression="happy" variant="character" />
             {#if $cheffyConversion === 'used'}
               <h3 class="conv-title">Cheffy already helped you get started</h3>
               <p class="conv-body">
-                Create your free kitchen to save ideas, or unlock Kitchen+ to keep cooking with
+                Create your free kitchen to save ideas, or unlock Cook+ to keep cooking with
                 Cheffy.
               </p>
             {:else if signedIn}
               <h3 class="conv-title">Keep cooking with Cheffy</h3>
               <p class="conv-body">
-                Kitchen+ gives you Cheffy, Nourish, saved drafts, recipe tools, and more ways to
+                Cook+ gives you Cheffy, Nourish, saved drafts, recipe tools, and more ways to
                 build your kitchen.
               </p>
             {:else}
@@ -602,11 +602,11 @@
                   Create your free kitchen
                 </button>
                 <button type="button" class="conv-secondary" on:click={convUnlockKitchenPlus}>
-                  Unlock Kitchen+
+                  Unlock Cook+
                 </button>
               {:else}
                 <button type="button" class="conv-primary" on:click={convUnlockKitchenPlus}>
-                  Unlock Kitchen+
+                  Unlock Cook+
                 </button>
               {/if}
               <button type="button" class="conv-ghost" on:click={convKeepExploring}>

--- a/src/components/CheffyNoteReview.svelte
+++ b/src/components/CheffyNoteReview.svelte
@@ -523,7 +523,7 @@
            impulse lane. -->
       <div class="nr-gate">
         <CheffyAvatar size={72} expression="neutral" variant="character" />
-        <h2>Cheffy photo review is a Pro Kitchen feature</h2>
+        <h2>Cheffy photo review comes with Cook+</h2>
         <p>Get a drafted reply or a recipe guess for any dish photo on the feed.</p>
         <div class="nr-example">
           <span class="nr-example-label">The kind of reply Cheffy drafts:</span>

--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -44,26 +44,26 @@ if (typeof window !== 'undefined' && 'serviceWorker' in navigator) {
   }
 }
 
-// Intercept fetch requests for __data.json files that don't exist in static builds
-// This is a backup in case the Service Worker doesn't catch the request
+// Intercept fetch requests for __data.json files that don't exist in
+// packaged static/Capacitor builds. Do NOT treat bare localhost as static —
+// `pnpm dev` / `vite preview` / `wrangler pages dev` all serve from localhost
+// and need real SvelteKit __data.json responses for client-side navigation.
 if (typeof window !== 'undefined') {
   const originalFetch = window.fetch;
   window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
-    
-    // For __data.json requests, check if this is a static/Capacitor build
-    // Static builds serve from localhost, web builds serve from zap.cooking
+
     if (url.includes('__data.json')) {
-      const isStaticBuild = window.location.hostname === 'localhost' || 
-                           window.location.hostname === '127.0.0.1' ||
-                           window.location.protocol === 'file:' ||
-                           window.location.protocol === 'capacitor:';
-      
-      if (isStaticBuild) {
-        // In static builds, __data.json doesn't exist - return mock data immediately
-        // Don't even try to fetch as it will log errors
-        console.debug('[hooks] Intercepting __data.json request in static build');
-        
+      const protocol = window.location.protocol;
+      const isPackagedStatic =
+        protocol === 'file:' ||
+        protocol === 'capacitor:' ||
+        // Capacitor Android/iOS WebView may still use http://localhost
+        !!(window as Window & { Capacitor?: unknown }).Capacitor;
+
+      if (isPackagedStatic) {
+        console.debug('[hooks] Intercepting __data.json request in packaged static build');
+
         const mockData = {
           type: 'data',
           nodes: [
@@ -75,15 +75,15 @@ if (typeof window !== 'undefined') {
             }
           ]
         };
-        
+
         return new Response(JSON.stringify(mockData), {
           status: 200,
           headers: { 'Content-Type': 'application/json' }
         });
       }
     }
-    
-    // For all other requests (or web __data.json), use original fetch
+
+    // For all other requests (or web/dev __data.json), use original fetch
     return originalFetch(input, init);
   };
 

--- a/src/lib/stores/cheffyChat.ts
+++ b/src/lib/stores/cheffyChat.ts
@@ -237,7 +237,7 @@ async function dispatchTurn(
     cheffyAnnounce.set(isRecipe ? 'Cheffy shared a recipe.' : 'Cheffy replied.');
 
     // Spend one preview turn. Only invite the visitor to create a free
-    // kitchen or unlock Kitchen+ once all preview turns are used up — let
+    // kitchen or unlock Cook+ once all preview turns are used up — let
     // them actually chat with Cheffy first.
     if (isExperience) {
       recordExperienceTurn();

--- a/src/routes/api/zappy/+server.ts
+++ b/src/routes/api/zappy/+server.ts
@@ -4,7 +4,7 @@
  * no env vars, analytics, or deployed routes break).
  *
  * Uses OpenAI gpt-4.1-mini to power Cheffy, Zap Cooking's kitchen
- * companion. Premium feature for Pro Kitchen members.
+ * companion. Included with any active membership (Cook+, Pro Kitchen, Founders).
  *
  * POST /api/zappy
  *
@@ -91,7 +91,7 @@ export const POST: RequestHandler = async ({ request, platform, cookies, url }) 
       );
     }
 
-    // Membership gate (Cheffy is a Pro Kitchen feature) with a single
+    // Membership gate (Cheffy is included with any active membership) with a single
     // controlled "experience" preview for non-members. Members are
     // unaffected. The experience path is the ONLY way a non-member can
     // reach Cheffy — and only once per device. `experienceGranted` stays
@@ -126,7 +126,7 @@ export const POST: RequestHandler = async ({ request, platform, cookies, url }) 
         const experienceModeAllowed = mode === 'chat' || mode === 'prompt' || mode === 'hungry';
         if (!isExperience || !experienceModeAllowed) {
           return json(
-            { ok: false, error: 'Cheffy is available to Pro Kitchen members.' },
+            { ok: false, error: 'Cheffy is available to Cook+ members.' },
             { status: 403 }
           );
         }
@@ -139,7 +139,7 @@ export const POST: RequestHandler = async ({ request, platform, cookies, url }) 
             {
               ok: false,
               code: 'CHEFFY_EXPERIENCE_USED',
-              error: 'Create your free kitchen or unlock Kitchen+ to keep cooking with Cheffy.'
+              error: 'Create your free kitchen or unlock Cook+ to keep cooking with Cheffy.'
             },
             { status: 429 }
           );

--- a/src/routes/api/zappy/note-review/+server.ts
+++ b/src/routes/api/zappy/note-review/+server.ts
@@ -146,7 +146,7 @@ export const POST: RequestHandler = async ({ request, platform }) => {
     }
     const authPubkey = verification.pubkey;
 
-    // Membership gate (Pro Kitchen) with the non-member credit path.
+    // Membership gate (any active membership) with the non-member credit path.
     // FAILS CLOSED on membership-service problems — see header comment
     // and issue #512 before "fixing" this to match the other endpoints.
     let creditGranted = false;
@@ -192,7 +192,7 @@ export const POST: RequestHandler = async ({ request, platform }) => {
             {
               ok: false,
               code: 'NOT_MEMBER',
-              error: 'Cheffy photo review is available to Pro Kitchen members — or 21 sats a draft.'
+              error: 'Cheffy photo review is available to Cook+ members — or 21 sats a draft.'
             },
             { status: 403 }
           );

--- a/src/routes/api/zappy/scan/+server.ts
+++ b/src/routes/api/zappy/scan/+server.ts
@@ -3,7 +3,7 @@
  * backwards-compatibility; the public feature is "Cheffy").
  *
  * Uses OpenAI GPT-4 Vision to analyze fridge/pantry images and detect ingredients.
- * Premium feature for Pro Kitchen members.
+ * Included with any active membership (Cook+, Pro Kitchen, Founders).
  *
  * POST /api/zappy/scan
  *
@@ -72,14 +72,14 @@ export const POST: RequestHandler = async ({ request, platform }) => {
       );
     }
 
-    // Check membership status (Pro Kitchen feature). Fail CLOSED when
+    // Check membership status (any active membership). Fail CLOSED when
     // gating is enabled but the caller sent no pubkey — otherwise a
     // non-member could reach this paid endpoint just by omitting it.
     const MEMBERSHIP_ENABLED = platform?.env?.MEMBERSHIP_ENABLED || env.MEMBERSHIP_ENABLED;
     if (MEMBERSHIP_ENABLED?.toLowerCase() === 'true') {
       if (!pubkey || typeof pubkey !== 'string' || !pubkey.trim()) {
         return json(
-          { ok: false, error: 'Cheffy is available to Pro Kitchen members.' },
+          { ok: false, error: 'Cheffy is available to Cook+ members.' },
           { status: 403 }
         );
       }
@@ -90,7 +90,7 @@ export const POST: RequestHandler = async ({ request, platform }) => {
           const isActive = await hasActiveMembership(pubkey, API_SECRET);
           if (!isActive) {
             return json(
-              { ok: false, error: 'Cheffy is available to Pro Kitchen members.' },
+              { ok: false, error: 'Cheffy is available to Cook+ members.' },
               { status: 403 }
             );
           }

--- a/src/routes/cheffy/+page.svelte
+++ b/src/routes/cheffy/+page.svelte
@@ -624,7 +624,7 @@
     <div class="flex flex-col min-w-0">
       <div class="flex items-center gap-2 flex-wrap">
         <h1>Cheffy</h1>
-        <span class="pro-chip">Pro Kitchen</span>
+        <span class="pro-chip">Cook+</span>
       </div>
       <p class="text-caption">Your kitchen companion</p>
     </div>
@@ -640,10 +640,10 @@
     <div class="flex flex-col items-center justify-center py-16 gap-6">
       <CheffyAvatar size={84} expression="neutral" variant="character" />
       <div class="text-center max-w-md">
-        <h2 class="mb-2">Cheffy is a Pro Kitchen feature</h2>
+        <h2 class="mb-2">Cheffy comes with Cook+</h2>
         <p class="text-caption mb-6">
           Cheffy is your kitchen companion — ask cooking questions, use what you have, fix a
-          mistake, or turn an idea into dinner. Unlock him with a Pro Kitchen membership.
+          mistake, or turn an idea into dinner. Unlock him with a Cook+ membership.
         </p>
         <Button on:click={() => goto('/membership')}>View Membership Options</Button>
       </div>

--- a/src/routes/explore/+page.svelte
+++ b/src/routes/explore/+page.svelte
@@ -494,11 +494,11 @@
               class="text-xs uppercase tracking-widest font-semibold mb-2"
               style="color: rgba(249,115,22,0.9);"
             >
-              Kitchen+
+              Cook+
             </p>
             <h3 class="text-lg font-bold text-white">Unlock your kitchen</h3>
             <p class="text-sm mt-1.5 text-gray-300">AI tools, private groups, and more.</p>
-            <a href="/membership" class="membership-teaser-cta"> Enter the Kitchen+ </a>
+            <a href="/membership" class="membership-teaser-cta"> Enter Cook+ </a>
           </div>
         </section>
       {/if}

--- a/src/routes/founders/+page.server.ts
+++ b/src/routes/founders/+page.server.ts
@@ -31,7 +31,10 @@ const FALLBACK_FOUNDERS = PRIORITY_FOUNDERS.map((pubkey, idx) => ({
   joined: null
 }));
 
-export const load: PageServerLoad = async ({ fetch, platform }) => {
+export const load: PageServerLoad = async ({ fetch, platform, setHeaders }) => {
+  // Never let CDN/browser cache an empty founders payload for SPA navigations.
+  setHeaders({ 'cache-control': 'private, no-store' });
+
   // Cloudflare uses platform.env, local dev uses $env
   const API_SECRET = platform?.env?.RELAY_API_SECRET || env.RELAY_API_SECRET;
 

--- a/src/routes/founders/+page.server.ts
+++ b/src/routes/founders/+page.server.ts
@@ -37,7 +37,7 @@ export const load: PageServerLoad = async ({ fetch, platform }) => {
 
   if (!API_SECRET) {
     console.warn('RELAY_API_SECRET not found, using fallback founders data');
-    return { founders: FALLBACK_FOUNDERS };
+    return { founders: FALLBACK_FOUNDERS, foundersAvailable: true };
   }
 
   try {
@@ -47,7 +47,16 @@ export const load: PageServerLoad = async ({ fetch, platform }) => {
       }
     });
 
+    if (!res.ok) {
+      console.error('Founders members API returned', res.status);
+      return { founders: [], foundersAvailable: false };
+    }
+
     const data = await res.json();
+    if (!data || !Array.isArray(data.members)) {
+      console.error('Founders members API returned unexpected payload');
+      return { founders: [], foundersAvailable: false };
+    }
 
     // Filter for active Genesis Founders and get only priority ones
     const allFounders = data.members
@@ -131,9 +140,9 @@ export const load: PageServerLoad = async ({ fetch, platform }) => {
       }))
     ];
 
-    return { founders };
+    return { founders, foundersAvailable: true };
   } catch (err) {
     console.error('Failed to load founders:', err);
-    return { founders: [] };
+    return { founders: [], foundersAvailable: false };
   }
 };

--- a/src/routes/founders/+page.svelte
+++ b/src/routes/founders/+page.svelte
@@ -21,13 +21,16 @@
     joined: string | null;
   }
 
-  // CustomAvatar and CustomName handle their own profile loading
-  let founders: Founder[] = (data.founders || []).map((f: any) => ({
+  // CustomAvatar and CustomName handle their own profile loading.
+  // Keep this reactive to `data` — a one-shot assignment freezes the first
+  // value and shows an empty list on client-side navigations.
+  $: founders = (data.founders || []).map((f: any) => ({
     number: f.number,
     pubkey: f.pubkey,
     tier: f.tier,
     joined: f.joined
   }));
+  $: foundersAvailable = data?.foundersAvailable === true;
 </script>
 
 <svelte:head>
@@ -43,7 +46,11 @@
     <h2>🔥 Founders Club</h2>
     <p class="subtitle">The first believers who made this possible</p>
 
-    {#if founders.length === 0}
+    {#if !foundersAvailable}
+      <div class="empty-state">
+        <p>Founders list is temporarily unavailable.</p>
+      </div>
+    {:else if founders.length === 0}
       <div class="empty-state">
         <p>No founders found.</p>
       </div>

--- a/src/routes/founders/+page.svelte
+++ b/src/routes/founders/+page.svelte
@@ -30,7 +30,11 @@
     tier: f.tier,
     joined: f.joined
   }));
-  $: foundersAvailable = data?.foundersAvailable === true;
+  // Prefer the explicit load flag; also accept a non-empty list so a stale
+  // client never treats real founders data as "unavailable".
+  $: foundersAvailable =
+    data?.foundersAvailable === true ||
+    (data?.foundersAvailable !== false && founders.length > 0);
 </script>
 
 <svelte:head>

--- a/src/routes/membership/+page.server.ts
+++ b/src/routes/membership/+page.server.ts
@@ -29,7 +29,7 @@ export const load: PageServerLoad = async ({ fetch, platform }) => {
 
   if (!API_SECRET) {
     console.error('RELAY_API_SECRET not found');
-    return { founders: [], error: 'Not configured' };
+    return { founders: [], foundersAvailable: false, error: 'Not configured' };
   }
 
   try {
@@ -39,7 +39,16 @@ export const load: PageServerLoad = async ({ fetch, platform }) => {
       }
     });
 
+    if (!res.ok) {
+      console.error('Founders members API returned', res.status);
+      return { founders: [], foundersAvailable: false, error: 'Failed to load' };
+    }
+
     const data = await res.json();
+    if (!data || !Array.isArray(data.members)) {
+      console.error('Founders members API returned unexpected payload');
+      return { founders: [], foundersAvailable: false, error: 'Failed to load' };
+    }
 
     // Filter for active Genesis Founders (both 'genesis_' and 'founder' prefixes)
     const allFounders = data.members
@@ -110,11 +119,11 @@ export const load: PageServerLoad = async ({ fetch, platform }) => {
       }))
     ];
 
-    return { founders };
+    return { founders, foundersAvailable: true };
 
   } catch (err) {
     console.error('Failed to load founders:', err);
-    return { founders: [], error: 'Failed to load' };
+    return { founders: [], foundersAvailable: false, error: 'Failed to load' };
   }
 };
 

--- a/src/routes/membership/+page.server.ts
+++ b/src/routes/membership/+page.server.ts
@@ -23,7 +23,10 @@ const PRIORITY_FOUNDERS = PRIORITY_FOUNDER_NPUBS.map(npub => {
   }
 }).filter(Boolean) as string[];
 
-export const load: PageServerLoad = async ({ fetch, platform }) => {
+export const load: PageServerLoad = async ({ fetch, platform, setHeaders }) => {
+  // Never let CDN/browser cache an empty founders payload for SPA navigations.
+  setHeaders({ 'cache-control': 'private, no-store' });
+
   // Cloudflare uses platform.env, local dev uses $env
   const API_SECRET = platform?.env?.RELAY_API_SECRET || env.RELAY_API_SECRET;
 

--- a/src/routes/membership/+page.svelte
+++ b/src/routes/membership/+page.svelte
@@ -821,7 +821,9 @@
 
     {#if showFoundersList}
       <section class="genesis-founders-link">
-        <a href="/founders" class="founders-link-button"> View Founders Club Members </a>
+        <a href="/founders" class="founders-link-button" data-sveltekit-reload>
+          View Founders Club Members
+        </a>
       </section>
     {/if}
 

--- a/src/routes/membership/+page.svelte
+++ b/src/routes/membership/+page.svelte
@@ -73,11 +73,14 @@
   // Genesis founders constants
   const TOTAL_GENESIS_SPOTS = 21;
 
-  // Track actual founders count from server
-  const actualFoundersCount = data.founders?.length || 0;
-
-  $: spotsTaken = actualFoundersCount;
-  $: spotsRemaining = TOTAL_GENESIS_SPOTS - spotsTaken;
+  // Reactive to `data` so CSR navigations pick up load results (a one-shot
+  // `const count = data.founders?.length || 0` freezes the initial value,
+  // which is often 0 before/without a successful load).
+  // `foundersAvailable` distinguishes a real empty list from a failed load —
+  // never render "0 taken" as a placeholder for unavailable data.
+  $: foundersAvailable = data?.foundersAvailable === true;
+  $: spotsTaken = foundersAvailable ? (data.founders?.length ?? 0) : null;
+  $: spotsRemaining = spotsTaken === null ? null : TOTAL_GENESIS_SPOTS - spotsTaken;
   $: isSoldOut = spotsRemaining === 0;
   $: isLoggedIn = $userPublickey && $userPublickey.length > 0;
 
@@ -684,7 +687,11 @@
           <div class="genesis-hero-text">
             <h2>Founders Club</h2>
             <p class="genesis-hero-countdown">
-              {spotsTaken} of {TOTAL_GENESIS_SPOTS} seats taken
+              {#if spotsTaken === null}
+                {TOTAL_GENESIS_SPOTS} seats
+              {:else}
+                {spotsTaken} of {TOTAL_GENESIS_SPOTS} seats taken
+              {/if}
             </p>
           </div>
           <div class="genesis-hero-arrow">
@@ -744,7 +751,9 @@
               <ul class="benefit-list">
                 <li>
                   <span class="checkmark">✓</span>
-                  <span class="feature-text">Founders Club badge (#{spotsTaken + 1}-21)</span>
+                  <span class="feature-text">
+                    Founders Club badge (#{spotsTaken === null ? '?' : spotsTaken + 1}-21)
+                  </span>
                 </li>
                 <li>
                   <span class="checkmark">✓</span>
@@ -780,9 +789,13 @@
 
           <div class="genesis-checkout-urgency">
             <p>
-              <strong>{spotsTaken} of {TOTAL_GENESIS_SPOTS} seats taken</strong>
-              {#if spotsRemaining > 0}
-                — {spotsRemaining} remaining
+              {#if spotsTaken === null}
+                <strong>{TOTAL_GENESIS_SPOTS} seats</strong>
+              {:else}
+                <strong>{spotsTaken} of {TOTAL_GENESIS_SPOTS} seats taken</strong>
+                {#if spotsRemaining !== null && spotsRemaining > 0}
+                  — {spotsRemaining} remaining
+                {/if}
               {/if}
             </p>
           </div>

--- a/src/routes/membership/+page.svelte
+++ b/src/routes/membership/+page.svelte
@@ -22,14 +22,45 @@
   // Pricing data
   const cookAnnualPrice = 49;
   const cookMonthlyPrice = 4.99;
-  const proAnnualPrice = 89;
-  const proMonthlyPrice = 8.99;
 
   $: cookMonthlyEquivalent = (cookAnnualPrice / 12).toFixed(2);
-  $: proMonthlyEquivalent = (proAnnualPrice / 12).toFixed(2);
   $: savingsPercent = Math.round(
     ((cookMonthlyPrice * 12 - cookAnnualPrice) / (cookMonthlyPrice * 12)) * 100
   );
+
+  let openFaqIndex: number | null = null;
+
+  const faqs: { question: string; answer: string }[] = [
+    {
+      question: 'How many Cheffy messages do I get?',
+      answer:
+        'Cook+ includes 300 Cheffy messages per month. That is a generous monthly allowance for everyday cooking help — ask questions, use what you have, or turn an idea into dinner.'
+    },
+    {
+      question: 'Can I cancel anytime?',
+      answer:
+        'Yes. Cancel anytime from your membership page (card members use the billing portal; Lightning members contact support). You keep access through the end of your current billing period.'
+    },
+    {
+      question: 'Bitcoin or card — which should I use?',
+      answer:
+        'Both work. Bitcoin via Lightning is preferred and often a bit cheaper; cards are accepted through Stripe if that is easier for you. You choose at checkout.'
+    },
+    {
+      question: 'What happens to my recipes if I cancel?',
+      answer:
+        'Your recipes stay yours. Content you published remains on the network under your keys. You would lose Cook+ tools and member perks after your paid period ends, not the recipes you already saved or shared.'
+    },
+    {
+      question: 'How does billing work?',
+      answer:
+        'Choose annual ($49/year) or monthly ($4.99/month). Annual is the better value. Subscriptions renew for the period you picked unless you cancel before renewal.'
+    }
+  ];
+
+  function toggleFaq(index: number) {
+    openFaqIndex = openFaqIndex === index ? null : index;
+  }
 
   function handlePeriodChange(newPeriod: 'annual' | 'monthly') {
     billingPeriod = newPeriod;
@@ -164,7 +195,6 @@
   import { onMount } from 'svelte';
   import CookingPotIcon from 'phosphor-svelte/lib/CookingPot';
   import StarIcon from 'phosphor-svelte/lib/Star';
-  import ShieldCheckIcon from 'phosphor-svelte/lib/ShieldCheck';
   import LightningIcon from 'phosphor-svelte/lib/Lightning';
   import RobotIcon from 'phosphor-svelte/lib/Robot';
   import StorefrontIcon from 'phosphor-svelte/lib/Storefront';
@@ -203,27 +233,25 @@
   // Perks by tier
   const TIER_PERKS: Record<string, { icon: typeof CookingPotIcon; label: string }[]> = {
     cook_plus: [
-      { icon: RobotIcon, label: 'AI Recipe Extraction' },
-      { icon: ShieldCheckIcon, label: 'Verified NIP-05 Identity' },
+      { icon: RobotIcon, label: 'Sous Chef & Nourish' },
+      { icon: CookingPotIcon, label: 'Cheffy — Kitchen Companion' },
       { icon: StorefrontIcon, label: 'Market Access' },
-      { icon: StarIcon, label: 'Priority Relay Access' }
+      { icon: StarIcon, label: 'Member Badge & Collections' }
     ],
     pro_kitchen: [
-      { icon: RobotIcon, label: 'AI Recipe Extraction' },
+      { icon: RobotIcon, label: 'Sous Chef & Nourish' },
+      { icon: CookingPotIcon, label: 'Cheffy — Kitchen Companion' },
       { icon: LightningIcon, label: 'Lightning-Gated Recipes' },
-      { icon: ShieldCheckIcon, label: 'Verified NIP-05 Identity' },
       { icon: StorefrontIcon, label: 'Market Access' },
-      { icon: StarIcon, label: 'Priority Relay Access' },
-      { icon: CookingPotIcon, label: 'Cheffy — Your Kitchen Companion' }
+      { icon: StarIcon, label: 'Member Badge & Collections' }
     ],
     founders: [
       { icon: CrownIcon, label: 'Lifetime Access — All Features' },
-      { icon: RobotIcon, label: 'AI Recipe Extraction' },
+      { icon: RobotIcon, label: 'Sous Chef & Nourish' },
+      { icon: CookingPotIcon, label: 'Cheffy — Kitchen Companion' },
       { icon: LightningIcon, label: 'Lightning-Gated Recipes' },
-      { icon: ShieldCheckIcon, label: 'Verified NIP-05 Identity' },
       { icon: StorefrontIcon, label: 'Market Access' },
-      { icon: StarIcon, label: 'Priority Relay Access' },
-      { icon: CookingPotIcon, label: 'Cheffy — Your Kitchen Companion' }
+      { icon: StarIcon, label: 'Founders Recognition' }
     ]
   };
 
@@ -303,21 +331,25 @@
   }
 
   function handleCardClick() {
-    if (isSoldOut) return;
     showFoundersList = !showFoundersList;
   }
 
   function goToCookPlusCheckout() {
     goto(`/membership/cook-plus-checkout?period=${billingPeriod}`);
   }
-
-  function goToProKitchenCheckout() {
-    goto(`/membership/pro-kitchen-checkout?period=${billingPeriod}`);
-  }
 </script>
 
 <svelte:head>
-  <title>Membership - zap.cooking</title>
+  <title>Cook+ Membership — AI Cooking Tools | Zap Cooking</title>
+  <meta
+    name="description"
+    content="Sous Chef pulls recipes from any link or photo. Nourish scores what they do for your body. Cheffy answers your kitchen questions with generous monthly credits. One membership unlocks all of it."
+  />
+  <meta property="og:title" content="Cook+ Membership — AI Cooking Tools | Zap Cooking" />
+  <meta
+    property="og:description"
+    content="Sous Chef pulls recipes from any link or photo. Nourish scores what they do for your body. Cheffy answers your kitchen questions with generous monthly credits. One membership unlocks all of it."
+  />
 </svelte:head>
 
 <div class="membership-page">
@@ -449,188 +481,31 @@
     <section class="hero">
       <h1>Your Kitchen, Supercharged</h1>
       <p>
-        AI-powered recipe tools, a private Nostr relay, and Bitcoin-native payments — all in one
-        membership.
+        Sous Chef pulls recipes from any link or photo. Nourish scores what they do for your body.
+        Cheffy answers your kitchen questions — with generous monthly credits included. One
+        membership unlocks all of it.
       </p>
     </section>
 
     <!-- Value Props Row -->
     <section class="value-props">
-      <div class="value-prop">
+      <a href="/souschef" class="value-prop">
         <span class="value-prop-icon">✨</span>
-        <span class="value-prop-label">AI Recipe Tools</span>
-      </div>
-      <div class="value-prop">
-        <span class="value-prop-icon">📡</span>
-        <span class="value-prop-label">Private Relay</span>
-      </div>
-      <div class="value-prop">
-        <span class="value-prop-icon">⚡</span>
-        <span class="value-prop-label">Bitcoin Payments</span>
-      </div>
+        <span class="value-prop-label">Sous Chef</span>
+      </a>
+      <a href="/nourish" class="value-prop">
+        <span class="value-prop-icon">🌱</span>
+        <span class="value-prop-label">Nourish</span>
+      </a>
+      <a href="/cheffy" class="value-prop">
+        <span class="value-prop-icon">🧑‍🍳</span>
+        <span class="value-prop-label">Cheffy</span>
+      </a>
       <div class="value-prop">
         <span class="value-prop-icon">🔓</span>
         <span class="value-prop-label">Own Your Data</span>
       </div>
     </section>
-
-    <!-- Founders Club Hero Section -->
-    <section class="genesis-founders-hero">
-      <div
-        class="genesis-hero-card {isSoldOut ? 'sold-out' : ''}"
-        on:click={handleCardClick}
-        on:keydown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            handleCardClick();
-          }
-        }}
-        role="button"
-        tabindex="0"
-        aria-expanded={showFoundersList}
-        aria-label="Toggle Founders Club list"
-      >
-        <div class="genesis-hero-content">
-          <div class="genesis-hero-icon">🔥</div>
-          <div class="genesis-hero-text">
-            <h2>Founders Club</h2>
-            <p class="genesis-hero-countdown">
-              {spotsTaken}/{TOTAL_GENESIS_SPOTS} taken
-            </p>
-          </div>
-          <div class="genesis-hero-arrow">
-            <svg
-              class="arrow-icon {showFoundersList ? 'rotated' : ''}"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-            >
-              <path d="M6 9l6 6 6-6" />
-            </svg>
-          </div>
-        </div>
-        {#if spotsRemaining > 0}
-          <div class="genesis-hero-progress">
-            <div class="progress-bar">
-              <div
-                class="progress-fill"
-                style="width: {(spotsTaken / TOTAL_GENESIS_SPOTS) * 100}%"
-              ></div>
-            </div>
-            <p class="progress-text">{spotsRemaining} spots remaining</p>
-            <p class="urgency-text">These spots won't last — claim yours before they're gone</p>
-          </div>
-        {/if}
-        {#if !showFoundersList}
-          <p class="card-hint">Click to learn more</p>
-        {/if}
-      </div>
-    </section>
-
-    <!-- Founders Club Checkout Section (shown when expanded) -->
-    {#if showFoundersList && !isSoldOut}
-      <section class="genesis-checkout-section">
-        <div class="genesis-checkout-card">
-          <div class="genesis-checkout-header">
-            <h3>Join Founders Club</h3>
-            <p class="genesis-checkout-price">$210 <span>lifetime</span></p>
-          </div>
-
-          <div class="genesis-checkout-benefits">
-            <h4>What you get:</h4>
-
-            <!-- Lifetime Membership -->
-            <div class="benefit-section">
-              <h5 class="section-header">Lifetime Membership</h5>
-              <ul class="benefit-list">
-                <li>
-                  <span class="checkmark">✓</span>
-                  <span class="feature-text">Lifetime Pro Kitchen membership (never expires)</span>
-                </li>
-                <li>
-                  <span class="checkmark">✓</span>
-                  <span class="feature-text">All future Pro Kitchen features included</span>
-                </li>
-              </ul>
-            </div>
-
-            <!-- Section Divider -->
-            <div class="section-divider"></div>
-
-            <!-- Founders Club Exclusive -->
-            <div class="benefit-section">
-              <h5 class="section-header">Founders Club Exclusive</h5>
-              <ul class="benefit-list">
-                <li>
-                  <span class="checkmark">✓</span>
-                  <span class="feature-text">Founders Club badge (#{spotsTaken + 1}-21)</span>
-                </li>
-                <li>
-                  <span class="checkmark">✓</span>
-                  <span class="feature-text">Name permanently displayed as a Founder</span>
-                </li>
-              </ul>
-            </div>
-
-            <!-- Section Divider -->
-            <div class="section-divider"></div>
-
-            <!-- Access & Features -->
-            <div class="benefit-section">
-              <h5 class="section-header">Access & Features</h5>
-              <ul class="benefit-list">
-                <li>
-                  <span class="checkmark">✓</span>
-                  <span class="feature-text">Verified @zap.cooking NIP-05 identity</span>
-                </li>
-                <li>
-                  <span class="checkmark">✓</span>
-                  <span class="feature-text">Access to pantry.zap.cooking relay</span>
-                </li>
-                <li>
-                  <span class="checkmark">✓</span>
-                  <span class="feature-text">Nourish recipe intelligence</span>
-                </li>
-                <li>
-                  <span class="checkmark">✓</span>
-                  <span class="feature-text">Buy and sell on the Market</span>
-                </li>
-              </ul>
-            </div>
-          </div>
-
-          <div class="genesis-checkout-urgency">
-            <p>Only <strong>{spotsRemaining} of {TOTAL_GENESIS_SPOTS} spots remaining</strong></p>
-          </div>
-
-          <button
-            class="genesis-claim-button"
-            on:click={handleClaimSpot}
-            disabled={isCheckingOut || isSoldOut || !isLoggedIn}
-          >
-            {#if !isLoggedIn}
-              Login to Claim Your Spot
-            {:else if isCheckingOut}
-              Processing...
-            {:else if isSoldOut}
-              Sold Out
-            {:else}
-              Claim Your Spot
-            {/if}
-          </button>
-        </div>
-      </section>
-    {/if}
-
-    <!-- Founders Club Link (shown when expanded) -->
-    {#if showFoundersList}
-      <section class="genesis-founders-link">
-        <a href="/founders" class="founders-link-button"> View Founders Club Members </a>
-      </section>
-    {/if}
 
     <!-- Active Membership Management (legacy card, hidden when API dashboard shows) -->
     {#if hasActiveCardMembership && currentMembership && !isActiveMemberApi}
@@ -670,13 +545,13 @@
       </section>
     {/if}
 
-    <!-- Membership Tiers Section -->
+    <!-- Membership Plan -->
     <section class="tiers" id="pricing">
-      <h2 class="section-label">Choose Your Plan</h2>
+      <h2 class="section-label">Cook+ Membership</h2>
 
       <PricingToggle period={billingPeriod} onPeriodChange={handlePeriodChange} {savingsPercent} />
 
-      <div class="tiers-grid">
+      <div class="tiers-grid single-tier">
         <div class="tier-card cook-plus">
           <h3>Cook+</h3>
           <div class="price">
@@ -699,26 +574,35 @@
           </div>
 
           <div class="tier-benefits">
-            <!-- Premium Tools -->
             <div class="benefit-section">
-              <h4 class="section-header">Premium Tools</h4>
+              <h4 class="section-header">AI Cooking Tools</h4>
               <ul class="benefit-list">
                 <li>
                   <span class="feature-icon">✨</span>
                   <div class="feature-content">
                     <a href="/souschef" class="feature-link"
-                      >Sous Chef - Extract recipes from any link, photo, or pasted text instantly</a
+                      >Sous Chef — Pull recipes from any link, photo, or pasted text instantly</a
                     >
-                    <span class="feature-subtext">Save time - let it do the work</span>
+                    <span class="feature-subtext">Save time — let it do the work</span>
                   </div>
                 </li>
                 <li>
                   <span class="feature-icon">🌱</span>
                   <div class="feature-content">
                     <a href="/nourish" class="feature-link"
-                      >Nourish - Recipe intelligence scores for gut health, protein, and real food</a
+                      >Nourish — See how recipes score for gut health, protein, and real food</a
                     >
                     <span class="feature-subtext">Understand what your food is doing for you</span>
+                  </div>
+                </li>
+                <li>
+                  <span class="feature-icon">🧑‍🍳</span>
+                  <div class="feature-content">
+                    <a href="/cheffy" class="feature-link"
+                      >Cheffy — Ask cooking questions, use what you have, or turn an idea into
+                      dinner</a
+                    >
+                    <span class="feature-subtext">Generous monthly credits included</span>
                   </div>
                 </li>
               </ul>
@@ -726,18 +610,9 @@
 
             <div class="section-divider"></div>
 
-            <!-- Community & Content -->
             <div class="benefit-section">
               <h4 class="section-header">Community & Content</h4>
               <ul class="benefit-list">
-                <li>
-                  <span class="checkmark">✓</span>
-                  <span class="feature-text">Verified @zap.cooking NIP-05 identity</span>
-                </li>
-                <li>
-                  <span class="checkmark">✓</span>
-                  <span class="feature-text">Access to pantry.zap.cooking private relay</span>
-                </li>
                 <li>
                   <span class="checkmark">✓</span>
                   <a href="/market" class="feature-link">Buy and sell on the Market</a>
@@ -750,12 +625,19 @@
                   <span class="checkmark">✓</span>
                   <span class="feature-text">Exclusive Cook+ member badge</span>
                 </li>
+                <li>
+                  <span class="checkmark">✓</span>
+                  <span class="feature-text">Verified @zap.cooking NIP-05 identity</span>
+                </li>
+                <li>
+                  <span class="checkmark">✓</span>
+                  <span class="feature-text">Access to pantry.zap.cooking private relay</span>
+                </li>
               </ul>
             </div>
 
             <div class="section-divider"></div>
 
-            <!-- Member Perks -->
             <div class="benefit-section">
               <h4 class="section-header">Member Perks</h4>
               <ul class="benefit-list">
@@ -771,111 +653,7 @@
             </div>
           </div>
 
-          <button class="tier-button" on:click={goToCookPlusCheckout}>Join Cook+</button>
-          <div class="payment-indicators">
-            <span>⚡ Bitcoin preferred</span>
-            <span class="separator">•</span>
-            <span>💳 Card accepted</span>
-          </div>
-        </div>
-
-        <div class="tier-card pro-kitchen">
-          <div class="popular-badge-floating">Most Popular</div>
-          <h3>Pro Kitchen</h3>
-          <div class="price">
-            <div class="price-container">
-              {#if billingPeriod === 'annual'}
-                $89<span>/year</span>
-              {:else}
-                $8.99<span>/mo</span>
-              {/if}
-            </div>
-            <div class="price-subtext">
-              {#if billingPeriod === 'annual'}
-                That's just ${proMonthlyEquivalent}/month
-              {:else}
-                <button class="annual-link" on:click={switchToAnnual}>
-                  or $89/year — save with annual
-                </button>
-              {/if}
-            </div>
-          </div>
-
-          <div class="tier-benefits">
-            <!-- Includes All Cook+ Features -->
-            <div class="benefit-section">
-              <h4 class="section-header">Includes All Cook+ Features</h4>
-              <ul class="benefit-list">
-                <li>
-                  <span class="checkmark">✓</span>
-                  <span class="feature-text muted-text"
-                    >Everything in Cook+ (Sous Chef, Nourish, NIP-05 identity, Market access, pantry
-                    relay, collections, badge, early access, voting)</span
-                  >
-                </li>
-              </ul>
-            </div>
-
-            <div class="section-divider"></div>
-
-            <!-- Pro Kitchen Exclusive Features -->
-            <div class="benefit-section">
-              <h4 class="section-header">Pro Kitchen Exclusive Features</h4>
-              <ul class="benefit-list">
-                <li>
-                  <span class="checkmark">✓</span>
-                  <a href="/premium" class="feature-link">Lightning-gated recipes</a>
-                </li>
-                <li>
-                  <span class="checkmark">✓</span>
-                  <span class="feature-text">Priority recipe promotion</span>
-                </li>
-              </ul>
-            </div>
-
-            <div class="section-divider"></div>
-
-            <!-- Kitchen Tools -->
-            <div class="benefit-section">
-              <h4 class="section-header">Kitchen Tools</h4>
-              <ul class="benefit-list">
-                <li>
-                  <span class="feature-icon">🧑‍🍳</span>
-                  <div class="feature-content">
-                    <a href="/cheffy" class="feature-link"
-                      >Cheffy - Ask cooking questions, use what you have, fix a mistake, or turn an
-                      idea into dinner</a
-                    >
-                    <span class="feature-subtext">Your kitchen companion</span>
-                  </div>
-                </li>
-                <li>
-                  <span class="feature-icon">📸</span>
-                  <div class="feature-content">
-                    <span class="feature-text"
-                      >Cheffy photo review - draft a reply or recipe from any dish photo on the feed</span
-                    >
-                  </div>
-                </li>
-                <li>
-                  <span class="feature-icon">✨</span>
-                  <div class="feature-content">
-                    <span class="feature-text">Sous Chef features</span>
-                  </div>
-                </li>
-                <li>
-                  <span class="feature-icon">🌱</span>
-                  <div class="feature-content">
-                    <span class="feature-text">Nourish recipe intelligence</span>
-                  </div>
-                </li>
-              </ul>
-            </div>
-          </div>
-
-          <button class="tier-button primary" on:click={goToProKitchenCheckout}
-            >Join Pro Kitchen</button
-          >
+          <button class="tier-button primary" on:click={goToCookPlusCheckout}>Join Cook+</button>
           <div class="payment-indicators">
             <span>⚡ Bitcoin preferred</span>
             <span class="separator">•</span>
@@ -884,8 +662,183 @@
         </div>
       </div>
     </section>
+
+    <!-- Founders Club story -->
+    <section class="genesis-founders-hero">
+      <div
+        class="genesis-hero-card founders-story {isSoldOut ? 'sold-out' : ''}"
+        on:click={handleCardClick}
+        on:keydown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleCardClick();
+          }
+        }}
+        role="button"
+        tabindex="0"
+        aria-expanded={showFoundersList}
+        aria-label="Toggle Founders Club details"
+      >
+        <div class="genesis-hero-content">
+          <div class="genesis-hero-icon">🔥</div>
+          <div class="genesis-hero-text">
+            <h2>Founders Club</h2>
+            <p class="genesis-hero-countdown">
+              {spotsTaken} of {TOTAL_GENESIS_SPOTS} seats taken
+            </p>
+          </div>
+          <div class="genesis-hero-arrow">
+            <svg
+              class="arrow-icon {showFoundersList ? 'rotated' : ''}"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <path d="M6 9l6 6 6-6" />
+            </svg>
+          </div>
+        </div>
+        <p class="founders-story-copy">
+          Founders Club is a capped lifetime membership — {TOTAL_GENESIS_SPOTS} seats total — for
+          people who want to back Zap Cooking early and keep Pro Kitchen access for life. Seats are
+          limited by that hard cap, not by a countdown.
+        </p>
+        {#if !showFoundersList}
+          <p class="card-hint">{isSoldOut ? 'Sold out — view founders' : 'Click to learn more'}</p>
+        {/if}
+      </div>
+    </section>
+
+    {#if showFoundersList && !isSoldOut}
+      <section class="genesis-checkout-section">
+        <div class="genesis-checkout-card">
+          <div class="genesis-checkout-header">
+            <h3>Join Founders Club</h3>
+            <p class="genesis-checkout-price">$210 <span>lifetime</span></p>
+          </div>
+
+          <div class="genesis-checkout-benefits">
+            <h4>What you get:</h4>
+
+            <div class="benefit-section">
+              <h5 class="section-header">Lifetime Membership</h5>
+              <ul class="benefit-list">
+                <li>
+                  <span class="checkmark">✓</span>
+                  <span class="feature-text">Lifetime Pro Kitchen membership (never expires)</span>
+                </li>
+                <li>
+                  <span class="checkmark">✓</span>
+                  <span class="feature-text">All future Pro Kitchen features included</span>
+                </li>
+              </ul>
+            </div>
+
+            <div class="section-divider"></div>
+
+            <div class="benefit-section">
+              <h5 class="section-header">Founders Club Exclusive</h5>
+              <ul class="benefit-list">
+                <li>
+                  <span class="checkmark">✓</span>
+                  <span class="feature-text">Founders Club badge (#{spotsTaken + 1}-21)</span>
+                </li>
+                <li>
+                  <span class="checkmark">✓</span>
+                  <span class="feature-text">Name permanently displayed as a Founder</span>
+                </li>
+              </ul>
+            </div>
+
+            <div class="section-divider"></div>
+
+            <div class="benefit-section">
+              <h5 class="section-header">Access & Features</h5>
+              <ul class="benefit-list">
+                <li>
+                  <span class="checkmark">✓</span>
+                  <span class="feature-text">Sous Chef, Nourish, and Cheffy</span>
+                </li>
+                <li>
+                  <span class="checkmark">✓</span>
+                  <a href="/market" class="feature-link">Buy and sell on the Market</a>
+                </li>
+                <li>
+                  <span class="checkmark">✓</span>
+                  <span class="feature-text">Verified @zap.cooking NIP-05 identity</span>
+                </li>
+                <li>
+                  <span class="checkmark">✓</span>
+                  <span class="feature-text">Access to pantry.zap.cooking relay</span>
+                </li>
+              </ul>
+            </div>
+          </div>
+
+          <div class="genesis-checkout-urgency">
+            <p>
+              <strong>{spotsTaken} of {TOTAL_GENESIS_SPOTS} seats taken</strong>
+              {#if spotsRemaining > 0}
+                — {spotsRemaining} remaining
+              {/if}
+            </p>
+          </div>
+
+          <button
+            class="genesis-claim-button"
+            on:click={handleClaimSpot}
+            disabled={isCheckingOut || isSoldOut || !isLoggedIn}
+          >
+            {#if !isLoggedIn}
+              Login to Claim Your Spot
+            {:else if isCheckingOut}
+              Processing...
+            {:else if isSoldOut}
+              Sold Out
+            {:else}
+              Claim Your Spot
+            {/if}
+          </button>
+        </div>
+      </section>
+    {/if}
+
+    {#if showFoundersList}
+      <section class="genesis-founders-link">
+        <a href="/founders" class="founders-link-button"> View Founders Club Members </a>
+      </section>
+    {/if}
+
+    <!-- FAQ -->
+    <section class="membership-faq" id="faq">
+      <h2 class="section-label">Frequently Asked Questions</h2>
+      <div class="faq-list">
+        {#each faqs as faq, index}
+          <div class="faq-item" class:open={openFaqIndex === index}>
+            <button
+              type="button"
+              class="faq-question"
+              aria-expanded={openFaqIndex === index}
+              on:click={() => toggleFaq(index)}
+            >
+              <span>{faq.question}</span>
+              <span class="faq-chevron" aria-hidden="true">{openFaqIndex === index ? '−' : '+'}</span>
+            </button>
+            {#if openFaqIndex === index}
+              <div class="faq-answer" role="region">
+                <p>{faq.answer}</p>
+              </div>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    </section>
   {/if}
 </div>
+
 
 <style>
   /* Member Dashboard */
@@ -1537,6 +1490,11 @@
     margin: 0 auto;
   }
 
+  .tiers-grid.single-tier {
+    max-width: 420px;
+    grid-template-columns: 1fr;
+  }
+
   .tier-card {
     background: var(--color-bg-secondary);
     border: 2px solid var(--color-input-border);
@@ -1881,6 +1839,12 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    text-decoration: none;
+    color: inherit;
+  }
+
+  a.value-prop:hover .value-prop-label {
+    color: var(--color-primary, #f97316);
   }
 
   .value-prop-icon {
@@ -1891,6 +1855,67 @@
     font-size: 0.95rem;
     font-weight: 500;
     color: var(--color-text-secondary);
+  }
+
+  .founders-story-copy {
+    color: var(--color-text-secondary);
+    font-size: 0.95rem;
+    line-height: 1.5;
+    margin: 0.75rem 0 0 0;
+    position: relative;
+    z-index: 1;
+    text-align: left;
+  }
+
+  .membership-faq {
+    max-width: 720px;
+    margin: 2.5rem auto 1rem;
+  }
+
+  .faq-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .faq-item {
+    border: 1px solid var(--color-input-border);
+    border-radius: 12px;
+    background: var(--color-bg-secondary);
+    overflow: hidden;
+  }
+
+  .faq-question {
+    width: 100%;
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1rem 1.15rem;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    text-align: left;
+    color: var(--color-text-primary);
+    font-size: 1rem;
+    font-weight: 600;
+  }
+
+  .faq-chevron {
+    color: var(--color-text-secondary);
+    font-size: 1.25rem;
+    line-height: 1;
+  }
+
+  .faq-answer {
+    padding: 0 1.15rem 1.15rem;
+    color: var(--color-text-secondary);
+    font-size: 0.95rem;
+    line-height: 1.55;
+  }
+
+  .faq-answer p {
+    margin: 0;
   }
 
   /* Urgency text */


### PR DESCRIPTION
## Summary
- Restructures `/membership` around one Cook+ plan: AI tools first (Sous Chef, Nourish, Cheffy), Community perks with plain-language items before NIP-05/relay, Founders as a capped story section, and a new FAQ.
- Removes the Pro Kitchen card from the membership sales page (checkout route / `TierCard.svelte` left untouched).
- Aligns Cheffy user-facing copy with the real entitlement gate: **any active membership already unlocks Cheffy** (no server/config change required).



## Follow-up: founders taken-count bugfix

**Root cause:** `/membership` did `const actualFoundersCount = data.founders?.length || 0` (and `/founders` did a one-shot `let founders = data.founders...`). That freezes whatever value `data` had when the component first initialized — often `0` / `[]` on client-side navigation — and never updates when the load result arrives. Failed loads also returned `{ founders: [] }`, which the UI treated as a real “0 taken.”

**Fix:**
- Derive `spotsTaken` / founders list reactively from `data`
- Load functions now return `foundersAvailable: true|false`
- When unavailable, membership shows “21 seats” (no taken-count); founders shows an unavailable state — never “0 taken” as a placeholder

## Entitlements (blocking check)
**Cook+ already has Cheffy.** No flag/config change was needed.

| Layer | Gate | Result |
| --- | --- | --- |
| Frontend (`/cheffy`, `CheffyMessenger`) | `membershipMap[pk]?.active` | Any active tier, including `cook_plus` |
| API (`/api/zappy`, `/scan`, `/note-review`) | `hasActiveMembership(pubkey)` in `$lib/membershipApi.server.ts` | Any active membership; not Pro-Kitchen-specific |

Misleading “Pro Kitchen feature” UI/API strings that would confuse a Cook+ buyer were updated to Cook+. Checkout/payment logic was not touched.

## Final page copy (for review)

### Hero
**Your Kitchen, Supercharged**

Sous Chef pulls recipes from any link or photo. Nourish scores what they do for your body. Cheffy answers your kitchen questions — with generous monthly credits included. One membership unlocks all of it.

### Chips
Sous Chef · Nourish · Cheffy · Own Your Data  
(first three link to `/souschef`, `/nourish`, `/cheffy`)

### Plan card — Cook+
**$49/year** or **$4.99/month** (annual/monthly toggle unchanged)

**AI Cooking Tools**
- Sous Chef — Pull recipes from any link, photo, or pasted text instantly
- Nourish — See how recipes score for gut health, protein, and real food
- Cheffy — Ask cooking questions, use what you have, or turn an idea into dinner *(Generous monthly credits included)*

**Community & Content** (plain-language first)
- Buy and sell on the Market
- Featured recipe collections
- Exclusive Cook+ member badge
- Verified @zap.cooking NIP-05 identity
- Access to pantry.zap.cooking private relay

**Member Perks**
- Early access to new features
- Vote on features and roadmap

### Founders
Founders Club is a capped lifetime membership — **21 seats total** — for people who want to back Zap Cooking early and keep Pro Kitchen access for life. Seats are limited by that hard cap, not by a countdown.

Taken count still comes from `data.founders.length` / `spotsTaken` (same source as the previous widget).

### FAQ
1. **How many Cheffy messages do I get?** — Cook+ includes 300 Cheffy messages per month. That is a generous monthly allowance for everyday cooking help — ask questions, use what you have, or turn an idea into dinner.
2. **Can I cancel anytime?** — Yes. Cancel anytime from your membership page (card members use the billing portal; Lightning members contact support). You keep access through the end of your current billing period.
3. **Bitcoin or card — which should I use?** — Both work. Bitcoin via Lightning is preferred and often a bit cheaper; cards are accepted through Stripe if that is easier for you. You choose at checkout.
4. **What happens to my recipes if I cancel?** — Your recipes stay yours. Content you published remains on the network under your keys. You would lose Cook+ tools and member perks after your paid period ends, not the recipes you already saved or shared.
5. **How does billing work?** — Choose annual ($49/year) or monthly ($4.99/month). Annual is the better value. Subscriptions renew for the period you picked unless you cancel before renewal.

### Cheffy 300/mo cap behavior
**Not determinable from this repo.** There is no implemented monthly 300-message counter, quota, or at-cap UX in the Cheffy client or `/api/zappy` handlers. FAQ states the product allowance (300/mo) without inventing what happens when the cap is hit. Needs follow-up if enforcement lives elsewhere or is not built yet.

## Files changed
- `src/routes/membership/+page.svelte` — single-tier sales page, hero/chips/Founders/FAQ/meta
- `src/routes/cheffy/+page.svelte` — Cook+ wording on gate + chip (matches real entitlement)
- `src/components/CheffyMessenger.svelte` — Cook+ conversion/gate copy; Kitchen+ → Cook+
- `src/components/CheffyNoteReview.svelte` — Cook+ upsell copy (matches real entitlement)
- `src/routes/explore/+page.svelte` — Kitchen+ teaser → Cook+
- `src/lib/stores/cheffyChat.ts` — comment Kitchen+ → Cook+
- `src/routes/api/zappy/+server.ts` — member error strings + comments aligned to any-active-membership
- `src/routes/api/zappy/scan/+server.ts` — same
- `src/routes/api/zappy/note-review/+server.ts` — same

## Kitchen+ → Cook+
All user-facing `Kitchen+` instances replaced (explore teaser, Cheffy messenger, zappy experience-used error, comment).

## Pro Kitchen references left unchanged (outside this sales pitch)
Listed for coordination; not renamed (identifiers / still-valid Pro Kitchen product surfaces):
- `/membership/pro-kitchen-checkout`, success/tiers config, paymentStore, confirmation, TierCard
- Lightning-gated create flow (`/create/gated`, GateRecipeToggle)
- Pack/cookbook export Pro Kitchen free-unlimited UX
- Settings “Upgrade to Pro Kitchen”, MembershipBadge name, Nip05ClaimModal tier label
- Genesis Founders “lifetime Pro Kitchen” benefit copy (still accurate for that SKU)
- Unused `FAQSection.svelte` (not mounted on `/membership`)
- API/Stripe display strings that still sell or activate the Pro Kitchen SKU

## Test plan
- [ ] Cloudflare Pages preview: `/membership` shows hero → chips → single Cook+ card → Founders story → FAQ
- [ ] Annual/monthly toggle still works; Join Cook+ still goes to `/membership/cook-plus-checkout?period=…`
- [ ] Pro Kitchen card is gone from `/membership`; `/membership/pro-kitchen-checkout` still loads if hit directly
- [ ] Cook+ member can open `/cheffy` (already entitled via `active` membership)
- [ ] Non-member still sees Cook+ upsell, not Kitchen+/Pro Kitchen Cheffy gate copy
- [ ] Meta title/description/og tags are Cook+ AI-tools pitch; og:image unchanged


Made with [Cursor](https://cursor.com)
