### PR TITLE
fix(membership): force a membership refresh after payment completes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.687",
+  "version": "4.2.688",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/stores/membershipStatus.test.ts
+++ b/src/lib/stores/membershipStatus.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { get } from 'svelte/store';
+
+/**
+ * `browser` is mocked true because every path in this store is a no-op on the
+ * server — without it `refreshMembership` returns null before it ever fetches
+ * and the tests would assert nothing.
+ */
+vi.mock('$app/environment', () => ({ browser: true }));
+
+import {
+  refreshMembership,
+  queueMembershipLookup,
+  getMembership,
+  membershipStatusMap,
+  __resetMembershipStatusStoreForTests
+} from './membershipStatus';
+
+const PK_A = 'a'.repeat(64);
+const PK_B = 'b'.repeat(64);
+
+function statusPayload(pubkey: string, active: boolean, tier = 'cook_plus') {
+  return { [pubkey]: { active, tier } };
+}
+
+/** Reads the pubkeys a recorded fetch call asked for. */
+function requestedPubkeys(call: unknown[]): string[] {
+  const url = String(call[0]);
+  const raw = decodeURIComponent(url.split('pubkeys=')[1] ?? '');
+  return raw ? raw.split(',') : [];
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  __resetMembershipStatusStoreForTests();
+  vi.useFakeTimers();
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+function respondWith(body: Record<string, unknown>) {
+  return Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
+}
+
+describe('refreshMembership', () => {
+  it('bypasses a cached inactive result and returns the fresh one', async () => {
+    fetchMock.mockReturnValueOnce(respondWith(statusPayload(PK_A, false, 'member')));
+    queueMembershipLookup(PK_A);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(get(membershipStatusMap)[PK_A]).toEqual({
+      active: false,
+      tier: 'member',
+      expiresAt: undefined
+    });
+
+    // A second queued lookup must NOT refetch — this is the defect's mechanism.
+    queueMembershipLookup(PK_A);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    fetchMock.mockReturnValueOnce(respondWith(statusPayload(PK_A, true, 'cook_plus')));
+    const result = await refreshMembership(PK_A);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ active: true, tier: 'cook_plus', expiresAt: undefined });
+  });
+
+  it('publishes the fresh status to membershipStatusMap for every consumer', async () => {
+    fetchMock.mockReturnValueOnce(respondWith(statusPayload(PK_A, false, 'member')));
+    await getMembership([PK_A]);
+    expect(get(membershipStatusMap)[PK_A].active).toBe(false);
+
+    fetchMock.mockReturnValueOnce(respondWith(statusPayload(PK_A, true, 'pro_kitchen')));
+    await refreshMembership(PK_A);
+
+    expect(get(membershipStatusMap)[PK_A]).toEqual({
+      active: true,
+      tier: 'pro_kitchen',
+      expiresAt: undefined
+    });
+  });
+
+  it('requests with cache: no-store so an HTTP-cached answer cannot be reused', async () => {
+    fetchMock.mockReturnValueOnce(respondWith(statusPayload(PK_A, true)));
+    await refreshMembership(PK_A);
+
+    expect(fetchMock.mock.calls[0][1]).toEqual({ cache: 'no-store' });
+  });
+
+  it('leaves the batch path uninstrumented — queued lookups send no init', async () => {
+    fetchMock.mockReturnValueOnce(respondWith(statusPayload(PK_A, false)));
+    queueMembershipLookup(PK_A);
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(fetchMock.mock.calls[0][1]).toBeUndefined();
+  });
+
+  it('normalizes the pubkey and accepts mixed case', async () => {
+    fetchMock.mockReturnValueOnce(respondWith(statusPayload(PK_A, true)));
+    const result = await refreshMembership(PK_A.toUpperCase());
+
+    expect(requestedPubkeys(fetchMock.mock.calls[0])).toEqual([PK_A]);
+    expect(result?.active).toBe(true);
+  });
+
+  it('returns null without fetching for a malformed pubkey', async () => {
+    expect(await refreshMembership('not-a-pubkey')).toBeNull();
+    expect(await refreshMembership(null)).toBeNull();
+    expect(await refreshMembership(undefined)).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the previous value rather than throwing when the lookup fails', async () => {
+    fetchMock.mockReturnValueOnce(respondWith(statusPayload(PK_A, true)));
+    await refreshMembership(PK_A);
+
+    fetchMock.mockReturnValueOnce(Promise.resolve({ ok: false, status: 503 }));
+    const result = await refreshMembership(PK_A);
+
+    expect(result).toEqual({ active: true, tier: 'cook_plus', expiresAt: undefined });
+  });
+});
+
+describe('refreshMembership vs. the debounced batch', () => {
+  it('is not overwritten by a batch that was already in flight', async () => {
+    // The batch resolves only when we release it — this is the ordering that
+    // produced the bug: stale answer lands last.
+    let releaseBatch: (value: unknown) => void = () => {};
+    const batchResponse = new Promise((resolve) => {
+      releaseBatch = resolve;
+    });
+    fetchMock.mockReturnValueOnce(
+      batchResponse.then(() => ({ ok: true, json: () => Promise.resolve(statusPayload(PK_A, false, 'member')) }))
+    );
+
+    queueMembershipLookup(PK_A);
+    await vi.advanceTimersByTimeAsync(100);
+
+    fetchMock.mockReturnValueOnce(respondWith(statusPayload(PK_A, true, 'cook_plus')));
+    await refreshMembership(PK_A);
+    expect(get(membershipStatusMap)[PK_A].active).toBe(true);
+
+    releaseBatch(null);
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(get(membershipStatusMap)[PK_A]).toEqual({
+      active: true,
+      tier: 'cook_plus',
+      expiresAt: undefined
+    });
+  });
+
+  // Enforced by the existing `!statusCache.has` check on the failure path, not
+  // by the epoch guard — verified by mutation: removing the epoch check leaves
+  // this green, removing the cache check does not.
+  it('is not overwritten by an in-flight batch that fails', async () => {
+    let failBatch: (reason: unknown) => void = () => {};
+    const batchResponse = new Promise((_resolve, reject) => {
+      failBatch = reject;
+    });
+    fetchMock.mockReturnValueOnce(batchResponse);
+
+    queueMembershipLookup(PK_A);
+    await vi.advanceTimersByTimeAsync(100);
+
+    fetchMock.mockReturnValueOnce(respondWith(statusPayload(PK_A, true)));
+    await refreshMembership(PK_A);
+
+    failBatch(new Error('network down'));
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(get(membershipStatusMap)[PK_A].active).toBe(true);
+  });
+
+  it('does not suppress other pubkeys in the same superseded batch', async () => {
+    let releaseBatch: (value: unknown) => void = () => {};
+    const batchResponse = new Promise((resolve) => {
+      releaseBatch = resolve;
+    });
+    fetchMock.mockReturnValueOnce(
+      batchResponse.then(() => ({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            ...statusPayload(PK_A, false, 'member'),
+            ...statusPayload(PK_B, true, 'founders')
+          })
+      }))
+    );
+
+    queueMembershipLookup(PK_A);
+    queueMembershipLookup(PK_B);
+    await vi.advanceTimersByTimeAsync(100);
+
+    fetchMock.mockReturnValueOnce(respondWith(statusPayload(PK_A, true, 'cook_plus')));
+    await refreshMembership(PK_A);
+
+    releaseBatch(null);
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(get(membershipStatusMap)[PK_A].active).toBe(true);
+    expect(get(membershipStatusMap)[PK_B]).toEqual({
+      active: true,
+      tier: 'founders',
+      expiresAt: undefined
+    });
+  });
+
+  it('drops a queued-but-unflushed lookup for the same pubkey', async () => {
+    queueMembershipLookup(PK_A);
+    fetchMock.mockReturnValueOnce(respondWith(statusPayload(PK_A, true)));
+    await refreshMembership(PK_A);
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets the later of two concurrent refreshes win', async () => {
+    let releaseFirst: (value: unknown) => void = () => {};
+    const firstResponse = new Promise((resolve) => {
+      releaseFirst = resolve;
+    });
+    fetchMock.mockReturnValueOnce(
+      firstResponse.then(() => ({ ok: true, json: () => Promise.resolve(statusPayload(PK_A, false, 'member')) }))
+    );
+    const first = refreshMembership(PK_A);
+
+    fetchMock.mockReturnValueOnce(respondWith(statusPayload(PK_A, true, 'cook_plus')));
+    await refreshMembership(PK_A);
+
+    releaseFirst(null);
+    await first;
+
+    expect(get(membershipStatusMap)[PK_A].active).toBe(true);
+  });
+});
+
+describe('existing batching behaviour is unchanged', () => {
+  it('still coalesces queued lookups into one request per debounce window', async () => {
+    fetchMock.mockReturnValueOnce(
+      respondWith({ ...statusPayload(PK_A, false), ...statusPayload(PK_B, true) })
+    );
+
+    queueMembershipLookup(PK_A);
+    queueMembershipLookup(PK_B);
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(requestedPubkeys(fetchMock.mock.calls[0]).sort()).toEqual([PK_A, PK_B].sort());
+  });
+
+  it('still serves getMembership from the cache after a refresh', async () => {
+    fetchMock.mockReturnValueOnce(respondWith(statusPayload(PK_A, true, 'founders')));
+    await refreshMembership(PK_A);
+
+    const result = await getMembership([PK_A]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result[PK_A]).toEqual({ active: true, tier: 'founders', expiresAt: undefined });
+  });
+});

--- a/src/lib/stores/membershipStatus.ts
+++ b/src/lib/stores/membershipStatus.ts
@@ -146,8 +146,11 @@ export function queueMembershipLookup(pubkey: string | null | undefined): void {
  * per-avatar request storm that took `getMembership` out of `Avatar.svelte`.
  * Callers must keep it that way — one call per completed payment.
  *
- * Never rejects: a failed lookup is swallowed by `fetchBatch` and leaves the
- * previous value in place, so a caller can await it without risking the page.
+ * Never rejects: a failed lookup is swallowed by `fetchBatch`. If a previous
+ * value exists it is left in place; if the cache had no entry yet, the failure
+ * path writes the inactive placeholder (`{active:false, tier:'unknown'}`) that
+ * `fetchBatch` has always written for an unknown pubkey. Callers can await
+ * without risking the page.
  */
 export async function refreshMembership(
   pubkey: string | null | undefined

--- a/src/lib/stores/membershipStatus.ts
+++ b/src/lib/stores/membershipStatus.ts
@@ -19,6 +19,17 @@ const inFlight = new Set<string>();
 const queued = new Set<string>();
 let flushTimer: ReturnType<typeof setTimeout> | null = null;
 
+// Bumped every time a forced refresh is issued for a pubkey. A batch that was
+// already in flight when the refresh started carries an older answer, and
+// without this it would land after the refresh and restore the stale value —
+// the exact defect the refresh exists to fix. Each fetch captures the epoch of
+// every pubkey it requested and drops any whose epoch moved underneath it.
+const refreshEpoch = new Map<string, number>();
+
+function epochOf(pubkey: string): number {
+  return refreshEpoch.get(pubkey) ?? 0;
+}
+
 const mapStore = writable<Record<string, MembershipStatus>>({});
 export const membershipStatusMap = { subscribe: mapStore.subscribe };
 
@@ -53,21 +64,24 @@ function normalizeStatus(raw: { active?: boolean; tier?: string; expiresAt?: str
   };
 }
 
-async function fetchBatch(pubkeys: string[]): Promise<void> {
+async function fetchBatch(pubkeys: string[], init?: RequestInit): Promise<void> {
   if (!browser || pubkeys.length === 0) return;
 
   const requested = [...new Set(pubkeys)];
   requested.forEach((pk) => inFlight.add(pk));
+  const startEpochs = new Map(requested.map((pk) => [pk, epochOf(pk)]));
+  const superseded = (pubkey: string): boolean => epochOf(pubkey) !== startEpochs.get(pubkey);
 
   try {
     const query = encodeURIComponent(requested.join(','));
-    const res = await fetch(`/api/membership?pubkeys=${query}`);
+    const res = await fetch(`/api/membership?pubkeys=${query}`, init);
     if (!res.ok) {
       throw new Error(`Membership fetch failed with status ${res.status}`);
     }
 
     const payload = (await res.json()) as MembershipResponse;
     for (const pubkey of requested) {
+      if (superseded(pubkey)) continue;
       const raw = payload?.[pubkey];
       if (raw) {
         updateStore(pubkey, normalizeStatus(raw));
@@ -78,6 +92,11 @@ async function fetchBatch(pubkeys: string[]): Promise<void> {
   } catch (error) {
     console.warn('[membershipStatus] Batch fetch failed:', error);
     for (const pubkey of requested) {
+      // No epoch check needed here: this path only writes a placeholder for a
+      // pubkey with no value at all, so a refresh that wrote one is already
+      // safe. Adding the guard would change behaviour only when the refresh
+      // failed too, and then it would leave the pubkey with no entry instead
+      // of the placeholder this path has always written.
       if (!statusCache.has(pubkey)) {
         updateStore(pubkey, { active: false, tier: 'unknown' });
       }
@@ -110,6 +129,42 @@ export function queueMembershipLookup(pubkey: string | null | undefined): void {
   if (statusCache.has(normalized) || inFlight.has(normalized)) return;
   queued.add(normalized);
   scheduleFlush();
+}
+
+/**
+ * Force a fresh lookup for one pubkey, ignoring anything already cached.
+ *
+ * `queueMembershipLookup` and `getMembership` both return early on a cached
+ * pubkey, and the cache has no TTL — so a `{active:false}` read taken before a
+ * payment completes is the answer every membership surface gets for the life of
+ * the tab (avatar ring, belt badge, header, Cheffy). Call this once after a
+ * payment is confirmed; every consumer reads `membershipStatusMap`, so the one
+ * write reaches all of them.
+ *
+ * Deliberately NOT wired into the debounced queue: this is a single known
+ * pubkey at a known moment, not feed traffic, so it does not reintroduce the
+ * per-avatar request storm that took `getMembership` out of `Avatar.svelte`.
+ * Callers must keep it that way — one call per completed payment.
+ *
+ * Never rejects: a failed lookup is swallowed by `fetchBatch` and leaves the
+ * previous value in place, so a caller can await it without risking the page.
+ */
+export async function refreshMembership(
+  pubkey: string | null | undefined
+): Promise<MembershipStatus | null> {
+  if (!browser) return null;
+  const normalized = normalizePubkey(pubkey);
+  if (!normalized) return null;
+
+  // Bump before the fetch, so any batch already in flight for this pubkey is
+  // treated as superseded when it lands.
+  refreshEpoch.set(normalized, epochOf(normalized) + 1);
+  // A queued-but-unflushed lookup for this pubkey would only re-ask the same
+  // question a moment later.
+  queued.delete(normalized);
+
+  await fetchBatch([normalized], { cache: 'no-store' });
+  return statusCache.get(normalized) ?? null;
 }
 
 export async function getMembership(pubkeys: string[]): Promise<Record<string, MembershipStatus>> {
@@ -154,6 +209,7 @@ export function __resetMembershipStatusStoreForTests(): void {
   statusCache.clear();
   inFlight.clear();
   queued.clear();
+  refreshEpoch.clear();
   if (flushTimer) {
     clearTimeout(flushTimer);
     flushTimer = null;

--- a/src/routes/membership/confirmation/+page.svelte
+++ b/src/routes/membership/confirmation/+page.svelte
@@ -5,6 +5,7 @@
   import { page } from '$app/stores';
   import { userPublickey, ndk } from '$lib/nostr';
   import { claimNip05, checkUsernameAvailable, validateUsername, updateProfileWithNip05 } from '$lib/nip05Service';
+  import { refreshMembership } from '$lib/stores/membershipStatus';
 
   // --- Tier Configuration ---
   const TIERS: Record<string, {
@@ -158,6 +159,10 @@
     if (paymentMethod === 'lightning') {
       nip05 = nip05Param;
       nip05Username = nip05UsernameParam;
+      // Lightning registers the member server-side before redirecting here, so
+      // this branch never calls complete-payment — but the client cache is just
+      // as stale as on the Stripe path, and for the same reason.
+      void refreshMembership($userPublickey);
       // If NIP-05 was already assigned during payment, show success state
       if (nip05Username) {
         chosenName = nip05Username;
@@ -202,6 +207,16 @@
         } catch {}
         throw new Error(errorMessage);
       }
+
+      // Membership is live on the server as of this response. The client store
+      // still holds the {active:false} it read before checkout and has no TTL,
+      // so without this the member is a non-member on every membership surface
+      // — avatar ring, belt, header, Cheffy — until they reload the tab.
+      // Placed on the shared success path so both complete-payment endpoints
+      // (genesis and standard) are covered. Not awaited: consumers subscribe to
+      // membershipStatusMap and update when it lands, and the success screen
+      // must not be able to hang behind a second round trip.
+      void refreshMembership($userPublickey);
 
       const data = JSON.parse(responseText);
       subscriptionEnd = data.subscriptionEnd || null;


### PR DESCRIPTION
Fixes the stale client-side membership state Seth hit after a live Stripe checkout (prep room, 2026-07-31 23:15Z). Assigned by Chief; built to Seth's spec and his acceptance test.

## The defect

`src/lib/stores/membershipStatus.ts` caches per pubkey in a module-level `Map` with **no TTL and no invalidation path anywhere in the file**. Both readers return early on a cached pubkey — `queueMembershipLookup:110`, `getMembership:123`. So the `{active:false}` written before checkout is the answer for the life of the tab.

It is **not only Cheffy**. The same store feeds `Avatar.svelte:56`, `Header.svelte:85`, `MembershipBeltBadge.svelte`, `CheffyExploreInvite:54`, `CheffyMessenger:67`, `CheffyNoteReview:100`, `LandingImportHero:55`. A member who just paid gets no badge, no belt, no Cheffy — until they reload.

## The change

**`refreshMembership(pubkey)`** — bypasses the cache, requests with `cache: 'no-store'`, writes through `membershipStatusMap` so all consumers update from the one call. Never rejects: a failed lookup leaves the previous value in place.

**Called from `membership/confirmation/+page.svelte`** on the shared success path after the POST returns, which covers *both* endpoints (`/api/genesis/complete-payment` and `/api/membership/complete-payment`) — hanging it off one would leave Founders broken.

**Also on the lightning branch (`:159-169`).** Not in the original report: that branch returns before the Stripe path because its data arrives in the URL, but the member was registered server-side and the client cache is stale for exactly the same reason. One line, same defect.

**Write ordering.** A batch already in flight when the refresh starts carries the older answer and would land after it — restoring the stale value the refresh just removed. Writes are epoch-guarded per pubkey: each fetch captures the epoch of every pubkey it requested and drops any whose epoch moved underneath it. Also makes the last of two concurrent refreshes win.

**Not routed through the debounced queue.** `Avatar.svelte:52` documents why `getMembership` was removed from it — one HTTP request per mounted avatar, hundreds per feed page. This is one known pubkey at one known moment; the docstring says so, so the next caller does not undo that lesson.

**Not a TTL on the cache.** Chief's scope call, and I agree — different change, different blast radius. Fileable separately.

## Verification (worktree `wt-membership-refresh`, head `b0d5f9d`, base `4a0790c5`)

- **1069 tests pass / 69 files**, up 14 from the new `membershipStatus.test.ts` (the store had no test file before, despite exporting `__resetMembershipStatusStoreForTests`).
- **Every new test mutation-checked** — mutant built, watched fail, restored. Killed: dropping the epoch guard, dropping the epoch bump, dropping `cache: 'no-store'`, dropping the redundant-queue cleanup, and re-adding a cache check inside `refreshMembership` (the original bug).
- One guard I wrote **did not survive mutation** — an epoch check on the fetch-failure path stayed green when removed, because the pre-existing `!statusCache.has` check already blocks that write. Removed it rather than ship an untestable branch; the comment there records why.
- `svelte-check`: **0 errors**, 150 warnings (baseline).
- Production `vite build`: clean.
- `/membership/confirmation` renders HTTP 200 on a dev server with `MEMBERSHIP_ENABLED=true`.

## Not verified

- **Seth's acceptance test itself has not been run** — it needs a live payment. Complete a payment and open Cheffy without reloading. The unit tests reproduce the sequence (cached inactive → refresh → active, plus the in-flight-batch race), but no real checkout has exercised this build.
- No browser has been observed making the request; `$userPublickey` is empty in a headless render, so the refresh short-circuits to `null` there.

Reviewer: **Prep**. Seth or Daniel merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)