### PR TITLE
feat(nav): floating back-to-top button + tap-header/search shortcuts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.688",
+  "version": "4.2.689",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.689",
+  "version": "4.2.690",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
+  import { browser } from '$app/environment';
   import { page } from '$app/stores';
   import { userPublickey, userProfilePictureOverride } from '$lib/nostr';
   import { triggerExploreNav } from '$lib/exploreNav';
@@ -134,6 +135,19 @@
     }
   }
 
+  /**
+   * Engaging search jumps the page back to the top, so results/typing aren't
+   * happening while the user is stranded mid-feed. Scrolls the #app-scroll
+   * container (the element the app actually scrolls) with a window fallback.
+   * Additive — does not interfere with focusing the input or opening the
+   * mobile search overlay.
+   */
+  function scrollToTopOnSearch() {
+    if (!browser) return;
+    const el = document.getElementById('app-scroll');
+    (el ?? window).scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
 </script>
 
 <!-- Mobile-first sleek header -->
@@ -171,8 +185,10 @@
        the pipe's vertical line to 12px (10px here + the input's 2px margin),
        matching the header's 12px top/bottom padding so the search box has
        equal visual padding on all three framed sides. -->
+  <!-- focusin (not click) so keyboard tabbing into search also jumps to top. -->
   <div
     class="hidden sm:flex flex-1 self-center print:hidden min-w-[280px] lg:max-w-xs xl:max-w-2xl xl:min-w-[500px] lg:pl-2.5"
+    on:focusin={scrollToTopOnSearch}
   >
     <TagsSearchAutocomplete
       placeholderString={'Search recipes, tags, or users...'}
@@ -186,7 +202,10 @@
     <!-- Search icon (mobile only) -->
     <div class="block sm:hidden">
       <button
-        on:click={() => mobileSearchOpen.set(true)}
+        on:click={() => {
+          scrollToTopOnSearch();
+          mobileSearchOpen.set(true);
+        }}
         class="zh-iconbtn"
         aria-label="Search"
       >

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -33,6 +33,7 @@
   import { weblnConnected } from '$lib/wallet/webln';
   import { bitcoinConnectEnabled, bitcoinConnectWalletInfo } from '$lib/wallet/bitcoinConnect';
   import { cookingToolsStore, cookingToolsOpen } from '$lib/stores/cookingToolsWidget';
+  import { scrollActiveSurfaceToTop } from '$lib/activeScrollSurface';
   import {
     membershipStatusMap,
     queueMembershipLookup,
@@ -144,8 +145,7 @@
    */
   function scrollToTopOnSearch() {
     if (!browser) return;
-    const el = document.getElementById('app-scroll');
-    (el ?? window).scrollTo({ top: 0, behavior: 'smooth' });
+    scrollActiveSurfaceToTop(document.getElementById('app-scroll'));
   }
 
 </script>

--- a/src/components/ScrollToTopButton.svelte
+++ b/src/components/ScrollToTopButton.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+  /**
+   * Floating "back to top" button.
+   *
+   * Appears once the page has been scrolled down a screenful, and smooth-
+   * scrolls the #app-scroll container back to the top on tap. Watches the
+   * same #app-scroll element the rest of the app scrolls in (the layout's
+   * overflow-y-auto container), with a window-scroll fallback mirroring
+   * CreateMenuButton's pattern. Mounted once in the root layout so it's
+   * available on every scrollable surface (feeds, recipes, profile, …).
+   */
+  import { onMount, onDestroy } from 'svelte';
+  // fade, not fly: fly sets an inline transform, which would override the
+  // translateX(-50%) that centers the button and jump it left mid-animation.
+  import { fade } from 'svelte/transition';
+  import CaretUpIcon from 'phosphor-svelte/lib/CaretUp';
+
+  // Show only after scrolling at least this many px down, so it never
+  // competes with page chrome when the user is already near the top.
+  const SHOW_THRESHOLD_PX = 600;
+  // Matches CreateMenuButton's fade-out window, so both floating controls
+  // dim and restore in step while the user is scrolling.
+  const SCROLL_IDLE_MS = 160;
+
+  let visible = false;
+  let isScrolling = false;
+  let scrollEl: HTMLElement | null = null;
+  let scrollTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  function onScroll() {
+    const top = scrollEl?.scrollTop ?? window.scrollY ?? 0;
+    visible = top > SHOW_THRESHOLD_PX;
+
+    // Dim while actively scrolling (same treatment as the compose FAB) so
+    // the control stays out of the way of the content passing under it.
+    isScrolling = true;
+    if (scrollTimeout) clearTimeout(scrollTimeout);
+    scrollTimeout = setTimeout(() => {
+      isScrolling = false;
+    }, SCROLL_IDLE_MS);
+  }
+
+  function scrollToTop() {
+    const target = scrollEl ?? window;
+    target.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  onMount(() => {
+    if (typeof window === 'undefined') return;
+    // Defer one tick so #app-scroll exists after the layout mounts.
+    scrollEl = document.getElementById('app-scroll');
+    if (scrollEl) {
+      scrollEl.addEventListener('scroll', onScroll, { passive: true });
+    }
+    // Fallback for any route that scrolls the window rather than the
+    // container (matches CreateMenuButton's dual-listener approach).
+    window.addEventListener('scroll', onScroll, { passive: true });
+    onScroll();
+  });
+
+  onDestroy(() => {
+    if (typeof window !== 'undefined') {
+      scrollEl?.removeEventListener('scroll', onScroll);
+      window.removeEventListener('scroll', onScroll);
+    }
+    if (scrollTimeout) {
+      clearTimeout(scrollTimeout);
+      scrollTimeout = null;
+    }
+  });
+</script>
+
+{#if visible}
+  <button
+    type="button"
+    on:click={scrollToTop}
+    aria-label="Back to top"
+    class="scroll-to-top-btn"
+    class:is-scrolling={isScrolling}
+    transition:fade={{ duration: 150 }}
+  >
+    <CaretUpIcon size={22} weight="bold" />
+  </button>
+{/if}
+
+<style>
+  .scroll-to-top-btn {
+    position: fixed;
+    /* Centered on the CONTENT area, not the raw viewport: on wide desktop
+       the fixed sidebar occupies the left edge, so viewport-centering would
+       sit visibly right of the content column. --content-left is the
+       sidebar offset (0 on mobile, set per-breakpoint below), so the
+       midpoint is (content-left + 100%) / 2. Keeps it clear of the compose
+       FAB (bottom-right) and cooking-tools widget (bottom-left) either way.
+       --bottom-nav-height lifts it above the mobile bottom nav. */
+    --content-left: 0px;
+    left: calc(50% + var(--content-left) / 2);
+    transform: translateX(-50%);
+    bottom: calc(var(--bottom-nav-height, 0px) + 1rem + var(--timer-widget-offset, 0px));
+    z-index: 40;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.75rem;
+    height: 2.75rem;
+    border-radius: 9999px;
+    cursor: pointer;
+    color: var(--color-text-primary);
+    background-color: var(--color-input-bg);
+    border: 1px solid var(--color-input-border);
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
+    transition: transform 0.12s ease, background-color 0.12s ease, opacity 0.12s ease;
+  }
+  .scroll-to-top-btn:hover {
+    background-color: var(--color-bg-hover, var(--color-input-bg));
+  }
+  /* Dim out of the way while scrolling — mirrors .create-trigger.is-scrolling
+     on the compose FAB so both floating controls behave identically. */
+  .scroll-to-top-btn.is-scrolling {
+    opacity: 0.45;
+  }
+  .scroll-to-top-btn:active {
+    /* Keep the centering translate — a bare scale() would drop it and
+       snap the button to the left edge mid-press. */
+    transform: translateX(-50%) scale(0.92);
+  }
+  /* Desktop has no bottom nav; tuck closer to the bottom edge. The sidebar
+     offsets match the layout's #app-scroll margins (lg:ml-[calc(14rem+5px)],
+     xl:ml-[calc(20rem+5px)]) so the button centers on the content column. */
+  @media (min-width: 1024px) {
+    .scroll-to-top-btn {
+      --content-left: calc(14rem + 5px);
+      bottom: 1.25rem;
+    }
+  }
+  @media (min-width: 1280px) {
+    .scroll-to-top-btn {
+      --content-left: calc(20rem + 5px);
+    }
+  }
+</style>

--- a/src/components/ScrollToTopButton.svelte
+++ b/src/components/ScrollToTopButton.svelte
@@ -14,6 +14,7 @@
   // translateX(-50%) that centers the button and jump it left mid-animation.
   import { fade } from 'svelte/transition';
   import CaretUpIcon from 'phosphor-svelte/lib/CaretUp';
+  import { getActiveScrollTop, scrollActiveSurfaceToTop } from '$lib/activeScrollSurface';
 
   // Show only after scrolling at least this many px down, so it never
   // competes with page chrome when the user is already near the top.
@@ -28,7 +29,7 @@
   let scrollTimeout: ReturnType<typeof setTimeout> | null = null;
 
   function onScroll() {
-    const top = scrollEl?.scrollTop ?? window.scrollY ?? 0;
+    const top = getActiveScrollTop(scrollEl);
     visible = top > SHOW_THRESHOLD_PX;
 
     // Dim while actively scrolling (same treatment as the compose FAB) so
@@ -41,13 +42,12 @@
   }
 
   function scrollToTop() {
-    const target = scrollEl ?? window;
-    target.scrollTo({ top: 0, behavior: 'smooth' });
+    scrollActiveSurfaceToTop(scrollEl);
   }
 
   onMount(() => {
     if (typeof window === 'undefined') return;
-    // Defer one tick so #app-scroll exists after the layout mounts.
+    // Resolve the container after this component and its parent layout mount.
     scrollEl = document.getElementById('app-scroll');
     if (scrollEl) {
       scrollEl.addEventListener('scroll', onScroll, { passive: true });

--- a/src/lib/activeScrollSurface.test.ts
+++ b/src/lib/activeScrollSurface.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getActiveScrollTop, scrollActiveSurfaceToTop } from './activeScrollSurface';
+
+function createScrollElement(scrollTop: number) {
+  return {
+    scrollTop,
+    scrollTo: vi.fn()
+  } as unknown as HTMLElement;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('active scroll surface', () => {
+  it('reports the larger window offset when the app container is mounted but idle', () => {
+    vi.stubGlobal('window', { scrollY: 900, scrollTo: vi.fn() });
+
+    expect(getActiveScrollTop(createScrollElement(0))).toBe(900);
+  });
+
+  it('scrolls the app container when it has the larger offset', () => {
+    const scrollEl = createScrollElement(900);
+    const windowScrollTo = vi.fn();
+    vi.stubGlobal('window', { scrollY: 100, scrollTo: windowScrollTo });
+
+    scrollActiveSurfaceToTop(scrollEl);
+
+    expect(scrollEl.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+    expect(windowScrollTo).not.toHaveBeenCalled();
+  });
+
+  it('scrolls the window when it has the larger offset', () => {
+    const scrollEl = createScrollElement(0);
+    const windowScrollTo = vi.fn();
+    vi.stubGlobal('window', { scrollY: 900, scrollTo: windowScrollTo });
+
+    scrollActiveSurfaceToTop(scrollEl);
+
+    expect(windowScrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+    expect(scrollEl.scrollTo).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/activeScrollSurface.ts
+++ b/src/lib/activeScrollSurface.ts
@@ -1,0 +1,14 @@
+export function getActiveScrollTop(scrollEl: HTMLElement | null): number {
+  const elementTop = scrollEl?.scrollTop ?? 0;
+  const windowTop = typeof window === 'undefined' ? 0 : (window.scrollY ?? 0);
+  return Math.max(elementTop, windowTop);
+}
+
+export function scrollActiveSurfaceToTop(scrollEl: HTMLElement | null): void {
+  if (typeof window === 'undefined') return;
+
+  const elementTop = scrollEl?.scrollTop ?? 0;
+  const windowTop = window.scrollY ?? 0;
+  const target = scrollEl && elementTop >= windowTop ? scrollEl : window;
+  target.scrollTo({ top: 0, behavior: 'smooth' });
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -11,6 +11,7 @@
   import NotificationSubscriber from '../components/NotificationSubscriber.svelte';
   import Footer from '../components/Footer.svelte';
   import CreateMenuButton from '../components/CreateMenuButton.svelte';
+  import ScrollToTopButton from '../components/ScrollToTopButton.svelte';
   import PostModal from '../components/PostModal.svelte';
   import LongformEditorModal from '../components/reads/LongformEditorModal.svelte';
   import WalletModal from '../components/wallet/WalletModal.svelte';
@@ -220,6 +221,16 @@
     walletWelcomeSeen = true;
     if (browser) localStorage.setItem(WALLET_WELCOME_KEY, '1');
     openWallet('setup');
+  }
+
+  // Tap the header's empty padding area → smooth-scroll back to top. Only
+  // fires on |self (the wrapper), so real header interactions (search, logo,
+  // buttons) are unaffected. Mirrors the iOS/Twitter "tap status bar" habit.
+  function scrollToTop() {
+    if (!browser) return;
+    const el = document.getElementById('app-scroll');
+    const target = el ?? window;
+    target.scrollTo({ top: 0, behavior: 'smooth' });
   }
 
   // Handle deep links from Capacitor (for NIP-46 pairing)
@@ -559,6 +570,8 @@
            and rubber-band-bounces behind it. -->
       <div
         class="header-blur fixed top-0 left-0 right-0 lg:left-[calc(14rem_+_5px)] xl:left-[calc(20rem_+_5px)] z-30 py-3 px-4"
+        on:click|self={scrollToTop}
+        title="Back to top"
       >
         <Header />
         <!-- Decorative connector (desktop): a vertical line just left of
@@ -593,6 +606,9 @@
       </div>
       {#if !$page.url.pathname.startsWith('/messages') && !$page.url.pathname.startsWith('/groups') && !$postComposerOpen}
         <CreateMenuButton variant="floating" />
+      {/if}
+      {#if !$page.url.pathname.startsWith('/messages') && !$page.url.pathname.startsWith('/groups')}
+        <ScrollToTopButton />
       {/if}
       <BottomNav />
       <CookingToolsWidget />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -63,6 +63,7 @@
   // Refresh engagement counts when the tab returns from background
   import { tabVisibleAfterHide } from '$lib/tabVisibility';
   import { refreshActiveEngagement } from '$lib/engagementCache';
+  import { scrollActiveSurfaceToTop } from '$lib/activeScrollSurface';
 
   // Version-skew guard: when a new deploy is detected (kit.version
   // pollInterval in svelte.config.js), turn the next client-side navigation
@@ -228,9 +229,7 @@
   // buttons) are unaffected. Mirrors the iOS/Twitter "tap status bar" habit.
   function scrollToTop() {
     if (!browser) return;
-    const el = document.getElementById('app-scroll');
-    const target = el ?? window;
-    target.scrollTo({ top: 0, behavior: 'smooth' });
+    scrollActiveSurfaceToTop(document.getElementById('app-scroll'));
   }
 
   // Handle deep links from Capacitor (for NIP-46 pairing)
@@ -571,7 +570,6 @@
       <div
         class="header-blur fixed top-0 left-0 right-0 lg:left-[calc(14rem_+_5px)] xl:left-[calc(20rem_+_5px)] z-30 py-3 px-4"
         on:click|self={scrollToTop}
-        title="Back to top"
       >
         <Header />
         <!-- Decorative connector (desktop): a vertical line just left of


### PR DESCRIPTION
## Problem

Long feeds (explore, recipes, profile, …) had no quick way back to the top — users had to swipe/scroll all the way back up.

## Three affordances, all mounted once in the root layout (work on every page)

1. **Floating back-to-top button** (`ScrollToTopButton.svelte`). Appears after scrolling ~600px; smooth-scrolls the `#app-scroll` container back to the top.
   - **Centered on the content column, not the viewport.** On wide desktop the fixed sidebar occupies the left edge, so viewport-centering would sit visibly right of the content. A `--content-left` CSS var matches the layout's own `#app-scroll` margins (`0` / `14rem+5px` at `lg` / `20rem+5px` at `xl`). Verified 0px delta from the content center at mobile, lg, and xl.
   - **Dims while scrolling** (0.45 opacity, 160ms idle window), mirroring the compose FAB's `.is-scrolling` treatment so both floating controls behave alike. (Deliberately keeps `pointer-events` active, unlike the FAB — tapping back-to-top mid-scroll is reasonable.)
   - Stays clear of the compose FAB (bottom-right) and cooking-tools widget (bottom-left).
   - `fade` rather than `fly` transition, since `fly`'s inline transform would override the centering `translateX(-50%)` mid-animation.

2. **Tap the header's empty padding area → scroll to top.** Wired with `on:click|self` so it only fires on the wrapper itself, never on real header interactions (search, logo, intelligence menu, buttons). Mirrors the iOS/Twitter "tap status bar" habit.

3. **Engaging search returns to top**, so results/typing aren't happening while the user is stranded mid-feed. Desktop uses `on:focusin` (so keyboard tabbing counts too); mobile scrolls alongside opening the search overlay. Both additive — focusing the input and opening the overlay behave exactly as before.

Hidden on `/messages` and `/groups` (chat views, which manage their own scroll).

## Testing

- `pnpm run check` — clean (one pre-existing unrelated error in `renewalRetry.test.ts`, not touched here).
- Full test suite — 1037/1037 passing.
- **Verified live** in a headless browser: button hidden at top, appears after scroll, real click returns `scrollTop` to `0`; content-centering measured at 0px delta across mobile/lg/xl; scroll-fade confirmed (`0.45` mid-scroll → `1` after idle).

🫒 Pressed with [Claude Code](https://claude.com/claude-code)