### PR TITLE
fix(og): drop dead logo_with_text.png card tags on 4 routes; match Bluesky Cardyb

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.688",
+  "version": "4.2.689",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/recipeOgHtml.server.test.ts
+++ b/src/lib/recipeOgHtml.server.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for `isCrawler`'s User-Agent matching.
+ *
+ * Two properties are being pinned, and they pull in opposite directions:
+ *  1. every unfurler we claim to support actually matches (Bluesky was the
+ *     gap — `Bluesky Cardyb/1.1` fell through to the SPA shell and got a
+ *     generic card);
+ *  2. no in-app browser UA matches. A false positive serves a human the
+ *     empty-body crawler document instead of the app — that is the reason
+ *     WhatsApp/Pinterest/Bluesky are matched only in their dedicated-crawler
+ *     form, and the reason those negatives are asserted here and not just
+ *     described in the comment above `CRAWLER_UA`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isCrawler } from './recipeOgHtml.server';
+
+describe('isCrawler', () => {
+  it('matches the Bluesky link-card fetcher', () => {
+    expect(isCrawler('Bluesky Cardyb/1.1')).toBe(true);
+  });
+
+  it('matches a future Bluesky Cardyb version (no version suffix required)', () => {
+    expect(isCrawler('Bluesky Cardyb/2.0')).toBe(true);
+  });
+
+  it('does NOT match a bare "Bluesky" in-app browser UA', () => {
+    expect(
+      isCrawler(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Bluesky/1.87'
+      )
+    ).toBe(false);
+  });
+
+  const crawlers = [
+    ['Facebook', 'facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)'],
+    ['X / Twitter', 'Twitterbot/1.0'],
+    [
+      'LinkedIn',
+      'LinkedInBot/1.0 (compatible; Mozilla/5.0; Apache-HttpClient +http://www.linkedin.com)'
+    ],
+    ['Discord', 'Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)'],
+    ['Slack', 'Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)'],
+    ['Telegram', 'TelegramBot (like TwitterBot)'],
+    ['WhatsApp', 'WhatsApp/2.23.20.0 A'],
+    [
+      'Apple',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15 (Applebot/0.1)'
+    ],
+    ['Mastodon', 'http.rb/5.1.1 (Mastodon/4.2.1; +https://mastodon.social/)']
+  ] as const;
+
+  for (const [label, ua] of crawlers) {
+    it(`still matches ${label}`, () => {
+      expect(isCrawler(ua)).toBe(true);
+    });
+  }
+
+  const humans = [
+    [
+      'WhatsApp in-app browser',
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 WhatsApp'
+    ],
+    [
+      'Pinterest in-app browser',
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [Pinterest/iOS]'
+    ],
+    [
+      'desktop Chrome',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36'
+    ]
+  ] as const;
+
+  for (const [label, ua] of humans) {
+    it(`does NOT match ${label}`, () => {
+      expect(isCrawler(ua)).toBe(false);
+    });
+  }
+
+  it('does not match a missing User-Agent', () => {
+    expect(isCrawler(null)).toBe(false);
+    expect(isCrawler('')).toBe(false);
+  });
+});

--- a/src/lib/recipeOgHtml.server.ts
+++ b/src/lib/recipeOgHtml.server.ts
@@ -35,11 +35,16 @@ import { probeImageDimensions } from './imageDimensions.server';
  *     carries a normal `Mozilla/…` UA and must fall through to the SPA.
  *   - `Pinterest/<n>` / `Pinterestbot` — likewise (bare "Pinterest" appears in
  *     the Pinterest in-app browser).
+ *   - `Bluesky Cardyb` — Bluesky's link-card fetcher (`Bluesky Cardyb/1.1`).
+ *     Matched as the two-word form, never bare "Bluesky": the Bluesky mobile
+ *     app's in-app browser carries a normal `Mozilla/…` UA, but the app name
+ *     is exactly the kind of token that shows up in one. The version suffix is
+ *     deliberately NOT required, so a future `Cardyb/2.x` still matches.
  * Snapchat and bare "Yahoo" are intentionally omitted: their in-app browsers
  * carry those words and neither is a recipe link-unfurler worth the risk.
  */
 const CRAWLER_UA =
-  /(facebookexternalhit|facebookcatalog|Facebot|Twitterbot|LinkedInBot|Slackbot|Slack-ImgProxy|Discordbot|TelegramBot|WhatsApp\/\d|Pinterest\/\d|Pinterestbot|redditbot|Googlebot|Google-InspectionTool|bingbot|Applebot|Embedly|Quora Link Preview|vkShare|W3C_Validator|outbrain|SkypeUriPreview|nuzzel|Bitlybot|Baiduspider|ia_archiver|MetaInspector|Iframely|SummalyBot|Mastodon|Pleroma|Yeti)/i;
+  /(facebookexternalhit|facebookcatalog|Facebot|Twitterbot|LinkedInBot|Slackbot|Slack-ImgProxy|Discordbot|TelegramBot|WhatsApp\/\d|Pinterest\/\d|Pinterestbot|Bluesky Cardyb|redditbot|Googlebot|Google-InspectionTool|bingbot|Applebot|Embedly|Quora Link Preview|vkShare|W3C_Validator|outbrain|SkypeUriPreview|nuzzel|Bitlybot|Baiduspider|ia_archiver|MetaInspector|Iframely|SummalyBot|Mastodon|Pleroma|Yeti)/i;
 
 /** Only these route prefixes get bot OG injection. */
 const ROUTE_RE = /^\/(recipe|r)\/([^/]+)\/?$/;

--- a/src/routes/explore/+page.svelte
+++ b/src/routes/explore/+page.svelte
@@ -336,9 +336,10 @@
     property="og:description"
     content="Discover recipes, collections, and cooks on zap.cooking"
   />
-  <meta property="og:image" content="https://zap.cooking/logo_with_text.png" />
+  <!-- og:image / twitter:image / twitter:card come from +layout.svelte:533-541.
+       This route is not in `hasCustomOgTags`, so the layout's set is emitted here
+       and a page-level copy would be a second, silently-drifting claim. -->
 
-  <meta name="twitter:card" content="summary" />
   <meta property="twitter:domain" content="zap.cooking" />
   <meta property="twitter:url" content="https://zap.cooking/explore" />
   <meta name="twitter:title" content="Explore - zap.cooking" />
@@ -346,7 +347,6 @@
     name="twitter:description"
     content="Discover recipes, collections, and cooks on zap.cooking"
   />
-  <meta property="twitter:image" content="https://zap.cooking/logo_with_text.png" />
 </svelte:head>
 
 <PullToRefresh bind:this={pullToRefreshEl} on:refresh={handleRefresh}>

--- a/src/routes/explore/+page.svelte
+++ b/src/routes/explore/+page.svelte
@@ -336,9 +336,10 @@
     property="og:description"
     content="Discover recipes, collections, and cooks on zap.cooking"
   />
-  <!-- og:image / twitter:image / twitter:card come from +layout.svelte:533-541.
-       This route is not in `hasCustomOgTags`, so the layout's set is emitted here
-       and a page-level copy would be a second, silently-drifting claim. -->
+  <!-- og:image / twitter:image / twitter:card come from the `{#if !hasCustomOgTags}`
+       block in +layout.svelte's <svelte:head>. This route is not in `hasCustomOgTags`,
+       so the layout's set is emitted here and a page-level copy would be a second,
+       silently-drifting claim. -->
 
   <meta property="twitter:domain" content="zap.cooking" />
   <meta property="twitter:url" content="https://zap.cooking/explore" />

--- a/src/routes/explore/all/+page.svelte
+++ b/src/routes/explore/all/+page.svelte
@@ -92,9 +92,10 @@
   <meta property="og:type" content="website" />
   <meta property="og:title" content="All Tags - zap.cooking" />
   <meta property="og:description" content="Browse all recipe tags on zap.cooking" />
-  <!-- og:image / twitter:image / twitter:card come from +layout.svelte:533-541.
-       This route is not in `hasCustomOgTags`, so the layout's set is emitted here
-       and a page-level copy would be a second, silently-drifting claim. -->
+  <!-- og:image / twitter:image / twitter:card come from the `{#if !hasCustomOgTags}`
+       block in +layout.svelte's <svelte:head>. This route is not in `hasCustomOgTags`,
+       so the layout's set is emitted here and a page-level copy would be a second,
+       silently-drifting claim. -->
 
   <meta property="twitter:domain" content="zap.cooking" />
   <meta property="twitter:url" content="https://zap.cooking/explore/all" />

--- a/src/routes/explore/all/+page.svelte
+++ b/src/routes/explore/all/+page.svelte
@@ -92,14 +92,14 @@
   <meta property="og:type" content="website" />
   <meta property="og:title" content="All Tags - zap.cooking" />
   <meta property="og:description" content="Browse all recipe tags on zap.cooking" />
-  <meta property="og:image" content="https://zap.cooking/logo_with_text.png" />
+  <!-- og:image / twitter:image / twitter:card come from +layout.svelte:533-541.
+       This route is not in `hasCustomOgTags`, so the layout's set is emitted here
+       and a page-level copy would be a second, silently-drifting claim. -->
 
-  <meta name="twitter:card" content="summary" />
   <meta property="twitter:domain" content="zap.cooking" />
   <meta property="twitter:url" content="https://zap.cooking/explore/all" />
   <meta name="twitter:title" content="All Tags - zap.cooking" />
   <meta name="twitter:description" content="Browse all recipe tags on zap.cooking" />
-  <meta property="twitter:image" content="https://zap.cooking/logo_with_text.png" />
 </svelte:head>
 
 <div class="flex flex-col gap-6">

--- a/src/routes/kitchen/+page.svelte
+++ b/src/routes/kitchen/+page.svelte
@@ -37,14 +37,14 @@
   <meta property="og:type" content="website" />
   <meta property="og:title" content="The Kitchen - zap.cooking" />
   <meta property="og:description" content="The Kitchen is Zap Cooking's primary public feed relay. Discover global food content, follow your favorite cooks, and engage with the community." />
-  <meta property="og:image" content="https://zap.cooking/logo_with_text.png" />
+  <!-- og:image / twitter:image / twitter:card come from +layout.svelte:533-541.
+       This route is not in `hasCustomOgTags`, so the layout's set is emitted here
+       and a page-level copy would be a second, silently-drifting claim. -->
 
-  <meta name="twitter:card" content="summary" />
   <meta property="twitter:domain" content="zap.cooking" />
   <meta property="twitter:url" content="https://zap.cooking/kitchen" />
   <meta name="twitter:title" content="The Kitchen - zap.cooking" />
   <meta name="twitter:description" content="The Kitchen is Zap Cooking's primary public feed relay. Discover global food content, follow your favorite cooks, and engage with the community." />
-  <meta property="twitter:image" content="https://zap.cooking/logo_with_text.png" />
 </svelte:head>
 
 <PullToRefresh bind:this={pullToRefreshEl} on:refresh={handleRefresh}>

--- a/src/routes/kitchen/+page.svelte
+++ b/src/routes/kitchen/+page.svelte
@@ -37,9 +37,10 @@
   <meta property="og:type" content="website" />
   <meta property="og:title" content="The Kitchen - zap.cooking" />
   <meta property="og:description" content="The Kitchen is Zap Cooking's primary public feed relay. Discover global food content, follow your favorite cooks, and engage with the community." />
-  <!-- og:image / twitter:image / twitter:card come from +layout.svelte:533-541.
-       This route is not in `hasCustomOgTags`, so the layout's set is emitted here
-       and a page-level copy would be a second, silently-drifting claim. -->
+  <!-- og:image / twitter:image / twitter:card come from the `{#if !hasCustomOgTags}`
+       block in +layout.svelte's <svelte:head>. This route is not in `hasCustomOgTags`,
+       so the layout's set is emitted here and a page-level copy would be a second,
+       silently-drifting claim. -->
 
   <meta property="twitter:domain" content="zap.cooking" />
   <meta property="twitter:url" content="https://zap.cooking/kitchen" />

--- a/src/routes/pantry/+page.svelte
+++ b/src/routes/pantry/+page.svelte
@@ -83,9 +83,10 @@
   <meta property="og:type" content="website" />
   <meta property="og:title" content="The Pantry 🏪 - zap.cooking" />
   <meta property="og:description" content="The Pantry is a members-only corner of Zap Cooking for deeper conversations, early access, and shaping what's next." />
-  <!-- og:image / twitter:image / twitter:card come from +layout.svelte:533-541.
-       This route is not in `hasCustomOgTags`, so the layout's set is emitted here
-       and a page-level copy would be a second, silently-drifting claim. -->
+  <!-- og:image / twitter:image / twitter:card come from the `{#if !hasCustomOgTags}`
+       block in +layout.svelte's <svelte:head>. This route is not in `hasCustomOgTags`,
+       so the layout's set is emitted here and a page-level copy would be a second,
+       silently-drifting claim. -->
 
   <meta property="twitter:domain" content="zap.cooking" />
   <meta property="twitter:url" content="https://zap.cooking/pantry" />

--- a/src/routes/pantry/+page.svelte
+++ b/src/routes/pantry/+page.svelte
@@ -83,14 +83,14 @@
   <meta property="og:type" content="website" />
   <meta property="og:title" content="The Pantry 🏪 - zap.cooking" />
   <meta property="og:description" content="The Pantry is a members-only corner of Zap Cooking for deeper conversations, early access, and shaping what's next." />
-  <meta property="og:image" content="https://zap.cooking/logo_with_text.png" />
+  <!-- og:image / twitter:image / twitter:card come from +layout.svelte:533-541.
+       This route is not in `hasCustomOgTags`, so the layout's set is emitted here
+       and a page-level copy would be a second, silently-drifting claim. -->
 
-  <meta name="twitter:card" content="summary" />
   <meta property="twitter:domain" content="zap.cooking" />
   <meta property="twitter:url" content="https://zap.cooking/pantry" />
   <meta name="twitter:title" content="The Pantry 🏪 - zap.cooking" />
   <meta name="twitter:description" content="The Pantry is a members-only corner of Zap Cooking for deeper conversations, early access, and shaping what's next." />
-  <meta property="twitter:image" content="https://zap.cooking/logo_with_text.png" />
 </svelte:head>
 
 <div class="flex flex-col gap-8">


### PR DESCRIPTION
Fixes the blank social card on the page we are actually advertising, and one literal crawler-matching bug. Both are one-line-class changes; they ship together because Chief asked for one standalone PR tonight.

Spec: `PLANS/SOCIAL_CARD_IMAGE_SPEC_2026_08_02.md` (Prep). Diagnosis: Chief, prep room thread `88c826df…`. Base `3c6c164`.

## 1 — Four routes emitted a dead `og:image` on top of the layout's good one

`/explore` (which is what `https://zap.cooking` resolves to), `/explore/all`, `/pantry` and `/kitchen` each shipped **two** complete card claims. The layout's is correct. The page-level one pointed at `https://zap.cooking/logo_with_text.png`, which does not exist in `static/` and is referenced nowhere else in `src/`. The SPA catch-all answers that URL **HTTP 200 with `content-type: text/html`** — so a crawler asking for an image gets a 6.6 KB HTML document and renders an empty placeholder. Stacked on it, the same block downgraded `twitter:card` from `summary_large_image` to `summary`.

**Deleted, not repointed** — Prep's call, and I agree with the reasoning:

- `+layout.svelte:533-541` already emits `social-share.png` + `summary_large_image` on all four routes. None of them is in `hasCustomOgTags` (`:188-193`, which lists only `/recipe/`, `/r/`, `/pack/`, `note1*`, `nevent1*`), so deletion cannot leave a page with no image.
- One image claim per document is the only construction correct on **both** crawler rules. Seth's screenshot is X taking the **last** occurrence; Facebook documents taking the **first**. No allowlist resolves that; one claim does.
- This is duplication that already drifted once. That is how the bug happened.

Each route keeps its own `og:title` / `og:description` / `og:url` / `twitter:title` / `twitter:description`.

**Scope, explicitly:** this delivers *one image claim per document*, **not** one tag set. `og:title` / `og:description` / `og:url` stay duplicated against the layout's on all four routes, so those pages still split by crawler on the title. Chief's correction, logged rather than fixed. `src/routes/user/[slug]/+page.svelte:1724` also emits `twitter:card summary` and is **deliberately untouched** — its `og:image` is the member's avatar and `summary` is the right card for a person.

## 2 — `Bluesky Cardyb` added to `CRAWLER_UA`

`recipeOgHtml.server.ts`. Bluesky's link-card fetcher (`Bluesky Cardyb/1.1`) fell through to the SPA shell, so recipe links posted to Bluesky got a generic card instead of the recipe's.

Matched as the **two-word form**, never bare `Bluesky`: the Bluesky mobile app's in-app browser carries the app name inside an otherwise normal `Mozilla/…` UA, and a false positive here serves a **human** the empty-body crawler document instead of the app. Version suffix deliberately not required, so a future `Cardyb/2.x` still matches. Same treatment WhatsApp and Pinterest already get.

New `src/lib/recipeOgHtml.server.test.ts` (16 tests) pins both directions — every unfurler we claim to support matches, and no in-app browser UA does. That second half was described in a comment and asserted nowhere.

## Verified

- **The card itself, read out of rendered HTML.** `vite dev`, `curl -A "Mozilla/5.0 (compatible; Twitterbot/1.0)"` on all four routes.
  - **Baseline** (`/explore`, page file stashed back to `3c6c164`): two `og:image` — `social-share.png` then `logo_with_text.png` — and two `twitter:card` — `summary_large_image` then `summary`. Reproduces production exactly.
  - **After:** all four routes → `logo_with_text` occurrences **0**; exactly one `og:image`, one `twitter:image`, one `twitter:card`, all `social-share.png` / `summary_large_image`, all carrying the layout's Svelte scope class. Each route's own page-scope tags still render, so the head block is still live — it just no longer makes an image claim.
- `grep -rn logo_with_text src/ static/` → no matches.
- **1128 tests pass / 73 files.** 16 new, all mutation-checked: dropping the token fails both Bluesky-match tests; loosening it to bare `Bluesky` fails the in-app-browser negative.
- `svelte-check` → **0 errors**.
- Production `vite build` → clean.
- `prettier --check`: the five pre-existing files are **already dirty at `3c6c164`** (verified by stashing my diff and re-running in place) — my diff adds nothing. The new test file is formatted.

## Not verified

- **Nothing has been probed against production.** Per the Jul 30 finding, no CI check tells us a Cloudflare deploy is live — the probe is the definition of deployed, and that probe is Prep's, after merge.
- **No real crawler has fetched this.** The Bluesky match is asserted against UA strings I wrote from Bluesky's published `Bluesky Cardyb/1.1`; no Cardyb request has been observed against our server, before or after.
- X is holding the broken scrape for `https://zap.cooking` and merging this does not repair it. The scheduled post has to be deleted and recreated after the deploy — Seth's, and there is a 9:33 AM clock on it.

Depends on no Cloudflare toggle. The 1200×630 transformation work (Problem B) is unrelated and stays queued behind Prep's spec.

Reviewer: **Prep**. Merge: **Seth**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
