### PR TITLE
Authenticate the fridge scanner instead of trusting a pubkey it was handed

### DIFF
--- a/src/components/CheffyMessenger.svelte
+++ b/src/components/CheffyMessenger.svelte
@@ -14,7 +14,7 @@
   import { onMount, onDestroy, tick } from 'svelte';
   import { browser } from '$app/environment';
   import { goto } from '$app/navigation';
-  import { userPublickey } from '$lib/nostr';
+  import { ndk, userPublickey } from '$lib/nostr';
   import {
     membershipStatusMap,
     queueMembershipLookup,
@@ -23,6 +23,7 @@
   import { parseMarkdown } from '$lib/parser';
   import { PROMPT_PLACEHOLDERS, SCAN_ERROR_LINE, photoFormatLine } from '$lib/cheffy';
   import { fileToBase64, identifyPhotoFile, PHOTO_MAX_BYTES } from '$lib/photoAsk';
+  import { scanFridgePhoto } from '$lib/photoScan';
   import {
     cheffyOpen,
     cheffyThread,
@@ -309,14 +310,9 @@
     clearAttachedPhoto();
     try {
       const base64 = await fileToBase64(file);
-      const resp = await fetch('/api/zappy/scan', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ image: base64, pubkey: $userPublickey })
-      });
-      const data = await resp.json();
-      if (!resp.ok || !data.ok) throw new Error(data.error || SCAN_ERROR_LINE);
-      const ingredients: string[] = data.ingredients || [];
+      const result = await scanFridgePhoto({ ndk: $ndk, imageBase64: base64 });
+      if (!result.ok) throw new Error(result.error || SCAN_ERROR_LINE);
+      const ingredients: string[] = result.ingredients;
       if (ingredients.length > 0) {
         cheffyDraft.set(`I have: ${ingredients.join(', ')}`);
         await tick();

--- a/src/lib/photoScan.test.ts
+++ b/src/lib/photoScan.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Unit tests for the fridge-scan client helper.
+ *
+ * The signer and fetch are injected, so what runs here is the helper's
+ * own contract: the bytes it signs are the bytes it sends, and a refused
+ * signature comes back typed instead of as a raw signer string.
+ *
+ * Mirrors photoAsk.test.ts, with one deliberate difference pinned below:
+ * a failed fetch propagates here rather than becoming a typed NETWORK
+ * result, because both call sites already catch and render it and
+ * changing that sentence is a copy decision.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type NDK from '@nostr-dev-kit/ndk';
+import { scanFridgePhoto } from './photoScan';
+import { PHOTO_SIGN_FAILED_LINE } from './cheffy';
+
+const NDK_STUB = {} as NDK;
+const IMAGE = 'BASE64IMAGEDATA';
+const ORIGIN = 'https://zap.cooking';
+
+function okResponse(data: unknown) {
+  return { ok: true, status: 200, json: async () => data };
+}
+function errResponse(status: number, data: unknown) {
+  return { ok: false, status, json: async () => data };
+}
+
+/** A signer that records what it was asked to sign. */
+function recordingSigner() {
+  const seen: { method: string; url: string; bodyString?: string }[] = [];
+  const signHeader = vi.fn(async (_ndk: NDK, opts: any) => {
+    seen.push(opts);
+    return 'Nostr signed-header';
+  });
+  return { seen, signHeader: signHeader as any };
+}
+
+describe('scanFridgePhoto — signing', () => {
+  it('signs the exact string it sends', async () => {
+    const { seen, signHeader } = recordingSigner();
+    const fetchFn = vi.fn(async () => okResponse({ ok: true, ingredients: ['eggs'] })) as any;
+
+    await scanFridgePhoto({
+      ndk: NDK_STUB,
+      imageBase64: IMAGE,
+      signHeader,
+      fetchFn,
+      origin: ORIGIN
+    });
+
+    const signedBody = seen[0].bodyString;
+    const sentBody = fetchFn.mock.calls[0][1].body;
+    expect(sentBody).toBe(signedBody);
+    // A body-hash-bound header is worthless if the two ever diverge.
+    expect(JSON.parse(sentBody)).toEqual({ image: IMAGE });
+  });
+
+  it('no longer sends a pubkey in the body', async () => {
+    // The whole point of the change: identity comes from the signed
+    // header, not from a field the caller can type.
+    const { signHeader } = recordingSigner();
+    const fetchFn = vi.fn(async () => okResponse({ ok: true, ingredients: [] })) as any;
+
+    await scanFridgePhoto({
+      ndk: NDK_STUB,
+      imageBase64: IMAGE,
+      signHeader,
+      fetchFn,
+      origin: ORIGIN
+    });
+
+    expect(JSON.parse(fetchFn.mock.calls[0][1].body).pubkey).toBeUndefined();
+  });
+
+  it('binds the header to this endpoint and method', async () => {
+    const { seen, signHeader } = recordingSigner();
+    const fetchFn = vi.fn(async () => okResponse({ ok: true, ingredients: [] })) as any;
+
+    await scanFridgePhoto({
+      ndk: NDK_STUB,
+      imageBase64: IMAGE,
+      signHeader,
+      fetchFn,
+      origin: ORIGIN
+    });
+
+    expect(seen[0].method).toBe('POST');
+    expect(seen[0].url).toBe(`${ORIGIN}/api/zappy/scan`);
+    expect(fetchFn.mock.calls[0][0]).toBe('/api/zappy/scan');
+    expect(fetchFn.mock.calls[0][1].headers.Authorization).toBe('Nostr signed-header');
+  });
+
+  it('returns SIGN_FAILED without sending anything when the signer refuses', async () => {
+    const signHeader = vi.fn(async () => {
+      throw new Error('no signer');
+    }) as any;
+    const fetchFn = vi.fn() as any;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await scanFridgePhoto({
+      ndk: NDK_STUB,
+      imageBase64: IMAGE,
+      signHeader,
+      fetchFn,
+      origin: ORIGIN
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('SIGN_FAILED');
+      // The raw signer message is diagnostic, never copy.
+      expect(result.error).toBe(PHOTO_SIGN_FAILED_LINE);
+      expect(result.error).not.toContain('no signer');
+    }
+    expect(fetchFn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('calls onSigned after signing and before the fetch', async () => {
+    const { signHeader } = recordingSigner();
+    const order: string[] = [];
+    const fetchFn = vi.fn(async () => {
+      order.push('fetch');
+      return okResponse({ ok: true, ingredients: [] });
+    }) as any;
+
+    await scanFridgePhoto({
+      ndk: NDK_STUB,
+      imageBase64: IMAGE,
+      onSigned: () => order.push('signed'),
+      signHeader,
+      fetchFn,
+      origin: ORIGIN
+    });
+
+    expect(order).toEqual(['signed', 'fetch']);
+  });
+});
+
+describe('scanFridgePhoto — responses', () => {
+  it('returns the ingredient list on success', async () => {
+    const { signHeader } = recordingSigner();
+    const fetchFn = vi.fn(async () =>
+      okResponse({ ok: true, ingredients: ['eggs', 'milk'] })
+    ) as any;
+
+    const result = await scanFridgePhoto({
+      ndk: NDK_STUB,
+      imageBase64: IMAGE,
+      signHeader,
+      fetchFn,
+      origin: ORIGIN
+    });
+
+    expect(result).toEqual({ ok: true, ingredients: ['eggs', 'milk'] });
+  });
+
+  it('treats a missing ingredient list as empty, not as a failure', async () => {
+    const { signHeader } = recordingSigner();
+    const fetchFn = vi.fn(async () => okResponse({ ok: true })) as any;
+
+    const result = await scanFridgePhoto({
+      ndk: NDK_STUB,
+      imageBase64: IMAGE,
+      signHeader,
+      fetchFn,
+      origin: ORIGIN
+    });
+
+    // The old inline code did `data.ingredients || []`, and the callers
+    // show their own line for an empty list. Same behaviour.
+    expect(result).toEqual({ ok: true, ingredients: [] });
+  });
+
+  it('passes the server error line and status through on a 401', async () => {
+    const { signHeader } = recordingSigner();
+    const fetchFn = vi.fn(async () =>
+      errResponse(401, { ok: false, error: 'Authentication required' })
+    ) as any;
+
+    const result = await scanFridgePhoto({
+      ndk: NDK_STUB,
+      imageBase64: IMAGE,
+      signHeader,
+      fetchFn,
+      origin: ORIGIN
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(401);
+      expect(result.error).toBe('Authentication required');
+    }
+  });
+
+  it('passes the rate-limit code and line through on a 429', async () => {
+    const { signHeader } = recordingSigner();
+    const fetchFn = vi.fn(async () =>
+      errResponse(429, { ok: false, code: 'RATE_LIMITED', error: 'Cheffy needs a breather.' })
+    ) as any;
+
+    const result = await scanFridgePhoto({
+      ndk: NDK_STUB,
+      imageBase64: IMAGE,
+      signHeader,
+      fetchFn,
+      origin: ORIGIN
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('RATE_LIMITED');
+      expect(result.error).toBe('Cheffy needs a breather.');
+    }
+  });
+
+  it('lets a failed fetch propagate, as the inline call did', async () => {
+    const { signHeader } = recordingSigner();
+    const fetchFn = vi.fn(async () => {
+      throw new Error('Failed to fetch');
+    }) as any;
+
+    await expect(
+      scanFridgePhoto({ ndk: NDK_STUB, imageBase64: IMAGE, signHeader, fetchFn, origin: ORIGIN })
+    ).rejects.toThrow('Failed to fetch');
+  });
+});

--- a/src/lib/photoScan.ts
+++ b/src/lib/photoScan.ts
@@ -1,0 +1,87 @@
+/**
+ * Cheffy fridge scan — client request plumbing.
+ *
+ * Kept in a plain module (not a component) so it is unit-testable —
+ * repo convention: logic in .ts, no Svelte component tests. The server
+ * contract lives at POST /api/zappy/scan (NIP-98 auth, body-hash bound);
+ * `askAboutPhoto` in photoAsk.ts is the template this mirrors.
+ *
+ * This existed as an inline fetch duplicated in CheffyMessenger.svelte
+ * and /cheffy/+page.svelte. Both now call this, because the signing step
+ * is the part that must not be written twice.
+ */
+
+import type NDK from '@nostr-dev-kit/ndk';
+import { signNip98AuthHeader } from './nip98';
+import { PHOTO_SIGN_FAILED_LINE } from './cheffy';
+
+export interface ScanRequestOpts {
+  ndk: NDK;
+  /** Base64 image data, no `data:` prefix — see fileToBase64 in photoAsk.ts. */
+  imageBase64: string;
+  /** Called once the NIP-98 header is signed, before the fetch (NIP-46 round trips are slow). */
+  onSigned?: () => void;
+  /** Test injection points. */
+  signHeader?: typeof signNip98AuthHeader;
+  fetchFn?: typeof fetch;
+  origin?: string;
+}
+
+export type ScanResult =
+  | { ok: true; ingredients: string[] }
+  | { ok: false; code?: string; error?: string; status?: number };
+
+/**
+ * Sign and send a fridge-scan request.
+ *
+ * DELIBERATELY UNLIKE `askAboutPhoto`, this does NOT catch a failed
+ * fetch. Both call sites already wrap the call in try/catch and render
+ * `err.message`, and converting a dropped connection into a typed result
+ * would change the sentence a member reads — that is copy, and it is not
+ * this change's to make. Signing failure is the one new failure mode
+ * here, and it reuses the line ask-photo already ships for exactly it.
+ */
+export async function scanFridgePhoto(opts: ScanRequestOpts): Promise<ScanResult> {
+  const { ndk, imageBase64, onSigned, signHeader = signNip98AuthHeader, fetchFn = fetch } = opts;
+
+  // The signed payload hash and the fetch body must be the same string.
+  const bodyString = JSON.stringify({ image: imageBase64 });
+
+  const origin =
+    opts.origin ?? (typeof location !== 'undefined' ? location.origin : 'https://zap.cooking');
+
+  let authorization: string;
+  try {
+    authorization = await signHeader(ndk, {
+      method: 'POST',
+      url: `${origin}/api/zappy/scan`,
+      bodyString
+    });
+  } catch (err) {
+    // The real message is diagnostic, not copy — an unhandled signer
+    // string put "User rejected the request." on screen in Cheffy's voice.
+    console.warn('[Zappy Scan] signing failed:', err);
+    return { ok: false, code: 'SIGN_FAILED', error: PHOTO_SIGN_FAILED_LINE };
+  }
+
+  onSigned?.();
+
+  const resp = await fetchFn('/api/zappy/scan', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: authorization },
+    body: bodyString
+  });
+  const data: Record<string, unknown> = await resp.json().catch(() => ({}));
+  if (resp.ok && data.ok === true) {
+    const ingredients = Array.isArray(data.ingredients)
+      ? (data.ingredients as unknown[]).filter((i): i is string => typeof i === 'string')
+      : [];
+    return { ok: true, ingredients };
+  }
+  return {
+    ok: false,
+    code: typeof data.code === 'string' ? data.code : undefined,
+    error: typeof data.error === 'string' ? data.error : undefined,
+    status: resp.status
+  };
+}

--- a/src/routes/api/zappy/scan/+server.ts
+++ b/src/routes/api/zappy/scan/+server.ts
@@ -6,11 +6,12 @@
  * Included with any active membership (Cook+, Pro Kitchen, Founders).
  *
  * POST /api/zappy/scan
+ * Requires NIP-98 HTTP auth (kind-27235 Authorization header with
+ * body-hash payload binding — the note-review / ask-photo pattern).
  *
  * Body:
  * {
- *   image: string (base64 encoded image),
- *   pubkey?: string
+ *   image: string (base64 encoded image)
  * }
  *
  * Returns:
@@ -26,15 +27,23 @@
  * or, at the per-IP cap:
  *   429 { ok: false, code: 'RATE_LIMITED', error: string, retryAfter: number }
  *
- * NOT authenticated. The `pubkey` in the body is unverified — it gates
- * membership but is not proof of identity, so the rate limit below keys
- * on the client address instead. Adding NIP-98 here would change the
- * contract on both callers and is deliberately out of scope.
+ * The membership gate used to read a `pubkey` off this endpoint's own
+ * request body. A body pubkey is an identity claim, not an identity —
+ * npubs are public by construction, so one member npub read off a relay
+ * bought free vision calls. The pubkey now comes back verified from
+ * `verifyNip98` and the body field is gone; ask-photo already refused to
+ * repeat the old shape (see its header comment).
+ *
+ * The fail-OPEN posture on membership-service errors is UNCHANGED here —
+ * unlike note-review and ask-photo, which fail closed. That divergence is
+ * tracked in https://github.com/zapcooking/frontend/issues/512 and is a
+ * separate decision from authentication.
  */
 
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { CHEFFY_VISION_MODEL } from '$lib/cheffyPrompt.server';
+import { verifyNip98 } from '$lib/nip98.server';
 import { checkPerIpRateLimit } from '$lib/ipRateLimit.server';
 import { SCAN_RATE_LIMIT_LINE } from '$lib/cheffy';
 
@@ -68,8 +77,24 @@ export const POST: RequestHandler = async ({ request, getClientAddress, platform
       return json({ ok: false, error: 'OpenAI API key not configured' }, { status: 500 });
     }
 
-    const body = await request.json();
-    const { image, pubkey } = body;
+    // Read the body ONCE as raw bytes — the same bytes feed the NIP-98
+    // payload-hash check and the JSON parse (note-review / ask-photo
+    // pattern; `request.json()` here would consume it first).
+    let bodyBytes: Uint8Array;
+    try {
+      bodyBytes = new Uint8Array(await request.arrayBuffer());
+    } catch {
+      return json({ ok: false, error: 'Invalid request body' }, { status: 400 });
+    }
+
+    let body: Record<string, unknown>;
+    try {
+      body = JSON.parse(new TextDecoder().decode(bodyBytes)) as Record<string, unknown>;
+    } catch {
+      return json({ ok: false, error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    const { image } = body ?? {};
 
     // Validate request
     if (!image || typeof image !== 'string') {
@@ -85,17 +110,21 @@ export const POST: RequestHandler = async ({ request, getClientAddress, platform
       );
     }
 
-    // Check membership status (any active membership). Fail CLOSED when
-    // gating is enabled but the caller sent no pubkey — otherwise a
-    // non-member could reach this paid endpoint just by omitting it.
+    // NIP-98: proves key control and binds the header to this exact
+    // body. Uniform 401 regardless of failure reason (no info leak); the
+    // reason is logged for greppable diagnostics.
+    const verification = await verifyNip98(request, { bodyBytes });
+    if (!verification.ok) {
+      console.warn(`[Zappy Scan] NIP-98 rejected (${verification.reason})`);
+      return json({ ok: false, error: 'Authentication required' }, { status: 401 });
+    }
+    const pubkey = verification.pubkey;
+
+    // Check membership status (any active membership). The "no pubkey"
+    // 403 that used to sit here is gone: verifyNip98 above cannot succeed
+    // without one, so it was unreachable rather than removed.
     const MEMBERSHIP_ENABLED = platform?.env?.MEMBERSHIP_ENABLED || env.MEMBERSHIP_ENABLED;
     if (MEMBERSHIP_ENABLED?.toLowerCase() === 'true') {
-      if (!pubkey || typeof pubkey !== 'string' || !pubkey.trim()) {
-        return json(
-          { ok: false, error: 'Cheffy is available to Cook+ members.' },
-          { status: 403 }
-        );
-      }
       const API_SECRET = platform?.env?.RELAY_API_SECRET || env.RELAY_API_SECRET;
       if (API_SECRET) {
         try {
@@ -109,8 +138,9 @@ export const POST: RequestHandler = async ({ request, getClientAddress, platform
           }
         } catch (err) {
           console.error('[Zappy Scan] Error checking membership:', err);
-          // Fail open ONLY for membership-service outages, not for a
-          // missing pubkey (handled above).
+          // Fail open ONLY for membership-service outages. An
+          // unauthenticated caller never gets this far — the 401 above
+          // is not subject to this.
         }
       }
     }
@@ -119,12 +149,21 @@ export const POST: RequestHandler = async ({ request, getClientAddress, platform
     // limited request costs nothing, and below the membership gate so a
     // non-member's 403 doesn't consume a member's quota.
     //
-    // Keyed on the client address, NOT on `pubkey`. Unlike note-review —
-    // where the pubkey comes back verified from `verifyNip98` and is a
-    // strictly better identity than an IP — the `pubkey` here is an
-    // unverified string off the request body (see the destructure above).
-    // A pubkey-keyed bucket would be reset by typing a different pubkey,
-    // which is the exact hole this is meant to close.
+    // STILL keyed on the client address, NOT on the (now verified)
+    // pubkey — and that is deliberate, not a leftover.
+    //
+    // note-review and ask-photo key on the pubkey because a verified
+    // pubkey is a strictly better identity than an IP, and both fail
+    // CLOSED on any membership problem, so reaching their limiter at all
+    // means somebody paid. This endpoint fails OPEN (see the header
+    // comment and issue #512), and when MEMBERSHIP_ENABLED is off it has
+    // no membership gate at all. In either of those states a keypair is
+    // free to mint, so a pubkey-keyed bucket would be no ceiling on the
+    // vision spend whatsoever. The IP bucket is the only cost ceiling
+    // that survives a membership outage.
+    //
+    // Move this to the pubkey when — and only when — this endpoint fails
+    // closed like its siblings. The two go together.
     let ip = '127.0.0.1';
     try {
       ip = getClientAddress();

--- a/src/routes/api/zappy/scan/scan.test.ts
+++ b/src/routes/api/zappy/scan/scan.test.ts
@@ -1,10 +1,10 @@
 /**
  * Unit tests for POST /api/zappy/scan.
  *
- * Collaborators (membership API, rate limiter, OpenAI fetch) are mocked
- * at the module boundary; the endpoint's own validation, gating, and
- * response-shaping logic runs for real. Mirrors the harness in
- * ../note-review/noteReview.test.ts.
+ * Collaborators (NIP-98 verifier, membership API, rate limiter, OpenAI
+ * fetch) are mocked at the module boundary; the endpoint's own
+ * validation, gating, and response-shaping logic runs for real. Mirrors
+ * the harness in ../ask-photo/askPhoto.test.ts.
  *
  * The point of the rate-limit cases is the *ordering*: the cap has to
  * sit below the membership gate (a 403 must not spend a member's quota)
@@ -15,10 +15,12 @@ import { SCAN_RATE_LIMIT_LINE } from '$lib/cheffy';
 import { POST } from './+server';
 
 const mocks = vi.hoisted(() => ({
+  verifyNip98: vi.fn(),
   hasActiveMembership: vi.fn(),
   checkPerIpRateLimit: vi.fn()
 }));
 
+vi.mock('$lib/nip98.server', () => ({ verifyNip98: mocks.verifyNip98 }));
 vi.mock('$lib/membershipApi.server', () => ({ hasActiveMembership: mocks.hasActiveMembership }));
 vi.mock('$lib/ipRateLimit.server', () => ({ checkPerIpRateLimit: mocks.checkPerIpRateLimit }));
 
@@ -38,12 +40,13 @@ type EventOpts = {
   env?: Record<string, unknown> | null;
   /** Throw from getClientAddress, as SvelteKit does without CF headers. */
   noClientAddress?: boolean;
+  rawBody?: string;
 };
 
 function makeEvent(body: unknown, opts: EventOpts = {}) {
   const request = new Request(new URL(ENDPOINT), {
     method: 'POST',
-    body: JSON.stringify(body)
+    body: opts.rawBody ?? JSON.stringify(body)
   });
   const env =
     opts.env === null
@@ -70,11 +73,12 @@ async function call(body: unknown, opts: EventOpts = {}) {
 }
 
 function validBody(overrides: Record<string, unknown> = {}) {
-  return { image: IMAGE, pubkey: PUBKEY, ...overrides };
+  return { image: IMAGE, ...overrides };
 }
 
 beforeEach(() => {
   vi.stubGlobal('fetch', fetchMock);
+  mocks.verifyNip98.mockReset().mockResolvedValue({ ok: true, pubkey: PUBKEY });
   mocks.hasActiveMembership.mockReset().mockResolvedValue(true);
   mocks.checkPerIpRateLimit.mockReset().mockResolvedValue({ limited: false, ipHash: 'h' });
   fetchMock.mockReset().mockResolvedValue(openaiOk('["eggs", "milk"]'));
@@ -94,8 +98,56 @@ describe('under the rate limit', () => {
   });
 });
 
+describe('NIP-98 authentication', () => {
+  it('401s when the header is missing or bad, and spends nothing', async () => {
+    for (const reason of ['missing-header', 'invalid-signature', 'payload-mismatch']) {
+      mocks.checkPerIpRateLimit.mockClear();
+      mocks.hasActiveMembership.mockClear();
+      fetchMock.mockClear();
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mocks.verifyNip98.mockResolvedValue({ ok: false, reason });
+
+      const { res, data } = await call(validBody());
+
+      expect(res.status).toBe(401);
+      expect(data.ok).toBe(false);
+      // The 401 sits ABOVE the membership call, the limiter and OpenAI —
+      // an unauthenticated caller costs us nothing and burns nobody's
+      // allowance.
+      expect(mocks.hasActiveMembership).not.toHaveBeenCalled();
+      expect(mocks.checkPerIpRateLimit).not.toHaveBeenCalled();
+      expect(fetchMock).not.toHaveBeenCalled();
+      // Reason is logged, never returned — uniform 401, no info leak.
+      expect(String(data.error)).not.toContain(reason);
+      expect(String(warn.mock.calls[0][0])).toContain(reason);
+      warn.mockRestore();
+    }
+  });
+
+  it('binds the header to this exact body', async () => {
+    await call(validBody());
+    const [, opts] = mocks.verifyNip98.mock.calls[0];
+    // Without the body bytes the verifier cannot check the payload tag,
+    // so a header signed for one photo would replay against another.
+    expect(opts.bodyBytes).toBeInstanceOf(Uint8Array);
+    expect(new TextDecoder().decode(opts.bodyBytes)).toBe(JSON.stringify(validBody()));
+  });
+
+  it('gates membership on the verified pubkey, not on anything in the body', async () => {
+    await call(validBody({ pubkey: 'b'.repeat(64) }));
+    expect(mocks.hasActiveMembership).toHaveBeenCalledTimes(1);
+    expect(mocks.hasActiveMembership.mock.calls[0][0]).toBe(PUBKEY);
+  });
+
+  it('400s on a body that is not JSON, before authenticating', async () => {
+    const { res } = await call(null, { rawBody: 'not json' });
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
 describe('rate limiting', () => {
-  it('keys the bucket on the client address, not the unverified body pubkey', async () => {
+  it('keys the bucket on the client address, not the verified pubkey', async () => {
     await call(validBody());
     expect(mocks.checkPerIpRateLimit).toHaveBeenCalledTimes(1);
     const [kv, params] = mocks.checkPerIpRateLimit.mock.calls[0];
@@ -108,8 +160,13 @@ describe('rate limiting', () => {
   });
 
   it('does not let a different pubkey reset the bucket', async () => {
-    await call(validBody({ pubkey: 'b'.repeat(64) }));
-    await call(validBody({ pubkey: 'c'.repeat(64) }));
+    // Verified now, but still free to mint — this endpoint fails OPEN on
+    // membership problems and has no gate at all when MEMBERSHIP_ENABLED
+    // is off, so the IP bucket is the only surviving cost ceiling.
+    mocks.verifyNip98.mockResolvedValueOnce({ ok: true, pubkey: 'b'.repeat(64) });
+    await call(validBody());
+    mocks.verifyNip98.mockResolvedValueOnce({ ok: true, pubkey: 'c'.repeat(64) });
+    await call(validBody());
     const ips = mocks.checkPerIpRateLimit.mock.calls.map((c: any[]) => c[1].ip);
     expect(ips).toEqual([CLIENT_IP, CLIENT_IP]);
   });
@@ -161,25 +218,23 @@ describe('rate limiting', () => {
 });
 
 describe('membership gate is not regressed', () => {
-  it('403s on a missing pubkey when gating is on, and spends no quota', async () => {
-    for (const pubkey of [undefined, '', '   ', 42]) {
-      mocks.checkPerIpRateLimit.mockClear();
-      fetchMock.mockClear();
-      const { res } = await call(validBody({ pubkey }));
-      expect(res.status).toBe(403);
-      // The 403 must sit ABOVE the limiter — a non-member probing the
-      // endpoint must not burn a real member's per-IP allowance.
-      expect(mocks.checkPerIpRateLimit).not.toHaveBeenCalled();
-      expect(fetchMock).not.toHaveBeenCalled();
-    }
-  });
-
   it('403s for a non-member and spends no quota', async () => {
     mocks.hasActiveMembership.mockResolvedValue(false);
     const { res } = await call(validBody());
     expect(res.status).toBe(403);
     expect(mocks.checkPerIpRateLimit).not.toHaveBeenCalled();
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('still fails OPEN when the membership service throws', async () => {
+    // Unchanged by adding NIP-98, and deliberately unlike note-review /
+    // ask-photo. Tracked in issue #512; pinned here so the divergence is
+    // a decision rather than a drift.
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mocks.hasActiveMembership.mockRejectedValue(new Error('membership service down'));
+    const { res } = await call(validBody());
+    expect(res.status).toBe(200);
+    error.mockRestore();
   });
 
   it('still rate limits when membership gating is off', async () => {

--- a/src/routes/cheffy/+page.svelte
+++ b/src/routes/cheffy/+page.svelte
@@ -10,6 +10,7 @@
     isPhotoAskRetryable,
     PHOTO_MAX_BYTES
   } from '$lib/photoAsk';
+  import { scanFridgePhoto } from '$lib/photoScan';
   import {
     membershipStatusMap,
     queueMembershipLookup,
@@ -623,16 +624,11 @@
     clearAttachedPhoto();
     try {
       const base64 = await fileToBase64(file);
-      const response = await fetch('/api/zappy/scan', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ image: base64, pubkey: $userPublickey })
-      });
-      const data = await response.json();
-      if (!response.ok || !data.ok) {
-        throw new Error(data.error || SCAN_ERROR_LINE);
+      const result = await scanFridgePhoto({ ndk: $ndk, imageBase64: base64 });
+      if (!result.ok) {
+        throw new Error(result.error || SCAN_ERROR_LINE);
       }
-      detectedIngredients = data.ingredients || [];
+      detectedIngredients = result.ingredients;
       if (detectedIngredients.length > 0) {
         input = `I have: ${detectedIngredients.join(', ')}`;
       } else {


### PR DESCRIPTION
## What's open today

`/api/zappy/scan` gates paid vision inference on a `pubkey` read off its own request body:

```js
const { image, pubkey } = body;
...
const isActive = await hasActiveMembership(pubkey, API_SECRET);
```

A body pubkey is an identity claim, not an identity. Npubs are public by construction, so one member npub read off a relay buys free vision calls. `ask-photo` refused to repeat the shape when it shipped and said so in its own header comment; this closes it.

The docstring said adding NIP-98 "would change the contract on both callers and is deliberately out of scope." Both callers are in this repo — `CheffyMessenger.svelte:312` and `cheffy/+page.svelte:626` — and there is **no Android caller**: `git grep 'zappy/scan' -- '*.kt'` over `zap_cooking_android` at `8ee69a1` returns nothing. So the contract change is two call sites, both ours.

## Server

NIP-98, body-hash bound, using the same `verifyNip98` and the same uniform-401-with-logged-reason shape as `ask-photo` and `note-review`. Body is read once as bytes so the same bytes feed the payload hash and the JSON parse. The membership gate now reads the verified pubkey, and the old "no pubkey → 403" branch is gone because `verifyNip98` cannot succeed without one — unreachable, not removed.

## Two things I did NOT port, per "flag anything that isn't a straight port"

**1. The rate limit stays keyed on the client address, not the now-verified pubkey.**

This is the one real judgment call. `note-review` and `ask-photo` key on the pubkey, and the existing comment here said the IP key was only because the pubkey was unverified — so the mechanical move would be to switch it. I didn't, and the reasoning is in the code:

Those two fail **closed** on any membership problem, so reaching their limiter at all means somebody paid. This endpoint fails **open**, and when `MEMBERSHIP_ENABLED` is off it has no membership gate at all. In either of those states a keypair is free to mint, so a pubkey-keyed bucket would be no ceiling on the vision spend whatsoever. The IP bucket is the only cost ceiling that survives a membership outage.

The comment now says to move it to the pubkey when — and only when — this endpoint fails closed like its siblings. **If you'd rather have per-member buckets now, that's a one-line change and it should be Dr Sats' call, since it's a spend ceiling.**

**2. The fail-open posture (issue #512) is untouched**, and now pinned by a test so it stays a decision rather than a drift.

## Client

The inline fetch was duplicated in both callers; it moves to `$lib/photoScan.ts`, mirroring `photoAsk.ts`. The signing step is the part that must not be written twice.

- **No new member-facing string.** A refused signature reuses `PHOTO_SIGN_FAILED_LINE` — already shipped, already reviewed, and already the line for "Cheffy needs your approval to send a photo" on the photo-ask path.
- A failed fetch still **propagates**, unlike `askAboutPhoto` which types it. Both callers already catch and render `err.message`; converting that would change the sentence a member reads on a dropped connection, which is copy and not this change's to make. Pinned by a test.

## Reachability check (no signed-out regression)

Scan is only reachable to a signed-in member on both surfaces, so nobody loses the feature:

- `CheffyMessenger.svelte` — the attach button that opens Scan renders only `{#if !inExperience}` (`:770`), and `showSignInGate` (`:106`) covers `!inExperience && !signedIn`. Signed-out visitors never see the entry point.
- `/cheffy` — `onMount:197` redirects to `/login` without a pubkey.

What does change for signed-in members: **scan now costs a signer approval before the upload**, exactly as ask-photo does. NIP-46 users get a round trip they didn't have.

## Verification

- `npx vitest run` — **61 files, 984 tests, all pass** (full suite, not scoped)
- `scan.test.ts` extended: 401 above the membership call / limiter / OpenAI, reason logged but never returned, header bound to the exact body, membership gated on the verified pubkey not the body, fail-open pinned. `photoScan.test.ts` new, 10 tests.
- **Mutation-checked** — three separate mutants, each failed the test that claims to cover it: dropping `bodyBytes` from the verify call, removing the 401 branch, and signing a different string than is sent.
- `svelte-check` — **0 errors**, 150 warnings (baseline)
- `prettier --check` on the two new files — clean. `CheffyMessenger.svelte` is already dirty at `origin/main`, so it is not reformatted here.
- The two `Workers Builds` checks fail on every PR including merged ones — pre-existing.

## Not verified

- No live request against a deployed build. The verifier itself is unchanged and already carries `nip98.server.test.ts`.
- I did not read production env, so I can't tell you whether `MEMBERSHIP_ENABLED` is currently true. It changes who was exposed before this, not whether the change is right.

## Suggested reviewer

**Prep** for the port, and **Dr Sats** on the rate-limit key — that bucket is the cost ceiling on vision spend.
