### PR TITLE
fix(stripe): require NIP-98 auth on create-portal-session (gates the metadata backfill)

### DIFF
--- a/src/routes/api/stripe/create-portal-session/+server.ts
+++ b/src/routes/api/stripe/create-portal-session/+server.ts
@@ -12,6 +12,18 @@
  *   returnUrl: string     // URL to redirect back to after portal
  * }
  *
+ * Requires a NIP-98 `Authorization` header signed by `pubkey` itself
+ * (pair with signNip98AuthHeader in $lib/nip98). Unlike check-status,
+ * which degrades to a public shape when the signature is absent, this
+ * endpoint refuses: everything behind it is private billing data.
+ *
+ * The portal it opens is the member's whole Stripe billing console —
+ * cancel the subscription, read invoice history with name, email,
+ * billing address and card last4, change the payment method. A pubkey
+ * is public by construction on Nostr, so possession of one cannot be
+ * the credential. Before this gate, a request body was the only thing
+ * standing between any pubkey and that console.
+ *
  * Returns:
  * {
  *   url: string           // Stripe-hosted portal URL
@@ -20,6 +32,7 @@
 
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
+import { verifyNip98 } from '$lib/nip98.server';
 
 export const POST: RequestHandler = async ({ request, platform }) => {
   // Membership feature flag guard
@@ -28,23 +41,70 @@ export const POST: RequestHandler = async ({ request, platform }) => {
     return json({ error: 'Forbidden' }, { status: 403 });
   }
 
+  // Read the body bytes ONCE — NIP-98 payload verification and JSON
+  // parsing must see the same bytes (see verifyNip98's doc comment on
+  // body-consumption semantics on Cloudflare Workers).
+  let pubkey: unknown;
+  let returnUrl: unknown;
+  let bodyBytes: Uint8Array;
   try {
-    const body = await request.json();
-    const { pubkey, returnUrl } = body;
+    bodyBytes = new Uint8Array(await request.arrayBuffer());
+    ({ pubkey, returnUrl } = JSON.parse(new TextDecoder().decode(bodyBytes)));
+  } catch {
+    return json({ error: 'pubkey is required' }, { status: 400 });
+  }
 
-    if (!pubkey) {
-      return json({ error: 'pubkey is required' }, { status: 400 });
+  if (!pubkey || typeof pubkey !== 'string') {
+    return json({ error: 'pubkey is required' }, { status: 400 });
+  }
+
+  if (!returnUrl || typeof returnUrl !== 'string') {
+    return json({ error: 'returnUrl is required' }, { status: 400 });
+  }
+
+  // Validate pubkey format
+  if (!/^[0-9a-fA-F]{64}$/.test(pubkey)) {
+    return json({ error: 'Invalid pubkey format' }, { status: 400 });
+  }
+
+  // Identity gate. The pubkey in the body names whose billing console
+  // this opens, so it is exactly the pubkey that has to have signed.
+  // Ordered after the shape checks above because expectedPubkey is
+  // derived from the body — and before any Stripe call, so an
+  // unauthenticated request costs us no API request and learns nothing
+  // about whether that pubkey has a subscription.
+  const verification = await verifyNip98(request, {
+    expectedPubkey: pubkey.toLowerCase(),
+    bodyBytes
+  });
+  if (!verification.ok) {
+    console.warn('[Stripe Portal] NIP-98 rejected:', verification.reason);
+    return json({ error: 'forbidden' }, { status: 403 });
+  }
+
+  // Constrain the post-portal redirect to this deployment's own origin.
+  //
+  // Derived from `request.url`, NOT from the client-supplied `Origin`
+  // header: an attacker sets that header freely, so validating against
+  // it authorizes whatever it claims. (create-session/+server.ts:62-72
+  // validates its successUrl/cancelUrl against the header — same
+  // endpoint family, same weakness, separate change.)
+  //
+  // Relative values are resolved against that origin, so the common
+  // `window.location.href` and a bare `/settings` both pass.
+  const requestOrigin = new URL(request.url).origin;
+  let resolvedReturnUrl: string;
+  try {
+    const target = new URL(returnUrl, requestOrigin);
+    if (target.origin !== requestOrigin) {
+      return json({ error: 'returnUrl must match the request origin' }, { status: 400 });
     }
+    resolvedReturnUrl = target.toString();
+  } catch {
+    return json({ error: 'Invalid returnUrl format' }, { status: 400 });
+  }
 
-    if (!returnUrl) {
-      return json({ error: 'returnUrl is required' }, { status: 400 });
-    }
-
-    // Validate pubkey format
-    if (!/^[0-9a-fA-F]{64}$/.test(pubkey)) {
-      return json({ error: 'Invalid pubkey format' }, { status: 400 });
-    }
-
+  try {
     // Get Stripe secret key
     const stripeKey = platform?.env?.STRIPE_SECRET_KEY || env.STRIPE_SECRET_KEY;
     if (!stripeKey) {
@@ -125,7 +185,7 @@ export const POST: RequestHandler = async ({ request, platform }) => {
     // Create portal session
     const portalSession = await stripe.billingPortal.sessions.create({
       customer: customerId,
-      return_url: returnUrl,
+      return_url: resolvedReturnUrl,
     });
 
     return json({ url: portalSession.url });

--- a/src/routes/api/stripe/create-portal-session/portalAuth.test.ts
+++ b/src/routes/api/stripe/create-portal-session/portalAuth.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Who can open a member's Stripe billing console, and where it can send them back.
+ *
+ * The portal this endpoint creates is the member's whole billing console:
+ * cancel the subscription, read invoice history with name, email, billing
+ * address and card last4, change the payment method. Before the NIP-98 gate,
+ * the only thing standing between any caller and that console was a request
+ * body — and a Nostr pubkey is public by construction, so possession of one
+ * was never a credential.
+ *
+ * These tests pin the gate itself rather than the verifier (which
+ * src/lib/nip98.server.test.ts already covers exhaustively). What they exist
+ * to catch is the gate being bypassed at THIS route: an unsigned request, a
+ * request signed by the wrong key, a signature lifted from one body and
+ * replayed against another, and a signature valid for a different endpoint.
+ * Each of those reaches Stripe if the wiring is wrong, and each is silent.
+ *
+ * They also pin that no Stripe call happens before the gate — an
+ * unauthenticated caller must not be able to use response timing or a
+ * 404-vs-403 split to learn whether a given pubkey has a subscription.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { finalizeEvent, generateSecretKey, getPublicKey, type VerifiedEvent } from 'nostr-tools';
+import { normalizeUrl, sha256Hex } from '$lib/nip98';
+
+const ENDPOINT = 'https://zap.cooking/api/stripe/create-portal-session';
+
+const sk = generateSecretKey();
+const PUBKEY = getPublicKey(sk);
+const otherSk = generateSecretKey();
+const OTHER_PUBKEY = getPublicKey(otherSk);
+
+/** Records every Stripe surface the handler touches, so "did we call Stripe" is assertable. */
+const stripeCalls = vi.hoisted(() => ({
+  search: vi.fn(),
+  sessionsList: vi.fn(),
+  portalCreate: vi.fn()
+}));
+
+vi.mock('stripe', () => {
+  class StripeStub {
+    subscriptions = { search: stripeCalls.search };
+    checkout = { sessions: { list: stripeCalls.sessionsList } };
+    billingPortal = { sessions: { create: stripeCalls.portalCreate } };
+  }
+  return { default: StripeStub };
+});
+
+import { POST } from './+server';
+
+async function signAuthHeader(opts: {
+  bodyString: string;
+  url?: string;
+  method?: string;
+  secretKey?: Uint8Array;
+}): Promise<string> {
+  const tags: string[][] = [
+    ['u', normalizeUrl(opts.url ?? ENDPOINT)],
+    ['method', (opts.method ?? 'POST').toUpperCase()],
+    ['payload', await sha256Hex(new TextEncoder().encode(opts.bodyString))]
+  ];
+  const event: VerifiedEvent = finalizeEvent(
+    {
+      kind: 27235,
+      created_at: Math.floor(Date.now() / 1000),
+      tags,
+      content: ''
+    },
+    opts.secretKey ?? sk
+  );
+  return `Nostr ${btoa(JSON.stringify(event))}`;
+}
+
+function post(bodyString: string, authorization?: string) {
+  const headers = new Headers({ 'Content-Type': 'application/json' });
+  if (authorization) headers.set('Authorization', authorization);
+  const request = new Request(ENDPOINT, { method: 'POST', headers, body: bodyString });
+  return POST({
+    request,
+    platform: {
+      env: {
+        MEMBERSHIP_ENABLED: 'true',
+        STRIPE_SECRET_KEY: 'sk_test'
+      }
+    }
+  } as never);
+}
+
+function body(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    pubkey: PUBKEY,
+    returnUrl: 'https://zap.cooking/settings',
+    ...overrides
+  });
+}
+
+/** True when the handler reached Stripe at all, on any of its three surfaces. */
+function touchedStripe(): boolean {
+  return (
+    stripeCalls.search.mock.calls.length > 0 ||
+    stripeCalls.sessionsList.mock.calls.length > 0 ||
+    stripeCalls.portalCreate.mock.calls.length > 0
+  );
+}
+
+beforeEach(() => {
+  stripeCalls.search.mockReset().mockResolvedValue({
+    data: [{ customer: 'cus_1' }]
+  });
+  stripeCalls.sessionsList.mockReset().mockResolvedValue({ data: [] });
+  stripeCalls.portalCreate
+    .mockReset()
+    .mockResolvedValue({ url: 'https://billing.stripe.com/session/live_1' });
+});
+
+describe('create-portal-session — identity gate', () => {
+  it('opens the portal for a request signed by the pubkey it names', async () => {
+    const bodyString = body();
+    const response = await post(bodyString, await signAuthHeader({ bodyString }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      url: 'https://billing.stripe.com/session/live_1'
+    });
+    expect(stripeCalls.portalCreate).toHaveBeenCalledWith({
+      customer: 'cus_1',
+      return_url: 'https://zap.cooking/settings'
+    });
+  });
+
+  it('refuses an unsigned request — the pre-gate behaviour, and the whole point', async () => {
+    const response = await post(body());
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: 'forbidden' });
+    expect(touchedStripe()).toBe(false);
+  });
+
+  it('refuses a request signed by a different pubkey than the one in the body', async () => {
+    // The attack this closes: an attacker signs with their OWN key (which they
+    // can always do) and names the victim's pubkey in the body.
+    const bodyString = body();
+    const response = await post(
+      bodyString,
+      await signAuthHeader({ bodyString, secretKey: otherSk })
+    );
+
+    expect(response.status).toBe(403);
+    expect(touchedStripe()).toBe(false);
+  });
+
+  it('refuses a signature whose own pubkey is the victim but was signed for another body', async () => {
+    // Body-swap replay: a header legitimately signed for pubkey A's request is
+    // reused against a body naming pubkey A but a different returnUrl. The
+    // payload tag is what stops it.
+    const signedBody = body({ returnUrl: 'https://zap.cooking/settings' });
+    const sentBody = body({ returnUrl: 'https://zap.cooking/membership' });
+    const response = await post(sentBody, await signAuthHeader({ bodyString: signedBody }));
+
+    expect(response.status).toBe(403);
+    expect(touchedStripe()).toBe(false);
+  });
+
+  it('refuses a signature bound to a different endpoint', async () => {
+    // check-status is the endpoint the same page already signs for, so a
+    // lifted header is a realistic mistake as well as a realistic attack.
+    const bodyString = body();
+    const response = await post(
+      bodyString,
+      await signAuthHeader({
+        bodyString,
+        url: 'https://zap.cooking/api/membership/check-status'
+      })
+    );
+
+    expect(response.status).toBe(403);
+    expect(touchedStripe()).toBe(false);
+  });
+
+  it('accepts an uppercase pubkey in the body against a lowercase signer', async () => {
+    // Event pubkeys are lowercase hex; the body regex accepts either case. The
+    // gate lowercases before comparing, so this must not be a 403.
+    const bodyString = body({ pubkey: PUBKEY.toUpperCase() });
+    const response = await post(bodyString, await signAuthHeader({ bodyString }));
+
+    expect(response.status).toBe(200);
+  });
+
+  it('rejects a malformed pubkey before doing any signature or Stripe work', async () => {
+    const response = await post(body({ pubkey: 'not-a-pubkey' }));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'Invalid pubkey format' });
+    expect(touchedStripe()).toBe(false);
+  });
+
+  it('still rejects the pubkey-less body that handleManageSubscription sends', async () => {
+    // membership/+page.svelte:286 posts {sessionId, returnUrl} and has never
+    // worked. Pinned as unchanged by this PR, not fixed by it.
+    const response = await post(JSON.stringify({ sessionId: 'cs_1', returnUrl: '/membership' }));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'pubkey is required' });
+    expect(touchedStripe()).toBe(false);
+  });
+});
+
+describe('create-portal-session — returnUrl', () => {
+  it('rejects a foreign origin', async () => {
+    const bodyString = body({ returnUrl: 'https://evil.example/steal' });
+    const response = await post(bodyString, await signAuthHeader({ bodyString }));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: 'returnUrl must match the request origin'
+    });
+    expect(stripeCalls.portalCreate).not.toHaveBeenCalled();
+  });
+
+  it('resolves a relative returnUrl against the request origin', async () => {
+    const bodyString = body({ returnUrl: '/settings?tab=membership' });
+    const response = await post(bodyString, await signAuthHeader({ bodyString }));
+
+    expect(response.status).toBe(200);
+    expect(stripeCalls.portalCreate).toHaveBeenCalledWith({
+      customer: 'cus_1',
+      return_url: 'https://zap.cooking/settings?tab=membership'
+    });
+  });
+
+  it('rejects a protocol-relative URL pointing off-origin', async () => {
+    // `//evil.example/x` resolves to https://evil.example/x, not to a path.
+    // A naive startsWith('/') check would let this through.
+    const bodyString = body({ returnUrl: '//evil.example/x' });
+    const response = await post(bodyString, await signAuthHeader({ bodyString }));
+
+    expect(response.status).toBe(400);
+    expect(stripeCalls.portalCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a javascript: returnUrl', async () => {
+    const bodyString = body({ returnUrl: 'javascript:alert(1)' });
+    const response = await post(bodyString, await signAuthHeader({ bodyString }));
+
+    expect(response.status).toBe(400);
+    expect(stripeCalls.portalCreate).not.toHaveBeenCalled();
+  });
+
+  it('requires returnUrl at all', async () => {
+    const response = await post(JSON.stringify({ pubkey: PUBKEY }));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'returnUrl is required' });
+    expect(touchedStripe()).toBe(false);
+  });
+});
+
+describe('create-portal-session — unchanged behaviour', () => {
+  it('403s when the membership flag is off, before reading the body', async () => {
+    const request = new Request(ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: body()
+    });
+    const response = await POST({
+      request,
+      platform: { env: { MEMBERSHIP_ENABLED: 'false', STRIPE_SECRET_KEY: 'sk_test' } }
+    } as never);
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: 'Forbidden' });
+    expect(touchedStripe()).toBe(false);
+  });
+
+  it('404s an authenticated member with no resolvable Stripe customer', async () => {
+    stripeCalls.search.mockResolvedValue({ data: [] });
+    stripeCalls.sessionsList.mockResolvedValue({ data: [] });
+
+    const bodyString = body();
+    const response = await post(bodyString, await signAuthHeader({ bodyString }));
+
+    expect(response.status).toBe(404);
+    expect(stripeCalls.portalCreate).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the checkout-session walk when metadata search finds nothing', async () => {
+    stripeCalls.search.mockResolvedValue({ data: [] });
+    stripeCalls.sessionsList.mockResolvedValue({
+      data: [{ metadata: { pubkey: PUBKEY }, customer: 'cus_fallback' }]
+    });
+
+    const bodyString = body();
+    const response = await post(bodyString, await signAuthHeader({ bodyString }));
+
+    expect(response.status).toBe(200);
+    expect(stripeCalls.portalCreate).toHaveBeenCalledWith({
+      customer: 'cus_fallback',
+      return_url: 'https://zap.cooking/settings'
+    });
+  });
+
+  it('survives a metadata-search outage by falling back', async () => {
+    stripeCalls.search.mockRejectedValue(new Error('search index unavailable'));
+    stripeCalls.sessionsList.mockResolvedValue({
+      data: [{ metadata: { pubkey: PUBKEY }, customer: 'cus_fallback' }]
+    });
+
+    const bodyString = body();
+    const response = await post(bodyString, await signAuthHeader({ bodyString }));
+
+    expect(response.status).toBe(200);
+    expect(stripeCalls.portalCreate).toHaveBeenCalled();
+  });
+
+  it('does not leak a subscription-existence signal to an unauthenticated caller', async () => {
+    // A member WITH a subscription and a pubkey with none must be
+    // indistinguishable without a signature: same status, same body.
+    stripeCalls.search.mockResolvedValue({ data: [] });
+    const withNone = await post(body({ pubkey: OTHER_PUBKEY }));
+    stripeCalls.search.mockResolvedValue({ data: [{ customer: 'cus_1' }] });
+    const withOne = await post(body());
+
+    expect(withNone.status).toBe(withOne.status);
+    expect(await withNone.json()).toEqual(await withOne.json());
+    expect(touchedStripe()).toBe(false);
+  });
+});

--- a/src/routes/membership/+page.svelte
+++ b/src/routes/membership/+page.svelte
@@ -3,6 +3,7 @@
   import { goto } from '$app/navigation';
   import { onDestroy } from 'svelte';
   import { userPublickey } from '$lib/nostr';
+  import { signNip98AuthHeader } from '$lib/nip98';
   import { membershipStore, formatMembershipExpiry } from '$lib/membershipStore';
   import {
     membershipStatusMap,
@@ -119,38 +120,64 @@
 
     // Try Stripe portal first — works for any card member regardless of local state.
     // Falls back to email if no Stripe subscription is found (404).
+    //
+    // The portal endpoint requires NIP-98 auth signed by this pubkey. A member
+    // without a signer (read-only session) cannot produce one, so skip straight
+    // to the email fallback rather than sending a request that can only 403 —
+    // that keeps the outcome for those members exactly what it was before the
+    // gate: a human they can write to.
+    const bodyString = JSON.stringify({
+      pubkey: $userPublickey,
+      returnUrl: window.location.href
+    });
+    let authorization: string | null = null;
     try {
-      const response = await fetch('/api/stripe/create-portal-session', {
+      authorization = await signNip98AuthHeader($ndk, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          pubkey: $userPublickey,
-          returnUrl: window.location.href
-        })
+        url: `${location.origin}/api/stripe/create-portal-session`,
+        bodyString
       });
+    } catch (err) {
+      console.error('[Membership] NIP-98 signing unavailable, using email fallback:', err);
+    }
 
-      if (response.ok) {
-        const { url } = await response.json();
-        if (url) {
-          window.location.href = url;
+    if (authorization) {
+      try {
+        const response = await fetch('/api/stripe/create-portal-session', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: authorization },
+          body: bodyString
+        });
+
+        if (response.ok) {
+          const { url } = await response.json();
+          if (url) {
+            window.location.href = url;
+            return;
+          }
+        }
+
+        // 404 = no Stripe subscription found → fall through to email.
+        // 403 = auth rejected. Also a fall-through: the response body is a
+        // greppable server string, not copy to show a member, and the email
+        // path reaches a person who can cancel it by hand.
+        if (response.status !== 404 && response.status !== 403) {
+          const errData = await response
+            .json()
+            .catch(() => ({ error: 'Failed to open cancellation portal' }));
+          throw new Error(errData.error || 'Failed to open cancellation portal');
+        }
+        if (response.status === 403) {
+          console.error('[Membership] Portal rejected NIP-98 auth, using email fallback');
+        }
+      } catch (err) {
+        // If we got a real error (not a 404/403 fallthrough), show it and stop
+        if (err instanceof Error) {
+          console.error('[Membership] Cancel error:', err);
+          cancelError = err.message;
+          cancellingMembership = false;
           return;
         }
-      }
-
-      // 404 = no Stripe subscription found → fall through to email
-      if (response.status !== 404) {
-        const errData = await response
-          .json()
-          .catch(() => ({ error: 'Failed to open cancellation portal' }));
-        throw new Error(errData.error || 'Failed to open cancellation portal');
-      }
-    } catch (err) {
-      // If we got a real error (not a 404 fallthrough), show it and stop
-      if (err instanceof Error) {
-        console.error('[Membership] Cancel error:', err);
-        cancelError = err.message;
-        cancellingMembership = false;
-        return;
       }
     }
 

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -471,13 +471,24 @@
     if (!pk) return;
     portalLoading = true;
     try {
+      // NIP-98 auth proves we own this pubkey. Required, not optional:
+      // the portal is the full billing console, so the endpoint refuses
+      // an unsigned request rather than degrading like check-status.
+      const bodyString = JSON.stringify({
+        pubkey: pk,
+        returnUrl: window.location.href
+      });
       const res = await fetch('/api/stripe/create-portal-session', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          pubkey: pk,
-          returnUrl: window.location.href
-        })
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: await signNip98AuthHeader($ndk, {
+            method: 'POST',
+            url: `${location.origin}/api/stripe/create-portal-session`,
+            bodyString
+          })
+        },
+        body: bodyString
       });
       if (res.ok) {
         const { url } = await res.json();


### PR DESCRIPTION
## Why this is in front of the backfill

`create-portal-session` took `pubkey` from the request body and checked only that it was 64 hex characters. No identity check of any kind — `git grep -nE "verifyNip98|Authorization|nip98" src/routes/api/stripe/` returned zero hits at `34f10cc`.

What that endpoint hands back is the member's **whole Stripe billing console**: cancel the subscription, read invoice history with name, email, billing address and card last4, change the payment method. A pubkey is public by construction on Nostr, so possession of one was never a credential.

**Measured, not inferred.** At `34f10cc`, over HTTP against `vite dev`, no `Authorization` header, arbitrary pubkey, `returnUrl: https://evil.example/x`:

```
[Stripe Portal] Subscription metadata search failed, falling back: Invalid API Key provided: sk_test_fake
[Stripe Portal] Error creating portal session: StripeAuthenticationError
→ 500 {"error":"Failed to create portal session"}
```

It **reached Stripe**. It failed only because the local API key was fake. With the production key that request resolves a customer and returns a portal URL. Same request on this branch: `403 {"error":"forbidden"}`, Stripe never touched.

**This is latent today, and the backfill is what arms it.** #603's `subscriptions.search({query: "metadata['pubkey']:'…'"})` resolves nothing right now because no live subscription carries a pubkey. Stamping the three metadata keys onto those live subscriptions closes exactly that gap. So the gate has to be **deployed** before the paste — not merged, deployed. Merging queues the Cloudflare build; the gate does not exist until that build is live. Same trap as member-relay #13 needing its container rebuild before #603 meant anything.

## Server

- Require a NIP-98 header signed by the pubkey named in the body, using the existing `verifyNip98` — the same helper and the same shape as `api/membership/check-status`. **Unlike check-status, which degrades to a public shape when the signature is absent, this refuses.** Everything behind it is private billing data; there is no public tier of it.
- The gate runs **before any Stripe call**. An unauthenticated caller spends none of our API budget and cannot use a 404-vs-403 split to learn whether a given pubkey has a subscription. Pinned by a test.
- Body bytes are read once and shared with the payload verification, per `verifyNip98`'s Cloudflare Workers note.
- Constrain `return_url` to the request's own origin, resolved from `request.url` — **not** from the client-supplied `Origin` header. Relative values still resolve, so `window.location.href` and a bare `/settings` both pass.

### One thing I did not fix, deliberately

`create-session/+server.ts:62-72` validates its `successUrl`/`cancelUrl` against `request.headers.get('origin')`, which an attacker sets freely — so that check authorizes whatever the header claims. Same endpoint family, same weakness, **separate change**: it is the checkout path, not the billing-console path, and folding it in here widens a PR that is trying to land in hours. Flagged, not touched. There is a comment at the new check pointing at it so the divergence is legible.

## Clients

The two call sites that send a pubkey now sign:

- **`settings/+page.svelte:474`** already signed NIP-98 for `check-status` fifteen lines above and posted here unsigned. Now signs.
- **`membership/+page.svelte:123`** (`handleCancelMembership`) needed more care because it has an email fallback. It now **skips the portal attempt entirely when no signer is available**, and treats a 403 like the existing 404 fall-through. A read-only member lands on the same `mailto:` path they land on today rather than being shown a raw server string.

**No new user-facing copy.** The two new 400 strings (`returnUrl must match the request origin`, `Invalid returnUrl format`) are unreachable from a browser — `returnUrl` is `window.location.href`, same-origin with the fetch by construction. `forbidden` is never displayed: `membership` swallows 403 into the email fallback, and `settings` only reads the body when `res.ok`. Nothing here needs Growth.

**`membership/+page.svelte:286`** (`handleManageSubscription`) posts `{sessionId, returnUrl}` with no pubkey and **has never worked** — it returned 400 before and returns the same 400 now. Pinned by a test as unchanged, not fixed here (Chief flagged it as separable and I kept it that way).

## Verification

| Check | Result |
|---|---|
| `svelte-check --threshold error` | **0 errors** (150 warnings, pre-existing) |
| Full suite `npx vitest run` | **1055 tests / 68 files pass** |
| New tests | **18**, all mutation-checked |
| `/settings`, `/membership` under `vite dev` | render **200** |
| Unsigned POST over real HTTP | **403**, Stripe never reached |
| Baseline unsigned POST over real HTTP | **reached Stripe** (see above) |

The 18 tests hit the gate at *this route* rather than re-testing the verifier (`src/lib/nip98.server.test.ts` already covers that exhaustively): unsigned, signed-by-wrong-key impersonation, body-swap replay, a signature valid for `check-status` replayed here, case-insensitive pubkey match, the four `returnUrl` cases, and the five pre-existing behaviours the gate must not disturb.

Every one was mutation-checked — mutant applied, failure observed, file restored:

| Mutant | Tests killed |
|---|---|
| Gate removed entirely | 5 |
| `expectedPubkey` dropped | 1 — the impersonation test |
| `bodyBytes` dropped | 1 — the replay test |
| Raw `returnUrl` sent to Stripe | 1 — relative resolution |
| Origin equality check removed | 3 |

Prettier: the three edited files were **already dirty at `34f10cc`** (checked in-repo by restoring the baseline file in place) so I did not reformat them. The new test file is prettier-clean, matching `renewalRetry.test.ts`.

## Unable to verify

- **No signed request has been exercised against real Stripe.** The happy path is tested against a stubbed Stripe client, and over HTTP I only exercised rejection paths. The first real signed round-trip will be a member clicking Manage/Cancel after deploy.
- **The packaged Capacitor build is untested.** Its fetch interceptors (`app.html:26`, `hooks.client.ts:48`) are scoped to `__data.json` only, so API calls there already do not reach the server — I do not believe this changes anything for that build, but I have not run it.
- **Stale tabs**: a browser holding the pre-deploy client posts unsigned and gets 403. It degrades safely — `membership` falls back to email, `settings` does nothing visible — but it is a real window until reload.

## Review

**No human has reviewed this.** I am opening it ready rather than draft because it gates a step Seth intends to take today and a draft cannot be merged — green checks here mean CI, not a signoff.

Requested: **@Dr Sats** on the billing path (this is an auth boundary on subscription management), and **Prep** on the 403-into-email-fallback choice at `membership/+page.svelte` — that one hides a genuine auth misconfiguration behind a graceful path, and I picked it over showing a member the word "forbidden". If you would rather it surface loudly, that is a one-line change plus a string, and the string would then need Growth.

Suggested reviewer: **Dr Sats**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)