### PR TITLE
fix(stripe): extend a membership when a card subscription renews

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.686",
+  "version": "4.2.687",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/memberRegistration.renew.test.ts
+++ b/src/lib/memberRegistration.renew.test.ts
@@ -1,0 +1,139 @@
+/**
+ * `renewMember`'s 404 handling.
+ *
+ * A renewal has no client-side fallback — a swallowed error is a lost renewal
+ * and a member billed but locked out — so the only 404 that may end the attempt
+ * is the relay's own "no such member" answer. Every other 404 has to be rethrown
+ * so the webhook returns non-2xx and Stripe redelivers. The case that makes this
+ * concrete is deploying the relay's `api` container: the proxy stays up and can
+ * answer 404 while the API is restarting.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renewMember } from './memberRegistration.server';
+
+const fetchMock = vi.fn();
+
+/** The relay's /renew handler returns exactly this on a missing member. */
+const MEMBER_NOT_FOUND = JSON.stringify({ error: 'Member not found' });
+
+function response(status: number, body: string) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => body,
+    json: async () => JSON.parse(body)
+  };
+}
+
+function renew() {
+  return renewMember({
+    pubkey: 'a'.repeat(64),
+    subscriptionMonths: 12,
+    paymentId: 'stripe_renewal_in_test123',
+    apiSecret: 'test-secret'
+  });
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock);
+  fetchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('renewMember 404 handling', () => {
+  it("reports notFound for the relay's own missing-member answer", async () => {
+    fetchMock.mockResolvedValue(response(404, MEMBER_NOT_FOUND));
+
+    await expect(renew()).resolves.toEqual({
+      renewed: false,
+      alreadyApplied: false,
+      notFound: true,
+      subscriptionEnd: null
+    });
+  });
+
+  // The sharp one. A 404 from anything other than the relay handler means we do
+  // not know whether the membership exists, so ending the attempt here would
+  // drop a renewal the member paid for.
+  it('throws on a 404 that is not the relay handler answering', async () => {
+    const foreign404s = [
+      '<html><head><title>404 Not Found</title></head></html>',
+      '',
+      JSON.stringify({ error: 'Not Found' }),
+      JSON.stringify({ message: 'Member not found' }),
+      'Member not found'
+    ];
+
+    for (const body of foreign404s) {
+      fetchMock.mockResolvedValue(response(404, body));
+      await expect(renew(), JSON.stringify(body)).rejects.toThrow('Failed to renew member: 404');
+    }
+  });
+
+  it('throws on any other non-2xx', async () => {
+    fetchMock.mockResolvedValue(response(500, JSON.stringify({ error: 'Internal server error' })));
+
+    await expect(renew()).rejects.toThrow('Failed to renew member: 500');
+  });
+});
+
+describe('renewMember success paths', () => {
+  it('reports a renewal with the new subscription_end', async () => {
+    fetchMock.mockResolvedValue(
+      response(
+        200,
+        JSON.stringify({
+          success: true,
+          action: 'renewed',
+          member: { subscription_end: '2027-07-30T00:00:00.000Z' }
+        })
+      )
+    );
+
+    await expect(renew()).resolves.toEqual({
+      renewed: true,
+      alreadyApplied: false,
+      notFound: false,
+      subscriptionEnd: '2027-07-30T00:00:00.000Z'
+    });
+  });
+
+  // member-relay's idempotency guard answers 200, not an error, so that Stripe
+  // does not retry a delivery it just declined.
+  it('reports alreadyApplied on a repeat delivery', async () => {
+    fetchMock.mockResolvedValue(
+      response(
+        200,
+        JSON.stringify({
+          success: true,
+          action: 'already_applied',
+          member: { subscription_end: '2027-07-30T00:00:00.000Z' }
+        })
+      )
+    );
+
+    const result = await renew();
+
+    expect(result.alreadyApplied).toBe(true);
+    expect(result.renewed).toBe(false);
+    expect(result.subscriptionEnd).toBe('2027-07-30T00:00:00.000Z');
+  });
+
+  it('sends only subscription_months and payment_id to the relay', async () => {
+    fetchMock.mockResolvedValue(
+      response(200, JSON.stringify({ success: true, action: 'renewed', member: {} }))
+    );
+
+    await renew();
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`https://pantry.zap.cooking/api/members/${'a'.repeat(64)}/renew`);
+    expect(JSON.parse(init.body)).toEqual({
+      subscription_months: 12,
+      payment_id: 'stripe_renewal_in_test123'
+    });
+  });
+});

--- a/src/lib/memberRegistration.server.ts
+++ b/src/lib/memberRegistration.server.ts
@@ -2,7 +2,7 @@
  * Shared member registration logic.
  *
  * Used by:
- *  - Stripe webhook (checkout.session.completed)
+ *  - Stripe webhook (checkout.session.completed, invoice.paid)
  *  - Stripe complete-payment (client-side redirect)
  *  - Strike webhook (invoice.paid)
  *
@@ -25,6 +25,25 @@ export interface RegisterMemberResult {
   subscriptionEnd: string;
   nip05: string | null;
   nip05Username: string | null;
+}
+
+export interface RenewMemberParams {
+  pubkey: string;
+  subscriptionMonths: number;
+  paymentId: string;
+  apiSecret: string;
+}
+
+export interface RenewMemberResult {
+  renewed: boolean;
+  /**
+   * The relay already holds this paymentId and declined to extend again — a
+   * repeat webhook delivery. Reported by the relay, not decided here.
+   */
+  alreadyApplied: boolean;
+  /** No membership record to extend. Nothing was written. */
+  notFound: boolean;
+  subscriptionEnd: string | null;
 }
 
 /**
@@ -123,6 +142,68 @@ export async function registerMember(params: RegisterMemberParams): Promise<Regi
     subscriptionEnd: subscriptionEnd.toISOString(),
     nip05,
     nip05Username,
+  };
+}
+
+/**
+ * Extend an existing membership by `subscriptionMonths`.
+ *
+ * Deliberately NOT registerMember. That helper returns early when the member is
+ * already active — which is precisely the case a renewal is for — so a renewal
+ * routed through it is swallowed exactly when it matters. This one always reaches
+ * the relay's `/renew` endpoint, which extends from max(subscription_end, NOW())
+ * and resets status to 'active'.
+ *
+ * Idempotent on `paymentId`, but NOT here — the check belongs to the relay and
+ * this function only reports it. Stripe redelivers a webhook on any non-2xx
+ * response and on timeout, and a redelivery that lands twice adds a term the
+ * member never paid for. We stamp the Stripe invoice id into `payment_id`; the
+ * relay's `/renew` refuses to re-apply one it already holds and answers
+ * `action: 'already_applied'`.
+ *
+ * Two reasons the check is not done here. It cannot be: the relay's
+ * `GET /api/members/:pubkey` does not SELECT `payment_id` (nor `payment_method`),
+ * so `lookupMember(...).member.payment_id` is always undefined — the field is on
+ * the TypeScript type and never on the wire. And it should not be: a
+ * read-then-write across a network is not atomic, so two concurrent redeliveries
+ * would both read "not yet applied" and both renew.
+ *
+ * **Deployment order matters.** Against a relay that predates that guard, every
+ * redelivery renews again. Ship the relay first.
+ *
+ * Throws on any relay error the caller should retry.
+ */
+export async function renewMember(params: RenewMemberParams): Promise<RenewMemberResult> {
+  const { pubkey, subscriptionMonths, paymentId, apiSecret } = params;
+
+  const renewRes = await fetch(`https://pantry.zap.cooking/api/members/${pubkey}/renew`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiSecret}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      subscription_months: subscriptionMonths,
+      payment_id: paymentId,
+    }),
+  });
+
+  if (!renewRes.ok) {
+    if (renewRes.status === 404) {
+      return { renewed: false, alreadyApplied: false, notFound: true, subscriptionEnd: null };
+    }
+    const responseText = await renewRes.text();
+    throw new Error(`Failed to renew member: ${renewRes.status} ${responseText}`);
+  }
+
+  const data = await renewRes.json();
+  const alreadyApplied = data?.action === 'already_applied';
+
+  return {
+    renewed: !alreadyApplied,
+    alreadyApplied,
+    notFound: false,
+    subscriptionEnd: data?.member?.subscription_end ?? null,
   };
 }
 

--- a/src/lib/memberRegistration.server.ts
+++ b/src/lib/memberRegistration.server.ts
@@ -146,6 +146,21 @@ export async function registerMember(params: RegisterMemberParams): Promise<Regi
 }
 
 /**
+ * Is this 404 body the relay saying the member does not exist?
+ *
+ * Deliberately an exact match on the relay's own string rather than a substring
+ * or a "has an error field" test: an HTML error page from a proxy, an empty body,
+ * or any other service's JSON must all read as false so the caller retries.
+ */
+function isMemberNotFoundBody(responseText: string): boolean {
+  try {
+    return JSON.parse(responseText)?.error === 'Member not found';
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Extend an existing membership by `subscriptionMonths`.
  *
  * Deliberately NOT registerMember. That helper returns early when the member is
@@ -189,10 +204,19 @@ export async function renewMember(params: RenewMemberParams): Promise<RenewMembe
   });
 
   if (!renewRes.ok) {
-    if (renewRes.status === 404) {
+    const responseText = await renewRes.text();
+
+    // A 404 is terminal only when it is the relay's OWN "no such member" answer
+    // (`api/index.ts` returns exactly `{"error":"Member not found"}` from
+    // /renew). Status alone is not enough: anything in front of the API can
+    // answer 404 while the API container itself is down — which is precisely
+    // what deploying the relay's `api` service creates a window for. Treating
+    // that as terminal returns 200 to Stripe and drops the renewal permanently,
+    // so anything we cannot positively identify is rethrown for redelivery.
+    if (renewRes.status === 404 && isMemberNotFoundBody(responseText)) {
       return { renewed: false, alreadyApplied: false, notFound: true, subscriptionEnd: null };
     }
-    const responseText = await renewRes.text();
+
     throw new Error(`Failed to renew member: ${renewRes.status} ${responseText}`);
   }
 

--- a/src/lib/memberRegistration.server.ts
+++ b/src/lib/memberRegistration.server.ts
@@ -4,7 +4,7 @@
  * Used by:
  *  - Stripe webhook (checkout.session.completed, invoice.paid)
  *  - Stripe complete-payment (client-side redirect)
- *  - Strike webhook (invoice.paid)
+ *  - Strike webhook (receive-request.receive-completed)
  *
  * Handles relay API registration + NIP-05 auto-claim with idempotency.
  */

--- a/src/lib/stripeRenewal.test.ts
+++ b/src/lib/stripeRenewal.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import { planRenewalFromInvoice, renewalPaymentId, monthsForPeriod } from './stripeRenewal';
+
+const PUBKEY = 'a'.repeat(64);
+
+/**
+ * An `invoice.paid` event body, shaped the way Stripe sends it on API version
+ * 2025-12-15.clover: the subscription's metadata snapshot lives under
+ * `parent.subscription_details.metadata`, not on the invoice itself.
+ */
+function invoice(
+  overrides: {
+    billing_reason?: string;
+    metadata?: Record<string, string> | null;
+    id?: string;
+  } = {}
+) {
+  const { billing_reason = 'subscription_cycle', id = 'in_test123' } = overrides;
+  const metadata =
+    'metadata' in overrides
+      ? overrides.metadata
+      : { pubkey: PUBKEY, tier: 'cook', period: 'annual' };
+
+  return {
+    id,
+    billing_reason,
+    customer: 'cus_test123',
+    parent: {
+      type: 'subscription_details',
+      subscription_details: {
+        subscription: 'sub_test123',
+        metadata
+      }
+    }
+  };
+}
+
+describe('planRenewalFromInvoice', () => {
+  it('renews on a recurring cycle', () => {
+    const decision = planRenewalFromInvoice(invoice());
+
+    expect(decision).toEqual({
+      action: 'renew',
+      pubkey: PUBKEY,
+      subscriptionMonths: 12,
+      paymentId: 'stripe_renewal_in_test123',
+      period: 'annual',
+      tier: 'cook'
+    });
+  });
+
+  it('extends a monthly subscription by one month', () => {
+    const decision = planRenewalFromInvoice(
+      invoice({ metadata: { pubkey: PUBKEY, tier: 'cook', period: 'monthly' } })
+    );
+
+    expect(decision.action).toBe('renew');
+    expect((decision as any).subscriptionMonths).toBe(1);
+  });
+
+  it('treats the legacy 2year period as twelve months, matching registerMember', () => {
+    const decision = planRenewalFromInvoice(
+      invoice({ metadata: { pubkey: PUBKEY, tier: 'cook', period: '2year' } })
+    );
+
+    expect(decision.action).toBe('renew');
+    expect((decision as any).subscriptionMonths).toBe(12);
+  });
+
+  // The sharp one. Stripe fires invoice.paid for the FIRST invoice of a
+  // subscription too, with billing_reason 'subscription_create' — the same
+  // payment checkout.session.completed already registered. If this ever starts
+  // returning 'renew', every new card member silently gets double the term they
+  // paid for, and it reads as generosity rather than as a bug.
+  it('does not renew on the first invoice of a subscription', () => {
+    const decision = planRenewalFromInvoice(invoice({ billing_reason: 'subscription_create' }));
+
+    expect(decision).toEqual({
+      action: 'skip',
+      reason: 'not-a-renewal-cycle',
+      value: 'subscription_create'
+    });
+  });
+
+  it('does not renew on a proration from a plan change', () => {
+    const decision = planRenewalFromInvoice(invoice({ billing_reason: 'subscription_update' }));
+
+    expect(decision.action).toBe('skip');
+    expect((decision as any).reason).toBe('not-a-renewal-cycle');
+  });
+
+  it('does not renew on a manual invoice', () => {
+    const decision = planRenewalFromInvoice(invoice({ billing_reason: 'manual' }));
+
+    expect(decision.action).toBe('skip');
+    expect((decision as any).reason).toBe('not-a-renewal-cycle');
+  });
+
+  // A subscription created before subscription_data.metadata was added. Nothing
+  // in the codebase can recover whose membership this is; the handler logs it
+  // for manual reconciliation. It must never guess.
+  it('skips with no-pubkey when the subscription carries no metadata', () => {
+    const decision = planRenewalFromInvoice(invoice({ metadata: null }));
+
+    expect(decision).toEqual({ action: 'skip', reason: 'no-pubkey' });
+  });
+
+  it('skips with no-pubkey when parent is absent entirely', () => {
+    const decision = planRenewalFromInvoice({
+      id: 'in_test123',
+      billing_reason: 'subscription_cycle'
+    });
+
+    expect(decision).toEqual({ action: 'skip', reason: 'no-pubkey' });
+  });
+
+  it('rejects a malformed pubkey rather than passing it to the relay', () => {
+    const decision = planRenewalFromInvoice(
+      invoice({ metadata: { pubkey: 'not-a-pubkey', tier: 'cook', period: 'annual' } })
+    );
+
+    expect(decision).toEqual({
+      action: 'skip',
+      reason: 'invalid-pubkey',
+      value: 'not-a-pubkey'
+    });
+  });
+
+  // Refused, not defaulted: guessing 12 gives away a year, guessing 1 strands an
+  // annual member eleven months early.
+  it('refuses an unrecognized period instead of defaulting', () => {
+    const decision = planRenewalFromInvoice(
+      invoice({ metadata: { pubkey: PUBKEY, tier: 'cook', period: 'weekly' } })
+    );
+
+    expect(decision).toEqual({
+      action: 'skip',
+      reason: 'invalid-period',
+      value: 'weekly'
+    });
+  });
+
+  it('refuses a missing period', () => {
+    const decision = planRenewalFromInvoice(
+      invoice({ metadata: { pubkey: PUBKEY, tier: 'cook' } })
+    );
+
+    expect(decision.action).toBe('skip');
+    expect((decision as any).reason).toBe('invalid-period');
+  });
+});
+
+describe('renewalPaymentId', () => {
+  // The relay dedupes redeliveries on payment_id, so this must depend on the
+  // invoice and nothing else. A timestamp or counter here would make every
+  // Stripe retry look like a new payment and add a term the member never bought.
+  it('is stable across calls for the same invoice', () => {
+    expect(renewalPaymentId('in_abc')).toBe(renewalPaymentId('in_abc'));
+  });
+
+  it('differs between invoices', () => {
+    expect(renewalPaymentId('in_abc')).not.toBe(renewalPaymentId('in_def'));
+  });
+
+  it('is distinguishable from a first-purchase payment_id', () => {
+    // registerMember writes `${tier}_${method}_${Date.now()}`.
+    expect(renewalPaymentId('in_abc').startsWith('stripe_renewal_')).toBe(true);
+  });
+});
+
+describe('monthsForPeriod', () => {
+  it('agrees with registerMember on every period the checkout can write', () => {
+    // registerMember: `period === 'annual' ? 12 : 1`, after handleCheckoutCompleted
+    // normalizes '2year' to 'annual'.
+    expect(monthsForPeriod('annual')).toBe(12);
+    expect(monthsForPeriod('2year')).toBe(12);
+    expect(monthsForPeriod('monthly')).toBe(1);
+  });
+});

--- a/src/lib/stripeRenewal.test.ts
+++ b/src/lib/stripeRenewal.test.ts
@@ -105,6 +105,53 @@ describe('planRenewalFromInvoice', () => {
     expect(decision).toEqual({ action: 'skip', reason: 'no-pubkey' });
   });
 
+  // A webhook endpoint carries its own api_version, independent of the SDK, and
+  // an endpoint pinned before Basil (2025-03-31) delivers the metadata snapshot
+  // on the invoice itself with no `parent` at all. Without the fallback every
+  // renewal on such an endpoint skips as no-pubkey — silent, permanent, and in
+  // the money direction.
+  it('renews on the pre-Basil shape, where subscription_details is on the invoice', () => {
+    const decision = planRenewalFromInvoice({
+      id: 'in_test123',
+      billing_reason: 'subscription_cycle',
+      customer: 'cus_test123',
+      subscription_details: {
+        subscription: 'sub_test123',
+        metadata: { pubkey: PUBKEY, tier: 'cook', period: 'annual' }
+      }
+    });
+
+    expect(decision).toEqual({
+      action: 'renew',
+      pubkey: PUBKEY,
+      subscriptionMonths: 12,
+      paymentId: 'stripe_renewal_in_test123',
+      period: 'annual',
+      tier: 'cook'
+    });
+  });
+
+  // The Basil snapshot wins when both are present: it is the one Stripe
+  // documents as immutable, and a mutable fallback must not shadow it.
+  it('prefers parent.subscription_details when both shapes are present', () => {
+    const decision = planRenewalFromInvoice({
+      id: 'in_test123',
+      billing_reason: 'subscription_cycle',
+      parent: {
+        subscription_details: {
+          metadata: { pubkey: PUBKEY, tier: 'cook', period: 'annual' }
+        }
+      },
+      subscription_details: {
+        metadata: { pubkey: 'b'.repeat(64), tier: 'pro', period: 'monthly' }
+      }
+    });
+
+    expect(decision.action).toBe('renew');
+    expect((decision as any).pubkey).toBe(PUBKEY);
+    expect((decision as any).subscriptionMonths).toBe(12);
+  });
+
   it('skips with no-pubkey when parent is absent entirely', () => {
     const decision = planRenewalFromInvoice({
       id: 'in_test123',
@@ -147,6 +194,21 @@ describe('planRenewalFromInvoice', () => {
 
     expect(decision.action).toBe('skip');
     expect((decision as any).reason).toBe('invalid-period');
+  });
+
+  // Without an id the idempotency key is the CONSTANT
+  // `stripe_renewal_undefined`, and the relay dedupes on exactly that string —
+  // so the first renewal to send it wins and every later one, for any other
+  // member, is declined as already-applied.
+  it('refuses an invoice with no id rather than deriving a constant payment_id', () => {
+    for (const id of [undefined, null, '', 123] as any[]) {
+      const withoutId: any = invoice();
+      withoutId.id = id;
+
+      const decision = planRenewalFromInvoice(withoutId);
+
+      expect(decision, String(id)).toEqual({ action: 'skip', reason: 'no-invoice-id' });
+    }
   });
 });
 

--- a/src/lib/stripeRenewal.ts
+++ b/src/lib/stripeRenewal.ts
@@ -1,0 +1,123 @@
+/**
+ * Deciding whether a Stripe `invoice.paid` extends a membership, and by how much.
+ *
+ * Split out of the webhook handler so the decision can be tested without a
+ * Stripe account, a relay, or a network. Everything here is pure: it takes an
+ * invoice-shaped object and returns either a plan or a reason for declining.
+ * The handler does the logging and the relay call.
+ *
+ * Background: `checkout.session.completed` is the only event that ever wrote a
+ * membership, and Stripe fires it on the initial checkout only. Renewals arrive
+ * as invoices, so without this path a card renews at Stripe and the membership
+ * record never moves — the member is billed and locked out.
+ */
+
+/** Periods `createCheckoutSession` has ever written into metadata. */
+const KNOWN_PERIODS = ['annual', '2year', 'monthly'] as const;
+
+export type RenewalSkipReason =
+  /** Not a recurring cycle — the first invoice, a manual one, or a proration. */
+  | 'not-a-renewal-cycle'
+  /** Subscription predates `subscription_data.metadata`. Needs a human. */
+  | 'no-pubkey'
+  | 'invalid-pubkey'
+  | 'invalid-period';
+
+export interface RenewalPlan {
+  action: 'renew';
+  pubkey: string;
+  subscriptionMonths: number;
+  /** Written to the relay's `payment_id`; the relay dedupes redeliveries on it. */
+  paymentId: string;
+  period: string;
+  tier: string | undefined;
+}
+
+export interface RenewalSkip {
+  action: 'skip';
+  reason: RenewalSkipReason;
+  /** The offending value, for the log line. Never a secret. */
+  value?: string;
+}
+
+export type RenewalDecision = RenewalPlan | RenewalSkip;
+
+/**
+ * The idempotency key for a renewal.
+ *
+ * Stripe redelivers a webhook on any non-2xx response and on timeout. The relay
+ * refuses to apply a `payment_id` it already holds, so this must be derived
+ * from the invoice and nothing else — no timestamp, no counter. Prefixed to stay
+ * distinguishable from the `{tier}_{method}_{Date.now()}` ids `registerMember`
+ * writes on first purchase.
+ */
+export function renewalPaymentId(invoiceId: string): string {
+  return `stripe_renewal_${invoiceId}`;
+}
+
+/**
+ * Months to extend for a metadata `period`.
+ *
+ * Mirrors `registerMember`, which is `period === 'annual' ? 12 : 1` after
+ * `handleCheckoutCompleted` normalizes the legacy `'2year'` to `'annual'`. The
+ * two must agree: a member who bought a year and renews should get a year.
+ */
+export function monthsForPeriod(period: string): number {
+  return period === 'monthly' ? 1 : 12;
+}
+
+/**
+ * Decide what an `invoice.paid` event should do.
+ *
+ * Takes the raw event object rather than a Stripe type because the webhook
+ * handler receives untyped JSON — every field here is treated as absent-until-
+ * proven, which is also what makes the skip cases testable.
+ */
+export function planRenewalFromInvoice(invoice: any): RenewalDecision {
+  // Only a recurring cycle extends a membership.
+  //
+  // The first invoice of a subscription carries `subscription_create` and is
+  // already covered by `checkout.session.completed`. Extending on that too
+  // would silently give every new card member double the term they paid for —
+  // and it would look like generosity rather than a bug, so nothing would
+  // report it. `subscription_update` (proration on a plan change) is excluded
+  // for the same reason: money moved, but not for another full period.
+  if (invoice?.billing_reason !== 'subscription_cycle') {
+    return {
+      action: 'skip',
+      reason: 'not-a-renewal-cycle',
+      value: invoice?.billing_reason
+    };
+  }
+
+  // `invoice.parent.subscription_details.metadata` is an immutable snapshot of
+  // the subscription's metadata taken when the invoice was finalized. It is NOT
+  // the checkout session's metadata — Stripe does not copy that onto the
+  // subscription, which is why `subscription_data.metadata` has to be set at
+  // checkout for any of this to resolve.
+  const metadata = invoice?.parent?.subscription_details?.metadata || {};
+  const { pubkey, tier, period } = metadata;
+
+  if (!pubkey) {
+    return { action: 'skip', reason: 'no-pubkey' };
+  }
+
+  if (typeof pubkey !== 'string' || !/^[0-9a-fA-F]{64}$/.test(pubkey)) {
+    return { action: 'skip', reason: 'invalid-pubkey', value: String(pubkey) };
+  }
+
+  // An unrecognized period is refused rather than defaulted. Guessing 12 gives
+  // away a year; guessing 1 strands an annual member eleven months early.
+  if (!period || !KNOWN_PERIODS.includes(period)) {
+    return { action: 'skip', reason: 'invalid-period', value: String(period) };
+  }
+
+  return {
+    action: 'renew',
+    pubkey,
+    subscriptionMonths: monthsForPeriod(period),
+    paymentId: renewalPaymentId(invoice.id),
+    period,
+    tier
+  };
+}

--- a/src/lib/stripeRenewal.ts
+++ b/src/lib/stripeRenewal.ts
@@ -21,7 +21,9 @@ export type RenewalSkipReason =
   /** Subscription predates `subscription_data.metadata`. Needs a human. */
   | 'no-pubkey'
   | 'invalid-pubkey'
-  | 'invalid-period';
+  | 'invalid-period'
+  /** No invoice id, so no idempotency key can be derived. */
+  | 'no-invoice-id';
 
 export interface RenewalPlan {
   action: 'renew';
@@ -90,12 +92,23 @@ export function planRenewalFromInvoice(invoice: any): RenewalDecision {
     };
   }
 
-  // `invoice.parent.subscription_details.metadata` is an immutable snapshot of
-  // the subscription's metadata taken when the invoice was finalized. It is NOT
-  // the checkout session's metadata — Stripe does not copy that onto the
-  // subscription, which is why `subscription_data.metadata` has to be set at
+  // The subscription's metadata snapshot, taken when the invoice was finalized.
+  // It is NOT the checkout session's metadata — Stripe does not copy that onto
+  // the subscription, which is why `subscription_data.metadata` has to be set at
   // checkout for any of this to resolve.
-  const metadata = invoice?.parent?.subscription_details?.metadata || {};
+  //
+  // Two shapes, because a webhook endpoint carries its OWN `api_version`,
+  // independent of the SDK's pinned one: `parent.subscription_details` is the
+  // Basil (2025-03-31) and later shape, `invoice.subscription_details` is what an
+  // endpoint pinned before Basil delivers. Reading both removes the dependency
+  // on a dashboard setting nobody here can see — on a pre-Basil endpoint the
+  // first is undefined for every delivery, so every renewal would skip as
+  // `no-pubkey`: logged as needing a human, and indistinguishable from the
+  // benign pre-deploy case.
+  const metadata =
+    invoice?.parent?.subscription_details?.metadata ||
+    invoice?.subscription_details?.metadata ||
+    {};
   const { pubkey, tier, period } = metadata;
 
   if (!pubkey) {
@@ -110,6 +123,16 @@ export function planRenewalFromInvoice(invoice: any): RenewalDecision {
   // away a year; guessing 1 strands an annual member eleven months early.
   if (!period || !KNOWN_PERIODS.includes(period)) {
     return { action: 'skip', reason: 'invalid-period', value: String(period) };
+  }
+
+  // The invoice id IS the idempotency key, and it is the only input here that
+  // reaches the relay unvalidated. Absent, `renewalPaymentId` yields the
+  // constant `stripe_renewal_undefined`, which the relay's `payment_id` guard
+  // would then treat as already-applied across UNRELATED members — the first
+  // such renewal writes it, every later one is silently declined. Refused rather
+  // than defaulted, for the same reason as `period`.
+  if (typeof invoice.id !== 'string' || !invoice.id) {
+    return { action: 'skip', reason: 'no-invoice-id' };
   }
 
   return {

--- a/src/lib/stripeRenewal.ts
+++ b/src/lib/stripeRenewal.ts
@@ -12,7 +12,15 @@
  * record never moves — the member is billed and locked out.
  */
 
-/** Periods `createCheckoutSession` has ever written into metadata. */
+/**
+ * Periods this accepts from subscription metadata.
+ *
+ * `createCheckoutSession` emits only `'annual' | 'monthly'` today — its own
+ * parameter type says so. `'2year'` is a legacy value: it was a real checkout
+ * period until monthly replaced it, so it can still be sitting in Stripe
+ * metadata on an old object, and `handleCheckoutCompleted` accepts it for that
+ * reason. It is kept here to match, not because this path emits it.
+ */
 const KNOWN_PERIODS = ['annual', '2year', 'monthly'] as const;
 
 export type RenewalSkipReason =

--- a/src/lib/stripeService.server.ts
+++ b/src/lib/stripeService.server.ts
@@ -103,6 +103,18 @@ export async function createCheckoutSession(params: {
       period: params.period,
       ...(params.pubkey ? { pubkey: params.pubkey } : {}),
     },
+    // Stripe does not copy session metadata onto the subscription it creates.
+    // Renewal invoices carry a snapshot of the SUBSCRIPTION's metadata
+    // (invoice.parent.subscription_details.metadata), so without this the
+    // invoice.paid handler has a customer and a subscription and no pubkey —
+    // no way to identify whose membership to extend.
+    subscription_data: {
+      metadata: {
+        tier: params.tier,
+        period: params.period,
+        ...(params.pubkey ? { pubkey: params.pubkey } : {}),
+      },
+    },
   });
   
   if (!session.url) {

--- a/src/routes/api/stripe/create-portal-session/+server.ts
+++ b/src/routes/api/stripe/create-portal-session/+server.ts
@@ -59,19 +59,59 @@ export const POST: RequestHandler = async ({ request, platform }) => {
       typescript: true,
     });
 
-    // Find the customer by searching checkout sessions with this pubkey in metadata
-    const sessions = await stripe.checkout.sessions.list({
-      limit: 10,
-    });
-
     let customerId: string | null = null;
 
-    for (const session of sessions.data) {
-      if (session.metadata?.pubkey === pubkey && session.customer) {
-        customerId = typeof session.customer === 'string'
-          ? session.customer
-          : session.customer.id;
-        break;
+    // Resolve pubkey -> customer from subscription metadata.
+    //
+    // createCheckoutSession stamps the pubkey onto `subscription_data.metadata`,
+    // so every subscription created from this deploy onward is addressable by
+    // it. That is the same write the invoice.paid renewal handler reads, used in
+    // the other direction: the renewal needs Stripe object -> pubkey, the portal
+    // needs pubkey -> Stripe object.
+    //
+    // Cancelled and past_due subscriptions are searchable too, which is correct
+    // here — a member managing their billing is often exactly the member whose
+    // subscription is no longer active.
+    try {
+      const found = await stripe.subscriptions.search({
+        query: `metadata['pubkey']:'${pubkey}'`,
+        limit: 1,
+      });
+
+      const subscription = found.data[0];
+      if (subscription?.customer) {
+        customerId = typeof subscription.customer === 'string'
+          ? subscription.customer
+          : subscription.customer.id;
+      }
+    } catch (searchError: any) {
+      // Search is a separate Stripe surface with its own index and its own
+      // failure modes. Losing it must not take the portal down — the fallback
+      // below is what shipped before this and still resolves recent checkouts.
+      console.error('[Stripe Portal] Subscription metadata search failed, falling back:', searchError?.message);
+    }
+
+    // Fallback: walk recent checkout sessions.
+    //
+    // Retained, not replaced. It is the only path that resolves a customer for
+    // a subscription created before subscription_data.metadata was added, and
+    // the only one that resolves a one-time `mode: 'payment'` customer (the
+    // Founders) at all, since those have no subscription to search. Its known
+    // limit is that it is account-wide and capped at 10, so it silently stops
+    // working for anyone who is not among the last ten checkouts platform-wide.
+    // Deleting it is a separate decision from adding the search above.
+    if (!customerId) {
+      const sessions = await stripe.checkout.sessions.list({
+        limit: 10,
+      });
+
+      for (const session of sessions.data) {
+        if (session.metadata?.pubkey === pubkey && session.customer) {
+          customerId = typeof session.customer === 'string'
+            ? session.customer
+            : session.customer.id;
+          break;
+        }
       }
     }
 

--- a/src/routes/api/stripe/webhook/+server.ts
+++ b/src/routes/api/stripe/webhook/+server.ts
@@ -8,15 +8,22 @@
  *
  * Events handled:
  *  - checkout.session.completed  — registers member after successful payment
+ *  - invoice.paid                — extends membership on a recurring renewal
  *  - customer.subscription.updated — logs subscription changes
  *  - customer.subscription.deleted — logs cancellation
+ *
+ * `invoice.payment_succeeded` is intentionally NOT handled: Stripe fires it for
+ * the same invoice as `invoice.paid`, so handling both would race two renewals
+ * for one payment. `invoice.paid` must be enabled on the endpoint in the Stripe
+ * Dashboard or renewals will silently do nothing.
  *
  * Configure in Stripe Dashboard > Webhooks with signing secret in STRIPE_WEBHOOK_SECRET.
  */
 
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
-import { registerMember } from '$lib/memberRegistration.server';
+import { registerMember, renewMember } from '$lib/memberRegistration.server';
+import { planRenewalFromInvoice } from '$lib/stripeRenewal';
 
 export const POST: RequestHandler = async ({ request, platform }) => {
   // Membership feature flag guard
@@ -77,6 +84,11 @@ export const POST: RequestHandler = async ({ request, platform }) => {
         break;
       }
 
+      case 'invoice.paid': {
+        await handleInvoicePaid(event.data.object, platform);
+        break;
+      }
+
       case 'customer.subscription.updated': {
         const subscription = event.data.object;
         console.log('[Stripe Webhook] Subscription updated:', {
@@ -84,7 +96,9 @@ export const POST: RequestHandler = async ({ request, platform }) => {
           status: subscription.status,
           currentPeriodEnd: subscription.current_period_end,
         });
-        // Future: extend subscription on renewal
+        // Renewal extension is driven by invoice.paid, not by this event —
+        // subscription.updated fires for plan/price/status changes too, and
+        // carries no signal that money actually moved.
         break;
       }
 
@@ -199,4 +213,97 @@ async function handleCheckoutCompleted(session: any, platform: any) {
     // Don't throw — webhook should still return 200 to prevent Stripe retries
     // The client-side complete-payment flow serves as a fallback
   }
+}
+
+/**
+ * Handle invoice.paid for a recurring subscription cycle.
+ *
+ * Extends the member's subscription_end by one billing period. This is the only
+ * path that keeps a card member active past their first term — Stripe fires
+ * checkout.session.completed on the initial checkout only.
+ *
+ * Unlike handleCheckoutCompleted, relay failures here are RETHROWN so the
+ * endpoint returns 500 and Stripe redelivers. Registration has a client-side
+ * fallback; renewal has none, so a swallowed error is a lost renewal and a
+ * member locked out of access they paid for. Validation failures are still
+ * logged-and-returned — a redelivery cannot fix missing metadata.
+ */
+async function handleInvoicePaid(invoice: any, platform: any) {
+  const decision = planRenewalFromInvoice(invoice);
+
+  if (decision.action === 'skip') {
+    // 'no-pubkey' is the one skip that needs a person. It means a live card
+    // subscription was created before subscription_data.metadata existed, so
+    // nothing in this codebase can say whose membership to extend — it has to
+    // be reconciled by hand against the Stripe customer. Everything else here
+    // is an ordinary event we are correct to ignore.
+    if (decision.reason === 'no-pubkey') {
+      const subscriptionDetails = invoice?.parent?.subscription_details;
+      console.error('[Stripe Webhook] Renewal invoice has no pubkey in subscription metadata — manual reconciliation required:', {
+        invoiceId: invoice?.id,
+        customer: invoice?.customer,
+        subscription: typeof subscriptionDetails?.subscription === 'string'
+          ? subscriptionDetails.subscription
+          : subscriptionDetails?.subscription?.id,
+      });
+      return;
+    }
+
+    if (decision.reason === 'not-a-renewal-cycle') {
+      console.log('[Stripe Webhook] Invoice paid, not a renewal cycle — skipping:', {
+        invoiceId: invoice?.id,
+        billingReason: decision.value,
+      });
+      return;
+    }
+
+    console.error(`[Stripe Webhook] Renewal invoice rejected (${decision.reason}):`, {
+      invoiceId: invoice?.id,
+      value: decision.value,
+    });
+    return;
+  }
+
+  console.log('[Stripe Webhook] Renewal invoice paid:', {
+    invoiceId: invoice.id,
+    tier: decision.tier,
+    period: decision.period,
+    subscriptionMonths: decision.subscriptionMonths,
+  });
+
+  const API_SECRET = platform?.env?.RELAY_API_SECRET || env.RELAY_API_SECRET;
+  if (!API_SECRET) {
+    console.error('[Stripe Webhook] RELAY_API_SECRET not configured');
+    return;
+  }
+
+  const result = await renewMember({
+    pubkey: decision.pubkey,
+    subscriptionMonths: decision.subscriptionMonths,
+    paymentId: decision.paymentId,
+    apiSecret: API_SECRET,
+  });
+
+  if (result.notFound) {
+    console.error('[Stripe Webhook] Renewal for a pubkey with no membership record — nothing extended:', {
+      invoiceId: invoice.id,
+      pubkey: decision.pubkey.substring(0, 16) + '...',
+    });
+    return;
+  }
+
+  if (result.alreadyApplied) {
+    console.log('[Stripe Webhook] Renewal already applied (repeat delivery):', {
+      invoiceId: invoice.id,
+      pubkey: decision.pubkey.substring(0, 16) + '...',
+    });
+    return;
+  }
+
+  console.log('[Stripe Webhook] Membership renewed:', {
+    invoiceId: invoice.id,
+    pubkey: decision.pubkey.substring(0, 16) + '...',
+    subscriptionMonths: decision.subscriptionMonths,
+    subscriptionEnd: result.subscriptionEnd,
+  });
 }

--- a/src/routes/api/stripe/webhook/+server.ts
+++ b/src/routes/api/stripe/webhook/+server.ts
@@ -238,7 +238,11 @@ async function handleInvoicePaid(invoice: any, platform: any) {
     // be reconciled by hand against the Stripe customer. Everything else here
     // is an ordinary event we are correct to ignore.
     if (decision.reason === 'no-pubkey') {
-      const subscriptionDetails = invoice?.parent?.subscription_details;
+      // Both shapes, matching planRenewalFromInvoice — otherwise the one log line
+      // that exists for the case needing a human names no subscription at all on
+      // a pre-Basil endpoint.
+      const subscriptionDetails =
+        invoice?.parent?.subscription_details || invoice?.subscription_details;
       console.error('[Stripe Webhook] Renewal invoice has no pubkey in subscription metadata — manual reconciliation required:', {
         invoiceId: invoice?.id,
         customer: invoice?.customer,
@@ -257,8 +261,12 @@ async function handleInvoicePaid(invoice: any, platform: any) {
       return;
     }
 
+    // `customer` is logged alongside the invoice id because one of these reasons
+    // is a MISSING invoice id, and without the customer that line names nothing
+    // anyone could reconcile against.
     console.error(`[Stripe Webhook] Renewal invoice rejected (${decision.reason}):`, {
       invoiceId: invoice?.id,
+      customer: invoice?.customer,
       value: decision.value,
     });
     return;

--- a/src/routes/api/stripe/webhook/+server.ts
+++ b/src/routes/api/stripe/webhook/+server.ts
@@ -225,8 +225,10 @@ async function handleCheckoutCompleted(session: any, platform: any) {
  * Unlike handleCheckoutCompleted, relay failures here are RETHROWN so the
  * endpoint returns 500 and Stripe redelivers. Registration has a client-side
  * fallback; renewal has none, so a swallowed error is a lost renewal and a
- * member locked out of access they paid for. Validation failures are still
- * logged-and-returned — a redelivery cannot fix missing metadata.
+ * member locked out of access they paid for. A missing RELAY_API_SECRET is
+ * thrown for the same reason — it is a misconfiguration a redelivery can outlive.
+ * Only validation failures are logged-and-returned, because a redelivery carries
+ * the same absent metadata and can never do better.
  */
 async function handleInvoicePaid(invoice: any, platform: any) {
   const decision = planRenewalFromInvoice(invoice);
@@ -279,10 +281,19 @@ async function handleInvoicePaid(invoice: any, platform: any) {
     subscriptionMonths: decision.subscriptionMonths,
   });
 
+  // A missing secret is a server misconfiguration, not a bad event, so it is
+  // THROWN rather than returned: returning would answer Stripe 200 and drop the
+  // renewal permanently, and a redelivery genuinely can succeed once the binding
+  // is fixed — Stripe retries over ~3 days, which is long enough for a person to
+  // notice and bind it. That is the same reasoning as the 404 discrimination in
+  // `renewMember`, and the opposite of the validation skips above, where a
+  // redelivery carries the same absent metadata and can never do better.
   const API_SECRET = platform?.env?.RELAY_API_SECRET || env.RELAY_API_SECRET;
   if (!API_SECRET) {
-    console.error('[Stripe Webhook] RELAY_API_SECRET not configured');
-    return;
+    console.error('[Stripe Webhook] RELAY_API_SECRET not configured — renewal not applied, letting Stripe redeliver:', {
+      invoiceId: invoice.id,
+    });
+    throw new Error('RELAY_API_SECRET not configured');
   }
 
   const result = await renewMember({

--- a/src/routes/api/stripe/webhook/renewalRetry.test.ts
+++ b/src/routes/api/stripe/webhook/renewalRetry.test.ts
@@ -1,0 +1,182 @@
+/**
+ * What the renewal path answers Stripe, and why the answer matters.
+ *
+ * Stripe redelivers on any non-2xx and on timeout, and STOPS on a 2xx. So the
+ * status code is the whole retry policy: a 200 on a renewal that did not happen
+ * drops it permanently, and the member is billed and locked out with nothing but
+ * a log line. The handler therefore has to split two cases that look alike from
+ * inside a `catch`:
+ *
+ *  - it CANNOT ever work (absent/invalid metadata) → 200, because a redelivery
+ *    carries the same absent metadata.
+ *  - it could work later (misconfigured secret, relay down) → non-2xx, because a
+ *    redelivery over Stripe's ~3-day window can outlive the outage.
+ *
+ * These tests pin that split. They exist because the missing-`RELAY_API_SECRET`
+ * branch was on the wrong side of it, and no test in this repo reached the
+ * handler at all — `stripeRenewal.test.ts` covers the decision, and
+ * `memberRegistration.renew.test.ts` covers the relay call, but neither sees
+ * which status the endpoint returns.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { env } from '$env/dynamic/private';
+
+const mocks = vi.hoisted(() => ({
+  renewMember: vi.fn(),
+  registerMember: vi.fn()
+}));
+
+vi.mock('$lib/memberRegistration.server', () => ({
+  renewMember: mocks.renewMember,
+  registerMember: mocks.registerMember
+}));
+
+// The handler dynamically imports `stripe` and only uses it to verify the
+// signature, so the stub hands the parsed body straight back as the event.
+vi.mock('stripe', () => {
+  class StripeStub {
+    webhooks = {
+      constructEvent: (rawBody: string) => JSON.parse(rawBody)
+    };
+  }
+  return { default: StripeStub };
+});
+
+import { POST } from './+server';
+
+const PUBKEY = 'a'.repeat(64);
+
+/** A renewal invoice that `planRenewalFromInvoice` accepts outright. */
+function renewalInvoice(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'in_renewal_1',
+    customer: 'cus_1',
+    billing_reason: 'subscription_cycle',
+    parent: {
+      subscription_details: {
+        subscription: 'sub_1',
+        metadata: { pubkey: PUBKEY, tier: 'cook', period: 'monthly' }
+      }
+    },
+    ...overrides
+  };
+}
+
+function post(invoice: unknown, platformEnv: Record<string, string> = {}) {
+  const request = new Request('https://zap.cooking/api/stripe/webhook', {
+    method: 'POST',
+    headers: { 'stripe-signature': 'sig' },
+    body: JSON.stringify({ id: 'evt_1', type: 'invoice.paid', data: { object: invoice } })
+  });
+  return POST({
+    request,
+    platform: {
+      env: {
+        MEMBERSHIP_ENABLED: 'true',
+        STRIPE_SECRET_KEY: 'sk_test',
+        STRIPE_WEBHOOK_SECRET: 'whsec_test',
+        ...platformEnv
+      }
+    }
+  } as never);
+}
+
+beforeEach(() => {
+  mocks.renewMember.mockReset().mockResolvedValue({
+    renewed: true,
+    alreadyApplied: false,
+    notFound: false,
+    subscriptionEnd: '2026-09-01T00:00:00Z'
+  });
+  mocks.registerMember.mockReset();
+  // envMock is shared and mutable; RELAY_API_SECRET must be absent unless a test
+  // puts it there, or the misconfiguration case silently stops being one.
+  delete env.RELAY_API_SECRET;
+});
+
+describe('invoice.paid retry semantics', () => {
+  it('500s without RELAY_API_SECRET so Stripe redelivers once it is bound', async () => {
+    const res = await post(renewalInvoice());
+
+    expect(res.status).toBe(500);
+    // Nothing was attempted, so nothing to reconcile — only the retry is owed.
+    expect(mocks.renewMember).not.toHaveBeenCalled();
+  });
+
+  it('reads RELAY_API_SECRET from process env when platform has none', async () => {
+    env.RELAY_API_SECRET = 'from-env';
+
+    const res = await post(renewalInvoice());
+
+    expect(res.status).toBe(200);
+    expect(mocks.renewMember.mock.calls[0][0].apiSecret).toBe('from-env');
+  });
+
+  it('200s and applies the renewal when the secret is bound', async () => {
+    const res = await post(renewalInvoice(), { RELAY_API_SECRET: 'shh' });
+
+    expect(res.status).toBe(200);
+    expect(mocks.renewMember).toHaveBeenCalledWith({
+      pubkey: PUBKEY,
+      subscriptionMonths: 1,
+      paymentId: 'stripe_renewal_in_renewal_1',
+      apiSecret: 'shh'
+    });
+  });
+
+  it('200s on a metadata skip even with no secret — the secret check is downstream', async () => {
+    // The discrimination the fix turns on: this invoice can never be renewed by
+    // any redelivery, so it must NOT be dragged into the 500 path. If the secret
+    // check ran before the decision, this would 500 forever on every unrelated
+    // pre-metadata subscription's renewal.
+    const res = await post(
+      renewalInvoice({ parent: { subscription_details: { subscription: 'sub_old' } } })
+    );
+
+    expect(res.status).toBe(200);
+    expect(mocks.renewMember).not.toHaveBeenCalled();
+  });
+
+  it('200s on the first invoice of a subscription without touching the relay', async () => {
+    const res = await post(renewalInvoice({ billing_reason: 'subscription_create' }), {
+      RELAY_API_SECRET: 'shh'
+    });
+
+    expect(res.status).toBe(200);
+    expect(mocks.renewMember).not.toHaveBeenCalled();
+  });
+
+  it('500s when the relay call throws, so the renewal is redelivered', async () => {
+    mocks.renewMember.mockRejectedValue(new Error('Failed to renew member: 503 upstream'));
+
+    const res = await post(renewalInvoice(), { RELAY_API_SECRET: 'shh' });
+
+    expect(res.status).toBe(500);
+  });
+
+  it('200s when the relay says the member does not exist — terminal, not retryable', async () => {
+    mocks.renewMember.mockResolvedValue({
+      renewed: false,
+      alreadyApplied: false,
+      notFound: true,
+      subscriptionEnd: null
+    });
+
+    const res = await post(renewalInvoice(), { RELAY_API_SECRET: 'shh' });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('200s on a redelivery the relay has already applied', async () => {
+    mocks.renewMember.mockResolvedValue({
+      renewed: false,
+      alreadyApplied: true,
+      notFound: false,
+      subscriptionEnd: '2026-09-01T00:00:00Z'
+    });
+
+    const res = await post(renewalInvoice(), { RELAY_API_SECRET: 'shh' });
+
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
**Ready for review at `5f394c9`.** The draft gate this PR opened with — *"does not go green without Dr Sats reading it, and must not merge before member-relay#13 is deployed"* — was **overruled by Chief on 2026-07-30 01:56Z, and the reasoning is on the record**: `renewMember`'s only caller is the `invoice.paid` branch, and Stripe does not deliver an event that is not ticked on the endpoint, so merging this cannot renew anything until the dashboard tick. The order that binds is **member-relay#13 deployed → then tick `invoice.paid`**, and it is unchanged. Dr Sats' two rulings (term policy, whether Founders need portal access) are still outstanding and were declared non-blocking for the merge.

## Review round 1 — three edits applied at `5f394c9`

@Prep reviewed this at `a29e2cd` and found two defects the tests structurally could not reach; @Chief found the third. All three are fixed in one commit, and the claims they falsified are corrected in place below rather than deleted, so the reasoning stays legible.

1. **The metadata read depended on a value nobody had read — the webhook endpoint's own `api_version`.** `invoice.parent` exists only on Stripe API version Basil (2025-03-31) and later, and an endpoint carries its own version independent of the SDK's pinned `2025-12-15.clover`. On a pre-Basil endpoint that field is `undefined` on **every** delivery, so every renewal skipped as `no-pubkey` — logged as "manual reconciliation required," indistinguishable from the benign pre-deploy case, silent and in the money direction. Now reads the pre-Basil `invoice.subscription_details.metadata` as a fallback, so the outcome no longer depends on a dashboard setting invisible from the repo. **This is what makes Prep's "read the API version on the same trip" step unnecessary.** The `no-pubkey` log line reads both shapes too, or the one line that exists for the case needing a human names no subscription at all.
2. **The 404 branch contradicted its own stated reasoning.** `renewMember` rethrew every non-2xx except 404, which returned `notFound` → handler logs → Stripe gets a 200 → **renewal dropped permanently**, directly against the rethrow rationale written above it. 404 is now terminal only when the body is the relay's own `{"error":"Member not found"}` (`member-relay api/index.ts:357`, exact match — not a substring, not "has an error field"). Anything else answering 404 is rethrown for redelivery, which matters because the proxy can answer 404 while the API container restarts — precisely the window `docker compose up -d api` opens for #13's deploy.
3. **`invoice.id` was the one input reaching the relay unvalidated** while pubkey and period were both checked. Absent, the idempotency key is the constant `stripe_renewal_undefined`, which #13's `payment_id` guard would then treat as already-applied **across unrelated members** — the first such renewal writes it, every later one is silently declined. Now refused as `no-invoice-id`. The generic rejection log gained `customer`, because a missing-invoice-id line that names no invoice names nothing anyone could reconcile against.

Prep's two other findings are **not** in this diff, by his own recommendation: `create-session/+server.ts` never validating `pubkey` (a subscription minted without one can never be renewed — the durable fix is the `/^[0-9a-fA-F]{64}$/` gate already used at `create-portal-session/+server.ts:44`), and `KNOWN_PERIODS` including a `'2year'` that only ever appeared in *session* metadata, making that branch unreachable and its test a fixture testing a fixture. Seth ruled the `2year` branch stays.

## The bug

A card renews at Stripe and the membership record does not move. **The member is billed and locked out.**

Verified at `0147316` / member-relay `c44a299`:

- `checkout.session.completed` is the only event that ever wrote a membership, and Stripe fires it on the **initial checkout only**.
- Renewals arrive as invoices. `invoice.paid` / `invoice.payment_succeeded` were handled **nowhere in `src`**. `customer.subscription.updated` was a `console.log` whose own comment read `// Future: extend subscription on renewal`.
- `member-relay api/cron.ts:29` flips `active` → `grace` once `subscription_end < NOW()`, and grace grants nothing — `api/index.ts:301` and `:326` both additionally require `subscription_end > NOW()`.
- Monthly is live at $4.99 (`membership/+page.svelte:24`), so the first monthly buyer's access ends **~30 days after they pay**, and `membership/+page.svelte:57` tells them the opposite.

**Zero card subscriptions exist today**, so this fix is forward-only *and* complete. Every card sale that lands before it deploys is a subscription that permanently needs manual Stripe-to-pubkey reconciliation, one member at a time. The deadline is not a date, it is the first card sale.

## Why the identity write is the actual fix

Stripe does not copy checkout-session metadata onto the subscription it creates. `invoice.paid` therefore arrived carrying a customer and a subscription and **no pubkey** — the handler had nothing to look the member up by. That is why it was left as a log line, and it is the whole reason this took a design rather than a case statement.

`subscription_data.metadata` at checkout is what makes the rest possible. The invoice carries an immutable snapshot of it at `parent.subscription_details.metadata` (confirmed in the pinned typings, `stripe@20.1.0`, `Invoices.d.ts:1052-1057`, API version `2025-12-15.clover`) — **and, per edit 1 above, at `invoice.subscription_details.metadata` on an endpoint pinned before Basil. The typings only describe the version the SDK is pinned to, not the version the endpoint delivers, which is why reading one shape was a dependency on a dashboard setting rather than on the code.**

**And the same write serves the portal in the other direction**, which is @Growth's second gate clause. `create-portal-session:62-73` resolved pubkey → customer by walking `stripe.checkout.sessions.list({limit: 10})` **account-wide** — so a member who wanted to cancel was findable only if they were among the platform's last ten checkouts, and a member who cannot cancel keeps getting charged. It now searches subscriptions by that metadata first.

The `sessions.list` walk is **retained as a fallback, not replaced**. It is the only path that resolves a customer for a subscription created before this deploy, and the only one that resolves a one-time `mode: 'payment'` customer (the Founders) at all, since those have no subscription to search. Deleting it is a separate decision from adding the search. Nothing gets worse for anyone.

This is *not* the pubkey ↔ customer column (PR-0). That column is still the durable answer — it needs no search index, and it covers one-time payments. This closes both directions of the gate from one write, with no schema change and no backfill.

## Two traps, both guarded and both tested

**1. `invoice.paid` fires for the first invoice too.** `billing_reason: 'subscription_create'` — the same payment `checkout.session.completed` already handled. Extending on it as well would give every new card member **double the term they paid for**: silently, in their favour, so nothing would report it. Only `'subscription_cycle'` renews; `subscription_update` (proration) is excluded for the same reason.

**2. Stripe redelivers on any non-2xx and on timeout.** The key is `stripe_renewal_{invoice.id}`, written to the relay's `payment_id`.

**The check is deliberately not in this repo.** Two reasons:

- It *cannot* be. `member-relay GET /api/members/:pubkey` (`api/index.ts:282-293`) does not `SELECT` `payment_id`. `lookupMember(...).member.payment_id` is **always `undefined`** — the field is on the TypeScript type and never on the wire. My first cut of this PR checked exactly that field, and it would have shipped a guard that could never fire.
- It *should* not be. A read-then-write across a network is not atomic: two concurrent redeliveries both read "not yet applied" and both renew.

**member-relay#13** puts it in the `UPDATE`'s `WHERE` clause and answers `action: 'already_applied'`. **That PR must deploy first** — against a relay without it, every redelivery renews again.

`renewMember` also cannot be `registerMember`: `memberRegistration.server.ts:42` returns early when the member is already active, which is precisely the case a renewal is for.

Relay failures are **rethrown** so the endpoint 500s and Stripe redelivers — registration has a client-side fallback, renewal has none, and a swallowed error is a member locked out of access they paid for. **The single exception is a 404 whose body is the relay's own `Member not found`, which is terminal because a redelivery cannot conjure a membership record; as of edit 2 above, every other 404 is rethrown like anything else.** Validation failures are logged and swallowed; a redelivery cannot fix absent metadata. The one that needs a person, `no-pubkey`, logs the customer and subscription ids for manual reconciliation.

## Shape

`planRenewalFromInvoice` is split into `src/lib/stripeRenewal.ts` as a pure function so the decision is testable without a Stripe account, a relay, or a network. The handler does logging and the relay call.

## Verified

Re-run at `5f394c9`, in the `wt-stripe-renewal` worktree, on one machine:

- `svelte-check` — **0 errors**, 150 warnings.
- Full suite (`vitest run`, not scoped) — **994 passed, 0 failed, 62 files**. The two `googleBackup/googleBackupCrypto.test.ts` failures reported at `a29e2cd` did not recur; they are a 5s timeout on 600k-round PBKDF2 under parallel load, a pre-existing flake either way, and worth a `testTimeout` eventually.
- **24 new tests** (15 at `a29e2cd` + 9 in round 1), mutation-checked one at a time. At `a29e2cd`: removing the `billing_reason` guard fails 3, defaulting an unknown period fails 2, making the payment id time-varying fails 1. Round 1: dropping the pre-Basil fallback fails 1, reversing the two shapes' precedence fails 1, dropping the `invoice.id` guard fails 1, reverting the 404 check to status-only fails 1, and loosening it to a substring match fails 1. Five mutants built, run, and restored.
- `renewMember` had **no test coverage at all** before round 1 — the 404 discrimination, both success paths, and the request body are now covered in `src/lib/memberRegistration.renew.test.ts`.
- Prettier: `memberRegistration.server.ts` and `stripe/webhook/+server.ts` were **already dirty at `a29e2cd`** (baseline restored in-repo and checked there, not in `/tmp`) — not reformatted; the diffs prettier wants in them are on pre-existing lines. All three new files are clean. Note the CI `lint` job is `continue-on-error: true` (`checks.yaml:87-91`) against ~563 files of repo-wide formatting debt, so this is convention, not a gate.

## Not verified — and this is the honest limit of it

**Nothing here has been exercised against Stripe.** No live `invoice.paid`, no live `subscriptions.search`, no live renewal. Verifying it needs a Stripe test-mode subscription with a test clock advanced past a cycle, which I cannot run. What is tested is the decision logic; what is not tested is that Stripe sends what the typings say it sends.

**`invoice.paid` must be enabled on the endpoint in the Stripe Dashboard** or renewals will silently do nothing. That is a console action, not a code one, and it comes **after** member-relay#13 is deployed.

**"Zero card subscriptions exist today" is a Stripe dashboard fact, and nobody in this repo has read it** — Prep's point, and it is fair against the claim made near the top of this body, which was derived from our own records. If even one live card subscription exists, that member is already on the billed-and-locked-out path and this PR logs them rather than saving them. One dashboard query answers it.

## Not in scope, and named so nobody assumes otherwise

`membership/+page.svelte:57`, `:42`, `:465` and `:471-472` are @Growth's, and she has stated she is **not** editing them: they are the only member-visible evidence the resolver was broken, and they go true together. Her position predates this PR — she should confirm whether the portal half here changes it. What we owe anyone billed for access they did not have is @Dr Sats'; if this lands before the first card sale, it is a question with no instances.

