### PR TITLE
fix(footer): stop the links row orphaning, move account deletion into Settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.705",
+  "version": "4.2.706",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -43,28 +43,18 @@
       >
         ⚡ Support
       </button>
-      <span class="footer-sep">·</span>
       <a href="/about" class="hover:text-primary transition-colors">About</a>
-      <span class="footer-sep">·</span>
       <a href="/founders" class="hover:text-primary transition-colors">Founders</a>
-      <span class="footer-sep">·</span>
       <a href="/sponsors" class="hover:text-primary transition-colors">Sponsors</a>
-      <span class="footer-sep">·</span>
       <a
         href="https://github.com/zapcooking/frontend/issues/new"
         target="_blank"
         rel="noopener noreferrer"
         class="hover:text-primary transition-colors">Report a Bug</a
       >
-      <span class="footer-sep">·</span>
       <a href="/terms" class="hover:text-primary transition-colors">Terms</a>
-      <span class="footer-sep">·</span>
       <a href="/privacy" class="hover:text-primary transition-colors">Privacy</a>
-      <span class="footer-sep">·</span>
       <a href="/child-safety" class="hover:text-primary transition-colors">Safety</a>
-      <span class="footer-sep">·</span>
-      <a href="/delete-account" class="hover:text-primary transition-colors">Delete Account</a>
-      <span class="footer-sep">·</span>
       <a href="/disclosure" class="hover:text-primary transition-colors">Disclosure</a>
     </nav>
 
@@ -73,7 +63,6 @@
       <span>&copy; {currentYear} zap.cooking</span>
       <span class="footer-sep">·</span>
       <span>v{VERSION}</span>
-      <span class="footer-sep">·</span>
       <a
         href={`https://github.com/zapcooking/frontend/commit/${BUILD_HASH}`}
         target="_blank"
@@ -253,6 +242,22 @@
     font-size: 0.75rem;
     line-height: 1.2;
     text-align: left;
+  }
+
+  /*
+   * Separators are drawn on the links themselves rather than as their own
+   * flex items.
+   *
+   * As standalone spans every dot was an independent wrap opportunity, so a
+   * break could strand a `·` at the end of a line or leave one link alone on
+   * the next (see the "Disclosure" orphan this replaces). Attached to the
+   * item, a link and its trailing dot always move together.
+   */
+  .footer-links > :not(:last-child)::after {
+    content: '·';
+    opacity: 0.4;
+    margin-left: 0.5rem;
+    /* The gap already spaces items; this only offsets the dot itself. */
   }
 
   .footer-sep {

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1682,6 +1682,27 @@
             </button>
           </div>
         {/if}
+
+        <!-- Account deletion. Moved here from the site footer, where it sat
+             between "Safety" and "Disclosure" as an ordinary utility link —
+             an irreversible account action doesn't belong next to the terms
+             and privacy links, and it's what people look for in Settings. -->
+        <div class="border-t border-[var(--color-input-border)] pt-5">
+          <p class="text-sm font-medium mb-1" style="color: var(--color-text-primary)">
+            Delete Account
+          </p>
+          <p class="text-xs text-caption mb-3">
+            Request removal of your account data from zap.cooking. Your Nostr identity and any
+            notes already published to relays are not affected — they aren't ours to delete.
+          </p>
+          <a
+            href="/delete-account"
+            class="inline-flex items-center gap-1.5 px-4 py-2 bg-red-500/10 hover:bg-red-500/20 text-red-500 rounded-lg text-sm font-medium transition-colors"
+          >
+            <TrashIcon size={16} />
+            Delete Account
+          </a>
+        </div>
       </div>
     </Accordion>
   </div>


### PR DESCRIPTION
Two related footer changes.

## 1. The links row no longer orphans

**Before:** `⚡ Support · About · Founders · Sponsors · Report a Bug · Terms · Privacy · Safety · Delete Account` — then **`Disclosure`** alone on a second line.

Two causes, both fixed:

**Separators were their own flex items.** Each `<span class="footer-sep">·</span>` sat in the flex flow as an independent element, so every dot was its own wrap opportunity — a break could strand a `·` at the end of a line or leave a single link on the next. They're now `::after` pseudo-elements on the links themselves, so a link and its trailing dot always move together. Spacing is unchanged (the `0.5rem` that used to come from the flex gap now comes from the pseudo-element's `margin-left`, with the gap still separating items).

**One item too many.** Removing "Delete Account" (see below) takes the row from 9 items to 8 wide ones.

Measured after the change:

| Container width | Result |
|---|---|
| Default (42rem) | **1 line**, no wrap |
| 520px | 7 + 2 |
| 380px | 4 + 5 |
| 300px | 4 + 4 + 1 |

It still wraps when genuinely too narrow — that's what wrapping is for — but it now breaks *between links* and never leaves a separator hanging.

## 2. Account deletion moved into Settings

"Delete Account" sat in the footer between "Safety" and "Disclosure", styled identically to the terms/privacy links. An irreversible account action shouldn't read as an ordinary utility link, and Settings is where people look for it.

It's now at the end of **Settings → Security**, as a red action with a short explanation:

> Request removal of your account data from zap.cooking. Your Nostr identity and any notes already published to relays are not affected — they aren't ours to delete.

That caveat is worth stating up front: the `/delete-account` route is unchanged and still does exactly what it did, but the footer link gave no hint about what deletion can and can't reach.

## Verification

- `pnpm check` — 1 error / 152 warnings, identical to `main` (pre-existing `delete`-operator error)
- `pnpm test` — 1267 passed
- Checked in a browser: footer renders on one line at desktop width; wrap points measured at 520/380/300px as above

Worth a look on a real phone — my narrow-width numbers come from constraining the container in the page rather than an actual mobile viewport.
