### PR TITLE
fix(share): copy the NIP-21 note URI instead of a bare identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.705",
+  "version": "4.2.706",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -3912,9 +3912,9 @@
     })();
   }
 
-  function handlePostCopy(event: CustomEvent<{ noteId: string }>) {
+  function handlePostCopy(event: CustomEvent<{ noteUri: string }>) {
     // Copy handled by PostActionsMenu component
-    console.log('Note ID copied:', event.detail.noteId);
+    console.log('Note URI copied:', event.detail.noteUri);
   }
 
   function handlePostShare(event: CustomEvent<{ url: string }>, noteEvent?: NDKEvent) {

--- a/src/components/PostActionsMenu.svelte
+++ b/src/components/PostActionsMenu.svelte
@@ -24,7 +24,8 @@
   } | null = null;
 
   const dispatch = createEventDispatcher<{
-    copy: { noteId: string };
+    /** The copied NIP-21 URI (`nostr:nevent1…`). */
+    copy: { noteUri: string };
     downloadImage: { event: NDKEvent; engagementData: any };
   }>();
 
@@ -55,22 +56,29 @@
   async function handleCopy() {
     if (!browser) return;
 
-    const noteId = nip19.neventEncode({
+    // Copy the NIP-21 URI, not a bare bech32 identifier.
+    //
+    // What people do with this is paste it into a composer, and a
+    // prefix-less `nevent1…` renders as a wall of raw text in most clients
+    // — which is how zap.cooking ended up being the authoring client that
+    // produced exactly the broken notes issue #637 was about. The `nostr:`
+    // prefix is what makes a pasted reference resolve into an embed.
+    const noteUri = `nostr:${nip19.neventEncode({
       id: event.id,
       author: event.pubkey,
       kind: event.kind
-    });
+    })}`;
     try {
-      await navigator.clipboard.writeText(noteId);
+      await navigator.clipboard.writeText(noteUri);
       copied = true;
-      dispatch('copy', { noteId });
+      dispatch('copy', { noteUri });
       if (copyTimeout) clearTimeout(copyTimeout);
       copyTimeout = setTimeout(() => {
         copied = false;
         closeMenu();
       }, 800);
     } catch (error) {
-      console.error('Failed to copy note ID:', error);
+      console.error('Failed to copy note URI:', error);
     }
   }
 
@@ -200,7 +208,7 @@
           <span>Copied!</span>
         {:else}
           <CopyIcon size={16} class="text-caption" />
-          <span>Copy Note ID</span>
+          <span>Copy Note URI</span>
         {/if}
       </button>
       <button


### PR DESCRIPTION
Follow-up to #638 (which fixed the rendering half of #637). This fixes the authoring half.

## The bug

**"Copy Note ID" copied a bare `nevent1…`** — no `nostr:` prefix.

That made zap.cooking the *source* of exactly the broken notes #637 was about: copy a note here, paste it into any composer, and it lands as a wall of raw bech32 rather than an embed. The note in the original report was posted "via Sidecar" — copied out of zap.cooking, pasted elsewhere.

## The change

`PostActionsMenu.handleCopy()` now copies the NIP-21 URI (`nostr:nevent1…`), and the menu item is relabelled **"Copy Note URI"** — the old label promised an ID, and a URI is a different thing, so the copy should say what it now hands you.

The dispatched event payload was renamed `noteId` → `noteUri` to match, along with its one consumer in `FoodstrFeedOptimized` (a `console.log`; nothing behavioral depends on it).

## Scope: this was the only authoring-side gap

I checked the other paths that could emit a reference, and they were already correct:

- **Mentions** — `mentionUtils.ts:71,116,123` and `mentionComposer.ts:424,671` already emit `nostr:${npub}`
- **Quote / repost** — `NoteRepost` and `MemoryNoteCard` pass a bare nevent into `openComposerWithQuote`, but that's an internal handle; `PostComposer.svelte:473,635` adds the prefix when building the content
- **`TagsSearchAutocomplete`** — a search box that navigates, never inserts into content
- **"Copy Link"** — correctly copies a URL, unchanged

## Deliberately not changed: "Copy npub"

`handleCopyNpub` still copies a bare `npub1…`. Unlike "Copy Note ID", that label names the format explicitly — an npub *is* the thing being asked for, and it's commonly pasted into places that want the raw form (profile lookups, other tools).

Happy to make it `nostr:npub1…` too if you'd rather every copy action produce a pasteable reference, but it's a different judgement call than the note one and worth deciding on its own.

## Verification

- `pnpm check` — 1 error / 152 warnings, identical to `main` (pre-existing `delete`-operator error)
- `pnpm test` — 1267 passed

Manual check worth doing: copy a note from the ⋯ menu and paste it into the composer — it should resolve to an embed rather than raw text.
