### PR TITLE
Let members ask Cheffy about a photo, and stop mislabelling the scanner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.685",
+  "version": "4.2.686",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.684",
+  "version": "4.2.685",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.683",
+  "version": "4.2.684",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/CheffyMessenger.svelte
+++ b/src/components/CheffyMessenger.svelte
@@ -278,6 +278,17 @@
     sendCheffy($cheffyDraft);
   }
 
+  // Hand a scanned file to the composer as an attached photo. Every
+  // non-success exit of handleScan does this, which is what makes
+  // SCAN_ERROR_LINE's "the photo's still here" true: the member who
+  // scanned a plated dish is one Send away from asking about it, instead
+  // of re-opening the menu and re-picking the file we threw away.
+  function holdScanPhoto(file: File) {
+    clearAttachedPhoto();
+    attachedPhoto = file;
+    attachedPhotoUrl = URL.createObjectURL(file);
+  }
+
   async function handleScan(event: Event) {
     const inputEl = event.target as HTMLInputElement;
     const file = inputEl.files?.[0];
@@ -312,9 +323,13 @@
         composerEl?.focus();
       } else {
         scanError = SCAN_ERROR_LINE;
+        holdScanPhoto(file);
+        await tick();
+        composerEl?.focus();
       }
     } catch (err) {
       scanError = err instanceof Error ? err.message : SCAN_ERROR_LINE;
+      holdScanPhoto(file);
     } finally {
       isScanning = false;
       if (inputEl) inputEl.value = '';
@@ -611,7 +626,11 @@
                     </div>
                   {:else if m.kind === 'error'}
                     <div class="err">
-                      <p class="err-line">{m.statusLine}</p>
+                      <!-- A photo turn that failed with a typed server code
+                           carries no flavour line: the detail below already
+                           names the cause, and a second narrator above it
+                           would invent a different one. -->
+                      {#if m.statusLine}<p class="err-line">{m.statusLine}</p>{/if}
                       <p class="err-detail">{m.content}</p>
                       <button
                         type="button"
@@ -835,7 +854,7 @@
                 <ImageIcon size={20} /> Upload an image
               </button>
               <button type="button" role="menuitem" class="attach-item" on:click={pickScan}>
-                <ScanIcon size={20} /> Scan my fridge or pantry
+                <ScanIcon size={20} /> Scan a fridge or pantry for ingredients
               </button>
               <button type="button" role="menuitem" class="attach-item" on:click={handoffSousChef}>
                 <ClipboardIcon size={20} /> Paste a recipe

--- a/src/components/CheffyMessenger.svelte
+++ b/src/components/CheffyMessenger.svelte
@@ -22,6 +22,7 @@
   } from '$lib/stores/membershipStatus';
   import { parseMarkdown } from '$lib/parser';
   import { PROMPT_PLACEHOLDERS, SCAN_ERROR_LINE } from '$lib/cheffy';
+  import { fileToBase64, PHOTO_MAX_BYTES } from '$lib/photoAsk';
   import {
     cheffyOpen,
     cheffyThread,
@@ -33,6 +34,7 @@
     cheffyExperienceCount,
     cheffyConversion,
     sendCheffy,
+    askCheffyAboutPhoto,
     retryCheffy,
     startOverCheffy,
     closeCheffy
@@ -43,6 +45,7 @@
     STARTER_SUGGESTIONS,
     CONTEXT_RECIPE,
     CONTEXT_GENERAL,
+    PHOTO_ASK_SUGGESTIONS,
     type CheffySuggestion
   } from './CheffySuggestionChips.svelte';
   import XIcon from 'phosphor-svelte/lib/X';
@@ -125,8 +128,11 @@
   // ── Composer ───────────────────────────────────────────────────
   let placeholderIndex = 0;
   let placeholderTimer: ReturnType<typeof setInterval>;
-  $: placeholder = PROMPT_PLACEHOLDERS[placeholderIndex];
-  $: canSend = $cheffyDraft.trim().length > 0 && !$cheffyLoading;
+  // With a photo attached the composer is asking about it, so the
+  // rotating cooking placeholders would be misleading.
+  $: placeholder = attachedPhoto ? 'Ask about this photo…' : PROMPT_PLACEHOLDERS[placeholderIndex];
+  // A photo alone is a valid send — the server fills in the question.
+  $: canSend = ($cheffyDraft.trim().length > 0 || attachedPhoto !== null) && !$cheffyLoading;
 
   async function autoSize() {
     await tick();
@@ -142,7 +148,7 @@
   function onComposerKeydown(e: KeyboardEvent) {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      if (canSend) sendCheffy($cheffyDraft);
+      submitComposer();
     }
   }
 
@@ -161,7 +167,10 @@
   $: lastMsgId = $cheffyThread[$cheffyThread.length - 1]?.id;
 
   async function handleSuggestion(s: CheffySuggestion) {
-    if (s.behavior === 'send') {
+    // While a photo is held, even a 'send' chip only seeds the composer:
+    // sendCheffy would fire a text-only turn and strand the attachment.
+    // The send button is what carries the file.
+    if (s.behavior === 'send' && !attachedPhoto) {
       sendCheffy(s.prompt);
       return;
     }
@@ -187,24 +196,86 @@
   }
 
   // ── Attachment action sheet ────────────────────────────────────
+  // Two destinations, and the menu now says which is which. Camera and
+  // Upload attach the photo to the composer so the member can ask a
+  // question about it (POST /api/zappy/ask-photo); Scan is the narrow
+  // fridge/pantry ingredient reader it always was (POST /api/zappy/scan).
   let attachOpen = false;
   let cameraInput: HTMLInputElement;
   let uploadInput: HTMLInputElement;
+  let scanInput: HTMLInputElement;
   let isScanning = false;
   let scanError = '';
 
-  function pickUpload() {
+  function pickAskUpload() {
     attachOpen = false;
     uploadInput?.click();
   }
-  function pickCamera() {
+  function pickAskCamera() {
     attachOpen = false;
     cameraInput?.click();
+  }
+  function pickScan() {
+    attachOpen = false;
+    scanInput?.click();
   }
   function handoffSousChef() {
     attachOpen = false;
     closeCheffy();
     goto('/souschef');
+  }
+
+  // ── Attached photo (the "ask about a photo" path) ──────────────
+  // Held in the composer until the member sends, so the question and the
+  // photo travel together. The store mints its own preview URL for the
+  // thread bubble; this one belongs to the composer chip and is released
+  // the moment the chip goes away.
+  let attachedPhoto: File | null = null;
+  let attachedPhotoUrl = '';
+
+  function clearAttachedPhoto() {
+    if (attachedPhotoUrl) {
+      URL.revokeObjectURL(attachedPhotoUrl);
+      attachedPhotoUrl = '';
+    }
+    attachedPhoto = null;
+  }
+
+  async function handleAttachPhoto(event: Event) {
+    const inputEl = event.target as HTMLInputElement;
+    const file = inputEl.files?.[0];
+    // Reset immediately so re-picking the same file still fires change.
+    if (inputEl) inputEl.value = '';
+    if (!file) return;
+    if (!file.type.startsWith('image/')) {
+      scanError = 'Please choose an image file.';
+      return;
+    }
+    if (file.size > PHOTO_MAX_BYTES) {
+      scanError = 'That image is a little big — try one under 10MB.';
+      return;
+    }
+    scanError = '';
+    clearAttachedPhoto();
+    attachedPhoto = file;
+    attachedPhotoUrl = URL.createObjectURL(file);
+    await tick();
+    composerEl?.focus();
+  }
+
+  // Single send entry point: a held photo makes this a photo turn, and
+  // an empty question is fine (the server supplies the default ask).
+  function submitComposer() {
+    if (!canSend) return;
+    if (attachedPhoto) {
+      const file = attachedPhoto;
+      const question = $cheffyDraft;
+      clearAttachedPhoto();
+      scanError = '';
+      askCheffyAboutPhoto(file, question);
+      return;
+    }
+    sendCheffy($cheffyDraft);
   }
 
   async function handleScan(event: Event) {
@@ -244,15 +315,6 @@
       isScanning = false;
       if (inputEl) inputEl.value = '';
     }
-  }
-
-  function fileToBase64(file: File): Promise<string> {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => resolve((reader.result as string).split(',')[1]);
-      reader.onerror = reject;
-      reader.readAsDataURL(file);
-    });
   }
 
   // ── Open / close side effects ──────────────────────────────────
@@ -368,6 +430,7 @@
   onDestroy(() => {
     unsub();
     if (placeholderTimer) clearInterval(placeholderTimer);
+    clearAttachedPhoto();
     if (browser && $cheffyOpen) onClose();
   });
 </script>
@@ -434,6 +497,8 @@
                 class="menu-item"
                 on:click={() => {
                   menuOpen = false;
+                  clearAttachedPhoto();
+                  scanError = '';
                   startOverCheffy();
                 }}
                 disabled={$cheffyLoading || $cheffyThread.length === 0}
@@ -513,7 +578,20 @@
         {:else}
           {#each $cheffyThread as m (m.id)}
             {#if m.role === 'user'}
-              <div class="msg msg-user"><div class="bubble-user">{m.content}</div></div>
+              <div class="msg msg-user">
+                <div class="bubble-user">
+                  {#if m.imagePreview}
+                    <!-- Display only. This never reaches /api/zappy —
+                         see the imagePreview docs in cheffyChat.ts. -->
+                    <img
+                      class="bubble-photo"
+                      src={m.imagePreview}
+                      alt="What you asked Cheffy about"
+                    />
+                  {/if}
+                  {#if m.content}<span class="bubble-text">{m.content}</span>{/if}
+                </div>
+              </div>
             {:else}
               <div class="msg msg-cheffy">
                 <CheffyAvatar
@@ -618,9 +696,10 @@
       </div>
 
       <!-- Starter suggestions — a single scrollable row directly above
-           the composer; removed once the conversation begins or the
-           conversion card takes over. -->
-      {#if $cheffyThread.length === 0 && !$cheffyConversion}
+           the composer; removed once the conversation begins, the
+           conversion card takes over, or a photo is attached (its own
+           chips are the relevant ones then, and two rows read as one). -->
+      {#if $cheffyThread.length === 0 && !$cheffyConversion && !attachedPhoto}
         <div class="starter-row">
           <CheffySuggestionChips
             suggestions={STARTER_SUGGESTIONS}
@@ -637,6 +716,30 @@
         <div class="cheffy-composer">
           {#if scanError}
             <p class="scan-error" role="alert">{scanError}</p>
+          {/if}
+          {#if attachedPhoto}
+            <!-- Held photo: the question and the picture travel together
+                 on send, so the member gets to say what they're asking. -->
+            <div class="photo-chip">
+              <img class="photo-chip-thumb" src={attachedPhotoUrl} alt="" />
+              <span class="photo-chip-name">{attachedPhoto.name}</span>
+              <button
+                type="button"
+                class="photo-chip-remove"
+                aria-label="Remove photo"
+                on:click={clearAttachedPhoto}
+              >
+                <XIcon size={14} weight="bold" />
+              </button>
+            </div>
+            <div class="photo-chip-row">
+              <CheffySuggestionChips
+                compact
+                suggestions={PHOTO_ASK_SUGGESTIONS}
+                ariaLabel="Questions to ask about this photo"
+                onSelect={handleSuggestion}
+              />
+            </div>
           {/if}
           <div class="composer-row">
             {#if !inExperience}
@@ -673,7 +776,7 @@
               class="composer-send"
               aria-label="Send message"
               disabled={!canSend}
-              on:click={() => sendCheffy($cheffyDraft)}
+              on:click={submitComposer}
             >
               {#if $cheffyLoading}
                 <ArrowsClockwiseIcon size={18} class="animate-spin" />
@@ -685,24 +788,35 @@
         </div>
 
         {#if !inExperience}
-          <!-- Hidden file inputs for scan/photo/upload -->
+          <!-- Hidden file inputs. Camera/upload attach the photo to the
+               composer; the third is the ingredient scanner. -->
           <input
             bind:this={cameraInput}
             type="file"
             accept="image/*"
             capture="environment"
             class="hidden"
-            on:change={handleScan}
+            on:change={handleAttachPhoto}
           />
           <input
             bind:this={uploadInput}
             type="file"
             accept="image/*"
             class="hidden"
+            on:change={handleAttachPhoto}
+          />
+          <input
+            bind:this={scanInput}
+            type="file"
+            accept="image/*"
+            class="hidden"
             on:change={handleScan}
           />
 
-          <!-- Attachment action sheet -->
+          <!-- Attachment action sheet. Every label here names what the
+               code actually does: the two general photo entries ask
+               Cheffy about the picture, and the scanner says it reads a
+               fridge or pantry, which is the only thing it can do. -->
           {#if attachOpen}
             <button
               class="attach-scrim"
@@ -710,14 +824,14 @@
               on:click={() => (attachOpen = false)}
             ></button>
             <div class="attach-sheet" role="menu" aria-label="Add to Cheffy">
-              <button type="button" role="menuitem" class="attach-item" on:click={pickUpload}>
-                <ScanIcon size={20} /> Scan ingredients
-              </button>
-              <button type="button" role="menuitem" class="attach-item" on:click={pickCamera}>
+              <button type="button" role="menuitem" class="attach-item" on:click={pickAskCamera}>
                 <CameraIcon size={20} /> Take a photo
               </button>
-              <button type="button" role="menuitem" class="attach-item" on:click={pickUpload}>
+              <button type="button" role="menuitem" class="attach-item" on:click={pickAskUpload}>
                 <ImageIcon size={20} /> Upload an image
+              </button>
+              <button type="button" role="menuitem" class="attach-item" on:click={pickScan}>
+                <ScanIcon size={20} /> Scan my fridge or pantry
               </button>
               <button type="button" role="menuitem" class="attach-item" on:click={handoffSousChef}>
                 <ClipboardIcon size={20} /> Paste a recipe
@@ -1004,6 +1118,19 @@
     overflow-wrap: anywhere;
     word-break: break-word;
   }
+  /* Attached photo inside the member's own bubble. Capped so a portrait
+     shot can't push the answer off-screen. */
+  .bubble-photo {
+    display: block;
+    max-width: 100%;
+    max-height: 200px;
+    border-radius: 10px;
+    object-fit: cover;
+  }
+  .bubble-photo + .bubble-text {
+    display: block;
+    margin-top: 7px;
+  }
   .msg-cheffy {
     gap: 8px;
     align-items: flex-start;
@@ -1120,6 +1247,48 @@
     margin: 0 0 8px;
     font-size: 0.8rem;
     color: #ef4444;
+  }
+  /* Held-photo chip above the composer row. */
+  .photo-chip {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+    padding: 5px 6px;
+    border: 1px solid var(--color-input-border);
+    border-radius: 12px;
+  }
+  .photo-chip-thumb {
+    width: 38px;
+    height: 38px;
+    flex-shrink: 0;
+    border-radius: 8px;
+    object-fit: cover;
+  }
+  .photo-chip-name {
+    flex: 1;
+    min-width: 0;
+    font-size: 0.8rem;
+    color: var(--color-text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .photo-chip-remove {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    flex-shrink: 0;
+    border-radius: 999px;
+    color: var(--color-text-secondary);
+  }
+  .photo-chip-remove:hover {
+    background-color: var(--color-bg-secondary);
+  }
+  .photo-chip-row {
+    margin: 0 -4px 8px;
   }
   .composer-row {
     display: flex;

--- a/src/components/CheffyMessenger.svelte
+++ b/src/components/CheffyMessenger.svelte
@@ -292,6 +292,10 @@
     }
     isScanning = true;
     scanError = '';
+    // Scanning fills the draft with an ingredient list; a held photo
+    // would still win on Send and dispatch a photo-ask instead. Drop it
+    // so the two stay mutually exclusive (matches /cheffy).
+    clearAttachedPhoto();
     try {
       const base64 = await fileToBase64(file);
       const resp = await fetch('/api/zappy/scan', {

--- a/src/components/CheffySuggestionChips.svelte
+++ b/src/components/CheffySuggestionChips.svelte
@@ -27,6 +27,16 @@
     { label: 'Surprise me', prompt: 'Surprise me with something good to make.', behavior: 'send' }
   ];
 
+  // Shown under an attached photo, before it is sent. All 'populate' —
+  // a photo turn is dispatched by the composer's send button (it needs
+  // the file, which a chip doesn't carry), so these seed the question
+  // and let the member send it or edit it first.
+  export const PHOTO_ASK_SUGGESTIONS: CheffySuggestion[] = [
+    { label: 'What is this?', prompt: 'What is this?', behavior: 'populate' },
+    { label: 'How do I make this?', prompt: 'How do I make this?', behavior: 'populate' },
+    { label: 'What went wrong?', prompt: 'What went wrong?', behavior: 'populate' }
+  ];
+
   // Contextual follow-ups after a structured recipe (max four).
   export const CONTEXT_RECIPE: CheffySuggestion[] = [
     { label: 'Scale servings', prompt: 'Scale this recipe to serve ', behavior: 'populate' },

--- a/src/lib/cheffy.ts
+++ b/src/lib/cheffy.ts
@@ -96,9 +96,35 @@ export const ERROR_LINES: string[] = [
  * the question was wrong (a plated dish has no ingredients to
  * enumerate). Name that, and point at the path that does answer it,
  * instead of blaming the member's camera.
+ *
+ * "the photo's still here" is a claim about code, not a reassurance.
+ * Both scan surfaces hand the file to the composer as an attached photo
+ * on every non-success exit — `handleScan` (CheffyMessenger.svelte) and
+ * `handleFileSelect` (routes/cheffy/+page.svelte). If either stops doing
+ * that, this sentence points at a photo that isn't there and has to
+ * change with it.
  */
 export const SCAN_ERROR_LINE =
-  "Cheffy didn't spot any ingredients in that one. If it's a finished dish, ask Cheffy about the photo instead.";
+  "Cheffy didn't spot any ingredients in that one. If it's a finished dish, ask your question below — the photo's still here.";
+
+/**
+ * Client-side failure lines for a photo ask.
+ *
+ * Both replace an exception message that used to reach the member
+ * verbatim inside a Cheffy bubble ("User rejected the request.",
+ * "window.nostr is undefined"). The underlying message still goes to
+ * `console.warn` — it is diagnostic, not copy.
+ *
+ * Signing is the likeliest failure on this path because it is the only
+ * step that depends on software we do not ship, so it gets the line that
+ * names where to look. "signer app" is the term the login overlay
+ * already uses.
+ */
+export const PHOTO_SIGN_FAILED_LINE =
+  'Cheffy needs your approval to send a photo. Check your signer app and try again.';
+
+export const PHOTO_NETWORK_ERROR_LINE =
+  "Cheffy couldn't be reached. Check your connection and try again.";
 
 /**
  * Pick a line from a pool, avoiding `avoid` (usually the previously

--- a/src/lib/cheffy.ts
+++ b/src/lib/cheffy.ts
@@ -88,8 +88,17 @@ export const ERROR_LINES: string[] = [
   'Cheffy got distracted by something on the stove.'
 ];
 
-/** Error line specific to a failed ingredient scan. */
-export const SCAN_ERROR_LINE = 'Cheffy could not read those ingredients. Try a clearer photo.';
+/**
+ * Error line specific to a failed ingredient scan.
+ *
+ * The scanner asks exactly one question of a photo — what ingredients
+ * are visible — so an empty result usually means the photo was fine and
+ * the question was wrong (a plated dish has no ingredients to
+ * enumerate). Name that, and point at the path that does answer it,
+ * instead of blaming the member's camera.
+ */
+export const SCAN_ERROR_LINE =
+  "Cheffy didn't spot any ingredients in that one. If it's a finished dish, ask Cheffy about the photo instead.";
 
 /**
  * Pick a line from a pool, avoiding `avoid` (usually the previously

--- a/src/lib/cheffyPrompt.server.ts
+++ b/src/lib/cheffyPrompt.server.ts
@@ -10,10 +10,11 @@
  *   - /api/zappy            — chat (SYSTEM_INSTRUCTION, FORMAT_SYSTEM_INSTRUCTION)
  *   - /api/zappy/scan       — CHEFFY_VISION_MODEL
  *   - /api/zappy/note-review — note-photo comment/recipe prompts + model
+ *   - /api/zappy/ask-photo  — "ask about a photo" prompt + model
  */
 
 // Vision-capable model shared by the Cheffy vision endpoints (scan,
-// note-review). Chat uses gpt-4.1-mini separately.
+// note-review, ask-photo). Chat uses gpt-4.1-mini separately.
 export const CHEFFY_VISION_MODEL = 'gpt-4o-mini';
 
 // ---------------------------------------------------------------------------
@@ -162,6 +163,51 @@ Reverse-engineer a plausible, complete, home-cook-achievable recipe for the dish
 ${CHEFFY_RECIPE_FORMAT_BLOCK}
 
 ${NOTE_REVIEW_SHARED_RULES}`;
+
+// ---------------------------------------------------------------------------
+// Ask about a photo (/api/zappy/ask-photo)
+// ---------------------------------------------------------------------------
+
+// Used when the member attaches a photo and sends it without typing a
+// question. Server-side default (the HUNGRY_PROMPT pattern) so the wire
+// never carries an empty user turn.
+export const PHOTO_ASK_DEFAULT_QUESTION = 'What can you tell me about this photo?';
+
+/**
+ * The member is asking about a photo THEY chose, in their own words, and
+ * the answer lands in their Cheffy thread like any other turn. So this
+ * prompt is composed from the chat blocks, not note-review's:
+ *
+ *  - The question is NOT fenced as untrusted. In note-review the note
+ *    text is someone else's kind-1 content; here it is the member's own
+ *    message, and fencing it would degrade the answer to the person
+ *    asking. The safety rules below stand regardless of who typed it.
+ *  - Two rules carry over from NOTE_REVIEW_SHARED_RULES verbatim: the
+ *    people/bodies rule and the NOT_FOOD sentinel. The nutrition clause
+ *    does NOT carry over — Cheffy chat answers nutrition questions today
+ *    (the shipped "Estimate nutrition" follow-up chip), and a photo turn
+ *    must not be stricter than the same question typed without a photo.
+ */
+export const CHEFFY_PHOTO_ASK_INSTRUCTION = `You are Cheffy, the kitchen companion inside Zap Cooking. A Zap Cooking member has sent you a photo along with a question about it. Answer their question about what is in the photo.
+
+${CHEFFY_VOICE_BLOCK}
+
+${CHEFFY_SAFETY_BLOCK}
+
+TASK
+Answer the member's question directly, using what you can actually see in the photo. Describe what is visible rather than inventing detail — when the photo does not settle something, say so plainly and give your best read ("Looks braised rather than roasted, going by the sauce —"). Short question, short answer.
+
+SUGGESTION vs COMPLETE RECIPE
+Distinguish a suggestion from a complete recipe. For questions, identifications, troubleshooting, and substitutions, answer conversationally in plain markdown — do NOT force everything into a recipe. Only when the member actually wants a complete recipe (they ask how to make it, ask for the recipe, or ask you to recreate it), output a single complete recipe in EXACTLY this format and nothing else around it (the section names and the emoji prefixes inside Details are required — the editor parses them):
+
+${CHEFFY_RECIPE_FORMAT_BLOCK}
+
+A recipe built from a photo is your interpretation, not the cook's actual recipe — make that clear in the title by appending "(from a photo)" (e.g. "Rustic Skillet Lasagna (from a photo)").
+
+RULES
+- The photo may include people. NEVER comment on people, bodies, or anyone's appearance — only the food.
+- Never critique unprompted and never food-shame. If the member asks what went wrong, be specific and kind about the food, never about the cook.
+- If the image does not clearly show food, drink, or a kitchen, respond with exactly "${NOT_FOOD_PREFIX}" followed by one short, playful sentence about what you can see instead. Produce nothing else in that case.`;
 
 /**
  * Build the user-message text for a note review. The note text is

--- a/src/lib/cheffyPrompt.server.ts
+++ b/src/lib/cheffyPrompt.server.ts
@@ -171,7 +171,14 @@ ${NOTE_REVIEW_SHARED_RULES}`;
 // Used when the member attaches a photo and sends it without typing a
 // question. Server-side default (the HUNGRY_PROMPT pattern) so the wire
 // never carries an empty user turn.
-export const PHOTO_ASK_DEFAULT_QUESTION = 'What can you tell me about this photo?';
+// This is the one string in the feature the member never sees, so if the
+// answer feels off-target they have no way to know what was asked. It has
+// to be predictable enough that the answer reads as obviously responsive.
+// Its subject is the food, not the photo — "about this photo" invites
+// commentary on the picture — and it does not ask what Cheffy would DO
+// with it, which pointed at someone's own dinner manufactures exactly the
+// unsolicited critique the carried-over rules forbid.
+export const PHOTO_ASK_DEFAULT_QUESTION = 'What is this, and what can you tell me about it?';
 
 /**
  * The member is asking about a photo THEY chose, in their own words, and

--- a/src/lib/photoAsk.test.ts
+++ b/src/lib/photoAsk.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import type NDK from '@nostr-dev-kit/ndk';
 import { askAboutPhoto, QUESTION_MAX_CHARS, PHOTO_MAX_BYTES } from './photoAsk';
+import { PHOTO_SIGN_FAILED_LINE, PHOTO_NETWORK_ERROR_LINE } from './cheffy';
 
 const NDK_STUB = {} as NDK;
 const IMAGE = 'BASE64IMAGEDATA';
@@ -131,7 +132,13 @@ describe('askAboutPhoto — signing', () => {
       origin: ORIGIN
     });
 
-    expect(result).toEqual({ ok: false, code: 'SIGN_FAILED', error: 'no signer' });
+    // `error` is rendered verbatim in a Cheffy bubble, so it is copy: the
+    // signer's own message ("User rejected the request.") must not be it.
+    expect(result).toEqual({
+      ok: false,
+      code: 'SIGN_FAILED',
+      error: PHOTO_SIGN_FAILED_LINE
+    });
     // A failed signature must not put the image on the wire.
     expect(fetchFn).not.toHaveBeenCalled();
   });
@@ -213,6 +220,7 @@ describe('askAboutPhoto — result mapping', () => {
       throw new Error('offline');
     }) as any;
     const result = await askAboutPhoto({ ...base, fetchFn });
-    expect(result).toEqual({ ok: false, code: 'NETWORK', error: 'offline' });
+    // Fixed line, not the thrown message — see the SIGN_FAILED case.
+    expect(result).toEqual({ ok: false, code: 'NETWORK', error: PHOTO_NETWORK_ERROR_LINE });
   });
 });

--- a/src/lib/photoAsk.test.ts
+++ b/src/lib/photoAsk.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Unit tests for the photo-ask client helper.
+ *
+ * The signer and fetch are injected, so what runs here is the helper's
+ * own contract: it never throws, every failure comes back typed, and
+ * the bytes it signs are the bytes it sends.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type NDK from '@nostr-dev-kit/ndk';
+import { askAboutPhoto, QUESTION_MAX_CHARS, PHOTO_MAX_BYTES } from './photoAsk';
+
+const NDK_STUB = {} as NDK;
+const IMAGE = 'BASE64IMAGEDATA';
+const ORIGIN = 'https://zap.cooking';
+
+function okResponse(data: unknown) {
+  return { ok: true, status: 200, json: async () => data };
+}
+function errResponse(status: number, data: unknown) {
+  return { ok: false, status, json: async () => data };
+}
+
+/** A signer that records what it was asked to sign. */
+function recordingSigner() {
+  const seen: { method: string; url: string; bodyString?: string }[] = [];
+  const signHeader = vi.fn(async (_ndk: NDK, opts: any) => {
+    seen.push(opts);
+    return 'Nostr signed-header';
+  });
+  return { seen, signHeader: signHeader as any };
+}
+
+describe('caps', () => {
+  it('mirrors the server question cap', () => {
+    expect(QUESTION_MAX_CHARS).toBe(500);
+  });
+
+  it('a file at the client cap still fits the endpoint wire cap', () => {
+    // Base64 is 4/3 of the input plus padding. A file the composer
+    // accepts must not then be rejected by the endpoint — that would
+    // surface as a raw "Image too large" after the upload finished.
+    // (This is why the endpoint's cap is 14MiB and not scan's 13MiB.)
+    const encodedLength = 4 * Math.ceil(PHOTO_MAX_BYTES / 3);
+    expect(encodedLength).toBeLessThanOrEqual(14 * 1024 * 1024);
+  });
+});
+
+describe('askAboutPhoto — signing', () => {
+  it('signs the exact string it sends', async () => {
+    const { seen, signHeader } = recordingSigner();
+    const fetchFn = vi.fn(async () => okResponse({ ok: true, output: 'Soup.' })) as any;
+
+    await askAboutPhoto({
+      ndk: NDK_STUB,
+      imageBase64: IMAGE,
+      question: 'what is this?',
+      signHeader,
+      fetchFn,
+      origin: ORIGIN
+    });
+
+    const signedBody = seen[0].bodyString;
+    const sentBody = fetchFn.mock.calls[0][1].body;
+    expect(sentBody).toBe(signedBody);
+    // A body-hash-bound header is worthless if the two ever diverge.
+    expect(JSON.parse(sentBody)).toEqual({ image: IMAGE, question: 'what is this?' });
+  });
+
+  it('binds the header to this endpoint and method', async () => {
+    const { seen, signHeader } = recordingSigner();
+    const fetchFn = vi.fn(async () => okResponse({ ok: true, output: 'Soup.' })) as any;
+
+    await askAboutPhoto({
+      ndk: NDK_STUB,
+      imageBase64: IMAGE,
+      signHeader,
+      fetchFn,
+      origin: ORIGIN
+    });
+
+    expect(seen[0].method).toBe('POST');
+    expect(seen[0].url).toBe(`${ORIGIN}/api/zappy/ask-photo`);
+    expect(fetchFn.mock.calls[0][0]).toBe('/api/zappy/ask-photo');
+    expect(fetchFn.mock.calls[0][1].headers.Authorization).toBe('Nostr signed-header');
+  });
+
+  it('omits an empty question so the server supplies its default', async () => {
+    const { signHeader } = recordingSigner();
+    const fetchFn = vi.fn(async () => okResponse({ ok: true, output: 'Soup.' })) as any;
+
+    await askAboutPhoto({
+      ndk: NDK_STUB,
+      imageBase64: IMAGE,
+      question: '   ',
+      signHeader,
+      fetchFn,
+      origin: ORIGIN
+    });
+
+    expect(JSON.parse(fetchFn.mock.calls[0][1].body)).toEqual({ image: IMAGE });
+  });
+
+  it('caps a long question rather than erroring', async () => {
+    const { signHeader } = recordingSigner();
+    const fetchFn = vi.fn(async () => okResponse({ ok: true, output: 'Soup.' })) as any;
+
+    await askAboutPhoto({
+      ndk: NDK_STUB,
+      imageBase64: IMAGE,
+      question: 'x'.repeat(QUESTION_MAX_CHARS + 250),
+      signHeader,
+      fetchFn,
+      origin: ORIGIN
+    });
+
+    const body = JSON.parse(fetchFn.mock.calls[0][1].body);
+    expect(body.question).toHaveLength(QUESTION_MAX_CHARS);
+  });
+
+  it('returns SIGN_FAILED and never throws when the signer refuses', async () => {
+    const signHeader = vi.fn(async () => {
+      throw new Error('no signer');
+    }) as any;
+    const fetchFn = vi.fn() as any;
+
+    const result = await askAboutPhoto({
+      ndk: NDK_STUB,
+      imageBase64: IMAGE,
+      signHeader,
+      fetchFn,
+      origin: ORIGIN
+    });
+
+    expect(result).toEqual({ ok: false, code: 'SIGN_FAILED', error: 'no signer' });
+    // A failed signature must not put the image on the wire.
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('fires onSigned after signing and before the fetch', async () => {
+    const order: string[] = [];
+    const signHeader = vi.fn(async () => {
+      order.push('sign');
+      return 'Nostr h';
+    }) as any;
+    const fetchFn = vi.fn(async () => {
+      order.push('fetch');
+      return okResponse({ ok: true, output: 'Soup.' });
+    }) as any;
+
+    await askAboutPhoto({
+      ndk: NDK_STUB,
+      imageBase64: IMAGE,
+      onSigned: () => order.push('onSigned'),
+      signHeader,
+      fetchFn,
+      origin: ORIGIN
+    });
+
+    expect(order).toEqual(['sign', 'onSigned', 'fetch']);
+  });
+});
+
+describe('askAboutPhoto — result mapping', () => {
+  const { signHeader } = recordingSigner();
+  const base = { ndk: NDK_STUB, imageBase64: IMAGE, signHeader, origin: ORIGIN };
+
+  it('passes a successful answer through', async () => {
+    const fetchFn = vi.fn(async () =>
+      okResponse({ ok: true, output: 'A bowl of ribollita.' })
+    ) as any;
+    const result = await askAboutPhoto({ ...base, fetchFn });
+    expect(result).toEqual({ ok: true, output: 'A bowl of ribollita.' });
+  });
+
+  it('rejects a 200 that is missing the output field', async () => {
+    const fetchFn = vi.fn(async () => okResponse({ ok: true })) as any;
+    const result = await askAboutPhoto({ ...base, fetchFn });
+    expect(result.ok).toBe(false);
+  });
+
+  for (const code of [
+    'NOT_MEMBER',
+    'MEMBERSHIP_UNAVAILABLE',
+    'RATE_LIMITED',
+    'NOT_FOOD',
+    'IMAGE_UNREADABLE'
+  ]) {
+    // A `for` loop, not it.each — the asymmetric/each helpers don't
+    // typecheck under this repo's svelte-check.
+    it(`passes the ${code} server code through with its line`, async () => {
+      const fetchFn = vi.fn(async () =>
+        errResponse(422, { ok: false, code, error: 'server line' })
+      ) as any;
+      const result = await askAboutPhoto({ ...base, fetchFn });
+      expect(result).toEqual({ ok: false, code, error: 'server line', status: 422 });
+    });
+  }
+
+  it('survives a non-JSON error body', async () => {
+    const fetchFn = vi.fn(async () => ({
+      ok: false,
+      status: 502,
+      json: async () => {
+        throw new Error('not json');
+      }
+    })) as any;
+    const result = await askAboutPhoto({ ...base, fetchFn });
+    expect(result).toEqual({ ok: false, code: undefined, error: undefined, status: 502 });
+  });
+
+  it('returns NETWORK and never throws when the fetch rejects', async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new Error('offline');
+    }) as any;
+    const result = await askAboutPhoto({ ...base, fetchFn });
+    expect(result).toEqual({ ok: false, code: 'NETWORK', error: 'offline' });
+  });
+});

--- a/src/lib/photoAsk.ts
+++ b/src/lib/photoAsk.ts
@@ -1,0 +1,117 @@
+/**
+ * Cheffy "Ask about a photo" — client request plumbing.
+ *
+ * Kept in a plain module (not a component) so it is unit-testable —
+ * repo convention: logic in .ts, no Svelte component tests. The server
+ * contract lives at POST /api/zappy/ask-photo (NIP-98 auth, body-hash
+ * bound); `requestNoteReview` in noteReview.ts is the template this
+ * mirrors.
+ */
+
+import type NDK from '@nostr-dev-kit/ndk';
+import { signNip98AuthHeader } from './nip98';
+
+/** Mirrors the server cap — a longer question just loses its tail. */
+export const QUESTION_MAX_CHARS = 500;
+
+/**
+ * Client-side file cap, matching the existing scan composer's check and
+ * the "try one under 10MB" line the composer shows. The endpoint's wire
+ * cap is sized to hold the base64 expansion of this — see the comment
+ * on IMAGE_MAX_CHARS in ask-photo/+server.ts.
+ */
+export const PHOTO_MAX_BYTES = 10 * 1024 * 1024;
+
+export type PhotoAskResult =
+  | { ok: true; output: string }
+  | { ok: false; code?: string; error?: string; status?: number };
+
+export interface PhotoAskRequestOpts {
+  ndk: NDK;
+  /** Base64 image data, no `data:` prefix — see fileToBase64. */
+  imageBase64: string;
+  /** The member's own question. Trimmed and capped here; defaulted server-side when empty. */
+  question?: string;
+  /** Called once the NIP-98 header is signed, before the fetch (NIP-46 round trips are slow). */
+  onSigned?: () => void;
+  /** Test injection points. */
+  signHeader?: typeof signNip98AuthHeader;
+  fetchFn?: typeof fetch;
+  origin?: string;
+}
+
+/**
+ * Read a File as base64 with the `data:` prefix stripped — the shape
+ * both photo endpoints take on the wire.
+ *
+ * Single copy on purpose. This existed as three-line duplicates inside
+ * CheffyMessenger.svelte and /cheffy/+page.svelte; both now import it
+ * from here.
+ */
+export function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve((reader.result as string).split(',')[1]);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
+/**
+ * Sign and send a photo-ask request. Never throws — every failure mode
+ * comes back typed, so the caller renders a Cheffy line rather than an
+ * exception.
+ */
+export async function askAboutPhoto(opts: PhotoAskRequestOpts): Promise<PhotoAskResult> {
+  const { ndk, imageBase64, onSigned, signHeader = signNip98AuthHeader, fetchFn = fetch } = opts;
+
+  const question = opts.question?.trim().slice(0, QUESTION_MAX_CHARS);
+  const body: Record<string, unknown> = { image: imageBase64 };
+  if (question) body.question = question;
+  // The signed payload hash and the fetch body must be the same string.
+  const bodyString = JSON.stringify(body);
+
+  const origin =
+    opts.origin ?? (typeof location !== 'undefined' ? location.origin : 'https://zap.cooking');
+
+  let authorization: string;
+  try {
+    authorization = await signHeader(ndk, {
+      method: 'POST',
+      url: `${origin}/api/zappy/ask-photo`,
+      bodyString
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'SIGN_FAILED',
+      error: err instanceof Error ? err.message : 'Signing failed'
+    };
+  }
+
+  onSigned?.();
+
+  try {
+    const resp = await fetchFn('/api/zappy/ask-photo', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: authorization },
+      body: bodyString
+    });
+    const data: Record<string, unknown> = await resp.json().catch(() => ({}));
+    if (resp.ok && data.ok === true && typeof data.output === 'string') {
+      return { ok: true, output: data.output };
+    }
+    return {
+      ok: false,
+      code: typeof data.code === 'string' ? data.code : undefined,
+      error: typeof data.error === 'string' ? data.error : undefined,
+      status: resp.status
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'NETWORK',
+      error: err instanceof Error ? err.message : 'Network error'
+    };
+  }
+}

--- a/src/lib/photoAsk.ts
+++ b/src/lib/photoAsk.ts
@@ -10,6 +10,7 @@
 
 import type NDK from '@nostr-dev-kit/ndk';
 import { signNip98AuthHeader } from './nip98';
+import { PHOTO_SIGN_FAILED_LINE, PHOTO_NETWORK_ERROR_LINE } from './cheffy';
 
 /** Mirrors the server cap — a longer question just loses its tail. */
 export const QUESTION_MAX_CHARS = 500;
@@ -82,11 +83,11 @@ export async function askAboutPhoto(opts: PhotoAskRequestOpts): Promise<PhotoAsk
       bodyString
     });
   } catch (err) {
-    return {
-      ok: false,
-      code: 'SIGN_FAILED',
-      error: err instanceof Error ? err.message : 'Signing failed'
-    };
+    // `error` is rendered verbatim inside a Cheffy bubble, so it is copy,
+    // not a stack trace: an unhandled signer message put "User rejected
+    // the request." in Cheffy's voice. The real one is diagnostic.
+    console.warn('[Photo Ask] signing failed:', err);
+    return { ok: false, code: 'SIGN_FAILED', error: PHOTO_SIGN_FAILED_LINE };
   }
 
   onSigned?.();
@@ -108,10 +109,7 @@ export async function askAboutPhoto(opts: PhotoAskRequestOpts): Promise<PhotoAsk
       status: resp.status
     };
   } catch (err) {
-    return {
-      ok: false,
-      code: 'NETWORK',
-      error: err instanceof Error ? err.message : 'Network error'
-    };
+    console.warn('[Photo Ask] request failed:', err);
+    return { ok: false, code: 'NETWORK', error: PHOTO_NETWORK_ERROR_LINE };
   }
 }

--- a/src/lib/stores/cheffyChat.test.ts
+++ b/src/lib/stores/cheffyChat.test.ts
@@ -165,7 +165,7 @@ describe('answer mapping', () => {
     expect(answer.content).toBe('That is a very smug cat, and not lunch.');
   });
 
-  it('a typed server failure becomes an error bubble carrying the real reason', async () => {
+  it('a typed server failure becomes an error bubble carrying the real reason, and nothing else', async () => {
     mocks.askAboutPhoto.mockResolvedValue({
       ok: false,
       code: 'RATE_LIMITED',
@@ -175,6 +175,17 @@ describe('answer mapping', () => {
     const answer = get(cheffyThread)[1];
     expect(answer.kind).toBe('error');
     expect(answer.content).toBe("Cheffy needs a breather — you've hit the photo limit for now.");
+    // No flavour line above a named cause — the bubble renders the
+    // statusLine only when it is non-empty, so a second narrator would
+    // otherwise invent a different reason above the real one.
+    expect(answer.statusLine).toBe('');
+  });
+
+  it('an UNtyped failure keeps the flavour line — there is no reason to show instead', async () => {
+    mocks.askAboutPhoto.mockResolvedValue({ ok: false, error: 'Cheffy could not respond.' });
+    await askCheffyAboutPhoto(PHOTO, 'what is this?');
+    const answer = get(cheffyThread)[1];
+    expect(answer.kind).toBe('error');
     expect(answer.statusLine).toBeTruthy();
   });
 
@@ -194,17 +205,63 @@ describe('turn hygiene', () => {
     expect(get(cheffyLoading)).toBe(false);
   });
 
-  it('retry is disabled after a photo turn — it would re-ask text-only', async () => {
+  // The error bubble renders "Try again" unconditionally, gated only on
+  // `loading`. Nothing in the component can see `lastTurn`, so the button
+  // is only honest if every turn that can produce an error bubble is
+  // replayable — and replayable as ITSELF. These three are that audit.
+  it('retry after a failed photo turn re-issues the PHOTO request, not a text one', async () => {
     mocks.askAboutPhoto.mockResolvedValue({ ok: false, error: 'boom' });
     await askCheffyAboutPhoto(PHOTO, 'what is this?');
-    const before = get(cheffyThread).length;
+    expect(get(cheffyThread)[1].kind).toBe('error');
 
+    mocks.askAboutPhoto.mockResolvedValue({ ok: true, output: 'Ribollita.' });
     await retryCheffy();
 
-    // retryCheffy routes through /api/zappy, which has never seen the
-    // photo. It must no-op rather than silently ask a different question.
+    // Same file, same question, same endpoint — and /api/zappy, which has
+    // never seen the photo, is not touched.
+    expect(mocks.askAboutPhoto).toHaveBeenCalledTimes(2);
+    expect(mocks.askAboutPhoto.mock.calls[1][0].question).toBe('what is this?');
+    expect(mocks.fileToBase64.mock.calls[1][0]).toBe(PHOTO);
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(get(cheffyThread)).toHaveLength(before);
+    expect(get(cheffyThread)[1].content).toBe('Ribollita.');
+  });
+
+  it('retrying a photo turn does not append a second copy of the question', async () => {
+    mocks.askAboutPhoto.mockResolvedValue({ ok: false, error: 'boom' });
+    await askCheffyAboutPhoto(PHOTO, 'what is this?');
+
+    mocks.askAboutPhoto.mockResolvedValue({ ok: true, output: 'Ribollita.' });
+    await retryCheffy();
+
+    // The member's own bubble — and their photo — survived the first
+    // attempt; re-appending would show the question twice.
+    const userTurns = get(cheffyThread).filter((m) => m.role === 'user');
+    expect(userTurns).toHaveLength(1);
+    expect(userTurns[0].imagePreview).toMatch(/^blob:/);
+    expect(get(cheffyThread)).toHaveLength(2);
+  });
+
+  it('a text turn after a photo turn still retries as TEXT', async () => {
+    // The ordering hazard in carrying two turn shapes: the photo must not
+    // become sticky and hijack a later text turn's retry.
+    mocks.askAboutPhoto.mockResolvedValue({ ok: true, output: 'Ribollita.' });
+    await askCheffyAboutPhoto(PHOTO, 'what is this?');
+    fetchMock.mockResolvedValue({
+      ok: false,
+      json: async () => ({ ok: false, error: 'chat is down' })
+    });
+    await sendCheffy('and what wine goes with it?');
+    expect(get(cheffyThread)[3].kind).toBe('error');
+
+    const photoCallsBefore = mocks.askAboutPhoto.mock.calls.length;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true, output: 'A Chianti.' })
+    });
+    await retryCheffy();
+
+    expect(mocks.askAboutPhoto).toHaveBeenCalledTimes(photoCallsBefore);
+    expect(get(cheffyThread)[3].content).toBe('A Chianti.');
   });
 
   it('ignores a second photo while a turn is in flight', async () => {

--- a/src/lib/stores/cheffyChat.test.ts
+++ b/src/lib/stores/cheffyChat.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Cheffy messenger store — photo-ask turns.
+ *
+ * The assertion this file exists for is the first one: after a photo
+ * turn, the history posted to /api/zappy carries the member's QUESTION
+ * and nothing else from that turn — no preview URL, no base64. That is
+ * the property the whole "ask about a photo" design rests on (Option A:
+ * the image is sent once, to its own endpoint, and never becomes
+ * history), so it is asserted rather than left as a comment.
+ *
+ * The photo endpoint itself is covered in src/lib/photoAsk.test.ts and
+ * src/routes/api/zappy/ask-photo/askPhoto.test.ts; here it is mocked so
+ * the store's own sequencing and result mapping run for real.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { get } from 'svelte/store';
+
+const mocks = vi.hoisted(() => {
+  // cheffyChat reads localStorage at module load (experience counter)
+  // and mints object URLs for thumbnails. Neither exists in the node
+  // test environment, and both must be in place before the import.
+  const memory = new Map<string, string>();
+  (globalThis as any).localStorage = {
+    getItem: (k: string) => memory.get(k) ?? null,
+    setItem: (k: string, v: string) => void memory.set(k, v),
+    removeItem: (k: string) => void memory.delete(k)
+  };
+  const revoked: string[] = [];
+  let urlSeq = 0;
+  (globalThis as any).URL.createObjectURL = () => `blob:preview-${++urlSeq}`;
+  (globalThis as any).URL.revokeObjectURL = (u: string) => void revoked.push(u);
+
+  return {
+    revoked,
+    askAboutPhoto: vi.fn(),
+    fileToBase64: vi.fn()
+  };
+});
+
+vi.mock('$app/environment', () => ({ browser: true }));
+vi.mock('$lib/nostr', async () => {
+  const { writable } = await import('svelte/store');
+  return { ndk: writable<unknown>({}), userPublickey: writable('a'.repeat(64)) };
+});
+vi.mock('$lib/photoAsk', () => ({
+  askAboutPhoto: mocks.askAboutPhoto,
+  fileToBase64: mocks.fileToBase64
+}));
+
+import {
+  cheffyThread,
+  cheffyDraft,
+  cheffyLoading,
+  askCheffyAboutPhoto,
+  sendCheffy,
+  retryCheffy,
+  startOverCheffy
+} from './cheffyChat';
+
+const BASE64 = 'BASE64IMAGEDATAxyz';
+const PHOTO = new File(['fake-bytes'], 'soup.jpg', { type: 'image/jpeg' });
+
+const fetchMock = vi.fn();
+
+/** The body of the (single) /api/zappy chat request. */
+function chatBody() {
+  return JSON.parse(fetchMock.mock.calls[0][1].body);
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock);
+  fetchMock.mockReset().mockResolvedValue({
+    ok: true,
+    json: async () => ({ ok: true, output: 'Simmer it low and slow.' })
+  });
+  mocks.askAboutPhoto.mockReset().mockResolvedValue({
+    ok: true,
+    output: 'That looks like a bowl of ribollita.'
+  });
+  mocks.fileToBase64.mockReset().mockResolvedValue(BASE64);
+  mocks.revoked.length = 0;
+  // startOverCheffy is a no-op while a turn is in flight.
+  cheffyLoading.set(false);
+  startOverCheffy();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('the image never becomes history', () => {
+  it('a later chat turn sends the question but no preview URL and no base64', async () => {
+    await askCheffyAboutPhoto(PHOTO, 'what is this?');
+    await sendCheffy('and how do I make it?');
+
+    const body = chatBody();
+    const wire = JSON.stringify(body);
+
+    expect(wire).not.toContain('imagePreview');
+    expect(wire).not.toContain(BASE64);
+    expect(wire).not.toContain('blob:');
+
+    // The question itself DOES carry, so the follow-up has its context.
+    expect(body.messages).toContainEqual({ role: 'user', content: 'what is this?' });
+    expect(body.messages).toContainEqual({
+      role: 'assistant',
+      content: 'That looks like a bowl of ribollita.'
+    });
+  });
+
+  it('the preview is on the message for display, and only there', async () => {
+    await askCheffyAboutPhoto(PHOTO, 'what is this?');
+    const userMsg = get(cheffyThread)[0];
+    expect(userMsg.role).toBe('user');
+    expect(userMsg.imagePreview).toMatch(/^blob:/);
+    expect(userMsg.content).toBe('what is this?');
+  });
+
+  it('a photo turn with no question leaves an empty content, not a placeholder', async () => {
+    // The default ask is supplied server-side, so nothing the member
+    // did not type shows up in their own bubble or in later history.
+    await askCheffyAboutPhoto(PHOTO, '');
+    expect(get(cheffyThread)[0].content).toBe('');
+
+    await sendCheffy('follow-up');
+    // buildHistory drops empty-content messages, so the photo turn's
+    // user bubble contributes nothing rather than an empty string.
+    expect(chatBody().messages).toEqual([
+      { role: 'assistant', content: 'That looks like a bowl of ribollita.' }
+    ]);
+  });
+});
+
+describe('answer mapping', () => {
+  it('a structured recipe answer lands as a recipe card', async () => {
+    mocks.askAboutPhoto.mockResolvedValue({
+      ok: true,
+      output:
+        '# Ribollita (from a photo)\n\nA Tuscan bread soup.\n\n## Ingredients\n- bread\n\n## Directions\n1. Simmer.'
+    });
+    await askCheffyAboutPhoto(PHOTO, 'how do I make this?');
+    const answer = get(cheffyThread)[1];
+    expect(answer.kind).toBe('recipe');
+    expect(answer.expression).toBe('happy');
+  });
+
+  it('a conversational answer lands as text', async () => {
+    await askCheffyAboutPhoto(PHOTO, 'what is this?');
+    const answer = get(cheffyThread)[1];
+    expect(answer.kind).toBe('text');
+    expect(answer.content).toBe('That looks like a bowl of ribollita.');
+  });
+
+  it('NOT_FOOD is an answer, not an error bubble', async () => {
+    // The member picked this file themselves — there is no dead-link
+    // ambiguity here, so Cheffy's playful line is the reply.
+    mocks.askAboutPhoto.mockResolvedValue({
+      ok: false,
+      code: 'NOT_FOOD',
+      error: 'That is a very smug cat, and not lunch.'
+    });
+    await askCheffyAboutPhoto(PHOTO, 'what is this?');
+    const answer = get(cheffyThread)[1];
+    expect(answer.kind).toBe('text');
+    expect(answer.content).toBe('That is a very smug cat, and not lunch.');
+  });
+
+  it('a typed server failure becomes an error bubble carrying the real reason', async () => {
+    mocks.askAboutPhoto.mockResolvedValue({
+      ok: false,
+      code: 'RATE_LIMITED',
+      error: "Cheffy needs a breather — you've hit the photo limit for now."
+    });
+    await askCheffyAboutPhoto(PHOTO, 'what is this?');
+    const answer = get(cheffyThread)[1];
+    expect(answer.kind).toBe('error');
+    expect(answer.content).toBe("Cheffy needs a breather — you've hit the photo limit for now.");
+    expect(answer.statusLine).toBeTruthy();
+  });
+
+  it('never throws when reading the file fails', async () => {
+    mocks.fileToBase64.mockRejectedValue(new Error('could not read that file'));
+    await askCheffyAboutPhoto(PHOTO, 'what is this?');
+    expect(get(cheffyThread)[1].kind).toBe('error');
+    expect(get(cheffyLoading)).toBe(false);
+  });
+});
+
+describe('turn hygiene', () => {
+  it('clears the composer draft and releases loading', async () => {
+    cheffyDraft.set('what is this?');
+    await askCheffyAboutPhoto(PHOTO, 'what is this?');
+    expect(get(cheffyDraft)).toBe('');
+    expect(get(cheffyLoading)).toBe(false);
+  });
+
+  it('retry is disabled after a photo turn — it would re-ask text-only', async () => {
+    mocks.askAboutPhoto.mockResolvedValue({ ok: false, error: 'boom' });
+    await askCheffyAboutPhoto(PHOTO, 'what is this?');
+    const before = get(cheffyThread).length;
+
+    await retryCheffy();
+
+    // retryCheffy routes through /api/zappy, which has never seen the
+    // photo. It must no-op rather than silently ask a different question.
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(get(cheffyThread)).toHaveLength(before);
+  });
+
+  it('ignores a second photo while a turn is in flight', async () => {
+    let release!: (v: unknown) => void;
+    mocks.askAboutPhoto.mockReturnValue(new Promise((r) => (release = r)));
+
+    const first = askCheffyAboutPhoto(PHOTO, 'what is this?');
+    await askCheffyAboutPhoto(PHOTO, 'and this?');
+    expect(mocks.askAboutPhoto).toHaveBeenCalledTimes(1);
+
+    release({ ok: true, output: 'Ribollita.' });
+    await first;
+  });
+
+  it('Start over hands back the preview URLs it minted', async () => {
+    await askCheffyAboutPhoto(PHOTO, 'what is this?');
+    const preview = get(cheffyThread)[0].imagePreview;
+
+    startOverCheffy();
+
+    expect(get(cheffyThread)).toHaveLength(0);
+    expect(mocks.revoked).toContain(preview);
+  });
+});

--- a/src/lib/stores/cheffyChat.ts
+++ b/src/lib/stores/cheffyChat.ts
@@ -11,7 +11,7 @@
  */
 import { writable, derived, get } from 'svelte/store';
 import { browser } from '$app/environment';
-import { userPublickey } from '$lib/nostr';
+import { ndk, userPublickey } from '$lib/nostr';
 import {
   pickLine,
   looksLikeStructuredRecipe,
@@ -20,6 +20,7 @@ import {
   ERROR_LINES,
   type CheffyExpression
 } from '$lib/cheffy';
+import { askAboutPhoto, fileToBase64 } from '$lib/photoAsk';
 
 export type ChatRole = 'user' | 'cheffy';
 export type ChatKind = 'text' | 'recipe' | 'pending' | 'error';
@@ -31,6 +32,20 @@ export interface ChatMessage {
   kind: ChatKind;
   expression?: CheffyExpression;
   statusLine?: string; // pending loading line / friendly error line
+  /**
+   * Object URL for a photo the member attached to this turn — DISPLAY
+   * ONLY, and the whole safety of the photo-ask design rests on that.
+   *
+   * `buildHistory` below projects exactly `role` + `content`, so a
+   * field that isn't `content` is structurally incapable of reaching
+   * /api/zappy. The image is sent once, to /api/zappy/ask-photo, and
+   * never enters conversation history. Do not read this in
+   * buildHistory, and do not move image data into `content`: that is
+   * Option B, and it needs the history sanitiser rewritten first
+   * (api/zappy/+server.ts caps content at 4000 chars, which would
+   * silently truncate a base64 image into a corrupt fragment).
+   */
+  imagePreview?: string;
 }
 
 // ── UI state ────────────────────────────────────────────────────
@@ -289,6 +304,113 @@ export async function sendCheffy(content: string, mode: 'chat' | 'hungry' = 'cha
   );
 }
 
+// ── Ask about a photo ───────────────────────────────────────────
+// Object URLs minted for attached-photo thumbnails. Tracked so a thread
+// reset can hand them back rather than leaking them for the session.
+let photoPreviewUrls: string[] = [];
+
+function releasePhotoPreviews() {
+  if (!browser) return;
+  for (const url of photoPreviewUrls) {
+    try {
+      URL.revokeObjectURL(url);
+    } catch {
+      // already revoked / not an object URL — nothing to do
+    }
+  }
+  photoPreviewUrls = [];
+}
+
+/**
+ * Attach a photo, ask a question about it, get an answer in the thread.
+ *
+ * One vision call, to /api/zappy/ask-photo — NOT through /api/zappy.
+ * The question goes into the turn's `content` (so follow-up text turns
+ * keep their context); the image goes onto `imagePreview`, which
+ * `buildHistory` cannot see. An empty question is allowed: the server
+ * supplies the default ask.
+ */
+export async function askCheffyAboutPhoto(file: File, question: string) {
+  if (get(cheffyLoading)) return;
+
+  const text = question.trim();
+  const preview = browser ? URL.createObjectURL(file) : undefined;
+  if (preview) photoPreviewUrls.push(preview);
+
+  cheffyThread.update((t) => [
+    ...t,
+    { id: nextId(), role: 'user', content: text, kind: 'text', imagePreview: preview }
+  ]);
+  cheffyStarted.set(true);
+  cheffyDraft.set('');
+  // A photo turn is not replayable: retryCheffy() re-sends `lastTurn`
+  // through /api/zappy, which would silently ask a text-only version of
+  // a question about a picture. Clearing it disables retry for this
+  // turn — a wrong retry is worse than no retry.
+  lastTurn = null;
+
+  cheffyLoading.set(true);
+  const expectRecipe = looksLikeRecipeRequest(text);
+  const statusLine = pickLine(expectRecipe ? COOKING_LINES : THINKING_LINES, lastStatusLine);
+  lastStatusLine = statusLine;
+  const pendingId = nextId();
+  cheffyThread.update((t) => [
+    ...t,
+    {
+      id: pendingId,
+      role: 'cheffy',
+      content: '',
+      kind: 'pending',
+      expression: expectRecipe ? 'cooking' : 'thinking',
+      statusLine
+    }
+  ]);
+
+  const settle = (patch: Partial<ChatMessage>) => {
+    cheffyThread.update((t) => t.map((m) => (m.id === pendingId ? { ...m, ...patch } : m)));
+  };
+
+  try {
+    const imageBase64 = await fileToBase64(file);
+    const result = await askAboutPhoto({ ndk: get(ndk), imageBase64, question: text });
+
+    if (result.ok) {
+      const isRecipe = looksLikeStructuredRecipe(result.output);
+      settle({
+        kind: isRecipe ? 'recipe' : 'text',
+        content: result.output,
+        expression: isRecipe ? 'happy' : 'neutral'
+      });
+      cheffyAnnounce.set(isRecipe ? 'Cheffy shared a recipe.' : 'Cheffy replied.');
+      return;
+    }
+
+    // NOT_FOOD is a refusal, not a failure: the member uploaded the file
+    // themselves, so there is no dead-link ambiguity here (the hedging
+    // the note-review client does exists because THAT path takes a URL
+    // and can get a CDN fallback image). Land Cheffy's playful line in
+    // the thread as an ordinary answer rather than an error bubble.
+    if (result.code === 'NOT_FOOD' && result.error) {
+      settle({ kind: 'text', content: result.error, expression: 'neutral' });
+      cheffyAnnounce.set('Cheffy replied.');
+      return;
+    }
+
+    throw new Error(result.error || 'Cheffy could not respond.');
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : 'Cheffy could not respond.';
+    settle({
+      kind: 'error',
+      content: detail,
+      expression: 'concerned',
+      statusLine: pickLine(ERROR_LINES, statusLine)
+    });
+    cheffyAnnounce.set('Cheffy hit a snag.');
+  } finally {
+    cheffyLoading.set(false);
+  }
+}
+
 /**
  * Enter the first-use experience from the /explore invite. Opens the
  * messenger as a non-member preview and sends the one prompt. If this
@@ -320,6 +442,7 @@ export async function retryCheffy() {
 
 export function startOverCheffy() {
   if (get(cheffyLoading)) return;
+  releasePhotoPreviews();
   cheffyThread.set([]);
   cheffyDraft.set('');
   cheffyStarted.set(false);

--- a/src/lib/stores/cheffyChat.ts
+++ b/src/lib/stores/cheffyChat.ts
@@ -140,7 +140,23 @@ export const cheffyLoading = writable(false);
 let msgSeq = 0;
 const nextId = () => `c${++msgSeq}`;
 let lastStatusLine = '';
-let lastTurn: { prompt: string; mode: 'chat' | 'hungry' } | null = null;
+/**
+ * The turn `retryCheffy()` would re-issue.
+ *
+ * The error bubble renders "Try again" unconditionally, gated only on
+ * `loading` — nothing in the component can see this variable. So it must
+ * be non-null whenever an error bubble can exist, or that button is
+ * enabled and does nothing.
+ *
+ * A photo turn cannot be replayed as a text turn: it goes to a different
+ * endpoint, and re-sending the question alone through /api/zappy would
+ * silently ask a different question about a picture Cheffy never saw. So
+ * it is a separate variant that carries its own file rather than a null.
+ */
+type LastTurn =
+  | { kind: 'text'; prompt: string; mode: 'chat' | 'hungry' }
+  | { kind: 'photo'; file: File; question: string };
+let lastTurn: LastTurn | null = null;
 
 // ── Open / close ────────────────────────────────────────────────
 export function openCheffy() {
@@ -293,7 +309,7 @@ export async function sendCheffy(content: string, mode: 'chat' | 'hungry' = 'cha
     { id: nextId(), role: 'user', content: display, kind: 'text' }
   ]);
   cheffyStarted.set(true);
-  lastTurn = { prompt: mode === 'hungry' ? '' : text, mode };
+  lastTurn = { kind: 'text', prompt: mode === 'hungry' ? '' : text, mode };
   if (mode !== 'hungry') cheffyDraft.set('');
 
   await dispatchTurn(
@@ -343,12 +359,26 @@ export async function askCheffyAboutPhoto(file: File, question: string) {
   ]);
   cheffyStarted.set(true);
   cheffyDraft.set('');
-  // A photo turn is not replayable: retryCheffy() re-sends `lastTurn`
-  // through /api/zappy, which would silently ask a text-only version of
-  // a question about a picture. Clearing it disables retry for this
-  // turn — a wrong retry is worse than no retry.
-  lastTurn = null;
+  // Recorded as a PHOTO turn, holding the file, so the error bubble's
+  // Try again re-issues it against /api/zappy/ask-photo. Recording
+  // nothing would leave that button enabled and dead; recording it as
+  // text would ask a different question. The file is already reachable
+  // for the session via the preview object URL above, so keeping this
+  // reference stores nothing new.
+  lastTurn = { kind: 'photo', file, question: text };
 
+  await dispatchPhotoTurn(file, text);
+}
+
+/**
+ * Issue one photo request into a fresh pending bubble and settle it.
+ *
+ * Split out of askCheffyAboutPhoto so a retry re-runs exactly this and
+ * nothing else — the member's own bubble, with their photo on it, is
+ * already in the thread from the first attempt and must not be appended
+ * twice.
+ */
+async function dispatchPhotoTurn(file: File, text: string) {
   cheffyLoading.set(true);
   const expectRecipe = looksLikeRecipeRequest(text);
   const statusLine = pickLine(expectRecipe ? COOKING_LINES : THINKING_LINES, lastStatusLine);
@@ -368,6 +398,23 @@ export async function askCheffyAboutPhoto(file: File, question: string) {
 
   const settle = (patch: Partial<ChatMessage>) => {
     cheffyThread.update((t) => t.map((m) => (m.id === pendingId ? { ...m, ...patch } : m)));
+  };
+
+  /**
+   * A flavour line stands in for an explanation we don't have. When the
+   * server named the cause, putting one above the real reason is a
+   * second narrator inventing a different one — so a typed failure
+   * speaks for itself and untyped 500s keep the pool. Photo turns only;
+   * the chat error path is unchanged.
+   */
+  const settleError = (detail: string, code?: string) => {
+    settle({
+      kind: 'error',
+      content: detail,
+      expression: 'concerned',
+      statusLine: code ? '' : pickLine(ERROR_LINES, statusLine)
+    });
+    cheffyAnnounce.set('Cheffy hit a snag.');
   };
 
   try {
@@ -396,16 +443,12 @@ export async function askCheffyAboutPhoto(file: File, question: string) {
       return;
     }
 
-    throw new Error(result.error || 'Cheffy could not respond.');
+    settleError(result.error || 'Cheffy could not respond.', result.code);
   } catch (err) {
-    const detail = err instanceof Error ? err.message : 'Cheffy could not respond.';
-    settle({
-      kind: 'error',
-      content: detail,
-      expression: 'concerned',
-      statusLine: pickLine(ERROR_LINES, statusLine)
-    });
-    cheffyAnnounce.set('Cheffy hit a snag.');
+    // Only unexpected exceptions land here (fileToBase64) — askAboutPhoto
+    // never throws. No typed code, so the flavour pool applies.
+    console.warn('[Photo Ask] turn failed:', err);
+    settleError('Cheffy could not respond.');
   } finally {
     cheffyLoading.set(false);
   }
@@ -430,13 +473,22 @@ export function startCheffyExperience(content: string, mode: 'chat' | 'hungry' =
 
 export async function retryCheffy() {
   if (get(cheffyLoading) || !lastTurn) return;
+  const turn = lastTurn;
   cheffyThread.update((t) => t.filter((m) => m.kind !== 'error'));
+
+  if (turn.kind === 'photo') {
+    // Re-issue the photo request only. The member's bubble, and the
+    // photo on it, are still in the thread from the first attempt.
+    await dispatchPhotoTurn(turn.file, turn.question);
+    return;
+  }
+
   const apiHistory = buildHistory(true);
   await dispatchTurn(
-    lastTurn.prompt,
-    lastTurn.mode,
+    turn.prompt,
+    turn.mode,
     apiHistory,
-    lastTurn.mode === 'hungry' || looksLikeRecipeRequest(lastTurn.prompt)
+    turn.mode === 'hungry' || looksLikeRecipeRequest(turn.prompt)
   );
 }
 

--- a/src/routes/api/zappy/ask-photo/+server.ts
+++ b/src/routes/api/zappy/ask-photo/+server.ts
@@ -194,7 +194,14 @@ export const POST: RequestHandler = async ({ request, platform }) => {
         {
           ok: false,
           code: 'RATE_LIMITED',
-          error: "Cheffy needs a breather — you've hit the photo limit for now.",
+          // Carries its own next step: this is the whole bubble. A typed
+          // failure suppresses the random ERROR_LINES flavour pick above
+          // it (see the photo-turn error path in cheffyChat.ts), so there
+          // is nothing else on screen telling the member what to do. No
+          // number — two limits can fire (PER_HOUR, PER_DAY) and the
+          // response doesn't say which, so a count would be unsourced.
+          error:
+            "Cheffy needs a breather — you've hit the photo limit for now. Give it a little while and try again.",
           retryAfter: rl.body.retryAfter
         },
         { status: 429 }

--- a/src/routes/api/zappy/ask-photo/+server.ts
+++ b/src/routes/api/zappy/ask-photo/+server.ts
@@ -51,8 +51,9 @@ import {
 } from '$lib/cheffyPrompt.server';
 
 // The member's own question — trimmed and capped, never an error. A
-// longer question just loses its tail.
-export const QUESTION_MAX_CHARS = 500;
+// longer question just loses its tail. Unexported on purpose: SvelteKit
+// only allows handler exports from +server.ts. Client mirror: photoAsk.ts.
+const QUESTION_MAX_CHARS = 500;
 
 // The client cap is 10 MiB of FILE (photoAsk.PHOTO_MAX_BYTES), and the
 // composer tells the member "try one under 10MB". Base64 is 4/3 of the

--- a/src/routes/api/zappy/ask-photo/+server.ts
+++ b/src/routes/api/zappy/ask-photo/+server.ts
@@ -1,0 +1,323 @@
+/**
+ * Cheffy "Ask about a photo" API.
+ *
+ * A member attaches a photo in the Cheffy composer, types a question,
+ * and Cheffy answers it in the thread. One vision call per attached
+ * photo. The image arrives base64-in-request and is never stored, never
+ * added to conversation history, and never reaches /api/zappy.
+ *
+ * This is the general path the attach menu always promised. The
+ * ingredient scanner (/api/zappy/scan) keeps its own narrow job:
+ * fridge/pantry photo in, ingredient list out.
+ *
+ * POST /api/zappy/ask-photo
+ * Requires NIP-98 HTTP auth (kind-27235 Authorization header with
+ * body-hash payload binding — the note-review / extract-recipe pattern).
+ *
+ * Body:
+ * {
+ *   image: string,     // base64, no data: prefix
+ *   question?: string  // the member's own question; defaults server-side
+ * }
+ *
+ * Returns:
+ *   { ok: true, output: string }
+ *   { ok: false, error: string, code?: "NOT_MEMBER" |
+ *     "MEMBERSHIP_UNAVAILABLE" | "RATE_LIMITED" | "NOT_FOOD" | "IMAGE_UNREADABLE" }
+ *
+ * DELIBERATE DEVIATION from /api/zappy/scan, the closest sibling: this
+ * endpoint authenticates with NIP-98 rather than gating on a pubkey
+ * supplied in its own request body. A body pubkey is an identity claim,
+ * not an identity — npubs are public by construction, so one member npub
+ * read off a relay would buy free vision calls. Fixing scan's gate is a
+ * separate, real piece of work; this endpoint simply does not repeat it.
+ *
+ * Like note-review (decision D5), this fails CLOSED when the membership
+ * service is unreachable (503 MEMBERSHIP_UNAVAILABLE) — vision calls
+ * cost money and there are no legacy callers to strand. Fail-open
+ * consistency across the zappy endpoints is tracked in
+ * https://github.com/zapcooking/frontend/issues/512.
+ */
+
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import { verifyNip98 } from '$lib/nip98.server';
+import { checkPerIpRateLimit } from '$lib/ipRateLimit.server';
+import {
+  CHEFFY_VISION_MODEL,
+  CHEFFY_PHOTO_ASK_INSTRUCTION,
+  PHOTO_ASK_DEFAULT_QUESTION,
+  NOT_FOOD_PREFIX
+} from '$lib/cheffyPrompt.server';
+
+// The member's own question — trimmed and capped, never an error. A
+// longer question just loses its tail.
+export const QUESTION_MAX_CHARS = 500;
+
+// The client cap is 10 MiB of FILE (photoAsk.PHOTO_MAX_BYTES), and the
+// composer tells the member "try one under 10MB". Base64 is 4/3 of the
+// input, so a file at exactly that cap encodes to ~13.33 MiB — which
+// means scan's 13 MiB wire cap is fractionally too small to hold the
+// file size its own client-side check lets through. Sized here to
+// actually cover the promise rather than copied across.
+//
+// (scan/+server.ts:68 has the same latent gap, and its comment claims
+// otherwise: "~10MB original = ~13MB base64". Real, pre-existing, and
+// deliberately not touched here — this endpoint just doesn't repeat it.)
+const IMAGE_MAX_CHARS = 14 * 1024 * 1024;
+
+// Per-pubkey budget. NIP-98 gives a verified identity, so the bucket key
+// is the pubkey rather than the caller's IP. Same caps as note-review.
+const PER_HOUR = 8;
+const PER_DAY = 30;
+
+// "How do I make this?" answers with a full structured recipe, so the
+// cap matches note-review's recipe mode rather than its comment mode.
+const MAX_TOKENS = 1200;
+
+export const POST: RequestHandler = async ({ request, platform }) => {
+  try {
+    const OPENAI_API_KEY = (platform?.env as any)?.OPENAI_API_KEY || env.OPENAI_API_KEY;
+    if (!OPENAI_API_KEY) {
+      return json({ ok: false, error: 'OpenAI API key not configured' }, { status: 500 });
+    }
+
+    // Read the body ONCE as raw bytes — the same bytes feed the NIP-98
+    // payload-hash check and the JSON parse (note-review pattern).
+    let bodyBytes: Uint8Array;
+    try {
+      bodyBytes = new Uint8Array(await request.arrayBuffer());
+    } catch {
+      return json({ ok: false, error: 'Invalid request body' }, { status: 400 });
+    }
+
+    let body: Record<string, unknown>;
+    try {
+      body = JSON.parse(new TextDecoder().decode(bodyBytes)) as Record<string, unknown>;
+    } catch {
+      return json({ ok: false, error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    const { image, question } = body ?? {};
+
+    if (typeof image !== 'string' || image.length === 0) {
+      return json({ ok: false, error: 'Image data is required' }, { status: 400 });
+    }
+    if (image.length > IMAGE_MAX_CHARS) {
+      return json(
+        { ok: false, error: 'Image too large. Please use a smaller image.' },
+        { status: 400 }
+      );
+    }
+
+    // Empty or absent question → the server-side default, so the model
+    // always gets a real ask and the wire never carries an empty turn.
+    const askedQuestion =
+      typeof question === 'string' && question.trim()
+        ? question.trim().slice(0, QUESTION_MAX_CHARS)
+        : PHOTO_ASK_DEFAULT_QUESTION;
+
+    // NIP-98: proves key control and binds the header to this exact
+    // body. Uniform 401 regardless of failure reason (no info leak); the
+    // reason is logged for greppable diagnostics.
+    const verification = await verifyNip98(request, { bodyBytes });
+    if (!verification.ok) {
+      console.warn(`[Photo Ask] NIP-98 rejected (${verification.reason})`);
+      return json({ ok: false, error: 'Authentication required' }, { status: 401 });
+    }
+    const authPubkey = verification.pubkey;
+
+    // Membership gate (any active membership). FAILS CLOSED on
+    // membership-service problems — see the header comment and issue
+    // #512 before "fixing" this to match scan.
+    const MEMBERSHIP_ENABLED = platform?.env?.MEMBERSHIP_ENABLED || env.MEMBERSHIP_ENABLED;
+    if (MEMBERSHIP_ENABLED?.toLowerCase() === 'true') {
+      const API_SECRET = platform?.env?.RELAY_API_SECRET || env.RELAY_API_SECRET;
+      if (!API_SECRET) {
+        // Gating on but no secret is a deploy misconfiguration; treat it
+        // like an outage rather than silently waving callers through.
+        console.error('[Photo Ask] MEMBERSHIP_ENABLED without RELAY_API_SECRET');
+        return json(
+          {
+            ok: false,
+            code: 'MEMBERSHIP_UNAVAILABLE',
+            error: "Cheffy can't check your membership right now. Please try again shortly."
+          },
+          { status: 503 }
+        );
+      }
+      let isMember = false;
+      try {
+        const { hasActiveMembership } = await import('$lib/membershipApi.server');
+        isMember = await hasActiveMembership(authPubkey, API_SECRET);
+      } catch (err) {
+        console.error('[Photo Ask] Membership check failed (failing closed):', err);
+        return json(
+          {
+            ok: false,
+            code: 'MEMBERSHIP_UNAVAILABLE',
+            error: "Cheffy can't check your membership right now. Please try again shortly."
+          },
+          { status: 503 }
+        );
+      }
+      if (!isMember) {
+        return json(
+          { ok: false, code: 'NOT_MEMBER', error: 'Cheffy is available to Cook+ members.' },
+          { status: 403 }
+        );
+      }
+    }
+
+    // Per-pubkey rate limit, backed by the NOURISH_FLAGS KV namespace.
+    // The helper's `ip` param is just the string salted + hashed into
+    // the bucket key — a verified pubkey is a strictly better identity
+    // for it than an IP. checkPerIpRateLimit fails open silently when no
+    // KV is bound; be loud about it here so a missing binding shows up
+    // in logs instead of quietly unmetering the endpoint.
+    //
+    // This is the cost ceiling for the whole feature: 8/hour, 30/day per
+    // member, one vision call each.
+    const kv = platform?.env?.NOURISH_FLAGS;
+    if (!kv) {
+      console.warn('[Photo Ask] NOURISH_FLAGS KV not bound — photo-ask rate limiting is disabled');
+    }
+    const rl = await checkPerIpRateLimit(kv, {
+      ip: authPubkey,
+      scope: 'photo-ask',
+      perHour: PER_HOUR,
+      perDay: PER_DAY
+    });
+    if (rl.limited) {
+      return json(
+        {
+          ok: false,
+          code: 'RATE_LIMITED',
+          error: "Cheffy needs a breather — you've hit the photo limit for now.",
+          retryAfter: rl.body.retryAfter
+        },
+        { status: 429 }
+      );
+    }
+
+    // Detect image type from the base64 header or default to jpeg
+    // (scan's detection, unchanged).
+    let mimeType = 'image/jpeg';
+    if (image.startsWith('/9j/')) {
+      mimeType = 'image/jpeg';
+    } else if (image.startsWith('iVBOR')) {
+      mimeType = 'image/png';
+    } else if (image.startsWith('R0lGOD')) {
+      mimeType = 'image/gif';
+    } else if (image.startsWith('UklGR')) {
+      mimeType = 'image/webp';
+    }
+
+    const openaiResponse = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${OPENAI_API_KEY}`
+      },
+      body: JSON.stringify({
+        model: CHEFFY_VISION_MODEL,
+        messages: [
+          { role: 'system', content: CHEFFY_PHOTO_ASK_INSTRUCTION },
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: askedQuestion },
+              {
+                type: 'image_url',
+                image_url: {
+                  url: `data:${mimeType};base64,${image}`,
+                  // 'high', unlike scan and note-review. Enumerating jars
+                  // on a shelf works at low detail; identifying a plated
+                  // dish does not, and identifying the dish is the whole
+                  // feature. This is the single knob that moves per-call
+                  // cost — the usage log below is how we measure it.
+                  detail: 'high'
+                }
+              }
+            ]
+          }
+        ],
+        max_tokens: MAX_TOKENS,
+        temperature: 0.7
+      })
+    });
+
+    if (!openaiResponse.ok) {
+      const errorData: any = await openaiResponse.json().catch(() => ({}));
+      const errCode = errorData?.error?.code || '';
+      const errMessage = errorData?.error?.message || '';
+      // OpenAI couldn't decode the image (corrupt file, unsupported
+      // format that slipped past the client's mime check). Typed so the
+      // client can render a friendly dead-end rather than a raw error.
+      if (
+        errCode.includes('image') ||
+        /downloading|image_url|unsupported image|invalid image/i.test(errMessage)
+      ) {
+        console.warn(`[Photo Ask] Image unreadable: ${errCode} ${errMessage}`);
+        return json(
+          {
+            ok: false,
+            code: 'IMAGE_UNREADABLE',
+            error: "Cheffy couldn't get a good look at that photo. Try another one?"
+          },
+          { status: 422 }
+        );
+      }
+      console.error('[Photo Ask] OpenAI API error:', errorData);
+      return json(
+        { ok: false, error: 'Cheffy could not finish that one. Please try again.' },
+        { status: 500 }
+      );
+    }
+
+    const openaiData = await openaiResponse.json();
+    const output: string | undefined = openaiData.choices?.[0]?.message?.content;
+    if (!output || !output.trim()) {
+      return json(
+        { ok: false, error: 'Cheffy went quiet for a second. Please try again.' },
+        { status: 500 }
+      );
+    }
+
+    // Measured, not modelled. `detail: 'high'` is the one variable in
+    // this feature's cost, so every completed call reports its token
+    // usage from day one — week-one logs give a real per-call number
+    // instead of an estimate. Deliberately above the NOT_FOOD check: a
+    // refusal still spent a vision call and still belongs in the total.
+    if (openaiData.usage) {
+      const u = openaiData.usage;
+      console.log(
+        `[Photo Ask] usage model=${CHEFFY_VISION_MODEL} detail=high prompt=${u.prompt_tokens} completion=${u.completion_tokens} total=${u.total_tokens}`
+      );
+    }
+
+    // Prompt-level refusal: the photo isn't food. Typed so the client
+    // can land Cheffy's playful line in the thread as an answer rather
+    // than as an error bubble.
+    const trimmed = output.trim();
+    if (trimmed.startsWith(NOT_FOOD_PREFIX)) {
+      const line = trimmed.slice(NOT_FOOD_PREFIX.length).trim();
+      return json(
+        {
+          ok: false,
+          code: 'NOT_FOOD',
+          error: line || "That doesn't look like food to Cheffy — try a photo of a dish."
+        },
+        { status: 422 }
+      );
+    }
+
+    return json({ ok: true, output: trimmed });
+  } catch (error: any) {
+    console.error('[Photo Ask] Error:', error);
+    return json(
+      { ok: false, error: error.message || 'An unexpected error occurred' },
+      { status: 500 }
+    );
+  }
+};

--- a/src/routes/api/zappy/ask-photo/askPhoto.test.ts
+++ b/src/routes/api/zappy/ask-photo/askPhoto.test.ts
@@ -14,7 +14,8 @@ import {
   PHOTO_ASK_DEFAULT_QUESTION,
   NOT_FOOD_PREFIX
 } from '$lib/cheffyPrompt.server';
-import { POST, QUESTION_MAX_CHARS } from './+server';
+import { QUESTION_MAX_CHARS } from '$lib/photoAsk';
+import { POST } from './+server';
 
 const mocks = vi.hoisted(() => ({
   verifyNip98: vi.fn(),

--- a/src/routes/api/zappy/ask-photo/askPhoto.test.ts
+++ b/src/routes/api/zappy/ask-photo/askPhoto.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Unit tests for POST /api/zappy/ask-photo.
+ *
+ * Collaborators (NIP-98 verifier, membership API, rate limiter, OpenAI
+ * fetch) are mocked at the module boundary; the endpoint's own
+ * validation, gating, prompt assembly, and response shaping run for
+ * real — including the fail-CLOSED membership posture it shares with
+ * note-review and deliberately does not share with scan.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  CHEFFY_VISION_MODEL,
+  CHEFFY_PHOTO_ASK_INSTRUCTION,
+  PHOTO_ASK_DEFAULT_QUESTION,
+  NOT_FOOD_PREFIX
+} from '$lib/cheffyPrompt.server';
+import { POST, QUESTION_MAX_CHARS } from './+server';
+
+const mocks = vi.hoisted(() => ({
+  verifyNip98: vi.fn(),
+  hasActiveMembership: vi.fn(),
+  checkPerIpRateLimit: vi.fn()
+}));
+
+vi.mock('$lib/nip98.server', () => ({ verifyNip98: mocks.verifyNip98 }));
+vi.mock('$lib/membershipApi.server', () => ({ hasActiveMembership: mocks.hasActiveMembership }));
+vi.mock('$lib/ipRateLimit.server', () => ({ checkPerIpRateLimit: mocks.checkPerIpRateLimit }));
+
+const PUBKEY = 'a'.repeat(64);
+const ENDPOINT = 'https://zap.cooking/api/zappy/ask-photo';
+// A JPEG base64 prefix, so the mime sniffing has something real to read.
+const IMAGE = '/9j/4AAQSkZJRg';
+
+const fetchMock = vi.fn();
+
+function openaiOk(content: string, usage?: Record<string, number>) {
+  return {
+    ok: true,
+    json: async () => ({ choices: [{ message: { content } }], ...(usage ? { usage } : {}) })
+  };
+}
+
+function openaiError(status: number, error: Record<string, unknown>) {
+  return { ok: false, status, json: async () => ({ error }) };
+}
+
+type EventOpts = { env?: Record<string, unknown> | null; rawBody?: string };
+
+function makeEvent(body: unknown, opts: EventOpts = {}) {
+  const url = new URL(ENDPOINT);
+  const request = new Request(url, {
+    method: 'POST',
+    body: opts.rawBody ?? JSON.stringify(body)
+  });
+  const env =
+    opts.env === null
+      ? {}
+      : (opts.env ?? {
+          OPENAI_API_KEY: 'test-key',
+          MEMBERSHIP_ENABLED: 'true',
+          RELAY_API_SECRET: 'secret',
+          NOURISH_FLAGS: { kv: true }
+        });
+  return { request, url, platform: { env } } as any;
+}
+
+async function call(body: unknown, opts: EventOpts = {}) {
+  const res = await POST(makeEvent(body, opts));
+  return { res, data: await res.json() };
+}
+
+/** The JSON body of the (single) OpenAI call this endpoint made. */
+function openaiPayload() {
+  return JSON.parse(fetchMock.mock.calls[0][1].body);
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock);
+  mocks.verifyNip98.mockReset().mockResolvedValue({ ok: true, pubkey: PUBKEY });
+  mocks.hasActiveMembership.mockReset().mockResolvedValue(true);
+  mocks.checkPerIpRateLimit.mockReset().mockResolvedValue({ limited: false, ipHash: 'h' });
+  fetchMock.mockReset().mockResolvedValue(openaiOk('That is a bowl of ribollita.'));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('request validation', () => {
+  it('500s without an OpenAI key', async () => {
+    const { res } = await call({ image: IMAGE }, { env: null });
+    expect(res.status).toBe(500);
+  });
+
+  it('400s on invalid JSON', async () => {
+    const { res } = await call(null, { rawBody: 'not json' });
+    expect(res.status).toBe(400);
+  });
+
+  it('400s without an image', async () => {
+    const { res, data } = await call({ question: 'what is this?' });
+    expect(res.status).toBe(400);
+    expect(data.error).toMatch(/image/i);
+  });
+
+  it('400s on an oversize image, before any OpenAI call', async () => {
+    const { res } = await call({ image: 'x'.repeat(14 * 1024 * 1024 + 1) });
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('auth', () => {
+  it('401s when the NIP-98 header is missing or invalid', async () => {
+    mocks.verifyNip98.mockResolvedValue({ ok: false, reason: 'missing-header' });
+    const { res, data } = await call({ image: IMAGE });
+    expect(res.status).toBe(401);
+    // Uniform message — the reason is logged, never returned.
+    expect(data.error).toBe('Authentication required');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('gates on the VERIFIED pubkey, never on a body-supplied one', async () => {
+    // scan takes its pubkey from the request body; this endpoint must
+    // not, or one public npub buys anyone free vision calls.
+    await call({ image: IMAGE, pubkey: 'f'.repeat(64) });
+    expect(mocks.hasActiveMembership).toHaveBeenCalledWith(PUBKEY, 'secret');
+    expect(mocks.checkPerIpRateLimit.mock.calls[0][1].ip).toBe(PUBKEY);
+  });
+});
+
+describe('membership gate', () => {
+  it('403s a non-member with NOT_MEMBER, before any OpenAI call', async () => {
+    mocks.hasActiveMembership.mockResolvedValue(false);
+    const { res, data } = await call({ image: IMAGE });
+    expect(res.status).toBe(403);
+    expect(data.code).toBe('NOT_MEMBER');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('fails CLOSED with 503 when the membership service throws', async () => {
+    mocks.hasActiveMembership.mockRejectedValue(new Error('relay api down'));
+    const { res, data } = await call({ image: IMAGE });
+    expect(res.status).toBe(503);
+    expect(data.code).toBe('MEMBERSHIP_UNAVAILABLE');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('fails CLOSED with 503 when gating is on but the API secret is missing', async () => {
+    const { res, data } = await call(
+      { image: IMAGE },
+      { env: { OPENAI_API_KEY: 'test-key', MEMBERSHIP_ENABLED: 'true' } }
+    );
+    expect(res.status).toBe(503);
+    expect(data.code).toBe('MEMBERSHIP_UNAVAILABLE');
+    expect(mocks.hasActiveMembership).not.toHaveBeenCalled();
+  });
+
+  it('skips the membership check entirely when gating is off', async () => {
+    const { res } = await call(
+      { image: IMAGE },
+      { env: { OPENAI_API_KEY: 'test-key', MEMBERSHIP_ENABLED: 'false' } }
+    );
+    expect(res.status).toBe(200);
+    expect(mocks.hasActiveMembership).not.toHaveBeenCalled();
+  });
+});
+
+describe('rate limit', () => {
+  it('429s with RATE_LIMITED and spends no OpenAI call', async () => {
+    mocks.checkPerIpRateLimit.mockResolvedValue({
+      limited: true,
+      body: { retryAfter: 900 }
+    });
+    const { res, data } = await call({ image: IMAGE });
+    expect(res.status).toBe(429);
+    expect(data.code).toBe('RATE_LIMITED');
+    expect(data.retryAfter).toBe(900);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('is scoped and capped per member — the feature cost ceiling', async () => {
+    await call({ image: IMAGE });
+    const opts = mocks.checkPerIpRateLimit.mock.calls[0][1];
+    expect(opts.scope).toBe('photo-ask');
+    expect(opts.perHour).toBe(8);
+    expect(opts.perDay).toBe(30);
+  });
+
+  it('runs AFTER the membership gate, so a 403 spends no quota', async () => {
+    mocks.hasActiveMembership.mockResolvedValue(false);
+    await call({ image: IMAGE });
+    expect(mocks.checkPerIpRateLimit).not.toHaveBeenCalled();
+  });
+});
+
+describe('the OpenAI request', () => {
+  it('sends the photo-ask system prompt with the member question and image', async () => {
+    await call({ image: IMAGE, question: 'what went wrong?' });
+    const payload = openaiPayload();
+
+    expect(payload.model).toBe(CHEFFY_VISION_MODEL);
+    expect(payload.messages[0]).toEqual({
+      role: 'system',
+      content: CHEFFY_PHOTO_ASK_INSTRUCTION
+    });
+    const user = payload.messages[1];
+    expect(user.role).toBe('user');
+    // The member's own question, NOT wrapped in note-review's untrusted
+    // fence — fencing it would degrade the answer to the person asking.
+    expect(user.content[0]).toEqual({ type: 'text', text: 'what went wrong?' });
+    expect(user.content[0].text).not.toContain('"""');
+    expect(user.content[1].image_url.url).toBe(`data:image/jpeg;base64,${IMAGE}`);
+  });
+
+  it("asks for high detail — low detail can't identify a plated dish", async () => {
+    await call({ image: IMAGE });
+    expect(openaiPayload().messages[1].content[1].image_url.detail).toBe('high');
+  });
+
+  it('substitutes the default question when none is given', async () => {
+    await call({ image: IMAGE });
+    expect(openaiPayload().messages[1].content[0].text).toBe(PHOTO_ASK_DEFAULT_QUESTION);
+  });
+
+  it('substitutes the default question for a whitespace-only one', async () => {
+    await call({ image: IMAGE, question: '   \n ' });
+    expect(openaiPayload().messages[1].content[0].text).toBe(PHOTO_ASK_DEFAULT_QUESTION);
+  });
+
+  it('caps a long question rather than rejecting it', async () => {
+    await call({ image: IMAGE, question: 'y'.repeat(QUESTION_MAX_CHARS + 400) });
+    expect(openaiPayload().messages[1].content[0].text).toHaveLength(QUESTION_MAX_CHARS);
+  });
+
+  it('detects png and webp from the base64 prefix', async () => {
+    await call({ image: 'iVBORw0KGgo' });
+    expect(openaiPayload().messages[1].content[1].image_url.url).toContain(
+      'data:image/png;base64,'
+    );
+
+    fetchMock.mockClear();
+    await call({ image: 'UklGRlIA' });
+    expect(openaiPayload().messages[1].content[1].image_url.url).toContain(
+      'data:image/webp;base64,'
+    );
+  });
+
+  it('leaves room for a full recipe answer', async () => {
+    await call({ image: IMAGE, question: 'how do I make this?' });
+    expect(openaiPayload().max_tokens).toBe(1200);
+  });
+});
+
+describe('responses', () => {
+  it('returns the trimmed answer on success', async () => {
+    fetchMock.mockResolvedValue(openaiOk('  A bowl of ribollita.  '));
+    const { res, data } = await call({ image: IMAGE });
+    expect(res.status).toBe(200);
+    expect(data).toEqual({ ok: true, output: 'A bowl of ribollita.' });
+  });
+
+  it('422s NOT_FOOD with the sentinel stripped off the playful line', async () => {
+    fetchMock.mockResolvedValue(openaiOk(`${NOT_FOOD_PREFIX} That is a very smug cat.`));
+    const { res, data } = await call({ image: IMAGE });
+    expect(res.status).toBe(422);
+    expect(data.code).toBe('NOT_FOOD');
+    expect(data.error).toBe('That is a very smug cat.');
+    expect(data.error).not.toContain(NOT_FOOD_PREFIX);
+  });
+
+  it('422s IMAGE_UNREADABLE when OpenAI cannot decode the photo', async () => {
+    fetchMock.mockResolvedValue(
+      openaiError(400, { code: 'invalid_image_format', message: 'unsupported image' })
+    );
+    const { res, data } = await call({ image: IMAGE });
+    expect(res.status).toBe(422);
+    expect(data.code).toBe('IMAGE_UNREADABLE');
+  });
+
+  it('500s (untyped) on any other OpenAI failure', async () => {
+    fetchMock.mockResolvedValue(openaiError(500, { code: 'server_error', message: 'boom' }));
+    const { res, data } = await call({ image: IMAGE });
+    expect(res.status).toBe(500);
+    expect(data.code).toBeUndefined();
+  });
+
+  it('500s on an empty completion rather than returning a blank answer', async () => {
+    fetchMock.mockResolvedValue(openaiOk('   '));
+    const { res } = await call({ image: IMAGE });
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('cost instrumentation', () => {
+  it('logs token usage on a successful call — the measured number for the meter', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    fetchMock.mockResolvedValue(
+      openaiOk('A bowl of ribollita.', {
+        prompt_tokens: 1400,
+        completion_tokens: 120,
+        total_tokens: 1520
+      })
+    );
+    await call({ image: IMAGE });
+    const line = log.mock.calls
+      .map((c: unknown[]) => String(c[0]))
+      .find((l: string) => l.includes('[Photo Ask] usage'));
+    expect(line).toBeDefined();
+    expect(line).toContain('prompt=1400');
+    expect(line).toContain('total=1520');
+  });
+
+  it('logs usage for a NOT_FOOD refusal too — it still spent a vision call', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    fetchMock.mockResolvedValue(
+      openaiOk(`${NOT_FOOD_PREFIX} A cat.`, {
+        prompt_tokens: 1400,
+        completion_tokens: 8,
+        total_tokens: 1408
+      })
+    );
+    const { res } = await call({ image: IMAGE });
+    expect(res.status).toBe(422);
+    expect(
+      log.mock.calls
+        .map((c: unknown[]) => String(c[0]))
+        .some((l: string) => l.includes('[Photo Ask] usage'))
+    ).toBe(true);
+  });
+});

--- a/src/routes/cheffy/+page.svelte
+++ b/src/routes/cheffy/+page.svelte
@@ -91,7 +91,15 @@
   let threadEl: HTMLDivElement;
   let loading = false; // a request is in flight
   let announce = ''; // sr-only live-region status
-  let lastTurn: { prompt: string; mode: 'chat' | 'hungry' } | null = null;
+  // The turn retryLast() would re-issue. The error bubble renders "Try
+  // again" unconditionally, so this must be non-null whenever an error
+  // bubble can exist — otherwise the button is enabled and does nothing.
+  // A photo turn goes to a different endpoint and cannot be replayed as
+  // text, so it is its own variant carrying the file rather than a null.
+  type LastTurn =
+    | { kind: 'text'; prompt: string; mode: 'chat' | 'hungry' }
+    | { kind: 'photo'; file: File; question: string };
+  let lastTurn: LastTurn | null = null;
   let lastStatusLine = '';
 
   let msgSeq = 0;
@@ -326,7 +334,7 @@
     const apiHistory = buildHistory();
     const display = mode === 'hungry' ? 'Surprise me 🎲' : text;
     thread = [...thread, { id: nextId(), role: 'user', content: display, kind: 'text' }];
-    lastTurn = { prompt: mode === 'hungry' ? '' : text, mode };
+    lastTurn = { kind: 'text', prompt: mode === 'hungry' ? '' : text, mode };
 
     if (mode !== 'hungry') {
       input = '';
@@ -344,14 +352,23 @@
 
   async function retryLast() {
     if (loading || !lastTurn) return;
+    const turn = lastTurn;
     // Drop any error bubbles, then re-issue the same turn.
     thread = thread.filter((m) => m.kind !== 'error');
+
+    if (turn.kind === 'photo') {
+      // Re-issue the photo request only. The member's bubble, and the
+      // photo on it, are still in the thread from the first attempt.
+      await dispatchPhotoTurn(turn.file, turn.question);
+      return;
+    }
+
     const apiHistory = buildHistory(true);
     await dispatchTurn(
-      lastTurn.prompt,
-      lastTurn.mode,
+      turn.prompt,
+      turn.mode,
       apiHistory,
-      lastTurn.mode === 'hungry' || looksLikeRecipeRequest(lastTurn.prompt)
+      turn.mode === 'hungry' || looksLikeRecipeRequest(turn.prompt)
     );
   }
 
@@ -607,9 +624,13 @@
         input = `I have: ${detectedIngredients.join(', ')}`;
       } else {
         scanError = SCAN_ERROR_LINE;
+        holdScanPhoto(file);
+        await tick();
+        promptEl?.focus();
       }
     } catch (err) {
       scanError = err instanceof Error ? err.message : SCAN_ERROR_LINE;
+      holdScanPhoto(file);
     } finally {
       isScanning = false;
       if (inputEl) inputEl.value = '';
@@ -627,6 +648,19 @@
       attachedPhotoUrl = '';
     }
     attachedPhoto = null;
+  }
+
+  // Hand a scanned file to the composer as an attached photo. Every
+  // non-success exit of handleFileSelect does this, which is what makes
+  // SCAN_ERROR_LINE's "the photo's still here" true: the member who
+  // scanned a plated dish is one Send away from asking about it, instead
+  // of re-picking the file we threw away.
+  function holdScanPhoto(file: File) {
+    clearAttachedPhoto();
+    detectedIngredients = [];
+    showIngredientInput = false;
+    attachedPhoto = file;
+    attachedPhotoUrl = URL.createObjectURL(file);
   }
 
   async function handlePhotoSelect(event: Event) {
@@ -674,11 +708,24 @@
     ];
     input = '';
     scanError = '';
-    // A photo turn is not replayable — retryLast() would re-send it as a
-    // text-only question through /api/zappy. No retry beats a wrong one.
-    lastTurn = null;
+    // Recorded as a PHOTO turn, holding the file, so the error bubble's
+    // Try again re-issues it against /api/zappy/ask-photo instead of
+    // asking a different question as text — or doing nothing at all. The
+    // file is already reachable for the session via the preview object
+    // URL above, so this reference stores nothing new.
+    lastTurn = { kind: 'photo', file, question: text };
     await scrollAfterTurn();
 
+    await dispatchPhotoTurn(file, text);
+  }
+
+  /**
+   * Issue one photo request into a fresh pending bubble and settle it.
+   * Split out of askPhotoTurn so a retry re-runs exactly this — the
+   * member's own bubble, with their photo on it, is already in the
+   * thread and must not be appended twice.
+   */
+  async function dispatchPhotoTurn(file: File, text: string) {
     loading = true;
     const expectRecipe = looksLikeRecipeRequest(text);
     const statusLine = pickLine(expectRecipe ? COOKING_LINES : THINKING_LINES, lastStatusLine);
@@ -696,6 +743,21 @@
 
     const settle = (patch: Partial<ChatMessage>) => {
       thread = thread.map((m) => (m.id === pending.id ? { ...m, ...patch } : m));
+    };
+
+    // A flavour line stands in for an explanation we don't have. When the
+    // server named the cause, one above the real reason is a second
+    // narrator inventing a different one — so a typed failure speaks for
+    // itself and untyped 500s keep the pool. Photo turns only; the chat
+    // error path in dispatchTurn is unchanged.
+    const settleError = (detail: string, code?: string) => {
+      settle({
+        kind: 'error',
+        content: detail,
+        expression: 'concerned',
+        statusLine: code ? '' : pickLine(ERROR_LINES, statusLine)
+      });
+      announce = 'Cheffy hit a snag.';
     };
 
     try {
@@ -721,16 +783,12 @@
         return;
       }
 
-      throw new Error(result.error || 'Cheffy could not respond.');
+      settleError(result.error || 'Cheffy could not respond.', result.code);
     } catch (err) {
-      const detail = err instanceof Error ? err.message : 'Cheffy could not respond.';
-      settle({
-        kind: 'error',
-        content: detail,
-        expression: 'concerned',
-        statusLine: pickLine(ERROR_LINES, statusLine)
-      });
-      announce = 'Cheffy hit a snag.';
+      // Only unexpected exceptions land here (fileToBase64) —
+      // askAboutPhoto never throws. No typed code, so the pool applies.
+      console.warn('[Photo Ask] turn failed:', err);
+      settleError('Cheffy could not respond.');
     } finally {
       loading = false;
       await scrollAfterTurn();
@@ -860,7 +918,10 @@
                   </div>
                 {:else if m.kind === 'error'}
                   <div class="error-bubble">
-                    <p class="error-line">{m.statusLine}</p>
+                    <!-- A photo turn that failed with a typed server code
+                         carries no flavour line: the detail below already
+                         names the cause. -->
+                    {#if m.statusLine}<p class="error-line">{m.statusLine}</p>{/if}
                     <p class="error-detail">{m.content}</p>
                     <button type="button" class="retry-btn" on:click={retryLast} disabled={loading}>
                       <ArrowsClockwiseIcon size={14} />
@@ -1061,15 +1122,18 @@
             class="scan-pill"
             on:click={triggerScan}
             disabled={isScanning || loading}
-            title="Scan my fridge or pantry"
-            aria-label="Scan my fridge or pantry"
+            title="Scan a fridge or pantry for ingredients"
+            aria-label="Scan a fridge or pantry for ingredients"
           >
             {#if isScanning}
               <ArrowsClockwiseIcon size={14} class="animate-spin" />
               <span>Scanning</span>
             {:else}
               <CameraIcon size={14} weight="fill" />
-              <span>Scan my fridge or pantry</span>
+              <!-- The pill is a control, not the choice: the full label
+                   lives in title/aria-label, and the sheet in the
+                   messenger is where the two photo paths are told apart. -->
+              <span>Scan for ingredients</span>
             {/if}
           </button>
         </div>

--- a/src/routes/cheffy/+page.svelte
+++ b/src/routes/cheffy/+page.svelte
@@ -2,7 +2,8 @@
   import { onMount, onDestroy, tick } from 'svelte';
   import { browser } from '$app/environment';
   import { goto } from '$app/navigation';
-  import { userPublickey } from '$lib/nostr';
+  import { ndk, userPublickey } from '$lib/nostr';
+  import { askAboutPhoto, fileToBase64, PHOTO_MAX_BYTES } from '$lib/photoAsk';
   import {
     membershipStatusMap,
     queueMembershipLookup,
@@ -42,6 +43,7 @@
   import HeartIcon from 'phosphor-svelte/lib/Heart';
   import Checkmark from 'phosphor-svelte/lib/CheckFat';
   import CameraIcon from 'phosphor-svelte/lib/Camera';
+  import ImageIcon from 'phosphor-svelte/lib/Image';
   import ShuffleIcon from 'phosphor-svelte/lib/Shuffle';
   import PaperPlaneIcon from 'phosphor-svelte/lib/PaperPlaneTilt';
   import XIcon from 'phosphor-svelte/lib/X';
@@ -75,6 +77,14 @@
     kind: ChatKind;
     expression?: CheffyExpression;
     statusLine?: string; // pending loading line / friendly error line
+    /**
+     * Object URL for a photo the member attached — DISPLAY ONLY.
+     * `buildHistory` projects `role` + `content` only, so this field is
+     * structurally incapable of reaching /api/zappy. The image is sent
+     * once, to /api/zappy/ask-photo, and never enters history. Same
+     * contract as ChatMessage.imagePreview in stores/cheffyChat.ts.
+     */
+    imagePreview?: string;
   }
 
   let thread: ChatMessage[] = [];
@@ -115,6 +125,17 @@
   let newIngredient = '';
   let showIngredientInput = false;
 
+  // ── Ask about a photo state ──────────────────────────────────
+  // Distinct from the scanner: the photo is held until the member sends
+  // so their question travels with it. Scanning and asking are mutually
+  // exclusive — starting one clears the other, so the composer is never
+  // showing an ingredient list and a held photo at the same time.
+  let photoInput: HTMLInputElement;
+  let attachedPhoto: File | null = null;
+  let attachedPhotoUrl = '';
+  // Preview URLs handed to thread bubbles; released on Start over.
+  let photoPreviewUrls: string[] = [];
+
   // ── Save / Share state ───────────────────────────────────────
   let isSaving = false;
   let copiedId: string | null = null;
@@ -144,7 +165,9 @@
 
   $: hasInAppWallet = $activeWallet && ($activeWallet.kind === 3 || $activeWallet.kind === 4);
 
-  $: canSend = (input.trim().length > 0 || detectedIngredients.length > 0) && !loading;
+  $: canSend =
+    (input.trim().length > 0 || detectedIngredients.length > 0 || attachedPhoto !== null) &&
+    !loading;
 
   let unsubMembershipReady: (() => void) | null = null;
 
@@ -188,6 +211,8 @@
     if (placeholderInterval) clearInterval(placeholderInterval);
     if (copyTimeout) clearTimeout(copyTimeout);
     if (zapSuccessTimeout) clearTimeout(zapSuccessTimeout);
+    releasePhotoPreviews();
+    clearAttachedPhoto();
   });
 
   // ── Conversation engine ──────────────────────────────────────
@@ -332,12 +357,27 @@
 
   function startOver() {
     if (loading) return;
+    releasePhotoPreviews();
+    clearAttachedPhoto();
     thread = [];
     input = '';
     detectedIngredients = [];
     scanError = '';
     lastTurn = null;
     announce = 'Conversation cleared.';
+  }
+
+  /** Hand back the object URLs minted for thread thumbnails. */
+  function releasePhotoPreviews() {
+    if (!browser) return;
+    for (const url of photoPreviewUrls) {
+      try {
+        URL.revokeObjectURL(url);
+      } catch {
+        // already revoked — nothing to do
+      }
+    }
+    photoPreviewUrls = [];
   }
 
   function onStarter(e: CustomEvent<StarterPrompt>) {
@@ -348,7 +388,7 @@
   function onComposerKeydown(e: KeyboardEvent) {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      if (canSend) send(input);
+      submitComposer();
     }
   }
 
@@ -548,6 +588,9 @@
     }
     isScanning = true;
     scanError = '';
+    // Scanning takes the composer over with an ingredient list, so a
+    // held photo would be stranded — drop it (see handlePhotoSelect).
+    clearAttachedPhoto();
     try {
       const base64 = await fileToBase64(file);
       const response = await fetch('/api/zappy/scan', {
@@ -573,16 +616,140 @@
     }
   }
 
-  function fileToBase64(file: File): Promise<string> {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => {
-        const result = reader.result as string;
-        resolve(result.split(',')[1]);
-      };
-      reader.onerror = reject;
-      reader.readAsDataURL(file);
-    });
+  // ── Ask about a photo ────────────────────────────────────────
+  function triggerPhotoAttach() {
+    photoInput?.click();
+  }
+
+  function clearAttachedPhoto() {
+    if (attachedPhotoUrl) {
+      URL.revokeObjectURL(attachedPhotoUrl);
+      attachedPhotoUrl = '';
+    }
+    attachedPhoto = null;
+  }
+
+  async function handlePhotoSelect(event: Event) {
+    const inputEl = event.target as HTMLInputElement;
+    const file = inputEl.files?.[0];
+    // Reset immediately so re-picking the same file still fires change.
+    if (inputEl) inputEl.value = '';
+    if (!file) return;
+    if (!file.type.startsWith('image/')) {
+      scanError = 'Please choose an image file.';
+      return;
+    }
+    if (file.size > PHOTO_MAX_BYTES) {
+      scanError = 'That image is a little big — try one under 10MB.';
+      return;
+    }
+    scanError = '';
+    clearAttachedPhoto();
+    // A held photo and a scanned ingredient list would both claim the
+    // composer; the photo wins because the member just chose it.
+    detectedIngredients = [];
+    showIngredientInput = false;
+    input = '';
+    attachedPhoto = file;
+    attachedPhotoUrl = URL.createObjectURL(file);
+    await tick();
+    promptEl?.focus();
+  }
+
+  /**
+   * One vision call to /api/zappy/ask-photo, rendered into the same
+   * thread as any other turn. Deliberately parallel to dispatchTurn
+   * rather than folded into it: that path posts chat history to
+   * /api/zappy, and this one must never do that.
+   */
+  async function askPhotoTurn(file: File, question: string) {
+    if (loading) return;
+    const text = question.trim();
+    const preview = browser ? URL.createObjectURL(file) : undefined;
+    if (preview) photoPreviewUrls = [...photoPreviewUrls, preview];
+
+    thread = [
+      ...thread,
+      { id: nextId(), role: 'user', content: text, kind: 'text', imagePreview: preview }
+    ];
+    input = '';
+    scanError = '';
+    // A photo turn is not replayable — retryLast() would re-send it as a
+    // text-only question through /api/zappy. No retry beats a wrong one.
+    lastTurn = null;
+    await scrollAfterTurn();
+
+    loading = true;
+    const expectRecipe = looksLikeRecipeRequest(text);
+    const statusLine = pickLine(expectRecipe ? COOKING_LINES : THINKING_LINES, lastStatusLine);
+    lastStatusLine = statusLine;
+    const pending: ChatMessage = {
+      id: nextId(),
+      role: 'cheffy',
+      content: '',
+      kind: 'pending',
+      expression: expectRecipe ? 'cooking' : 'thinking',
+      statusLine
+    };
+    thread = [...thread, pending];
+    await scrollAfterTurn();
+
+    const settle = (patch: Partial<ChatMessage>) => {
+      thread = thread.map((m) => (m.id === pending.id ? { ...m, ...patch } : m));
+    };
+
+    try {
+      const imageBase64 = await fileToBase64(file);
+      const result = await askAboutPhoto({ ndk: $ndk, imageBase64, question: text });
+
+      if (result.ok) {
+        const isRecipe = looksLikeStructuredRecipe(result.output);
+        settle({
+          kind: isRecipe ? 'recipe' : 'text',
+          content: result.output,
+          expression: isRecipe ? 'happy' : 'neutral'
+        });
+        announce = isRecipe ? 'Cheffy shared a recipe.' : 'Cheffy replied.';
+        return;
+      }
+
+      // NOT_FOOD is a refusal, not a failure — the member picked the
+      // file themselves, so Cheffy's playful line is the answer here.
+      if (result.code === 'NOT_FOOD' && result.error) {
+        settle({ kind: 'text', content: result.error, expression: 'neutral' });
+        announce = 'Cheffy replied.';
+        return;
+      }
+
+      throw new Error(result.error || 'Cheffy could not respond.');
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : 'Cheffy could not respond.';
+      settle({
+        kind: 'error',
+        content: detail,
+        expression: 'concerned',
+        statusLine: pickLine(ERROR_LINES, statusLine)
+      });
+      announce = 'Cheffy hit a snag.';
+    } finally {
+      loading = false;
+      await scrollAfterTurn();
+    }
+  }
+
+  // Single send entry point for the Ask Cheffy button and Enter: a held
+  // photo makes this a photo turn. An empty question is fine — the
+  // server supplies the default ask.
+  function submitComposer() {
+    if (!canSend) return;
+    if (attachedPhoto) {
+      const file = attachedPhoto;
+      const question = input;
+      clearAttachedPhoto();
+      void askPhotoTurn(file, question);
+      return;
+    }
+    void send(input);
   }
 
   function removeIngredient(ingredient: string) {
@@ -665,7 +832,18 @@
         {#each thread as m (m.id)}
           {#if m.role === 'user'}
             <div class="msg msg-user">
-              <div class="bubble-user">{m.content}</div>
+              <div class="bubble-user">
+                {#if m.imagePreview}
+                  <!-- Display only. Never reaches /api/zappy — see the
+                       imagePreview docs on ChatMessage above. -->
+                  <img
+                    class="bubble-photo"
+                    src={m.imagePreview}
+                    alt="What you asked Cheffy about"
+                  />
+                {/if}
+                {#if m.content}<span class="bubble-text">{m.content}</span>{/if}
+              </div>
             </div>
           {:else}
             <div class="msg msg-cheffy">
@@ -836,6 +1014,23 @@
         </div>
       {/if}
 
+      {#if attachedPhoto}
+        <!-- Held photo: the question and the picture travel together on
+             send, so the member gets to say what they're asking. -->
+        <div class="photo-chip">
+          <img class="photo-chip-thumb" src={attachedPhotoUrl} alt="" />
+          <span class="photo-chip-name">{attachedPhoto.name}</span>
+          <button
+            type="button"
+            class="photo-chip-remove"
+            aria-label="Remove photo"
+            on:click={clearAttachedPhoto}
+          >
+            <XIcon size={14} weight="bold" />
+          </button>
+        </div>
+      {/if}
+
       <!-- Input -->
       <div class="relative">
         <label for="cheffy-input" class="sr-only">Message Cheffy</label>
@@ -843,28 +1038,41 @@
           id="cheffy-input"
           bind:this={promptEl}
           bind:value={input}
-          placeholder={currentPlaceholder}
+          placeholder={attachedPhoto ? 'Ask about this photo…' : currentPlaceholder}
           rows="2"
           class="input auto-grow resize-none text-base w-full pb-12"
           disabled={loading}
           on:keydown={onComposerKeydown}
         ></textarea>
-        <button
-          type="button"
-          class="scan-pill"
-          on:click={triggerScan}
-          disabled={isScanning || loading}
-          title="Show Cheffy your fridge"
-          aria-label="Show Cheffy your fridge"
-        >
-          {#if isScanning}
-            <ArrowsClockwiseIcon size={14} class="animate-spin" />
-            <span>Scanning</span>
-          {:else}
-            <CameraIcon size={14} weight="fill" />
-            <span>Show Cheffy your fridge</span>
-          {/if}
-        </button>
+        <div class="composer-pills">
+          <button
+            type="button"
+            class="scan-pill"
+            on:click={triggerPhotoAttach}
+            disabled={isScanning || loading}
+            title="Ask about a photo"
+            aria-label="Ask Cheffy about a photo"
+          >
+            <ImageIcon size={14} weight="fill" />
+            <span>Ask about a photo</span>
+          </button>
+          <button
+            type="button"
+            class="scan-pill"
+            on:click={triggerScan}
+            disabled={isScanning || loading}
+            title="Scan my fridge or pantry"
+            aria-label="Scan my fridge or pantry"
+          >
+            {#if isScanning}
+              <ArrowsClockwiseIcon size={14} class="animate-spin" />
+              <span>Scanning</span>
+            {:else}
+              <CameraIcon size={14} weight="fill" />
+              <span>Scan my fridge or pantry</span>
+            {/if}
+          </button>
+        </div>
       </div>
 
       <input
@@ -874,6 +1082,13 @@
         capture="environment"
         class="hidden"
         on:change={handleFileSelect}
+      />
+      <input
+        bind:this={photoInput}
+        type="file"
+        accept="image/*"
+        class="hidden"
+        on:change={handlePhotoSelect}
       />
 
       <!-- Actions -->
@@ -891,7 +1106,7 @@
           variant="primary"
           class="w-full sm:flex-[3] py-3"
           disabled={!canSend}
-          on:click={() => send(input)}
+          on:click={submitComposer}
         >
           {#if loading}
             <ArrowsClockwiseIcon size={18} class="animate-spin" />
@@ -1081,6 +1296,57 @@
     white-space: pre-wrap;
     word-break: break-word;
   }
+  /* Attached photo inside the member's own bubble. Capped so a portrait
+     shot can't push the answer off-screen. */
+  .bubble-photo {
+    display: block;
+    max-width: 100%;
+    max-height: 240px;
+    border-radius: 10px;
+    object-fit: cover;
+  }
+  .bubble-photo + .bubble-text {
+    display: block;
+    margin-top: 8px;
+  }
+  /* Held-photo chip above the composer. */
+  .photo-chip {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 8px;
+    border: 1px solid var(--color-input-border);
+    border-radius: 12px;
+  }
+  .photo-chip-thumb {
+    width: 42px;
+    height: 42px;
+    flex-shrink: 0;
+    border-radius: 8px;
+    object-fit: cover;
+  }
+  .photo-chip-name {
+    flex: 1;
+    min-width: 0;
+    font-size: 0.85rem;
+    color: var(--color-text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .photo-chip-remove {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    flex-shrink: 0;
+    border-radius: 999px;
+    color: var(--color-text-secondary);
+  }
+  .photo-chip-remove:hover {
+    background-color: var(--color-hover, rgba(127, 127, 127, 0.12));
+  }
   .msg-cheffy {
     gap: 10px;
     align-items: flex-start;
@@ -1218,10 +1484,20 @@
     overflow-y: auto;
   }
 
-  .scan-pill {
+  /* Two pills now share the composer's bottom-right corner, so the
+     absolute positioning moved from the pill to this row. They wrap on
+     narrow screens rather than overflowing the textarea. */
+  .composer-pills {
     position: absolute;
     bottom: 0.5rem;
     right: 0.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 6px;
+    max-width: calc(100% - 1rem);
+  }
+  .scan-pill {
     display: inline-flex;
     align-items: center;
     gap: 6px;


### PR DESCRIPTION
Implements `PLANS/CHEFFY_ASK_ABOUT_A_PHOTO_SPEC_2026_07_26.md` (Option A, decided by Seth, spec by Prep). Off `c6f4574`.

## What Seth hit

He photographed a finished bowl of soup, tapped **Upload an image**, and got *"Cheffy could not read those ingredients. Try a clearer photo."* The photo was fine.

All three image entries in the attach menu ran `handleScan` → `/api/zappy/scan`, whose prompt is hardcoded to fridge/pantry ingredient enumeration and which returns `string[]`. A plated dish has no ingredients on a shelf to enumerate, so the scanner correctly returned nothing and we blamed his camera for a mismatch between his photo and the only question we ask of one. **The image never reached Cheffy** — it was digested to a word list server-side and the file discarded client-side.

## What this does

A member attaches a photo, types a question, and Cheffy answers it in the thread. One vision call per attached photo.

The copy fix and the build ship together because the labels only become true when the ask path exists:

| Item | Before | After |
|---|---|---|
| Take a photo | scan | **ask** |
| Upload an image | scan | **ask** |
| Scan ingredients | scan | → **Scan my fridge or pantry** (scan, unchanged) |

## `NEW /api/zappy/ask-photo`

note-review's structure, scan's transport.

- **NIP-98 auth, body-hash bound.** `scan` gates on a pubkey supplied in its own request body — an identity *claim*, not an identity. npubs are public by construction, so one member npub read off a relay buys free vision calls. Not repeated here. **Fixing `scan`'s own gate is separate and not in this PR.**
- **Membership gate fails CLOSED** (503 `MEMBERSHIP_UNAVAILABLE`), matching note-review's D5 rather than scan's fail-open. Vision costs money.
- **Rate limit 8/hr, 30/day**, keyed on the *verified* pubkey, `scope: 'photo-ask'`. Below the membership gate (a 403 spends no quota) and above the OpenAI call (a 429 costs nothing). That placement is the feature's cost ceiling; both edges have a test that fails against the moved limiter.
- **`detail: 'high'`**, unlike scan and note-review. Enumerating jars on a shelf works at low detail; identifying a plated dish does not, and identifying the dish is the whole feature. It's also the one knob that moves per-call cost, so **every completed call logs OpenAI's token usage** — deliberately above the `NOT_FOOD` check, since a refusal still spent a vision call. Week-one logs give @Dr Sats a *measured* number.

## The image is not history — asserted, not commented

`ChatMessage` gains `imagePreview`, and `buildHistory` projects `role` + `content` only, so a display field is structurally incapable of reaching `/api/zappy`. A store test runs a photo turn, then a text turn, and reads the **actual chat request body**: no `imagePreview`, no base64, no blob URL — and the member's question *does* carry, so the follow-up keeps its context. Mutating `buildHistory` to include the field is what makes that test fail.

Base64 in-request means the photo is **stored nowhere**: never in the delete-account matrix, never a retention row, never needs a deletion path. `/api/zappy` is untouched — no wire-contract change, no sanitiser rewrite, no model swap for chat.

## One deviation from the spec, found by a test

The spec said match scan's 13 MiB wire cap. Base64 is 4/3 of the input, so a file at the 10 MiB client cap encodes to **~13.33 MiB** — scan's cap is fractionally too small to hold what its own client-side check lets through, and its comment claims otherwise (*"~10MB original = ~13MB base64"*). The cap here is **14 MiB**, sized to actually cover the "try one under 10MB" line the composer shows. **scan's identical latent gap is real, pre-existing, and left alone.**

## Prompt composition (no change to `SYSTEM_INSTRUCTION`)

- **The member's question is NOT fenced as untrusted.** note-review fences note text because it's someone else's kind-1 content; here it's the member's own message, and fencing would degrade the answer to the person asking.
- **The people/bodies rule and the `NOT_FOOD` sentinel carry over verbatim. The nutrition clause does not** — Cheffy chat answers nutrition questions today (the shipped *"Estimate nutrition"* chip), and a photo turn must not be stricter than the same question typed without a photo. Flagging this one for Prep to re-rule if he'd rather it carry.

## Two behaviours worth knowing

**`NOT_FOOD` lands as an ordinary answer, not an error bubble.** The note-review client hedges that code because *that* path takes a URL and can get a CDN fallback image for a dead link. Here the member picked the file, so there's no such ambiguity and Cheffy's playful line is the reply.

**Retry is disabled on a photo turn.** `retryCheffy()` re-sends through `/api/zappy`, which has never seen the photo — it would silently ask a text-only version of a question about a picture. A wrong retry is worse than no retry.

## `/cheffy` gets a parallel handler, not a shared one

That page duplicates the messenger's engine and has an ingredient-chip composer the messenger lacks. Refactoring the two engines together mid-campaign is the wrong trade (spec §4.6). Attaching and scanning clear each other, so the composer never shows an ingredient list and a held photo at once.

## Verified at this tree

- `svelte-check` **0 errors / 150 warnings / 47 files** = baseline exactly.
- Full `vitest`: **58 files / 912 tests / 0 failures** (baseline 55/856 + the 56 added here).
- **All 56 mutation-checked** — eight targeted mutants built by hand, each killed by exactly one test: leaking `imagePreview` into history · not clearing `lastTurn` · `NOT_FOOD` → error bubble · `detail` high→low · limiter below the OpenAI call · limiter above the membership gate · fail-open on membership outage · signing a different body than we send.
- **Exercised in a real browser on both surfaces** (playwright-core against a scratch route, `window.WebSocket` faked so nothing can leave the machine, the endpoint stubbed so no OpenAI call is made): attach-menu labels; **"Upload an image" attaching instead of scanning — Seth's exact path**; chip with thumbnail, filename and remove; the three prefill chips populating; a real NIP-98-signed POST carrying `{image, question}`; the photo rendering in the member's bubble above their question; the answer rendering; and the follow-up turn's chat history containing neither a blob URL nor `imagePreview`. Mutation-checked by reverting `CheffyMessenger` to `c6f4574`: no photo chip ever appears.

**Not verified:** no live OpenAI call has been made, so nobody has seen a real answer, a real 429, or the strings against production copy.

## Before merge

- **@Growth** — new user-facing strings have not been reviewed: three menu labels, the composer placeholder (*"Ask about this photo…"*), the three prefill chips (*What is this? / How do I make this? / What went wrong?*), the rewritten `SCAN_ERROR_LINE`, and the endpoint's rate-limit and unreadable-image lines. The rate-limit line is note-review's shipped line with one noun changed. Substance in spec §4.5 and §4.7.
- **@Dr Sats** — does a photo ask count against the published 300 msgs/mo? Spec recommends yes. Does not gate the build.
- **@SHIP** — this touches nothing in the Play submission but competes for the same days as PR-0…PR-5 before Aug 10.

**Fallback is a date:** if this isn't merged by **Aug 3**, the menu labels and the error line ship alone as a copy-only PR.

I don't merge my own work — Seth or Daniel presses the button.
