### PR TITLE
Let the fridge scanner accept the file size it told the member to send

### DIFF
--- a/src/routes/api/zappy/ask-photo/+server.ts
+++ b/src/routes/api/zappy/ask-photo/+server.ts
@@ -57,14 +57,11 @@ const QUESTION_MAX_CHARS = 500;
 
 // The client cap is 10 MiB of FILE (photoAsk.PHOTO_MAX_BYTES), and the
 // composer tells the member "try one under 10MB". Base64 is 4/3 of the
-// input, so a file at exactly that cap encodes to ~13.33 MiB — which
-// means scan's 13 MiB wire cap is fractionally too small to hold the
-// file size its own client-side check lets through. Sized here to
-// actually cover the promise rather than copied across.
+// input, so a file at exactly that cap encodes to ~13.33 MiB. Sized here
+// to actually cover the promise rather than estimated.
 //
-// (scan/+server.ts:68 has the same latent gap, and its comment claims
-// otherwise: "~10MB original = ~13MB base64". Real, pre-existing, and
-// deliberately not touched here — this endpoint just doesn't repeat it.)
+// scan/+server.ts had the same gap with a 13 MiB cap and a comment that
+// claimed otherwise; it now matches this number, for this reason.
 const IMAGE_MAX_CHARS = 14 * 1024 * 1024;
 
 // Per-pubkey budget. NIP-98 gives a verified identity, so the bucket key

--- a/src/routes/api/zappy/scan/+server.ts
+++ b/src/routes/api/zappy/scan/+server.ts
@@ -76,9 +76,20 @@ export const POST: RequestHandler = async ({ request, getClientAddress, platform
       return json({ ok: false, error: 'Image data is required' }, { status: 400 });
     }
 
-    // Check image size (rough estimate: base64 is ~33% larger than binary)
-    // Limit to ~10MB original = ~13MB base64
-    if (image.length > 13 * 1024 * 1024) {
+    // Sized to hold the base64 expansion of the client's own file cap,
+    // rather than estimated. Both scan surfaces reject above
+    // PHOTO_MAX_BYTES (10 MiB) and say "try one under 10MB"; base64 is
+    // 4/3 of the input, so a file at exactly that cap encodes to ~13.33
+    // MiB. The previous 13 MiB wire cap was fractionally SMALLER than
+    // what the client lets through, so the top ~2.5% of allowed files
+    // uploaded and were then rejected here — after the wait, with a
+    // sentence that contradicts the one the composer just showed.
+    //
+    // A size limit is a chain, not a number: the gate a member meets
+    // first has to be the strictest, and every gate downstream strictly
+    // looser. ask-photo/+server.ts already sizes IMAGE_MAX_CHARS this
+    // way for the same reason.
+    if (image.length > 14 * 1024 * 1024) {
       return json(
         { ok: false, error: 'Image too large. Please use a smaller image.' },
         { status: 400 }

--- a/src/routes/api/zappy/scan/scan.test.ts
+++ b/src/routes/api/zappy/scan/scan.test.ts
@@ -12,6 +12,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SCAN_RATE_LIMIT_LINE } from '$lib/cheffy';
+import { PHOTO_MAX_BYTES } from '$lib/photoAsk';
 import { POST } from './+server';
 
 const mocks = vi.hoisted(() => ({
@@ -200,6 +201,23 @@ describe('validation still precedes the limiter', () => {
     const { res } = await call(validBody({ image: undefined }));
     expect(res.status).toBe(400);
     expect(mocks.checkPerIpRateLimit).not.toHaveBeenCalled();
+  });
+
+  it('accepts a file at the client cap once base64 has expanded it', async () => {
+    // The chain: both scan surfaces reject above PHOTO_MAX_BYTES and
+    // promise "under 10MB", so the wire cap here must be able to hold
+    // what that promise lets through. Base64 is 4/3 of the input plus
+    // padding. Under the old 13 MiB cap this exact request 400'd — the
+    // top ~2.5% of allowed files uploaded and were then refused.
+    const encodedLength = 4 * Math.ceil(PHOTO_MAX_BYTES / 3);
+    const { res } = await call(validBody({ image: '/9j/' + 'A'.repeat(encodedLength - 4) }));
+    expect(res.status).toBe(200);
+  });
+
+  it('400s above the wire cap, before any OpenAI call', async () => {
+    const { res } = await call(validBody({ image: 'x'.repeat(14 * 1024 * 1024 + 1) }));
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('500s without an OpenAI key without spending quota', async () => {


### PR DESCRIPTION
Prep ruled this ships as a standalone PR off `main`, mine, before Aug 10, **only after #593 → #595 merged**. Both merged early today (00:37Z and 00:45Z), so the gate is clear.

## The band

Both scan surfaces reject a file above `PHOTO_MAX_BYTES` (10 MiB) and tell the member *"That image is a little big — try one under 10MB."* Base64 is 4/3 of the input, so a file at exactly that cap encodes to **~13.33 MiB** — and the wire cap here was **13 MiB**.

That's a ~256 KiB band, the top ~2.5% of files the client deliberately lets through. They upload in full, then get rejected on arrival with *"Image too large. Please use a smaller image."* — after the wait, contradicting the sentence the composer had just shown them. The comment (`~10MB original = ~13MB base64`) described the estimate, not the arithmetic.

Reachable from **two** doors, not one: `CheffyMessenger.svelte:312` and `cheffy/+page.svelte:626`, both gated at 10 MiB client-side.

## The number

14 MiB — the number `ask-photo/+server.ts` already uses, for exactly this reason. Its comment called out this gap as pre-existing and deliberately untouched; that note is now updated rather than left describing a defect that's fixed.

**Prep's rule, which is the whole point:** a size limit is a chain, not a number. The gate a member meets first must be the strictest, every gate downstream strictly looser. A rejection after they have waited is a link out of order, and its wording is a symptom, never the fix.

This does **not** touch gate 1 (which cap — 10 on Cheffy, 20 on Nourish + souschef), which Prep held: unblocking that needs to know what member photos actually weigh, and nobody has that. This only makes the server honour the cap the client already enforces.

## Tests

Two new cases in `scan.test.ts`: a file at exactly the client cap, base64-expanded, now 200s; anything above the wire cap still 400s before any OpenAI call. Mutation-checked — reverting `14` to `13` fails the first one and nothing else.

## Verification

- `npx vitest run` — **60 files, 972 tests, all pass** (full suite)
- `svelte-check` — **0 errors**, 150 warnings (baseline)
- `prettier` — `scan/+server.ts` is already dirty at `origin/main`, so it is not reformatted here.
- The two `Workers Builds` checks fail on every PR including merged ones — pre-existing.

## Not verified

**Derived, not observed.** I did not post a request in the band against a deployed build; the arithmetic and the two client caps are read from source at `0147316`.

## Ordering with #599

#599 (NIP-98 on this endpoint) touches the same file but different hunks — the size check and its neighbours are untouched there. Either merge order works; if git does complain it's a one-line resolution.

## Suggested reviewer

**Prep** — this is his ruling, and gate 2 (templating the digit into the 4 Cheffy copy sites) is explicitly sequenced strictly after this lands.
