### PR TITLE
Split the checkout billing disclosure by payment method

### DIFF
--- a/src/routes/membership/+page.svelte
+++ b/src/routes/membership/+page.svelte
@@ -54,7 +54,7 @@
     {
       question: 'How does billing work?',
       answer:
-        'Choose annual ($49/year) or monthly ($4.99/month). Annual is the better value. Subscriptions renew for the period you picked unless you cancel before renewal.'
+        'Choose annual ($49/year) or monthly ($4.99/month). Annual is the better value. Card subscriptions renew for the period you picked unless you cancel before renewal. A Lightning payment covers one term and does not renew on its own — you renew it yourself when the term is up.'
     }
   ];
 

--- a/src/routes/membership/cook-plus-checkout/+page.svelte
+++ b/src/routes/membership/cook-plus-checkout/+page.svelte
@@ -25,7 +25,20 @@
 
   // Cook+ pricing (dynamic based on period)
   $: COOK_PLUS_PRICE_USD = selectedPeriod === 'annual' ? 49 : 4.99;
-  
+
+  // Billing disclosure. It has to track BOTH the period and the payment method,
+  // because the two paths are different products: card is a Stripe subscription
+  // (`mode: 'subscription'` at stripeService.server.ts:96, with a recurring
+  // year/month interval at :89-91) and renews on its own; Lightning buys a fixed
+  // term (api/membership/strike-webhook/+server.ts:123 -> registerMember with
+  // paymentMethod 'lightning_strike', which sets subscriptionMonths 12 or 1 at
+  // memberRegistration.server.ts:57-61) with no
+  // subscription behind it, so it lapses. One hardcoded line cannot be true for both.
+  // Deliberately no dollar amount here: the price is already on screen in
+  // .checkout-price, and stripeService sets `allow_promotion_codes: true`, so a
+  // code entered on Stripe's hosted page can change what's actually charged.
+  $: billingTermNoun = selectedPeriod === 'annual' ? 'year' : 'month';
+
   // Dynamic Bitcoin pricing (fetched from API)
   let bitcoinPriceLoading = true;
   let bitcoinPriceError: string | null = null;
@@ -441,12 +454,6 @@
         </div>
       </div>
 
-      <div class="billing-disclosure">
-        <p>Subscriptions renew for the period you picked unless you cancel before renewal.</p>
-        <p>Cancel anytime from your membership page. You keep access through the end of your current billing period.</p>
-        <p>Except where required by law, we do not provide prorated refunds for partial billing periods.</p>
-      </div>
-
       <div class="checkout-benefits">
         <h3>What you get:</h3>
         
@@ -601,6 +608,17 @@
         </div>
       {/if}
 
+      <div class="billing-disclosure">
+        {#if paymentMethod === 'stripe'}
+          <p>Paying by card — this is a subscription. It renews automatically each {billingTermNoun} until you cancel.</p>
+          <p>Cancel anytime from your membership page. You keep access through the end of your current billing period.</p>
+          <p>Except where required by law, we do not provide prorated refunds for partial billing periods.</p>
+        {:else}
+          <p>Paying by Lightning — one payment covers one {billingTermNoun}. It does not renew on its own; you'll need to renew when the {billingTermNoun} is up.</p>
+          <p>Except where required by law, we do not provide prorated refunds for partial billing periods.</p>
+        {/if}
+      </div>
+
       <button
         class="checkout-button"
         on:click={proceedToCheckout}
@@ -718,7 +736,9 @@
   }
 
   .billing-disclosure {
-    margin: -0.5rem 0 1.75rem;
+    /* Sits directly above the pay button, after the payment-method selector,
+       so the terms on screen always match the method the buyer has chosen. */
+    margin: 0 0 1.25rem;
     padding: 0.85rem 1rem;
     border-radius: 8px;
     background: rgba(255, 255, 255, 0.04);


### PR DESCRIPTION
## What

The billing disclosure on the Cook+ checkout said one thing to every buyer:

> Subscriptions renew for the period you picked unless you cancel before renewal.

That is true on the card path and **false on the Lightning path**. This splits it, and moves it to where the buyer can act on it.

## Why the two paths are different products

| | Card | Lightning |
|---|---|---|
| What is created | Stripe subscription — `mode: 'subscription'` (`stripeService.server.ts:96`) with a recurring `year`/`month` interval (`:89-91`) | A fixed term — `strike-webhook/+server.ts:123` calls `registerMember` with `paymentMethod: 'lightning_strike'` |
| Renews itself | yes | **no** — `subscriptionMonths` is 12 or 1, then it ends (`memberRegistration.server.ts:57-61`) |
| Anything to cancel | yes | no |

One hardcoded line cannot be true for both.

## Changes

- **Branch the disclosure on `paymentMethod`.** Card keeps renew + cancel + refund. Lightning gets "one payment covers one {term}, it does not renew on its own" + refund.
- **Move it below the payment-method selector**, directly above the pay button. It previously sat above the benefits list — before the buyer had chosen a method, so it could not have been accurate for their choice.
- **Track the period toggle** via `billingTermNoun`, so it reads "each year" / "each month" rather than a fixed noun.
- **Fix the same claim in the membership FAQ** (`membership/+page.svelte:57`), the other place the renewal promise is made.

The refund sentence applies to both paths and stays on both. The cancel sentence is card-only.

## Deliberately not in this PR

- **No dollar amount in the disclosure.** The price is already on screen, and `stripeService` sets `allow_promotion_codes: true` — a code entered on Stripe's hosted page can change what is actually charged, so a hardcoded amount in the terms could be wrong.
- **No change to the Lightning payment path itself.** Issue #523 (in-app wallet at checkout) is separate and unaddressed here.

## Verified

- `pnpm test` — **55 files / 856 tests passed**, run in this worktree at `df91081`.
- Each code claim above read at `origin/main` `be1b958` and re-confirmed in the working tree. One citation in an earlier draft of the code comment pointed at `verify-lightning-payment/+server.ts`, which does not exist at `be1b958`; corrected to the real path before commit.

## Not verified

- I did not render the checkout in a browser. The move changes where the block sits in the DOM; the margin was adjusted (`-0.5rem 0 1.75rem` → `0 0 1.25rem`) for the new position, but **spacing above the pay button is unconfirmed visually.**
- I did not test either payment path end to end.

## Review

**Copy is unreviewed and I am not the owner of it.** Growth owns user-facing strings; Dr Sats owns billing language. Both should read the four sentences before this merges. Human merges — I do not.
