### PR TITLE
fix(recovery): never offer an empty follow list as a restore option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.705",
+  "version": "4.2.706",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/FollowListRecoveryModal.svelte
+++ b/src/components/FollowListRecoveryModal.svelte
@@ -180,7 +180,13 @@
       {#if scanResult.candidates.length === 0}
         <div class="flex flex-col items-center gap-2 py-8 text-center">
           <UsersIcon size={36} class="opacity-30" />
-          <p class="text-sm" style="color: var(--color-text-secondary)">No follow list versions found.</p>
+          <p class="text-sm" style="color: var(--color-text-secondary)">
+            No recoverable follow list found.
+          </p>
+          <p class="text-xs max-w-xs" style="color: var(--color-text-secondary)">
+            Nothing on these relays holds an earlier version with follows in it. Trying again later,
+            or from a different network, may reach relays that do.
+          </p>
         </div>
       {:else}
         <div class="flex flex-col gap-2">
@@ -215,10 +221,6 @@
                     {#if candidate.isCurrent}
                       <span class="text-[11px] px-1.5 py-0.5 rounded font-medium"
                         style="background: rgba(96,165,250,0.15); color: #60a5fa">Current</span>
-                    {/if}
-                    {#if candidate.followCount === 0}
-                      <span class="text-[11px] px-1.5 py-0.5 rounded font-medium"
-                        style="background: rgba(107,114,128,0.2); color: var(--color-text-secondary)">Empty</span>
                     {/if}
                   </div>
                   <p class="text-xs" style="color: var(--color-text-primary)">

--- a/src/lib/followRecovery.test.ts
+++ b/src/lib/followRecovery.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import {
+  selectRecoveryCandidates,
+  pickRecommendedRecovery,
+  type FollowListCandidate
+} from './followRecovery';
+
+/**
+ * The rule this pins: recovery never offers an EMPTY follow list.
+ *
+ * Restoring a zero-follow version publishes a kind:3 with no follows —
+ * wiping the list the user came here to rescue. Empty versions are also
+ * noise on a screen someone reaches while stressed.
+ *
+ * The awkward part is that an empty list is often the user's CURRENT one,
+ * so it still has to count for the "is this better than what I have?"
+ * comparison even though it can't be offered.
+ */
+
+function candidate(
+  eventId: string,
+  followCount: number,
+  createdAt: number
+): FollowListCandidate {
+  return {
+    event: { id: eventId } as any,
+    eventId,
+    createdAt,
+    followCount,
+    followPubkeys: Array.from({ length: followCount }, (_, i) => `pk${i}`),
+    foundOnRelays: ['wss://relay.example'],
+    isCurrent: false,
+    isRecommended: false
+  };
+}
+
+/** Newest first — the order scanFollowListHistory produces. */
+const newestFirst = (...c: FollowListCandidate[]) =>
+  [...c].sort((a, b) => b.createdAt - a.createdAt);
+
+describe('empty versions are never offered', () => {
+  it('drops a zero-follow version from the candidate list', () => {
+    const result = selectRecoveryCandidates(
+      newestFirst(candidate('empty', 0, 300), candidate('good', 120, 200))
+    );
+
+    expect(result.candidates.map((c) => c.eventId)).toEqual(['good']);
+  });
+
+  it('drops every empty version, keeping order', () => {
+    const result = selectRecoveryCandidates(
+      newestFirst(
+        candidate('e1', 0, 500),
+        candidate('a', 50, 400),
+        candidate('e2', 0, 300),
+        candidate('b', 90, 200)
+      )
+    );
+
+    expect(result.candidates.map((c) => c.eventId)).toEqual(['a', 'b']);
+  });
+
+  it('returns nothing to offer when every version is empty', () => {
+    const result = selectRecoveryCandidates(
+      newestFirst(candidate('e1', 0, 200), candidate('e2', 0, 100))
+    );
+
+    expect(result.candidates).toEqual([]);
+    expect(result.recommended).toBeNull();
+  });
+
+  it('never recommends an empty version', () => {
+    const result = selectRecoveryCandidates(
+      newestFirst(candidate('empty', 0, 300), candidate('good', 10, 200))
+    );
+
+    expect(result.recommended?.followCount).toBeGreaterThan(0);
+  });
+});
+
+describe('current is still computed from the unfiltered list', () => {
+  it('marks the newest version as current even when it is empty', () => {
+    // The whole reason someone is here: their live list got wiped.
+    const result = selectRecoveryCandidates(
+      newestFirst(candidate('wiped', 0, 300), candidate('good', 120, 200))
+    );
+
+    expect(result.current?.eventId).toBe('wiped');
+    expect(result.current?.isCurrent).toBe(true);
+  });
+
+  it('does not promote an older non-empty version to current', () => {
+    const result = selectRecoveryCandidates(
+      newestFirst(candidate('wiped', 0, 300), candidate('good', 120, 200))
+    );
+
+    const good = result.candidates.find((c) => c.eventId === 'good');
+    expect(good?.isCurrent).toBe(false);
+  });
+
+  it('recommends recovery when the current list is empty', () => {
+    const result = selectRecoveryCandidates(
+      newestFirst(candidate('wiped', 0, 300), candidate('good', 120, 200))
+    );
+
+    expect(result.recommended?.eventId).toBe('good');
+  });
+});
+
+describe('recommendation', () => {
+  it('prefers the largest list over merely the newest', () => {
+    const result = selectRecoveryCandidates(
+      newestFirst(
+        candidate('current', 5, 400),
+        candidate('small', 20, 300),
+        candidate('big', 300, 200)
+      )
+    );
+
+    expect(result.recommended?.eventId).toBe('big');
+  });
+
+  it('recommends nothing when current is already the biggest', () => {
+    const result = selectRecoveryCandidates(
+      newestFirst(candidate('current', 500, 400), candidate('older', 100, 300))
+    );
+
+    expect(result.recommended).toBeNull();
+  });
+
+  it('never recommends the current version itself', () => {
+    const result = selectRecoveryCandidates(
+      newestFirst(candidate('current', 100, 400), candidate('older', 100, 300))
+    );
+
+    expect(result.recommended?.eventId).not.toBe('current');
+  });
+});
+
+describe('edge cases', () => {
+  it('handles an empty scan', () => {
+    const result = selectRecoveryCandidates([]);
+
+    expect(result.current).toBeNull();
+    expect(result.candidates).toEqual([]);
+    expect(result.recommended).toBeNull();
+  });
+
+  it('offers nothing when the only version is the current non-empty one', () => {
+    const result = selectRecoveryCandidates([candidate('only', 42, 100)]);
+
+    expect(result.candidates.map((c) => c.eventId)).toEqual(['only']);
+    expect(result.recommended).toBeNull();
+  });
+
+  it('pickRecommendedRecovery still filters empties when called directly', () => {
+    // Defense in depth: the helper is exported and used elsewhere.
+    const empty = candidate('empty', 0, 300);
+    expect(pickRecommendedRecovery([empty], null)).toBeNull();
+  });
+});

--- a/src/lib/followRecovery.ts
+++ b/src/lib/followRecovery.ts
@@ -104,6 +104,41 @@ async function queryRelayForFollowEvents(
 	}
 }
 
+/**
+ * Decide what recovery offers, given every version found on relays.
+ *
+ * Pure and exported so the rule below is testable without touching a relay.
+ *
+ * Two things matter here:
+ *
+ * 1. `current` is the newest version and is computed BEFORE empties are
+ *    dropped. An empty current list is the usual reason someone is on this
+ *    screen, and the recommendation compares against its follow count —
+ *    filtering first would mislabel an older non-empty list as "current"
+ *    and skew that comparison.
+ * 2. Empty versions are never offered. Restoring one publishes a kind:3
+ *    with no follows — wiping the list the user came here to rescue — so
+ *    it isn't a recovery option, and listing rows they must read past only
+ *    makes a stressful screen noisier.
+ */
+export function selectRecoveryCandidates(allCandidates: FollowListCandidate[]): {
+	current: FollowListCandidate | null;
+	candidates: FollowListCandidate[];
+	recommended: FollowListCandidate | null;
+} {
+	const current = allCandidates[0] ?? null;
+	if (current) current.isCurrent = true;
+
+	const recommended = pickRecommendedRecovery(allCandidates, current);
+	if (recommended) recommended.isRecommended = true;
+
+	return {
+		current,
+		candidates: allCandidates.filter((c) => c.followCount > 0),
+		recommended
+	};
+}
+
 export async function scanFollowListHistory(
 	pubkey: string,
 	userRelays: string[] = [],
@@ -158,18 +193,14 @@ export async function scanFollowListHistory(
 		(a, b) => b.createdAt - a.createdAt
 	);
 
-	const current = allCandidates[0] ?? null;
-	if (current) current.isCurrent = true;
+	const { current, candidates, recommended } = selectRecoveryCandidates(allCandidates);
 
-	const recommended = pickRecommendedRecovery(allCandidates, current);
-	if (recommended) recommended.isRecommended = true;
-
-	const count = allCandidates.length;
+	const count = candidates.length;
 	onProgress?.(
-		`Found ${count} distinct version${count === 1 ? '' : 's'} — ${respondingRelays.length} of ${relays.length} relays had versions.`
+		`Found ${count} recoverable version${count === 1 ? '' : 's'} — ${respondingRelays.length} of ${relays.length} relays responded.`
 	);
 
-	return { current, candidates: allCandidates, recommended, queriedRelays: relays, respondingRelays };
+	return { current, candidates, recommended, queriedRelays: relays, respondingRelays };
 }
 
 export function pickRecommendedRecovery(


### PR DESCRIPTION
## The problem

Follow-list recovery listed **empty (0-follow) versions** as rows in the results.

They already had no Restore button, so they weren't restorable — but they were still rows the user had to read past, on a screen someone reaches while stressed about having lost their follows. Restoring one would publish a `kind:3` with no follows, i.e. wipe the very list they came to rescue, so they were never a legitimate option.

## The fix

Empties are filtered **at the source**, in `followRecovery.ts`, so every entry point behaves identically — the profile page today, Settings → Backup in #641, and anything added later.

The subtlety is that an empty list is usually the user's **current** one — that's why they're on this screen — so it still has to count for the "is this better than what I have?" comparison even though it can't be offered. So:

- `current` is computed from the **unfiltered** list. Filtering first would promote an older non-empty version to "current" and skew the recommendation against the wrong baseline.
- Only the returned `candidates` array is filtered.

That logic moved into an exported pure `selectRecoveryCandidates()` so it's testable without touching a relay.

### Also

- Removed the now-unreachable **"Empty"** badge from the modal. The `followCount > 0` guard on the Restore button stays as defense in depth.
- The progress line now says "Found N **recoverable** versions" rather than counting versions that were never offerable.
- The empty state distinguishes *nothing found* from *nothing worth restoring*:

  > No recoverable follow list found.
  > Nothing on these relays holds an earlier version with follows in it. Trying again later, or from a different network, may reach relays that do.

## Tests

`followRecovery.ts` had **no test coverage**. 13 tests added, pinning both halves of the rule:

- empty versions dropped from candidates, in every position, order preserved
- all-empty scan offers nothing and recommends nothing
- an empty version is never recommended
- **the newest version is still marked `current` even when empty** — and an older non-empty one is not promoted
- recovery is still recommended when the current list is empty
- recommendation prefers the largest list over the newest, recommends nothing when current is already largest, never recommends current itself
- empty scan, single-version scan, and `pickRecommendedRecovery` called directly

## Verification

- `pnpm check` — 1 error / 152 warnings, identical to `main` (pre-existing `delete`-operator error)
- `pnpm test` — 1280 passed

The scan itself needs relays and a signed-in user, so the end-to-end flow is worth a manual pass; the logic under it is now covered.
