### PR TITLE
Replace relay.damus.io with relay.nostr.net in the five runtime lists

### DIFF
--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -450,10 +450,10 @@
   const SEVEN_DAYS_SECONDS = 7 * 24 * 60 * 60;
 
   // Relay pools by purpose - optimized based on speed test results
-  // Speed test: nostr.wine (305ms) > nos.lol (342ms) > purplepag.es (356ms) > relay.damus.io (394ms)
+  // Speed test: nostr.wine (305ms) > nos.lol (342ms) > purplepag.es (356ms)
   // NOTE: All URLs are normalized (no trailing slashes) to prevent duplicate connections
   const RELAY_POOLS = {
-    recipes: ['wss://nos.lol', 'wss://relay.damus.io'], // General relays with recipe content
+    recipes: ['wss://nos.lol', 'wss://relay.nostr.net'], // General relays with recipe content
     fallback: ['wss://relay.primal.net', 'wss://nostr.wine', 'wss://antiprimal.net'], // Fast general relays for broader discovery
     discovery: [
       'wss://nostr.wine',

--- a/src/lib/authManager.ts
+++ b/src/lib/authManager.ts
@@ -917,7 +917,7 @@ export class AuthManager {
       relays = Array.from(this.ndk.pool.relays.keys()) as string[];
     }
     if (relays.length === 0) {
-      relays = ['wss://relay.damus.io', 'wss://nos.lol'];
+      relays = ['wss://relay.nostr.net', 'wss://nos.lol'];
     }
 
     // Store pending pairing info including secret for validation

--- a/src/lib/connectionManager.ts
+++ b/src/lib/connectionManager.ts
@@ -75,11 +75,16 @@ export class ConnectionManager {
 
     if (relayUrls.length === 0) {
       console.warn('⚠️ No relay URLs configured in NDK instance');
-      // Add some default relays if none are configured
+      // Add some default relays if none are configured.
+      // Four URLs, four distinct operators by NIP-11 pubkey - this is the
+      // last-resort path, so every entry has to be independently operated to
+      // be worth listing. nostr.mom used to sit here and publishes the same
+      // pubkey as nos.lol (c5fadeb5d90d68ba...), which made this a
+      // four-entry, three-operator list.
       const defaultRelays = [
         'wss://purplepag.es',
         'wss://nos.lol',
-        'wss://nostr.mom',
+        'wss://relay.nostr.net',
         'wss://relay.primal.net'
       ];
       relayUrls.push(...defaultRelays);

--- a/src/lib/countQuery.ts
+++ b/src/lib/countQuery.ts
@@ -43,11 +43,16 @@ const COUNT_CACHE_TTL = 60 * 1000; // 1 minute cache for counts
 const nip45SupportedRelays = new Set<string>();
 const nip45UnsupportedRelays = new Set<string>();
 
-// Relays known to support NIP-45 COUNT - prioritize fastest/most reliable
+// Relays known to support NIP-45 COUNT.
+// Both verified answering COUNT on 2026-07-26. relay.nostr.net replaced
+// relay.damus.io, which was announced for shutdown by end of July 2026 and was
+// already refusing 6 of 10 connections when measured. Corpus size matters here
+// because these counts are shown to users: relay.nostr.net holds ~54k kind:30023
+// events, so it counts accurately rather than merely quickly.
 const KNOWN_NIP45_RELAYS = [
-  'wss://relay.damus.io',      // 394ms - fast and reliable
-  'wss://nos.lol'               // 342ms - fastest
-  // Note: nostr.wine (305ms) and relay.nostr.band removed - in blocked relays list
+  'wss://relay.nostr.net',
+  'wss://nos.lol'
+  // Note: nostr.wine and relay.nostr.band removed - in blocked relays list
 ];
 
 // Server API configuration

--- a/src/lib/recipePack.ts
+++ b/src/lib/recipePack.ts
@@ -28,7 +28,7 @@ export const MY_RECIPES_TAG = 'my-recipes';
 // the hints rotate across a pack's recipe tags — between them, both
 // high-uptime general relays get coverage. Recipes publish via "all"
 // mode, so they land on both.
-export const RECIPE_PACK_RELAY_HINTS = ['wss://relay.damus.io', 'wss://relay.primal.net'];
+export const RECIPE_PACK_RELAY_HINTS = ['wss://relay.nostr.net', 'wss://relay.primal.net'];
 
 export type RecipePackSource =
   | { type: 'cookbook' }

--- a/src/routes/api/counts/batch/+server.ts
+++ b/src/routes/api/counts/batch/+server.ts
@@ -24,11 +24,12 @@ interface BatchResponse {
   errors: string[];
 }
 
-// Relays to query for counts - prioritize fastest, most reliable
-const COUNT_RELAYS = [
-  'wss://relay.damus.io',      // 394ms - fast and reliable
-  'wss://nos.lol'              // 342ms - fastest (if it supports NIP-45)
-];
+// Relays to query for counts. Both verified answering NIP-45 COUNT on
+// 2026-07-26. relay.nostr.net replaced relay.damus.io (shutting down end of
+// July 2026, and already refusing 6 of 10 connections when measured); it holds
+// the larger kind:30023 corpus of the two, which is what keeps these
+// user-visible counts accurate.
+const COUNT_RELAYS = ['wss://relay.nostr.net', 'wss://nos.lol'];
 
 /**
  * Send a NIP-45 COUNT query to a relay


### PR DESCRIPTION
Closes the last piece of the `relay.damus.io` removal, plus one adjacent operator-duplication fix found after the branch was opened.

Rebased onto `23362eb` (`origin/main` after #583 merged). `pnpm check` **0 errors / 150 warnings**, byte-identical to main's baseline. `pnpm test` **856/856**.

## Commit 1 — the five blocked lists

#581 took damus out everywhere it could be removed outright. **Five lists could not be**, because deleting the entry there would have left one relay behind. This supplies the replacement.

| File | Before | After |
|---|---|---|
| `src/lib/countQuery.ts:47` | `relay.damus.io` + `nos.lol` | `relay.nostr.net` + `nos.lol` |
| `src/routes/api/counts/batch/+server.ts:28` | same | same |
| `src/components/FoodstrFeedOptimized.svelte:456` | `nos.lol` + `relay.damus.io` | `nos.lol` + `relay.nostr.net` |
| `src/lib/authManager.ts:920` | `relay.damus.io` + `nos.lol` | `relay.nostr.net` + `nos.lol` |
| `src/lib/recipePack.ts:31` | `relay.damus.io` + `relay.primal.net` | `relay.nostr.net` + `relay.primal.net` |

## Commit 2 — `connectionManager.ts:79`

Added after the branch opened. `defaultRelays` is the pool used when NDK reports **no relays configured at all** — the path that runs after everything else has already failed. It listed `purplepag.es`, `nos.lol`, **`nostr.mom`**, `relay.primal.net`.

`nostr.mom` publishes NIP-11 pubkey `c5fadeb5d90d68ba…` — **the same pubkey `nos.lol` publishes.** Four URLs, three operators, in the one list where independent operation matters most. Now `relay.nostr.net` in that slot: four URLs, four operators.

Credit to Growth, who found it checking a draft post against the tree. The original probe looked at relay lists and missed this one.

## Why not `relay.nostr.build`

It was the first pick. Its own NIP-11 declares `payment_required: true`, `auth_required: true`, `restricted_writes: true`, with a **69,000-sat admission fee**:

```
CLOSED  auth-required: authenticate with AUTH before subscribing
CLOSED  auth-required: authenticate with AUTH before counting
OK false blocked: payment required, visit https://relay.nostr.build to get access
```

Reads are AUTH-gated and most of these lists run in a logged-out visitor's browser.

## Why `relay.nostr.net` over `offchain.pub`

`countQuery.ts` and `api/counts/batch` produce numbers **rendered to users**. `offchain.pub` holds ~1,200 kind:30023 events; `relay.nostr.net` holds ~54,004. On the smaller corpus those counts are *wrong*, not slow.

Separately — and this only surfaced afterwards — **`offchain.pub` is on our own blocklist** (`followOutbox.ts:115` `BLOCKED_RELAYS`). It was never a viable candidate and should not have been offered as one. `relay.nostr.net` is not on that list, and already appears in `followRecovery.ts:22`.

## What was measured (2026-07-26)

- NIP-45 `COUNT` answered — **54,004** kind:30023 · REQ→EOSE **205 ms**
- Accepted signed writes of kinds **1, 4, 30017, 30023, 30402**
- Kind **24133** probed separately and accepted — that's what `authManager` needs for NIP-46 bunker pairing, and the original probe didn't cover ephemeral kinds
- Operator `efe5d120df0cc290…`, distinct from `nos.lol` `c5fadeb5d90d68ba…`, `relay.primal.net` `dd9b989dfe5e0840…` and `purplepag.es` `fa984bd7dbb282f0…`

That last check is load-bearing: `nostr.mom` passes every capability column and shares nos.lol's pubkey. It would have looked like the right answer in every list here.

## This isn't only shutdown cleanup

Ten interleaved connection attempts against a control on 2026-07-26: `relay.damus.io` opened **4/10**, `nos.lol` opened **10/10**. Its NIP-11 document still serves fine over HTTPS, so it reads as "up."

## Not verified

- **One machine, one network.** The damus number has a control behind it; the latency figures do not — the same relay measured 739 ms and 1055 ms an hour apart. Order-of-magnitude, not benchmark.
- **Write columns are a lower bound** — probed with a throwaway key holding no sats and no social graph.
- **No browser run.** These are constant swaps with no rendering change; the residual risk is behaviour under real traffic, not layout.
- **Docs still reference damus** (`docs/dev/FEED_INVENTORY.md`, `docs/mobile/UX_DEV_NOTES.md`, `docs/deployment/CLOUDFLARE_TESTING.md`, and three more). Deliberately untouched — no runtime effect.
- **Android is unaffected and still unowned.** Different repo, different PR, wants to land before the Aug 10 RC.

## Known and deliberately NOT in this PR

Two further operator/capability problems verified at `23362eb`, both left for a separate decision:

- **`relays/relaySets.ts:56` `articles`** — 5 URLs, 4 operators (`eden.nostr.land` and `relay.noswhere.com` share `52b4a076…`). It also lists **`nostr.wine`, which is paid-write** (`restricted: sign up at https://nostr.wine to write events`) *and* on our own `BLOCKED_RELAYS`. This set feeds a real publish path (`LongformEditorModal.svelte:359`), so one of five publish targets rejects every article.
- **`followRecovery.ts:26` `ARCHIVAL_RELAYS`** — merged with `DEFAULT_RELAYS` at `:109` and `:212`, so `nostr.mom` and `nos.lol` land in the same pool. Also contains `nostr.wine` and `offchain.pub`, both blocklisted elsewhere. Read path, so the cost is wasted connections rather than failures.

Full probe data: `RESEARCH/RELAY_PROBE_2026_07_26.md`.

Reviewer: Chief. No user-facing copy in this diff. Human merges — not me.
