### PR TITLE
Delete four relay constructs that nothing reads

### DIFF
--- a/src/lib/articleOutbox.ts
+++ b/src/lib/articleOutbox.ts
@@ -89,12 +89,6 @@ const CONFIG = {
     'wss://purplepag.es',            // Good for profile/content discovery
     'wss://antiprimal.net',          // Broad content discovery
   ],
-  
-  // Fallback relays if primary ones fail
-  FALLBACK_RELAYS: [
-    'wss://nostr.mutinywallet.com',
-    'wss://relay.snort.social',
-  ]
 };
 
 // ═══════════════════════════════════════════════════════════════

--- a/src/lib/membershipNotificationService.ts
+++ b/src/lib/membershipNotificationService.ts
@@ -4,7 +4,7 @@
 * Sends Nostr DMs to users when their membership is about to expire.
 */
 
-import NDK, { NDKEvent, NDKPrivateKeySigner, NDKRelaySet } from '@nostr-dev-kit/ndk';
+import NDK, { NDKEvent, NDKPrivateKeySigner } from '@nostr-dev-kit/ndk';
 import { nip04 } from 'nostr-tools';
 
 export interface ExpiringMember {
@@ -13,14 +13,6 @@ export interface ExpiringMember {
   tier: string;
   payment_id: string;
 }
-
-// Reliable relays for DM delivery
-const DM_RELAYS = [
-  'wss://nos.lol',
-  'wss://nostr.wine',
-  'wss://relay.snort.social',
-  'wss://purplepag.es'
-];
 
 /**
 * Check for memberships expiring within the specified days

--- a/src/lib/relayListCache.ts
+++ b/src/lib/relayListCache.ts
@@ -64,13 +64,6 @@ const CONFIG = {
   // IndexedDB settings
   CLEANUP_INTERVAL_MS: 30 * 60 * 1000,      // Cleanup expired entries every 30 min
   MAX_DB_ENTRIES: 10000,                    // Max entries in IndexedDB
-  
-  // Discovery relays for fetching relay lists
-  DISCOVERY_RELAYS: [
-    'wss://purplepag.es',
-    'wss://nos.lol',
-    'wss://relay.primal.net'
-  ]
 };
 
 // ═══════════════════════════════════════════════════════════════

--- a/src/lib/relaySelector.ts
+++ b/src/lib/relaySelector.ts
@@ -12,7 +12,6 @@
 import { browser } from '$app/environment';
 import { relayListCache, type RelayList, normalizeRelayUrl } from './relayListCache';
 import { getConnectionManager, type RelayHealth } from './connectionManager';
-import { standardRelays } from './consts';
 
 // ═══════════════════════════════════════════════════════════════
 // TYPES
@@ -57,7 +56,6 @@ export interface CoverageResult {
 
 export interface RelaySelector {
   selectForAuthor(pubkey: string, count?: number): Promise<SelectionResult>;
-  selectForPublish(): Promise<SelectionResult>;
   selectOptimalCoverage(pubkeys: string[], maxRelaysPerAuthor?: number): Promise<CoverageResult>;
   recordSuccess(relay: string, latencyMs: number): void;
   recordFailure(relay: string): void;
@@ -511,26 +509,6 @@ class RelaySelectorImpl implements RelaySelector {
       relays: selected.map(s => s.url),
       scores: selected,
       fallbackUsed
-    };
-  }
-  
-  async selectForPublish(): Promise<SelectionResult> {
-    await this.loadStats();
-    
-    // For publishing, use our standard relays + any connected relays
-    const connectedRelays = this.getConnectedRelays();
-    const allCandidates = [...new Set([...standardRelays, ...connectedRelays])];
-    
-    // Rank by reliability for publishing (higher bar)
-    const ranked = this.rankRelays(allCandidates);
-    
-    // For publishing, select more relays for redundancy
-    const selected = ranked.slice(0, 4);
-    
-    return {
-      relays: selected.map(s => s.url),
-      scores: selected,
-      fallbackUsed: false
     };
   }
   


### PR DESCRIPTION
## What

Deletes four relay constructs that nothing reads. No behavior change.

| Construct | Where | Call sites |
|---|---|---|
| `DM_RELAYS` | `membershipNotificationService.ts:18` | 0 |
| `CONFIG.FALLBACK_RELAYS` | `articleOutbox.ts:94` | 0 |
| `selectForPublish()` | `relaySelector.ts:60` (interface) + `:517` (impl) | 0 |
| `CONFIG.DISCOVERY_RELAYS` | `relayListCache.ts:69` | 0 |

## Why this is worth a PR rather than a cleanup someday

These are not stale scraps. They are well-named, well-commented relay lists, and during the relay inventory each one was read as live configuration by someone acting on it:

- **`DM_RELAYS`** was taken for the renewal-DM delivery set. The renewal notice actually goes out from `api/cron/check-expiring-memberships/+server.ts:76-79`, a different list of different relays.
- **`articleOutbox` `FALLBACK_RELAYS`** names `nostr.mutinywallet.com` and `relay.snort.social` — two relays we never contact. Both were candidates for the privacy policy's enumeration of "relays we connect to," which would have published a false statement.
- **`selectForPublish`** was the sole reason a contradiction looked live: `nostr.wine` sits in three `BLOCKED_RELAYS` sets *and* in `standardRelays`, and this dead function was the only code that would ever have acted on the conflict.
- **`CONFIG.DISCOVERY_RELAYS`** was found last and by accident, three minutes before the inventory froze.

Four different people were misled by these in one evening. Deleting them removes a class of error, not an instance.

## Also removed, because they became unused

- `NDKRelaySet` — the unused import in `membershipNotificationService`, presumably what `DM_RELAYS` was built for.
- `standardRelays` in `relaySelector` — its only reader was `selectForPublish`.

## Verified

- **Zero call sites**, checked with `git grep` across the whole tracked tree at `be1b958`, not just `src/`. The one remaining `DM_RELAYS`-shaped name, `FALLBACK_DM_RELAYS` in `nip17.ts:40`, is a different and live construct and is untouched.
- **No dynamic access.** None of the three `CONFIG` objects is exported, and `grep 'CONFIG\['` returns nothing in any of the three files, so the property deletions cannot be reached by string key.
- `pnpm test` — **55 files / 856 tests passed**.
- `pnpm check` — **0 errors, 150 warnings in 47 files**, byte-identical to the same command run on a `main`-based worktree. That is what rules out an implementer or caller of `selectForPublish` that grep would miss.

## Not verified

- I did not run the app. The argument here is that no code path reaches these, which is a static claim; if any of them were reachable through a mechanism grep and the type checker both miss, I have not covered it.

## Scope

Nothing here depends on the open decision about which relay replaces `relay.damus.io`. That decision is unaffected by this PR.

Human merges — I do not.
