### PR TITLE
fix(content): render nostr references that omit the nostr: prefix

### DIFF
--- a/src/components/NoteContent.svelte
+++ b/src/components/NoteContent.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { nip19 } from 'nostr-tools';
+  import { scanNostrRefs, type ScannedRef } from '$lib/nostrRefScan';
   import { goto } from '$app/navigation';
   import type { NDKEvent } from '@nostr-dev-kit/ndk';
   import ProfileLink from './ProfileLink.svelte';
@@ -180,12 +181,6 @@
 
   // Parse content and create clickable links for URLs, hashtags, and nostr references
   function parseContent(text: string) {
-    // Include naddr1 for addressable events (recipes, long-form content).
-    // noffer1 (CLINK static offers) is detected both as a bare token and with
-    // the optional `nostr:` prefix — when present we render an inline "⚡ Pay"
-    // pill (NofferButton) instead of treating it as plain text.
-    const urlRegex =
-      /(https?:\/\/[^\s]+)|nostr:(nevent1|note1|npub1|nprofile1|naddr1|noffer1)([023456789acdefghjklmnpqrstuvwxyz]+)|\b(noffer1)([023456789acdefghjklmnpqrstuvwxyz]{6,})/g;
     const hashtagRegex = /#[\w]+/g;
 
     const parts = [];
@@ -193,46 +188,9 @@
     let match;
     let keyCounter = 0;
 
-    // First find URLs and nostr references
-    const urlMatches: Array<{
-      index: number;
-      content: string;
-      type: 'url' | 'nostr';
-      url?: string;
-      prefix?: string;
-      data?: string;
-    }> = [];
-    urlRegex.lastIndex = 0;
-    while ((match = urlRegex.exec(text)) !== null) {
-      const [fullMatch, url, nostrPrefix, nostrData, bareNofferPrefix, bareNofferData] = match;
-      if (url) {
-        urlMatches.push({
-          index: match.index,
-          content: fullMatch,
-          type: 'url',
-          url: url
-        });
-      } else if (nostrPrefix && nostrData) {
-        urlMatches.push({
-          index: match.index,
-          content: fullMatch,
-          type: 'nostr',
-          prefix: nostrPrefix,
-          data: nostrData
-        });
-      } else if (bareNofferPrefix && bareNofferData) {
-        // Bare `noffer1…` (no `nostr:` prefix) — treat the same as a
-        // nostr:noffer1 reference so the downstream renderer surfaces a
-        // Pay button.
-        urlMatches.push({
-          index: match.index,
-          content: fullMatch,
-          type: 'nostr',
-          prefix: bareNofferPrefix,
-          data: bareNofferData
-        });
-      }
-    }
+    // Links + nostr references, with or without the `nostr:` prefix.
+    // Lives in $lib/nostrRefScan so the regex is unit-testable.
+    const urlMatches: ScannedRef[] = scanNostrRefs(text);
 
     // Helper to check if index is inside a URL/nostr reference
     function isInUrl(index: number): boolean {

--- a/src/lib/nostrRefScan.test.ts
+++ b/src/lib/nostrRefScan.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import { nip19 } from 'nostr-tools';
+import { scanNostrRefs } from './nostrRefScan';
+
+/**
+ * Issue #637: a note containing a reference WITHOUT the `nostr:` prefix
+ * rendered as a wall of raw bech32 instead of an embed. Several clients
+ * emit prefix-less references and most clients render them anyway, so this
+ * read as zap.cooking being broken rather than the authoring client.
+ *
+ * The risky part is a regex run over arbitrary user text, so these pin the
+ * failure modes as much as the fix.
+ */
+
+const PUBKEY = 'a'.repeat(64);
+const EVENT_ID = 'b'.repeat(64);
+
+const NPUB = nip19.npubEncode(PUBKEY);
+const NOTE = nip19.noteEncode(EVENT_ID);
+const NEVENT = nip19.neventEncode({ id: EVENT_ID });
+const NPROFILE = nip19.nprofileEncode({ pubkey: PUBKEY });
+const NADDR = nip19.naddrEncode({ identifier: 'my-recipe', pubkey: PUBKEY, kind: 30023 });
+
+const nostrRefs = (text: string) => scanNostrRefs(text).filter((r) => r.type === 'nostr');
+const urls = (text: string) => scanNostrRefs(text).filter((r) => r.type === 'url');
+
+describe('prefixed references (existing behavior)', () => {
+  it('matches every entity type with a nostr: prefix', () => {
+    for (const token of [NPUB, NOTE, NEVENT, NPROFILE, NADDR]) {
+      const found = nostrRefs(`look at nostr:${token} ok`);
+      expect(found).toHaveLength(1);
+      expect(found[0].content).toBe(`nostr:${token}`);
+    }
+  });
+});
+
+describe('bare references (the fix)', () => {
+  it('matches every entity type without a prefix', () => {
+    for (const token of [NPUB, NOTE, NEVENT, NPROFILE, NADDR]) {
+      const found = nostrRefs(`look at ${token} ok`);
+      expect(found).toHaveLength(1);
+      expect(found[0].content).toBe(token);
+    }
+  });
+
+  it('reports the prefix and data so the renderer can branch on type', () => {
+    const [ref] = nostrRefs(NEVENT);
+    expect(ref.prefix).toBe('nevent1');
+    expect(ref.data).toBe(NEVENT.slice('nevent1'.length));
+  });
+
+  it('handles the reported case — a bare nevent alone on a line', () => {
+    const found = nostrRefs(`GM PV\n\n#foodstr\n${NEVENT}`);
+    expect(found).toHaveLength(1);
+  });
+
+  it('still matches a bare noffer1, which predates this change', () => {
+    const found = nostrRefs('pay noffer1qqsxyz234567');
+    expect(found).toHaveLength(1);
+    expect(found[0].prefix).toBe('noffer1');
+  });
+});
+
+describe('URL branch stays first', () => {
+  it('keeps a njump-style link whole instead of carving the nevent out', () => {
+    const text = `https://njump.me/${NEVENT}`;
+    const scanned = scanNostrRefs(text);
+
+    expect(scanned).toHaveLength(1);
+    expect(scanned[0].type).toBe('url');
+    expect(scanned[0].url).toBe(text);
+  });
+
+  it('does not treat a bech32 token inside any URL as a separate reference', () => {
+    expect(nostrRefs(`https://example.com/p/${NPUB}?x=1`)).toHaveLength(0);
+  });
+});
+
+describe('scheme-less hosts are not mangled', () => {
+  it('ignores a bare npub that is actually a hostname label', () => {
+    // The https? branch never sees this, and carving the npub out would
+    // mangle the link.
+    expect(nostrRefs(`${NPUB}.blossom.band/img.png`)).toHaveLength(0);
+  });
+
+  it('ignores a bare token followed by a path separator', () => {
+    expect(nostrRefs(`${NPUB}/some/path`)).toHaveLength(0);
+  });
+
+  it('still matches when followed by ordinary punctuation', () => {
+    expect(nostrRefs(`see ${NPUB}, thanks`)).toHaveLength(1);
+    expect(nostrRefs(`see ${NPUB}!`)).toHaveLength(1);
+  });
+});
+
+describe('undecodable tokens fall through to text', () => {
+  it('ignores a bech32-alphabet run that is not a real reference', () => {
+    // Right alphabet, right prefix, garbage payload.
+    expect(nostrRefs('npub1qqqqqqqqqq')).toHaveLength(0);
+  });
+
+  it('ignores a truncated paste', () => {
+    expect(nostrRefs(NEVENT.slice(0, 30))).toHaveLength(0);
+  });
+
+  it('does not trust a bad checksum even at full length', () => {
+    // Flip a character in the data part — length passes, decode must not.
+    const corrupted = NPUB.slice(0, -1) + (NPUB.endsWith('q') ? 'p' : 'q');
+    expect(nostrRefs(corrupted)).toHaveLength(0);
+  });
+
+  it('still trusts a prefixed reference without decoding it', () => {
+    // An explicit `nostr:` is a declaration of intent; the renderer handles
+    // failure. Only bare guesses get the decode gate.
+    expect(nostrRefs('nostr:npub1qqqqqqqqqq')).toHaveLength(1);
+  });
+});
+
+describe('mixed content', () => {
+  it('finds several references and a url in order', () => {
+    const text = `hi ${NPUB} see https://example.com and nostr:${NOTE}`;
+    const scanned = scanNostrRefs(text);
+
+    expect(scanned.map((r) => r.type)).toEqual(['nostr', 'url', 'nostr']);
+    expect(scanned.map((r) => r.index)).toEqual([...scanned.map((r) => r.index)].sort((a, b) => a - b));
+  });
+
+  it('returns nothing for plain prose', () => {
+    expect(scanNostrRefs('just a normal note about cooking beans')).toHaveLength(0);
+  });
+
+  it('reports indices that map back to the source text', () => {
+    const text = `abc ${NEVENT} def`;
+    const [ref] = scanNostrRefs(text);
+
+    expect(text.slice(ref.index, ref.index + ref.content.length)).toBe(ref.content);
+  });
+});

--- a/src/lib/nostrRefScan.ts
+++ b/src/lib/nostrRefScan.ts
@@ -1,0 +1,98 @@
+import { nip19 } from 'nostr-tools';
+
+/**
+ * Scan note content for links and nostr references.
+ *
+ * Extracted from NoteContent.svelte so the tricky part — a regex run over
+ * arbitrary user text — is unit-testable. The interleaving with hashtags
+ * and the rendering itself stay in the component.
+ *
+ * References may or may not carry the `nostr:` prefix. NIP-27 says they
+ * should, but several clients emit prefix-less ones and most clients render
+ * them anyway, so refusing to would read as zap.cooking being broken rather
+ * than the authoring client (issue #637).
+ */
+
+export interface ScannedRef {
+  index: number;
+  content: string;
+  type: 'url' | 'nostr';
+  url?: string;
+  prefix?: string;
+  data?: string;
+}
+
+/**
+ * Ordering is load-bearing: the URL branch comes FIRST so
+ * `https://njump.me/nevent1…` matches as a link instead of being carved up.
+ */
+const REF_RE =
+  /(https?:\/\/[^\s]+)|nostr:(nevent1|note1|npub1|nprofile1|naddr1|noffer1)([023456789acdefghjklmnpqrstuvwxyz]+)|\b(nevent1|note1|npub1|nprofile1|naddr1|noffer1)([023456789acdefghjklmnpqrstuvwxyz]{6,})/g;
+
+/**
+ * Does a bech32 token actually decode?
+ *
+ * Only applied to PREFIX-LESS matches. A `nostr:` prefix is an explicit
+ * declaration of intent and is trusted as before; a bare run of bech32
+ * characters is a guess, and this is what makes the guess safe — it rejects
+ * prose false positives and truncated pastes, and is stricter than the
+ * regex's `{6,}` length bound.
+ *
+ * `noffer1` is exempt: NofferButton owns its own parsing and nip19 has no
+ * such type.
+ */
+function isDecodableNostrRef(token: string): boolean {
+  if (token.startsWith('noffer1')) return true;
+  try {
+    nip19.decode(token);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function scanNostrRefs(text: string): ScannedRef[] {
+  const out: ScannedRef[] = [];
+  let match: RegExpExecArray | null;
+
+  REF_RE.lastIndex = 0;
+  while ((match = REF_RE.exec(text)) !== null) {
+    const [fullMatch, url, nostrPrefix, nostrData, barePrefix, bareData] = match;
+
+    if (url) {
+      out.push({ index: match.index, content: fullMatch, type: 'url', url });
+      continue;
+    }
+
+    if (nostrPrefix && nostrData) {
+      out.push({
+        index: match.index,
+        content: fullMatch,
+        type: 'nostr',
+        prefix: nostrPrefix,
+        data: nostrData
+      });
+      continue;
+    }
+
+    if (barePrefix && bareData) {
+      // Scheme-less host: `npub1abc….blossom.band/img.png` is a URL the
+      // https? branch never sees, and carving the npub out of it would
+      // mangle the link. If a domain-ish character follows, leave it as text.
+      const after = text[match.index + fullMatch.length];
+      if (after === '.' || after === '/') continue;
+
+      if (!isDecodableNostrRef(`${barePrefix}${bareData}`)) continue;
+
+      out.push({
+        index: match.index,
+        content: fullMatch,
+        type: 'nostr',
+        prefix: barePrefix,
+        data: bareData
+      });
+    }
+  }
+
+  return out;
+}

--- a/src/lib/profileResolver.ts
+++ b/src/lib/profileResolver.ts
@@ -67,10 +67,15 @@ export function decodeNostrProfile(nostrString: string): string | null {
 // Decode nostr profile string to get pubkey AND any embedded relay hints.
 export function decodeNostrProfileFull(nostrString: string): { pubkey: string; relays: string[] } | null {
   try {
-    if (!nostrString.startsWith('nostr:nprofile1') && !nostrString.startsWith('nostr:npub1')) {
+    // The `nostr:` prefix is optional: several clients emit prefix-less
+    // references and NoteContent now parses them, so rejecting them here
+    // would leave a bare npub1/nprofile1 rendering as raw bech32 (issue
+    // #637). nip19.decode below is still the real validation.
+    const token = nostrString.replace(/^nostr:/, '');
+    if (!token.startsWith('nprofile1') && !token.startsWith('npub1')) {
       return null;
     }
-    const decoded = nip19.decode(nostrString.replace('nostr:', ''));
+    const decoded = nip19.decode(token);
     if (decoded.type === 'nprofile') {
       return { pubkey: decoded.data.pubkey, relays: decoded.data.relays ?? [] };
     } else if (decoded.type === 'npub') {


### PR DESCRIPTION
Fixes #637.

## The fix

`NoteContent`'s scanner required `nostr:` on every entity type except `noffer1`, which already had a bare branch. That bare branch is now extended to `nevent1|note1|npub1|nprofile1|naddr1`, so a prefix-less reference renders as an embed instead of a wall of raw bech32.

`decodeNostrProfileFull()` in `src/lib/profileResolver.ts` hard-required the prefix too. Without that change a bare `npub1`/`nprofile1` would have fallen through to `displayName = nostrString` and still shown raw text.

Rendering needed nothing: `isBlockPart()` already treats these as block-level, the template already branches on every prefix, and `NoteEmbed` normalizes with `replace(/^nostr:/, '')` so it accepts a bare token.

## The three hazards from the issue, and what each turned into

**Scheme-less hosts.** `npub1….blossom.band/img.png` is a URL the `https?://` branch never sees, and carving the npub out would mangle it. A bare match followed by `.` or `/` is left as text.

**URL branch ordering.** Kept first, so `https://njump.me/nevent1…` still matches as a link. Pinned by a test rather than left to alternation order surviving a future edit.

**Validation.** Prefix-less matches now go through `nip19.decode()` and fall back to plain text on throw. This rejects prose false positives, truncated pastes, and bad checksums — and is stricter than the regex's `{6,}` bound.

An explicit `nostr:` prefix is still trusted without decoding: it's a declaration of intent, and the renderer already handles resolution failure. Only bare guesses get the decode gate. `noffer1` is exempt since `NofferButton` owns its parsing and nip19 has no such type.

## One structural change

The scanner moved out of `NoteContent.svelte` into `src/lib/nostrRefScan.ts` (`scanNostrRefs`). It's a regex over arbitrary user content with three known footguns and had **no test coverage at all** — inside a `.svelte` file it wasn't reachable from a unit test. The interleaving with hashtags and all rendering stay in the component.

## Tests

17 new in `nostrRefScan.test.ts`, built on real `nip19`-encoded fixtures:

- every entity type matches both with and without the prefix
- the reported shape — a bare `nevent` alone on a line after hashtags
- `noffer1` still matches, unchanged
- njump-style links stay whole; a token inside any URL is not carved out
- `npub….blossom.band/img.png` and `npub…/path` are ignored; ordinary trailing punctuation still matches
- garbage payloads, truncated pastes and flipped-checksum tokens fall through to text
- a prefixed reference is still accepted without decoding
- mixed content keeps source order, and reported indices map back to the input

## Verification

- `pnpm check` — 1 error / 152 warnings, identical to `main` (pre-existing `delete`-operator error)
- `pnpm test` — 1254 passed
- Checked in a browser against the note from the issue: the bech32 wall now renders as the embedded "Zap Cooking Helper" note.
