### PR TITLE
fix(security): migrate legacy Spark mnemonics at login instead of on wallet open

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.700",
+  "version": "4.2.701",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/spark/index.ts
+++ b/src/lib/spark/index.ts
@@ -12,7 +12,9 @@ import {
   loadMnemonic,
   hasMnemonic,
   deleteMnemonic,
-  clearAllSparkWallets
+  clearAllSparkWallets,
+  hasLegacyMnemonic,
+  migrateLegacyMnemonic
 } from './storage';
 import { logger } from '$lib/logger';
 import {
@@ -2114,5 +2116,44 @@ export function getSparkLightningAddress(): string | null {
   return get(lightningAddress);
 }
 
+// Pubkeys already swept this session — the sweep is idempotent, but
+// there's no reason to re-check on every auth-state emission.
+const legacyMnemonicSwept = new Set<string>();
+
+/**
+ * Proactively upgrade a legacy V1 mnemonic to V2 at login.
+ *
+ * V1 derives its key from the (public) pubkey, so a V1 record is readable
+ * by anyone who can read localStorage. The existing migration only runs
+ * inside loadMnemonic — i.e. when the user opens the Spark wallet — which
+ * leaves the record exposed indefinitely for users who never open it.
+ *
+ * Skipped for NIP-46 sessions (canCreateNostrBackup is false: a bunker
+ * round-trip per encrypt isn't viable here), so those keep V1 until the
+ * wallet is opened, exactly as before. Never throws — a failed migration
+ * leaves V1 in place and retries on the next login.
+ *
+ * @param pubkey The user's Nostr public key (hex string).
+ */
+export async function sweepLegacyMnemonic(pubkey: string): Promise<void> {
+  if (!browser || !pubkey) return;
+  if (legacyMnemonicSwept.has(pubkey)) return;
+  if (!hasLegacyMnemonic(pubkey)) return;
+  if (!canCreateNostrBackup()) return;
+
+  legacyMnemonicSwept.add(pubkey);
+  try {
+    const migrated = await migrateLegacyMnemonic(pubkey);
+    if (migrated) {
+      logger.info('Migrated legacy V1 mnemonic to V2 at login', 'spark');
+    }
+  } catch (e) {
+    // Signer denied or unavailable — V1 record is untouched. Allow a
+    // retry on the next login rather than marking this pubkey done.
+    legacyMnemonicSwept.delete(pubkey);
+    logger.warn('Legacy mnemonic migration deferred', 'spark', e);
+  }
+}
+
 // Export storage utilities
-export { clearAllSparkWallets, deleteMnemonic, loadMnemonic };
+export { clearAllSparkWallets, deleteMnemonic, loadMnemonic, hasLegacyMnemonic };

--- a/src/lib/spark/storage.test.ts
+++ b/src/lib/spark/storage.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { xchacha20poly1305 } from '@noble/ciphers/chacha.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { hexToBytes, bytesToHex } from '@noble/hashes/utils.js';
+
+/**
+ * V1 -> V2 mnemonic migration.
+ *
+ * V1 derived its encryption key as sha256(pubkey). The pubkey is public,
+ * so a V1 record is decryptable by anyone who can read localStorage —
+ * these records must be upgraded proactively, and must never be dropped
+ * when the upgrade can't complete.
+ */
+
+const { encryption } = vi.hoisted(() => ({
+  encryption: {
+    encrypt: vi.fn(),
+    decrypt: vi.fn(),
+    detectEncryptionMethod: vi.fn()
+  }
+}));
+
+vi.mock('$lib/encryptionService', () => encryption);
+
+import {
+  hasLegacyMnemonic,
+  hasMnemonic,
+  migrateLegacyMnemonic,
+  loadMnemonic
+} from './storage';
+
+const PUBKEY = 'b'.repeat(64);
+const MNEMONIC = 'abandon abandon abandon abandon about';
+const KEY = `spark_wallet_${PUBKEY}`;
+
+/** Build a V1 record exactly the way the legacy writer did. */
+function makeV1Record(pubkey: string, mnemonic: string): string {
+  const key = sha256(hexToBytes(pubkey));
+  const nonce = new Uint8Array(24).fill(7);
+  const cipher = xchacha20poly1305(key, nonce);
+  const ciphertext = cipher.encrypt(new TextEncoder().encode(mnemonic));
+  const out = new Uint8Array(nonce.length + ciphertext.length);
+  out.set(nonce);
+  out.set(ciphertext, nonce.length);
+  return bytesToHex(out);
+}
+
+let store: Map<string, string>;
+
+beforeEach(() => {
+  store = new Map();
+  (globalThis as any).localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => store.set(k, String(v)),
+    removeItem: (k: string) => store.delete(k),
+    clear: () => store.clear(),
+    get length() {
+      return store.size;
+    },
+    key: (i: number) => [...store.keys()][i] ?? null
+  };
+
+  encryption.encrypt.mockReset();
+  encryption.decrypt.mockReset();
+  encryption.detectEncryptionMethod.mockReset();
+  encryption.encrypt.mockResolvedValue({ ciphertext: 'V2-CIPHERTEXT', method: 'nip44v2' });
+  encryption.decrypt.mockResolvedValue(MNEMONIC);
+  encryption.detectEncryptionMethod.mockReturnValue('nip44v2');
+});
+
+describe('hasLegacyMnemonic', () => {
+  it('is true for a V1 hex record', () => {
+    store.set(KEY, makeV1Record(PUBKEY, MNEMONIC));
+    expect(hasLegacyMnemonic(PUBKEY)).toBe(true);
+  });
+
+  it('is false for a V2 record', () => {
+    store.set(KEY, JSON.stringify({ version: 2, ciphertext: 'V2-CIPHERTEXT' }));
+    expect(hasLegacyMnemonic(PUBKEY)).toBe(false);
+  });
+
+  it('is false when nothing is stored', () => {
+    expect(hasLegacyMnemonic(PUBKEY)).toBe(false);
+  });
+});
+
+describe('migrateLegacyMnemonic', () => {
+  it('rewrites a V1 record as V2 without changing the mnemonic', async () => {
+    store.set(KEY, makeV1Record(PUBKEY, MNEMONIC));
+
+    const migrated = await migrateLegacyMnemonic(PUBKEY);
+
+    expect(migrated).toBe(true);
+    // The plaintext handed to encrypt() is the original mnemonic — proves
+    // the V1 decrypt path is still correct.
+    expect(encryption.encrypt).toHaveBeenCalledWith(PUBKEY, MNEMONIC);
+    expect(JSON.parse(store.get(KEY)!)).toEqual({ version: 2, ciphertext: 'V2-CIPHERTEXT' });
+    expect(hasLegacyMnemonic(PUBKEY)).toBe(false);
+  });
+
+  it('is a no-op for records already on V2', async () => {
+    const v2 = JSON.stringify({ version: 2, ciphertext: 'V2-CIPHERTEXT' });
+    store.set(KEY, v2);
+
+    expect(await migrateLegacyMnemonic(PUBKEY)).toBe(false);
+    expect(encryption.encrypt).not.toHaveBeenCalled();
+    expect(store.get(KEY)).toBe(v2);
+  });
+
+  it('is a no-op when nothing is stored', async () => {
+    expect(await migrateLegacyMnemonic(PUBKEY)).toBe(false);
+    expect(store.has(KEY)).toBe(false);
+  });
+
+  it('leaves the V1 record intact when the signer refuses to encrypt', async () => {
+    const v1 = makeV1Record(PUBKEY, MNEMONIC);
+    store.set(KEY, v1);
+    encryption.encrypt.mockRejectedValue(new Error('signer denied'));
+
+    await expect(migrateLegacyMnemonic(PUBKEY)).rejects.toThrow('signer denied');
+
+    // Never lose the mnemonic: V1 survives so a later attempt can retry.
+    expect(store.get(KEY)).toBe(v1);
+    expect(hasMnemonic(PUBKEY)).toBe(true);
+    expect(hasLegacyMnemonic(PUBKEY)).toBe(true);
+  });
+
+  it('leaves the record alone when the V1 payload cannot be decrypted', async () => {
+    store.set(KEY, 'deadbeef');
+
+    expect(await migrateLegacyMnemonic(PUBKEY)).toBe(false);
+    expect(store.get(KEY)).toBe('deadbeef');
+    expect(encryption.encrypt).not.toHaveBeenCalled();
+  });
+});
+
+describe('loadMnemonic still reads both formats', () => {
+  it('reads a V1 record and migrates it on the way out', async () => {
+    store.set(KEY, makeV1Record(PUBKEY, MNEMONIC));
+
+    expect(await loadMnemonic(PUBKEY)).toBe(MNEMONIC);
+    expect(hasLegacyMnemonic(PUBKEY)).toBe(false);
+  });
+
+  it('reads a V2 record via the encryption service', async () => {
+    store.set(KEY, JSON.stringify({ version: 2, ciphertext: 'V2-CIPHERTEXT' }));
+
+    expect(await loadMnemonic(PUBKEY)).toBe(MNEMONIC);
+    expect(encryption.decrypt).toHaveBeenCalledWith(PUBKEY, 'V2-CIPHERTEXT', 'nip44v2');
+  });
+});

--- a/src/lib/spark/storage.ts
+++ b/src/lib/spark/storage.ts
@@ -1,3 +1,22 @@
+/**
+ * At-rest storage for the Spark wallet mnemonic.
+ *
+ * V2 wraps the mnemonic in a NIP-44 encrypt-to-self envelope. Note the
+ * honest limitation: for plaintext-nsec sessions the wrapping key is the
+ * identity key sitting in `nostrcooking_privateKey` in the same
+ * localStorage, so an attacker who can read one key can read the other —
+ * the envelope is not a defense against local storage compromise there.
+ * It IS a real defense for NIP-07 and passkey-vault sessions, where the
+ * identity key never sits at rest, and it collapses to vault strength
+ * once a user enrolls a passkey.
+ *
+ * Deriving the envelope key from something else was considered and
+ * rejected: it would orphan every mnemonic already stored as V2.
+ *
+ * V1 (legacy) derived its key as `sha256(pubkey)` — the pubkey is public,
+ * so a V1 record is decryptable by anyone who can read localStorage. V1
+ * records must be migrated on sight, not merely on next wallet open.
+ */
 import { xchacha20poly1305 } from '@noble/ciphers/chacha.js'
 import { sha256 } from '@noble/hashes/sha2.js'
 import { hexToBytes } from '@noble/hashes/utils.js'
@@ -100,6 +119,55 @@ export async function loadMnemonic(pubkey: string): Promise<string | null> {
  */
 export function hasMnemonic(pubkey: string): boolean {
 	return localStorage.getItem(`${LOCAL_STORAGE_KEY_PREFIX}${pubkey}`) !== null
+}
+
+/**
+ * Is this pubkey's stored mnemonic still in the legacy V1 format?
+ *
+ * Cheap and synchronous (no decryption, no signer) so it can gate the
+ * login-time sweep without cost for the common V2 case.
+ * @param pubkey The user's Nostr public key (hex string).
+ */
+export function hasLegacyMnemonic(pubkey: string): boolean {
+	const raw = localStorage.getItem(`${LOCAL_STORAGE_KEY_PREFIX}${pubkey}`)
+	if (!raw) return false
+	try {
+		const parsed = JSON.parse(raw) as StoredMnemonicV2
+		return !(parsed?.version === 2 && !!parsed.ciphertext)
+	} catch {
+		// Not JSON — a V1 legacy hex string.
+		return true
+	}
+}
+
+/**
+ * Upgrade a V1 record to V2 without opening the wallet.
+ *
+ * `loadMnemonic` already migrates on read, but it only runs when the user
+ * actually opens the Spark wallet — so a V1 record could sit decryptable-
+ * by-anyone indefinitely. This is the proactive sweep, called once per
+ * pubkey at login.
+ *
+ * V1 data is left untouched unless the V2 write succeeds, so a failure
+ * here can never lose the mnemonic; the next attempt simply retries.
+ *
+ * @param pubkey The user's Nostr public key (hex string).
+ * @returns True if a record was migrated, false if there was nothing to do.
+ */
+export async function migrateLegacyMnemonic(pubkey: string): Promise<boolean> {
+	const raw = localStorage.getItem(`${LOCAL_STORAGE_KEY_PREFIX}${pubkey}`)
+	if (!raw || !hasLegacyMnemonic(pubkey)) return false
+
+	const mnemonic = decryptV1(pubkey, raw)
+	if (!mnemonic) {
+		console.error('[Wallet Storage] Could not decrypt V1 mnemonic for migration')
+		return false
+	}
+
+	// saveMnemonic overwrites the key only after encrypt() resolves, so a
+	// signer denial throws here and leaves the V1 record in place.
+	await saveMnemonic(pubkey, mnemonic)
+	return true
 }
 
 /**

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -42,7 +42,11 @@
     clearAllWallets,
     openWallet
   } from '$lib/wallet';
-  import { disconnectWallet as disconnectSparkWallet, clearAllSparkWallets } from '$lib/spark';
+  import {
+    disconnectWallet as disconnectSparkWallet,
+    clearAllSparkWallets,
+    sweepLegacyMnemonic
+  } from '$lib/spark';
   import { loadOneTapZapSettings } from '$lib/autoZapSettings';
   import { weblnConnected } from '$lib/wallet/webln';
   import { bitcoinConnectEnabled, bitcoinConnectWalletInfo } from '$lib/wallet/bitcoinConnect';
@@ -385,6 +389,11 @@
         // Sync with legacy userPublickey store for compatibility
         if (state.isAuthenticated && state.publicKey) {
           userPublickey.set(state.publicKey);
+          // Upgrade a legacy V1 Spark mnemonic (key = sha256(pubkey), so
+          // readable by anyone with localStorage access) without waiting
+          // for the user to open the wallet. Deferred so it never competes
+          // with first paint; no-ops when there's nothing to migrate.
+          setTimeout(() => void sweepLegacyMnemonic(state.publicKey), 2500);
           // Message subscriptions are lazy — initialized when user navigates to /messages.
           // This avoids flooding browser signers with NIP-44 decrypt requests on login.
           // Pre-connect pantry relay shortly after login so groups load instantly


### PR DESCRIPTION
## Problem

Spark wallet mnemonics are stored under `spark_wallet_<pubkey>`. The legacy V1 format derived its encryption key as `sha256(pubkey)` — and the pubkey is public. A V1 record is therefore decryptable by anyone who can read localStorage; the encryption provides no real protection.

V1 records were already migrated to V2 (NIP-44 encrypt-to-self), but only inside `loadMnemonic()` — which runs when the user actually opens the Spark wallet. A user who has a wallet but never opens the panel keeps a world-readable seed phrase indefinitely.

## Changes

**Proactive migration at login** (`src/lib/spark/storage.ts`)

- `hasLegacyMnemonic(pubkey)` — synchronous format check, no decryption and no signer, so it's cheap enough to run on every login and no-ops instantly for the common V2 case.
- `migrateLegacyMnemonic(pubkey)` — decrypts V1 and rewrites as V2. The stored key is only overwritten after `encrypt()` resolves, so a signer denial throws with the V1 record still in place. A failed migration can never lose the mnemonic.

**Sweep orchestration** (`src/lib/spark/index.ts`)

`sweepLegacyMnemonic(pubkey)` wraps the guards: browser-only, once per pubkey per session, nothing to do unless `hasLegacyMnemonic`, and `canCreateNostrBackup()` must be true. It never throws; on failure it un-marks the pubkey so the next login retries rather than giving up permanently.

NIP-46 sessions are skipped, since `canCreateNostrBackup()` is false there (a bunker round-trip per encrypt isn't viable). Those keep exactly today's migrate-on-wallet-open behavior.

**Wiring** (`src/routes/+layout.svelte`)

Called from the auth-state subscription on login, deferred 2.5s so it never competes with first paint.

**Documented the V2 circularity** (header comment in `storage.ts`)

Stated plainly: for plaintext-nsec sessions the NIP-44 wrapping key is the identity key sitting in the same localStorage, so the envelope is not a defense against local storage compromise in that case. It is a real defense for NIP-07 and passkey-vault sessions, where the identity key never sits at rest, and it collapses to vault strength once a passkey is enrolled.

Also recorded why re-deriving the envelope key from something else was rejected: it would orphan every mnemonic already stored as V2. No derivation change in this PR.

## Tests

New `src/lib/spark/storage.test.ts` (10 tests), building V1 fixtures with the real legacy scheme:

- `hasLegacyMnemonic` across V1, V2, and absent records
- Migration rewrites V1 as V2 and preserves the mnemonic exactly (asserted on the plaintext handed to `encrypt`)
- No-op on records already V2, and when nothing is stored
- **V1 record survives intact when the signer refuses to encrypt** — the "never lose the mnemonic" guarantee
- Undecryptable payload is left untouched
- `loadMnemonic` still reads both formats

## Verification

- `pnpm check` — 1 error / 152 warnings, identical to `main` (the `delete`-operator error is pre-existing)
- `pnpm test` — 1206 passed
