### PR TITLE
Stop destroying the reply draft when publishing fails

### DIFF
--- a/src/components/comments/ReplyComposer.svelte
+++ b/src/components/comments/ReplyComposer.svelte
@@ -308,6 +308,19 @@
 		}
 
 		posting = true;
+		// Declared outside the try so the catch can restore it; reassigned
+		// below once the final text is extracted.
+		let draftSnapshot: {
+			text: string;
+			images: string[];
+			videos: string[];
+			poll: PollConfig | null;
+		} = {
+			text: composerText,
+			images: [...uploadedImages],
+			videos: [...uploadedVideos],
+			poll: pollConfig
+		};
 		try {
 			if (composerEl) {
 				composerText = mentionCtrl.extractText();
@@ -317,6 +330,19 @@
 			let content = mentionCtrl.replacePlainMentions(composerText.trim());
 			const mediaUrls = [...uploadedImages, ...uploadedVideos];
 			const capturedPollConfig = pollConfig;
+			// Snapshot what the member typed BEFORE clearing. The composer is
+			// cleared optimistically so a successful post feels instant, but
+			// the publish below can still fail — and without this the draft is
+			// gone and the error toast's "please try again" has nothing to try
+			// again with. Holds the pre-processing state (raw text, media URLs,
+			// poll config), not the built `content`, so a restore gives back
+			// exactly what was typed rather than the mention-substituted form.
+			draftSnapshot = {
+				text: composerText,
+				images: [...uploadedImages],
+				videos: [...uploadedVideos],
+				poll: pollConfig
+			};
 			clearState();
 			if (mediaUrls.length > 0) {
 				const mediaText = mediaUrls.join('\n');
@@ -343,6 +369,16 @@
 
 			onPosted?.(posted);
 		} catch (error) {
+			// Put the draft back. The optimistic clear above assumed success;
+			// this is the branch where that assumption was wrong, and the
+			// member should not lose what they wrote. Restoring composerText
+			// while lastRendered is still '' (clearState reset both) is what
+			// re-renders the contenteditable, via the reactive syncContent
+			// block above.
+			composerText = draftSnapshot.text;
+			uploadedImages = draftSnapshot.images;
+			uploadedVideos = draftSnapshot.videos;
+			pollConfig = draftSnapshot.poll;
 			// Technical details to console; human-friendly message to the user.
 			console.error('[ReplyComposer] post failed:', error);
 			showToast('error', "Couldn't post comment — please try again.");


### PR DESCRIPTION
**Not #519.** This is the precondition I hit while reading it. #519 itself is still blocked on @Prep's shape call — see the channel.

## The bug

`ReplyComposer.handleSubmit` clears the composer at `:320` and publishes at `:335`. The clear is unconditional and runs **first**. So every failure lands in a catch that logs, toasts *"Couldn't post comment — please try again,"* and leaves the member staring at an empty composer.

There is nothing to try again with. `composerText`, `uploadedImages`, `uploadedVideos`, `pollConfig` and the contenteditable's `innerHTML` are all already gone, and nothing puts them back.

*Scope of that negative:* the only writes to `composerText` in `ReplyComposer.svelte` are the initializer (`:86`), the mention controller's text callback (`:181`), `clearState` (`:281`), and the pre-submit extract (`:313`). No restore anywhere in the file.

## It is not the house pattern

`PostComposer.svelte` clears early **only** on `variant === 'modal'` (`:519-523`) — and that is earned, because that path runs through `publishQueue.publishWithRetry` with a pending indicator behind it. On its inline variant it resets only inside the `success` and `queued` branches (`:533`, `:541`), **never on error**.

ReplyComposer took the modal's optimistic clear without the queue that justifies it. All four of its mounters are inline (`CommentCard:284`, `CommentThread:132` and `:186`, `[nip19]/+page.svelte:935`) — none has a queue.

## The fix

Snapshot the pre-processing state immediately before `clearState`, restore it in the catch.

It deliberately does **not** keep the built `content`: that string has mentions substituted and media appended, so restoring it would hand the member back something they did not type. Restoring `composerText` while `lastRendered` is still `''` is what re-renders the contenteditable, via the existing reactive `syncContent` block at `:188`.

## Why this blocks #519 rather than being cosmetic

#519 asks for the publish-timeout signed-event retry from `noteReview.ts`. Of the three copy constants there, **only `PUBLISH_FAILED_LINE` is reusable outside Cheffy's voice** — `POST_TIMEOUT_LINE` and `SIGN_FAILED_LINE` both name Cheffy, and ReplyComposer is a generic comment composer, not a Cheffy surface.

That one reusable line reads: *"The relays didn't take that one. **Your draft is safe** — give it another go."*

On this component that sentence is **false today**. This PR makes it true. Shipping #519's copy first would have put a reassurance on screen that the code did not honour.

## Verification

At `2de8404`, worktree `REPOS/wt-reply-draft`, off `c6f4574`:

- `svelte-check` — **0 errors, 150 warnings, 47 files** = baseline exactly
- `vitest run` — **55 files, 856 tests, 0 failures** = baseline exactly
- `prettier --check` flags this file — **already dirty at `c6f4574`**, verified by restoring the baseline file in place. Not reformatted.

## Not verified

- **No test, and no way to add a meaningful one here.** ReplyComposer is a Svelte component and this repo has no component-render harness — no testing-library, no jsdom/happy-dom, zero `render(` in any test. The restore path has no seam to assert on. Extracting four lines of state restore purely to create one would be premature abstraction; if the harness Prep sized (~a day, post-Aug-17) lands, this is a good first case for it.
- **The restore has not been exercised at runtime.** It needs an authenticated session with a signer plus an induced publish failure, which I cannot drive headlessly. The change is type-checked and compiles; the behaviour is reasoned from the code, not observed.

Do not merge on my say-so.

Suggested reviewers: **Prep** (it changes what a failed reply does, and it interacts with the #519 shape call that is already his).