### PR TITLE
Rate limit the fridge scanner to 8/hour, 30/day per IP

### DIFF
--- a/src/lib/cheffy.ts
+++ b/src/lib/cheffy.ts
@@ -92,6 +92,21 @@ export const ERROR_LINES: string[] = [
 export const SCAN_ERROR_LINE = 'Cheffy could not read those ingredients. Try a clearer photo.';
 
 /**
+ * Error line for a rate-limited ingredient scan.
+ *
+ * Derived from the already-shipped note-review limit line
+ * (`api/zappy/note-review/+server.ts`, "Cheffy needs a breather — you've
+ * hit the photo-review limit for now.") with one noun changed to name
+ * the right feature. It exists because the alternatives are both wrong
+ * in front of a user: the limiter's own body carries the raw token
+ * `rate_limited`, and falling through to SCAN_ERROR_LINE tells someone
+ * who is rate-limited to retry with a clearer photo — a retry that also
+ * gets a 429.
+ */
+export const SCAN_RATE_LIMIT_LINE =
+  "Cheffy needs a breather — you've hit the fridge-scan limit for now.";
+
+/**
  * Pick a line from a pool, avoiding `avoid` (usually the previously
  * shown line) so consecutive states don't repeat. Falls back to the
  * first line for single-entry pools.

--- a/src/routes/api/zappy/scan/+server.ts
+++ b/src/routes/api/zappy/scan/+server.ts
@@ -23,11 +23,24 @@
  *   ok: false,
  *   error: string
  * }
+ * or, at the per-IP cap:
+ *   429 { ok: false, code: 'RATE_LIMITED', error: string, retryAfter: number }
+ *
+ * NOT authenticated. The `pubkey` in the body is unverified — it gates
+ * membership but is not proof of identity, so the rate limit below keys
+ * on the client address instead. Adding NIP-98 here would change the
+ * contract on both callers and is deliberately out of scope.
  */
 
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { CHEFFY_VISION_MODEL } from '$lib/cheffyPrompt.server';
+import { checkPerIpRateLimit } from '$lib/ipRateLimit.server';
+import { SCAN_RATE_LIMIT_LINE } from '$lib/cheffy';
+
+// Same per-IP cap extract-recipe uses for its paid-model path.
+const SCAN_PER_HOUR = 8;
+const SCAN_PER_DAY = 30;
 
 const SCAN_PROMPT = `You are analyzing a photo of a refrigerator, pantry, or food items for the Zap Cooking app.
 
@@ -47,7 +60,7 @@ Respond with ONLY a JSON array of ingredient names, nothing else. Example:
 
 If no food items are clearly visible, respond with an empty array: []`;
 
-export const POST: RequestHandler = async ({ request, platform }) => {
+export const POST: RequestHandler = async ({ request, getClientAddress, platform }) => {
   try {
     // Check for OpenAI API key
     const OPENAI_API_KEY = (platform?.env as any)?.OPENAI_API_KEY || env.OPENAI_API_KEY;
@@ -100,6 +113,52 @@ export const POST: RequestHandler = async ({ request, platform }) => {
           // missing pubkey (handled above).
         }
       }
+    }
+
+    // Per-IP cap on the vision model. Sits above the OpenAI call so a
+    // limited request costs nothing, and below the membership gate so a
+    // non-member's 403 doesn't consume a member's quota.
+    //
+    // Keyed on the client address, NOT on `pubkey`. Unlike note-review —
+    // where the pubkey comes back verified from `verifyNip98` and is a
+    // strictly better identity than an IP — the `pubkey` here is an
+    // unverified string off the request body (see the destructure above).
+    // A pubkey-keyed bucket would be reset by typing a different pubkey,
+    // which is the exact hole this is meant to close.
+    let ip = '127.0.0.1';
+    try {
+      ip = getClientAddress();
+    } catch {
+      // Local dev / missing CF headers.
+    }
+    // checkPerIpRateLimit fails open silently when no KV is bound; be
+    // loud about it here so a missing binding shows up in logs instead
+    // of quietly leaving this endpoint unmetered.
+    const kv = platform?.env?.NOURISH_FLAGS;
+    if (!kv) {
+      console.warn('[Zappy Scan] NOURISH_FLAGS KV not bound — scan rate limiting is disabled');
+    }
+    const rl = await checkPerIpRateLimit(kv, {
+      ip,
+      scope: 'zappy-scan',
+      perHour: SCAN_PER_HOUR,
+      perDay: SCAN_PER_DAY
+    });
+    if (rl.limited) {
+      // Not the limiter's bare body: both callers render `data.error`
+      // straight into the scan error UI (CheffyMessenger.svelte:232,
+      // cheffy/+page.svelte:560), so `rl.body.error` would put the raw
+      // token `rate_limited` on screen. Same `ok:false` + `code` shape
+      // note-review uses for its 429.
+      return json(
+        {
+          ok: false,
+          code: 'RATE_LIMITED',
+          error: SCAN_RATE_LIMIT_LINE,
+          retryAfter: rl.body.retryAfter
+        },
+        { status: 429 }
+      );
     }
 
     // Detect image type from base64 header or default to jpeg

--- a/src/routes/api/zappy/scan/scan.test.ts
+++ b/src/routes/api/zappy/scan/scan.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Unit tests for POST /api/zappy/scan.
+ *
+ * Collaborators (membership API, rate limiter, OpenAI fetch) are mocked
+ * at the module boundary; the endpoint's own validation, gating, and
+ * response-shaping logic runs for real. Mirrors the harness in
+ * ../note-review/noteReview.test.ts.
+ *
+ * The point of the rate-limit cases is the *ordering*: the cap has to
+ * sit below the membership gate (a 403 must not spend a member's quota)
+ * and above the OpenAI call (a 429 must not cost anything).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SCAN_RATE_LIMIT_LINE } from '$lib/cheffy';
+import { POST } from './+server';
+
+const mocks = vi.hoisted(() => ({
+  hasActiveMembership: vi.fn(),
+  checkPerIpRateLimit: vi.fn()
+}));
+
+vi.mock('$lib/membershipApi.server', () => ({ hasActiveMembership: mocks.hasActiveMembership }));
+vi.mock('$lib/ipRateLimit.server', () => ({ checkPerIpRateLimit: mocks.checkPerIpRateLimit }));
+
+const PUBKEY = 'a'.repeat(64);
+const CLIENT_IP = '203.0.113.7';
+const ENDPOINT = 'https://zap.cooking/api/zappy/scan';
+/** Minimal base64 whose prefix makes the endpoint detect a JPEG. */
+const IMAGE = '/9j/' + 'A'.repeat(64);
+
+const fetchMock = vi.fn();
+
+function openaiOk(content: string) {
+  return { ok: true, json: async () => ({ choices: [{ message: { content } }] }) };
+}
+
+type EventOpts = {
+  env?: Record<string, unknown> | null;
+  /** Throw from getClientAddress, as SvelteKit does without CF headers. */
+  noClientAddress?: boolean;
+};
+
+function makeEvent(body: unknown, opts: EventOpts = {}) {
+  const request = new Request(new URL(ENDPOINT), {
+    method: 'POST',
+    body: JSON.stringify(body)
+  });
+  const env =
+    opts.env === null
+      ? {}
+      : (opts.env ?? {
+          OPENAI_API_KEY: 'test-key',
+          MEMBERSHIP_ENABLED: 'true',
+          RELAY_API_SECRET: 'secret',
+          NOURISH_FLAGS: { kv: true }
+        });
+  return {
+    request,
+    platform: { env },
+    getClientAddress: () => {
+      if (opts.noClientAddress) throw new Error('no client address');
+      return CLIENT_IP;
+    }
+  } as any;
+}
+
+async function call(body: unknown, opts: EventOpts = {}) {
+  const res = await POST(makeEvent(body, opts));
+  return { res, data: await res.json() };
+}
+
+function validBody(overrides: Record<string, unknown> = {}) {
+  return { image: IMAGE, pubkey: PUBKEY, ...overrides };
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock);
+  mocks.hasActiveMembership.mockReset().mockResolvedValue(true);
+  mocks.checkPerIpRateLimit.mockReset().mockResolvedValue({ limited: false, ipHash: 'h' });
+  fetchMock.mockReset().mockResolvedValue(openaiOk('["eggs", "milk"]'));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('under the rate limit', () => {
+  it('200s and returns ingredients, unchanged', async () => {
+    const { res, data } = await call(validBody());
+    expect(res.status).toBe(200);
+    expect(data).toEqual({ ok: true, ingredients: ['eggs', 'milk'] });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('rate limiting', () => {
+  it('keys the bucket on the client address, not the unverified body pubkey', async () => {
+    await call(validBody());
+    expect(mocks.checkPerIpRateLimit).toHaveBeenCalledTimes(1);
+    const [kv, params] = mocks.checkPerIpRateLimit.mock.calls[0];
+    expect(kv).toEqual({ kv: true });
+    expect(params.ip).toBe(CLIENT_IP);
+    expect(params.ip).not.toBe(PUBKEY);
+    expect(params.scope).toBe('zappy-scan');
+    expect(params.perHour).toBe(8);
+    expect(params.perDay).toBe(30);
+  });
+
+  it('does not let a different pubkey reset the bucket', async () => {
+    await call(validBody({ pubkey: 'b'.repeat(64) }));
+    await call(validBody({ pubkey: 'c'.repeat(64) }));
+    const ips = mocks.checkPerIpRateLimit.mock.calls.map((c: any[]) => c[1].ip);
+    expect(ips).toEqual([CLIENT_IP, CLIENT_IP]);
+  });
+
+  it('falls back to a loopback IP when getClientAddress throws', async () => {
+    const { res } = await call(validBody(), { noClientAddress: true });
+    expect(res.status).toBe(200);
+    expect(mocks.checkPerIpRateLimit.mock.calls[0][1].ip).toBe('127.0.0.1');
+  });
+
+  it('429s over the limit WITHOUT calling OpenAI', async () => {
+    mocks.checkPerIpRateLimit.mockResolvedValue({
+      limited: true,
+      ipHash: 'h',
+      body: { error: 'rate_limited', retryAfter: 3600, scope: 'per-hour' }
+    });
+    const { res, data } = await call(validBody());
+    expect(res.status).toBe(429);
+    expect(data.ok).toBe(false);
+    expect(data.code).toBe('RATE_LIMITED');
+    expect(data.retryAfter).toBe(3600);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('sends a human error line, never the raw rate_limited token', async () => {
+    // Both callers render `data.error` straight into the scan error UI.
+    mocks.checkPerIpRateLimit.mockResolvedValue({
+      limited: true,
+      ipHash: 'h',
+      body: { error: 'rate_limited', retryAfter: 3600, scope: 'per-hour' }
+    });
+    const { data } = await call(validBody());
+    expect(data.error).toBe(SCAN_RATE_LIMIT_LINE);
+    expect(data.error).not.toMatch(/rate_limited/);
+  });
+
+  it('warns loudly when no KV is bound instead of silently unmetering', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await call(validBody(), {
+      env: { OPENAI_API_KEY: 'test-key', MEMBERSHIP_ENABLED: 'false' }
+    });
+    expect(mocks.checkPerIpRateLimit.mock.calls[0][0]).toBeUndefined();
+    // Asserted on the call args rather than expect.stringContaining —
+    // the asymmetric matchers do not typecheck under svelte-check in
+    // this repo (same limitation as it.each; see noteReview.test.ts).
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toContain('NOURISH_FLAGS');
+  });
+});
+
+describe('membership gate is not regressed', () => {
+  it('403s on a missing pubkey when gating is on, and spends no quota', async () => {
+    for (const pubkey of [undefined, '', '   ', 42]) {
+      mocks.checkPerIpRateLimit.mockClear();
+      fetchMock.mockClear();
+      const { res } = await call(validBody({ pubkey }));
+      expect(res.status).toBe(403);
+      // The 403 must sit ABOVE the limiter — a non-member probing the
+      // endpoint must not burn a real member's per-IP allowance.
+      expect(mocks.checkPerIpRateLimit).not.toHaveBeenCalled();
+      expect(fetchMock).not.toHaveBeenCalled();
+    }
+  });
+
+  it('403s for a non-member and spends no quota', async () => {
+    mocks.hasActiveMembership.mockResolvedValue(false);
+    const { res } = await call(validBody());
+    expect(res.status).toBe(403);
+    expect(mocks.checkPerIpRateLimit).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('still rate limits when membership gating is off', async () => {
+    const { res } = await call(validBody(), {
+      env: {
+        OPENAI_API_KEY: 'test-key',
+        MEMBERSHIP_ENABLED: 'false',
+        NOURISH_FLAGS: { kv: true }
+      }
+    });
+    expect(res.status).toBe(200);
+    expect(mocks.checkPerIpRateLimit).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('validation still precedes the limiter', () => {
+  it('400s on a missing image without spending quota', async () => {
+    const { res } = await call(validBody({ image: undefined }));
+    expect(res.status).toBe(400);
+    expect(mocks.checkPerIpRateLimit).not.toHaveBeenCalled();
+  });
+
+  it('500s without an OpenAI key without spending quota', async () => {
+    const { res } = await call(validBody(), { env: null });
+    expect(res.status).toBe(500);
+    expect(mocks.checkPerIpRateLimit).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Partially addresses #511. **Does not close it** — see "Out of scope" below.

`POST /api/zappy/scan` calls a vision model with no cap of any kind; the only guard was a 13MB image-size check. This adds `checkPerIpRateLimit` at **8/hour, 30/day**, the same numbers and helper `extract-recipe` uses for its paid-model path.

## One correction to the issue body

#511 suggests keying on `pubkey`. **This keys on `getClientAddress()` instead.** The `pubkey` here is an unverified string off the request body (`+server.ts:59`) — it gates membership but proves nothing, so a pubkey-keyed bucket is reset by typing a different pubkey, which is the exact hole being closed. `note-review` can key on a pubkey because `verifyNip98` hands it back a verified one; this endpoint has no such check.

## Placement is the substance, and both edges are tested

The cap sits **below the membership gate** (a non-member's 403 must not spend a real member's allowance) and **above the OpenAI fetch** (a 429 must cost nothing). Moving it past either edge fails a test — I checked by building both mutants.

## The 429 body is not the limiter's bare body — please read this part

Both callers render `data.error` straight into the scan error UI:

- `CheffyMessenger.svelte:232` — `throw new Error(data.error || SCAN_ERROR_LINE)`
- `cheffy/+page.svelte:560` — same

So returning `rl.body` verbatim puts the raw token **`rate_limited`** on screen. Omitting the field instead falls through to `SCAN_ERROR_LINE` = *"Cheffy could not read those ingredients. Try a clearer photo."* — advice that earns another 429. Both options are wrong in front of a user, so the response mirrors `note-review`'s 429 shape (`ok:false`, `code:'RATE_LIMITED'`, `error`, `retryAfter`).

**@Growth — one new customer-facing string, needs your read before merge.** `SCAN_RATE_LIMIT_LINE` in `src/lib/cheffy.ts`:

> "Cheffy needs a breather — you've hit the fridge-scan limit for now."

That is the already-shipped `note-review` limit line (`note-review/+server.ts:226`, *"…you've hit the photo-review limit for now."*) with one noun changed to name the right feature. I derived it rather than invented it precisely because copy isn't my call; it's a single exported constant, so a different wording is a one-line change.

## Loud on a missing binding

`checkPerIpRateLimit` fails open silently when no KV is bound. The missing binding is logged, as `note-review:208` does for the same reason — a no-op limiter that reads as covered is worse than no limiter.

## Out of scope

**NIP-98 on this endpoint.** It changes the contract on both callers and is an auth boundary — that needs @Seth or Daniel, not me. Shipping the IP cap alone bounds the cost damage and waits on nobody, but it means **#511 stays open**.

## Verification

At `c6f4574` + this branch, in `REPOS/wt-zappy-scan-rl`:

- `svelte-check` — **0 errors, 150 warnings, 47 files** = baseline exactly
- Full `vitest run` — **56 files, 868 tests, 0 failures** (baseline 55/856, plus the 12 added here). Not a scoped run.
- All 12 tests **mutation-checked**: each fails against a targeted mutant — pubkey keying, bare `rl.body`, limiter above the gate, limiter below the fetch, warn removed. No decorative assertions.
- `prettier --check` flags `scan/+server.ts` — **it is already dirty at `c6f4574`**, verified by restoring the baseline file in place and re-running. Not reformatted, to keep the diff readable.

## Not verified

- **No live test.** Nobody has seen a real 429 from this endpoint or the string rendered in the UI. The limiter and KV are mocked at the module boundary; `checkPerIpRateLimit` itself is unchanged and already exercised by five other call sites.
- The `it.each`/asymmetric-matcher limitation under `svelte-check` is pre-existing; noted in a comment where I worked around it.

Do not merge on my say-so — @Seth merges.

Suggested reviewers: **Growth** (the one new string) and **Prep** (the 429 contract change on two callers).