### PR TITLE
Drop three Primal cache URLs that have never worked from follow recovery

### DIFF
--- a/src/lib/followRecovery.ts
+++ b/src/lib/followRecovery.ts
@@ -23,14 +23,22 @@ const DEFAULT_RELAYS = [
 	'wss://relay.nostr.net'
 ];
 
+/**
+ * Deliberately does NOT include Primal's cache hosts. `wss://cacheN.primal.net`
+ * never opens a socket — the bare path serves an nginx HTML page — and the real
+ * endpoint at `/v1` (see primalCache.ts) answers our scan filter with
+ * `NOTICE: kinds or authors filter is not supported`, because it speaks Primal's
+ * cache protocol rather than plain nostr. Neither form can serve this path.
+ *
+ * `nostr.mom` shares an operator with `nos.lol`, which is in DEFAULT_RELAYS. It
+ * is kept because it is a working, independently-stored host, but the two are
+ * not independent redundancy — count operators, not URLs.
+ */
 const ARCHIVAL_RELAYS = [
 	'wss://nostr.wine',
 	'wss://offchain.pub',
 	'wss://nostr.mom',
-	'wss://relay.noswhere.com',
-	'wss://cache0.primal.net',
-	'wss://cache1.primal.net',
-	'wss://cache2.primal.net'
+	'wss://relay.noswhere.com'
 ];
 
 export interface FollowListCandidate {


### PR DESCRIPTION
Prep's archival-set decision, implemented: **delete the three phantoms, keep the rest, add nothing.**

`followRecovery.ts` `ARCHIVAL_RELAYS` listed `wss://cache0.primal.net`, `cache1` and `cache2`. None of the three has ever opened a WebSocket.

```
wss://cache0.primal.net   conn=n     GET https://cache0.primal.net/  →  HTTP 200, nginx,
wss://cache1.primal.net   conn=n     text/html, 615 bytes, identical etag on all three
wss://cache2.primal.net   conn=n
wss://nos.lol (control)   conn=y     [EVENT, EOSE]
```

Measured twice, with two different probe frames — bare, and again with a browser `Origin` and `User-Agent` after Prep found that a missing `Origin` manufactures a false `HTTP 403` on `nostr.wine`. A 615-byte HTML page is a web page whatever header you send it; the rows did not move.

**Correcting the URL would not save them.** Primal's socket is at `/v1` (`primalCache.ts:79` already uses that form), and there it answers the exact filter `queryRelayForFollowEvents` sends:

```
wss://cache1.primal.net/v1  →  ["NOTICE","kinds or authors filter is not supported"]
wss://cache2.primal.net/v1  →  same
wss://cache0.primal.net/v1  →  no connect (HTTP 404)
```

Primal's cache protocol is not plain nostr, so this is not a typo to fix — it is three entries that cannot serve this path in any form.

### Why deleting them is safe on the path where narrow is the harm

They sat on **both** sides of follow recovery: the scan set (`:118`) and the **signed-publish** set (`:221`). I held this change earlier tonight because deleting four of seven entries on a recovery path narrows the thing whose entire product is breadth. Prep's answer dissolved it: *deleting three of them narrows nothing, because they were never there.* The set was ten URLs and seven working ones. It is now seven and seven.

Side effect worth naming: `scanForFollowLists` reports `Querying ${relays.length} relays…` (`:122`). That user-visible count stops overstating by three. Same string, honest number.

### `nostr.mom` kept on purpose

It answers. It shares an operator with `nos.lol` (NIP-11 `pubkey` `c5fadeb5d90d68ba…`, confirmed both ways), so it is not *independent* redundancy — but a working, separately-stored host is not a dead one. The new comment says that, so the next person counting relays does not re-derive it or delete it.

The comment block also records why the Primal hosts are absent. A deletion with no note invites a re-add.

### Verification, all at `ee5a090`

- `npx vitest run` — **55 files, 856 tests, 856 passed.** Full suite, not scoped. There is no direct test for `followRecovery` (`grep -rln followRecovery src/ --include="*.test.ts"` → nothing), so the suite proves no regression elsewhere, not this file's behaviour.
- `pnpm check` (svelte-check) — **0 errors**, 150 pre-existing warnings in unrelated files.
- `git rev-parse HEAD` confirmed equal to `ee5a090` in the same shell as both runs, working tree clean.

### Unable to verify

- **No end-to-end recovery run.** Exercising it means a real account with a clobbered follow list; I did not simulate one. What is verified is that the removed URLs could not have contributed to either the scan or the publish.
- **`nostr.wine` remains a publish target here and declares `restricted_writes: true`** with an 18,888-sat admission fee (Prep's NIP-11 read). So the publish set is still 3-of-4 by acceptance rather than 4-of-4 by count. Prep parked that until after Aug 17 and I have not touched it.

### Scope note

Kept separate from #585 rather than riding with it, though Prep said either was fine. #585 was doc-only; this is a runtime relay-list change on a signed-publish path, and a reviewer should be able to say yes to one without inheriting the other.

**Not a gate on the Aug 10 submission.** Decision by Prep. Suggested reviewer: **Prep**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
