### PR TITLE
fix(signup): return the buyer to checkout, close every exit, and stop claiming an account that doesn't exist yet

### DIFF
--- a/src/components/LoginFormIOS.svelte
+++ b/src/components/LoginFormIOS.svelte
@@ -612,8 +612,8 @@
                    the end of step 2, and modalCleanup() discards the keypair. The old wording
                    claimed an account existed at the one moment closing this would take it away. -->
               <p class="text-sm text-green-700">
-                ✓ Your key is ready. Save it below — you'll finish setting up your profile in the
-                next step.
+                Your key is ready. Save it below — you'll finish setting up your profile in the next
+                step.
               </p>
             </div>
           {/if}

--- a/src/components/LoginFormIOS.svelte
+++ b/src/components/LoginFormIOS.svelte
@@ -49,7 +49,13 @@
   let generateModal = false;
   let showPrivateKey = false;
   let backupStep = 1;
+  // Mirrors LoginOverlay: the step advances on either real save. link.click()
+  // cannot report whether the file was actually written, so a download-only
+  // gate blocked someone who copied the key into a password manager while
+  // passing someone who dismissed the save. The npub is not a backup.
   let backupDownloaded = false;
+  let backupCopied = false;
+  $: backupSaved = backupDownloaded || backupCopied;
   let bunkerConnectionString = '';
   let bunkerError = '';
   let bunkerConnecting = false;
@@ -150,6 +156,7 @@
     generatedKeys = authManager.generateKeyPair();
     backupStep = 1;
     backupDownloaded = false;
+    backupCopied = false;
   }
 
   function downloadKeysBackup() {
@@ -254,6 +261,19 @@
     }
   }
 
+  // Copying the nsec is a real backup and clears the same step the file does,
+  // but only if the clipboard write resolved — a rejected write must not count
+  // as a saved key.
+  async function copyBackupKey() {
+    if (!browser || !generatedKeys) return;
+    try {
+      await navigator.clipboard.writeText(nip19.nsecEncode(generatedKeys.privateKey));
+      backupCopied = true;
+    } catch {
+      // Leave the step gated; the download remains available.
+    }
+  }
+
   function modalCleanup() {
     nsecModal = false;
     bunkerModal = false;
@@ -261,6 +281,7 @@
     showPrivateKey = false;
     backupStep = 1;
     backupDownloaded = false;
+    backupCopied = false;
     nsecInput = '';
     nsecError = '';
     generatedKeys = null;
@@ -571,10 +592,10 @@
           </p>
 
           <div>
+            <!-- One duration promise, and it is the headline's above. -->
             <Button on:click={generateNewKeys} primary={true} class="w-full spark-glow">
               Create Profile
             </Button>
-            <p class="text-xs text-caption text-center mt-2">Takes less than 10 seconds</p>
           </div>
         </div>
       {:else}
@@ -582,8 +603,13 @@
           <!-- Calm intro message -->
           {#if backupStep === 1}
             <div class="bg-green-50 border border-green-200 rounded-lg p-3">
+              <!-- generateNewKeys() makes a keypair in memory and nothing else; nothing is
+                   published or stored and nobody is signed in until useGeneratedKeys() runs at
+                   the end of step 2, and modalCleanup() discards the keypair. The old wording
+                   claimed an account existed at the one moment closing this would take it away. -->
               <p class="text-sm text-green-700">
-                ✓ Your profile has been created. Save your backup key below to recover it later.
+                ✓ Your key is ready. Save it below — you'll finish setting up your profile in the
+                next step.
               </p>
             </div>
           {/if}
@@ -604,8 +630,7 @@
                     class="flex-1 min-w-0 input text-sm font-mono p-3"
                   ></textarea>
                   <button
-                    on:click={() =>
-                      generatedKeys && copyToClipboard(nip19.nsecEncode(generatedKeys.privateKey))}
+                    on:click={copyBackupKey}
                     class="flex-shrink-0 px-3 py-2 bg-accent-gray hover:opacity-80 rounded-lg text-sm font-medium transition-colors"
                     style="color: var(--color-text-primary)"
                   >
@@ -686,13 +711,15 @@
             <Button
               on:click={() => (backupStep = 2)}
               primary={false}
-              class="w-full {!backupDownloaded ? 'opacity-50 cursor-not-allowed' : ''}"
-              disabled={!backupDownloaded}
+              class="w-full {!backupSaved ? 'opacity-50 cursor-not-allowed' : ''}"
+              disabled={!backupSaved}
             >
               Next
             </Button>
-            {#if !backupDownloaded}
-              <p class="text-xs text-caption text-center">Download the backup file to continue.</p>
+            {#if !backupSaved}
+              <p class="text-xs text-caption text-center">
+                Save your key to continue — download the file, or reveal and copy it.
+              </p>
             {/if}
           {:else}
             <p class="text-xs text-caption uppercase tracking-wide mb-2">Step 2</p>

--- a/src/components/LoginFormIOS.svelte
+++ b/src/components/LoginFormIOS.svelte
@@ -20,6 +20,7 @@
   import { goto } from '$app/navigation';
   import { nip19 } from 'nostr-tools';
   import { createAuthManager, type AuthState } from '$lib/authManager';
+  import { showToast } from '$lib/toast';
   import { onMount, onDestroy } from 'svelte';
 
   let authManager: any = null;
@@ -270,7 +271,10 @@
       await navigator.clipboard.writeText(nip19.nsecEncode(generatedKeys.privateKey));
       backupCopied = true;
     } catch {
-      // Leave the step gated; the download remains available.
+      // Leave the step gated — but say so. A silent failure here would leave
+      // Next disabled while the hint under it still says to reveal and copy,
+      // which is the same shape of dead end this step was fixed to remove.
+      showToast('error', 'Could not copy — select the text and copy it manually');
     }
   }
 

--- a/src/components/LoginOverlay.svelte
+++ b/src/components/LoginOverlay.svelte
@@ -69,7 +69,15 @@
   let generateModal = false;
   let showPrivateKey = false;
   let backupStep = 1;
+  // Two ways to have saved the key, and the step advances on either. The
+  // download cannot be verified — link.click() returns whether or not the
+  // browser's save dialog was completed — so gating only on it blocked
+  // someone who put the key in a password manager while still passing
+  // someone who cancelled the dialog. Copying the nsec is the other real
+  // save; the npub is not a backup and does not count.
   let backupDownloaded = false;
+  let backupCopied = false;
+  $: backupSaved = backupDownloaded || backupCopied;
   let bunkerModal = false;
   let nip46UniversalModal = false;
 
@@ -513,6 +521,7 @@
     generatedKeys = authManager.generateKeyPair();
     backupStep = 1;
     backupDownloaded = false;
+    backupCopied = false;
     secureEnrolled = false;
     secureError = '';
     secureOrphanNote = false;
@@ -660,13 +669,28 @@
     }
   }
 
-  async function copyToClipboard(text: string) {
-    if (!browser) return;
+  // Returns whether the write actually landed. A caller that gates a step on
+  // a successful copy needs that answer — a rejected clipboard write must not
+  // count as a saved key. "Copied" rather than "Link copied": the three call
+  // sites copy a pairing URI, an npub, and an nsec, and only one is a link.
+  async function copyToClipboard(text: string): Promise<boolean> {
+    if (!browser) return false;
     try {
       await navigator.clipboard.writeText(text);
-      showToast('success', 'Link copied');
+      showToast('success', 'Copied');
+      return true;
     } catch {
-      showToast('error', 'Could not copy — copy the link manually');
+      showToast('error', 'Could not copy — select the text and copy it manually');
+      return false;
+    }
+  }
+
+  // Copying the nsec into a password manager is a real backup, so it clears
+  // the same step the downloaded file does — but only if the copy succeeded.
+  async function copyBackupKey() {
+    if (!generatedKeys) return;
+    if (await copyToClipboard(nip19.nsecEncode(generatedKeys.privateKey))) {
+      backupCopied = true;
     }
   }
 
@@ -718,6 +742,7 @@
     showPrivateKey = false;
     backupStep = 1;
     backupDownloaded = false;
+    backupCopied = false;
     nsecInput = '';
     nsecError = '';
     bunkerConnectionString = '';
@@ -1182,8 +1207,10 @@
             </div>
             <p class="text-sm text-caption">When you continue, we'll create your profile and show you a backup key to save for safekeeping.</p>
             <div>
+              <!-- The hero above already gives a duration. "Takes less than 10 seconds"
+                   contradicted it on the same screen, and neither number covers a flow that is
+                   four more screens plus a file save. One promise, and it is the headline's. -->
               <Button on:click={generateNewKeys} primary={true} class="w-full spark-glow">Create Profile</Button>
-              <p class="text-xs text-caption text-center mt-2">Takes less than 10 seconds</p>
             </div>
           </div>
         {:else if securePending}
@@ -1249,7 +1276,14 @@
                     <strong>this key is your account</strong>, and it's the only way back in if you
                     ever lose access to your passkeys.
                   {:else}
-                    ✓ Your profile has been created. Save your backup key below to recover it later.
+                    <!-- Not "your profile has been created": generateNewKeys() makes a keypair in
+                         this browser and nothing else. Nothing is published or stored and nobody is
+                         signed in until useGeneratedKeys() runs at the end of step 2, and
+                         modalCleanup() discards the keypair — so the old wording claimed an account
+                         existed at the one moment closing the box would take it away. State what is
+                         true, and that a step is left. -->
+                    ✓ Your key is ready. Save it below — you'll finish setting up your profile in
+                    the next step.
                   {/if}
                 </p>
               </div>
@@ -1261,7 +1295,7 @@
                 {#if showPrivateKey}
                   <div class="flex flex-col sm:flex-row gap-2">
                     <textarea id="private-key-textarea" readonly value={nip19.nsecEncode(generatedKeys.privateKey)} rows="2" class="flex-1 min-w-0 input text-sm font-mono p-3"></textarea>
-                    <button on:click={() => generatedKeys && copyToClipboard(nip19.nsecEncode(generatedKeys.privateKey))} class="flex-shrink-0 px-3 py-2 bg-accent-gray hover:opacity-80 rounded-lg text-sm font-medium transition-colors" style="color: var(--color-text-primary)">Copy</button>
+                    <button on:click={copyBackupKey} class="flex-shrink-0 px-3 py-2 bg-accent-gray hover:opacity-80 rounded-lg text-sm font-medium transition-colors" style="color: var(--color-text-primary)">Copy</button>
                   </div>
                   <div class="flex items-center justify-between mt-1.5">
                     <p class="text-xs text-amber-600">⚠️ Anyone with this key can control your profile. Never share it.</p>
@@ -1287,9 +1321,9 @@
                 <p class="text-sm text-caption">Download a backup file with your keys and safety notes.</p>
                 <Button on:click={downloadKeysBackup} primary={true} class="w-full mt-3">Download backup file</Button>
               </div>
-              <Button on:click={() => (backupStep = 2)} primary={false} class="w-full {!backupDownloaded ? 'opacity-50 cursor-not-allowed' : ''}" disabled={!backupDownloaded}>Next</Button>
-              {#if !backupDownloaded}
-                <p class="text-xs text-caption text-center">Download the backup file to continue.</p>
+              <Button on:click={() => (backupStep = 2)} primary={false} class="w-full {!backupSaved ? 'opacity-50 cursor-not-allowed' : ''}" disabled={!backupSaved}>Next</Button>
+              {#if !backupSaved}
+                <p class="text-xs text-caption text-center">Save your key to continue — download the file, or reveal and copy it.</p>
               {/if}
             {:else}
               <p class="text-xs text-caption uppercase tracking-wide mb-2">Step 2</p>

--- a/src/components/LoginOverlay.svelte
+++ b/src/components/LoginOverlay.svelte
@@ -1421,7 +1421,17 @@
         <img src="/zapcooking-text-light.svg" alt="Zap Cooking" class="signin-wordmark-img signin-wordmark-img--light" />
         <img src="/zapcooking-text-dark.svg" alt="" aria-hidden="true" class="signin-wordmark-img signin-wordmark-img--dark" />
       </h1>
-      <p class="signin-tagline">Share recipes and get paid by your community.</p>
+      <!-- Someone sent here from Cook+ checkout is not browsing; they were
+           about to pay. Say why the account step exists and promise the return
+           trip, which onComplete/goto(redirect) below actually delivers. -->
+      <p class="signin-tagline">
+        {#if ($page.url.searchParams.get('redirect') ?? '').startsWith('/membership/cook-plus-checkout')}
+          Cook+ is tied to your Zap Cooking account. Create one and we'll bring you right back to
+          checkout.
+        {:else}
+          Share recipes and get paid by your community.
+        {/if}
+      </p>
 
       {#if vaultRecord && vaultSupported && !authState.isAuthenticated}
         <!-- Locked passkey vault: unlock is the primary action, but every

--- a/src/components/LoginOverlay.svelte
+++ b/src/components/LoginOverlay.svelte
@@ -673,14 +673,21 @@
   // a successful copy needs that answer — a rejected clipboard write must not
   // count as a saved key. "Copied" rather than "Link copied": the three call
   // sites copy a pairing URI, an npub, and an nsec, and only one is a link.
-  async function copyToClipboard(text: string): Promise<boolean> {
+  // manualHint names the way out when the clipboard refuses, and it differs by
+  // screen: the key screens render the value in a field you can select, the
+  // pairing screen renders it only as a QR code (:991) with no text on it at
+  // all. One sentence cannot be true on both, so the caller supplies it.
+  async function copyToClipboard(
+    text: string,
+    manualHint = 'select the text and copy it manually'
+  ): Promise<boolean> {
     if (!browser) return false;
     try {
       await navigator.clipboard.writeText(text);
       showToast('success', 'Copied');
       return true;
     } catch {
-      showToast('error', 'Could not copy — select the text and copy it manually');
+      showToast('error', `Could not copy — ${manualHint}`);
       return false;
     }
   }
@@ -1000,7 +1007,7 @@
                   📱 Open Signer
                 </Button>
               {/if}
-              <Button on:click={() => copyToClipboard(nip46PairingUri)} primary={false} class="w-full">
+              <Button on:click={() => copyToClipboard(nip46PairingUri, 'scan the QR code instead')} primary={false} class="w-full">
                 📋 Copy Link
               </Button>
             </div>
@@ -1282,8 +1289,8 @@
                          modalCleanup() discards the keypair — so the old wording claimed an account
                          existed at the one moment closing the box would take it away. State what is
                          true, and that a step is left. -->
-                    ✓ Your key is ready. Save it below — you'll finish setting up your profile in
-                    the next step.
+                    Your key is ready. Save it below — you'll finish setting up your profile in the
+                    next step.
                   {/if}
                 </p>
               </div>

--- a/src/components/SuggestedFollowsModal.svelte
+++ b/src/components/SuggestedFollowsModal.svelte
@@ -216,23 +216,22 @@
   }
 </script>
 
-<Modal bind:open noHeader={true} allowOverflow={false}>
+<!-- cleanup={skip} covers the two exits the Close buttons above do not: Escape
+     (Modal.svelte:66-68) and a backdrop click (:147 on:click|self), both of
+     which call Modal's close() (:136-140). close() invokes cleanup and only
+     then sets open = false, so without this prop those two paths propagate
+     open=false up through bind:open to LoginOverlay's showSuggestedFollows and
+     unmount the modal WITHOUT ever running onComplete — same dead end as the
+     buttons had. Every other Modal in the login flow already passes cleanup
+     (LoginOverlay:829, :867, :941, :994, :1146, :1360); this one was the
+     outlier. Four exits, one behaviour. -->
+<Modal bind:open noHeader={true} allowOverflow={false} cleanup={skip}>
   <div class="flex flex-col gap-3 login-modal-body">
-    <button
-      type="button"
-      class="login-modal-logo-btn"
-      aria-label="Close"
-      on:click={skip}
-    >
+    <button type="button" class="login-modal-logo-btn" aria-label="Close" on:click={skip}>
       <img src="/zapcooking-text-light.svg" alt="" aria-hidden="true" class="dark:hidden" />
       <img src="/zapcooking-text-dark.svg" alt="" aria-hidden="true" class="hidden dark:block" />
     </button>
-    <button
-      type="button"
-      class="login-modal-close-btn"
-      aria-label="Close"
-      on:click={skip}
-    >
+    <button type="button" class="login-modal-close-btn" aria-label="Close" on:click={skip}>
       <CloseIcon size={24} />
     </button>
     <!-- Header -->

--- a/src/components/SuggestedFollowsModal.svelte
+++ b/src/components/SuggestedFollowsModal.svelte
@@ -206,6 +206,11 @@
     }
   }
 
+  // Closing this modal means the same thing as skipping it: the account is
+  // already created and following anyone is optional. Every exit routes here
+  // so onComplete always runs — it is the only thing that closes the login
+  // overlay and returns the new member to ?redirect=, which is checkout when
+  // they arrived from Cook+. Setting `open = false` directly is a dead end.
   function skip() {
     onComplete();
   }
@@ -217,7 +222,7 @@
       type="button"
       class="login-modal-logo-btn"
       aria-label="Close"
-      on:click={() => (open = false)}
+      on:click={skip}
     >
       <img src="/zapcooking-text-light.svg" alt="" aria-hidden="true" class="dark:hidden" />
       <img src="/zapcooking-text-dark.svg" alt="" aria-hidden="true" class="hidden dark:block" />
@@ -226,7 +231,7 @@
       type="button"
       class="login-modal-close-btn"
       aria-label="Close"
-      on:click={() => (open = false)}
+      on:click={skip}
     >
       <CloseIcon size={24} />
     </button>

--- a/src/routes/membership/cook-plus-checkout/+page.svelte
+++ b/src/routes/membership/cook-plus-checkout/+page.svelte
@@ -108,9 +108,12 @@
   onMount(() => {
     if (!browser) return;
     
-    // Redirect to login if not logged in
+    // Redirect to login if not logged in. Carry the query string, not just the
+    // path: `?period` is the billing choice the member already made on
+    // /membership, and dropping it returns them to the `annual` fallback at
+    // :23-24 — a different price than the one they clicked.
     if (!isLoggedIn) {
-      goto('/login?redirect=/membership/cook-plus-checkout');
+      goto('/login?redirect=' + encodeURIComponent($page.url.pathname + $page.url.search));
     }
 
     // Check for payment success (Stripe)


### PR DESCRIPTION
Three commits on one journey: a logged-out visitor who starts a Cook+ purchase, creates an account, and comes back. Reviewed in prep room from six screenshots Seth posted of the live `/login` flow (`PLANS/SIGNUP_FLOW_REVIEW_2026_07_26.md`).

## What's here

**`a6f308b` — return the buyer to checkout, and carry their billing choice.** Both Close buttons in `SuggestedFollowsModal` route through `skip()` so `onComplete` always runs; the logged-out bounce carries `?period` (the $4.99/mo → $49/yr wrong-charge fix); the sign-in tagline is conditional for checkout arrivals.

**`b7a0813` — close the last two exits.** The buttons were 2 of 4 exits. Escape and a backdrop click both go through `Modal.close()`, which sets `open = false` and propagates up through `bind:open`, unmounting the modal without `onComplete` — so someone who just created an account and pressed Escape was signed in, stranded on `/login`, never back to checkout. `cleanup={skip}` is how every other Modal in this flow already handles it; this one was the outlier.

**`12b56bd` — say what is true on the backup step, and stop gating it on a file.**

1. **The success banner claimed an account that did not exist yet.** `generateNewKeys()` makes a keypair in memory and nothing else — nothing is published or stored and nobody is signed in until `useGeneratedKeys()` runs at the end of step 2 — and `modalCleanup()` nulls `generatedKeys`, wired to both close buttons on that screen. We told someone their profile had been created and then discarded it if they believed us and closed the box. Now: the key is ready, save it, one step left.

2. **The download gate blocked the careful and passed the careless.** `backupDownloaded` is set synchronously after `link.click()`, which cannot report whether the OS save dialog was completed. Pressing Cancel unlocked Next with no file; copying the key into a password manager did not unlock it at all. It required the least safe storage location and could not verify even that. Next now advances on either real save — and a copy counts only if the clipboard write resolved. The npub does not count.

3. **Two duration promises on one screen.** "Takes less than 10 seconds" sat under "in under a minute", and neither covers a flow that is four more screens plus a file save. Dropped.

Also: `copyToClipboard` returned void and toasted *"Link copied"* at three call sites, two of which copy a key. It now returns whether the write landed — which is what lets a step gate on a real copy — and says "Copied".

**`LoginFormIOS` carried all three defects verbatim.** Fixing only the web overlay would have left the native iOS app showing a sentence we had just decided was false.

## Verification

`svelte-check` 0 errors / 150 warnings / 47 files and `vitest` 55 files / 856 tests — both identical to the `c6f4574` baseline. Prettier status of both touched files is unchanged from their previous state (`LoginOverlay` carries pre-existing repo formatting debt; `LoginFormIOS` was and remains clean).

**Not verified in a browser.** This repo has no component-render harness — no testing-library, no jsdom or happy-dom — so there is no seam for asserting that Escape runs `onComplete`, or that Next unlocks after a copy. Everything here was traced in code. If we want this behaviour guarded rather than argued, that harness is the prerequisite, and it is not a pre-Aug-10 item.

## Deliberately not in this PR

The follow-step preselection (21 accounts, 15 of them popularity-ranked, all checked by default) is a decision, not a fix. The two-signups problem — the Google tile is a complete account-creation path labelled "Drive backup" — is a decision about what signing up *is*, and belongs with the post-Aug-17 first-run work. No new screens, no new tiles, no copy added to explain the existing ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
