### PR TITLE
Tell someone whose payment succeeded that we have their money

### DIFF
--- a/src/routes/membership/confirmation/+page.svelte
+++ b/src/routes/membership/confirmation/+page.svelte
@@ -61,7 +61,12 @@
 
   // --- State ---
   let loading = true;
-  let error: string | null = null;
+  // Which failure a member is looking at, not the developer string that caused it.
+  // The three states differ on what we can honestly claim about their money:
+  //   no-session    — reachable without a purchase, so it makes no payment claim
+  //   not-signed-in — they paid; the signer changed between checkout and return
+  //   incomplete    — they paid; whether registration finished is unknowable here
+  let errorKind: 'no-session' | 'not-signed-in' | 'incomplete' | null = null;
   let showContent = false;
 
   let tierKey = 'cook';
@@ -127,6 +132,15 @@
 
   $: canClaim = hasCustomName && isAvailable === true && !validationError && !isChecking;
 
+  // Support gets told which state the member was in; they can't see the console.
+  $: supportSubject = encodeURIComponent(
+    errorKind === 'no-session'
+      ? 'Membership: no purchase found to confirm'
+      : errorKind === 'not-signed-in'
+        ? 'Membership: paid, not signed in at return'
+        : 'Membership: payment taken, setup did not finish'
+  );
+
   onMount(async () => {
     if (!browser) return;
 
@@ -157,12 +171,12 @@
 
     // Stripe flow — complete payment via API
     if (!sessionId) {
-      error = 'No session ID provided';
+      errorKind = 'no-session';
       loading = false;
       return;
     }
     if (!$userPublickey) {
-      error = 'User not logged in';
+      errorKind = 'not-signed-in';
       loading = false;
       return;
     }
@@ -180,7 +194,8 @@
 
       const responseText = await response.text();
       if (!response.ok) {
-        let errorMessage = `Failed to complete payment (${response.status})`;
+        // Not "payment failed" — Stripe already charged; this is our registration call.
+        let errorMessage = `Membership registration failed (${response.status})`;
         try {
           const data = JSON.parse(responseText);
           errorMessage = data.error || errorMessage;
@@ -203,7 +218,11 @@
       setTimeout(() => { showContent = true; }, 100);
       initConfetti();
     } catch (err) {
-      error = err instanceof Error ? err.message : 'Failed to complete payment';
+      // Both a non-ok response from us and a dropped connection land here, and
+      // nothing on this page can tell them apart — so the member-facing copy
+      // states what already happened rather than guessing which side failed.
+      console.error('Failed to complete membership registration:', err);
+      errorKind = 'incomplete';
       loading = false;
     }
   });
@@ -352,13 +371,41 @@
       <div class="spinner"></div>
       <p class="loading-text">Completing your membership...</p>
     </div>
-  {:else if error}
+  {:else if errorKind}
+    <!--
+      No link out of this block, and that is deliberate. `session_id` lives only
+      in this page's query string and it is the only key that can complete the
+      registration for this purchase — navigating away discards it. The site
+      header is rendered on every route, so a member still has a way out; they
+      just don't get pushed through one from here. In particular the primary
+      action is never /membership: that is the page selling what they just paid
+      for, offered to the one person who must not buy again.
+    -->
     <div class="error-state">
-      <h1 class="error-heading">Something went wrong</h1>
-      <p class="error-text">{error}</p>
-      <button class="error-button" on:click={() => goto('/membership')}>
-        Back to Membership
-      </button>
+      {#if errorKind === 'no-session'}
+        <h1 class="error-heading">We couldn't find a purchase to confirm</h1>
+        <p class="error-text">
+          If you've just paid and landed here, email us and we'll sort it out.
+        </p>
+      {:else if errorKind === 'not-signed-in'}
+        <h1 class="error-heading">We couldn't finish setting up your membership</h1>
+        <p class="error-text">
+          Your payment went through — this part is on us, not you. Sign in with the
+          account you used at checkout, using <strong>Sign in</strong> at the top of
+          this page, then reload this page and we'll finish it. Don't buy again; we
+          have your payment.
+        </p>
+      {:else}
+        <h1 class="error-heading">We couldn't finish setting up your membership</h1>
+        <p class="error-text">
+          Your payment went through — we have it. What we can't confirm from this
+          page is whether your membership finished setting up. Don't buy again;
+          email us and we'll check and finish it.
+        </p>
+      {/if}
+      <a class="error-button" href="mailto:support@zap.cooking?subject={supportSubject}">
+        Email support@zap.cooking
+      </a>
     </div>
   {:else}
     <div class="content" class:visible={showContent}>
@@ -592,14 +639,21 @@
     margin: 0 0 8px 0;
   }
 
+  /* Was 0.45 at 14px for a one-line developer string. It now carries the only
+     instructions a member in this state gets, so it has to survive being read
+     by someone who has just been frightened. */
   .error-text {
     font-family: 'DM Sans', sans-serif;
-    color: rgba(255, 255, 255, 0.45);
-    font-size: 14px;
-    margin: 0 0 24px 0;
+    color: rgba(255, 255, 255, 0.75);
+    font-size: 15px;
+    line-height: 1.6;
+    max-width: 34rem;
+    margin: 0 auto 24px;
   }
 
   .error-button {
+    display: inline-block;
+    text-decoration: none;
     padding: 12px 28px;
     border-radius: 12px;
     border: 1px solid rgba(255, 255, 255, 0.1);


### PR DESCRIPTION
The post-payment failure screen. A member reaching it has been charged by Stripe thirty seconds ago and is being told `Something went wrong` next to a raw thrown string, with a button back to the page that sells what they just bought.

Copy plus the discriminator needed to pick between three sentences. One file.

## Before

```svelte
{:else if error}
  <div class="error-state">
    <h1 class="error-heading">Something went wrong</h1>
    <p class="error-text">{error}</p>
    <button class="error-button" on:click={() => goto('/membership')}>
      Back to Membership
    </button>
  </div>
```

## What's wrong with it

**The headline answers the wrong question.** The member has exactly one — *did you take my money?* — and this doesn't mention the money, so they answer it themselves and the frightened guess is the wrong one.

**`Failed to complete payment (500)` is false in the alarming direction.** Stripe charged them. Our *registration* call failed. That string is now developer-only and renamed `Membership registration failed`, because it was wrong in a log too.

**`User not logged in` tells a paying member they did something wrong.** They didn't — the signer state changed between checkout and return.

**`Back to Membership` is worse than a bad next step: it destroys the recovery.** `session_id` lives only in this page's query string and it is the only key that can complete registration for this purchase. Navigating away discards it. The button both invites a second purchase from the one person who must not make one *and* throws away the page's own way out.

## The change

`error` was doing two jobs — the render condition and the display string. It becomes `errorKind`, set at the three sites that actually assign: `:160`, `:165`, and the `catch`. (The `Failed to complete payment` string at `:183` is *built* and **thrown**; it is not an assignment site. Credit to @prep for catching that the branch I'd have keyed on doesn't exist.)

**`no-session`** — reachable without a purchase, so it makes no payment claim.

**`not-signed-in`** — gets an instruction, and it needs no control built. The recovery already existed and was invisible:

| link | evidence at `0147316` |
|---|---|
| the control is on this screen | `+layout.svelte:563` renders `<Header />` on every route; `Header.svelte:294-301` renders **Sign in** for logged-out users |
| opening it doesn't touch the URL | `Header.svelte:297` is `on:click={() => loginOverlayOpen.set(true)}` — a store flip, no `goto`, no `?redirect=` appended |
| signing in doesn't navigate | three `goto` sites in `LoginOverlay`; `:275` gated on `redirectTo \|\| pathname === '/login'`, `:725` inside `closeOverlay()` gated on `/login`, `:1428` the new-account path. On this URL the first two can't fire → **`session_id` survives** |
| the signer survives a reload | every login path in `authManager.ts` writes `localStorage['nostrcooking_loggedInPublicKey']`; `nostr.ts:601-603` hydrates `userPublickey` at **module scope**, before `onMount` |
| the reload completes the purchase | `onMount:130` re-reads `session_id` at `:135`, `:164` now sees a truthy key, the POST at `:171-178` proceeds — and that POST needs only the pubkey string, nothing on the path signs an event, so it works for a NIP-07/NIP-46 signer that hasn't reconnected |
| it can't cost them anything | `registerMember:40-51` returns `alreadyExists` when already active. Idempotent |

Two wordings are load-bearing and neither is a preference. *"the account you used at checkout"* can't shorten to "sign in" — the purchase carries the key that was in the browser at checkout, and any other key completes nothing. And it must never invite creating an account: `SuggestedFollowsModal onComplete` (`:1427-1428`) is the one login path that navigates unconditionally, losing `session_id` *and* holding the wrong key.

The sentence names the header and a reload — deliberately **not** a sign-in button added to the error state. `onMount` is one-shot, so such a button would authenticate while the error stayed on the page. `:92` is a *reactive* `pubkeyPrefix`, so the page visibly updates while the completion never re-runs — a dead control that moves.

**`incomplete`** — one headline covering two populations. A non-ok response from us and a dropped connection both land in the same `catch` and nothing here can tell them apart. Both arrived with `session_id` in the URL, which only Stripe's `success_url` produces, so the charge happened either way. The copy states what already happened rather than naming a side the record can't identify.

## No link out of the block

Primary action is `mailto:support@zap.cooking` with a per-branch subject. There is no navigation button at all — any of them discards `session_id`. `<Header />` renders on every route, so a member still has a way out; they're just not pushed through one from here. That reasoning is a comment on the block, because a screen with no exit is exactly the shape someone "fixes" by adding one back.

`.error-text` went from 45% opacity at 14px to 75% at 15px with a line-height and max-width. It was styled for a one-line developer string and now carries the only instructions a member in this state gets.

## Deliberately not in here

**"Your membership is already active."** The webhook is the other registration path and `registerMember:38-51` makes the second a no-op, so this screen is probably failing over a job that already succeeded — the most reassuring sentence available. It waits until someone reads whether Stripe actually delivers `checkout.session.completed` to that endpoint. A reassurance the code can't back is the failure class this whole change is about.

**Re-entry on this route** (reload or re-run the completion after login) is a lifecycle change on a live purchase-return path — Prep's, post-Aug-10.

## Checks

- `svelte-check` after `svelte-kit sync`: **0 errors, 0 warnings on this file**
- `vitest run`: **970 passed, 60 files**
- CI at `98b9a6a`: **`flag-guard`, `lint`, `check`, `test`, `build` all pass**; Cloudflare Pages passes

The two `Workers Builds` checks fail. They fail identically on #596 and #597, both of which merged — pre-existing, not introduced here. I have not diagnosed them and am not claiming a cause.

(A local `vite build` was still running when this PR was opened, so an earlier revision of this section claimed a pass I hadn't earned. CI's `build` job is the one that counts and it is green.)

Both run at `98b9a6a` in the worktree that produced it. Not exercised in a browser — the branches need a real failed Stripe return.

Full reasoning, including what was superseded and why: `OUTBOX/CONFIRMATION_ERROR_COPY_2026_07_28.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


