### PR TITLE
Gate Cheffy photos on their bytes, and say what we didn't recognize

### DIFF
--- a/src/components/CheffyMessenger.svelte
+++ b/src/components/CheffyMessenger.svelte
@@ -21,8 +21,8 @@
     type MembershipStatus
   } from '$lib/stores/membershipStatus';
   import { parseMarkdown } from '$lib/parser';
-  import { PROMPT_PLACEHOLDERS, SCAN_ERROR_LINE } from '$lib/cheffy';
-  import { fileToBase64, PHOTO_ACCEPT, PHOTO_MAX_BYTES } from '$lib/photoAsk';
+  import { PROMPT_PLACEHOLDERS, SCAN_ERROR_LINE, photoFormatLine } from '$lib/cheffy';
+  import { fileToBase64, identifyPhotoFile, PHOTO_MAX_BYTES } from '$lib/photoAsk';
   import {
     cheffyOpen,
     cheffyThread,
@@ -247,8 +247,8 @@
     // Reset immediately so re-picking the same file still fires change.
     if (inputEl) inputEl.value = '';
     if (!file) return;
-    if (!file.type.startsWith('image/')) {
-      scanError = 'Please choose an image file.';
+    if (!(await identifyPhotoFile(file))) {
+      scanError = photoFormatLine(file.type);
       return;
     }
     if (file.size > PHOTO_MAX_BYTES) {
@@ -293,11 +293,11 @@
     const inputEl = event.target as HTMLInputElement;
     const file = inputEl.files?.[0];
     if (!file) return;
-    if (!file.type.startsWith('image/')) {
-      scanError = 'Please choose an image file.';
+    if (!(await identifyPhotoFile(file))) {
+      scanError = photoFormatLine(file.type);
       return;
     }
-    if (file.size > 10 * 1024 * 1024) {
+    if (file.size > PHOTO_MAX_BYTES) {
       scanError = 'That image is a little big — try one under 10MB.';
       return;
     }
@@ -818,14 +818,20 @@
 
         {#if !inExperience}
           <!-- Hidden file inputs. Camera/upload attach the photo to the
-               composer; the third is the ingredient scanner. All three
-               filter to the formats the pipeline can actually read (see
-               PHOTO_ACCEPT) — the scanner included, because a scan that
-               finds nothing hands its file back as an ask photo. -->
+               composer; the third is the ingredient scanner.
+
+               `accept` is deliberately WIDE. It is a hint to a picker we
+               do not ship, so it cannot gate anything: a narrow value
+               greys out rows in someone else's file dialog and still
+               admits whatever arrives by another route. The format check
+               that does bind is identifyPhotoFile() in the change
+               handlers, which reads the file's own bytes. Widening this
+               costs nothing and avoids hiding a member's camera roll on
+               a platform we have not tested. -->
           <input
             bind:this={cameraInput}
             type="file"
-            accept={PHOTO_ACCEPT}
+            accept="image/*"
             capture="environment"
             class="hidden"
             on:change={handleAttachPhoto}
@@ -833,14 +839,14 @@
           <input
             bind:this={uploadInput}
             type="file"
-            accept={PHOTO_ACCEPT}
+            accept="image/*"
             class="hidden"
             on:change={handleAttachPhoto}
           />
           <input
             bind:this={scanInput}
             type="file"
-            accept={PHOTO_ACCEPT}
+            accept="image/*"
             class="hidden"
             on:change={handleScan}
           />

--- a/src/lib/cheffy.test.ts
+++ b/src/lib/cheffy.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { identifyPhotoFormat } from './photoAsk';
 import {
   looksLikeStructuredRecipe,
   pickLine,
   setCheffyPrompt,
   consumeCheffyPrompt,
   CHEFFY_PROMPT_KEY,
-  CHEFFY_PROMPT_MAX_AGE_MS
+  CHEFFY_PROMPT_MAX_AGE_MS,
+  photoFormatLine
 } from './cheffy';
 
 describe('looksLikeStructuredRecipe', () => {
@@ -105,4 +108,96 @@ describe('Cheffy prompt handoff', () => {
     );
     expect(consumeCheffyPrompt()).toBe(null);
   });
+});
+
+// ---------------------------------------------------------------------------
+// Pick-time format rejection copy
+// ---------------------------------------------------------------------------
+
+describe('photoFormatLine', () => {
+  it('names HEIC when the browser independently guessed it', () => {
+    // The noun is diagnosis, not a list item — it is the one fact that
+    // converts into an action outside our product.
+    for (const type of ['image/heic', 'image/heif', 'IMAGE/HEIC', 'image/heic-sequence']) {
+      expect(photoFormatLine(type)).toBe(
+        "Cheffy reads JPG, PNG, and WEBP — that one's a HEIC. Try another photo?"
+      );
+    }
+  });
+
+  it('claims nothing about the file when the type does not agree', () => {
+    // The byte gate catches HEIC bytes in a file named .jpg, where
+    // file.type is image/jpeg. Naming a format here would contradict the
+    // filename the member is looking at.
+    for (const type of ['image/jpeg', 'application/pdf', '', 'text/plain']) {
+      expect(photoFormatLine(type)).toBe(
+        "Cheffy doesn't recognize that file — it reads JPG, PNG, and WEBP. Try another photo?"
+      );
+    }
+  });
+
+  it('does not read like the server IMAGE_UNREADABLE line', () => {
+    // The gate is a narrowing, not a guarantee, so a photo can fail here
+    // OR at the model — instantly and for free, or after a signer
+    // approval, an upload and a wait with no Try again button. A member
+    // who reads the same sentence at both moments learns nothing from
+    // the second, which is the expensive one.
+    const server = readFileSync('src/routes/api/zappy/ask-photo/+server.ts', 'utf8');
+    const unreadable = "Cheffy couldn't get a good look at that photo. Try another one?";
+    expect(server, 'the live server line moved — re-check both wordings together').toContain(
+      unreadable
+    );
+    for (const type of ['image/heic', 'image/jpeg']) {
+      expect(photoFormatLine(type)).not.toBe(unreadable);
+      // "couldn't read"/"couldn't get a look" is the server's register.
+      // At pick time Cheffy has read nothing: sixteen bytes matched no
+      // signature.
+      expect(/couldn't (read|get)/.test(photoFormatLine(type))).toBe(false);
+    }
+  });
+
+  it('leaves GIF out of the sentence while the gate still accepts it', () => {
+    // A rejection message is advice, not a specification. This string
+    // renders only when no signature matched, and every GIF matches
+    // GIF8 — so no GIF holder, animated or still, can ever read it.
+    // Listing GIF would spend a clause on a format its reader does not
+    // have. Do not sync this list to the gate.
+    for (const type of ['image/heic', 'image/jpeg']) {
+      expect(/gif/i.test(photoFormatLine(type))).toBe(false);
+    }
+    expect(identifyPhotoFormat(new Uint8Array([0x47, 0x49, 0x46, 0x38]))).toBe('image/gif');
+  });
+});
+
+/**
+ * Wiring guard for the pick-time gate.
+ *
+ * Neither Cheffy surface is unit-testable — this repo has no component
+ * render harness — so this reads the source. It is a tripwire, not a
+ * proof: it can only see that the handlers call the byte gate, never
+ * that they call it on the right file.
+ */
+describe('the Cheffy photo inputs gate on bytes, not on file.type', () => {
+  const FILES = ['src/components/CheffyMessenger.svelte', 'src/routes/cheffy/+page.svelte'];
+
+  for (const file of FILES) {
+    it(`${file} gates every picked file through identifyPhotoFile`, () => {
+      const source = readFileSync(file, 'utf8');
+      // Two handlers per file: ask and scan.
+      expect(source.match(/await identifyPhotoFile\(file\)/g)?.length).toBe(2);
+      expect(source).toContain('photoFormatLine(file.type)');
+      // file.type is the browser's guess, derived from the filename. It
+      // names what failed; it must not decide.
+      expect(source).not.toContain("file.type.startsWith('image/')");
+    });
+
+    it(`${file} keeps accept wide — it is a hint to a picker we do not ship`, () => {
+      const source = readFileSync(file, 'utf8');
+      const accepts = source.match(/accept=[^\s>]+/g) ?? [];
+      expect(accepts.length).toBeGreaterThan(0);
+      for (const attr of accepts) {
+        expect(attr).toBe('accept="image/*"');
+      }
+    });
+  }
 });

--- a/src/lib/cheffy.ts
+++ b/src/lib/cheffy.ts
@@ -127,6 +127,48 @@ export const PHOTO_NETWORK_ERROR_LINE =
   "Cheffy couldn't be reached. Check your connection and try again.";
 
 /**
+ * Rejection line for a file the pick-time byte gate does not recognize.
+ *
+ * THIS IS NOT THE ONLY WAY A PHOTO FAILS, and the wording carries that.
+ * The gate is a NARROWING: an animated GIF, a corrupt JPEG with a clean
+ * header, anything the model refuses downstream still gets through here
+ * and comes back as IMAGE_UNREADABLE from the server, whose own live line
+ * is "Cheffy couldn't get a good look at that photo. Try another one?"
+ * (ask-photo/+server.ts:275-277, rendered verbatim via cheffyChat.ts:457
+ * settleError — the server string wins whenever it exists).
+ *
+ * So these two lines must NOT read alike. Different events, different
+ * costs: this one is instant and nothing left the browser; the server one
+ * arrives after a signer approval, an upload and a wait, and carries no
+ * Try again button (IMAGE_UNREADABLE is the one non-retryable code). A
+ * member who reads the same sentence at both moments learns nothing from
+ * the second, which is the expensive one.
+ *
+ * Hence "doesn't recognize", not "couldn't read": at pick time Cheffy has
+ * read nothing. We looked at sixteen bytes and matched no signature.
+ *
+ * THE LIST IS ADVICE, NOT A SPECIFICATION. identifyPhotoFormat also
+ * accepts GIF, and GIF is deliberately absent here: this string renders
+ * only when nothing matched, so no GIF holder — animated or still — ever
+ * reads it. Listing GIF would spend a clause on a format its reader does
+ * not have. The names here answer "what do I convert TO", and the gate
+ * remains the specification. Do not sync this list to the gate.
+ *
+ * The HEIC noun is diagnosis, not spec, and that is why it survives the
+ * same rule: it is the one fact that turns into an action outside our
+ * product. It renders only when the bytes matched nothing AND the browser
+ * independently guessed heic — two signals agreeing.
+ *
+ * Copy owner: Growth (rev 4). Do not reword without her.
+ */
+export function photoFormatLine(fileType: string): string {
+  if (/heic|heif/i.test(fileType)) {
+    return "Cheffy reads JPG, PNG, and WEBP — that one's a HEIC. Try another photo?";
+  }
+  return "Cheffy doesn't recognize that file — it reads JPG, PNG, and WEBP. Try another photo?";
+}
+
+/**
  * Error line for a rate-limited ingredient scan.
  *
  * Derived from the already-shipped note-review limit line

--- a/src/lib/photoAsk.test.ts
+++ b/src/lib/photoAsk.test.ts
@@ -9,9 +9,12 @@ import { describe, it, expect, vi } from 'vitest';
 import type NDK from '@nostr-dev-kit/ndk';
 import {
   askAboutPhoto,
+  identifyPhotoFile,
+  identifyPhotoFormat,
   isPhotoAskRetryable,
   QUESTION_MAX_CHARS,
-  PHOTO_MAX_BYTES
+  PHOTO_MAX_BYTES,
+  PHOTO_SIGNATURE_BYTES
 } from './photoAsk';
 import { PHOTO_SIGN_FAILED_LINE, PHOTO_NETWORK_ERROR_LINE } from './cheffy';
 
@@ -268,5 +271,106 @@ describe('isPhotoAskRetryable', () => {
     // reasonable thing to offer, so absence must not fail closed.
     expect(isPhotoAskRetryable(undefined)).toBe(true);
     expect(isPhotoAskRetryable('SOMETHING_WE_ADD_LATER')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pick-time format gate (byte signatures)
+// ---------------------------------------------------------------------------
+
+/**
+ * These tests are the specification the rejection copy is not: the gate
+ * decides what Cheffy accepts, and the two RIFF cases are the reason it
+ * reads sixteen bytes rather than four.
+ */
+describe('identifyPhotoFormat', () => {
+  const bytes = (...values: number[]) => new Uint8Array(values);
+  const ascii = (text: string) => Array.from(text, (c) => c.charCodeAt(0));
+
+  const ACCEPTED: Array<[string, Uint8Array]> = [
+    ['JPEG', bytes(0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10)],
+    ['PNG', bytes(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00)],
+    ['GIF87a', bytes(...ascii('GIF87a'))],
+    // Animated GIFs match too, and that is deliberate — the gate cannot
+    // tell 89a apart from 87a, so it narrows rather than guarantees.
+    ['GIF89a', bytes(...ascii('GIF89a'))],
+    ['WEBP', bytes(...ascii('RIFF'), 0x24, 0x00, 0x00, 0x00, ...ascii('WEBP'))]
+  ];
+
+  const EXPECTED_MIME: Record<string, string> = {
+    JPEG: 'image/jpeg',
+    PNG: 'image/png',
+    GIF87a: 'image/gif',
+    GIF89a: 'image/gif',
+    WEBP: 'image/webp'
+  };
+
+  for (const [label, head] of ACCEPTED) {
+    it(`identifies ${label}`, () => {
+      expect(identifyPhotoFormat(head)).toBe(EXPECTED_MIME[label]);
+    });
+  }
+
+  const REJECTED: Array<[string, Uint8Array]> = [
+    // An ISO-BMFF file opens with the size of its `ftyp` box, so a HEIC
+    // off an iPhone starts with zero bytes and can never match.
+    ['HEIC', bytes(0x00, 0x00, 0x00, 0x20, ...ascii('ftypheic'))],
+    ['HEIF', bytes(0x00, 0x00, 0x00, 0x18, ...ascii('ftypmif1'))],
+    // RIFF alone is not WEBP: WAV and AVI share the container.
+    ['WAV', bytes(...ascii('RIFF'), 0x24, 0x00, 0x00, 0x00, ...ascii('WAVE'))],
+    ['AVI', bytes(...ascii('RIFF'), 0x24, 0x00, 0x00, 0x00, ...ascii('AVI '))],
+    ['PDF', bytes(...ascii('%PDF-1.7'))],
+    ['BMP', bytes(...ascii('BM'), 0x36, 0x00, 0x00, 0x00)],
+    ['plain text', bytes(...ascii('hello there'))],
+    ['empty file', bytes()],
+    // A truncated header must answer null, not throw on a missing index.
+    ['a lone RIFF', bytes(...ascii('RIFF'))],
+    ['a PNG signature one byte short', bytes(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a)],
+    ['two bytes of a JPEG', bytes(0xff, 0xd8)]
+  ];
+
+  for (const [label, head] of REJECTED) {
+    it(`rejects ${label}`, () => {
+      expect(identifyPhotoFormat(head)).toBe(null);
+    });
+  }
+});
+
+describe('identifyPhotoFile', () => {
+  const fileOf = (values: number[], type: string) =>
+    new File([new Uint8Array(values)], 'photo', { type });
+
+  it('reads the bytes, not the browser-supplied type', async () => {
+    // A HEIC wearing a .jpg name: file.type says image/jpeg and the
+    // bytes say otherwise. The bytes are what we received.
+    const misnamed = fileOf([0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70], 'image/jpeg');
+    expect(await identifyPhotoFile(misnamed)).toBe(null);
+
+    // And the mirror case: a real PNG that some pickers hand over with
+    // no type at all is accepted today's rejection notwithstanding.
+    const typeless = fileOf([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], '');
+    expect(await identifyPhotoFile(typeless)).toBe('image/png');
+  });
+
+  it('reads only the leading signature bytes', async () => {
+    const big = fileOf([0xff, 0xd8, 0xff, ...new Array(4096).fill(0x41)], 'image/jpeg');
+    const slice = vi.spyOn(big, 'slice');
+    expect(await identifyPhotoFile(big)).toBe('image/jpeg');
+    expect(slice.mock.calls[0][0]).toBe(0);
+    expect(slice.mock.calls[0][1]).toBe(PHOTO_SIGNATURE_BYTES);
+  });
+
+  it('answers null when the file cannot be read at all', async () => {
+    // A file we cannot read is a file we cannot send, so an unreadable
+    // pick and an unrecognized one are the same answer to the caller.
+    const unreadable = {
+      slice: () => ({ arrayBuffer: () => Promise.reject(new Error('NotReadableError')) })
+    } as unknown as File;
+    expect(await identifyPhotoFile(unreadable)).toBe(null);
+  });
+
+  it('handles a file shorter than the signature window', async () => {
+    expect(await identifyPhotoFile(fileOf([0xff, 0xd8, 0xff], 'image/jpeg'))).toBe('image/jpeg');
+    expect(await identifyPhotoFile(fileOf([], 'image/jpeg'))).toBe(null);
   });
 });

--- a/src/lib/photoAsk.ts
+++ b/src/lib/photoAsk.ts
@@ -24,23 +24,104 @@ export const QUESTION_MAX_CHARS = 500;
 export const PHOTO_MAX_BYTES = 10 * 1024 * 1024;
 
 /**
- * File-picker filter for every Cheffy photo input, ask AND scan.
+ * Byte signatures for the image formats the Cheffy vision path reads.
  *
- * These are exactly the four formats both endpoints can identify from
- * the base64 prefix (ask-photo/+server.ts, scan/+server.ts). Anything
- * else is labelled image/jpeg by default and fails at the model — a HEIC
- * straight off an iPhone can never match, since an ISO-BMFF file opens
- * with a small `ftyp` box size, so its first bytes always base64 as
- * `AAAA`. `accept="image/*"` was simply wider than the pipeline reads.
+ * This replaced a picker `accept` filter, and the reason is the whole
+ * point of the check: `accept` is a HINT to a file picker we do not
+ * ship, and so is `file.type` — the browser derives it from the
+ * filename, so a HEIC named `.jpg` reports `image/jpeg`. Neither is
+ * something we received. The bytes are. This reads them.
  *
- * Scan shares it because a scan that finds nothing hands its file to the
- * composer as an ask photo (holdScanPhoto), so one picker feeds both.
+ * The list is NOT a server fact, though it was described as one while
+ * it lived in `accept`. Nothing in our code decides whether a photo is
+ * readable: both endpoints only LABEL the format from a base64 prefix
+ * and default anything unrecognised to image/jpeg, with no rejection
+ * branch (ask-photo/+server.ts, scan/+server.ts). The actual authority
+ * is OpenAI's decoder. So this table is our best statement of what the
+ * vision model reads, and the endpoints' tables are another statement
+ * of the same guess.
  *
- * One constant rather than five attributes: the value is a server fact,
- * and five copies of a server fact drift one at a time. Same list as
- * ImageUploader.svelte and nourish/NourishPhotoInput.svelte.
+ * A GATE HERE IS A NARROWING, NOT A GUARANTEE. A WAV also starts
+ * `RIFF`, an animated GIF also starts `GIF8`, and a truncated JPEG has
+ * a perfect header — all three pass this check and fail at the model.
+ * `IMAGE_UNREADABLE` and NON_RETRYABLE_CODES below are the PERMANENT
+ * backstop behind this function, never scaffolding it replaces. Do not
+ * read "we validate the format at pick time now" as making the server
+ * error path dead code; it is the only thing covering everything this
+ * table cannot see.
+ *
+ * Base64 prefixes were never the fact — they are what you get when you
+ * happen to be holding base64. 16 bytes is enough for all four,
+ * including WEBP's second marker.
  */
-export const PHOTO_ACCEPT = 'image/jpeg,image/png,image/webp,image/gif';
+const PHOTO_SIGNATURES: ReadonlyArray<{ mime: string; match: (b: Uint8Array) => boolean }> = [
+  // FF D8 FF
+  { mime: 'image/jpeg', match: (b) => b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff },
+  // 89 P N G CR LF ^Z LF
+  {
+    mime: 'image/png',
+    match: (b) =>
+      b[0] === 0x89 &&
+      b[1] === 0x50 &&
+      b[2] === 0x4e &&
+      b[3] === 0x47 &&
+      b[4] === 0x0d &&
+      b[5] === 0x0a &&
+      b[6] === 0x1a &&
+      b[7] === 0x0a
+  },
+  // "GIF8" — matches 87a and 89a alike, animation included.
+  {
+    mime: 'image/gif',
+    match: (b) => b[0] === 0x47 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x38
+  },
+  // "RIFF" at 0-3 AND "WEBP" at 8-11. RIFF alone is also WAV and AVI,
+  // so the second marker is what makes this a WEBP check.
+  {
+    mime: 'image/webp',
+    match: (b) =>
+      b[0] === 0x52 &&
+      b[1] === 0x49 &&
+      b[2] === 0x46 &&
+      b[3] === 0x46 &&
+      b[8] === 0x57 &&
+      b[9] === 0x45 &&
+      b[10] === 0x42 &&
+      b[11] === 0x50
+  }
+];
+
+/** Bytes to read off the front of a file to run every signature above. */
+export const PHOTO_SIGNATURE_BYTES = 16;
+
+/**
+ * The image format `bytes` opens with, or null if no signature matches.
+ *
+ * Null is the rejection: it means we cannot name the format, not that
+ * the file is corrupt. A HEIC straight off an iPhone lands here — an
+ * ISO-BMFF file opens with the size of its `ftyp` box, a small integer,
+ * so its first bytes are `00 00 00` and match nothing in the table.
+ */
+export function identifyPhotoFormat(bytes: Uint8Array): string | null {
+  for (const sig of PHOTO_SIGNATURES) {
+    if (sig.match(bytes)) return sig.mime;
+  }
+  return null;
+}
+
+/**
+ * Read a picked file's leading bytes and identify it. Returns null when
+ * the format is unknown OR the read itself fails — a file we cannot
+ * read is one we cannot send, so both are the same answer to the caller.
+ */
+export async function identifyPhotoFile(file: File): Promise<string | null> {
+  try {
+    const head = await file.slice(0, PHOTO_SIGNATURE_BYTES).arrayBuffer();
+    return identifyPhotoFormat(new Uint8Array(head));
+  } catch {
+    return null;
+  }
+}
 
 export type PhotoAskResult =
   | { ok: true; output: string }

--- a/src/routes/cheffy/+page.svelte
+++ b/src/routes/cheffy/+page.svelte
@@ -6,8 +6,8 @@
   import {
     askAboutPhoto,
     fileToBase64,
+    identifyPhotoFile,
     isPhotoAskRetryable,
-    PHOTO_ACCEPT,
     PHOTO_MAX_BYTES
   } from '$lib/photoAsk';
   import {
@@ -36,6 +36,7 @@
     ZAP_TOAST_LINES,
     ERROR_LINES,
     SCAN_ERROR_LINE,
+    photoFormatLine,
     pickLine,
     looksLikeStructuredRecipe,
     consumeCheffyPrompt
@@ -607,11 +608,11 @@
     const inputEl = event.target as HTMLInputElement;
     const file = inputEl.files?.[0];
     if (!file) return;
-    if (!file.type.startsWith('image/')) {
-      scanError = 'Please choose an image file.';
+    if (!(await identifyPhotoFile(file))) {
+      scanError = photoFormatLine(file.type);
       return;
     }
-    if (file.size > 10 * 1024 * 1024) {
+    if (file.size > PHOTO_MAX_BYTES) {
       scanError = 'That image is a little big — try one under 10MB.';
       return;
     }
@@ -681,8 +682,8 @@
     // Reset immediately so re-picking the same file still fires change.
     if (inputEl) inputEl.value = '';
     if (!file) return;
-    if (!file.type.startsWith('image/')) {
-      scanError = 'Please choose an image file.';
+    if (!(await identifyPhotoFile(file))) {
+      scanError = photoFormatLine(file.type);
       return;
     }
     if (file.size > PHOTO_MAX_BYTES) {
@@ -1161,13 +1162,17 @@
         </div>
       </div>
 
-      <!-- Both filter to the formats the pipeline can actually read (see
-           PHOTO_ACCEPT) — the scanner included, because a scan that finds
-           nothing hands its file back as an ask photo. -->
+      <!-- `accept` is deliberately WIDE. It is a hint to a picker we do not
+           ship, so it cannot gate anything: a narrow value greys out rows in
+           someone else's file dialog and still admits whatever arrives by
+           another route. The format check that does bind is
+           identifyPhotoFile() in the change handlers, which reads the file's
+           own bytes. Widening this costs nothing and avoids hiding a
+           member's camera roll on a platform we have not tested. -->
       <input
         bind:this={fileInput}
         type="file"
-        accept={PHOTO_ACCEPT}
+        accept="image/*"
         capture="environment"
         class="hidden"
         on:change={handleFileSelect}
@@ -1175,7 +1180,7 @@
       <input
         bind:this={photoInput}
         type="file"
-        accept={PHOTO_ACCEPT}
+        accept="image/*"
         class="hidden"
         on:change={handlePhotoSelect}
       />


### PR DESCRIPTION
> **Stacked on #593. These are one decision. #593 alone is the combination not to ship.**
>
> GitHub forces the merge order but it cannot force the pair. #593 narrows `accept` on five Cheffy file inputs; **nobody has tapped that on a real iPhone**, so an iOS library that opens effectively empty is live and unanswered. This PR takes those attributes back out and puts a gate behind them that actually binds. Merging #593 and stopping here leaves the one state that carries a risk `main` does not.
>
> | | `accept` | format gate | retry that re-sends the same bytes |
> |---|---|---|---|
> | `main` today | wide | none | **yes** |
> | #593 alone | **narrowed, unmeasured on a real picker** | none | fixed |
> | #593 + this | wide | **on the bytes** | fixed |

## What this changes

Every Cheffy photo input gated on `file.type.startsWith('image/')` and answered `'Please choose an image file.'` A HEIC passes that check — `image/heic` starts with `image/` — so an iPhone photo went all the way to the model before failing. That is Seth's original report.

`accept` and `file.type` are both **configuration of software we do not ship**. `accept` is a hint to someone else's file dialog. `file.type` is the browser's guess, usually derived from the filename — so a HEIC named `.jpg` reports `image/jpeg`. Neither is something we received. The bytes are.

- **`identifyPhotoFormat(bytes: Uint8Array)`** in `src/lib/photoAsk.ts` — reads the first 16 bytes and matches JPEG `FF D8 FF`, PNG `89 50 4E 47 0D 0A 1A 0A`, GIF `GIF8`, and WEBP `RIFF` at 0-3 **and** `WEBP` at 8-11. RIFF alone is also WAV and AVI; 16 bytes is enough to close that, so it is closed.
- **`identifyPhotoFile(file)`** — `file.slice(0, 16).arrayBuffer()`, null on an unreadable file (a file we cannot read is one we cannot send).
- **`PHOTO_ACCEPT` deleted.** All five inputs back to `accept="image/*"`, with the hint-not-a-gate reason in the comment at both sites.
- Four call sites → `photoFormatLine(file.type)`. **The gate reads the bytes; the string names what the browser called it.**
- Two bare `10 * 1024 * 1024` literals folded into `PHOTO_MAX_BYTES`.

**Client only.** The server's prefix table is duplicated across `ask-photo` and `scan`, both **label-only** — they set a mime and default to `image/jpeg` with no rejection branch. Deduping them is a second PR that touches scan.

## A gate at pick time is a narrowing, not a guarantee

Nothing in our code decides whether a photo is readable. **OpenAI's decoder does.** An animated GIF matches `GIF8` (87a and 89a are indistinguishable at the signature), a truncated JPEG has a clean header, a WAV is a RIFF — all pass this gate and fail at the model.

So `IMAGE_UNREADABLE` and the non-retryable set from #593 are the **permanent backstop behind this gate, never scaffolding it replaces.** That is written into both docstrings, because the next person to read "we validate the format at pick time now" will reasonably conclude the server error path is dead code.

## The copy

Growth's rev 4, pasted verbatim (`OUTBOX/CHEFFY_PHOTO_FORMAT_LINE_2026_07_26.md`):

> Cheffy reads JPG, PNG, and WEBP — that one's a HEIC. Try another photo?
> Cheffy doesn't recognize that file — it reads JPG, PNG, and WEBP. Try another photo?

Three decisions in it that look like bugs and are not:

- **GIF is in the gate and deliberately not in the sentence.** The string renders only when nothing matched, so no GIF holder — animated or still — can ever read it. A rejection message is advice, not a specification. Do not sync the list to the gate.
- **Neither branch says what the file *is*** except HEIC, where the bytes matching nothing and the browser independently guessing heic are two signals agreeing. Telling someone their `photo.jpg` is not a JPG is worse than saying nothing.
- **It must not read like the server's `IMAGE_UNREADABLE` line.** Different events, different costs: this one is instant and nothing left the browser; that one arrives after a signer approval, an upload and a wait, with no Try again button.

## Verified

- svelte-check **0 errors / 150 warnings / 47 files** — equals baseline.
- Full vitest **60 files / 970 tests / 0 failures**. Baseline measured at `566d16f` in a clean worktree is 60/942, so **+28 tests, no new files**.
- Prettier: `CheffyMessenger.svelte` is already dirty at `566d16f`, and this branch wants the **same 7 lines** changed — unrelated prose wrapping. Nothing added.
- All 28 tests mutation-checked. Nine hand mutants, all killed: WEBP losing its second marker (kills 3 — WAV and AVI are the point), reading the whole file instead of 16 bytes, an unreadable file falling back to jpeg, PNG truncated to 4 bytes, GIF put back in the sentence, the pick-time line copying the server's wording, the HEIC branch dropped, a handler reverted to `file.type`, one `accept` re-narrowed.

**Exercised in a real browser** (Playwright + a real ISO-BMFF HEIC, `/cheffy`, logged in, membership stubbed):

| File → door | at `566d16f` (#593) | at `a8e7f5f` (this) |
|---|---|---|
| HEIC → ask | **no alert** — accepted and held | the HEIC line, at pick time |
| HEIC bytes named `.jpg` → ask | **no alert** — accepted and held | the generic line, at pick time |
| real PNG → ask | no alert | no alert |
| HEIC → scan | **the file left the browser and the server answered** | the HEIC line, at pick time |

`RESEARCH/CHEFFY_BYTE_GATE_BROWSER_RUN_2026_07_26.md`.

## Not verified

- `setInputFiles` bypasses the file dialog, so the table above measures **the gate, not the picker**. It says nothing about what iOS hands over. Tapping *Upload an image* on this branch's preview is still the only instrument for that — and on this branch it also demonstrates the fix rather than sizing the old bug.
- No live OpenAI call (dev key unset), so `IMAGE_UNREADABLE` and `NOT_FOOD` remain unseen.
- The wiring test is a source scan: it sees that the handlers call the gate, never that they call it on the right file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
