### PR TITLE
feat(backup): export any backup version as JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.707",
+  "version": "4.2.708",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.705",
+  "version": "4.2.706",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.709",
+  "version": "4.2.710",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.706",
+  "version": "4.2.707",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.708",
+  "version": "4.2.709",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/NostrBackupSection.svelte
+++ b/src/components/NostrBackupSection.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { browser } from '$app/environment';
 	import { ndk, userPublickey } from '$lib/nostr';
+	import FollowListRecoveryModal from './FollowListRecoveryModal.svelte';
 	import { hasEncryptionSupport } from '$lib/encryptionService';
 	import {
 		backupFollows,
@@ -63,6 +64,17 @@
 	};
 	let expandedType: BackupType | null = null;
 	let versionsExpanded: Record<BackupType, boolean> = { follows: false, mute: false, profile: false };
+
+	/**
+	 * Mutable's follow-list recovery, surfaced here as well as on the profile
+	 * page.
+	 *
+	 * It scans relay history for earlier kind:3 events, so unlike Restore it
+	 * needs no zap.cooking backup at all — which makes Settings → Backup the
+	 * place someone actually looks after losing their follows. It stays
+	 * enabled precisely when "Restore" cannot help.
+	 */
+	let followRecoveryOpen = false;
 
 	// Wallet backup state (view-only) — check both types independently
 	interface WalletBackupInfo {
@@ -479,6 +491,15 @@
 					{/if}
 				</div>
 
+				{#if type === 'follows' && !status.loading && !status.exists}
+					<p class="text-xs text-caption mb-3">
+						No backup here yet — but your follow list may still be recoverable from
+						relay history. Try <span style="color: var(--color-text-primary)"
+							>Recover from relays</span
+						>.
+					</p>
+				{/if}
+
 				<!-- Actions -->
 				<div class="flex items-center gap-2 flex-wrap">
 					<button
@@ -514,6 +535,21 @@
 							Restore
 						{/if}
 					</button>
+
+					{#if type === 'follows'}
+						<!-- Recovery works from relay history, so it is NOT gated on
+						     status.exists — with no backup it's the only option left. -->
+						<button
+							class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors disabled:opacity-50"
+							style="background-color: var(--color-bg-secondary); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+							disabled={!$userPublickey}
+							on:click={() => (followRecoveryOpen = true)}
+							title="Scan relay history for an earlier follow list"
+						>
+							<ClockCounterClockwiseIcon size={14} />
+							Recover from relays
+						</button>
+					{/if}
 
 					{#if status.backupCount > 1}
 						<button
@@ -748,3 +784,9 @@
 		Refresh All
 	</button>
 </div>
+
+<!-- Mutable's follow-list recovery. Mounted here so it's reachable from
+     Settings → Backup, not only from a profile page. -->
+{#if $userPublickey}
+  <FollowListRecoveryModal bind:open={followRecoveryOpen} pubkey={$userPublickey} />
+{/if}

--- a/src/components/NostrBackupSection.svelte
+++ b/src/components/NostrBackupSection.svelte
@@ -589,22 +589,20 @@
 					style="border-color: var(--color-input-border);"
 				>
 					<div class="min-w-0">
-						<div class="flex items-center gap-1.5">
-							<p class="text-xs" style="color: var(--color-text-primary);">
-								Lost your follows?
-							</p>
-							<!-- Same attribution the recovery modal and MuteListEditor
-							     carry, so the feature is recognizable as Mutable's
-							     wherever it surfaces. -->
-							<span
-								class="flex items-center gap-1 flex-shrink-0"
-								style="color: var(--color-caption);"
-							>
-								<img src="/mutable_logo.svg" alt="" class="w-3.5 h-3.5 rounded-sm opacity-70" />
-								<span class="text-[11px]">Mutable</span>
-							</span>
-						</div>
-						<p class="text-[11px] text-caption">
+						<p class="text-xs font-medium" style="color: var(--color-text-primary);">
+							Follow List Recovery
+						</p>
+						<!-- Attribution matches the recovery modal and MuteListEditor so
+						     the feature reads as Mutable's wherever it surfaces. -->
+						<span
+							class="flex items-center gap-1 mt-0.5"
+							style="color: var(--color-caption);"
+						>
+							<span class="text-[11px]">powered by</span>
+							<img src="/mutable_logo.svg" alt="" class="w-3.5 h-3.5 rounded-sm opacity-70" />
+							<span class="text-[11px]">Mutable</span>
+						</span>
+						<p class="text-[11px] text-caption mt-0.5">
 							Search relay history for an earlier list — no backup needed.
 						</p>
 					</div>

--- a/src/components/NostrBackupSection.svelte
+++ b/src/components/NostrBackupSection.svelte
@@ -414,10 +414,41 @@
 	 * The file wraps the payload in a little provenance so it's still
 	 * intelligible months later, out of context.
 	 */
-	function handleExportJson(type: BackupType, index = 0) {
+	/**
+	 * The newest version that can actually be exported.
+	 *
+	 * `getBackupList` can contain entries whose payload failed to decrypt
+	 * (listXBackups pushes those without `data` so they still show in the
+	 * version history). Indexing blindly at 0 would hand back an entry with
+	 * nothing to write, so walk to the newest one that has data — which is
+	 * the newest version the user can see content for.
+	 */
+	function latestExportable(type: BackupType): { timestamp: number; data?: any } | undefined {
+		return getBackupList(type).find((b) => b.data);
+	}
+
+	/**
+	 * `timestamp` on a backup entry is in MILLISECONDS — it's written as
+	 * `Date.now()` (see nostrBackup.ts) and read back with a bare
+	 * `new Date(ts)` in formatFullTimestamp. Treating it as seconds pushes
+	 * the date past the range `toISOString()` accepts, which throws a
+	 * RangeError and silently kills the click handler.
+	 */
+	function isoOrNull(ms: number | null | undefined): string | null {
+		if (!ms || !Number.isFinite(ms) || Math.abs(ms) > 8.64e15) return null;
+		try {
+			return new Date(ms).toISOString();
+		} catch {
+			return null;
+		}
+	}
+
+	function handleExportJson(type: BackupType, index?: number) {
 		if (!browser) return;
-		const entry = getBackupList(type)[index];
+		const entry = index === undefined ? latestExportable(type) : getBackupList(type)[index];
 		if (!entry?.data) return;
+
+		const backedUpAt = isoOrNull(entry.timestamp);
 
 		const payload = {
 			source: 'zap.cooking',
@@ -425,15 +456,11 @@
 			pubkey: $userPublickey,
 			type,
 			kind: typeLabels[type].kind,
-			backedUpAt: entry.timestamp ? new Date(entry.timestamp * 1000).toISOString() : null,
+			backedUpAt,
 			data: entry.data
 		};
 
-		const stamp = new Date(
-			(entry.timestamp ? entry.timestamp * 1000 : Date.now())
-		)
-			.toISOString()
-			.slice(0, 10);
+		const stamp = (backedUpAt ?? new Date().toISOString()).slice(0, 10);
 		const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
 		const url = URL.createObjectURL(blob);
 		const link = document.createElement('a');
@@ -575,7 +602,7 @@
 					<button
 						class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors disabled:opacity-50"
 						style="background-color: var(--color-bg-secondary); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
-						disabled={!backupList[0]?.data}
+						disabled={!backupList.some((b) => b.data)}
 						on:click={() => handleExportJson(type)}
 						title="Download the latest backup as a JSON file"
 					>

--- a/src/components/NostrBackupSection.svelte
+++ b/src/components/NostrBackupSection.svelte
@@ -445,31 +445,74 @@
 
 	function handleExportJson(type: BackupType, index?: number) {
 		if (!browser) return;
-		const entry = index === undefined ? latestExportable(type) : getBackupList(type)[index];
-		if (!entry?.data) return;
+		messages[type] = null;
 
-		const backedUpAt = isoOrNull(entry.timestamp);
+		const list = getBackupList(type);
+		const entry = index === undefined ? latestExportable(type) : list[index];
+		if (!entry?.data) {
+			// Two very different causes, and the user can't tell them apart
+			// from a dead button: nothing backed up yet, versus backups that
+			// exist but wouldn't decrypt (signer refused, wrong account).
+			messages[type] = {
+				text:
+					list.length === 0
+						? 'Nothing to export yet — create a backup first.'
+						: 'Backup found but could not be read. Check you are signed in with the same account.',
+				type: 'error'
+			};
+			return;
+		}
 
-		const payload = {
-			source: 'zap.cooking',
-			exportedAt: new Date().toISOString(),
-			pubkey: $userPublickey,
-			type,
-			kind: typeLabels[type].kind,
-			backedUpAt,
-			data: entry.data
-		};
+		let url: string | null = null;
+		try {
+			const backedUpAt = isoOrNull(entry.timestamp);
+			const json = JSON.stringify(
+				{
+					source: 'zap.cooking',
+					exportedAt: new Date().toISOString(),
+					pubkey: $userPublickey,
+					type,
+					kind: typeLabels[type].kind,
+					backedUpAt,
+					data: entry.data
+				},
+				null,
+				2
+			);
 
-		const stamp = (backedUpAt ?? new Date().toISOString()).slice(0, 10);
-		const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
-		const url = URL.createObjectURL(blob);
-		const link = document.createElement('a');
-		link.href = url;
-		link.download = `zapcooking-${type}-${stamp}.json`;
-		document.body.appendChild(link);
-		link.click();
-		document.body.removeChild(link);
-		URL.revokeObjectURL(url);
+			const stamp = (backedUpAt ?? new Date().toISOString()).slice(0, 10);
+			url = URL.createObjectURL(new Blob([json], { type: 'application/json' }));
+
+			const link = document.createElement('a');
+			link.href = url;
+			link.download = `zapcooking-${type}-${stamp}.json`;
+			link.rel = 'noopener';
+			link.style.display = 'none';
+			document.body.appendChild(link);
+			link.click();
+
+			// Revoking synchronously after click() can cancel the download —
+			// the fetch of the blob is asynchronous, so tearing the URL down in
+			// the same tick races it. Same for removing the anchor. Defer both.
+			const anchor = link;
+			const objectUrl = url;
+			url = null; // ownership handed to the timeout
+			setTimeout(() => {
+				anchor.remove();
+				URL.revokeObjectURL(objectUrl);
+			}, 10_000);
+
+			messages[type] = { text: 'Exported as JSON', type: 'success' };
+		} catch (e) {
+			// Previously this failed silently, which is why "nothing happens"
+			// was all there was to go on.
+			if (url) URL.revokeObjectURL(url);
+			console.error('[backup] JSON export failed:', e);
+			messages[type] = {
+				text: e instanceof Error ? `Export failed: ${e.message}` : 'Export failed',
+				type: 'error'
+			};
+		}
 	}
 
 	function getBackupList(type: BackupType): Array<{ timestamp: number; data?: any }> {
@@ -602,7 +645,7 @@
 					<button
 						class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors disabled:opacity-50"
 						style="background-color: var(--color-bg-secondary); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
-						disabled={!backupList.some((b) => b.data)}
+						disabled={!$userPublickey}
 						on:click={() => handleExportJson(type)}
 						title="Download the latest backup as a JSON file"
 					>
@@ -735,7 +778,6 @@
 								<button
 									class="flex items-center gap-1 px-2 py-1 rounded text-xs transition-colors hover:opacity-80"
 									style="color: var(--color-caption);"
-									disabled={!backup.data}
 									on:click={() => handleExportJson(type, i)}
 									title="Download this version as a JSON file"
 								>

--- a/src/components/NostrBackupSection.svelte
+++ b/src/components/NostrBackupSection.svelte
@@ -491,14 +491,6 @@
 					{/if}
 				</div>
 
-				{#if type === 'follows' && !status.loading && !status.exists}
-					<p class="text-xs text-caption mb-3">
-						No backup here yet — but your follow list may still be recoverable from
-						relay history. Try <span style="color: var(--color-text-primary)"
-							>Recover from relays</span
-						>.
-					</p>
-				{/if}
 
 				<!-- Actions -->
 				<div class="flex items-center gap-2 flex-wrap">
@@ -535,21 +527,6 @@
 							Restore
 						{/if}
 					</button>
-
-					{#if type === 'follows'}
-						<!-- Recovery works from relay history, so it is NOT gated on
-						     status.exists — with no backup it's the only option left. -->
-						<button
-							class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors disabled:opacity-50"
-							style="background-color: var(--color-bg-secondary); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
-							disabled={!$userPublickey}
-							on:click={() => (followRecoveryOpen = true)}
-							title="Scan relay history for an earlier follow list"
-						>
-							<ClockCounterClockwiseIcon size={14} />
-							Recover from relays
-						</button>
-					{/if}
 
 					{#if status.backupCount > 1}
 						<button
@@ -599,6 +576,37 @@
 					</div>
 				{/if}
 			</div>
+
+			<!-- Relay-history recovery (Mutable).
+			     Deliberately NOT in the action row above: that row is about
+			     zap.cooking's own backups, and this reads other people's
+			     relays for an older kind:3. Grouping it with Backup/Restore
+			     both crowded the row into wrapping and implied it was the
+			     same kind of operation. -->
+			{#if type === 'follows'}
+				<div
+					class="px-4 py-2.5 border-t flex items-center justify-between gap-3 flex-wrap"
+					style="border-color: var(--color-input-border);"
+				>
+					<div class="min-w-0">
+						<p class="text-xs" style="color: var(--color-text-primary);">
+							Lost your follows?
+						</p>
+						<p class="text-[11px] text-caption">
+							Search relay history for an earlier list — no backup needed.
+						</p>
+					</div>
+					<button
+						class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors disabled:opacity-50 flex-shrink-0"
+						style="background-color: var(--color-bg-secondary); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+						disabled={!$userPublickey}
+						on:click={() => (followRecoveryOpen = true)}
+					>
+						<ClockCounterClockwiseIcon size={14} />
+						Recover from relays
+					</button>
+				</div>
+			{/if}
 
 			<!-- Version List (expandable) -->
 			{#if versionsExpanded[type] && backupList.length > 0}

--- a/src/components/NostrBackupSection.svelte
+++ b/src/components/NostrBackupSection.svelte
@@ -589,19 +589,30 @@
 					style="border-color: var(--color-input-border);"
 				>
 					<div class="min-w-0">
-						<p class="text-xs font-medium" style="color: var(--color-text-primary);">
-							Follow List Recovery
-						</p>
-						<!-- Attribution matches the recovery modal and MuteListEditor so
-						     the feature reads as Mutable's wherever it surfaces. -->
-						<span
-							class="flex items-center gap-1 mt-0.5"
-							style="color: var(--color-caption);"
+						<!-- Title and attribution share one line.
+						     `items-baseline` on the row, not `items-center`: the title
+						     is 12px and the attribution 11px, so centering them left
+						     nothing on a common baseline. The logo stays centered
+						     against its OWN text inside the inner span, and is sized
+						     to the 12px line so it doesn't stretch the line box. -->
+						<p
+							class="text-xs font-medium flex items-baseline gap-1.5 flex-wrap"
+							style="color: var(--color-text-primary);"
 						>
-							<span class="text-[11px]">powered by</span>
-							<img src="/mutable_logo.svg" alt="" class="w-3.5 h-3.5 rounded-sm opacity-70" />
-							<span class="text-[11px]">Mutable</span>
-						</span>
+							Follow List Recovery
+							<span
+								class="inline-flex items-center gap-1 font-normal"
+								style="color: var(--color-caption);"
+							>
+								<span class="text-[11px] leading-none">powered by</span>
+								<img
+									src="/mutable_logo.svg"
+									alt=""
+									class="w-3 h-3 rounded-sm opacity-70 flex-shrink-0"
+								/>
+								<span class="text-[11px] leading-none">Mutable</span>
+							</span>
+						</p>
 						<p class="text-[11px] text-caption mt-0.5">
 							Search relay history for an earlier list — no backup needed.
 						</p>

--- a/src/components/NostrBackupSection.svelte
+++ b/src/components/NostrBackupSection.svelte
@@ -30,6 +30,7 @@
 	import WarningIcon from 'phosphor-svelte/lib/Warning';
 	import CloudArrowUpIcon from 'phosphor-svelte/lib/CloudArrowUp';
 	import CloudArrowDownIcon from 'phosphor-svelte/lib/CloudArrowDown';
+	import DownloadSimpleIcon from 'phosphor-svelte/lib/DownloadSimple';
 	import CaretDownIcon from 'phosphor-svelte/lib/CaretDown';
 	import ArrowClockwiseIcon from 'phosphor-svelte/lib/ArrowClockwise';
 	import ClockCounterClockwiseIcon from 'phosphor-svelte/lib/ClockCounterClockwise';
@@ -401,6 +402,49 @@
 		}
 	}
 
+	/**
+	 * Download a backup's decrypted contents as JSON.
+	 *
+	 * These backups are NIP-78 events only the user can decrypt, which is
+	 * good for privacy and bad for portability: without this the data can
+	 * only ever be read back by this app, and only while the account's
+	 * signer still works. `listXBackups()` already decrypts eagerly, so the
+	 * payload is in hand — no extra signer round-trip.
+	 *
+	 * The file wraps the payload in a little provenance so it's still
+	 * intelligible months later, out of context.
+	 */
+	function handleExportJson(type: BackupType, index = 0) {
+		if (!browser) return;
+		const entry = getBackupList(type)[index];
+		if (!entry?.data) return;
+
+		const payload = {
+			source: 'zap.cooking',
+			exportedAt: new Date().toISOString(),
+			pubkey: $userPublickey,
+			type,
+			kind: typeLabels[type].kind,
+			backedUpAt: entry.timestamp ? new Date(entry.timestamp * 1000).toISOString() : null,
+			data: entry.data
+		};
+
+		const stamp = new Date(
+			(entry.timestamp ? entry.timestamp * 1000 : Date.now())
+		)
+			.toISOString()
+			.slice(0, 10);
+		const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+		const url = URL.createObjectURL(blob);
+		const link = document.createElement('a');
+		link.href = url;
+		link.download = `zapcooking-${type}-${stamp}.json`;
+		document.body.appendChild(link);
+		link.click();
+		document.body.removeChild(link);
+		URL.revokeObjectURL(url);
+	}
+
 	function getBackupList(type: BackupType): Array<{ timestamp: number; data?: any }> {
 		switch (type) {
 			case 'follows':
@@ -528,6 +572,17 @@
 						{/if}
 					</button>
 
+					<button
+						class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors disabled:opacity-50"
+						style="background-color: var(--color-bg-secondary); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+						disabled={!backupList[0]?.data}
+						on:click={() => handleExportJson(type)}
+						title="Download the latest backup as a JSON file"
+					>
+						<DownloadSimpleIcon size={14} />
+						Export JSON
+					</button>
+
 					{#if status.backupCount > 1}
 						<button
 							class="flex items-center gap-1 px-2 py-1.5 rounded-lg text-xs transition-colors hover:bg-[var(--color-bg-secondary)]"
@@ -649,15 +704,27 @@
 									<span class="text-caption flex-shrink-0">&middot; {getVersionSummary(type, i)}</span>
 								{/if}
 							</div>
-							<button
-								class="flex items-center gap-1 px-2 py-1 rounded text-xs transition-colors hover:opacity-80 flex-shrink-0 ml-2"
-								style="color: var(--color-primary);"
-								disabled={!backup.data || restoring[type]}
-								on:click={() => handleRestore(type, i)}
-							>
-								<CloudArrowDownIcon size={12} />
-								Restore
-							</button>
+							<div class="flex items-center gap-1 flex-shrink-0 ml-2">
+								<button
+									class="flex items-center gap-1 px-2 py-1 rounded text-xs transition-colors hover:opacity-80"
+									style="color: var(--color-caption);"
+									disabled={!backup.data}
+									on:click={() => handleExportJson(type, i)}
+									title="Download this version as a JSON file"
+								>
+									<DownloadSimpleIcon size={12} />
+									JSON
+								</button>
+								<button
+									class="flex items-center gap-1 px-2 py-1 rounded text-xs transition-colors hover:opacity-80"
+									style="color: var(--color-primary);"
+									disabled={!backup.data || restoring[type]}
+									on:click={() => handleRestore(type, i)}
+								>
+									<CloudArrowDownIcon size={12} />
+									Restore
+								</button>
+							</div>
 						</div>
 					{/each}
 				</div>

--- a/src/components/NostrBackupSection.svelte
+++ b/src/components/NostrBackupSection.svelte
@@ -589,9 +589,21 @@
 					style="border-color: var(--color-input-border);"
 				>
 					<div class="min-w-0">
-						<p class="text-xs" style="color: var(--color-text-primary);">
-							Lost your follows?
-						</p>
+						<div class="flex items-center gap-1.5">
+							<p class="text-xs" style="color: var(--color-text-primary);">
+								Lost your follows?
+							</p>
+							<!-- Same attribution the recovery modal and MuteListEditor
+							     carry, so the feature is recognizable as Mutable's
+							     wherever it surfaces. -->
+							<span
+								class="flex items-center gap-1 flex-shrink-0"
+								style="color: var(--color-caption);"
+							>
+								<img src="/mutable_logo.svg" alt="" class="w-3.5 h-3.5 rounded-sm opacity-70" />
+								<span class="text-[11px]">Mutable</span>
+							</span>
+						</div>
 						<p class="text-[11px] text-caption">
 							Search relay history for an earlier list — no backup needed.
 						</p>


### PR DESCRIPTION
> **Stacked on #641** — this branch is cut from `feat/settings-follow-recovery`, so it also contains that commit. Both touch `NostrBackupSection.svelte`; keeping them stacked avoids a guaranteed conflict. Merge #641 first and this diff reduces to the export commit alone.

## Why

Backups are NIP-78 events only the user can decrypt. That's right for privacy and wrong for portability: the data could only ever be read back *by this app*, and only for as long as the account's signer still works. There was no way to get a copy out.

## The change

**"Export JSON"** on every backup row — Follows, Mute List, Profile — downloading the latest backup's contents as a file.

The expandable **Versions** list gets a per-version **JSON** button too, next to its existing Restore. That's arguably the more useful one: when several versions exist, "export *this* one" is the thing you actually want.

`listFollowsBackups()` and friends already decrypt eagerly, so the payload is in hand — export costs no extra signer round-trip and no network call.

### File contents

The payload is wrapped in a little provenance so the file is still intelligible months later, out of context:

```json
{
  "source": "zap.cooking",
  "exportedAt": "2026-08-20T…",
  "pubkey": "…",
  "type": "follows",
  "kind": "kind:3",
  "backedUpAt": "2026-08-14T…",
  "data": { … }
}
```

Filename is `zapcooking-<type>-<backup date>.json` — dated by when the *backup* was taken, not when it was exported, so several exports of different versions don't collide.

Buttons are disabled when a row has no decrypted backup to export.

## Verification

- `pnpm check` — 1 error / 152 warnings, identical to `main` (pre-existing `delete`-operator error)
- `pnpm test` — 1267 passed
- Checked in a browser that all three rows render an Export JSON button, correctly disabled when there is nothing to export

**Not verified:** an actual download with real backup data, which needs a signed-in account with backups. The download path is the standard blob/anchor approach, but the resulting file is worth eyeballing once.

## Worth deciding separately

There's no **import** counterpart. Export alone is still worth having — it gets data out, which is the part that's currently impossible — but "restore from a JSON file" is the obvious follow-up if you want these files to be more than an archive.
