### PR TITLE
Recompute a collection's name and cover when its event actually loads

### DIFF
--- a/src/lib/collectionDisplay.test.ts
+++ b/src/lib/collectionDisplay.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { NDKEvent } from '@nostr-dev-kit/ndk';
+
+/**
+ * collectionDisplay imports DEFAULT_LIST_ID / DEFAULT_LIST_TITLE from the
+ * cookbook store, which reaches `$lib/nostr` and therefore
+ * `$app/environment`. Mocked at the boundary exactly as
+ * stores/cookbookStore.test.ts does — the store module itself stays real,
+ * so the default-list case below is asserted against the shipped
+ * constants rather than against a copy of them.
+ */
+vi.mock('$lib/nostr', async () => {
+  const { writable } = await import('svelte/store');
+  return {
+    ndk: writable<unknown>(null),
+    userPublickey: writable(''),
+    ensureNdkConnected: vi.fn(async () => {})
+  };
+});
+vi.mock('$lib/connectionMonitor', () => ({
+  isCurrentlyOnline: vi.fn(() => true),
+  onConnect: vi.fn(() => () => {})
+}));
+vi.mock('$lib/offlineStorage', () => ({
+  offlineStorage: {
+    getAllCookbooks: vi.fn(async () => []),
+    saveCookbook: vi.fn(async () => {}),
+    getPendingOperations: vi.fn(async () => []),
+    markCookbookSynced: vi.fn(async () => {}),
+    queueOperation: vi.fn(async () => {}),
+    removeOperation: vi.fn(async () => {}),
+    updateOperationRetry: vi.fn(async () => {}),
+    clearFailedOperations: vi.fn(async () => {}),
+    getQueueStatus: vi.fn(async () => ({ pending: 0, failed: 0 }))
+  }
+}));
+
+import {
+  getCollectionTitle,
+  getCollectionSummary,
+  getCollectionImage,
+  COLLECTION_FALLBACK_TITLE
+} from './collectionDisplay';
+import { DEFAULT_LIST_ID, DEFAULT_LIST_TITLE } from './stores/cookbookStore';
+
+/**
+ * These pin the function bodies, which were never the bug — the bug was
+ * that the component called them with no arguments, so Svelte saw no
+ * reactive dependency and ran them once at init. That defect lives in
+ * the compiled output, and its test is collectionReactivity.test.ts
+ * alongside the page. These two files are a pair; neither catches the
+ * other's failure.
+ */
+
+function ev(tags: string[][]): NDKEvent {
+  return { tags } as unknown as NDKEvent;
+}
+
+const COVER = 'https://image.nostr.build/cover.jpg';
+
+describe('getCollectionTitle', () => {
+  it('returns the title tag', () => {
+    expect(getCollectionTitle(ev([['title', 'Happy Food']]))).toBe('Happy Food');
+  });
+
+  it('falls back when there is no event yet', () => {
+    expect(getCollectionTitle(null)).toBe(COLLECTION_FALLBACK_TITLE);
+  });
+
+  it('falls back on an event with no title tag', () => {
+    expect(getCollectionTitle(ev([['d', 'happy-food']]))).toBe(COLLECTION_FALLBACK_TITLE);
+  });
+
+  it('falls back on an empty title tag rather than rendering nothing', () => {
+    expect(getCollectionTitle(ev([['title', '']]))).toBe(COLLECTION_FALLBACK_TITLE);
+  });
+
+  it('names the default list from its d tag, ignoring any stored title', () => {
+    const tags = [
+      ['d', DEFAULT_LIST_ID],
+      ['title', 'whatever was stored']
+    ];
+    expect(getCollectionTitle(ev(tags))).toBe(DEFAULT_LIST_TITLE);
+  });
+});
+
+describe('getCollectionSummary', () => {
+  it('returns the summary tag', () => {
+    expect(getCollectionSummary(ev([['summary', 'Everything worth making twice.']]))).toBe(
+      'Everything worth making twice.'
+    );
+  });
+
+  it('is undefined with no event and with no summary tag', () => {
+    expect(getCollectionSummary(null)).toBeUndefined();
+    expect(getCollectionSummary(ev([['d', 'happy-food']]))).toBeUndefined();
+  });
+});
+
+describe('getCollectionImage', () => {
+  it('prefers the loaded cover over the legacy image tag', () => {
+    const tags = [['image', 'https://image.nostr.build/legacy.jpg']];
+    expect(getCollectionImage(ev(tags), COVER)).toBe(COVER);
+  });
+
+  it('falls back to the legacy image tag when no cover has loaded', () => {
+    const tags = [['image', 'https://image.nostr.build/legacy.jpg']];
+    expect(getCollectionImage(ev(tags), undefined)).toBe('https://image.nostr.build/legacy.jpg');
+  });
+
+  it('is undefined with neither', () => {
+    expect(getCollectionImage(null, undefined)).toBeUndefined();
+    expect(getCollectionImage(ev([['d', 'happy-food']]), undefined)).toBeUndefined();
+  });
+});

--- a/src/lib/collectionDisplay.ts
+++ b/src/lib/collectionDisplay.ts
@@ -1,0 +1,52 @@
+/**
+ * Display values for a recipe collection (kind 30001), derived from the
+ * list event.
+ *
+ * Extracted from `routes/my-kitchen/[naddr]/+page@.svelte` for two
+ * reasons, and the second is the one that matters:
+ *
+ *  1. They are pure, so they can be unit-tested — this repo has no
+ *     component-render harness.
+ *  2. **Every input is a required parameter.** In the component these
+ *     were zero-argument closures over `event` and `coverImage`, and
+ *     `$: listTitle = getListTitle();` therefore had NO reactive
+ *     dependencies: Svelte reads dependencies from the identifiers
+ *     written inside the statement, and the only one there was the
+ *     function's own name. The statement ran once at init — before
+ *     `loadData()` had fetched anything — so the page rendered the
+ *     `'Collection'` fallback and no cover, permanently, on a
+ *     collection that had both.
+ *
+ * Taking the inputs as parameters is what makes the dependency visible
+ * to the compiler. Do not add an overload that reads module or
+ * component state instead: the signature IS the fix.
+ */
+
+import type { NDKEvent } from '@nostr-dev-kit/ndk';
+import { DEFAULT_LIST_ID, DEFAULT_LIST_TITLE } from '$lib/stores/cookbookStore';
+
+/** Shown when the event is absent or carries no title tag. */
+export const COLLECTION_FALLBACK_TITLE = 'Collection';
+
+export function getCollectionTitle(event: NDKEvent | null): string {
+  if (!event) return COLLECTION_FALLBACK_TITLE;
+  const dTag = event.tags.find((t) => t[0] === 'd')?.[1];
+  if (dTag === DEFAULT_LIST_ID) return DEFAULT_LIST_TITLE;
+  return event.tags.find((t) => t[0] === 'title')?.[1] || COLLECTION_FALLBACK_TITLE;
+}
+
+export function getCollectionSummary(event: NDKEvent | null): string | undefined {
+  return event?.tags.find((t) => t[0] === 'summary')?.[1];
+}
+
+/**
+ * The resolved cover: the loaded cover image when there is one, else the
+ * legacy `image` tag. `coverImage` is required rather than optional so a
+ * caller cannot silently drop the dependency that made this stale.
+ */
+export function getCollectionImage(
+  event: NDKEvent | null,
+  coverImage: string | undefined
+): string | undefined {
+  return coverImage || event?.tags.find((t) => t[0] === 'image')?.[1];
+}

--- a/src/routes/my-kitchen/[naddr]/+page@.svelte
+++ b/src/routes/my-kitchen/[naddr]/+page@.svelte
@@ -31,6 +31,11 @@
   import { NDKEvent } from '@nostr-dev-kit/ndk';
   import { clickOutside } from '$lib/clickOutside';
   import { formatDistanceToNow } from 'date-fns';
+  import {
+    getCollectionTitle,
+    getCollectionSummary,
+    getCollectionImage
+  } from '$lib/collectionDisplay';
 
   let loaded = false;
   let event: NDKEvent | null = null;
@@ -87,8 +92,8 @@
     const dTag = event.tags.find((t) => t[0] === 'd')?.[1] || '';
     sharePackSource = { type: 'collection', collectionDTag: dTag };
     sharePackATags = event.tags.filter((t) => t[0] === 'a').map((t) => t[1]);
-    sharePackTitle = getListTitle();
-    sharePackDescription = getListSummary() || '';
+    sharePackTitle = getCollectionTitle(event);
+    sharePackDescription = getCollectionSummary(event) || '';
     sharePackImage = coverImage || event.tags.find((t) => t[0] === 'image')?.[1];
     sharePackOpen = true;
   }
@@ -331,22 +336,6 @@
     loaded = true;
   }
 
-  function getListTitle(): string {
-    if (!event) return 'Collection';
-    const dTag = event.tags.find(t => t[0] === 'd')?.[1];
-    if (dTag === DEFAULT_LIST_ID) return DEFAULT_LIST_TITLE;
-    return event.tags.find(t => t[0] === 'title')?.[1] || 'Collection';
-  }
-
-  function getListSummary(): string | undefined {
-    return event?.tags.find(t => t[0] === 'summary')?.[1];
-  }
-
-  function getListImage(): string | undefined {
-    // Use coverImage if loaded, otherwise fall back to legacy image tag
-    return coverImage || event?.tags.find(t => t[0] === 'image')?.[1];
-  }
-  
   function openChangeCoverModal() {
     if (!event) return;
     const coverRecipeId = event.tags.find(t => t[0] === 'cover')?.[1];
@@ -479,9 +468,9 @@
 
   // Edit functionality
   function openEditModal() {
-    editTitle = getListTitle();
-    editSummary = getListSummary() || '';
-    const img = getListImage();
+    editTitle = getCollectionTitle(event);
+    editSummary = getCollectionSummary(event) || '';
+    const img = getCollectionImage(event, coverImage);
     editImages.set(img ? [img] : []);
     errorMessage = '';
     editModalOpen = true;
@@ -650,8 +639,8 @@
     if (navigator.share) {
       try {
         await navigator.share({
-          title: getListTitle(),
-          text: getListSummary() || `Check out this recipe collection on zap.cooking`,
+          title: getCollectionTitle(event),
+          text: getCollectionSummary(event) || `Check out this recipe collection on zap.cooking`,
           url
         });
       } catch (err) {
@@ -672,9 +661,15 @@
     }
   }
 
-  $: listTitle = getListTitle();
-  $: listSummary = getListSummary();
-  $: listImage = getListImage();
+  // Each of these passes its dependencies explicitly. Svelte reads a
+  // reactive statement's dependencies from the identifiers written
+  // inside it, so a zero-argument call here compiles to a statement with
+  // NO dependencies that runs once at init, before loadData() resolves.
+  // See src/lib/collectionDisplay.ts and the compile-time test alongside
+  // this file.
+  $: listTitle = getCollectionTitle(event);
+  $: listSummary = getCollectionSummary(event);
+  $: listImage = getCollectionImage(event, coverImage);
 
   $: og_meta = {
     title: `${listTitle} - zap.cooking`,

--- a/src/routes/my-kitchen/[naddr]/collectionReactivity.test.ts
+++ b/src/routes/my-kitchen/[naddr]/collectionReactivity.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Compile-time regression test for the collection page's derived values.
+ *
+ * The bug this pins was invisible to every other kind of test. The three
+ * functions were correct; the call sites were correct JavaScript; the
+ * page rendered without error. What was wrong lived only in the COMPILED
+ * output: `$: listTitle = getListTitle();` names no reactive variable, so
+ * Svelte compiled it into the instance body rather than into
+ * `$$self.$$.update`, and it ran exactly once — at init, with `event`
+ * still `null` — leaving the hero showing the `'Collection'` fallback and
+ * no cover on a collection that had both.
+ *
+ * So the assertion has to be about the compiler's output, not about
+ * behaviour we can call directly.
+ *
+ * TRAP, and it is worth reading before editing this file: the obvious
+ * implementation — `code.slice(code.indexOf('$$self.$$.update'))` — is a
+ * FALSE GREEN. Reactive statements with no dependencies are emitted AFTER
+ * the update block, so slicing to end-of-file finds them too and reports
+ * every statement as reactive, including the broken ones. It passes on
+ * the exact bug it claims to catch. The block has to be brace-matched,
+ * and `updatedLabel` below is the control that proves the extractor is
+ * discriminating rather than just always-true.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { compile, preprocess } from 'svelte/compiler';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+const PAGE = 'src/routes/my-kitchen/[naddr]/+page@.svelte';
+
+/** The body of `$$self.$$.update = () => { … }`, brace-matched. */
+function updateBlock(code: string): string {
+  const marker = '$$self.$$.update = () => {';
+  const start = code.indexOf(marker);
+  if (start === -1) return '';
+  let depth = 0;
+  let i = start + marker.length - 1;
+  for (; i < code.length; i++) {
+    if (code[i] === '{') depth++;
+    else if (code[i] === '}') {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  return code.slice(start, i + 1);
+}
+
+async function compiledUpdateBlock(): Promise<string> {
+  const src = readFileSync(PAGE, 'utf8');
+  const pre = await preprocess(src, vitePreprocess(), { filename: PAGE });
+  const { js } = compile(pre.code, { generate: 'dom', filename: PAGE });
+  return updateBlock(js.code);
+}
+
+function isRecomputed(block: string, name: string): boolean {
+  return new RegExp(`\\b${name} = `).test(block);
+}
+
+describe('collection page reactivity', () => {
+  it('recomputes title, summary and cover when the list event loads', async () => {
+    const block = await compiledUpdateBlock();
+    expect(block.length).toBeGreaterThan(0);
+
+    // Each of these must sit inside $$self.$$.update. Outside it, they
+    // run once at init and the page renders 'Collection' forever.
+    expect(isRecomputed(block, 'listTitle')).toBe(true);
+    expect(isRecomputed(block, 'listSummary')).toBe(true);
+    expect(isRecomputed(block, 'listImage')).toBe(true);
+  });
+
+  it('control: the extractor can tell the two cases apart', async () => {
+    const block = await compiledUpdateBlock();
+
+    // `updatedLabel` names `event` directly in its own statement and has
+    // always compiled correctly. If this ever reads false the extractor
+    // is broken, not the page.
+    expect(isRecomputed(block, 'updatedLabel')).toBe(true);
+
+    // And a name that is not a reactive statement at all must not match,
+    // or the regex is matching the whole file.
+    expect(isRecomputed(block, 'getCollectionTitle')).toBe(false);
+  });
+
+  it('control: brace-matching, not slice-to-end', async () => {
+    const src = readFileSync(PAGE, 'utf8');
+    const pre = await preprocess(src, vitePreprocess(), { filename: PAGE });
+    const { js } = compile(pre.code, { generate: 'dom', filename: PAGE });
+
+    // The naive extraction reaches past the block's closing brace. Prove
+    // the real one does not, so a future edit cannot quietly restore the
+    // false green described at the top of this file.
+    const naive = js.code.slice(js.code.indexOf('$$self.$$.update'));
+    const matched = updateBlock(js.code);
+    expect(matched.length).toBeLessThan(naive.length);
+    expect(matched.endsWith('}')).toBe(true);
+  });
+});


### PR DESCRIPTION
Ship's assignment. Root cause confirmed independently at `origin/main` `0147316` — see *Verification* for how, because the obvious version of this test is a false green.

## The bug

`my-kitchen/[naddr]/+page@.svelte:675-677`:

```js
$: listTitle = getListTitle();
$: listSummary = getListSummary();
$: listImage = getListImage();
```

Svelte reads a reactive statement's dependencies from the identifiers written **inside** it. The only identifier here is the function's own name — so these statements have **no dependencies**. They compile into the instance body instead of `$$self.$$.update` and run exactly once, at init, when `event` is `null` (`:36`) and `coverImage` is `undefined` (`:60`).

Result: `getListTitle()` hits its `if (!event) return 'Collection'` guard and the hero shows **Collection** for the rest of the session; `getListImage()` returns `undefined` and the cover never appears. `loadData()` then lands, the page re-renders, and both stale values come along unchanged.

My Kitchen's grid looks correct because it reads `list.title` / `list.image` straight off the store rows and never goes through these three.

**This is not what #598 fixes.** #598 is the publish side (`fork/+page.svelte`, image written to the wrong object). This is the read side, a different file, no conflict, either merge order.

## The fix

The three move to `$lib/collectionDisplay.ts` and take their inputs as **required parameters**. That's the fix rather than tidiness: writing `getCollectionTitle(event)` is what makes the dependency visible to the compiler. The bodies are lifted verbatim — they were never wrong. All seven call sites updated (`:90`, `:91`, `:482`–`:484`, `:653`, `:654`, `:675`–`:677`).

`coverImage` is a required parameter too, not optional, so a future caller can't silently drop the dependency that made this stale in the first place.

## Tests — two files, and they are a pair

`collectionDisplay.test.ts` (10 tests) pins the function bodies. It mocks `$lib/nostr` / `connectionMonitor` / `offlineStorage` at the boundary exactly as `stores/cookbookStore.test.ts` does, so the store module stays real and the default-list case is asserted against the shipped `DEFAULT_LIST_ID` / `DEFAULT_LIST_TITLE` rather than a copy.

`collectionReactivity.test.ts` (3 tests) is the one that pins **this** bug: it compiles the page and asserts the three land inside `$$self.$$.update`.

### The trap in that test, which I hit myself

The obvious implementation — `code.slice(code.indexOf('$$self.$$.update'))` — **passes on the broken code.** Dependency-less reactive statements are emitted *after* the update block, so slicing to end-of-file finds them too and reports every statement as reactive.

My first run of it reported all five values REACTIVE, including the three that are provably not. I only caught it because I had a faithful compiled repro to check against.

Measured, not assumed: with the bug reinstated, the naive extractor returns `true` for `listTitle`. The block is brace-matched instead, `updatedLabel` (which names `event` directly and always compiled correctly) is carried as a control proving the extractor still discriminates, and a third test asserts the matched block is strictly shorter than the naive slice so a future edit can't quietly restore the false green.

## Verification

- **Root cause established on my own evidence, twice.** A first repro was *unfaithful* — `event` was never reassigned, so Svelte treated it as constant and all statements fell out of the update block, which would have "confirmed" the diagnosis for the wrong reason. The faithful repro (with `event` assigned in a `loadData`) shows the split cleanly: `getListTitle()` → instance body, `getListTitle(event)` → inside `$$self.$$.update` guarded on `event`. Then confirmed on the real file: `listTitle` / `listSummary` / `listImage` RUNS-ONCE, `updatedLabel` REACTIVE.
- **Mutation-checked.** Reinstating the exact original shape (zero-arg closures over `event`) fails the compile test; both controls stay green, proving they aren't carrying the assertion.
- `npx vitest run` — **62 files, 983 tests, all pass** (full suite, not scoped)
- `svelte-check` — **0 errors**, 150 warnings (baseline)
- `prettier` — new files clean; `+page@.svelte` is already dirty at `origin/main`, so it is not reformatted here.
- `Workers Builds` is red on every PR including merged ones — pre-existing.

## Not verified

- **Nothing exercised in a live browser.** Source and compiler output only.
- I could not open Seth's screenshots — the Buzz media host 401s them unauthenticated, same wall Prep hit.
- **This fix assumes the event loads and carries a `title` tag.** If the event is `null` because the relay fetch missed, or genuinely has no title tag, the page still shows `Collection` and this PR does not change that. Prep's open question (are recipes listed on that screen?) discriminates those cases and is unanswered.

## Follow-up in the same file, not in this PR

Prep's finding at `:481-485`: the edit modal prefills from these same display functions, so an unknown title can be **saved** as `'Collection'`. That is a data-destruction bug rather than a wrong pixel, it survives this fix, and it gets its own PR stacked on this branch.

## Suggested reviewer

**Ship** — his diagnosis, and worth him seeing the false-green trap since the test he specified was the naive shape. **Prep** on whether the `title`-tag assumption above holds.
