### PR TITLE
Enable Stripe promotion codes on Cook+ Checkout Sessions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.676",
+  "version": "4.2.677",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/stripeService.server.ts
+++ b/src/lib/stripeService.server.ts
@@ -94,6 +94,7 @@ export async function createCheckoutSession(params: {
       },
     ],
     mode: 'subscription',
+    allow_promotion_codes: true,
     success_url: params.successUrl,
     cancel_url: params.cancelUrl,
     customer_email: params.customerEmail,


### PR DESCRIPTION
Allow customers to enter promo codes (e.g. FOODFRIENDS) during monthly and annual subscription checkout without changing the existing session flow.