### PR TITLE
fix(posts): show activity drawer on focused parent notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.697",
+  "version": "4.2.698",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/NoteActionBar.svelte
+++ b/src/components/NoteActionBar.svelte
@@ -32,6 +32,9 @@
   /** Show the "Ask Cheffy about this photo" trigger (image-bearing notes only) */
   export let showCheffy: boolean = true;
 
+  /** Override compact mode's default of hiding the engagement details drawer. */
+  export let showEngagementDetails: boolean | undefined = undefined;
+
   let zapModalOpen = false;
   let engagementOpen = false;
   let engagementEventId = event.id;
@@ -71,11 +74,13 @@
 
   let isCompact: boolean;
   let isFull: boolean;
+  let canShowEngagementDetails: boolean;
   let iconWrapClass: string;
   let zapWrapClass: string;
 
   $: isCompact = variant === 'compact';
   $: isFull = variant === 'full';
+  $: canShowEngagementDetails = showEngagementDetails ?? !isCompact;
   $: iconWrapClass = isFull
     ? 'hover:bg-accent-gray rounded-full p-1.5 transition-colors'
     : isCompact
@@ -120,20 +125,22 @@
       <NoteTotalZaps {event} onZapClick={openZapModal} />
     </div>
 
-    {#if !isCompact}
+    {#if (!isCompact && showCheffy) || canShowEngagementDetails}
       <div class="trailing-actions">
-        {#if showCheffy}
+        {#if !isCompact && showCheffy}
           <CheffyNoteReviewTrigger {event} wrapClass={iconWrapClass} />
         {/if}
-        <PostEngagementToggle
-          expanded={engagementOpen}
-          on:toggle={() => (engagementOpen = !engagementOpen)}
-        />
+        {#if canShowEngagementDetails}
+          <PostEngagementToggle
+            expanded={engagementOpen}
+            on:toggle={() => (engagementOpen = !engagementOpen)}
+          />
+        {/if}
       </div>
     {/if}
   </div>
 
-  {#if !isCompact}
+  {#if canShowEngagementDetails}
     <PostEngagementDrawer {event} open={engagementOpen} />
   {/if}
 </div>

--- a/src/lib/postEngagementToggle.test.ts
+++ b/src/lib/postEngagementToggle.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('focused thread engagement details', () => {
+  it('opts parent notes into the drawer without enabling every compact action bar', () => {
+    const actionBar = readFileSync('src/components/NoteActionBar.svelte', 'utf8');
+    const focusedNote = readFileSync('src/routes/[nip19]/+page.svelte', 'utf8');
+
+    expect(actionBar).toContain(
+      'export let showEngagementDetails: boolean | undefined = undefined'
+    );
+    expect(actionBar).toContain('showEngagementDetails ?? !isCompact');
+    expect(focusedNote).toMatch(
+      /<NoteActionBar\s+event=\{parentNote\}\s+variant="compact"\s+showEngagementDetails=\{true\}/
+    );
+    expect(focusedNote).toContain('<NoteActionBar event={nestedReply} variant="compact" />');
+  });
+});

--- a/src/routes/[nip19]/+page.svelte
+++ b/src/routes/[nip19]/+page.svelte
@@ -703,7 +703,11 @@
                   {/if}
                   <!-- Parent note actions -->
                   <div class="mt-2">
-                    <NoteActionBar event={parentNote} variant="compact" />
+                    <NoteActionBar
+                      event={parentNote}
+                      variant="compact"
+                      showEngagementDetails={true}
+                    />
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

- add an explicit activity-drawer opt-in for compact note action bars
- enable that control on parent notes in focused reply views
- preserve the existing compact layout for nested replies elsewhere

## Root cause

Focused reply views render parent notes with the compact action-bar variant. Compact mode unconditionally omitted both the activity toggle and drawer, forcing users to navigate into the parent note before they could inspect reactions, zaps, reposts, and relay visibility.

## Validation

- `vitest run src/lib/postEngagementToggle.test.ts src/lib/postEngagementDetails.test.ts` (4 tests passed)
- verified the parent drawer opens without changing the focused reply URL
- verified desktop and mobile layouts in Chromium
- `pnpm run check` reports only the existing `renewalRetry.test.ts` delete-operator error

_🥭 Simmered with Codex._
