### PR TITLE
Stop the list editor from deleting the cover image it just showed you

### DIFF
--- a/src/lib/listTags.test.ts
+++ b/src/lib/listTags.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { nip19 } from 'nostr-tools';
+import { buildListTags, listIdentifier, BOOKMARKS_IDENTIFIER } from './listTags';
+import { RECIPE_TAG_PREFIX_NEW } from './consts';
+
+/**
+ * The list editor republishes a kind-30001 at the same `d` address, so the
+ * tag set it emits is the whole list — anything missing is deleted, not
+ * left alone. These tests pin the round trip: load a list, change nothing,
+ * republish, and every tag the form showed is still there.
+ *
+ * The regression they guard is a cover image that was pushed onto the
+ * source event being read instead of the new event being published, so the
+ * republished list silently lost its cover while the page said 'Success!'.
+ */
+
+const PUBKEY = 'a723805cda67251191c8786f4da58f797e6977582301354ba8e91bcb0342dc9c';
+const COVER = 'https://image.nostr.build/cover.jpg';
+
+function naddrFor(identifier: string): string {
+  return nip19.naddrEncode({ kind: 30023, pubkey: PUBKEY, identifier });
+}
+
+function tagValue(tags: string[][], name: string): string | undefined {
+  return tags.find((t) => t[0] === name)?.[1];
+}
+
+describe('buildListTags', () => {
+  it('keeps the cover image on a round trip that changes nothing', () => {
+    const sourceTags = [
+      ['d', 'italian-favorites'],
+      ['title', 'Italian Favorites'],
+      ['image', COVER],
+      ['a', `30023:${PUBKEY}:carbonara`]
+    ];
+
+    const tags = buildListTags({
+      sourceTags,
+      title: 'Italian Favorites',
+      summary: '',
+      images: [COVER],
+      items: [{ naddr: naddrFor('carbonara') }]
+    });
+
+    expect(tagValue(tags, 'image')).toBe(COVER);
+  });
+
+  it('does not write the image onto the event it was read from', () => {
+    const sourceTags = [
+      ['d', 'italian-favorites'],
+      ['title', 'Italian Favorites']
+    ];
+    const before = JSON.stringify(sourceTags);
+
+    buildListTags({
+      sourceTags,
+      title: 'Italian Favorites',
+      summary: '',
+      images: [COVER],
+      items: []
+    });
+
+    expect(JSON.stringify(sourceTags)).toBe(before);
+  });
+
+  it('carries title, summary, cover and recipes together', () => {
+    const tags = buildListTags({
+      sourceTags: [['d', 'italian-favorites']],
+      title: 'Italian Favorites',
+      summary: 'Everything worth making twice.',
+      images: [COVER],
+      items: [{ naddr: naddrFor('carbonara') }, { naddr: naddrFor('cacio-e-pepe') }]
+    });
+
+    expect(tagValue(tags, 'title')).toBe('Italian Favorites');
+    expect(tagValue(tags, 'summary')).toBe('Everything worth making twice.');
+    expect(tagValue(tags, 'image')).toBe(COVER);
+    expect(tags.filter((t) => t[0] === 'a').map((t) => t[1])).toEqual([
+      `30023:${PUBKEY}:carbonara`,
+      `30023:${PUBKEY}:cacio-e-pepe`
+    ]);
+  });
+
+  it('gives a named list the zapcooking tag and a slugified identifier', () => {
+    const tags = buildListTags({
+      sourceTags: [['d', 'italian-favorites']],
+      title: 'Italian Favorites',
+      summary: '',
+      images: [],
+      items: []
+    });
+
+    expect(tagValue(tags, 't')).toBe(RECIPE_TAG_PREFIX_NEW);
+    expect(tagValue(tags, 'd')).toBe('italian-favorites');
+    expect(tagValue(tags, 'd')).toBe(listIdentifier('Italian Favorites'));
+  });
+
+  it('keeps the bookmarks identifier and does not tag it as a recipe list', () => {
+    const tags = buildListTags({
+      sourceTags: [['d', BOOKMARKS_IDENTIFIER]],
+      title: 'Bookmarks',
+      summary: '',
+      images: [],
+      items: []
+    });
+
+    expect(tagValue(tags, 'd')).toBe(BOOKMARKS_IDENTIFIER);
+    expect(tags.find((t) => t[0] === 't')).toBeUndefined();
+  });
+
+  it('omits summary and image when the member left them empty', () => {
+    const tags = buildListTags({
+      sourceTags: [['d', 'italian-favorites']],
+      title: 'Italian Favorites',
+      summary: '',
+      images: [],
+      items: []
+    });
+
+    expect(tags.find((t) => t[0] === 'summary')).toBeUndefined();
+    expect(tags.find((t) => t[0] === 'image')).toBeUndefined();
+  });
+});

--- a/src/lib/listTags.ts
+++ b/src/lib/listTags.ts
@@ -1,0 +1,69 @@
+/**
+ * Tag construction for kind-30001 recipe lists.
+ *
+ * Extracted from `routes/list/[slug]/fork/+page.svelte` so the tag set a
+ * republished list carries can be asserted in a test. That page is not a
+ * "fork" in the member's sense — `list/create/+page.svelte:52` redirects
+ * to it right after a list is created, and it is the only screen that
+ * adds recipes to a list, so its output overwrites the list the member
+ * just made at the same `d` address. Anything it drops is destroyed.
+ */
+
+import { nip19 } from 'nostr-tools';
+import { RECIPE_TAG_PREFIX_NEW } from '$lib/consts';
+
+/** The `d` identifier a list gets from its title. */
+export function listIdentifier(title: string): string {
+  return title.toLowerCase().replaceAll(' ', '-');
+}
+
+/** The reserved `d` value for a member's bookmarks list. */
+export const BOOKMARKS_IDENTIFIER = 'nostrcooking-bookmarks';
+
+export type ListItem = { naddr: string };
+
+export type ListTagsInput = {
+  /** Tags of the list event being republished, used only to detect the bookmarks list. */
+  sourceTags: string[][];
+  title: string;
+  summary: string;
+  /** Cover image URLs from the picker; the picker is capped at one. */
+  images: string[];
+  items: ListItem[];
+};
+
+/**
+ * Build the full tag set for the republished list event.
+ *
+ * Every tag the member can still see on the form has to be re-emitted
+ * here: a kind-30001 lands at the same `d` address and replaces the
+ * previous event wholesale, so an omitted tag is not "unchanged", it is
+ * deleted.
+ */
+export function buildListTags(input: ListTagsInput): string[][] {
+  const { sourceTags, title, summary, images, items } = input;
+  const tags: string[][] = [];
+
+  if (!sourceTags.find((t) => t[0] == 'd' && t[1] == BOOKMARKS_IDENTIFIER)) {
+    tags.push(['t', RECIPE_TAG_PREFIX_NEW]);
+    tags.push(['d', listIdentifier(title)]);
+  } else {
+    tags.push(['d', BOOKMARKS_IDENTIFIER]);
+  }
+  tags.push(['title', title]);
+  if (summary !== '') {
+    tags.push(['summary', summary]);
+  }
+  if (images.length === 1) {
+    tags.push(['image', images[0]]);
+  }
+  items.forEach((e) => {
+    const decoded = nip19.decode(e.naddr);
+    if (decoded.type === 'naddr') {
+      const data = decoded.data;
+      tags.push(['a', `${data.kind}:${data.pubkey}:${data.identifier}`]);
+    }
+  });
+
+  return tags;
+}

--- a/src/routes/list/[slug]/fork/+page.svelte
+++ b/src/routes/list/[slug]/fork/+page.svelte
@@ -10,7 +10,8 @@
   import ListComboBox from '../../../../components/ListComboBox.svelte';
   import Button from '../../../../components/Button.svelte';
   import ImagesComboBox from '../../../../components/ImagesComboBox.svelte';
-  import { RECIPE_TAG_PREFIX_NEW, RECIPE_TAGS } from '$lib/consts';
+  import { RECIPE_TAGS } from '$lib/consts';
+  import { buildListTags, listIdentifier } from '$lib/listTags';
   import PanLoader from '../../../../components/PanLoader.svelte';
 
   $: {
@@ -125,31 +126,19 @@
     try {
       const nevent = new NDKEvent($ndk);
       nevent.kind = 30001;
-      if (!event.tags.find((t) => t[0] == 'd' && t[1] == 'nostrcooking-bookmarks')) {
-        nevent.tags.push(['t', RECIPE_TAG_PREFIX_NEW]);
-        nevent.tags.push(['d', title.toLowerCase().replaceAll(' ', '-')]);
-      } else {
-        nevent.tags.push(['d', 'nostrcooking-bookmarks']);
-      }
-      nevent.tags.push(['title', title]);
-      if (summary !== '') {
-        nevent.tags.push(['summary', summary]);
-      }
-      if ($images.length === 1) {
-        event.tags.push(['image', $images[0]]);
-      }
-      $items.forEach((e) => {
-        const decoded = nip19.decode(e.naddr);
-        if (decoded.type === 'naddr') {
-          const data = decoded.data;
-          const newAtag = `${data.kind}:${data.pubkey}:${data.identifier}`;
-          nevent.tags.push(['a', newAtag]);
-        }
-      });
+      nevent.tags.push(
+        ...buildListTags({
+          sourceTags: event.tags,
+          title,
+          summary,
+          images: $images,
+          items: $items
+        })
+      );
       await nevent.publish();
       resultMessage = 'Success!';
       let naddr = nip19.naddrEncode({
-        identifier: title.toLowerCase().replaceAll(' ', '-'),
+        identifier: listIdentifier(title),
         kind: 30001,
         pubkey: nevent.pubkey
       });


### PR DESCRIPTION
## What breaks today

`src/routes/list/[slug]/fork/+page.svelte:139` pushes the cover image onto `event` — the old event being *read* — instead of `nevent`, the new one being *published*. Every other tag on that path uses `nevent`.

```js
if ($images.length === 1) {
  event.tags.push(['image', $images[0]]);   // wrong object
}
```

The republished kind 30001 lands at the same `d` address with no `image` tag, and `:150` says `'Success!'`.

**This is the standard create flow, not an edge case.** `list/create/+page.svelte:52` redirects here immediately after a list is created, and this screen is the only place to add recipes to a list. So: a member uploads a cover, adds their recipes on the very next screen, and the cover is gone. Verified at `origin/main` `0147316`.

A kind-30001 replaces its predecessor wholesale, so the tag set this screen emits *is* the list. An omitted tag is deleted, not left alone.

## The change

Tag construction moves to `src/lib/listTags.ts` as a pure function, and the image goes onto the returned tags. The seam is what lets the round trip be asserted at all — there's no component-render harness in this repo.

Everything else is lifted verbatim: the bookmarks-list branch, the `zapcooking` `t` tag, the empty-summary skip, the `a` tags. `listIdentifier` is now shared between the `d` tag and the naddr the page redirects to, which have to agree.

## Tests

`src/lib/listTags.test.ts`, 6 tests. The round trip: load a list, change nothing, republish, every tag survives.

Mutation-checked — reintroducing the exact bug (`sourceTags.push` instead of `tags.push`) fails 3 of the 6, including `does not write the image onto the event it was read from`, which pins the bug shape rather than just the symptom.

## Verification

- `npx vitest run` — **61 files, 976 tests, all pass** (full suite, not scoped)
- `svelte-check` — **0 errors**, 150 warnings (baseline)
- `prettier --check` on the two new files — clean. The `.svelte` file is already dirty at `origin/main`, so it is not reformatted here.
- The two `Workers Builds` checks fail on every PR including merged ones — pre-existing.

## Not verified

Not exercised in a browser against a live relay. The publish path itself is untouched (`nevent.publish()` as before); what changed is the tags handed to it.

## Suggested reviewer

**Prep** — acceptance is behavioural (cover survives the create → add-recipes hop), and the extraction is the only judgment call in here.
