### PR TITLE
Add Account and Data Deletion page at /delete-account

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.679",
+  "version": "4.2.680",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -63,6 +63,8 @@
       <span class="footer-sep">·</span>
       <a href="/child-safety" class="hover:text-primary transition-colors">Safety</a>
       <span class="footer-sep">·</span>
+      <a href="/delete-account" class="hover:text-primary transition-colors">Delete Account</a>
+      <span class="footer-sep">·</span>
       <a href="/disclosure" class="hover:text-primary transition-colors">Disclosure</a>
     </nav>
 

--- a/src/routes/delete-account/+page.svelte
+++ b/src/routes/delete-account/+page.svelte
@@ -1,0 +1,99 @@
+<svelte:head>
+  <title>Account and Data Deletion | Zap Cooking</title>
+  <meta
+    name="description"
+    content="How to request deletion of your Zap Cooking account and data — what we delete, what we cannot delete, and what we are required to keep."
+  />
+</svelte:head>
+
+<article class="max-w-2xl mx-auto">
+  <h1 class="text-3xl font-bold mb-8" style="color: var(--color-text-primary)">Account and Data Deletion</h1>
+
+  <div class="flex flex-col gap-6 leading-relaxed" style="color: var(--color-text-primary)">
+    <p class="text-sm opacity-75">
+      <strong>Zap Cooking</strong> — operated by Zap Cooking LLC<br />
+      Last updated: 25 July 2026
+    </p>
+
+    <hr style="border-color: var(--color-input-border)" />
+
+    <!-- How to request deletion -->
+    <h2 class="text-2xl font-bold mt-8 mb-4" style="color: var(--color-text-primary)">How to request deletion of your Zap Cooking account</h2>
+
+    <p><strong>Email <a href="mailto:support@zap.cooking" class="text-primary hover:underline">support@zap.cooking</a> with the subject line "Delete my account."</strong></p>
+
+    <p>Include the public key (npub) of the account you want deleted. You do not need to explain why.</p>
+
+    <p>We will acknowledge your request within 3 business days and complete deletion within 30 days.</p>
+
+    <p>If you are unsure which npub is yours, open your profile in the app — it is shown on your profile screen and can be copied from there.</p>
+
+    <hr style="border-color: var(--color-input-border)" />
+
+    <!-- What we delete -->
+    <h2 class="text-2xl font-bold mt-8 mb-4" style="color: var(--color-text-primary)">What we delete</h2>
+
+    <p>When your request is processed, we permanently delete:</p>
+
+    <ul class="list-disc pl-6 space-y-2">
+      <li><strong>Your membership and subscription records</strong> — Cook+ status, tier, and renewal state held against your public key</li>
+      <li><strong>Your AI credit balance and usage records</strong> — Cheffy and Sous Chef</li>
+      <li><strong>Your content stored on Pantry</strong>, the Nostr relay we operate at pantry.zap.cooking — recipes, posts, comments, reactions, and group messages held there</li>
+      <li><strong>Any support correspondence</strong> associated with your account</li>
+      <li><strong>Your encrypted key backup</strong>, if you used the Google Drive backup feature — see the note below</li>
+    </ul>
+
+    <p>We also issue deletion requests to other Nostr relays where we can identify your content.</p>
+
+    <hr style="border-color: var(--color-input-border)" />
+
+    <!-- What we cannot delete -->
+    <h2 class="text-2xl font-bold mt-8 mb-4" style="color: var(--color-text-primary)">What we cannot delete, and why</h2>
+
+    <p>Zap Cooking is built on Nostr, an open protocol. Some things are outside our control, and we would rather tell you plainly than imply otherwise.</p>
+
+    <p><strong>Content on relays we do not operate.</strong> Your posts and recipes are published to public Nostr relays run by unrelated parties. We can send deletion requests, and many relays honor them, but <strong>whether any given relay deletes your content is entirely that relay's decision. We cannot compel it.</strong></p>
+
+    <p><strong>Media on third-party hosts.</strong> Images and video are stored on Blossom media servers operated independently of Zap Cooking. We stop referencing and serving your media, but we cannot delete files from a host we do not run.</p>
+
+    <p><strong>Copies made by others.</strong> Anything published publicly may have been downloaded, screenshotted, or re-published by other users or services.</p>
+
+    <p><strong>Your keypair.</strong> Your Nostr private key belongs to you and exists independently of Zap Cooking. Deleting your Zap Cooking account does not delete or revoke your key, and you can continue using it with any other Nostr application. If you want to stop using the identity entirely, stop using the key — and consider publishing a NIP-62 request-to-vanish, which asks relays across the network to remove your data.</p>
+
+    <p><strong>Your Google Drive backup.</strong> The encrypted backup is stored in your own Google Drive, in an app-specific folder we cannot read or access. We remove our ability to write to it; to delete the file itself, go to Google Drive → Settings → Manage apps → Zap Cooking → Delete hidden app data.</p>
+
+    <hr style="border-color: var(--color-input-border)" />
+
+    <!-- What we keep -->
+    <h2 class="text-2xl font-bold mt-8 mb-4" style="color: var(--color-text-primary)">What we keep, and for how long</h2>
+
+    <ul class="list-disc pl-6 space-y-2">
+      <li><strong>Payment and transaction records</strong> — retained for 7 years as required by tax and accounting law. These records are keyed to your public key and a payment reference. They contain no name, card number, or billing address, because we never collect those.</li>
+      <li><strong>Records related to child safety, abuse, or law-enforcement matters</strong> — retained as required by law, including preservation obligations that follow a report to the National Center for Missing &amp; Exploited Children. See our <a href="/child-safety" class="text-primary hover:underline">Child Safety Standards</a>.</li>
+      <li><strong>Aggregate, non-identifying statistics</strong> — retained indefinitely. These cannot be linked back to you.</li>
+    </ul>
+
+    <p>Everything else is deleted.</p>
+
+    <hr style="border-color: var(--color-input-border)" />
+
+    <!-- Partial deletion -->
+    <h2 class="text-2xl font-bold mt-8 mb-4" style="color: var(--color-text-primary)">Deleting some of your data without deleting your account</h2>
+
+    <p>You do not have to delete your account to remove specific content. Within the app you can delete individual recipes, posts, and comments at any time. This issues a Nostr deletion request for that item, subject to the same relay limitations described above.</p>
+
+    <p>You can also mute or block other users, and mute words and phrases, from the app's safety settings.</p>
+
+    <hr style="border-color: var(--color-input-border)" />
+
+    <!-- Questions -->
+    <h2 class="text-2xl font-bold mt-8 mb-4" style="color: var(--color-text-primary)">Questions</h2>
+
+    <p><a href="mailto:support@zap.cooking" class="text-primary hover:underline">support@zap.cooking</a></p>
+
+    <p>
+      Zap Cooking LLC<br />
+      Tyrone, Pennsylvania, United States
+    </p>
+  </div>
+</article>


### PR DESCRIPTION
Publishes the Account and Data Deletion page. Hand-authored inline Svelte following the existing `/privacy` legal-page pattern (`max-w-2xl`, `text-2xl font-bold mt-8 mb-4` for `h2`, `list-disc pl-6 space-y-2`, `text-primary hover:underline`). SSR per-request — no `+page.ts`, no prerender — so the full text is in the raw HTML body with no JS execution.

The new route also displaces the `[nip19]` catch-all, which previously answered `/delete-account` with a 200 and an empty client-only shell. Static segments take routing precedence over dynamic params, so `/delete-account` now resolves to the real page.

## Content

Verbatim from the approved source, with the two pre-agreed deviations and nothing else:

1. The bracketed `[ADD WHEN PR-4 SHIPS: …]` block describing in-app deletion via Settings → Account → Delete account is **removed entirely** — not paraphrased or softened. That path does not exist yet and must not be published.
2. `[CONFIRM: 7]` rendered as a plain `7`.

A full text diff against the source confirms these are the **only** deviations — verified against both the source file and the server-rendered HTML.

The relay and Blossom limitation language under "What we cannot delete" is deliberate and states the boundary of what we can do. It must not be tightened into a stronger promise in later edits.

## Also included

- `Footer.svelte` — "Delete Account" link, between Safety and Disclosure.
- `/child-safety` linked where the source references it (the source used an absolute `https://zap.cooking/child-safety`; rendered as a relative internal link per house convention, same visible text).
- `package.json` version bump — added automatically by the repo's pre-commit hook.

## Verification (local)

- **Verbatim:** SSR text diffed against source — only the two authorized deviations present.
- `svelte-check`: 0 errors; no warnings in either touched file.
- Route resolves to the real page, not the catch-all: `<h1>Account and Data Deletion</h1>` and the correct `<title>` are both in the raw body.
- `grep -c "We cannot compel it"` → 1.
- No `[ADD WHEN`, `[CONFIRM`, or `PR-4` strings anywhere in the response body.
- Footer link and `/child-safety` cross-link both resolve.

## Known issue, not introduced here

Cloudflare Scrape Shield's Email Address Obfuscation rewrites `support@zap.cooking` to `[email&nbsp;protected]` in the raw HTML at the edge, restoring it only via JS. This page's primary instruction is to email that address, so a no-JS fetch by a Play reviewer will not show it. Same zone-level setting flagged on `/child-safety`; the fix is a Cloudflare Configuration Rule, not a code change. Called out for visibility — it is not a blocker for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)