### PR TITLE
Stop telling members we hold an encrypted copy of their Nostr private key

### DIFF
--- a/src/routes/delete-account/+page.svelte
+++ b/src/routes/delete-account/+page.svelte
@@ -58,8 +58,6 @@
       <li><strong>Your AI credit balance and usage records</strong> — Cheffy and Sous Chef</li>
       <li><strong>Your content stored on Pantry</strong>, the Nostr relay we operate at pantry.zap.cooking — recipes, posts, comments, reactions, and group messages held there</li>
       <li><strong>Any support correspondence</strong> associated with your account</li>
-      <li><strong>Your encrypted key backup</strong>, if you used the Google Drive backup feature — see the note below</li>
-      <li><strong>Your encrypted passkey vault</strong>, if you used passkey sign-in on the website — the encrypted copy of your key held on our servers</li>
     </ul>
 
     <p>We also issue deletion requests to other Nostr relays where we can identify your content.</p>
@@ -77,9 +75,9 @@
 
     <p><strong>Copies made by others.</strong> Anything published publicly may have been downloaded, screenshotted, or re-published by other users or services.</p>
 
-    <p><strong>Your keypair.</strong> Your Nostr private key belongs to you and exists independently of Zap Cooking. Deleting your Zap Cooking account does not delete or revoke your key, and you can continue using it with any other Nostr application. If you want to stop using the identity entirely, stop using the key — and consider publishing a NIP-62 request-to-vanish, which asks relays across the network to remove your data.</p>
+    <p><strong>Your keypair.</strong> Your Nostr private key belongs to you and exists independently of Zap Cooking. Protecting it with a passkey on the website keeps the encrypted copy in your own browser; it is not sent to us, so there is nothing of it for us to delete. Deleting your Zap Cooking account does not delete or revoke your key, and you can continue using it with any other Nostr application. If you want to stop using the identity entirely, stop using the key — and consider publishing a NIP-62 request-to-vanish, which asks relays across the network to remove your data.</p>
 
-    <p><strong>Your Google Drive backup.</strong> The encrypted backup is stored in your own Google Drive, in an app-specific folder we cannot read or access. We remove our ability to write to it; to delete the file itself, go to Google Drive → Settings → Manage apps → Zap Cooking → Delete hidden app data.</p>
+    <p><strong>Your Google Drive backup.</strong> The encrypted backup is stored in your own Google Drive, in an app-specific folder — Zap Cooking can see the backup files it put there, and nothing else in your Drive. We read that file when you restore your key, and it is encrypted before it leaves your device. Deleting your Zap Cooking account does not remove the file, and it does not withdraw the access you granted: to delete it, go to Google Drive → Settings → Manage apps → Zap Cooking → Delete hidden app data.</p>
 
     <hr style="border-color: var(--color-input-border)" />
 

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -87,7 +87,7 @@
 
     <p>The Service stores information on your device — application preferences in the mobile apps, and browser local storage on the website — to keep settings such as your theme, session state, and wallet connection details. This information stays on your device and is not sent to us.</p>
 
-    <p>Some settings are not only local. Your relay list and your mute and block lists are published to Nostr as events signed with your own key, which means they are stored on relays, including ours. Your private key stays on your device unless you choose to use one of our optional key backup features — Google Drive backup or passkey sign-in — each described in its own section below.</p>
+    <p>Some settings are not only local. Your relay list and your mute and block lists are published to Nostr as events signed with your own key, which means they are stored on relays, including ours. Your private key stays on your device unless you choose to use our optional Google Drive backup, described in its own section below. Protecting your key with a passkey does not send it anywhere — see section 8.</p>
 
     <h3 class="text-xl font-semibold mt-6 mb-3" style="color: var(--color-text-primary)">1.6 What we hold against your public key</h3>
 
@@ -204,17 +204,13 @@
     <p>If you do not use this feature, no Google integration occurs.</p>
 
     <!-- Section 8 -->
-    <h2 class="text-2xl font-bold mt-8 mb-4" style="color: var(--color-text-primary)">8. Passkey sign-in and encrypted key sync</h2>
+    <h2 class="text-2xl font-bold mt-8 mb-4" style="color: var(--color-text-primary)">8. Passkey protection</h2>
 
-    <p>On the Zap Cooking website you can optionally use a passkey to sign in. If you do, we store an encrypted copy of your Nostr private key on our servers, along with the public key of your passkey credential.</p>
+    <p>On the Zap Cooking website you can optionally protect your Nostr private key with a passkey — Face ID, Touch ID, or your device's screen lock. The key is encrypted on your device, and the encrypted copy stays on your device.</p>
 
-    <p><strong>We cannot read it.</strong> The key is encrypted on your device before it is sent, using a secret derived from your passkey that never leaves your device. What we hold is ciphertext we have no way to decrypt.</p>
+    <p><strong>Turning this on does not send your key to us.</strong> The encrypted copy is written to your browser's local storage and nowhere else.</p>
 
-    <p><strong>This means we cannot recover it for you.</strong> If you lose access to your passkey, we cannot restore your Nostr key from this backup, because we do not hold the means to decrypt it. Keep a separate copy of your key.</p>
-
-    <p>You can delete this stored copy at any time — see our <a href="/delete-account" class="text-primary hover:underline">Account and Data Deletion</a> page.</p>
-
-    <p>If you do not use passkey sign-in, we store no copy of your key.</p>
+    <p><strong>There is no recovery through us.</strong> If you lose access to your passkey and have no other copy of your key, the key is gone. Keep a separate copy — the backup file or the key you saved when you created your account.</p>
 
     <!-- Section 9 -->
     <h2 class="text-2xl font-bold mt-8 mb-4" style="color: var(--color-text-primary)">9. Crash reports</h2>


### PR DESCRIPTION
Our live privacy policy tells members we store an encrypted copy of their Nostr private key on our servers. We store none.

Ruled out of the Aug 1 passkey-flip queue by Dr Sats (exec, 2026-07-28) and ruled to ship with the next frontend deploy: *"The flip decision is should we hold members' keys. This is we say we already do, and we don't. Those are independent — the sentence is false under both branches."* Copy was drafted 2026-07-26 and reviewed by Prep; it had no owner, so I took it.

## The evidence, re-verified at `0147316` in this worktree

| claim | where |
|---|---|
| `PASSKEY_SYNC_ENABLED` is a hardcoded `false` | `src/lib/passkeySync.ts:43` |
| all four `uploadVault` call sites are behind it | `authManager.ts:1516`, `:1596`, `:1658`, `:1790` |
| enrollment writes to `localStorage` and nowhere else — zero `fetch` in the module | `passkeyVault.ts:34`, `:136`, `:141` |
| the antecedent is reachable, so it is a live false claim, not a dormant one | `PasskeyVaultSection` mounts unconditionally at `settings/+page.svelte:1489`; enroll gates on WebAuthn support, not on either flag |
| `restoreFromBackup` → `downloadBackup` | `googleBackup/googleBackupFlow.ts:59`, `googleBackup/driveBackup.ts:76` |
| Drive backup is live and has real members behind it | `googleBackup/googleBackupFlow.ts` imported only by `LoginOverlay.svelte` |
| Drive scope is `drive.appdata` only | `googleBackup/gis.ts:28` |
| `driveBackup.ts` exports `listBackups` / `downloadBackup` / `uploadBackup` and **no delete** — the Google menu path is the only control | `googleBackup/driveBackup.ts` |

## The seven edits

- **A** `privacy:90` — the key-backup list no longer names passkey sign-in.
- **B** `privacy:207` — heading. "Encrypted key sync" is not a thing we do.
- **C** `privacy:209` — five paragraphs about a stored copy become three about a local one.
- **D** `delete-account:62` — remove the passkey vault row. We delete nothing of it.
- **E** `delete-account:61` — remove the Drive row. It is in the "we permanently delete" list and the paragraph twenty lines down says we cannot.
- **F** `delete-account:82` — drop *"an app-specific folder we cannot read or access"* (we read it on restore) and *"we remove our ability to write to it"* (no revoke call exists in `src`; the Drive token is issued to the browser per gesture and never reaches our servers, so we hold nothing to revoke).
- **G** `delete-account:80` — the keypair paragraph gains the sentence it was missing, instead of a new paragraph twenty lines from the one that already owns the subject.

## Inventory vs mechanism — why the new copy never says "we store no copy"

Earlier drafts of C and G said *"We store no copy of your key."* That is an inventory claim about a live production KV: nothing writes it is a grep, whether it is empty is a read nobody has done. Prep killed it in review and the replacements state the mechanism only — *"turning this on does not send your key to us"*, *"written to your browser's local storage and nowhere else"* — which is the claim the code actually supports.

## Restore on flip

A, B, C and G's inserted clause are flag-dependent and revert verbatim if `PASSKEY_SYNC_ENABLED` is ever flipped. Restore text is in `OUTBOX/PRIVACY_PASSKEY_DISCLOSURE_MISMATCH_2026_07_26.md`. **E and F are wrong independent of any flag and do not go back.**

## Checks — what I ran, at `a5bacfc`, after this commit

- `pnpm check` — 0 errors, 150 warnings in 47 files (all pre-existing)
- `pnpm test` — 970 passed, 60 files
- `pnpm build` — succeeded
- `pnpm lint` — **prettier fails, and it fails identically on these two files at `origin/main`.** I checked out both files at `origin/main` and ran the same binary against them: same two warnings. The local prettier also reports `Ignored unknown option { pluginSearchDirs }`, i.e. it is not the version the repo config targets. CI is the authority here, not my shell.

Not exercised in a browser; neither page was rendered.

## Scoped

The four rows left in the delete list — membership records, AI credits, Pantry content, support correspondence — are claims about server-side deletion behaviour. **None of them were verified here.** Recorded so silence isn't read as clearance.

`privacy:202`'s *"We cannot read it"* is deliberately untouched: its object is the ciphertext, not the folder, immediately after "it is encrypted before it leaves your device". Defensible, and out of scope for this PR.
