### PR TITLE
Narrow the Cheffy photo pickers to the formats we can actually read

### DIFF
--- a/src/components/CheffyMessenger.svelte
+++ b/src/components/CheffyMessenger.svelte
@@ -22,7 +22,7 @@
   } from '$lib/stores/membershipStatus';
   import { parseMarkdown } from '$lib/parser';
   import { PROMPT_PLACEHOLDERS, SCAN_ERROR_LINE } from '$lib/cheffy';
-  import { fileToBase64, PHOTO_MAX_BYTES } from '$lib/photoAsk';
+  import { fileToBase64, PHOTO_ACCEPT, PHOTO_MAX_BYTES } from '$lib/photoAsk';
   import {
     cheffyOpen,
     cheffyThread,
@@ -816,7 +816,7 @@
           <input
             bind:this={cameraInput}
             type="file"
-            accept="image/*"
+            accept={PHOTO_ACCEPT}
             capture="environment"
             class="hidden"
             on:change={handleAttachPhoto}
@@ -824,14 +824,14 @@
           <input
             bind:this={uploadInput}
             type="file"
-            accept="image/*"
+            accept={PHOTO_ACCEPT}
             class="hidden"
             on:change={handleAttachPhoto}
           />
           <input
             bind:this={scanInput}
             type="file"
-            accept="image/*"
+            accept={PHOTO_ACCEPT}
             class="hidden"
             on:change={handleScan}
           />

--- a/src/lib/photoAccept.test.ts
+++ b/src/lib/photoAccept.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { PHOTO_ACCEPT } from './photoAsk';
+
+/**
+ * Keeps the Cheffy photo picker and the two vision endpoints agreeing on
+ * which image formats exist.
+ *
+ * PHOTO_ACCEPT is a *server* fact wearing a client hat: both endpoints
+ * identify the format from the base64 prefix and default everything they
+ * do not recognise to image/jpeg, so a file the picker admits but the
+ * sniffer cannot name is sent mislabelled and fails at the model. That is
+ * exactly what shipped — `accept="image/*"` admitted HEIC, which can
+ * never match, and the member got "couldn't get a good look at that
+ * photo" for a file that was fine.
+ *
+ * The pairing is what rots: someone adds a fifth prefix to a sniffer, or
+ * widens the picker, and the other half stays put. Neither change looks
+ * wrong on its own. So this asserts the two halves against each other
+ * rather than against a hardcoded list.
+ *
+ * Scoped honestly: this checks the FORMAT LIST agrees. It does not check
+ * that any given file decodes, and it is not a claim that OpenAI accepts
+ * all four.
+ */
+
+const ROOT = path.resolve(__dirname, '../..');
+const ENDPOINTS = [
+  'src/routes/api/zappy/ask-photo/+server.ts',
+  'src/routes/api/zappy/scan/+server.ts'
+];
+
+/** The base64 prefix → mime pairs a sniffer actually branches on. */
+function sniffedMimes(source: string): string[] {
+  const mimes: string[] = [];
+  // `if (image.startsWith('<prefix>')) { mimeType = '<mime>';`
+  const branch = /startsWith\('[^']+'\)\)\s*\{\s*mimeType\s*=\s*'([^']+)'/g;
+  let m: RegExpExecArray | null;
+  while ((m = branch.exec(source)) !== null) mimes.push(m[1]);
+  return mimes;
+}
+
+describe('PHOTO_ACCEPT tracks what the vision endpoints can identify', () => {
+  const accepted = PHOTO_ACCEPT.split(',');
+
+  it('is a comma-joined mime list with no spaces or wildcards', () => {
+    expect(PHOTO_ACCEPT).not.toContain(' ');
+    expect(PHOTO_ACCEPT).not.toContain('*');
+    for (const type of accepted) expect(type).toMatch(/^image\/[a-z0-9.+-]+$/);
+  });
+
+  for (const rel of ENDPOINTS) {
+    it(`matches the formats ${rel.split('/').slice(-2)[0]} sniffs`, () => {
+      const source = readFileSync(path.join(ROOT, rel), 'utf8');
+      const sniffed = sniffedMimes(source);
+
+      // Guards the regex itself: if the sniffer is refactored into a shape
+      // this no longer reads, the test must fail rather than pass on [].
+      expect(sniffed.length).toBeGreaterThan(0);
+      expect([...new Set(sniffed)].sort()).toEqual([...accepted].sort());
+    });
+  }
+});
+
+describe('the format the picker used to admit and the sniffer cannot name', () => {
+  /**
+   * An ISO-BMFF file (HEIC/HEIF/AVIF — the iPhone camera roll) opens with
+   * the size of its `ftyp` BOX, not of the file: a small integer, so the
+   * first three bytes are 00 00 00 and the base64 always begins "AAAA".
+   * None of the sniffed prefixes can start that way, which is why a HEIC
+   * is labelled image/jpeg and rejected downstream.
+   */
+  const isoBmffHeader = (boxSize: number, brand: string) => {
+    const bytes = Buffer.concat([
+      Buffer.from([
+        (boxSize >>> 24) & 0xff,
+        (boxSize >>> 16) & 0xff,
+        (boxSize >>> 8) & 0xff,
+        boxSize & 0xff
+      ]),
+      Buffer.from('ftyp' + brand, 'ascii')
+    ]);
+    return bytes.toString('base64');
+  };
+
+  const prefixes = ['/9j/', 'iVBOR', 'R0lGOD', 'UklGR'];
+
+  it('base64s as AAAA… for every realistic brand and box size', () => {
+    for (const brand of ['heic', 'heix', 'hevc', 'mif1', 'msf1', 'avif']) {
+      for (let size = 0x14; size <= 0x40; size += 4) {
+        const b64 = isoBmffHeader(size, brand);
+        expect(b64.startsWith('AAAA')).toBe(true);
+        for (const prefix of prefixes) expect(b64.startsWith(prefix)).toBe(false);
+      }
+    }
+  });
+
+  it('is therefore absent from PHOTO_ACCEPT', () => {
+    for (const type of ['image/heic', 'image/heif', 'image/avif']) {
+      expect(PHOTO_ACCEPT).not.toContain(type);
+    }
+  });
+});

--- a/src/lib/photoAsk.ts
+++ b/src/lib/photoAsk.ts
@@ -23,6 +23,30 @@ export const QUESTION_MAX_CHARS = 500;
  */
 export const PHOTO_MAX_BYTES = 10 * 1024 * 1024;
 
+/**
+ * File-picker filter for every Cheffy photo input, ask AND scan.
+ *
+ * These are exactly the four formats both endpoints can identify from
+ * the base64 prefix (ask-photo/+server.ts, scan/+server.ts). Anything
+ * else is labelled image/jpeg by default and fails at the model — a HEIC
+ * straight off an iPhone can never match, since an ISO-BMFF file opens
+ * with a small `ftyp` box size, so its first bytes always base64 as
+ * `AAAA`. `accept="image/*"` was simply wider than the pipeline reads.
+ *
+ * Scan shares it because a scan that finds nothing hands its file to the
+ * composer as an ask photo (holdScanPhoto), so one picker feeds both.
+ *
+ * One constant rather than five attributes: the value is a server fact,
+ * and five copies of a server fact drift one at a time. Same list as
+ * ImageUploader.svelte and nourish/NourishPhotoInput.svelte.
+ *
+ * This does NOT replace the `file.type.startsWith('image/')` checks at
+ * the change handlers: `accept` filters the picker, it does not bind it —
+ * a determined file can still arrive by other means, and the sniffer
+ * still defaults unknown bytes to jpeg.
+ */
+export const PHOTO_ACCEPT = 'image/jpeg,image/png,image/webp,image/gif';
+
 export type PhotoAskResult =
   | { ok: true; output: string }
   | { ok: false; code?: string; error?: string; status?: number };

--- a/src/routes/cheffy/+page.svelte
+++ b/src/routes/cheffy/+page.svelte
@@ -3,7 +3,7 @@
   import { browser } from '$app/environment';
   import { goto } from '$app/navigation';
   import { ndk, userPublickey } from '$lib/nostr';
-  import { askAboutPhoto, fileToBase64, PHOTO_MAX_BYTES } from '$lib/photoAsk';
+  import { askAboutPhoto, fileToBase64, PHOTO_ACCEPT, PHOTO_MAX_BYTES } from '$lib/photoAsk';
   import {
     membershipStatusMap,
     queueMembershipLookup,
@@ -1142,7 +1142,7 @@
       <input
         bind:this={fileInput}
         type="file"
-        accept="image/*"
+        accept={PHOTO_ACCEPT}
         capture="environment"
         class="hidden"
         on:change={handleFileSelect}
@@ -1150,7 +1150,7 @@
       <input
         bind:this={photoInput}
         type="file"
-        accept="image/*"
+        accept={PHOTO_ACCEPT}
         class="hidden"
         on:change={handlePhotoSelect}
       />


### PR DESCRIPTION
Follow-up to #592. Growth's priority call in `prep room`: **`accept` first, the button second — not close.**

`#592` merged as `00b446c`, which is `0c3a525`. Every fix made after that push is still **uncommitted** in `wt-cheffy-photo-ask`. This PR carries the first half of it, rebuilt on merged `main`.

## The defect, live on production right now

`accept="image/*"` at all five Cheffy photo inputs admits files the vision endpoints cannot identify. Both `ask-photo` and `scan` detect the format from the base64 prefix and **default anything unrecognised to `image/jpeg`**, so a HEIC off an iPhone camera roll is sent mislabelled and comes back as *"Cheffy couldn't get a good look at that photo"* — for a file that was fine.

For a feature whose premise is "photograph the thing in front of you", reported by Seth photographing a thing in front of him.

## A HEIC can never match — measured, not reasoned

An ISO-BMFF file opens with the size of its `ftyp` **box**, not of the file: a small integer, so the first three bytes are `00 00 00` and the base64 always begins `AAAA`. Checked across 6 brands (`heic/heix/hevc/mif1/msf1/avif`) × every box size `0x14`–`0x40` against all four sniffed prefixes — **no match in any combination**. That measurement is now a test rather than a comment.

The chain is exact: `fileToBase64` is `readAsDataURL` → `.split(',')[1]`, so the sniffer reads file byte 0.

## What changed

One exported `PHOTO_ACCEPT` (`photoAsk.ts`) at five call sites. The value is a **server** fact, and five copies of a server fact drift one at a time. Same list already used by `ImageUploader.svelte` and `nourish/NourishPhotoInput.svelte` — the sibling AI-vision photo input.

The scanner shares the constant: a scan that finds nothing hands its file to the composer as an ask photo (`holdScanPhoto`), so one picker genuinely feeds both endpoints.

**The constant and its docstring are Prep's**, recovered from the uncommitted worktree so the authored reasoning ships with the code rather than being paraphrased. I added one paragraph: `accept` filters a picker, it does not bind it, so this does **not** replace the existing `file.type.startsWith('image/')` checks.

## Verified at `3c55ab5`

- `svelte-check` **0 errors / 150 warnings / 47 files** = baseline exactly.
- Full `vitest` **61 files / 942 tests / 0 failures** — merged baseline is 60/937, so +1 file/+5 tests is all mine.
- **All 5 new tests mutation-checked**, each killed by a real assertion failure: widen the picker to HEIC, drop `gif` from the picker, add a 5th sniffer branch server-side without widening the picker, rename the sniffer's variable so the source regex reads nothing, and set a wildcard. The 3rd is the actual drift scenario; the 4th exists so the test cannot pass on an empty read.
- `prettier`: `CheffyMessenger.svelte` is already dirty at `00b446c`; unchanged by this PR, and not reformatted. The other three files are clean.

## Not verified

- **No live OpenAI call, and no upload from a real iPhone.** Whether iOS Safari transcodes HEIC to JPEG on our path is still unmeasured — so I am not claiming every iPhone hit this. On any platform that hands us a real HEIC, it did.
- The two red `Workers Builds` checks are red on every recent PR including merged ones. Cloudflare Pages deploys fine.

## Still open, not in this PR

The retryability mechanism (`isPhotoAskRetryable`, the `IMAGE_UNREADABLE` dead button) is **still uncommitted** in `wt-cheffy-photo-ask`. Growth ruled the predicate tonight — *can pressing this button ever succeed?* — which puts exactly `IMAGE_UNREADABLE` in the set. That is a second PR and it needs the comment rewritten to state that predicate rather than enumerate outcomes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)