### PR TITLE
Name the job each kitchen tool does in the header menu

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -203,7 +203,7 @@
           class="zh-iconbtn zh-intelligence-btn {onIntelligenceSurface || intelligenceMenuOpen
             ? 'is-active'
             : ''}"
-          aria-label="Intelligence tools"
+          aria-label="Kitchen help"
           aria-haspopup="menu"
           aria-expanded={intelligenceMenuOpen}
         >

--- a/src/components/IntelligenceMenu.svelte
+++ b/src/components/IntelligenceMenu.svelte
@@ -15,7 +15,7 @@
     {
       href: '/souschef',
       label: 'Sous Chef',
-      blurb: 'Recipe guidance & ideas',
+      blurb: 'Turn a link, text, or photo into a recipe',
       Icon: SparkleIcon,
       accent: 'rgb(168, 85, 247)'
     },
@@ -26,7 +26,7 @@
       // overpromise a full-page destination.
       action: openCheffy,
       label: 'Ask Cheffy',
-      blurb: 'Your kitchen companion',
+      blurb: 'Ask anything while you cook',
       Icon: CheffyIcon,
       // Cheffy's warm orange — uses the CSS var so the accent shifts
       // automatically between the light (#ec4700) and dark
@@ -36,7 +36,7 @@
     {
       href: '/nourish',
       label: 'Nourish',
-      blurb: 'Smart nutrition scoring',
+      blurb: "See what's actually in a meal",
       Icon: LeafIcon,
       accent: 'rgb(34, 197, 94)'
     }
@@ -79,9 +79,9 @@
 </script>
 
 {#if open}
-  <div bind:this={panelEl} class="intelligence-menu" role="menu" aria-label="Intelligence tools">
+  <div bind:this={panelEl} class="intelligence-menu" role="menu" aria-label="Kitchen help">
     <div class="header-row">
-      <span class="eyebrow">Intelligence</span>
+      <span class="eyebrow">Kitchen help</span>
     </div>
     {#each items as item}
       <button type="button" class="item" role="menuitem" on:click={() => activate(item)}>


### PR DESCRIPTION
Three shipped tools sit in the header menu under the eyebrow **Intelligence**, with blurbs that name a category instead of a job. A member who opens that menu is being asked to guess which door to take.

**Blurbs — before → after**

| Item | Before | After |
|---|---|---|
| Sous Chef | Recipe guidance & ideas | Turn a link, text, or photo into a recipe |
| Ask Cheffy | Your kitchen companion | Ask anything while you cook |
| Nourish | Smart nutrition scoring | See what's actually in a meal |

Two of these were wrong, not merely vague:

- **Nourish** promised "Smart nutrition scoring" while the destination page says *"Not a grade. Just guidance."* (`src/routes/nourish/+page.svelte:149`). The menu and the page it opens contradicted each other.
- **Sous Chef** undersold the input, which accepts a URL, pasted text, *or* a photo (`src/routes/souschef/+page.svelte:745`). The photo path is the most delightful one and the menu didn't mention it.

**Rename.** "Intelligence" names the technology, not the benefit — nobody arrives at a cooking site for intelligence tools. Renamed to **Kitchen help** in all three user-facing places so a screen reader doesn't still announce the old name:

- `IntelligenceMenu.svelte:82` panel `aria-label`
- `IntelligenceMenu.svelte:84` eyebrow
- `Header.svelte:206` header button `aria-label`

Class names, component names, and code comments keep the existing `Intelligence` naming — this is a copy change only, no markup or behavior.

**Scope and verification.** Six strings, two files. Verified against `origin/main` edc871ec. Grep over `src/` found no test asserting any changed string. Node modules aren't installed in this environment, so `pnpm test` / `pnpm check` were **not** run — worth a CI pass before merge. Prettier keeps `"See what's actually in a meal"` in double quotes under `singleQuote: true` because it contains an apostrophe.

Other nav surfaces (`MobileNavDrawer`, `DesktopSideNav`, `UserSidePanel`) list these tools as labels with no blurb slot, so they're untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)