### PR TITLE
Remove decommissioned relay.damus.io from runtime relay lists

### DIFF
--- a/members-relay/admin/public/app.js
+++ b/members-relay/admin/public/app.js
@@ -475,7 +475,7 @@ function app() {
         },
 
         fetchProfilesFromRelay(pubkeys) {
-            const relays = ['wss://purplepag.es', 'wss://relay.damus.io', 'wss://nos.lol'];
+            const relays = ['wss://purplepag.es', 'wss://nos.lol'];
             const subId = 'profiles_' + Math.random().toString(36).slice(2, 8);
             const remaining = new Set(pubkeys);
             let completed = 0;

--- a/scripts/delete-spark-backup.mjs
+++ b/scripts/delete-spark-backup.mjs
@@ -18,7 +18,6 @@ import WebSocket from 'ws';
 useWebSocketImplementation(WebSocket);
 
 const RELAYS = [
-  'wss://relay.damus.io',
   'wss://relay.nostr.band',
   'wss://nos.lol',
   'wss://relay.primal.net',

--- a/src/components/LongformFoodFeed.svelte
+++ b/src/components/LongformFoodFeed.svelte
@@ -86,7 +86,6 @@
 
       const articleRelays = [
         'wss://relay.primal.net',
-        'wss://relay.damus.io',
         'wss://nos.lol',
         'wss://nostr.wine'
       ];

--- a/src/components/Recipe/TopZappers.svelte
+++ b/src/components/Recipe/TopZappers.svelte
@@ -20,7 +20,6 @@
   let activeWebSockets: WebSocket[] = [];
 
   const AGGREGATOR_RELAYS = [
-    'wss://relay.damus.io',
     'wss://nos.lol',
     'wss://relay.primal.net',
     'wss://nostr.wine',

--- a/src/components/Recipe/TotalZaps.svelte
+++ b/src/components/Recipe/TotalZaps.svelte
@@ -19,7 +19,6 @@
   // Aggregator relays known to have good zap data
   // Tested for response time (<800ms) and zap coverage
   const AGGREGATOR_RELAYS = [
-    'wss://relay.damus.io',
     'wss://nos.lol',
     'wss://relay.primal.net',
     'wss://nostr.wine',

--- a/src/components/reads/LongformEditorModal.svelte
+++ b/src/components/reads/LongformEditorModal.svelte
@@ -388,7 +388,7 @@
 				identifier: identifier,
 				pubkey: $userPublickey,
 				kind: 30023,
-				relays: ['wss://relay.primal.net', 'wss://nos.lol', 'wss://relay.damus.io']
+				relays: ['wss://relay.primal.net', 'wss://nos.lol']
 			});
 			
 			// Delete the draft since it's now published

--- a/src/lib/articleOutbox.ts
+++ b/src/lib/articleOutbox.ts
@@ -84,7 +84,6 @@ const CONFIG = {
   // Article-optimized relays (good for longform content)
   ARTICLE_RELAYS: [
     'wss://relay.primal.net',        // Primal's relay (aggregated content)
-    'wss://relay.damus.io',          // Large general relay
     'wss://nos.lol',                 // Popular relay with good uptime
     'wss://nostr.wine',              // Premium relay with quality content
     'wss://purplepag.es',            // Good for profile/content discovery

--- a/src/lib/connectionManager.ts
+++ b/src/lib/connectionManager.ts
@@ -78,7 +78,6 @@ export class ConnectionManager {
       // Add some default relays if none are configured
       const defaultRelays = [
         'wss://purplepag.es',
-        'wss://relay.damus.io',
         'wss://nos.lol',
         'wss://nostr.mom',
         'wss://relay.primal.net'

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -1,5 +1,4 @@
 export const standardRelays = [
-  'wss://relay.damus.io',
   'wss://nos.lol',
   'wss://purplepag.es',
   'wss://relay.primal.net',

--- a/src/lib/engagementCache.ts
+++ b/src/lib/engagementCache.ts
@@ -8,7 +8,6 @@ import { extractZapAmountSats } from './zapAmount';
 // Aggregator relays that index zap receipts — LNURL providers publish kind:9735
 // to these relays, which may not overlap with the app's default relay set.
 const ZAP_AGGREGATOR_RELAYS = [
-  'wss://relay.damus.io',
   'wss://nos.lol',
   'wss://relay.primal.net'
 ];

--- a/src/lib/followOutbox.ts
+++ b/src/lib/followOutbox.ts
@@ -97,7 +97,6 @@ const CONFIG = {
   CONCURRENT_BATCHES: 6,            // More parallel (was 4)
   
   FALLBACK_RELAYS: [
-    'wss://relay.damus.io',
     'wss://nos.lol',
     'wss://relay.primal.net'
   ],

--- a/src/lib/followRecovery.ts
+++ b/src/lib/followRecovery.ts
@@ -16,7 +16,6 @@ import type { Event, EventTemplate } from 'nostr-tools';
 const FOLLOW_LIST_KIND = 3;
 
 const DEFAULT_RELAYS = [
-	'wss://relay.damus.io',
 	'wss://relay.primal.net',
 	'wss://nos.lol',
 	'wss://relay.snort.social',

--- a/src/lib/marketplace/products.ts
+++ b/src/lib/marketplace/products.ts
@@ -23,7 +23,6 @@ import { SUPPORTED_CURRENCIES, type CurrencyCode } from '$lib/currencyStore';
 
 // Relays that index marketplace events (matches Plebeian Market's relay set)
 export const MARKETPLACE_RELAYS = [
-	'wss://relay.damus.io',
 	'wss://nos.lol',
 	'wss://relay.nostr.net'
 ];

--- a/src/lib/membershipNotificationService.ts
+++ b/src/lib/membershipNotificationService.ts
@@ -16,7 +16,6 @@ export interface ExpiringMember {
 
 // Reliable relays for DM delivery
 const DM_RELAYS = [
-  'wss://relay.damus.io',
   'wss://nos.lol',
   'wss://nostr.wine',
   'wss://relay.snort.social',

--- a/src/lib/memories.ts
+++ b/src/lib/memories.ts
@@ -114,7 +114,6 @@ export function isReplyNote(event: { tags: string[][] }): boolean {
 
 /** Archive-friendly relays queried in addition to the standard set. */
 const ARCHIVE_RELAYS = [
-  'wss://relay.damus.io',
   'wss://nostr.wine',
   'wss://relay.primal.net'
 ];

--- a/src/lib/nip17.ts
+++ b/src/lib/nip17.ts
@@ -38,7 +38,6 @@ export function clearUnwrapCache(): void {
 }
 
 const FALLBACK_DM_RELAYS = [
-	'wss://relay.damus.io',
 	'wss://nos.lol',
 	'wss://relay.primal.net'
 ];

--- a/src/lib/nourish/nourishPublisher.server.ts
+++ b/src/lib/nourish/nourishPublisher.server.ts
@@ -27,7 +27,6 @@ import { buildNourishDTag } from './nourishRelay';
 /** Public relays — no AUTH. Primary index store today (see Phase 0 §0.5). */
 const PUBLIC_PUBLISH_RELAYS = [
 	'wss://nos.lol',
-	'wss://relay.damus.io',
 	'wss://relay.primal.net'
 ];
 

--- a/src/lib/queryBatcher.ts
+++ b/src/lib/queryBatcher.ts
@@ -122,7 +122,6 @@ const CONFIG = {
   
   // Fallback relays for authors without NIP-65
   FALLBACK_RELAYS: [
-    'wss://relay.damus.io',
     'wss://nos.lol',
     'wss://relay.primal.net',
     'wss://purplepag.es'

--- a/src/lib/recipePackOg.server.ts
+++ b/src/lib/recipePackOg.server.ts
@@ -10,7 +10,6 @@
 
 const RELAYS = [
 	'wss://relay.primal.net',
-	'wss://relay.damus.io',
 	'wss://nos.lol'
 ];
 

--- a/src/lib/relayListCache.ts
+++ b/src/lib/relayListCache.ts
@@ -68,7 +68,6 @@ const CONFIG = {
   // Discovery relays for fetching relay lists
   DISCOVERY_RELAYS: [
     'wss://purplepag.es',
-    'wss://relay.damus.io',
     'wss://nos.lol',
     'wss://relay.primal.net'
   ]

--- a/src/lib/relaySelector.ts
+++ b/src/lib/relaySelector.ts
@@ -101,7 +101,6 @@ const CONFIG = {
   
   // Fallback relays when author has no NIP-65
   FALLBACK_RELAYS: [
-    'wss://relay.damus.io',
     'wss://nos.lol',
     'wss://relay.primal.net',
     'wss://purplepag.es'

--- a/src/lib/relays/relaySets.ts
+++ b/src/lib/relays/relaySets.ts
@@ -20,7 +20,6 @@ export const RELAY_SETS: Record<string, RelaySet> = {
     description: 'Standard relay configuration for general use',
     relays: [
       'wss://nos.lol',
-      'wss://relay.damus.io',
       'wss://relay.primal.net'
     ]
   },
@@ -57,7 +56,6 @@ export const RELAY_SETS: Record<string, RelaySet> = {
     relays: [
       'wss://relay.primal.net',     // Primal - aggregated from 100+ relays
       'wss://nos.lol',               // Popular with good uptime
-      'wss://relay.damus.io',        // Large general relay
       'wss://nostr.wine',            // Quality content focus
       'wss://eden.nostr.land',       // Reliable general relay
       'wss://relay.noswhere.com'     // General relay with longform support

--- a/src/lib/stores/groupZapReceipts.ts
+++ b/src/lib/stores/groupZapReceipts.ts
@@ -14,7 +14,6 @@ import { ndk } from '$lib/nostr';
 import { extractZapAmountSats } from '$lib/zapAmount';
 
 const ZAP_RECEIPT_RELAYS = [
-	'wss://relay.damus.io',
 	'wss://nos.lol',
 	'wss://relay.primal.net'
 ];

--- a/src/routes/api/counts/[eventId]/+server.ts
+++ b/src/routes/api/counts/[eventId]/+server.ts
@@ -19,7 +19,6 @@ interface CountData {
 // Relays to query for counts (prioritize those known to support NIP-45)
 const COUNT_RELAYS = [
   'wss://nostr.wine',
-  'wss://relay.damus.io',
   'wss://relay.primal.net'
 ];
 

--- a/src/routes/api/cron/check-expiring-memberships/+server.ts
+++ b/src/routes/api/cron/check-expiring-memberships/+server.ts
@@ -75,7 +75,6 @@ export const GET: RequestHandler = async ({ request, platform }) => {
     // Use a minimal relay set for sending DMs
     const ndk = new NDK({
       explicitRelayUrls: [
-        'wss://relay.damus.io',
         'wss://nos.lol',
         'wss://purplepag.es'
       ]

--- a/src/routes/api/cron/test-notification/+server.ts
+++ b/src/routes/api/cron/test-notification/+server.ts
@@ -108,7 +108,6 @@ export const GET: RequestHandler = async ({ url, request, platform }) => {
     // Initialize NDK
     const ndk = new NDK({
       explicitRelayUrls: [
-        'wss://relay.damus.io',
         'wss://nos.lol',
         'wss://purplepag.es'
       ]

--- a/src/routes/polls/+page.svelte
+++ b/src/routes/polls/+page.svelte
@@ -38,7 +38,6 @@
 
   const POLL_RELAYS = [
     'wss://nos.lol',
-    'wss://relay.damus.io',
     'wss://relay.primal.net',
     'wss://nostr.wine',
     'wss://antiprimal.net'

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -156,7 +156,7 @@
     <p>Third-party services that receive information in connection with the Service:</p>
 
     <ul class="list-disc pl-6 space-y-2">
-      <li><strong>Nostr relays.</strong> Content you publish — recipes, posts, comments, reactions, profile information, group messages, and Market listings — is transmitted to Nostr relays. Some are operated by us; most are not. The application connects by default to <code>pantry.zap.cooking</code> (ours) and to independently operated relays including <code>nos.lol</code>, <code>relay.damus.io</code>, <code>relay.primal.net</code>, <code>nostr.wine</code>, and <code>eden.nostr.land</code>. You can change this list in the application's relay settings. <strong>Publishing to third-party relays is the normal operation of the service, not an exception</strong>, and content sent to a relay we do not operate is outside our control.</li>
+      <li><strong>Nostr relays.</strong> Content you publish — recipes, posts, comments, reactions, profile information, group messages, and Market listings — is transmitted to Nostr relays. Some are operated by us; most are not. The application connects by default to <code>pantry.zap.cooking</code> (ours) and to independently operated relays including <code>nos.lol</code>, <code>relay.primal.net</code>, <code>nostr.wine</code>, and <code>eden.nostr.land</code>. You can change this list in the application's relay settings. <strong>Publishing to third-party relays is the normal operation of the service, not an exception</strong>, and content sent to a relay we do not operate is outside our control.</li>
       <li><strong>Blossom media servers.</strong> Images and video you upload are stored on Blossom servers, which are operated independently of Zap Cooking. The default is <code>blossom.primal.net</code>; you can change it in settings. We do not host your media.</li>
       <li><strong>OpenAI.</strong> Content you submit to our AI features is sent to OpenAI for processing. See "AI features" below.</li>
       <li><strong>Giphy.</strong> When you search for a GIF, your typed search term is sent to <code>api.giphy.com</code>. We do not send your search terms anywhere else.</li>
@@ -221,7 +221,7 @@
 
     <p><strong>This is off unless you allow it.</strong> Each report requires your explicit confirmation before it is sent — nothing is transmitted automatically.</p>
 
-    <p>Reports are sent as encrypted Nostr direct messages to our development team, routed through the relays <code>relay.0xchat.com</code>, <code>relay.utxo.one/chat</code>, and <code>relay.damus.io</code>. A report contains diagnostic information about the failure and is associated with your public key.</p>
+    <p>Reports are sent as encrypted Nostr direct messages to our development team, routed through the relays <code>relay.0xchat.com</code> and <code>relay.utxo.one/chat</code>. A report contains diagnostic information about the failure and is associated with your public key.</p>
 
     <!-- Section 10 -->
     <h2 class="text-2xl font-bold mt-8 mb-4" style="color: var(--color-text-primary)">10. Data Security</h2>

--- a/src/routes/reads/+page.svelte
+++ b/src/routes/reads/+page.svelte
@@ -590,7 +590,6 @@
       const articleRelays = [
         'wss://relay.primal.net',
         'wss://nos.lol',
-        'wss://relay.damus.io',
         'wss://nostr.wine',
         'wss://antiprimal.net'
       ];


### PR DESCRIPTION
`relay.damus.io` is decommissioned at the end of July 2026. It is still in the default relay set, so a fresh install today would ship pointing at a dead relay.

Mechanical removal from **28 runtime relay lists** plus **2 privacy-policy references**. 29 files, 31 deletions, 4 insertions.

## Acceptance gate: no list left empty or single-relay

The one real hazard is removing an entry from a list that only had two. **I walked all 29 sites individually.** Every one leaves at least two surviving relays — the smallest results are 2-relay lists (`relaySets` `default`, `MARKETPLACE_RELAYS`, `engagementCache`, `nip17` DM fallback, `groupZapReceipts`, `memories` archive, `recipePackOg`, `nourishPublisher`, `api/counts/[eventId]`, `LongformEditorModal` naddr hint). None goes to 0 or 1.

The three highest-consequence spots are all in: `src/lib/consts.ts` (`standardRelays`), `src/lib/relays/relaySets.ts` (`default` and longform sets), `src/lib/relaySelector.ts` (`FALLBACK_RELAYS`).

## Privacy policy — needs @Growth and Dr Sats eyes

`src/routes/privacy/+page.svelte` has **two** references, and neither is a rewrite — each is one item deleted from an enumerated factual list, serial comma fixed, no surrounding sentence touched.

- **Line 159, §5 third-party sharing** — the default relay set. 6 relays → 5. Leaving it would publish a policy naming a relay we no longer connect to.
- **Line 224, §9 crash reports** — 3 relays → 2. **This line describes Android behavior, not frontend.** `CrashHandler.kt` `DEVELOPER_DM_RELAYS` is the code that makes it true, in the other repo.

**Ordering dependency — already satisfied.** `zap_cooking_android` #205 removed damus from `DEVELOPER_DM_RELAYS` and **is merged**. Had this PR landed first, the policy would have disclosed two crash-report relays while the shipped app still sent to three — an undisclosed third-party recipient of user data on a Play compliance surface. It did not; #205 went first.

## Deliberately not in this PR

**8 markdown docs** with historical mentions (`docs/passkey-investigation/`, `docs/dev/`, `docs/deployment/`, `docs/mobile/`, `NOURISH_MACROS_DISCOVERY.md`). Not a launch risk, and including them triples the diff.

**`src/components/FoodstrFeedOptimized.svelte:453`** — a speed-test benchmark comment naming damus at 394ms, not a live relay entry. Left in place deliberately.

**5 runtime files blocked by the acceptance gate** — damus is one of only two relays, so removing it leaves a single-relay list. Choosing a replacement is an infra decision, not a mechanical edit, so I stopped rather than inventing one:

| File | List | Result if cut |
|---|---|---|
| `src/lib/countQuery.ts:48` | `KNOWN_NIP45_RELAYS` | 2 → 1 |
| `src/routes/api/counts/batch/+server.ts:29` | `COUNT_RELAYS` | 2 → 1 |
| `src/components/FoodstrFeedOptimized.svelte:456` | `RELAY_POOLS.recipes` | 2 → 1 |
| `src/lib/authManager.ts:920` | NIP-46 pairing fallback | 2 → 1 |
| `src/lib/recipePack.ts:31` | `RECIPE_PACK_RELAY_HINTS` | 2 → 1 |

`recipePack.ts` is not just arithmetic: its hints **rotate across a pack's `a` tags** so both general relays get coverage (NIP-01 allows one relay URL per `a` tag). Cutting to one relay doesn't shrink a fallback set, it removes the rotation the code is built around. These five need a decision before the Jul 31 decommission; they are a named follow-up, not an oversight.

## Verified

- Rebased onto `origin/main` `9b72039`. Re-swept after rebase: the only remaining `relay.damus.io` references are the 8 docs and the 5 blocked files above.
- `npm run build` passes at `9b72039` + this commit (exit 0, built in 1m40s, `adapter-cloudflare` done).
- Confirmed **no relay name renders to a user** outside the privacy page: `TopZappers`/`TotalZaps` `AGGREGATOR_RELAYS` feed raw WebSockets, `polls` `POLL_RELAYS` and `reads` `articleRelays` go to `NDKRelaySet.fromRelayUrls`, `LongformEditorModal` is an `naddr` relay hint inside `nip19.naddrEncode`. None appear in Svelte markup.

## Not verified

- No runtime test against a live relay — build and static review only.
- Docs sweep is scoped to this repo's working tree; I did not check other repos.

Reviewers: **Growth / Dr Sats** on the two privacy strings, **Prep** on the 5 deferred files. Human merges — I do not.
