### PR TITLE
Add homepage Join free entry for logged-out visitors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.676",
+  "version": "4.2.677",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/HomepageJoinCta.svelte
+++ b/src/components/HomepageJoinCta.svelte
@@ -1,0 +1,29 @@
+<!--
+  Logged-out homepage entry for cold visitors (e.g. paid ads).
+  Links to /login → LoginOverlay “Create Profile”. No signup logic here.
+-->
+<section class="join-cta" aria-label="Join Zap Cooking">
+  <h2 class="text-2xl font-bold" style="color: var(--color-text-primary);">
+    New here? Join free
+  </h2>
+  <p class="text-sm" style="color: var(--color-text-secondary);">
+    Save recipes, follow cooks, and share your kitchen — create your profile in under a minute.
+  </p>
+  <a
+    href="/login"
+    class="rounded-full whitespace-nowrap inline-flex items-center justify-center gap-2 px-4 py-2.5 font-semibold transition duration-300 bg-primary text-white hover:opacity-80"
+  >
+    Join free
+  </a>
+</section>
+
+<style>
+  .join-cta {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+    padding-top: 0.25rem;
+  }
+</style>

--- a/src/routes/explore/+page.svelte
+++ b/src/routes/explore/+page.svelte
@@ -18,6 +18,7 @@
   import PullToRefresh from '../../components/PullToRefresh.svelte';
   import LongformFoodFeed from '../../components/LongformFoodFeed.svelte';
   import LandingImportHero from '../../components/LandingImportHero.svelte';
+  import HomepageJoinCta from '../../components/HomepageJoinCta.svelte';
   import CheffyHomeCard from '../../components/CheffyHomeCard.svelte';
   import CheffyExploreInvite from '../../components/CheffyExploreInvite.svelte';
   import type { NDKEvent } from '@nostr-dev-kit/ndk';
@@ -350,13 +351,9 @@
 
 <PullToRefresh bind:this={pullToRefreshEl} on:refresh={handleRefresh}>
   <div class="flex flex-col">
-    <!-- Orientation text for signed-out users -->
+    <!-- Cold-visitor join entry — logged-out only, above the fold -->
     {#if $userPublickey === ''}
-      <div class="mb-4 pt-1">
-        <p class="text-sm" style="color: var(--color-text-secondary);">
-          Recipes, ideas, and cooks from around the network.
-        </p>
-      </div>
+      <HomepageJoinCta />
     {/if}
 
     <!-- Explore Content -->


### PR DESCRIPTION
## Summary
- Adds a logged-out-only “New here? Join free” entry at the top of `/explore` so cold visitors (e.g. paid ads) have a visible path into account creation.
- Button links to existing `/login` → LoginOverlay Create Profile; no signup or passkey changes.

## Rendered copy (production build)
**Headline:** New here? Join free  
**Body:** Save recipes, follow cooks, and share your kitchen — create your profile in under a minute.  
**CTA:** Join free → `/login`

## Changed files
- `src/components/HomepageJoinCta.svelte` (new)
- `src/routes/explore/+page.svelte`
- `package.json` (version bump via pre-commit hook)

## Test plan
- [x] `pnpm build` succeeds
- [x] Production prerender/client bundle includes the copy above and `href="/login"`
- [ ] Logged out: CTA visible above the fold on mobile `/explore`
- [ ] Logged in: CTA not shown
- [ ] CTA opens existing Create Profile flow via `/login`


Made with [Cursor](https://cursor.com)