### PR TITLE
fix(embeds): render quoted long-form events as cards instead of raw markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.700",
+  "version": "4.2.701",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/NoteEmbed.svelte
+++ b/src/components/NoteEmbed.svelte
@@ -15,6 +15,8 @@
   import { extractZapAmountSats } from '$lib/zapAmount';
   import { formatAmount } from '$lib/utils';
   import NoteContent from './NoteContent.svelte';
+  import { getImageOrPlaceholder } from '$lib/placeholderImages';
+  import { RECIPE_TAGS } from '$lib/consts';
 
   export let nostrString: string;
   export let boostAmount: number = 0; // Optional boost amount in sats (passed from parent)
@@ -296,10 +298,48 @@
     return formatDistanceToNow(new Date(timestamp * 1000), { addSuffix: true });
   }
 
+  // ── Long-form (kind 30023) cards ──────────────────────────────────
+  //
+  // A long-form event's `content` is a full markdown document. Rendering
+  // it through NoteContent (a kind-1 plaintext renderer) dumps the whole
+  // recipe into the embed, headings and all. Render the event's metadata
+  // tags as a compact card instead — the same information other Nostr
+  // clients show for a quoted article.
+
+  function tagValue(e: NDKEvent, name: string): string {
+    return e.tags.find((t) => t[0] === name)?.[1]?.trim() || '';
+  }
+
+  function isRecipeEvent(e: NDKEvent): boolean {
+    return e.tags.some(
+      (t) => t[0] === 't' && RECIPE_TAGS.includes((t[1] || '').toLowerCase())
+    );
+  }
+
+  // Only render the card when there's a title to show. Long-form events
+  // from other clients without one fall back to the previous rendering
+  // rather than showing an empty card.
+  $: isLongform = !!event && event.kind === 30023 && !!tagValue(event, 'title');
+  $: articleTitle = event && isLongform ? tagValue(event, 'title') : '';
+  $: articleSummary = event && isLongform ? tagValue(event, 'summary') : '';
+  $: articleImage =
+    event && isLongform
+      ? getImageOrPlaceholder(tagValue(event, 'image'), event.id)
+      : '';
+  $: articleHashtags =
+    event && isLongform
+      ? event.tags
+          .filter((t) => t[0] === 't' && t[1])
+          .map((t) => t[1])
+          .slice(0, 3)
+      : [];
+
   function getNoteUrl(): string | null {
     if (!event) return null;
 
-    // Check if it's a recipe (kind 30023)
+    // Long-form (kind 30023) covers both recipes and reads, which live on
+    // different routes. A recipe carries a nostrcooking `t` tag; anything
+    // else is an article and belongs on /r/.
     if (event.kind === 30023) {
       const dTag = event.tags.find((t) => t[0] === 'd')?.[1];
       if (dTag && event.author?.hexpubkey) {
@@ -309,9 +349,9 @@
             kind: 30023,
             pubkey: event.author.hexpubkey
           });
-          return `/recipe/${naddr}`;
+          return isRecipeEvent(event) ? `/recipe/${naddr}` : `/r/${naddr}`;
         } catch (e) {
-          console.warn('Failed to encode recipe naddr:', e);
+          console.warn('Failed to encode long-form naddr:', e);
         }
       }
     }
@@ -458,8 +498,32 @@
       </div>
     {/if}
 
-    <!-- Full note content with truncation for long posts -->
-    {#if event.content.trim()}
+    {#if isLongform}
+      <!-- Long-form card: metadata tags, not the markdown body -->
+      <div class="article-embed">
+        <img
+          class="article-embed-image"
+          src={articleImage}
+          alt=""
+          loading="lazy"
+          on:error={handleImageError}
+        />
+        <div class="article-embed-body">
+          <p class="article-embed-title">{articleTitle}</p>
+          {#if articleSummary}
+            <p class="article-embed-summary">{articleSummary}</p>
+          {/if}
+          {#if articleHashtags.length > 0}
+            <div class="article-embed-tags">
+              {#each articleHashtags as tag}
+                <span class="article-embed-tag">#{tag}</span>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      </div>
+    {:else if event.content.trim()}
+      <!-- Full note content with truncation for long posts -->
       <div class="parent-quote-content" on:click|stopPropagation>
         <NoteContent content={event.content} collapsible={true} embedDepth={depth + 1} showLinkPreviews={false} />
       </div>
@@ -506,6 +570,73 @@
   .parent-quote-content {
     font-size: 0.875rem;
     margin-top: 0.375rem;
+  }
+
+  /* Long-form card: thumbnail beside title/summary/tags. */
+  .article-embed {
+    display: flex;
+    gap: 0.625rem;
+    margin-top: 0.375rem;
+    align-items: flex-start;
+  }
+
+  .article-embed-image {
+    flex-shrink: 0;
+    width: 5rem;
+    height: 5rem;
+    object-fit: cover;
+    border-radius: 0.375rem;
+    background: var(--color-bg-secondary);
+  }
+
+  .article-embed-body {
+    min-width: 0;
+    flex: 1;
+  }
+
+  .article-embed-title {
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: var(--color-text-primary);
+    line-height: 1.3;
+    margin: 0;
+    /* Two-line clamp keeps the embed compact regardless of title length. */
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .article-embed-summary {
+    font-size: 0.8125rem;
+    color: var(--color-caption);
+    line-height: 1.4;
+    margin: 0.1875rem 0 0;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .article-embed-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    margin-top: 0.375rem;
+  }
+
+  .article-embed-tag {
+    font-size: 0.6875rem;
+    color: var(--color-caption);
+    background: var(--color-bg-secondary);
+    border-radius: 9999px;
+    padding: 0.0625rem 0.4375rem;
+    max-width: 10rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .parent-quote-loading {


### PR DESCRIPTION
## Problem

Quoting a long-form event (kind 30023 — a recipe or a Reads article) rendered its **entire markdown body** inside the embed: `## Details`, `## Ingredients`, the full ingredient list, and so on, with literal `##` markers.

`NoteEmbed` had no per-kind branch — every embedded event rendered as avatar + author + `event.content` piped through `NoteContent`, which is a kind-1 plaintext renderer and doesn't parse markdown. For a kind-1 note that's correct; for a long-form event, `content` is a whole document.

Because `NoteEmbed` is shared, this affected every surface that renders a quoted note:

- Composer preview (`PostComposer` -> `NoteContent`)
- Community feed (`FoodstrFeedOptimized.svelte:5167,5176`)
- Thread / single-note views
- `RichTextNostr`
- DMs (`MessageBubble.svelte:182`)

Everything needed to render a proper card was already on the event, just unused: the `title`, `summary`, `image` and `t` tags.

## Changes

All in `src/components/NoteEmbed.svelte`.

**Long-form card.** Kind 30023 now renders a compact card — thumbnail, title, summary, up to three hashtags — instead of the markdown body. Titles and summaries are clamped to two lines and hashtags ellipsize, so the embed stays a fixed, predictable height no matter how long the article is.

The card is gated on a `title` tag being present. Long-form events from other clients that don't set one fall back to the previous rendering rather than showing an empty card. The thumbnail goes through the existing `getImageOrPlaceholder`, so a missing `image` tag degrades the same way our other cards do.

**Routing fix (pre-existing bug).** `getNoteUrl()` sent *all* kind-30023 events to `/recipe/{naddr}`, so quoting a Reads article linked to the recipe route. Recipes are now detected via a `nostrcooking` `t` tag (`RECIPE_TAGS` from `$lib/consts`) and routed to `/recipe/`; every other long-form event routes to `/r/`, matching `getArticleUrl()` in `articleUtils.ts`.

## Verification

- `pnpm check` — 1 error / 152 warnings, **identical to `main`** (verified by stashing and re-running; the `delete`-operator error at that line pre-exists and only shifted line number)
- `pnpm test` — 1196 passed, 80 files
- Rendered live against the real note that surfaced this (`60789375...`, located by querying relays for the recipe's `#a` tag): card renders with thumbnail, title "Bear Market Sludge", summary, and `#nostrcooking` tags
- Click-through verified — lands on `/recipe/naddr1vzqqqr4gupzpz36...`

**Not verified:** rendering below ~640px. The layout is narrow-safe by construction (flex row, `min-width: 0` on the text column, fixed 5rem thumbnail, two-line clamps, hashtag ellipsis), but it hasn't been checked on a real mobile viewport.
