### PR TITLE
fix(notes): preserve authored newlines in quoted posts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.695",
+  "version": "4.2.696",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -62,6 +62,7 @@
     type ReferencedNote
   } from '$lib/shareNoteImage';
   import { optimizeImageUrl, getOptimalFormat } from '$lib/imageOptimizer';
+  import { stripQuotedNoteReferences } from '$lib/feed/noteContent';
   import { compressedCacheManager, COMPRESSED_FEED_CACHE_CONFIG } from '$lib/compressedCache';
   import FeedErrorBoundary from './FeedErrorBoundary.svelte';
   import FeedPostSkeleton from './FeedPostSkeleton.svelte';
@@ -1007,14 +1008,7 @@
   // Get content without the quoted note reference (so it doesn't render as inline embed)
   function getContentWithoutQuote(content: string): string {
     try {
-      if (!content) return '';
-      return content
-        .replace(
-          /nostr:(nevent1[023456789acdefghjklmnpqrstuvwxyz]+|note1[023456789acdefghjklmnpqrstuvwxyz]+)/g,
-          ''
-        )
-        .replace(/\s+/g, ' ')
-        .trim();
+      return stripQuotedNoteReferences(content);
     } catch {
       return content || '';
     }

--- a/src/lib/feed/noteContent.test.ts
+++ b/src/lib/feed/noteContent.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { stripQuotedNoteReferences } from './noteContent';
+
+const NEVENT =
+  'nostr:nevent1qvzqqqqqqypzqvv660neqc6dh6r0zndec2v4kfhw833z30j4lzwycll2ntxqr4g2qy88wumn8ghj7mn0wvhxcmmv9uq3wamnwvaz7tmjv4kxz7fwwpexjmtpdshxuet59uqzpwelkuhmeara2plp6xpapjk3m9hvzzsapqtfq2wmfjk6k7euzjdscjpx7f';
+
+describe('stripQuotedNoteReferences', () => {
+  it('preserves paragraphs and profile mentions when removing a quoted event', () => {
+    const content =
+      'What do you call a sauce recipe on nostr:npub1xxdd8eusvdxmaph3fkuu9x2mymhrcc3ghe2l38zv0l4f4nqp659qskkt7a? \n\nOpen sauce. 🍝\n' +
+      NEVENT;
+
+    expect(stripQuotedNoteReferences(content)).toBe(
+      'What do you call a sauce recipe on nostr:npub1xxdd8eusvdxmaph3fkuu9x2mymhrcc3ghe2l38zv0l4f4nqp659qskkt7a? \n\nOpen sauce. 🍝'
+    );
+  });
+
+  it('preserves line breaks after a leading quote reference', () => {
+    expect(stripQuotedNoteReferences(`${NEVENT}\nFirst paragraph\n\nSecond paragraph`)).toBe(
+      'First paragraph\n\nSecond paragraph'
+    );
+  });
+
+  it('removes note references without changing ordinary spacing', () => {
+    const note = `nostr:note1${'q'.repeat(58)}`;
+
+    expect(stripQuotedNoteReferences(`Keep  these words\n${note}`)).toBe('Keep  these words');
+  });
+});

--- a/src/lib/feed/noteContent.ts
+++ b/src/lib/feed/noteContent.ts
@@ -1,0 +1,9 @@
+const QUOTED_NOTE_REFERENCE =
+  /nostr:(?:nevent1[023456789acdefghjklmnpqrstuvwxyz]+|note1[023456789acdefghjklmnpqrstuvwxyz]+)/g;
+
+/** Remove embedded quote references without collapsing the author's line breaks. */
+export function stripQuotedNoteReferences(content: string): string {
+  if (!content) return '';
+
+  return content.replace(QUOTED_NOTE_REFERENCE, '').trim();
+}


### PR DESCRIPTION
## Summary

- Preserve authored paragraph breaks when feed cards remove an embedded quoted-note reference.
- Move quoted-reference cleanup into a focused helper with regression coverage for `note1`, `nevent1`, and profile mentions.

## Why

Feed cards removed quoted-note references before rendering the remaining content. That cleanup also replaced every whitespace run with a single space, collapsing all newlines in posts that quoted another note.

The cleanup now removes only the quoted reference and outer whitespace, leaving the author's internal spacing and line breaks intact.

## Validation

- `vitest run src/lib/feed/noteContent.test.ts`: 3 tests passed.
- Prettier and `git diff --check` passed.
- `svelte-check` reports only the existing `renewalRetry.test.ts` delete-operator error.
- Verified the supplied sauce note in the local community feed; the blank line before "Open sauce" is preserved and the quoted note remains below it.

_🥭 Simmered with Codex._
