### PR TITLE
Opt legal-page contact addresses out of Cloudflare email obfuscation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.680",
+  "version": "4.2.681",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/routes/child-safety/+page.svelte
+++ b/src/routes/child-safety/+page.svelte
@@ -1,3 +1,19 @@
+<script lang="ts">
+  // Cloudflare Scrape Shield rewrites every email address in the served HTML to
+  // "[email protected]" at the edge — after the Worker responds — and restores it
+  // only by running /cdn-cgi/scripts/.../email-decode.min.js. S10 designates this
+  // address as the point of contact for Google Play, NCMEC, and law enforcement,
+  // so a no-JS fetch must still show it. <!--email_off--> is Cloudflare's opt-out.
+  //
+  // It has to be injected as raw HTML: Svelte strips comments from components
+  // (compilerOptions.preserveComments defaults to false), so markers written
+  // literally in the template never reach the edge and the opt-out silently
+  // does nothing. The markers wrap the whole anchor, not just the visible text,
+  // because Cloudflare rewrites the mailto: href as well as the link body.
+  const SUPPORT_EMAIL =
+    '<!--email_off--><a href="mailto:support@zap.cooking" class="text-primary hover:underline">support@zap.cooking</a><!--/email_off-->';
+</script>
+
 <svelte:head>
   <title>Child Safety Standards | Zap Cooking</title>
   <meta
@@ -95,7 +111,7 @@
     <!-- Section 6 -->
     <h2 class="text-2xl font-bold mt-8 mb-4" style="color: var(--color-text-primary)">6. How to report</h2>
 
-    <p><strong>By email</strong> — <a href="mailto:support@zap.cooking" class="text-primary hover:underline">support@zap.cooking</a>. This inbox is monitored and child safety reports are prioritized above all other correspondence. This is the reporting route from the web application and from any surface where an in-app control is not yet available.</p>
+    <p><strong>By email</strong> — {@html SUPPORT_EMAIL}. This inbox is monitored and child safety reports are prioritized above all other correspondence. This is the reporting route from the web application and from any surface where an in-app control is not yet available.</p>
 
     <p><strong>In the Android application</strong> — reporting controls are available in group chats today, including a dedicated child safety category, and are being extended across posts, recipes, comments, and profiles. Reports route directly to designated moderation accounts and require no email address or account.</p>
 
@@ -122,7 +138,7 @@
     <p>If you encounter content or conduct covered by these standards:</p>
 
     <ol class="list-decimal pl-6 space-y-2">
-      <li><strong>Report it</strong> using the in-app report control or by emailing <a href="mailto:support@zap.cooking" class="text-primary hover:underline">support@zap.cooking</a></li>
+      <li><strong>Report it</strong> using the in-app report control or by emailing {@html SUPPORT_EMAIL}</li>
       <li><strong>Block the account</strong> so it is removed from your view immediately</li>
       <li><strong>Report it directly to NCMEC</strong> at <a href="https://report.cybertip.org" target="_blank" rel="noopener noreferrer" class="text-primary hover:underline">report.cybertip.org</a>, or to local law enforcement — you do not need to wait for us, and you should not</li>
     </ol>
@@ -146,7 +162,7 @@
     <p>
       Seth Sager, Founder and Safety Lead<br />
       Zap Cooking LLC<br />
-      <a href="mailto:support@zap.cooking" class="text-primary hover:underline">support@zap.cooking</a>
+      {@html SUPPORT_EMAIL}
     </p>
 
     <p>This is a monitored address and the designated point of contact for child safety matters, including inquiries from Google Play, NCMEC, and law enforcement.</p>

--- a/src/routes/delete-account/+page.svelte
+++ b/src/routes/delete-account/+page.svelte
@@ -1,3 +1,19 @@
+<script lang="ts">
+  // Cloudflare Scrape Shield rewrites every email address in the served HTML to
+  // "[email protected]" at the edge — after the Worker responds — and restores it
+  // only by running /cdn-cgi/scripts/.../email-decode.min.js. This page's stated
+  // remedy is "email this address", so a no-JS fetch (Play reviewer, regulator)
+  // must still show it. <!--email_off--> is Cloudflare's opt-out marker.
+  //
+  // It has to be injected as raw HTML: Svelte strips comments from components
+  // (compilerOptions.preserveComments defaults to false), so markers written
+  // literally in the template never reach the edge and the opt-out silently
+  // does nothing. The markers wrap the whole anchor, not just the visible text,
+  // because Cloudflare rewrites the mailto: href as well as the link body.
+  const SUPPORT_EMAIL =
+    '<!--email_off--><a href="mailto:support@zap.cooking" class="text-primary hover:underline">support@zap.cooking</a><!--/email_off-->';
+</script>
+
 <svelte:head>
   <title>Account and Data Deletion | Zap Cooking</title>
   <meta
@@ -20,7 +36,7 @@
     <!-- How to request deletion -->
     <h2 class="text-2xl font-bold mt-8 mb-4" style="color: var(--color-text-primary)">How to request deletion of your Zap Cooking account</h2>
 
-    <p><strong>Email <a href="mailto:support@zap.cooking" class="text-primary hover:underline">support@zap.cooking</a> with the subject line "Delete my account."</strong></p>
+    <p><strong>Email {@html SUPPORT_EMAIL} with the subject line "Delete my account."</strong></p>
 
     <p>Include the public key (npub) of the account you want deleted. You do not need to explain why.</p>
 
@@ -89,7 +105,7 @@
     <!-- Questions -->
     <h2 class="text-2xl font-bold mt-8 mb-4" style="color: var(--color-text-primary)">Questions</h2>
 
-    <p><a href="mailto:support@zap.cooking" class="text-primary hover:underline">support@zap.cooking</a></p>
+    <p>{@html SUPPORT_EMAIL}</p>
 
     <p>
       Zap Cooking LLC<br />


### PR DESCRIPTION
Cloudflare Scrape Shield rewrites every email address in the served HTML to `[email&nbsp;protected]` at the edge — after the Worker responds — restoring it only by running `/cdn-cgi/scripts/.../email-decode.min.js`. The literal string `support@zap.cooking` appeared **zero times** in the production response body for both pages.

That is a defect on these two pages specifically:

- `/delete-account` states emailing the address as the **only** route for exercising the deletion right. Google Play's data-deletion policy requires a reachable mechanism at the submitted URL.
- `/child-safety` §10 designates it as the point of contact for **Google Play, NCMEC, and law enforcement**.

All three of those readers fetch the URL without executing JavaScript.

## Fix

Wraps each address in Cloudflare's `<!--email_off-->` opt-out markers — 2 occurrences on `/delete-account`, 3 on `/child-safety`.

## Two non-obvious constraints, verified rather than assumed

**1. The markers cannot be written literally in the template.** Svelte strips comments from components (`compilerOptions.preserveComments` defaults to `false`, and it is not set in `svelte.config.js`). Written literally, the markers would never reach the edge — the fix would look correct in source and in review while doing nothing.

This was confirmed against deployed HTML rather than assumed: the existing `<!-- Section N -->` template comments in these very files appear **zero times** in the production response. The markers are injected via `{@html}` instead, which survives compilation. Verified in SSR output:

```
Email <!-- HTML_TAG_START --><!--email_off--><a href="mailto:support@zap.cooking"
class="text-primary hover:underline">support@zap.cooking</a><!--/email_off--><!-- HTML_TAG_END -->
```

The `email_off` region is contiguous and strictly inside Svelte's hydration anchors. The opening marker was byte-compared against the expected literal — exact match, no stray whitespace.

**2. The markers wrap the whole anchor, not just the visible text.** Cloudflare rewrites the `mailto:` href as well as the link body. Wrapping only the text would leave `/cdn-cgi/l/email-protection` in the href and fail the "no email-protection string" gate.

## Content safety

Rendered text is unchanged on both pages — this is a markup-only change:

- `/child-safety` still matches its source **exactly at 77 blocks**.
- `/delete-account` still shows **only its two authorized deviations** (the removed `[ADD WHEN PR-4 SHIPS:…]` block and `[CONFIRM: 7]` → `7`).

`svelte-check`: 0 errors.

The `{@html}` content is a static compile-time constant with no interpolation and no user input, so it carries no injection surface.

## Verification

Local checks cannot validate this — the rewrite happens at the Cloudflare edge, not in the app. Gates will be run against production after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)