### PR TITLE
fix(recipe): address the delete tombstone at the event's own kind

### DIFF
--- a/src/components/GatedRecipePayment.svelte
+++ b/src/components/GatedRecipePayment.svelte
@@ -212,8 +212,16 @@
       {/if}
     </button>
 
-    <p class="text-xs text-caption text-center">
-      After payment, you'll have permanent access to this recipe
-    </p>
+    <!--
+      No caption under this button, deliberately. It used to read "After payment, you'll have
+      permanent access to this recipe", which this PR falsifies: deleting a gated recipe
+      replaces the kind-35000 event with a tombstone carrying no 'gated' tag, and checkIfGated
+      reads the gated note id off exactly that tag, so a buyer loses their route to what they
+      bought. A replacement was drafted and withdrawn rather than reworded — every candidate
+      described what paying gets you, and what paying gets you is an open question at the time
+      of writing, tracked outside this repo. A caption comes back when that is settled. The
+      same applies to premium/recipe/[slug]/+page.svelte's inline purchase block, which is a
+      second implementation of this same purchase.
+    -->
   </div>
 {/if}

--- a/src/components/Recipe/Recipe.svelte
+++ b/src/components/Recipe/Recipe.svelte
@@ -491,11 +491,19 @@
     isDeleting = true;
 
     try {
-      // For addressable events (kind 30023), the most reliable deletion method
-      // is to publish a replacement event with the same 'd' tag but marked as deleted.
+      // For addressable events the most reliable deletion method is to publish a
+      // replacement event with the same kind and 'd' tag but marked as deleted.
       // This overwrites the original on relays.
+      // This component renders two recipe kinds — public (30023) and premium
+      // (GATED_RECIPE_KIND, 35000) — and the tombstone must carry the SAME kind as
+      // the event being deleted, or it lands at a different address and overwrites
+      // whatever else lives there. Public and premium recipes derive their 'd' tag
+      // from the title identically (/create:343, /create/gated:187), so a hardcoded
+      // 30023 here blanks the author's public recipe when they delete a premium one
+      // of the same name.
+      const deleteKind = event.kind ?? 30023;
       const deleteEvent = new NDKEvent($ndk);
-      deleteEvent.kind = 30023;
+      deleteEvent.kind = deleteKind;
       deleteEvent.content = ''; // Empty content
 
       // Must use the same 'd' tag to replace the original
@@ -516,9 +524,9 @@
       deletionRequest.content = 'Recipe deleted by author';
       deletionRequest.tags.push(['e', event.id]);
       if (dTag) {
-        deletionRequest.tags.push(['a', `30023:${event.pubkey}:${dTag}`]);
+        deletionRequest.tags.push(['a', `${deleteKind}:${event.pubkey}:${dTag}`]);
       }
-      deletionRequest.tags.push(['k', '30023']);
+      deletionRequest.tags.push(['k', String(deleteKind)]);
 
       await deletionRequest.publish();
 

--- a/src/lib/nip108/premiumCopy.test.ts
+++ b/src/lib/nip108/premiumCopy.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Durability-claim tripwire for the premium (Lightning-gated recipe) surface.
+ *
+ * Four user-facing strings on this surface promised buyers "permanent access", and a
+ * fifth promised the author they would "always have access". Deleting a gated recipe
+ * replaces the kind-35000 event with a tombstone carrying no 'gated' tag, and
+ * checkIfGated() in ./client.ts reads the gated note id off exactly that tag — so a
+ * delete severs the buyer's route to what they bought, and the author's too. None of
+ * those five claims was ours to make. They were removed alongside the delete-address
+ * fix that made them plainly false.
+ *
+ * This scans DIRECTORIES rather than any one string, so it keeps holding after the
+ * strings it was written against are gone and covers files added later.
+ *
+ * IT IS A TRIPWIRE, NOT A GUARD. The vocabulary below is the set of phrasings we have
+ * actually shipped; a durability claim can be made in words that are not in it — the
+ * fifth string above was missed by exactly this kind of pattern before a human read the
+ * block. A green run means "none of the known phrasings is present", never "no claim of
+ * durability is made on this surface".
+ *
+ * Comments are stripped before matching, so writing up this history in a code comment
+ * does not trip it.
+ */
+
+const SURFACE_ROOTS = [
+  'src/routes/premium',
+  'src/routes/create/gated',
+  'src/lib/nip108',
+  'src/components/GatedRecipePayment.svelte'
+];
+
+const DURABILITY_VOCABULARY = /permanent|forever|lifetime|always have access/i;
+
+function collectSourceFiles(target: string): string[] {
+  const abs = path.resolve(target);
+  if (statSync(abs).isFile()) return [target];
+  return readdirSync(abs, { withFileTypes: true }).flatMap((entry) => {
+    const child = path.join(target, entry.name);
+    if (entry.isDirectory()) return collectSourceFiles(child);
+    if (!/\.(svelte|ts)$/.test(entry.name)) return [];
+    if (entry.name.endsWith('.test.ts')) return [];
+    return [child];
+  });
+}
+
+function stripComments(source: string): string {
+  return source
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+describe('premium surface makes no durability claim', () => {
+  const files = SURFACE_ROOTS.flatMap(collectSourceFiles);
+
+  it('finds the premium surface to scan', () => {
+    // Guards against the scan silently covering nothing if these paths move.
+    expect(files.length).toBeGreaterThan(3);
+    expect(files).toContain('src/components/GatedRecipePayment.svelte');
+  });
+
+  // A case per file, built in a loop rather than with it.each — it.each doesn't typecheck
+  // under svelte-check's TS setup here, the same limitation noted in
+  // routes/api/zappy/note-review/noteReview.test.ts:300.
+  for (const file of files) {
+    it(`${file} claims nothing about how long access lasts`, () => {
+      const offending = stripComments(readFileSync(path.resolve(file), 'utf-8'))
+        .split('\n')
+        .map((line, i) => ({ line: line.trim(), number: i + 1 }))
+        .filter(({ line }) => DURABILITY_VOCABULARY.test(line));
+
+      expect(
+        offending.map(({ number, line }) => `${file}:${number} ${line}`),
+        'A delete severs buyer and author access, so this surface cannot promise durability'
+      ).toEqual([]);
+    });
+  }
+});

--- a/src/lib/nip108/premiumCopy.test.ts
+++ b/src/lib/nip108/premiumCopy.test.ts
@@ -24,6 +24,14 @@ import path from 'node:path';
  *
  * Comments are stripped before matching, so writing up this history in a code comment
  * does not trip it.
+ *
+ * ONE FALSE POSITIVE TO EXPECT, AND THE FIX THAT IS WRONG. `lifetime` is also a
+ * membership tier value (`tier IN ('standard','premium','lifetime')` in the members
+ * schema), and create/gated is a membership-gated surface. No scanned file references it
+ * today, but the day a tier check lands in one of these directories this test fails on a
+ * word doing no copy work. NARROW THE PATTERN — exclude the tier usage — never drop the
+ * word: "lifetime access" is the strongest durability claim in the set and the one we
+ * would least want to ship unnoticed.
  */
 
 const SURFACE_ROOTS = [

--- a/src/routes/premium/+page.svelte
+++ b/src/routes/premium/+page.svelte
@@ -87,16 +87,34 @@
       subscription = $ndk.subscribe(filter);
 
       subscription.on('event', (event: NDKEvent) => {
-        // NOTE: this condition is always true and is deliberately left alone.
+        // This page has TWO sources and they interact. Read both before changing either:
+        //   1. this subscription — kind 35000 carrying GATED_RECIPE_TAG
+        //   2. loadServerStoredRecipes() below — GET /api/nip108/list, the KV store
+        // combinedRecipes (:39-49) renders a KV entry as a fallback card only when its
+        // gatedNoteId is absent from these events' 'gated' tags. It reads that absence as
+        // "not on relays yet" — but absence has other causes, and both notes below are one.
+        //
+        // NOTE: the condition below is always true and is deliberately left alone.
         // validateMarkdownTemplate() returns `MarkdownTemplate | string` ($lib/parser.ts:230)
         // and never null, so it filters nothing. Do NOT "fix" it to
         // `typeof ... !== 'string'`: /create/gated replaces a premium recipe's content
-        // with the preview text before publishing, so the on-relay content of every
-        // premium recipe fails template validation and the tightened check would empty
-        // this listing entirely.
-        // Deleted premium recipes need no check here: the tombstone published by
-        // Recipe.svelte's handleDelete carries no 't' tag, so the '#t' filter above
-        // excludes it once it has replaced the original.
+        // with the preview text before publishing, so EVERY premium recipe fails template
+        // validation. The tightened check drops them all from `events`, which also empties
+        // eventGatedIds — so the page does not go blank, it silently swaps the whole
+        // listing over to the KV fallback cards at :405, one per gated-store entry.
+        //
+        // Deleted premium recipes DO surface here, through that same fallback. The
+        // tombstone Recipe.svelte's handleDelete publishes carries 'd'/'deleted'/'title'
+        // and no 't' tag, so it never matches the '#t' filter above — and no 'gated' tag,
+        // so the recipe's id leaves eventGatedIds and its KV entry becomes a card offering
+        // to unlock a recipe that is gone. The card links to /premium/recipe/<naddr>, which
+        // renders "Recipe Deleted"; no payment can be taken, since the purchase UI needs
+        // gatedMetadata and that is null for a tombstone.
+        // Not fixed here, deliberately. Nothing removes the KV entry on delete — the five
+        // routes under /api/nip108 export no DELETE — so the listing cannot tell a deleted
+        // recipe from an unpropagated one. Suppressing the card client-side would need a
+        // second relay query for the tombstones this '#t' filter hides; that was priced and
+        // declined in #587 as a workaround for missing server state.
         if (validateMarkdownTemplate(event.content) !== null) {
           // Check if we already have this event
           if (!events.find(e => e.id === event.id)) {

--- a/src/routes/premium/+page.svelte
+++ b/src/routes/premium/+page.svelte
@@ -101,7 +101,7 @@
         // with the preview text before publishing, so EVERY premium recipe fails template
         // validation. The tightened check drops them all from `events`, which also empties
         // eventGatedIds — so the page does not go blank, it silently swaps the whole
-        // listing over to the KV fallback cards at :405, one per gated-store entry.
+        // listing over to the KV fallback cards at :412, one per gated-store entry.
         //
         // Deleted premium recipes DO surface here, through that same fallback. The
         // tombstone Recipe.svelte's handleDelete publishes carries 'd'/'deleted'/'title'
@@ -401,7 +401,14 @@
         </a>
       {/each}
 
-      <!-- Server-stored recipes (not yet on relays) -->
+      <!--
+        Gated-store entries with no matching 'gated' tag in `events`. "Not yet on relays" is
+        only one reason that can happen — a deleted recipe's tombstone drops the tag too, so
+        this block also renders cards for recipes that are gone. See the note on the
+        subscription above.
+        Note also that `sortedServerRecipes` (:57) is NOT filtered by showMyRecipesOnly, unlike
+        `filteredEvents` (:53) — these cards show on the My Recipes tab whoever authored them.
+      -->
       {#each sortedServerRecipes as recipe (recipe.gatedNoteId)}
         {@const recipeLink = recipe.naddr ? `/premium/recipe/${recipe.naddr}` : `/premium/recipe/${recipe.gatedNoteId}`}
         <a

--- a/src/routes/premium/+page.svelte
+++ b/src/routes/premium/+page.svelte
@@ -87,7 +87,16 @@
       subscription = $ndk.subscribe(filter);
 
       subscription.on('event', (event: NDKEvent) => {
-        // Validate it's a recipe format
+        // NOTE: this condition is always true and is deliberately left alone.
+        // validateMarkdownTemplate() returns `MarkdownTemplate | string` ($lib/parser.ts:230)
+        // and never null, so it filters nothing. Do NOT "fix" it to
+        // `typeof ... !== 'string'`: /create/gated replaces a premium recipe's content
+        // with the preview text before publishing, so the on-relay content of every
+        // premium recipe fails template validation and the tightened check would empty
+        // this listing entirely.
+        // Deleted premium recipes need no check here: the tombstone published by
+        // Recipe.svelte's handleDelete carries no 't' tag, so the '#t' filter above
+        // excludes it once it has replaced the original.
         if (validateMarkdownTemplate(event.content) !== null) {
           // Check if we already have this event
           if (!events.find(e => e.id === event.id)) {

--- a/src/routes/premium/+page.svelte
+++ b/src/routes/premium/+page.svelte
@@ -101,15 +101,18 @@
         // with the preview text before publishing, so EVERY premium recipe fails template
         // validation. The tightened check drops them all from `events`, which also empties
         // eventGatedIds — so the page does not go blank, it silently swaps the whole
-        // listing over to the KV fallback cards at :412, one per gated-store entry.
+        // listing over to the KV fallback cards at :437, one per gated-store entry.
         //
         // Deleted premium recipes DO surface here, through that same fallback. The
         // tombstone Recipe.svelte's handleDelete publishes carries 'd'/'deleted'/'title'
         // and no 't' tag, so it never matches the '#t' filter above — and no 'gated' tag,
         // so the recipe's id leaves eventGatedIds and its KV entry becomes a card offering
-        // to unlock a recipe that is gone. The card links to /premium/recipe/<naddr>, which
-        // renders "Recipe Deleted"; no payment can be taken, since the purchase UI needs
-        // gatedMetadata and that is null for a tombstone.
+        // to unlock a recipe that is gone. Where that card leads depends on whether the KV
+        // record ever got its naddr — see the note above the fallback-card {#each} in the
+        // markup below, which is also where the naddr problem is written up. With one it
+        // renders "Recipe Deleted"; without one the slug route rejects the link outright.
+        // Neither can take a payment: the purchase UI needs gatedMetadata, and that is
+        // null for a tombstone.
         // Not fixed here, deliberately. Nothing removes the KV entry on delete — the five
         // routes under /api/nip108 export no DELETE — so the listing cannot tell a deleted
         // recipe from an unpropagated one. Suppressing the card client-side would need a
@@ -306,9 +309,21 @@
     <div class="flex items-start gap-3">
       <LightningIcon size={20} weight="fill" class="text-amber-500 mt-0.5 flex-shrink-0" />
       <div>
+        <!--
+          This banner is the only text on the page saying what the page is, so it orients and
+          stops there. It used to read "Lightning-Gated Recipes — Creators can monetize their
+          exclusive recipes with Lightning payments. Pay once, get permanent access.", and
+          every clause of that was a claim we could not keep: "exclusive" and "monetize"
+          describe a gate holding, and "permanent access" is what this PR falsifies. The
+          replacement deliberately names no actor — a listing's authorPubkey is a body field
+          on store-gated/+server.ts:40-50 that nothing verifies against the caller, so "set by
+          the author" would assert more than the record knows. "Set when it was published" is
+          the one system claim left in it and it holds: the only write that can reach an
+          existing record is the PATCH at store-gated/+server.ts:131, which touches naddr
+          alone, and a repeat POST is refused with a 409 at :87-92 before storing.
+        -->
         <p class="text-sm" style="color: var(--color-text-primary);">
-          <strong>Lightning-Gated Recipes</strong> — Creators can monetize their exclusive recipes with Lightning payments. 
-          Pay once, get permanent access.
+          <strong>Premium recipes.</strong> Each one has a price on it, set when it was published.
         </p>
       </div>
     </div>
@@ -408,6 +423,16 @@
         subscription above.
         Note also that `sortedServerRecipes` (:57) is NOT filtered by showMyRecipesOnly, unlike
         `filteredEvents` (:53) — these cards show on the My Recipes tab whoever authored them.
+
+        The `recipe.naddr ? ... : ...` fallback below has never resolved in production. A KV
+        record is created without a naddr (store-gated/+server.ts:106 writes `naddr || ''`) and
+        completed by a second PATCH call that /create/gated/+page.svelte:256-266 wraps in a
+        try/catch commented "Non-critical". Both records live in the store on 2026-07-26 have
+        `naddr: ''`, so both take the gatedNoteId branch — and the slug route only parses
+        `naddr1...` (premium/recipe/[slug]/+page.svelte:56), throwing "Invalid recipe URL
+        format" at :153. Whatever fixes the deleted-card problem should decide who owns the
+        record between the two calls; a link built from a field that is allowed to stay empty
+        cannot be fixed here.
       -->
       {#each sortedServerRecipes as recipe (recipe.gatedNoteId)}
         {@const recipeLink = recipe.naddr ? `/premium/recipe/${recipe.naddr}` : `/premium/recipe/${recipe.gatedNoteId}`}

--- a/src/routes/premium/recipe/[slug]/+page.svelte
+++ b/src/routes/premium/recipe/[slug]/+page.svelte
@@ -266,6 +266,22 @@
       Try Again
     </button>
   </div>
+{:else if event && (event.tags.some((t) => t[0] === 'deleted') || !event.content || event.content.trim() === '')}
+  <!-- Deleted recipe tombstone — same check as /r/[naddr] and /recipe/[slug].
+       A deleted premium recipe is replaced by an empty event carrying a 'deleted'
+       tag, and checkIfGated() finds no gated tag on it, so without this branch it
+       falls through to the un-gated fallback below and renders as a blank recipe. -->
+  <div class="flex flex-col justify-center items-center min-h-[60vh] gap-4">
+    <h1 class="text-2xl font-bold" style="color: var(--color-text-primary);">Recipe Deleted</h1>
+    <p class="text-caption">This recipe has been deleted by its author.</p>
+    <a
+      href="/premium"
+      class="inline-flex items-center gap-2 text-sm hover:underline"
+      style="color: var(--color-text-secondary);"
+    >
+      ← Browse more premium recipes
+    </a>
+  </div>
 {:else if event && gatedMetadata && !hasAccess}
   <!-- Locked Premium Recipe View -->
   <div class="max-w-4xl mx-auto">

--- a/src/routes/premium/recipe/[slug]/+page.svelte
+++ b/src/routes/premium/recipe/[slug]/+page.svelte
@@ -415,10 +415,14 @@
           </div>
         </div>
 
-        <p class="text-center text-sm mt-4" style="color: var(--color-text-secondary);">
-          <LockOpenIcon size={16} class="inline mr-1" />
-          One-time payment. Permanent access to the full recipe.
-        </p>
+        <!--
+          No caption under this button, deliberately — see the matching note in
+          components/GatedRecipePayment.svelte, which is the other implementation of this
+          same purchase. It used to read "One-time payment. Permanent access to the full
+          recipe."; this PR falsifies it, and a replacement was drafted and withdrawn rather
+          than reworded because what paying gets you is an open question at the time of
+          writing. The two blocks had already drifted apart once, so keep them in step.
+        -->
         {/if}
       </div>
     </div>
@@ -476,10 +480,10 @@
       <div>
         {#if isAuthor}
           <p class="font-medium text-green-700 dark:text-green-400">Your Premium Recipe</p>
-          <p class="text-sm text-green-600 dark:text-green-500">As the author, you always have access to view this recipe.</p>
+          <p class="text-sm text-green-600 dark:text-green-500">As the author, you can view this recipe without paying.</p>
         {:else}
           <p class="font-medium text-green-700 dark:text-green-400">Recipe Unlocked!</p>
-          <p class="text-sm text-green-600 dark:text-green-500">You have permanent access to this premium recipe.</p>
+          <p class="text-sm text-green-600 dark:text-green-500">You've unlocked this premium recipe.</p>
         {/if}
       </div>
     </div>


### PR DESCRIPTION
Half 1 of the premium-delete fix, per @Prep's ruling in `#exec` (2026-07-26 06:07Z). Not bundled with the pantry publish-path item, which stays post-Aug-10.

Base: `c6f4574ca813999f59fd4572451dd5d189d475cd`, clean tree, `git rev-parse` in the same shell as every check below.

## The defect

`Recipe/Recipe.svelte:handleDelete` hardcoded `30023` three times — the replacement tombstone's kind (`:498`), the kind-5 `a` tag (`:519`), and the kind-5 `k` tag (`:521`). But the same component renders **premium recipes, kind 35000** (`GATED_RECIPE_KIND`, see `:66`/`:234`/`:268`), and the Delete item is gated on `isOwner` alone (`:1096`). `/r/[naddr]:165` and `/premium/recipe/[slug]:476` both mount it for a 35000.

So deleting a premium recipe wrote an empty `[Deleted]` event to `30023:<pubkey>:<slug>` while the recipe itself sat untouched at `35000:<pubkey>:<slug>`.

**The destructive variant.** `create/+page.svelte:343` and `create/gated/+page.svelte:187` derive the `d` tag with the identical formula (`title.toLowerCase().replaceAll(' ', '-')`). An author with a public *and* a premium recipe under the same title has both addresses populated — and deleting the **premium** one blanked the **public** one. It is the only path in that file where a delete destroys content the user did not select.

## The change

**1. Derive the kind from the event** (`Recipe.svelte`). One `const deleteKind = event.kind ?? 30023` used in all three places. `event.replaceableDTag()` on the line above was already kind-agnostic, so nothing else in `handleDelete` assumed 30023.

**On the public path this is a no-op by construction** — `event.kind` on a 30023 evaluates to 30023 and the emitted events are byte-identical. The only behaviour that changes is on kind 35000.

**2. Add the deleted-tombstone branch to `/premium/recipe/[slug]`.** That file had **zero** `deleted` hits, against `/r/[naddr]:156` and `/recipe/[slug]:214` which both hide on the tag. `checkIfGated()` finds no gated tag on a tombstone, so `gatedMetadata` stays null and it fell through to the un-gated `{:else if event}` fallback at `:476` and rendered a blank recipe. Predicate copied verbatim from `/r/[naddr]:156`; all three user-visible strings are verbatim reuses of live copy (`Recipe Deleted` / `This recipe has been deleted by its author.` from `/r/[naddr]:158-159`, `← Browse more premium recipes` from this file's own `:448`). No new customer-facing language.

**3. Document the trap at `premium/+page.svelte:89`,** in the code rather than only here.

```js
// the comment above it read: "Validate it's a recipe format"
if (validateMarkdownTemplate(event.content) !== null) {
```

`parser.ts:230` declares `validateMarkdownTemplate(markdown: string): MarkdownTemplate | string`. **It never returns null**, so the condition is always true and it filters nothing — and that no-op is load-bearing. `create/gated:229` replaces the event content with the preview before publishing, so a premium recipe's on-relay content is never a valid template. Tightening this to `typeof … !== 'string'` **empties the entire premium listing.** The old comment is precisely what would invite that tidy-up, so it is replaced with the reason.

The same comment records why no `deleted` check is needed on the listing: the tombstone carries no `t` tag, so the `'#t': [GATED_RECIPE_TAG]` filter above excludes it once it has replaced the original.

## Verified

- `pnpm check` (`svelte-kit sync && svelte-check`) — **0 errors**, 150 warnings in 47 files. Warning count unchanged from base.
- `pnpm test` (vitest) — **55 files, 856 tests, all pass.**
- `prettier --check` flags all three files **both before and after** this change; not reformatted, to keep the diff to the lines that matter.
- Every reader of the `deleted` tag in `src` is kind-agnostic — `Feed.svelte:47`, `user/[slug]:660`, `reads/[naddr]:200`, `recipe/[slug]:214`, `r/[naddr]:156` — so a 35000 tombstone is now hidden everywhere a 30023 one is. *Scoped to `grep -rn "t\[0\] === 'deleted'"` over `src`.*

## Not verified

- **No live test.** Nothing here was exercised against a real relay or a real premium recipe; there is no test harness for `handleDelete` and extracting it would be a refactor outside this scope.
- **I did not count how many gated recipes exist.** `store-gated/+server.ts` gates creation on `hasActiveMembership` and we have zero paying members, so any that exist came from a comped or admin account — a bound with a mechanism behind it, not a measurement.
- Whether any relay validates the kind-5 `k` tag against the `a` tag. The `['e', event.id]` tag at `:517` was always correct, so I am not claiming the old kind-5 failed everywhere — only that its `a` and `k` named the wrong record.

## Explicitly NOT in this PR

- **The publish path.** `handleDelete` still uses bare `.publish()` while create goes through `publishQueue.publishWithRetry(event, 'all')`, so the deletion still misses the pantry mirror. This fixes the **address**, not the **reach**. Prep dated that item post-Aug-10.
- **Half 2 — the encrypted copy on our server.** `src/lib/nip108/server-store.ts` exports 10 functions and none deletes gated content; `check-access` keeps serving a deleted premium recipe to anyone who paid. That is a product and money decision (revoke / honour / refund), not a missing function. Dr Sats and Prep, post-Aug-10.

Related: `RESEARCH/GATED_RECIPE_DELETE_2026_07_26.md`.

## Shipped behaviour for someone who already bought a premium recipe — READ BEFORE MERGING

Per @Prep's 06:16Z note, named here rather than left implicit. Verified at `c6f4574`, clean tree.

**This PR is a trade, not a pure no-op.** Correctly addressing the tombstone means the replacement event overwrites the real 35000 — and the replacement carries `d`, `deleted` and `title` and **no `gated` tag**. `lib/nip108/client.ts:126-129` reads `gatedNoteId` off exactly that tag and returns null without it, and `premium/recipe/[slug]:120,134,181` pass `metadata.gatedNoteId` to every `checkAccess` call. There is no cache and no purchases surface.

So **after this merges, deleting a premium recipe permanently cuts an existing buyer off from content they paid for, while the encrypted copy stays in our KV.** `check-access` would still answer yes; nothing has the id to ask it.

**Before this PR the buyer kept access and the author's *public* recipe got blanked instead.** Both are bad; the one this replaces destroys content the member did not select, and the exposed class is bounded by `store-gated`'s `hasActiveMembership` gate, so any buyer today bought from one of our own accounts.

**That is a default now in force for half 2, not a blank.** Prep's three answers were revoke / honour / refund. This ships a fourth — **revoke the access, retain the data, refund nothing** — chosen by an address fix rather than by a decision. Whoever opens half 2 is changing that default, not filling a gap.

## Second consequence, found after the PR was opened, and it contradicts a claim in this body

**The premium listing has a second data path I did not check, and this change makes a deleted premium recipe reappear on `/premium`.**

`premium/+page.svelte:164` fetches `/api/nip108/list`, and `:39-49` builds `serverOnlyRecipes` as *KV entries whose `gatedNoteId` is not present among the relay events*. Today the live 35000 carries the `gated` tag, so the KV entry is suppressed. Once the tombstone replaces it there is no `gated` tag anywhere in `events`, so the KV entry surfaces as a **server-only card at `:378` — title, preview, image, price and an "Unlock Recipe" overlay — linking to `/premium/recipe/<naddr>`.**

That link lands on the new deleted-tombstone branch and reads "Recipe Deleted". **No payment can be taken** — the purchase UI lives inside the `gatedMetadata && !hasAccess` branch and `gatedMetadata` is null for a tombstone. The damage is a stale card advertising a recipe that is gone.

**Partly pre-existing, made deterministic here.** The kind-5 request already carried `['e', event.id]` before this PR (`c6f4574:517`), which is a valid by-id NIP-09 request, so any relay honouring it produced this same stale card already. This change makes it happen on every relay rather than some.

**The root cause is half 2.** KV is the source of truth for "which premium recipes exist" and nothing here writes to it, so a deleted recipe and a not-yet-propagated one are indistinguishable from the listing's side. Any client-side suppression is a workaround for missing server state.

**This corrects the "would be dead code" claim above** — that reasoning was scoped to the relay subscription and I stated it about the page. Sequencing is @Prep's: merge as-is with the stale card as a named consequence, or hold for a client-side exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Update — `20531925` (comment rewrite, ruled blocking by @Prep)

The first pass of this PR shipped a code comment on `premium/+page.svelte` explaining that deleted premium recipes need no check there, because the tombstone carries no `t` tag and the `#t` filter excludes it. **That reasoning is retracted and it is now rewritten in the file**, because a PR body is read once and a comment is read by whoever opens the file next.

Two claims were wrong and both are corrected in place:

- **"deleted needs no check here"** — the `#t` filter is one of *two* data paths. `combinedRecipes` (`:39-49`) renders a KV entry as a fallback card whenever its `gatedNoteId` is absent from the events' `gated` tags, and a tombstone carries no `gated` tag. Deletion is what makes the card appear.
- **"the tightened check would empty this listing entirely"** — it would not. Dropping every 35000 from `events` also empties `eventGatedIds`, so *every* KV entry surfaces. The listing flips wholesale to fallback cards at `:405`; it does not go blank.

The rewritten comment states what both paths do, keeps the `validateMarkdownTemplate` trap (the condition is always true and must stay), and ends with why the card is **not** suppressed here: nothing removes the KV entry on delete — the five routes under `/api/nip108` export no `DELETE` — so the listing cannot distinguish a deleted recipe from an unpropagated one. A client-side exclusion would need a second relay query for the tombstones the `#t` filter hides; priced and declined as a workaround for missing server state.

*Not written as "cannot be fixed here" — the workaround exists and was declined. Over our own code, "cannot" means "have not."*

**Verified at `20531925439f715d50304011cc49df58a31c1dfd`**, `git rev-parse` in the same shell, clean tree: `pnpm check` **0 errors / 150 warnings in 47 files** (unchanged from base), `pnpm test` **55 files, 856 tests, all pass**. `prettier --check` flags this file before and after — pre-existing, not reformatted. Line references in the comment re-checked against the post-edit file: `combinedRecipes` at `:39`, the server-only `{#each}` at `:405`, `validateMarkdownTemplate` at `$lib/parser.ts:230`. Comment-only diff; no behaviour change.


---

## Update — `7e82bd78` (the copy set, ruled closed by @Prep 07:18Z)

Five user-facing strings on this surface promised durability. **This PR is what makes them false**, so they ship with it rather than behind a date — the rule is @Prep's and it applies to his own earlier hold. Wording is @Growth's throughout; nothing customer-facing here is mine.

**Reworded and kept — they describe an event, not a gate:**

| file:line | was | is |
|---|---|---|
| `premium/recipe/[slug]:463` | *As the author, you always have access to view this recipe.* | **As the author, you can view this recipe without paying.** |
| `premium/recipe/[slug]:466` | *You have permanent access to this premium recipe.* | **You've unlocked this premium recipe.** |

**Deleted, not replaced —** `GatedRecipePayment.svelte:216` (*After payment, you'll have permanent access to this recipe*) and `premium/recipe/[slug]:404` (*One-time payment. Permanent access to the full recipe.*). Every candidate replacement described what paying gets you, and that is not a claim available right now; deletion is the only edit true under both futures. A comment stands in each place recording why the caption is absent and that these are **two implementations of one purchase** — they had already drifted apart once, both carrying "permanent access."

**Replaced —** the `/premium` info banner (`:277-288` at base): *Lightning-Gated Recipes — Creators can monetize their exclusive recipes with Lightning payments. Pay once, get permanent access.* → **Premium recipes. Each one has a price on it, set when it was published.** It is the only text on that page saying what the page is, so it is replaced rather than cut. It deliberately names no actor: `store-gated/+server.ts` takes `authorPubkey` as a body field it never checks against the caller, so *"set by the author"* would assert more than the record knows. Its one system claim was checked against both write paths — the PATCH at `store-gated:131` touches `naddr` alone, and a repeat POST is refused 409 at `:87-92` before storing.

**A shared constant was built for the two pay-button captions and then removed with them.** `GATED_PURCHASE_DISCLOSURE_LINE` in `lib/nip108/client.ts`, imported by both purchase surfaces, plus its test file — all reverted, none of it committed. A dead export holding copy that reads as approved is a trap for whoever opens the file next.

**Added: `src/lib/nip108/premiumCopy.test.ts`.** A tripwire over `routes/premium`, `routes/create/gated`, `lib/nip108` and `GatedRecipePayment.svelte` for the durability vocabulary we have actually shipped (`permanent|forever|lifetime|always have access`). It scans **directories**, so it outlives the strings it was written against and covers files added later; comments are stripped before matching, so the history above can be written up in the code without tripping it. One guard case asserts the scan is not silently covering nothing.

**It is a tripwire, not a guard, and the file says so.** A pattern of this exact shape is what missed `:463` — a human reading the block found it. A green run means *none of the known phrasings is present*, never *no durability claim is made here*.

Built as a `for` loop rather than `it.each`: `it.each` does not typecheck under svelte-check here, the same limitation already noted at `routes/api/zappy/note-review/noteReview.test.ts:300`.

### Verified at `7e82bd783b9b771a9b5ebc95652bfc2d6f2701f4`

`git rev-parse` in the same shell, clean tree.

- `svelte-check` — **0 errors**, 150 warnings, 47 files with problems. Identical to base.
- `vitest run` (full suite) — **56 files, 866 tests, 864 pass.** The 2 failures are both in `src/lib/googleBackup/googleBackupCrypto.test.ts` (*PBKDF2 600k* parity cases), both `Test timed out in 5000ms`, and **both pass when that file is run alone** (7/7). Load-sensitive on this machine, untouched by this diff — reported rather than filtered out.
- The tripwire was **mutation-checked**: appending a line containing "permanent access" to `lib/nip108/types.ts` fails the run naming that file and line; reverted.
- `prettier --check` flags the two premium pages before and after, as at base; the new test file is prettier-clean.

### Not verified

- **No live test.** No premium recipe was created, bought or deleted against production for this change.
- **The strings were not seen rendered.** They were changed in source and typechecked; nobody loaded the pages.

### One correction to the previous update in this body

That section cited the server-only `{#each}` at `:405`. With the comment blocks added since, it is at **`:437`** in `premium/+page.svelte`, and the in-file comment now carries that number. Same block, moved by the comments.


### `0d821204` — one docstring line on the tripwire (comment-only)

`DURABILITY_VOCABULARY` contains `lifetime`, which is also a **membership tier value** — `member-relay@06e70c8 db/init.sql:21` constrains `tier` to `standard|premium|lifetime`, and `routes/create/gated` is a membership-gated surface. Nothing on the scanned surface references it today (the green run is the evidence), so this is latent.

The docstring now names the false positive **and the fix that would be wrong**: dropping `lifetime` from the regex removes the strongest durability claim in the set. Narrow the pattern to exclude a tier check; never drop the word. Raised by @Prep. `prettier --check` clean, tripwire still 10/10.
