### PR TITLE
fix(feed): default Following/Replies to All posts, and stop the food filter from switching mutes off

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.687",
+  "version": "4.2.688",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -1129,12 +1129,14 @@
     cachedMutedUsersKey = null;
   }
 
-  // Memoization cache for shouldIncludeEvent — keyed by event.id
-  // Cleared when mute list changes (see reactive block below)
+  // Memoization cache for the food-only shouldIncludeEvent — keyed by event.id.
+  // Mutes/hellthread live in passesFeedFilters (always-on), not here, so this
+  // cache does not encode mute state and does not need clearing on unmute.
+  // Cleared when the signed-in user changes (see reactive block below).
   const includeEventCache = new Map<string, boolean>();
 
   function shouldIncludeEvent(event: NDKEvent): boolean {
-    // Check memoization cache first (stable per event unless mute list changes)
+    // Food-test memoization only — stable per event for a given user session.
     const eventId = event.id;
     if (eventId) {
       const cached = includeEventCache.get(eventId);
@@ -1161,18 +1163,14 @@
   }
 
   function _shouldIncludeEventUncached(event: NDKEvent): boolean {
-    // For NIP-18 reposts (kind 6), inclusion decisions need to be made against the
-    // underlying note (food content, mutes on original author, etc.). If we can't
-    // expand the inner event, drop the repost.
+    // For NIP-18 reposts (kind 6), the food test needs the underlying note.
+    // If we can't expand the inner event, drop the repost. Mutes are enforced
+    // separately in passesFeedFilters so this stays strictly food-only.
     if (event.kind === 6) {
       const inner = expandRepostEvent(event);
       if (!inner) return false;
       return _shouldIncludeEventUncached(inner);
     }
-
-    // Mutes (see isMuted) run here too, so a memoized "include" is never
-    // returned for an event the member has muted.
-    if (isMuted(event)) return false;
 
     // Client-side filtered results: notes without hashtags that contain food words
     // These are discovered through client-side filtering
@@ -4277,10 +4275,9 @@
     return DEFAULT_ENGAGEMENT_INFO;
   }
 
-  // Reload mute list when user changes
+  // Reload mute list when user changes; clear the food-test cache for the new identity.
   $: if ($userPublickey) {
     muteListStore.load();
-    // Invalidate shouldIncludeEvent cache when user (and thus mute list) changes
     includeEventCache.clear();
   }
 

--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -26,7 +26,9 @@
     getCurrentRelayGeneration,
     onRelaySwitchStopSubscriptions
   } from '$lib/nostr';
-  import { hellthreadThreshold } from '$lib/hellthreadFilterSettings';
+  // The one implementation of the hellthread rule — the notification path uses
+  // the same export, so the two surfaces cannot drift.
+  import { isHellthread as isHellthreadNote } from '$lib/notificationUtils';
   import { foodFilterSetting } from '$lib/foodFilterSettings';
   import MediaLightbox from './MediaLightbox.svelte';
   import { muteListStore, mutedPubkeys } from '$lib/muteListStore';
@@ -1127,23 +1129,6 @@
     cachedMutedUsersKey = null;
   }
 
-  /**
-   * Detect if an event is a hellthread based on number of 'p' tags (mentions)
-   * @param event - NDKEvent to check
-   * @param threshold - Number of mentions that constitutes a hellthread (0 = disabled)
-   * @returns true if event should be hidden as a hellthread
-   */
-  function isHellthread(event: NDKEvent, threshold: number): boolean {
-    if (threshold === 0) return false; // Disabled
-
-    if (!event.tags || !Array.isArray(event.tags)) return false;
-
-    // Count 'p' tags (person mentions)
-    const mentionCount = event.tags.filter((tag) => Array.isArray(tag) && tag[0] === 'p').length;
-
-    return mentionCount >= threshold;
-  }
-
   // Memoization cache for shouldIncludeEvent — keyed by event.id
   // Cleared when mute list changes (see reactive block below)
   const includeEventCache = new Map<string, boolean>();
@@ -1197,11 +1182,6 @@
       if (hashtagCount > MAX_HASHTAGS) {
         return false;
       }
-      // Check hellthread threshold
-      const threshold = get(hellthreadThreshold);
-      if (isHellthread(event, threshold)) {
-        return false;
-      }
       return true;
     }
 
@@ -1217,15 +1197,11 @@
       return false;
     }
 
-    // Check hashtag spam
+    // Check hashtag spam. This one stays inside the food test on purpose: it is
+    // a curation call we made, with no setting and no string promising it, so it
+    // applies only where the food guess is in scope.
     const hashtagCount = getHashtagCount(event);
     if (hashtagCount > MAX_HASHTAGS) {
-      return false;
-    }
-
-    // Check hellthread threshold
-    const threshold = get(hellthreadThreshold);
-    if (isHellthread(event, threshold)) {
       return false;
     }
 
@@ -1233,9 +1209,13 @@
   }
 
   // ─── Feed policy ─────────────────────────────────────────────
-  // Mutes and the food filter are two different instructions from the member,
-  // and they are enforced separately. Mutes always apply; the food test only
-  // where it is active for the current view.
+  // Two different kinds of rule live here, and the difference decides scope:
+  // an instruction the member gave us (a control, a stored value, or a live
+  // string promising it) applies wherever that member reads; a curation
+  // heuristic we chose applies only where our guess is in scope.
+  // Mutes and the hellthread threshold are the first kind — they always run.
+  // The food test and MAX_HASHTAGS are the second — they run only where the
+  // food filter is active for the current view.
 
   /**
    * Does the member's mute list hide this event? Covers pubkey, word, tag and
@@ -1265,6 +1245,24 @@
   }
 
   /**
+   * Does the member's hellthread threshold hide this event? Set in /settings,
+   * where the copy promises it with no scope qualifier ("Hide notes with too
+   * many mentions… Set to 0 to disable"), and the notification path already
+   * applies it unconditionally — so the feed applies it wherever the member
+   * reads, not only inside the food test. A kind 6 repost is judged by the
+   * note it carries, same as mutes.
+   */
+  function isHellthread(event: NDKEvent): boolean {
+    if (event.kind === 6) {
+      const inner = expandRepostEvent(event);
+      if (!inner) return false;
+      return isHellthread(inner);
+    }
+
+    return isHellthreadNote(event);
+  }
+
+  /**
    * Does the food test apply to what is on screen right now?
    *  - Global Food: always. The tab carries the food promise in its own name
    *    and renders no toggle.
@@ -1290,6 +1288,7 @@
   /** The one question every feed path asks before showing an event. */
   function passesFeedFilters(event: NDKEvent): boolean {
     if (isMuted(event)) return false;
+    if (isHellthread(event)) return false;
     if (!foodFilterActive) return true;
     return shouldIncludeEvent(event);
   }

--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -27,14 +27,10 @@
     onRelaySwitchStopSubscriptions
   } from '$lib/nostr';
   import { hellthreadThreshold } from '$lib/hellthreadFilterSettings';
+  import { foodFilterSetting } from '$lib/foodFilterSettings';
   import MediaLightbox from './MediaLightbox.svelte';
   import { muteListStore, mutedPubkeys } from '$lib/muteListStore';
-  import {
-    isPubkeyMuted,
-    containsMutedWord,
-    hasMutedTag,
-    isThreadMuted
-  } from '$lib/mutableIntegration';
+  import { isEventMutedBy } from '$lib/muteFilter';
   import Avatar from './Avatar.svelte';
   import type { NDKSubscription } from '@nostr-dev-kit/ndk';
   import { NDKEvent, NDKSubscriptionCacheUsage } from '@nostr-dev-kit/ndk';
@@ -521,8 +517,12 @@
   let imageGenerationError: string | null = null;
   let expandedParentNotes: { [eventId: string]: boolean } = {}; // Track expanded parent notes
   let parentNoteCache: { [eventId: string]: NDKEvent | null } = {}; // Cache full parent notes
-  // Toggle for food filtering - defaults to OFF for profile view (show all posts), ON for other modes
-  let foodFilterEnabled = !authorPubkey;
+  // "Only Food" toggle — the member's own choice, persisted across reloads
+  // (see $lib/foodFilterSettings). Defaults OFF for Following, Replies and
+  // profile views: those are a promise about *who*, not about *what*. The
+  // Global Food tab renders no toggle and food-filters regardless — see
+  // foodFilterActive.
+  let foodFilterEnabled = get(foodFilterSetting);
 
   // Modals
   let zapModal = false;
@@ -1185,30 +1185,9 @@
       return _shouldIncludeEventUncached(inner);
     }
 
-    // Check muted users (both public and private lists)
-    if ($userPublickey && $muteListStore.muteList) {
-      const authorKey = event.author?.hexpubkey || event.pubkey;
-
-      // Check pubkey mute
-      if (authorKey && isPubkeyMuted($muteListStore.muteList, authorKey)) {
-        return false;
-      }
-
-      // Check word mutes
-      if (containsMutedWord($muteListStore.muteList, event.content)) {
-        return false;
-      }
-
-      // Check tag mutes
-      if (hasMutedTag($muteListStore.muteList, event.tags)) {
-        return false;
-      }
-
-      // Check thread mutes
-      if (isThreadMuted($muteListStore.muteList, event.id)) {
-        return false;
-      }
-    }
+    // Mutes (see isMuted) run here too, so a memoized "include" is never
+    // returned for an event the member has muted.
+    if (isMuted(event)) return false;
 
     // Client-side filtered results: notes without hashtags that contain food words
     // These are discovered through client-side filtering
@@ -1251,6 +1230,81 @@
     }
 
     return true;
+  }
+
+  // ─── Feed policy ─────────────────────────────────────────────
+  // Mutes and the food filter are two different instructions from the member,
+  // and they are enforced separately. Mutes always apply; the food test only
+  // where it is active for the current view.
+
+  /**
+   * Does the member's mute list hide this event? Covers pubkey, word, tag and
+   * thread mutes — the full NIP-51 list merged with the legacy localStorage
+   * one (see muteListStore). A kind 6 repost is judged by the note it carries.
+   */
+  function isMuted(event: NDKEvent): boolean {
+    if (!$userPublickey) return false;
+
+    const muteList = $muteListStore.muteList;
+    if (!muteList) return false;
+
+    if (event.kind === 6) {
+      const inner = expandRepostEvent(event);
+      // An unexpandable repost has nothing to check against the mute list;
+      // the food test is what drops it.
+      if (!inner) return false;
+      return isMuted(inner);
+    }
+
+    return isEventMutedBy(muteList, {
+      id: event.id,
+      pubkey: event.author?.hexpubkey || event.pubkey,
+      content: event.content,
+      tags: event.tags
+    });
+  }
+
+  /**
+   * Does the food test apply to what is on screen right now?
+   *  - Global Food: always. The tab carries the food promise in its own name
+   *    and renders no toggle.
+   *  - Members: never.
+   *  - Following / Replies / profile: whatever the member chose.
+   *
+   * Reactive so the empty state can read it directly.
+   */
+  $: foodFilterActive =
+    filterMode === 'members'
+      ? false
+      : filterMode === 'global' && !authorPubkey
+        ? true
+        : foodFilterEnabled;
+
+  /**
+   * Is the "Only Food" switch on screen? The empty state may only say "turn it
+   * off above" where there is something above to turn off.
+   */
+  $: foodToggleVisible =
+    filterMode === 'following' || filterMode === 'replies' || Boolean(authorPubkey);
+
+  /** The one question every feed path asks before showing an event. */
+  function passesFeedFilters(event: NDKEvent): boolean {
+    if (isMuted(event)) return false;
+    if (!foodFilterActive) return true;
+    return shouldIncludeEvent(event);
+  }
+
+  /**
+   * Set the "Only Food" toggle and reload. Shared by the switch above the feed
+   * and by the "Show all posts" button in the empty state, so the control the
+   * empty state points at is the control it flips.
+   */
+  function setFoodFilter(enabled: boolean) {
+    foodFilterEnabled = enabled;
+    foodFilterSetting.setEnabled(enabled);
+    seenEventIds.clear();
+    events = [];
+    loadFoodstrFeed(false);
   }
 
   // ═══════════════════════════════════════════════════════════════
@@ -1328,7 +1382,7 @@
               }
             : null
         }))
-        .filter(shouldIncludeEvent);
+        .filter(passesFeedFilters);
 
       if (cachedEvents.length === 0) return false;
 
@@ -1930,7 +1984,7 @@
               if (authorScope === 'top-level' && isReply(event)) return false;
               if (authorScope === 'replies' && !isReply(event)) return false;
             }
-            return shouldIncludeEvent(event);
+            return passesFeedFilters(event);
           });
 
           if (validCached.length > 0) {
@@ -2090,12 +2144,15 @@
         const outboxOptions: any = {
           since: timeWindow.since,
           kinds: [1, 6, 1068],
-          limit: foodFilterEnabled ? 200 : 300,
+          limit: foodFilterActive ? 200 : 300,
           timeoutMs: 5000,
           maxRelays: 10
         };
 
-        if (foodFilterEnabled) {
+        // Relay-side hashtag filter — kept on the same predicate as the
+        // client-side test so the wire query and the local filter cannot
+        // disagree about what this view is asking for.
+        if (foodFilterActive) {
           outboxOptions.additionalFilter = {
             '#t': FOOD_HASHTAGS
           };
@@ -2218,12 +2275,12 @@
         const repliesOutboxOptions: any = {
           since: timeWindow.since,
           kinds: [1, 6, 1068],
-          limit: foodFilterEnabled ? 200 : 300,
+          limit: foodFilterActive ? 200 : 300,
           timeoutMs: 5000,
           maxRelays: 10
         };
 
-        if (foodFilterEnabled) {
+        if (foodFilterActive) {
           repliesOutboxOptions.additionalFilter = {
             '#t': FOOD_HASHTAGS
           };
@@ -2479,7 +2536,7 @@
                   if (authorKey && mutedUsers.includes(authorKey)) return false;
                 }
                 if (isReply(event)) return false;
-                if (!shouldIncludeEvent(event)) return false;
+                if (!passesFeedFilters(event)) return false;
                 if (followedSet.size > 0) {
                   const authorKey = event.author?.hexpubkey || event.pubkey;
                   if (authorKey && followedSet.has(authorKey)) return false;
@@ -2586,14 +2643,10 @@
           if (authorScope === 'replies' && !isReply(event)) return false;
         }
 
-        // Apply food filter based on context
-        if (authorPubkey) {
-          // Profile view: respect the toggle
-          if (foodFilterEnabled && !shouldIncludeEvent(event)) return false;
-        } else {
-          // Global feed: always apply food filter
-          if (!shouldIncludeEvent(event)) return false;
+        // Mutes always; food test where it is active for this view
+        if (!passesFeedFilters(event)) return false;
 
+        if (!authorPubkey) {
           // Also exclude posts from followed users
           if (followedSet.size > 0) {
             const authorKey = event.author?.hexpubkey || event.pubkey;
@@ -2696,7 +2749,7 @@
 
       sub.on('event', (event: NDKEvent) => {
         if (filterMode === 'following' && isReply(event)) return;
-        if (foodFilterEnabled && !shouldIncludeEvent(event)) return;
+        if (!passesFeedFilters(event)) return;
         handleRealtimeEvent(event);
       });
 
@@ -2794,8 +2847,8 @@
         }
       }
 
-      // For profile view with food filter disabled, apply client-side filter
-      if (authorPubkey && foodFilterEnabled && !shouldIncludeEvent(event)) {
+      // Mutes always; food test where it is active for this view
+      if (!passesFeedFilters(event)) {
         return;
       }
       handleRealtimeEvent(event);
@@ -2843,7 +2896,7 @@
       const newEvents = contentEvents.filter((e) => {
         if (seenEventIds.has(e.id)) return false;
         if (isReply(e)) return false;
-        if (!shouldIncludeEvent(e)) return false;
+        if (!passesFeedFilters(e)) return false;
         if (followedSet.size > 0) {
           const authorKey = e.author?.hexpubkey || e.pubkey;
           if (authorKey && followedSet.has(authorKey)) return false;
@@ -2877,19 +2930,9 @@
     // Skip if already seen
     if (seenEventIds.has(event.id)) return;
 
-    // Validate content - apply food filter based on mode and toggle
-    if (filterMode === 'following' || filterMode === 'replies') {
-      // Following/Replies: respect foodFilterEnabled toggle
-      if (foodFilterEnabled && !shouldIncludeEvent(event)) return;
-    } else if (filterMode !== 'members') {
-      // Global feed: always apply food filter
-      // Profile view: respect the foodFilterEnabled toggle (matches initial load)
-      if (
-        authorPubkey ? foodFilterEnabled && !shouldIncludeEvent(event) : !shouldIncludeEvent(event)
-      )
-        return;
-    }
-    // Members mode: no food filter
+    // Mutes always; food test where it is active for this view (Global always,
+    // Members never, Following/Replies/profile per the member's choice).
+    if (!passesFeedFilters(event)) return;
 
     // Expand NIP-18 kind 6 reposts into their underlying note (with metadata)
     // so the rendering pipeline (which expects kind 1/1068) works correctly.
@@ -2980,8 +3023,7 @@
         const authorKey = event.author?.hexpubkey || event.pubkey;
         if (authorKey && mutedUsers.includes(authorKey)) return false;
       }
-      if (foodFilterEnabled) return shouldIncludeEvent(event);
-      return true;
+      return passesFeedFilters(event);
     });
   }
 
@@ -2993,8 +3035,7 @@
         const authorKey = event.author?.hexpubkey || event.pubkey;
         if (authorKey && mutedUsers.includes(authorKey)) return false;
       }
-      if (foodFilterEnabled) return shouldIncludeEvent(event);
-      return true;
+      return passesFeedFilters(event);
     });
   }
 
@@ -3137,8 +3178,8 @@
           // Exclude replies
           if (isReply(event)) return false;
 
-          // Apply food filter
-          if (!shouldIncludeEvent(event)) return false;
+          // Mutes always; food test where it is active for this view
+          if (!passesFeedFilters(event)) return false;
 
           // Exclude posts from followed users (they go in Following feed)
           if (followedSet.size > 0) {
@@ -3310,14 +3351,8 @@
           if (authorKey && mutedUsers.includes(authorKey)) return false;
         }
 
-        // Apply food filter based on context
-        // For profile view: respect the toggle
-        // For global feed: always filter for food content
-        if (authorPubkey) {
-          if (foodFilterEnabled && !shouldIncludeEvent(e)) return false;
-        } else {
-          if (!shouldIncludeEvent(e)) return false;
-        }
+        // Mutes always; food test where it is active for this view
+        if (!passesFeedFilters(e)) return false;
 
         // Exclude followed users from Global feed
         if (followedSet.size > 0) {
@@ -3373,13 +3408,13 @@
           since: paginationWindow.since,
           until: paginationWindow.until,
           kinds: [1, 6, 1068],
-          limit: foodFilterEnabled ? 100 : 150, // Fetch more when showing all posts
+          limit: foodFilterActive ? 100 : 150, // Fetch more when showing all posts
           timeoutMs: 5000,
           maxRelays: 10
         };
 
         // Only add food hashtag filter when food filter is enabled
-        if (foodFilterEnabled) {
+        if (foodFilterActive) {
           loadMoreOptions.additionalFilter = {
             '#t': FOOD_HASHTAGS // Server-side food filtering!
           };
@@ -3488,27 +3523,15 @@
           return false; // Global mode: exclude replies
         }
 
-        // Apply food filter based on context
-        if (authorPubkey) {
-          // Profile view: respect the toggle
-          if (foodFilterEnabled && !shouldIncludeEvent(e)) return false;
-        } else if (filterMode === 'following' || filterMode === 'replies') {
-          // Following/Replies: respect the toggle
-          if (foodFilterEnabled && !shouldIncludeEvent(e)) return false;
-        } else if (filterMode === 'global') {
-          // Global feed: always apply food filter
-          if (!shouldIncludeEvent(e)) return false;
+        // Mutes always; food test where it is active for this view
+        if (!passesFeedFilters(e)) return false;
 
-          // Exclude followed users from Global feed
-          if (followedSet.size > 0) {
-            const authorKey = e.author?.hexpubkey || e.pubkey;
-            if (authorKey && followedSet.has(authorKey)) {
-              return false;
-            }
+        // Exclude followed users from Global feed
+        if (!authorPubkey && filterMode === 'global' && followedSet.size > 0) {
+          const authorKey = e.author?.hexpubkey || e.pubkey;
+          if (authorKey && followedSet.has(authorKey)) {
+            return false;
           }
-        } else if (filterMode !== 'members') {
-          // Other modes: apply food filter based on toggle
-          if (foodFilterEnabled && !shouldIncludeEvent(e)) return false;
         }
 
         return true;
@@ -4404,7 +4427,7 @@
           // Try instant cache first
           const cached = loadFromInstantCache(filterMode);
           if (cached && cached.events.length > 0) {
-            const hydratedEvents = cached.events.map(hydrateFromCache).filter(shouldIncludeEvent);
+            const hydratedEvents = cached.events.map(hydrateFromCache).filter(passesFeedFilters);
 
             if (hydratedEvents.length > 0) {
               seenEventIds.clear();
@@ -4448,7 +4471,7 @@
           // Try instant cache first
           const cached = loadFromInstantCache(filterMode);
           if (cached && cached.events.length > 0) {
-            const hydratedEvents = cached.events.map(hydrateFromCache).filter(shouldIncludeEvent);
+            const hydratedEvents = cached.events.map(hydrateFromCache).filter(passesFeedFilters);
 
             if (hydratedEvents.length > 0) {
               seenEventIds.clear();
@@ -4565,7 +4588,7 @@
     // Step 1: Try to render cached content immediately (0ms perceived load)
     const cached = loadFromInstantCache(filterMode);
     if (cached && cached.events.length > 0) {
-      const hydratedEvents = cached.events.map(hydrateFromCache).filter(shouldIncludeEvent);
+      const hydratedEvents = cached.events.map(hydrateFromCache).filter(passesFeedFilters);
 
       if (hydratedEvents.length > 0) {
         // Add to seen set
@@ -4808,7 +4831,7 @@
       </div>
     {/if}
 
-    {#if filterMode === 'following' || filterMode === 'replies' || authorPubkey}
+    {#if foodToggleVisible}
       <div class="flex items-center justify-end gap-2 px-2 sm:px-0 mb-4">
         {#if foodFilterEnabled}
           <span class="text-sm">
@@ -4821,12 +4844,7 @@
           <span class="text-sm text-caption">All posts</span>
         {/if}
         <button
-          on:click={() => {
-            foodFilterEnabled = !foodFilterEnabled;
-            seenEventIds.clear();
-            events = [];
-            loadFoodstrFeed(false);
-          }}
+          on:click={() => setFoodFilter(!foodFilterEnabled)}
           class="relative inline-flex h-6 w-11 items-center rounded-full transition-colors {foodFilterEnabled
             ? 'bg-primary'
             : 'bg-accent-gray'}"
@@ -4921,7 +4939,9 @@
               Unmute User
             </button>
           {:else}
-            <!-- No posts found message -->
+            <!-- No posts found message. Split by the predicate that decides
+                 what is actually true: is a filter hiding posts, or are there
+                 none? Copy per OUTBOX/FEED_EMPTY_STATE_COPY_2026_07_30.md. -->
             <div style="color: var(--color-caption)">
               <svg
                 class="h-12 w-12 mx-auto mb-4 opacity-50"
@@ -4936,17 +4956,67 @@
                   d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
                 ></path>
               </svg>
-              <p class="text-lg font-medium">No cooking posts found</p>
-              <p class="text-sm">
-                Try posting with cooking tags like #foodstr, #cook, #cooking, etc.
-              </p>
+              {#if authorPubkey}
+                <!-- Profile view: one cook, not the follow graph -->
+                {#if foodFilterEnabled}
+                  <p class="text-lg font-medium">No cooking posts found</p>
+                  <p class="text-sm">
+                    This cook hasn't posted anything tagged as cooking. Turn off Only Food above to
+                    see everything they've posted.
+                  </p>
+                {:else}
+                  <p class="text-lg font-medium">No posts yet</p>
+                  <p class="text-sm">This cook hasn't posted anything yet.</p>
+                {/if}
+              {:else if filterMode === 'following' || filterMode === 'replies'}
+                {#if foodFilterEnabled}
+                  <p class="text-lg font-medium">No cooking posts found</p>
+                  <p class="text-sm">
+                    Only Food is hiding everything else here. Turn it off above to see all posts.
+                  </p>
+                {:else}
+                  <p class="text-lg font-medium">No posts yet</p>
+                  <p class="text-sm">
+                    {filterMode === 'replies'
+                      ? 'Nobody you follow has replied to anything recently.'
+                      : 'Nobody you follow has posted recently.'}
+                    <a href="/explore" class="underline hover:opacity-80">
+                      Find more cooks to follow
+                    </a>.
+                  </p>
+                {/if}
+              {:else if filterMode === 'members'}
+                <!-- Members feed: not covered by the copy review; unchanged. -->
+                <p class="text-lg font-medium">No cooking posts found</p>
+                <p class="text-sm">
+                  Try posting with cooking tags like #foodstr, #cook, #cooking, etc.
+                </p>
+              {:else}
+                <!-- Global Food: no toggle is rendered here, so there is no
+                     filter to point at — a load gap is the honest explanation. -->
+                <p class="text-lg font-medium">No cooking posts right now</p>
+                <p class="text-sm">
+                  Check back soon — new recipes and food posts get shared throughout the day.
+                </p>
+              {/if}
             </div>
-            <button
-              on:click={() => retryWithDelay()}
-              class="px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors"
-            >
-              Refresh Feed
-            </button>
+            {#if foodToggleVisible && foodFilterEnabled}
+              <!-- Refresh does not clear a filter; the toggle does. Same handler
+                   as the switch above the feed. -->
+              <button
+                on:click={() => setFoodFilter(false)}
+                class="px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors"
+              >
+                Show all posts
+              </button>
+            {:else if !foodToggleVisible}
+              <button
+                on:click={() => retryWithDelay()}
+                class="px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors"
+              >
+                Refresh Feed
+              </button>
+            {/if}
           {/if}
         </div>
       </div>

--- a/src/lib/foodFilterSettings.test.ts
+++ b/src/lib/foodFilterSettings.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+/**
+ * Tests for the persisted "Only Food" toggle.
+ *
+ * The store reads localStorage at module load, so each case that depends on a
+ * stored value re-imports the module with `vi.resetModules()` after seeding
+ * the stub.
+ */
+
+class LocalStorageStub {
+  private data = new Map<string, string>();
+  throwOnGet = false;
+  throwOnSet = false;
+
+  getItem(key: string): string | null {
+    if (this.throwOnGet) throw new Error('denied');
+    return this.data.has(key) ? (this.data.get(key) as string) : null;
+  }
+
+  setItem(key: string, value: string): void {
+    if (this.throwOnSet) throw new Error('quota');
+    this.data.set(key, value);
+  }
+
+  seed(key: string, value: string): void {
+    this.data.set(key, value);
+  }
+
+  raw(key: string): string | undefined {
+    return this.data.get(key);
+  }
+}
+
+const STORAGE_KEY = 'zapcooking_food_filter';
+
+let stub: LocalStorageStub;
+
+async function loadModule() {
+  vi.resetModules();
+  return await import('./foodFilterSettings');
+}
+
+beforeEach(() => {
+  stub = new LocalStorageStub();
+  (globalThis as any).localStorage = stub;
+});
+
+afterEach(() => {
+  delete (globalThis as any).localStorage;
+  vi.restoreAllMocks();
+});
+
+describe('readStoredFoodFilter', () => {
+  it('defaults to off when nothing is stored', async () => {
+    const { readStoredFoodFilter } = await loadModule();
+    expect(readStoredFoodFilter()).toBe(false);
+  });
+
+  it('reads a stored "true"', async () => {
+    stub.seed(STORAGE_KEY, 'true');
+    const { readStoredFoodFilter } = await loadModule();
+    expect(readStoredFoodFilter()).toBe(true);
+  });
+
+  it('reads a stored "false"', async () => {
+    stub.seed(STORAGE_KEY, 'false');
+    const { readStoredFoodFilter } = await loadModule();
+    expect(readStoredFoodFilter()).toBe(false);
+  });
+
+  it('falls back to the default on a value we never write', async () => {
+    // Boolean('0') is true — a coercing read would turn junk into "on".
+    stub.seed(STORAGE_KEY, '0');
+    const { readStoredFoodFilter } = await loadModule();
+    expect(readStoredFoodFilter()).toBe(false);
+  });
+
+  it('falls back to the default when localStorage throws', async () => {
+    stub.throwOnGet = true;
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { readStoredFoodFilter } = await loadModule();
+    expect(readStoredFoodFilter()).toBe(false);
+  });
+
+  it('falls back to the default when localStorage is absent (SSR)', async () => {
+    delete (globalThis as any).localStorage;
+    const { readStoredFoodFilter } = await loadModule();
+    expect(readStoredFoodFilter()).toBe(false);
+  });
+});
+
+describe('foodFilterSetting store', () => {
+  it('starts from the persisted value', async () => {
+    stub.seed(STORAGE_KEY, 'true');
+    const { foodFilterSetting } = await loadModule();
+    expect(get(foodFilterSetting)).toBe(true);
+  });
+
+  it('starts off when nothing is persisted', async () => {
+    const { foodFilterSetting } = await loadModule();
+    expect(get(foodFilterSetting)).toBe(false);
+  });
+
+  it('writes the choice through to localStorage', async () => {
+    const { foodFilterSetting } = await loadModule();
+
+    foodFilterSetting.setEnabled(true);
+    expect(get(foodFilterSetting)).toBe(true);
+    expect(stub.raw(STORAGE_KEY)).toBe('true');
+
+    foodFilterSetting.setEnabled(false);
+    expect(get(foodFilterSetting)).toBe(false);
+    expect(stub.raw(STORAGE_KEY)).toBe('false');
+  });
+
+  it('survives a reload — a stored choice is what the next load reads', async () => {
+    const first = await loadModule();
+    first.foodFilterSetting.setEnabled(true);
+
+    const second = await loadModule();
+    expect(get(second.foodFilterSetting)).toBe(true);
+  });
+
+  it('still updates the store when localStorage refuses the write', async () => {
+    const { foodFilterSetting } = await loadModule();
+    stub.throwOnSet = true;
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    foodFilterSetting.setEnabled(true);
+
+    expect(get(foodFilterSetting)).toBe(true);
+    expect(stub.raw(STORAGE_KEY)).toBeUndefined();
+  });
+});

--- a/src/lib/foodFilterSettings.test.ts
+++ b/src/lib/foodFilterSettings.test.ts
@@ -89,6 +89,19 @@ describe('readStoredFoodFilter', () => {
     const { readStoredFoodFilter } = await loadModule();
     expect(readStoredFoodFilter()).toBe(false);
   });
+
+  it('falls back to the default when merely accessing localStorage throws', async () => {
+    // Some environments throw SecurityError on the identifier itself, before getItem.
+    delete (globalThis as any).localStorage;
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      get() {
+        throw new Error('SecurityError');
+      }
+    });
+    const { readStoredFoodFilter } = await loadModule();
+    expect(readStoredFoodFilter()).toBe(false);
+  });
 });
 
 describe('foodFilterSetting store', () => {

--- a/src/lib/foodFilterSettings.ts
+++ b/src/lib/foodFilterSettings.ts
@@ -21,7 +21,13 @@ const STORAGE_KEY = 'zapcooking_food_filter';
 const DEFAULT_ENABLED = false;
 
 function hasLocalStorage(): boolean {
-  return typeof localStorage !== 'undefined';
+  // Accessing `localStorage` (not just getItem) can throw SecurityError in
+  // restricted contexts — same guard as `memories.ts`.
+  try {
+    return typeof localStorage !== 'undefined';
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/lib/foodFilterSettings.ts
+++ b/src/lib/foodFilterSettings.ts
@@ -1,0 +1,64 @@
+import { writable } from 'svelte/store';
+
+/**
+ * "Only Food" feed toggle — the member's own choice, persisted across reloads.
+ *
+ * Same shape as `hellthreadFilterSettings.ts` (a localStorage-backed writable),
+ * with one deliberate difference: localStorage is guarded with
+ * `typeof localStorage` instead of importing `browser` from
+ * `$app/environment`, so this module stays importable under vitest, where the
+ * `$app` alias is not available. `memories.ts` avoids that import for the same
+ * reason and uses the same guard.
+ *
+ * The default is OFF. Following and Replies are a promise about *who*, not
+ * about *what* — the member already filtered by choosing who to follow. The
+ * Global Food tab carries the food promise in its own name and applies the
+ * food test regardless of this setting (see `isFoodFilterActive` in
+ * `FoodstrFeedOptimized.svelte`).
+ */
+
+const STORAGE_KEY = 'zapcooking_food_filter';
+const DEFAULT_ENABLED = false;
+
+function hasLocalStorage(): boolean {
+  return typeof localStorage !== 'undefined';
+}
+
+/**
+ * Read the persisted setting. Anything other than the two values we write
+ * (missing key, corrupt value, localStorage throwing) falls back to the
+ * default rather than being coerced — `Boolean('false')` is `true`.
+ */
+export function readStoredFoodFilter(): boolean {
+  if (!hasLocalStorage()) return DEFAULT_ENABLED;
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === 'true') return true;
+    if (stored === 'false') return false;
+  } catch (error) {
+    console.error('Failed to load food filter setting from localStorage:', error);
+  }
+  return DEFAULT_ENABLED;
+}
+
+function createFoodFilterStore() {
+  const { subscribe, set } = writable<boolean>(readStoredFoodFilter());
+
+  return {
+    subscribe,
+    setEnabled: (enabled: boolean) => {
+      set(enabled);
+      if (!hasLocalStorage()) return;
+      try {
+        localStorage.setItem(STORAGE_KEY, enabled ? 'true' : 'false');
+      } catch (error) {
+        console.error('Failed to save food filter setting to localStorage:', error);
+      }
+    }
+  };
+}
+
+export const foodFilterSetting = createFoodFilterStore();
+
+export const FOOD_FILTER_STORAGE_KEY = STORAGE_KEY;
+export const FOOD_FILTER_DEFAULT = DEFAULT_ENABLED;

--- a/src/lib/mutableIntegration.ts
+++ b/src/lib/mutableIntegration.ts
@@ -3,42 +3,11 @@ import { get } from 'svelte/store';
 import { ndk } from '$lib/nostr';
 import { encrypt, decrypt, detectEncryptionMethod } from '$lib/encryptionService';
 
-// Type definitions (from mutable)
-export interface MutedPubkey {
-	type: 'pubkey';
-	value: string; // hex pubkey
-	reason?: string;
-	eventRef?: string;
-	private?: boolean;
-}
-
-export interface MutedWord {
-	type: 'word';
-	value: string;
-	reason?: string;
-	private?: boolean;
-}
-
-export interface MutedTag {
-	type: 'tag';
-	value: string;
-	reason?: string;
-	private?: boolean;
-}
-
-export interface MutedThread {
-	type: 'thread';
-	value: string; // event id
-	reason?: string;
-	private?: boolean;
-}
-
-export interface MuteList {
-	pubkeys: MutedPubkey[];
-	words: MutedWord[];
-	tags: MutedTag[];
-	threads: MutedThread[];
-}
+// Mute-list types and the pure checks that read them live in `muteFilter.ts`
+// so they stay importable outside the browser (see that file). Re-exported
+// here so existing `$lib/mutableIntegration` imports are unchanged.
+export * from '$lib/muteFilter';
+import type { MuteList, MutedPubkey, MutedWord, MutedTag, MutedThread } from '$lib/muteFilter';
 
 /**
  * Fetch user's mute list (kind:10000) from relays
@@ -188,40 +157,6 @@ export async function parseMuteListEvent(event: NDKEvent): Promise<MuteList> {
 	}
 
 	return muteList;
-}
-
-/**
- * Check if a pubkey is in the mute list
- */
-export function isPubkeyMuted(muteList: MuteList, pubkey: string): boolean {
-	return muteList.pubkeys.some((item) => item.value === pubkey);
-}
-
-/**
- * Check if content contains muted words
- */
-export function containsMutedWord(muteList: MuteList, content: string): boolean {
-	if (!content) return false;
-	const lowerContent = content.toLowerCase();
-	return muteList.words.some((item) => lowerContent.includes(item.value.toLowerCase()));
-}
-
-/**
- * Check if event has muted tags
- */
-export function hasMutedTag(muteList: MuteList, eventTags: string[][]): boolean {
-	const eventHashtags = eventTags
-		.filter((tag) => tag[0] === 't')
-		.map((tag) => tag[1]?.toLowerCase());
-
-	return muteList.tags.some((item) => eventHashtags.includes(item.value.toLowerCase()));
-}
-
-/**
- * Check if thread is muted
- */
-export function isThreadMuted(muteList: MuteList, eventId: string): boolean {
-	return muteList.threads.some((item) => item.value === eventId);
 }
 
 /**

--- a/src/lib/muteFilter.test.ts
+++ b/src/lib/muteFilter.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isPubkeyMuted,
+  containsMutedWord,
+  hasMutedTag,
+  isThreadMuted,
+  isEventMutedBy,
+  type MuteList
+} from './muteFilter';
+
+const EMPTY: MuteList = { pubkeys: [], words: [], tags: [], threads: [] };
+
+function muteList(partial: Partial<MuteList>): MuteList {
+  return { ...EMPTY, ...partial };
+}
+
+const ALICE = 'a'.repeat(64);
+const BOB = 'b'.repeat(64);
+const NOTE_ID = 'e'.repeat(64);
+
+describe('the individual checks', () => {
+  it('matches a muted pubkey exactly', () => {
+    const list = muteList({ pubkeys: [{ type: 'pubkey', value: ALICE }] });
+    expect(isPubkeyMuted(list, ALICE)).toBe(true);
+    expect(isPubkeyMuted(list, BOB)).toBe(false);
+  });
+
+  it('matches muted words case-insensitively, as substrings', () => {
+    const list = muteList({ words: [{ type: 'word', value: 'Spoiler' }] });
+    expect(containsMutedWord(list, 'big SPOILER ahead')).toBe(true);
+    expect(containsMutedWord(list, 'nothing to see')).toBe(false);
+    expect(containsMutedWord(list, '')).toBe(false);
+  });
+
+  it('matches muted hashtags case-insensitively', () => {
+    const list = muteList({ tags: [{ type: 'tag', value: 'Politics' }] });
+    expect(hasMutedTag(list, [['t', 'POLITICS']])).toBe(true);
+    expect(hasMutedTag(list, [['t', 'foodstr']])).toBe(false);
+    expect(hasMutedTag(list, [['p', 'politics']])).toBe(false);
+    expect(hasMutedTag(list, [])).toBe(false);
+  });
+
+  it('matches a muted thread by event id', () => {
+    const list = muteList({ threads: [{ type: 'thread', value: NOTE_ID }] });
+    expect(isThreadMuted(list, NOTE_ID)).toBe(true);
+    expect(isThreadMuted(list, 'f'.repeat(64))).toBe(false);
+  });
+});
+
+describe('isEventMutedBy', () => {
+  const event = {
+    id: NOTE_ID,
+    pubkey: ALICE,
+    content: 'braised short ribs, spoiler: they were good',
+    tags: [['t', 'foodstr']]
+  };
+
+  it('mutes nothing when there is no mute list', () => {
+    expect(isEventMutedBy(null, event)).toBe(false);
+    expect(isEventMutedBy(undefined, event)).toBe(false);
+  });
+
+  it('mutes nothing when the list is empty', () => {
+    expect(isEventMutedBy(EMPTY, event)).toBe(false);
+  });
+
+  it('catches a muted author', () => {
+    expect(isEventMutedBy(muteList({ pubkeys: [{ type: 'pubkey', value: ALICE }] }), event)).toBe(
+      true
+    );
+    expect(isEventMutedBy(muteList({ pubkeys: [{ type: 'pubkey', value: BOB }] }), event)).toBe(
+      false
+    );
+  });
+
+  it('catches a muted word — the kind of mute the food filter used to switch off', () => {
+    expect(isEventMutedBy(muteList({ words: [{ type: 'word', value: 'spoiler' }] }), event)).toBe(
+      true
+    );
+  });
+
+  it('catches a muted tag', () => {
+    expect(isEventMutedBy(muteList({ tags: [{ type: 'tag', value: 'foodstr' }] }), event)).toBe(
+      true
+    );
+  });
+
+  it('catches a muted thread', () => {
+    expect(isEventMutedBy(muteList({ threads: [{ type: 'thread', value: NOTE_ID }] }), event)).toBe(
+      true
+    );
+  });
+
+  it('tolerates an event with missing fields', () => {
+    const list = muteList({
+      pubkeys: [{ type: 'pubkey', value: ALICE }],
+      words: [{ type: 'word', value: 'spoiler' }],
+      tags: [{ type: 'tag', value: 'foodstr' }],
+      threads: [{ type: 'thread', value: NOTE_ID }]
+    });
+    expect(isEventMutedBy(list, {})).toBe(false);
+    expect(isEventMutedBy(list, { pubkey: BOB })).toBe(false);
+    expect(isEventMutedBy(list, { pubkey: ALICE })).toBe(true);
+  });
+
+  it('does not mute on an empty-string id or pubkey', () => {
+    // An unsigned/blank event must not collide with a mute entry.
+    const list = muteList({
+      pubkeys: [{ type: 'pubkey', value: '' }],
+      threads: [{ type: 'thread', value: '' }]
+    });
+    expect(isEventMutedBy(list, { id: '', pubkey: '' })).toBe(false);
+  });
+});

--- a/src/lib/muteFilter.test.ts
+++ b/src/lib/muteFilter.test.ts
@@ -40,6 +40,13 @@ describe('the individual checks', () => {
     expect(hasMutedTag(list, [])).toBe(false);
   });
 
+  it('tolerates malformed tags without throwing', () => {
+    const list = muteList({ tags: [{ type: 'tag', value: 'politics' }] });
+    const malformed = [null, 't', ['t'], ['t', 1], ['t', 'POLITICS']] as unknown as string[][];
+    expect(() => hasMutedTag(list, malformed)).not.toThrow();
+    expect(hasMutedTag(list, malformed)).toBe(true);
+  });
+
   it('matches a muted thread by event id', () => {
     const list = muteList({ threads: [{ type: 'thread', value: NOTE_ID }] });
     expect(isThreadMuted(list, NOTE_ID)).toBe(true);

--- a/src/lib/muteFilter.ts
+++ b/src/lib/muteFilter.ts
@@ -65,9 +65,14 @@ export function containsMutedWord(muteList: MuteList, content: string): boolean 
  * Check if event has muted tags
  */
 export function hasMutedTag(muteList: MuteList, eventTags: string[][]): boolean {
+  // Relays can send malformed tags (null/string entries). Skip anything that
+  // is not a real `t` tag with a string value so mute checks never throw.
   const eventHashtags = eventTags
-    .filter((tag) => tag[0] === 't')
-    .map((tag) => tag[1]?.toLowerCase());
+    .filter(
+      (tag): tag is string[] =>
+        Array.isArray(tag) && tag[0] === 't' && typeof tag[1] === 'string'
+    )
+    .map((tag) => tag[1].toLowerCase());
 
   return muteList.tags.some((item) => eventHashtags.includes(item.value.toLowerCase()));
 }

--- a/src/lib/muteFilter.ts
+++ b/src/lib/muteFilter.ts
@@ -1,0 +1,110 @@
+/**
+ * Mute-list types and the pure checks that read them.
+ *
+ * Split out of `mutableIntegration.ts` (which re-exports everything here, so
+ * existing imports are unchanged) because that module pulls in `$lib/nostr`
+ * and therefore `$app/environment`, which is not resolvable under vitest.
+ * These checks decide what a member does and does not see, so they are the
+ * part that needs tests.
+ */
+
+// Type definitions (from mutable)
+export interface MutedPubkey {
+  type: 'pubkey';
+  value: string; // hex pubkey
+  reason?: string;
+  eventRef?: string;
+  private?: boolean;
+}
+
+export interface MutedWord {
+  type: 'word';
+  value: string;
+  reason?: string;
+  private?: boolean;
+}
+
+export interface MutedTag {
+  type: 'tag';
+  value: string;
+  reason?: string;
+  private?: boolean;
+}
+
+export interface MutedThread {
+  type: 'thread';
+  value: string; // event id
+  reason?: string;
+  private?: boolean;
+}
+
+export interface MuteList {
+  pubkeys: MutedPubkey[];
+  words: MutedWord[];
+  tags: MutedTag[];
+  threads: MutedThread[];
+}
+
+/**
+ * Check if a pubkey is in the mute list
+ */
+export function isPubkeyMuted(muteList: MuteList, pubkey: string): boolean {
+  return muteList.pubkeys.some((item) => item.value === pubkey);
+}
+
+/**
+ * Check if content contains muted words
+ */
+export function containsMutedWord(muteList: MuteList, content: string): boolean {
+  if (!content) return false;
+  const lowerContent = content.toLowerCase();
+  return muteList.words.some((item) => lowerContent.includes(item.value.toLowerCase()));
+}
+
+/**
+ * Check if event has muted tags
+ */
+export function hasMutedTag(muteList: MuteList, eventTags: string[][]): boolean {
+  const eventHashtags = eventTags
+    .filter((tag) => tag[0] === 't')
+    .map((tag) => tag[1]?.toLowerCase());
+
+  return muteList.tags.some((item) => eventHashtags.includes(item.value.toLowerCase()));
+}
+
+/**
+ * Check if thread is muted
+ */
+export function isThreadMuted(muteList: MuteList, eventId: string): boolean {
+  return muteList.threads.some((item) => item.value === eventId);
+}
+
+/** The parts of an event the mute checks read. */
+export interface MutableEventLike {
+  id?: string;
+  pubkey?: string;
+  content?: string;
+  tags?: string[][];
+}
+
+/**
+ * Does the mute list hide this event?
+ *
+ * Composes the four checks above (pubkey, word, tag, thread) into the single
+ * question a feed actually asks, so callers can enforce mutes without also
+ * pulling in whatever topic filter they happen to run. A null or absent mute
+ * list mutes nothing.
+ */
+export function isEventMutedBy(
+  muteList: MuteList | null | undefined,
+  event: MutableEventLike
+): boolean {
+  if (!muteList) return false;
+
+  if (event.pubkey && isPubkeyMuted(muteList, event.pubkey)) return true;
+  if (containsMutedWord(muteList, event.content ?? '')) return true;
+  if (hasMutedTag(muteList, event.tags ?? [])) return true;
+  if (event.id && isThreadMuted(muteList, event.id)) return true;
+
+  return false;
+}

--- a/src/lib/notificationUtils.test.ts
+++ b/src/lib/notificationUtils.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import type { NDKEvent } from '@nostr-dev-kit/ndk';
+
+// The threshold store reaches for localStorage behind this flag; off keeps it
+// in memory, which is all these cases need.
+vi.mock('$app/environment', () => ({ browser: false }));
+
+import { isHellthread } from './notificationUtils';
+import { hellthreadThreshold } from './hellthreadFilterSettings';
+
+// isHellthread is the single implementation of the member's mention threshold.
+// The notification path and the feed both call it, so its edges are worth
+// pinning: they now decide what a member sees in Following, not only in
+// notifications.
+
+function noteWithMentions(count: number): NDKEvent {
+  const tags: string[][] = [['e', 'f'.repeat(64)]];
+  for (let i = 0; i < count; i++) {
+    tags.push(['p', String(i).padStart(64, '0')]);
+  }
+  tags.push(['t', 'foodstr']);
+  return { tags } as unknown as NDKEvent;
+}
+
+afterEach(() => {
+  hellthreadThreshold.reset();
+});
+
+describe('isHellthread', () => {
+  it('hides a note at or above the threshold and keeps one below it', () => {
+    hellthreadThreshold.setThreshold(25);
+
+    expect(isHellthread(noteWithMentions(24))).toBe(false);
+    expect(isHellthread(noteWithMentions(25))).toBe(true);
+    expect(isHellthread(noteWithMentions(26))).toBe(true);
+  });
+
+  it('is disabled at 0, the value the settings copy tells the member to use', () => {
+    hellthreadThreshold.setThreshold(0);
+
+    expect(isHellthread(noteWithMentions(100))).toBe(false);
+  });
+
+  it('defaults to 25 when the member has never set a threshold', () => {
+    expect(isHellthread(noteWithMentions(24))).toBe(false);
+    expect(isHellthread(noteWithMentions(25))).toBe(true);
+  });
+
+  it('counts only p tags', () => {
+    hellthreadThreshold.setThreshold(3);
+
+    const otherTags = {
+      tags: [
+        ['e', 'f'.repeat(64)],
+        ['t', 'foodstr'],
+        ['t', 'baking'],
+        ['q', 'a'.repeat(64)],
+        ['p', 'b'.repeat(64)]
+      ]
+    } as unknown as NDKEvent;
+
+    expect(isHellthread(otherTags)).toBe(false);
+    expect(isHellthread(noteWithMentions(3))).toBe(true);
+  });
+
+  it('keeps an event whose tags are missing or malformed', () => {
+    hellthreadThreshold.setThreshold(1);
+
+    expect(isHellthread({} as unknown as NDKEvent)).toBe(false);
+    expect(isHellthread({ tags: undefined } as unknown as NDKEvent)).toBe(false);
+    expect(isHellthread({ tags: 'p' } as unknown as NDKEvent)).toBe(false);
+    expect(isHellthread({ tags: [null, 'p', ['p', 'x']] } as unknown as NDKEvent)).toBe(true);
+  });
+});


### PR DESCRIPTION
Seth reported posts not showing on the Following feed on the web app. Prep's review: `RESEARCH/FOLLOWING_FEED_ONLY_FOOD_REVIEW_2026_07_30.md` (read at `4a0790c`). This is his changes 1–3 in the order he set, plus change 4 from his 23:41Z ruling, plus Growth's empty-state copy (`OUTBOX/FEED_EMPTY_STATE_COPY_2026_07_30.md`). Frontend only; nothing to do with the Android submission.

**Was drafted on one open question. Prep ruled it 2026-07-30 23:41Z — shipped as change 4 below, and this is out of draft.** Copy cleared by Growth 23:40Z.

## 1. Mutes no longer ride on the food filter

The four NIP-51 checks (pubkey, word, tag, thread) lived inside `shouldIncludeEvent`, and every Following/Replies path called that only `if (foodFilterEnabled)`. The check that *always* ran reads the legacy `localStorage['mutedUsers']` list, which holds pubkeys only.

So **Only Food OFF = word mutes, tag mutes, thread mutes and any pubkey muted from another client stop applying.** That is live today on profile view, which already defaults the toggle off — a defect on its own, and change 2 without it would have made it the default everywhere.

They now live in `isMuted(event)`, and 17 call sites go through one predicate:

```js
function passesFeedFilters(event) {
  if (isMuted(event)) return false;      // always
  if (!foodFilterActive) return true;    // food test only where it applies
  return shouldIncludeEvent(event);
}
```

Two things follow from making it uniform, both in the direction of "the mute list is the member's instruction":

- **Members mode never called `shouldIncludeEvent` on any path**, so it enforced nothing but the legacy pubkey list. It now enforces the full list.
- **The three instant-cache restore paths** filtered unconditionally. Without converting them the new default would not have reached the first paint.

## 2. Following and Replies default to All posts

`foodFilterEnabled` was `!authorPubkey` — ON everywhere except a profile view. Following is a promise about *who*, not about *what*.

Global Food is unchanged: it renders no toggle and carries the food promise in its own name. `foodFilterActive` now states that directly instead of leaving it implied across a dozen `authorPubkey ? … : …` branches.

## 3. The choice persists

New `src/lib/foodFilterSettings.ts` (`zapcooking_food_filter`), shaped after `hellthreadFilterSettings.ts`. It guards with `typeof localStorage` rather than importing `$app/environment`, so it is importable under vitest — `memories.ts` avoids that import for the same reason. The switch above the feed and the empty-state button share one `setFoodFilter(enabled)`.

## Copy (Growth's, signed off by her in `prep room`)

One string served every `filterMode` and told the viewer to "try posting" on a feed of *other people's* posts, with a Refresh button that cannot clear a filter. Split by the predicate that decides what is actually true; the button becomes **"Show all posts"** wired to the toggle handler wherever a filter is the cause.

`foodToggleVisible` is now one variable used both to render the switch and to decide whether a string may say "turn it off above".

> **One thing I inferred, @Growth:** your file gives bodies for the two profile-view cases but no headings. I used "No cooking posts found" (filter on) and "No posts yet" (filter off), matching your Following/Replies split. Say the word if you want them different.

## Why `muteFilter.ts` exists

`isEventMutedBy` and the four predicates it composes moved to a new `src/lib/muteFilter.ts`; `mutableIntegration.ts` re-exports them, so **no existing import changes**. That module pulls in `$lib/nostr` and therefore `$app/environment`, which vitest cannot resolve — and these checks decide what a member does and does not see, so they are the part that needed tests.

## Verification

| check | result |
|---|---|
| `npx vitest run` (full suite) | 71 files, **1083 passed** |
| new tests (`muteFilter`, `foodFilterSettings`) | 23 passed |
| mutation check — drop the word check / coerce the stored value / stop persisting | each mutant caught, restored |
| `svelte-check` | **0 errors**; 150 warnings, none in the touched files (pre-existing a11y at `:5498/5524/5529/5558`) |
| `NODE_OPTIONS=--max-old-space-size=6144 vite build` | built in 1m 15s |
| prettier | new files clean. `mutableIntegration.ts` was already dirty at `4a0790c` (tab-indented) — not reformatted |

**Read out of rendered HTML**, not just compiled — `vite dev` with `loading` forced false so the empty state reaches SSR (probe reverted, not in this diff):

- `/kitchen` following, filter **off** → toggle reads "All posts"; *"No posts yet" / "Nobody you follow has posted recently." /* "Find more cooks to follow" link; **no** Refresh button.
- `/kitchen` following, filter **on** → *"No cooking posts found" / "Only Food is hiding everything else here…"* + **"Show all posts"**.
- `/community` global → *"No cooking posts right now" / "Check back soon…"* + Refresh Feed retained, no toggle.

**Not rendered:** the profile branch. `/user/<npub>` never returns from the local dev server (SSR blocks on a relay profile fetch). Typechecked, and it shares the template with the two branches above.

**Not verified at all:** behaviour against live relays with a real follow list — i.e. whether the flip actually surfaces the post Seth reported. That needs a human on the deployed build.

## 4. The hellthread threshold applies wherever the member reads

This is what the PR was drafted on, and **Prep ruled it uniform, in this PR** (23:41Z). `isHellthread` was reached *only* from inside `_shouldIncludeEventUncached`, so the member's threshold (`/settings:528-531`) stopped applying the moment the food filter was off — which change 2 makes the default on Following. Same coupling as the mutes defect in change 1, one noun over.

His three reasons: `settings/+page.svelte:1308-1311` promises it with **no scope qualifier** ("Hide notes with too many mentions… Set to 0 to disable"), so profile view is already a copy-code violation today; `notificationUtils.ts:16-26` already applies it to the **notification path with no food condition**, so "everywhere the member reads" is the setting's existing meaning and the feed is the outlier; and the blast radius is spam-shaped — default 25, disabled at 0, and a note with 25+ `p` tags is pathological in every view.

The test he attached, so the next rule added to that function does not need another ruling: **is it the member's instruction, or our guess?** A control, a stored value, or a live string promising it → applies wherever that member reads. A curation heuristic we chose, with no control and no string → applies where the guess is in scope. By that test **`MAX_HASHTAGS = 5` stays inside the food test** — that reasoning is now a comment at the check itself.

Shipped as one line in `passesFeedFilters`, plus the collapse Prep flagged non-blocking: **the local implementation is deleted and the feed calls the exported `notificationUtils.isHellthread`**, so the two surfaces cannot drift. The local wrapper that remains does one thing — expand a kind 6 repost so it is judged by the note it carries, matching `isMuted` and preserving what the old in-food-test call did (it sat below the repost recursion).

**One side effect worth knowing:** the check now sits outside `shouldIncludeEvent`'s memo cache, which is invalidated on mute-list change only. A threshold edited in `/settings` previously stayed cached stale for already-seen events; it now takes effect on the next filter pass.

New `src/lib/notificationUtils.test.ts` — 5 tests over the shared rule (at/above/below the threshold, 0 disables, counts only `p` tags, malformed tags kept). Mutation-checked with four mutants: `>=`→`>`, drop the 0 guard, count every tag, drop the tags guard. Each caught; `git diff` on `notificationUtils.ts` empty afterwards.

Re-verified at `9e054ba`: full suite **1083 passed / 71 files**, `svelte-check` **0 errors**, production build clean, prettier clean on both touched files. Not re-rendered — change 4 alters no string.

## Recorded, not touched

- The composer writing no `t` tags — your separate item. It is *why* the relay-side `#t` filter can never match our own posts; this PR routes around it rather than fixing it.
- `MAX_HASHTAGS = 5` and the standalone-word `root` exclusion stay inside the food test — Prep's ruling in change 4 covers `MAX_HASHTAGS` explicitly (no setting, no UI, no string). Both now only bite when the toggle is deliberately on.
- The Primal-vs-outbox race is unchanged.

Implementation record: `PLANS/FOLLOWING_FEED_FILTER_BUILD_2026_07_30.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

