### PR TITLE
fix(security): gate admin routes with NIP-98 instead of spoofable pubkey comparison

### DIFF
--- a/src/lib/adminAuth.ts
+++ b/src/lib/adminAuth.ts
@@ -1,6 +1,10 @@
 // Admin hex pubkey (decoded from npub15u3cqhx6vuj3rywg0ph5mfv009lxja6cyvqn2jagaydukq6zmjwqex05rq)
 export const ADMIN_PUBKEY = 'a723805cda67251191c8786f4da58f797e6977582301354ba8e91bcb0342dc9c';
 
+// CLIENT-SIDE UI GATING ONLY. The admin pubkey is public knowledge, so a
+// plain string comparison is spoofable — server routes must authenticate
+// with verifyNip98(request, { expectedPubkey: ADMIN_PUBKEY }) instead
+// (see $lib/nip98.server and /api/admin/promos for the pattern).
 export function isAdmin(pubkey: string | null | undefined): boolean {
   return !!pubkey && pubkey === ADMIN_PUBKEY;
 }

--- a/src/routes/admin/nourish-flags/+page.svelte
+++ b/src/routes/admin/nourish-flags/+page.svelte
@@ -72,10 +72,17 @@
   $: authed = isAdmin($userPublickey);
 
   async function loadAnon() {
-    if (!$userPublickey) return;
-    const res = await fetch('/api/admin/nourish-flags', {
-      headers: { 'x-admin-pubkey': $userPublickey }
-    });
+    if (!$ndk || !$userPublickey) return;
+    const url = new URL('/api/admin/nourish-flags', window.location.origin).toString();
+    let authorization: string;
+    try {
+      authorization = await signNip98AuthHeader($ndk, { method: 'GET', url });
+    } catch (err) {
+      throw new Error(
+        err instanceof Error ? err.message : 'Could not sign admin auth'
+      );
+    }
+    const res = await fetch(url, { headers: { Authorization: authorization } });
     if (!res.ok) {
       throw new Error(`anon flag fetch failed: ${res.status}`);
     }

--- a/src/routes/api/admin/nourish-flags/+server.ts
+++ b/src/routes/api/admin/nourish-flags/+server.ts
@@ -6,9 +6,12 @@
  * flags live on the pantry relay and are queried client-side by the
  * admin page — this endpoint covers only the anon-via-Worker path.
  *
- * Auth: `x-admin-pubkey` header must match ADMIN_PUBKEY from
- * $lib/adminAuth. Same weak-but-consistent pattern as /sponsors.
- * A future FOLLOWUPS item formalizes this with NIP-98 HTTP-Auth.
+ * Auth: NIP-98 HTTP Auth — the caller signs a kind-27235 event bound
+ * to this URL and method; the signing pubkey must equal ADMIN_PUBKEY
+ * from $lib/adminAuth (same gate as /api/admin/promos). Header-only
+ * auth was too weak here: the admin pubkey is public, so a forged
+ * x-admin-pubkey header was enough to dump every flag record,
+ * including the full ipHash values.
  *
  * Response:
  *   {
@@ -28,6 +31,7 @@
 
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { ADMIN_PUBKEY } from '$lib/adminAuth';
+import { verifyNip98 } from '$lib/nip98.server';
 
 const LIST_PAGE_LIMIT = 1000; // KV list per-call cap.
 const GET_CONCURRENCY = 16; // max in-flight kv.get calls — bounds memory + CPU.
@@ -41,8 +45,9 @@ interface KvListResult {
 }
 
 export const GET: RequestHandler = async ({ request, platform }) => {
-  const adminPubkey = request.headers.get('x-admin-pubkey');
-  if (!adminPubkey || adminPubkey !== ADMIN_PUBKEY) {
+  const auth = await verifyNip98(request, { expectedPubkey: ADMIN_PUBKEY });
+  if (!auth.ok) {
+    console.warn('[admin.nourish-flags.auth-failed]', { reason: auth.reason });
     return json({ error: 'forbidden' }, { status: 403 });
   }
 

--- a/src/routes/api/sponsor/active/+server.ts
+++ b/src/routes/api/sponsor/active/+server.ts
@@ -5,6 +5,11 @@
  *
  * Optional query param: ?tier=headline or ?tier=kitchen_card
  *
+ * Admin mode: ?admin=true returns all sponsors (active + hidden)
+ * with full details. Gated by NIP-98 HTTP Auth — the signing pubkey
+ * must equal ADMIN_PUBKEY. The previous ?pubkey= comparison was
+ * spoofable since the admin pubkey is public.
+ *
  * Returns:
  * {
  *   sponsors: [{ id, title, description, imageUrl, linkUrl, tier, expiresAt }]
@@ -13,18 +18,23 @@
 
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { getActiveSponsors, getAllSponsors, type SponsorTier } from '$lib/sponsorStore.server';
-import { isAdmin } from '$lib/adminAuth';
+import { ADMIN_PUBKEY } from '$lib/adminAuth';
+import { verifyNip98 } from '$lib/nip98.server';
 
 const VALID_TIERS: SponsorTier[] = ['headline', 'kitchen_card'];
 
-export const GET: RequestHandler = async ({ url, platform }) => {
+export const GET: RequestHandler = async ({ url, request, platform }) => {
   try {
     const kv = platform?.env?.GATED_CONTENT ?? null;
 
     // Admin mode: return all sponsors (active + hidden) with full details
     const adminParam = url.searchParams.get('admin');
-    const pubkeyParam = url.searchParams.get('pubkey');
-    if (adminParam === 'true' && isAdmin(pubkeyParam)) {
+    if (adminParam === 'true') {
+      const auth = await verifyNip98(request, { expectedPubkey: ADMIN_PUBKEY });
+      if (!auth.ok) {
+        console.warn('[sponsor.active.admin-auth-failed]', { reason: auth.reason });
+        return json({ error: 'forbidden' }, { status: 403 });
+      }
       const allSponsors = await getAllSponsors(kv);
       const adminSponsors = allSponsors.map((s) => ({
         id: s.id,

--- a/src/routes/api/sponsor/admin/+server.ts
+++ b/src/routes/api/sponsor/admin/+server.ts
@@ -2,24 +2,43 @@
  * Admin Sponsor Moderation
  *
  * POST /api/sponsor/admin
- * Body: { action: 'hide' | 'unhide', sponsorId: string, adminPubkey: string }
+ * Body: { action: 'hide' | 'unhide', sponsorId: string }
+ *
+ * Gated by NIP-98 HTTP Auth — the caller signs a kind-27235 event
+ * bound to this URL, method, and the exact body bytes; the signing
+ * pubkey must equal ADMIN_PUBKEY (same gate as /api/admin/promos).
+ * The previous body-supplied `adminPubkey` check was spoofable: the
+ * admin pubkey is public, so anyone could pass it in the body.
  *
  * Returns: { success: true, sponsor: { id, status } }
  * 403 for unauthorized requests
  */
 
 import { json, type RequestHandler } from '@sveltejs/kit';
-import { isAdmin } from '$lib/adminAuth';
+import { ADMIN_PUBKEY } from '$lib/adminAuth';
+import { verifyNip98 } from '$lib/nip98.server';
 import { getSponsor, hideSponsor, unhideSponsor } from '$lib/sponsorStore.server';
 
 export const POST: RequestHandler = async ({ request, platform }) => {
   try {
-    const body = await request.json();
-    const { action, sponsorId, adminPubkey } = body;
-
-    if (!isAdmin(adminPubkey)) {
+    // Read body bytes ONCE — they back both the NIP-98 payload check
+    // and the JSON parse below (avoids request.clone() semantics on
+    // Workers; same pattern as /api/admin/promos).
+    const bodyBytes = new Uint8Array(await request.arrayBuffer());
+    const auth = await verifyNip98(request, {
+      expectedPubkey: ADMIN_PUBKEY,
+      bodyBytes
+    });
+    if (!auth.ok) {
+      console.warn('[sponsor.admin.auth-failed]', { reason: auth.reason });
       return json({ error: 'Unauthorized' }, { status: 403 });
     }
+
+    const body = JSON.parse(new TextDecoder().decode(bodyBytes)) as {
+      action?: unknown;
+      sponsorId?: unknown;
+    };
+    const { action, sponsorId } = body;
 
     if (!sponsorId || typeof sponsorId !== 'string') {
       return json({ error: 'Missing sponsorId' }, { status: 400 });

--- a/src/routes/sponsors/+page.svelte
+++ b/src/routes/sponsors/+page.svelte
@@ -2,8 +2,9 @@
   import { onMount, onDestroy } from 'svelte';
   import { goto } from '$app/navigation';
   import { browser } from '$app/environment';
-  import { userPublickey } from '$lib/nostr';
+  import { userPublickey, ndk } from '$lib/nostr';
   import { isAdmin } from '$lib/adminAuth';
+  import { signNip98AuthHeader } from '$lib/nip98';
   import { lightningService } from '$lib/lightningService';
   import {
     SPONSOR_PRICING,
@@ -35,6 +36,7 @@
   let showForm = false;
   let showInfoModal = false;
   let adminActionLoading: string | null = null;
+  let adminActionError = '';
 
   $: isAdminUser = isAdmin($userPublickey);
   $: headlineSponsors = activeSponsors.filter((s) => s.tier === 'headline');
@@ -55,11 +57,25 @@
   async function fetchActiveSponsors() {
     loadingSponsors = true;
     try {
-      let url = '/api/sponsor/active';
       if (isAdminUser) {
-        url += `?admin=true&pubkey=${$userPublickey}`;
+        // Admin view (active + hidden) is NIP-98-gated server-side.
+        // If signing isn't possible yet (signer still connecting), fall
+        // back to the public list — the admin-view reactivity block
+        // below re-fetches once auth state settles.
+        const url = new URL('/api/sponsor/active?admin=true', window.location.origin).toString();
+        try {
+          const authorization = await signNip98AuthHeader($ndk, { method: 'GET', url });
+          const res = await fetch(url, { headers: { Authorization: authorization } });
+          if (res.ok) {
+            const data = await res.json();
+            activeSponsors = data.sponsors || [];
+            return;
+          }
+        } catch {
+          // fall through to the public list
+        }
       }
-      const res = await fetch(url);
+      const res = await fetch('/api/sponsor/active');
       if (res.ok) {
         const data = await res.json();
         activeSponsors = data.sponsors || [];
@@ -74,17 +90,34 @@
   async function adminAction(sponsorId: string, action: 'hide' | 'unhide') {
     if (action === 'hide' && !confirm('Hide this sponsor? It will be removed from public view.')) return;
     adminActionLoading = sponsorId;
+    adminActionError = '';
     try {
-      const res = await fetch('/api/sponsor/admin', {
+      const bodyString = JSON.stringify({ action, sponsorId });
+      const url = new URL('/api/sponsor/admin', window.location.origin).toString();
+      const authorization = await signNip98AuthHeader($ndk, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ action, sponsorId, adminPubkey: $userPublickey }),
+        url,
+        bodyString
+      });
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: authorization
+        },
+        body: bodyString
       });
       if (res.ok) {
         await fetchActiveSponsors();
+      } else if (res.status === 403) {
+        adminActionError = 'Not authorized — admin sign-in required.';
+      } else {
+        const data = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
+        adminActionError = data.error || `HTTP ${res.status}`;
       }
     } catch (err) {
       console.error('[Sponsor Admin] Action failed:', err);
+      adminActionError = err instanceof Error ? err.message : 'Action failed';
     } finally {
       adminActionLoading = null;
     }
@@ -335,6 +368,9 @@
   <!-- B. Current Sponsors -->
   <section>
     <h2 class="text-lg font-semibold mb-3">Current Sponsors</h2>
+    {#if adminActionError}
+      <p class="text-sm mb-3" style="color: var(--color-danger, #dc2626);">{adminActionError}</p>
+    {/if}
     {#if loadingSponsors}
       <div class="showcase-loading">
         <div class="showcase-skeleton"></div>


### PR DESCRIPTION
## Problem

Two admin endpoints authenticated by comparing a caller-supplied pubkey string against the admin pubkey. That value came straight from the request — an `x-admin-pubkey` header on one route, a body field on the other — so anyone could send the (public) admin pubkey and be treated as an admin.

- `api/admin/nourish-flags` — trusted an `x-admin-pubkey` header
- `api/sponsor/admin` — trusted an `adminPubkey` body field, gating hide/unhide moderation
- `api/sponsor/active?admin=true` — revealed hidden sponsors based on a `?pubkey=` query param

A pubkey is public information. None of these proved possession of the corresponding private key.

`api/admin/promos` already did this correctly with NIP-98, so this is bringing the other routes up to the pattern that already exists in the codebase.

## Changes

**Server** — all three routes now verify a NIP-98 (kind 27235) signed auth event via `verifyNip98(request, { expectedPubkey: ADMIN_PUBKEY })`, which checks the signature, the method/URL binding, and the timestamp window. Failures return 403 and log the reason.

On `api/sponsor/admin` (POST) the body is read once as `bodyBytes` via `request.arrayBuffer()`, passed to `verifyNip98` for payload-hash verification, and the JSON parsed from those same bytes — so the verified bytes and the acted-on bytes cannot diverge. `adminPubkey` is dropped from the body contract entirely.

`api/sponsor/active` keeps its public, cached path exactly as-is; only the `?admin=true` branch now requires NIP-98, replacing the spoofable `?pubkey=` comparison.

**Client** — `admin/nourish-flags` and `sponsors` attach `Authorization: await signNip98AuthHeader($ndk, { method, url, bodyString })`, matching `admin/promos/+page.svelte`.

The sponsors page previously swallowed admin failures silently; it now falls back to the public sponsor list if signing fails, and surfaces moderation errors in an `adminActionError` message under the "Current Sponsors" heading.

**`src/lib/adminAuth.ts`** — `isAdmin` is kept for client-side UI gating (deciding whether to render admin controls) but is now documented as exactly that, with a note that server routes must authenticate with `verifyNip98`.

## Verification

- `pnpm check` — 1 error / 152 warnings, identical to `main` (the `delete`-operator error is pre-existing)
- `pnpm test` — 1196 passed; `nip98.server.test.ts` covers the verifier itself
- Rebased onto current `main` (only conflict was the auto-bumped version in `package.json`)
