### PR TITLE
Correct the getRelay() argument names in three files

### DIFF
--- a/src/lib/nip65Routing.ts
+++ b/src/lib/nip65Routing.ts
@@ -142,7 +142,7 @@ export async function buildInboxAwareRelaySet(opts: {
   const pool = (
     ndk as unknown as {
       pool: {
-        getRelay: (url: string, autoConnect: boolean, createIfMissing: boolean) => NDKRelay | null;
+        getRelay: (url: string, connect: boolean, temporary: boolean) => NDKRelay | null;
       };
     }
   ).pool;

--- a/src/lib/profileResolver.ts
+++ b/src/lib/profileResolver.ts
@@ -126,10 +126,12 @@ async function fetchProfileFromRelays(pubkey: string, ndkInstance: NDK, hintRela
 
     const relays = [];
     for (const url of relayUrls) {
-      // autoConnect=true, createIfMissing=true — purplepag.es etc.
-      // may not be in the pool yet; this opens a connection in the
-      // background. fetchEvent will queue against not-yet-ready
-      // relays and resolve when any of them returns.
+      // getRelay(url, connect, temporary) — NDK 2.10.0. Creation is
+      // unconditional when the relay is missing; the third argument is
+      // temporary, which arms a 30s removal timer (skipped for relays in
+      // explicitRelayUrls). purplepag.es etc. may not be in the pool yet;
+      // this opens a connection in the background. fetchEvent will queue
+      // against not-yet-ready relays and resolve when any of them returns.
       const relay = ndkInstance.pool?.getRelay(url, true, true);
       if (relay) relays.push(relay);
     }

--- a/src/lib/publishQueue.ts
+++ b/src/lib/publishQueue.ts
@@ -553,7 +553,8 @@ class PublishQueueManager {
       `[PublishQueue] base=${baseUrls.length} → ${targetRelays.length} relays after NIP-65 union`
     );
 
-    // Materialize relays via getRelay() with autoConnect=true, createIfMissing=true
+    // Materialize relays via getRelay(url, connect, temporary) — temporary=true
+    // arms a 30s removal timer, skipped for relays in explicitRelayUrls.
     const relaysToPublish: any[] = [];
     for (const url of targetRelays) {
       const relay = ndkInstance.pool.getRelay(url, true, true);


### PR DESCRIPTION
Prep spotted that `profileResolver.ts:129` documents `getRelay()`'s third argument as `createIfMissing`. NDK 2.10.0's signature is `getRelay(url, connect, temporary, filters)` (`dist/index.js:7747`) — there is no `createIfMissing` parameter.

Checking it turned up **two more sites with the same wrong names**, and one of them is not a comment:

| Site | Kind |
|---|---|
| `profileResolver.ts:129` | comment |
| `publishQueue.ts:556` | comment, over a publish path |
| `nip65Routing.ts:145` | **structural type annotation** on a hand-written `ndk as unknown as {...}` cast |

The type annotation is the one worth the PR. TypeScript ignores parameter names for structural compatibility, so it compiles clean while declaring the wrong contract to anyone who reads it.

### What the arguments actually do

`getRelay` creates unconditionally when the relay is missing (`dist/index.js:7748-7750`). The third argument is `temporary`, which routes through `useTemporaryRelay(relay, 30_000, filters)` (`:7617`) — that calls `addRelay(relay)` on its own default and arms a 30-second removal timer, skipped for relays already in `explicitRelayUrls` (`:7630-7631`).

### I checked whether the wrong name caused a wrong argument — it did not

All **five** `getRelay(url, true, true)` call sites in `src/` pass `temporary=true`, so I traced whether any of them wanted the relay to persist and unknowingly opted into a 30s teardown:

- **`engagementCache.ts:450`** — the one that looked live, because its relay set feeds a `closeOnEose: false` persistent subscription (`:472`). `ZAP_AGGREGATOR_RELAYS` is `nos.lol` + `relay.primal.net` (`:10-13`), both in `standardRelays`, so they are already in the pool and `useTemporaryRelay` is never reached. **No finding.**
- **`profileResolver.ts:133`** — `PROFILE_RELAY_URLS` is `purplepag.es` + `nostr.wine`, same situation for a default user. A user who removed them from settings gets them re-added temporarily and torn down after 30s, which is the better of the two behaviours.
- **`publishQueue.ts:559`** and **`nip65Routing.ts:152`** — publish targets, connected and used in the same tick.
- **`TagsSearchAutocomplete.svelte:333`** — `search.nostrarchives.com`, the one site whose relay is *not* in `standardRelays`, so it does get a real 30s timer. Its subscription is `closeOnEose: true` with a hard 5s timeout (`:342`, `:368-371`), so the search is always over first. **No finding.**

So this is documentation only. Stating it because a check I ran and did not report looks identical to one I never ran.

### Verification

- `pnpm check` (`svelte-check`) at `a872d26`: **0 errors**, 150 warnings — all pre-existing a11y/CSS warnings in unrelated files.
- No behaviour change and no type change. `git grep 'createIfMissing' -- src/` returns nothing at `a872d26`; the one remaining `autoConnect` hit is `nostr.ts:186` `autoConnectUserRelays`, a real NDK option.

### Unable to verify

Nothing outstanding. Scope of every negative above is `src/` at `a872d26`.

**Not a gate on anything.** Doc-only, merge whenever convenient.

Found by Prep. Suggested reviewer: **Prep**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
