### PR TITLE
Plan weeks with Cheffy from real Zap Cooking recipes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.711",
+  "version": "4.2.712",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.710",
+  "version": "4.2.711",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/planner/CheffyPlanModal.svelte
+++ b/src/components/planner/CheffyPlanModal.svelte
@@ -106,6 +106,7 @@
   $: normalizedPk = String($userPublickey || '')
     .trim()
     .toLowerCase();
+  $: signedIn = Boolean(normalizedPk);
   $: hasMembership = Boolean(membershipMap[normalizedPk]?.active);
   $: membershipKnown = Boolean(normalizedPk && membershipMap[normalizedPk]);
 
@@ -151,6 +152,11 @@
   function close() {
     open = false;
     dispatch('close');
+  }
+
+  function signIn() {
+    close();
+    goto('/login?redirect=' + encodeURIComponent('/my-kitchen/planner'));
   }
 
   function toggleIn<T>(list: T[], value: T): T[] {
@@ -349,7 +355,21 @@
     </span>
   </h1>
 
-  {#if !membershipKnown}
+  {#if !signedIn}
+    <div class="flex flex-col items-center text-center gap-4 py-8 px-2">
+      <CheffyAvatar size={72} expression="neutral" variant="character" />
+      <div>
+        <h2 class="text-lg font-semibold mb-2" style="color: var(--color-text-primary);">
+          Sign in to plan with Cheffy
+        </h2>
+        <p class="text-sm text-caption max-w-md mx-auto">
+          Cheffy plans your week from real Zap Cooking recipes — then you approve before anything
+          lands on the planner.
+        </p>
+      </div>
+      <Button primary on:click={signIn}>Sign in</Button>
+    </div>
+  {:else if !membershipKnown}
     <div class="flex flex-col items-center justify-center py-10 gap-3">
       <CheffyAvatar size={56} expression="thinking" animate />
       <p class="text-caption">Checking your kitchen…</p>

--- a/src/components/planner/CheffyPlanModal.svelte
+++ b/src/components/planner/CheffyPlanModal.svelte
@@ -1,0 +1,588 @@
+<script lang="ts">
+  /**
+   * Plan with Cheffy — focused meal-planning UI on top of the existing
+   * planner. Discovers real Zap Cooking recipes, asks Cheffy to arrange
+   * them, then previews before a single plannerStore.applyGeneratedPlan.
+   */
+  import { createEventDispatcher, onDestroy } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { ndk, userPublickey } from '$lib/nostr';
+  import {
+    membershipStatusMap,
+    queueMembershipLookup,
+    type MembershipStatus
+  } from '$lib/stores/membershipStatus';
+  import { plannerStore } from '$lib/stores/plannerStore';
+  import { DAY_KEYS, SLOT_KEYS, type MealPlanDayKey, type MealSlotKey } from '$lib/mealplan/schema';
+  import {
+    PREFERENCE_STYLES,
+    filterRecipeCandidates,
+    occupiedSlotSet,
+    parseExcludeIngredientsInput,
+    resolveTargetSlots,
+    slotKey,
+    type GeneratedMeal,
+    type MealPlanGenerationRequest,
+    type MealPlanStrategy,
+    type MealSlotRef,
+    type PreferenceStyleId,
+    type RecipeSource
+  } from '$lib/mealplan/generation';
+  import {
+    insufficientSlotCoverageMessage,
+    noEligibleRecipesMessage
+  } from '$lib/mealplan/slotEligibility';
+  import { requestCheffyMealPlan } from '$lib/mealplan/cheffyPlanClient';
+  import {
+    attachDiscoveredImages,
+    discoverRecipesForPlanning,
+    toWireCandidate,
+    type DiscoveredRecipe
+  } from '$lib/services/recipeDiscoveryService';
+  import { THINKING_LINES, pickLine } from '$lib/cheffy';
+  import Modal from '../Modal.svelte';
+  import Button from '../Button.svelte';
+  import CheffyAvatar from '../CheffyAvatar.svelte';
+  import CheffyIcon from '../icons/CheffyIcon.svelte';
+  import GeneratedPlanPreview from './GeneratedPlanPreview.svelte';
+
+  export let open = false;
+  export let weekId: string;
+  export let occupiedSlots: MealSlotRef[] = [];
+  export let readOnly = false;
+
+  const dispatch = createEventDispatcher<{ close: void; applied: void }>();
+
+  const DAY_LABELS: Record<MealPlanDayKey, string> = {
+    mon: 'Mon',
+    tue: 'Tue',
+    wed: 'Wed',
+    thu: 'Thu',
+    fri: 'Fri',
+    sat: 'Sat',
+    sun: 'Sun'
+  };
+  const SLOT_LABELS: Record<MealSlotKey, string> = {
+    breakfast: 'Breakfast',
+    lunch: 'Lunch',
+    dinner: 'Dinner',
+    snack: 'Snack'
+  };
+  const SOURCE_LABELS: { id: RecipeSource; label: string }[] = [
+    { id: 'all', label: 'All available sources' },
+    { id: 'my-recipes', label: 'My Recipes' },
+    { id: 'saved', label: 'Saved Recipes' },
+    { id: 'explore', label: 'Explore Zap Cooking' }
+  ];
+
+  type Step = 'form' | 'working' | 'preview';
+
+  let step: Step = 'form';
+  let mealSlots: MealSlotKey[] = ['dinner'];
+  let days: MealPlanDayKey[] = [...DAY_KEYS];
+  let styles: PreferenceStyleId[] = [];
+  let maxMinutes = '';
+  let servings = '';
+  let excludeText = '';
+  let notes = '';
+  let source: RecipeSource = 'all';
+  let strategy: MealPlanStrategy = 'fill-empty';
+  let error: string | null = null;
+  let statusLine = THINKING_LINES[0];
+  let preview: GeneratedMeal[] = [];
+  let coverageNote: string | null = null;
+  let discovered: DiscoveredRecipe[] = [];
+  let swappingKey: string | null = null;
+  let applying = false;
+  let regenerating = false;
+  let membershipMap: Record<string, MembershipStatus> = {};
+
+  const unsubMembership = membershipStatusMap.subscribe((v) => {
+    membershipMap = v;
+  });
+  onDestroy(unsubMembership);
+
+  $: if (open && $userPublickey) queueMembershipLookup($userPublickey);
+  $: normalizedPk = String($userPublickey || '')
+    .trim()
+    .toLowerCase();
+  $: hasMembership = Boolean(membershipMap[normalizedPk]?.active);
+  $: membershipKnown = Boolean(normalizedPk && membershipMap[normalizedPk]);
+
+  $: targetCount = resolveTargetSlots({
+    days,
+    mealSlots,
+    strategy,
+    occupiedSlots
+  }).length;
+
+  let wasOpen = false;
+  $: {
+    if (open && !wasOpen) {
+      resetForm();
+    }
+    if (!open && wasOpen) {
+      step = 'form';
+      error = null;
+    }
+    wasOpen = open;
+  }
+
+  function resetForm() {
+    step = 'form';
+    mealSlots = ['dinner'];
+    days = [...DAY_KEYS];
+    styles = [];
+    maxMinutes = '';
+    servings = '';
+    excludeText = '';
+    notes = '';
+    source = 'all';
+    strategy = 'fill-empty';
+    error = null;
+    coverageNote = null;
+    preview = [];
+    discovered = [];
+    swappingKey = null;
+    applying = false;
+    regenerating = false;
+  }
+
+  function close() {
+    open = false;
+    dispatch('close');
+  }
+
+  function toggleIn<T>(list: T[], value: T): T[] {
+    return list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
+  }
+
+  function toggleSlot(slot: MealSlotKey) {
+    const next = toggleIn(mealSlots, slot);
+    if (next.length) mealSlots = next;
+  }
+
+  function toggleDay(day: MealPlanDayKey) {
+    const next = toggleIn(days, day);
+    if (next.length) days = next;
+  }
+
+  function toggleStyle(id: PreferenceStyleId) {
+    styles = toggleIn(styles, id);
+  }
+
+  function buildRequest(
+    overrides: Partial<MealPlanGenerationRequest> = {}
+  ): MealPlanGenerationRequest | null {
+    if (!$ndk || !$userPublickey) return null;
+    const max = maxMinutes.trim() ? Number(maxMinutes) : undefined;
+    const serv = servings.trim() ? Number(servings) : undefined;
+    const filtered = filterRecipeCandidates(discovered.map(toWireCandidate), {
+      maxMinutes: max && Number.isFinite(max) && max > 0 ? max : undefined,
+      excludeIngredients: parseExcludeIngredientsInput(excludeText),
+      styles,
+      mealSlots,
+      excludeCoordinates: overrides.excludeCoordinates
+    });
+    if (filtered.length === 0) return null;
+    return {
+      weekId,
+      days,
+      mealSlots,
+      preferences: {
+        styles,
+        maxMinutes: max && Number.isFinite(max) && max > 0 ? max : undefined,
+        servings: serv && Number.isFinite(serv) && serv > 0 ? serv : undefined,
+        excludeIngredients: parseExcludeIngredientsInput(excludeText),
+        notes: notes.trim() || undefined
+      },
+      strategy,
+      candidates: filtered,
+      occupiedSlots,
+      ...overrides
+    };
+  }
+
+  async function generate(opts: { swap?: GeneratedMeal; regenerate?: boolean } = {}) {
+    if (readOnly) return;
+    error = null;
+    if (!opts.swap && !opts.regenerate) {
+      step = 'working';
+      statusLine = pickLine(THINKING_LINES, statusLine);
+    }
+
+    try {
+      if (!$ndk || !$userPublickey) {
+        throw new Error('Log in to plan with Cheffy.');
+      }
+      if (discovered.length === 0 || (!opts.swap && !opts.regenerate)) {
+        statusLine = pickLine(THINKING_LINES, statusLine);
+        discovered = await discoverRecipesForPlanning({
+          ndk: $ndk,
+          pubkey: $userPublickey,
+          source
+        });
+      }
+
+      const excludeCoordinates = opts.swap
+        ? preview
+            .filter((m) => slotKey(m.day, m.slot) !== slotKey(opts.swap!.day, opts.swap!.slot))
+            .map((m) => m.a)
+            .concat(opts.swap.a)
+        : [];
+      const request = buildRequest({
+        fillSlots: opts.swap ? [{ day: opts.swap.day, slot: opts.swap.slot }] : undefined,
+        excludeCoordinates: excludeCoordinates.length ? excludeCoordinates : undefined
+      });
+      if (!request) {
+        error = noEligibleRecipesMessage(mealSlots);
+        if (!opts.swap && !opts.regenerate) step = 'form';
+        return;
+      }
+
+      const result = await requestCheffyMealPlan(request);
+      if (!result.ok || !result.plan) {
+        if (result.code === 'NOT_MEMBER') {
+          error = result.error || 'Cheffy is available to Cook+ members.';
+        } else if (result.code === 'NO_CANDIDATES') {
+          error = result.error || noEligibleRecipesMessage(mealSlots);
+        } else {
+          error = result.error || 'Cheffy could not finish that plan.';
+        }
+        if (!opts.swap && !opts.regenerate) step = 'form';
+        return;
+      }
+
+      if (opts.swap) {
+        const replacement = result.plan.meals[0];
+        if (!replacement) {
+          error = 'Cheffy could not find another recipe for that slot.';
+          return;
+        }
+        preview = preview.map((m) =>
+          slotKey(m.day, m.slot) === slotKey(opts.swap!.day, opts.swap!.slot)
+            ? attachDiscoveredImages([replacement], discovered)[0]
+            : m
+        );
+      } else {
+        preview = attachDiscoveredImages(result.plan.meals, discovered);
+        const requestedSlots = resolveTargetSlots(request).length;
+        coverageNote = insufficientSlotCoverageMessage({
+          mealSlots,
+          found: preview.length,
+          requested: requestedSlots
+        });
+        step = 'preview';
+      }
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Cheffy could not finish that plan.';
+      if (!opts.swap && !opts.regenerate) step = 'form';
+    }
+  }
+
+  async function handleGenerate() {
+    await generate();
+  }
+
+  async function handleRegenerate() {
+    regenerating = true;
+    try {
+      await generate({ regenerate: true });
+    } finally {
+      regenerating = false;
+    }
+  }
+
+  async function handleSwap(e: CustomEvent<GeneratedMeal>) {
+    swappingKey = slotKey(e.detail.day, e.detail.slot);
+    error = null;
+    try {
+      await generate({ swap: e.detail });
+    } finally {
+      swappingKey = null;
+    }
+  }
+
+  function handleRemove(e: CustomEvent<GeneratedMeal>) {
+    preview = preview.filter(
+      (m) => slotKey(m.day, m.slot) !== slotKey(e.detail.day, e.detail.slot)
+    );
+  }
+
+  function handleApply() {
+    if (readOnly || preview.length === 0) return;
+    applying = true;
+    try {
+      const occupied = occupiedSlotSet(occupiedSlots);
+      const meals =
+        strategy === 'fill-empty'
+          ? preview.filter((m) => !occupied.has(slotKey(m.day, m.slot)))
+          : preview;
+      const ok = plannerStore.applyGeneratedPlan(weekId, meals, strategy);
+      if (!ok) {
+        error = 'Could not add those meals. This week may be read-only.';
+        return;
+      }
+      dispatch('applied');
+      close();
+    } finally {
+      applying = false;
+    }
+  }
+
+  function chipClass(on: boolean): string {
+    return on
+      ? 'bg-gradient-to-r from-orange-500 to-amber-500 text-white border-transparent'
+      : 'hover:bg-accent-gray';
+  }
+</script>
+
+<Modal bind:open cleanup={close} wide fullScreenMobile maxWidth="40rem">
+  <h1 slot="title">
+    <span class="flex items-center gap-2">
+      <CheffyAvatar
+        size={28}
+        expression={step === 'working' ? 'thinking' : 'happy'}
+        animate={step === 'working'}
+      />
+      Plan with Cheffy
+    </span>
+  </h1>
+
+  {#if !membershipKnown}
+    <div class="flex flex-col items-center justify-center py-10 gap-3">
+      <CheffyAvatar size={56} expression="thinking" animate />
+      <p class="text-caption">Checking your kitchen…</p>
+    </div>
+  {:else if !hasMembership}
+    <div class="flex flex-col items-center text-center gap-4 py-8 px-2">
+      <CheffyAvatar size={72} expression="neutral" variant="character" />
+      <div>
+        <h2 class="text-lg font-semibold mb-2" style="color: var(--color-text-primary);">
+          Cheffy comes with Cook+
+        </h2>
+        <p class="text-sm text-caption max-w-md mx-auto">
+          Cheffy plans your week from real Zap Cooking recipes — then you approve before anything
+          lands on the planner.
+        </p>
+      </div>
+      <Button primary on:click={() => goto('/membership')}>View Membership Options</Button>
+    </div>
+  {:else if readOnly}
+    <p class="text-sm text-caption">This week is read-only, so Cheffy cannot add meals to it.</p>
+  {:else if step === 'working'}
+    <div class="flex flex-col items-center justify-center py-12 gap-3">
+      <CheffyAvatar size={72} expression="cooking" animate />
+      <p class="text-sm font-medium" style="color: var(--color-text-primary);">{statusLine}</p>
+      <p class="text-xs text-caption">Finding real Zap Cooking recipes, then lining up the week.</p>
+    </div>
+  {:else if step === 'preview'}
+    {#if error}
+      <p class="text-sm text-red-500">{error}</p>
+    {/if}
+    {#if coverageNote}
+      <p class="text-sm text-caption">{coverageNote}</p>
+    {/if}
+    <GeneratedPlanPreview
+      meals={preview}
+      {swappingKey}
+      {applying}
+      {regenerating}
+      on:apply={handleApply}
+      on:regenerate={handleRegenerate}
+      on:swap={handleSwap}
+      on:remove={handleRemove}
+    />
+    <button
+      type="button"
+      class="text-xs text-caption self-start hover:underline"
+      on:click={() => {
+        step = 'form';
+        error = null;
+      }}
+    >
+      ← Edit preferences
+    </button>
+  {:else}
+    <form class="flex flex-col gap-5" on:submit|preventDefault={handleGenerate}>
+      {#if error}
+        <p class="text-sm text-red-500">{error}</p>
+      {/if}
+
+      <fieldset class="flex flex-col gap-2">
+        <legend class="text-sm font-semibold mb-1" style="color: var(--color-text-primary);"
+          >Meals to plan</legend
+        >
+        <div class="flex flex-wrap gap-2">
+          {#each SLOT_KEYS as slot}
+            <button
+              type="button"
+              class="px-3 py-1.5 rounded-full text-sm font-medium border transition-colors {chipClass(
+                mealSlots.includes(slot)
+              )}"
+              style={mealSlots.includes(slot)
+                ? ''
+                : 'border-color: var(--color-input-border); color: var(--color-text-primary);'}
+              aria-pressed={mealSlots.includes(slot)}
+              on:click={() => toggleSlot(slot)}
+            >
+              {SLOT_LABELS[slot]}
+            </button>
+          {/each}
+        </div>
+      </fieldset>
+
+      <fieldset class="flex flex-col gap-2">
+        <legend class="text-sm font-semibold mb-1" style="color: var(--color-text-primary);"
+          >Days</legend
+        >
+        <div class="flex flex-wrap gap-2">
+          {#each DAY_KEYS as day}
+            <button
+              type="button"
+              class="px-3 py-1.5 rounded-full text-sm font-medium border transition-colors {chipClass(
+                days.includes(day)
+              )}"
+              style={days.includes(day)
+                ? ''
+                : 'border-color: var(--color-input-border); color: var(--color-text-primary);'}
+              aria-pressed={days.includes(day)}
+              on:click={() => toggleDay(day)}
+            >
+              {DAY_LABELS[day]}
+            </button>
+          {/each}
+        </div>
+      </fieldset>
+
+      <fieldset class="flex flex-col gap-2">
+        <legend class="text-sm font-semibold mb-1" style="color: var(--color-text-primary);"
+          >Quick preferences</legend
+        >
+        <div class="flex flex-wrap gap-2">
+          {#each PREFERENCE_STYLES as style}
+            <button
+              type="button"
+              class="px-3 py-1.5 rounded-full text-sm font-medium border transition-colors {chipClass(
+                styles.includes(style.id)
+              )}"
+              style={styles.includes(style.id)
+                ? ''
+                : 'border-color: var(--color-input-border); color: var(--color-text-primary);'}
+              aria-pressed={styles.includes(style.id)}
+              on:click={() => toggleStyle(style.id)}
+            >
+              {style.label}
+            </button>
+          {/each}
+        </div>
+      </fieldset>
+
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <label class="flex flex-col gap-1 text-sm">
+          <span class="font-medium" style="color: var(--color-text-primary);"
+            >Maximum cooking time</span
+          >
+          <input
+            type="number"
+            min="5"
+            max="480"
+            step="5"
+            bind:value={maxMinutes}
+            placeholder="Minutes (optional)"
+            class="input w-full"
+          />
+        </label>
+        <label class="flex flex-col gap-1 text-sm">
+          <span class="font-medium" style="color: var(--color-text-primary);">Servings</span>
+          <input
+            type="number"
+            min="1"
+            max="24"
+            bind:value={servings}
+            placeholder="Optional"
+            class="input w-full"
+          />
+        </label>
+      </div>
+
+      <label class="flex flex-col gap-1 text-sm">
+        <span class="font-medium" style="color: var(--color-text-primary);"
+          >Ingredients to avoid</span
+        >
+        <input
+          type="text"
+          bind:value={excludeText}
+          placeholder="e.g. shellfish, peanuts"
+          class="input w-full"
+        />
+      </label>
+
+      <label class="flex flex-col gap-1 text-sm">
+        <span class="font-medium" style="color: var(--color-text-primary);">Anything else?</span>
+        <textarea
+          bind:value={notes}
+          rows="3"
+          maxlength="500"
+          placeholder="Keep weekdays easy. Give me something nicer Friday and Saturday. Don't use chicken more than twice."
+          class="input w-full"
+        ></textarea>
+      </label>
+
+      <fieldset class="flex flex-col gap-2">
+        <legend class="text-sm font-semibold mb-1" style="color: var(--color-text-primary);"
+          >Recipe source</legend
+        >
+        <div class="flex flex-col gap-1.5">
+          {#each SOURCE_LABELS as opt}
+            <label
+              class="flex items-center gap-2 text-sm"
+              style="color: var(--color-text-primary);"
+            >
+              <input type="radio" bind:group={source} value={opt.id} />
+              {opt.label}
+            </label>
+          {/each}
+        </div>
+      </fieldset>
+
+      <fieldset class="flex flex-col gap-2">
+        <legend class="text-sm font-semibold mb-1" style="color: var(--color-text-primary);"
+          >Existing meals</legend
+        >
+        <label class="flex items-start gap-2 text-sm" style="color: var(--color-text-primary);">
+          <input type="radio" bind:group={strategy} value="fill-empty" class="mt-0.5" />
+          <span>
+            <span class="font-medium">Fill empty slots</span>
+            <span class="block text-caption">Leave meals that are already on the planner.</span>
+          </span>
+        </label>
+        <label class="flex items-start gap-2 text-sm" style="color: var(--color-text-primary);">
+          <input type="radio" bind:group={strategy} value="replace-selected" class="mt-0.5" />
+          <span>
+            <span class="font-medium">Replace selected slots</span>
+            <span class="block text-caption">Overwrite the days and meals you chose above.</span>
+          </span>
+        </label>
+      </fieldset>
+
+      {#if targetCount === 0}
+        <p class="text-sm text-caption">
+          Those slots already have meals. Switch to replace, or pick empty days.
+        </p>
+      {/if}
+
+      <div class="flex justify-end gap-2 pt-1">
+        <Button on:click={close}>Cancel</Button>
+        <button
+          type="submit"
+          disabled={targetCount === 0 || mealSlots.length === 0 || days.length === 0}
+          class="inline-flex items-center gap-1.5 px-4 py-2 rounded-full text-sm font-medium text-white bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 transition-all disabled:opacity-50"
+        >
+          <CheffyIcon size={20} expression="happy" />
+          Plan with Cheffy
+        </button>
+      </div>
+    </form>
+  {/if}
+</Modal>

--- a/src/components/planner/GeneratedPlanPreview.svelte
+++ b/src/components/planner/GeneratedPlanPreview.svelte
@@ -1,0 +1,182 @@
+<script lang="ts">
+  /**
+   * Preview of a Cheffy-generated week before it is written to the planner.
+   * Meals stay local until the user approves.
+   */
+  import { createEventDispatcher } from 'svelte';
+  import { nip19 } from 'nostr-tools';
+  import type { MealPlanDayKey, MealSlotKey } from '$lib/mealplan/schema';
+  import { DAY_KEYS } from '$lib/mealplan/schema';
+  import type { GeneratedMeal } from '$lib/mealplan/generation';
+  import { slotKey } from '$lib/mealplan/generation';
+  import { getImageOrPlaceholder, getPlaceholderImage } from '$lib/placeholderImages';
+  import ArrowsClockwiseIcon from 'phosphor-svelte/lib/ArrowsClockwise';
+  import EyeIcon from 'phosphor-svelte/lib/Eye';
+  import XIcon from 'phosphor-svelte/lib/X';
+
+  export let meals: GeneratedMeal[] = [];
+  export let swappingKey: string | null = null;
+  export let applying = false;
+  export let regenerating = false;
+
+  const dispatch = createEventDispatcher<{
+    apply: void;
+    regenerate: void;
+    swap: GeneratedMeal;
+    remove: GeneratedMeal;
+    view: GeneratedMeal;
+  }>();
+
+  const DAY_LABELS: Record<MealPlanDayKey, string> = {
+    mon: 'Monday',
+    tue: 'Tuesday',
+    wed: 'Wednesday',
+    thu: 'Thursday',
+    fri: 'Friday',
+    sat: 'Saturday',
+    sun: 'Sunday'
+  };
+  const SLOT_LABELS: Record<MealSlotKey, string> = {
+    breakfast: 'Breakfast',
+    lunch: 'Lunch',
+    dinner: 'Dinner',
+    snack: 'Snack'
+  };
+
+  $: grouped = DAY_KEYS.map((day) => ({
+    day,
+    meals: meals.filter((m) => m.day === day)
+  })).filter((g) => g.meals.length > 0);
+
+  function recipeHref(a: string): string | null {
+    const parts = a.split(':');
+    if (parts.length !== 3) return null;
+    try {
+      return `/recipe/${nip19.naddrEncode({
+        kind: Number(parts[0]),
+        pubkey: parts[1],
+        identifier: parts[2]
+      })}`;
+    } catch {
+      return null;
+    }
+  }
+
+  function openRecipe(meal: GeneratedMeal) {
+    const href = recipeHref(meal.a);
+    if (href) window.open(href, '_blank', 'noopener');
+    dispatch('view', meal);
+  }
+</script>
+
+<div class="flex flex-col gap-4">
+  {#if meals.length === 0}
+    <p class="text-sm text-caption">Cheffy did not keep any meals in this preview.</p>
+  {:else}
+    <div class="flex flex-col gap-3">
+      {#each grouped as group (group.day)}
+        <section
+          class="rounded-xl p-3 flex flex-col gap-2"
+          style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+        >
+          <h3 class="text-sm font-semibold" style="color: var(--color-text-primary);">
+            {DAY_LABELS[group.day]}
+          </h3>
+          {#each group.meals as meal (slotKey(meal.day, meal.slot))}
+            {@const busy = swappingKey === slotKey(meal.day, meal.slot)}
+            <div
+              class="flex flex-col gap-1.5 rounded-lg px-2.5 py-2"
+              style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+            >
+              <div class="flex items-start gap-2.5">
+                <button
+                  type="button"
+                  class="w-14 h-14 rounded-lg overflow-hidden flex-shrink-0"
+                  style="background-color: var(--color-accent-gray);"
+                  aria-label="View {meal.title}"
+                  disabled={busy || applying || regenerating}
+                  on:click={() => openRecipe(meal)}
+                >
+                  <img
+                    src={getImageOrPlaceholder(meal.image, meal.a)}
+                    alt=""
+                    width="56"
+                    height="56"
+                    loading="lazy"
+                    class="w-full h-full object-cover"
+                    on:error={(e) => {
+                      const fallback = getPlaceholderImage(meal.a);
+                      if (e.currentTarget.src !== fallback) e.currentTarget.src = fallback;
+                    }}
+                  />
+                </button>
+                <div class="min-w-0 flex-1">
+                  <p class="text-[11px] uppercase tracking-wide text-caption">
+                    {SLOT_LABELS[meal.slot]}
+                  </p>
+                  <p class="text-sm font-medium truncate" style="color: var(--color-text-primary);">
+                    {meal.title}
+                  </p>
+                  {#if meal.reason}
+                    <p class="text-xs text-caption mt-0.5">{meal.reason}</p>
+                  {/if}
+                </div>
+                <button
+                  type="button"
+                  class="p-1.5 rounded-full hover:bg-accent-gray text-caption"
+                  aria-label="Remove {meal.title}"
+                  disabled={busy || applying || regenerating}
+                  on:click={() => dispatch('remove', meal)}
+                >
+                  <XIcon size={14} />
+                </button>
+              </div>
+              <div class="flex gap-2 flex-wrap">
+                <button
+                  type="button"
+                  class="flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium hover:bg-accent-gray"
+                  style="border: 1px solid var(--color-input-border); color: var(--color-text-primary);"
+                  disabled={busy || applying || regenerating}
+                  on:click={() => openRecipe(meal)}
+                >
+                  <EyeIcon size={12} />
+                  View
+                </button>
+                <button
+                  type="button"
+                  class="flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium hover:bg-accent-gray disabled:opacity-50"
+                  style="border: 1px solid var(--color-input-border); color: var(--color-text-primary);"
+                  disabled={busy || applying || regenerating}
+                  on:click={() => dispatch('swap', meal)}
+                >
+                  <ArrowsClockwiseIcon size={12} class={busy ? 'animate-spin' : ''} />
+                  {busy ? 'Swapping…' : 'Swap'}
+                </button>
+              </div>
+            </div>
+          {/each}
+        </section>
+      {/each}
+    </div>
+  {/if}
+
+  <div class="flex flex-col-reverse sm:flex-row gap-2 sm:justify-end pt-1">
+    <button
+      type="button"
+      class="px-4 py-2 rounded-full text-sm font-medium hover:bg-accent-gray disabled:opacity-50"
+      style="border: 1px solid var(--color-input-border); color: var(--color-text-primary);"
+      disabled={applying || regenerating || !!swappingKey}
+      on:click={() => dispatch('regenerate')}
+    >
+      {regenerating ? 'Regenerating…' : 'Regenerate plan'}
+    </button>
+    <button
+      type="button"
+      class="px-4 py-2 rounded-full text-sm font-medium text-white bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 transition-all disabled:opacity-50"
+      disabled={applying || regenerating || meals.length === 0 || !!swappingKey}
+      on:click={() => dispatch('apply')}
+    >
+      {applying ? 'Adding…' : 'Add meals to my planner'}
+    </button>
+  </div>
+</div>

--- a/src/components/planner/GeneratedPlanPreview.svelte
+++ b/src/components/planner/GeneratedPlanPreview.svelte
@@ -67,6 +67,12 @@
     if (href) window.open(href, '_blank', 'noopener');
     dispatch('view', meal);
   }
+
+  function handleThumbError(event: Event, seed: string) {
+    const img = event.currentTarget as HTMLImageElement;
+    const fallback = getPlaceholderImage(seed);
+    if (img.src !== fallback) img.src = fallback;
+  }
 </script>
 
 <div class="flex flex-col gap-4">
@@ -104,10 +110,7 @@
                     height="56"
                     loading="lazy"
                     class="w-full h-full object-cover"
-                    on:error={(e) => {
-                      const fallback = getPlaceholderImage(meal.a);
-                      if (e.currentTarget.src !== fallback) e.currentTarget.src = fallback;
-                    }}
+                    on:error={(e) => handleThumbError(e, meal.a)}
                   />
                 </button>
                 <div class="min-w-0 flex-1">

--- a/src/lib/mealplan/cheffyPlanClient.ts
+++ b/src/lib/mealplan/cheffyPlanClient.ts
@@ -1,0 +1,111 @@
+/**
+ * Client helper for POST /api/zappy/meal-plan.
+ *
+ * Identity is proved with NIP-98 (same pattern as Cheffy chat / scan).
+ * Preferences stay on this request — they are never written into the
+ * encrypted meal-plan payload.
+ */
+
+import { get } from 'svelte/store';
+import { ndk, userPublickey } from '$lib/nostr';
+import { signNip98AuthHeader } from '$lib/nip98';
+import {
+  parseGenerationRequest,
+  validateGeneratedMealPlan,
+  type GeneratedMealPlan,
+  type MealPlanGenerationRequest
+} from './generation';
+
+export type MealPlanApiErrorCode =
+  | 'NOT_MEMBER'
+  | 'AUTH_REQUIRED'
+  | 'RATE_LIMITED'
+  | 'NO_CANDIDATES'
+  | 'VALIDATION'
+  | 'CHEFFY_FAILED';
+
+export interface MealPlanApiResult {
+  ok: boolean;
+  plan?: GeneratedMealPlan;
+  error?: string;
+  code?: MealPlanApiErrorCode;
+}
+
+export async function requestCheffyMealPlan(
+  request: MealPlanGenerationRequest
+): Promise<MealPlanApiResult> {
+  const parsed = parseGenerationRequest(request);
+  if (!parsed.ok) {
+    return { ok: false, error: parsed.message, code: 'VALIDATION' };
+  }
+
+  const bodyString = JSON.stringify(parsed.request);
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (get(userPublickey)) {
+    try {
+      headers.Authorization = await signNip98AuthHeader(get(ndk), {
+        method: 'POST',
+        url: new URL('/api/zappy/meal-plan', window.location.origin).toString(),
+        bodyString
+      });
+    } catch (e) {
+      console.warn('[CheffyPlan] NIP-98 signing unavailable:', e);
+      return {
+        ok: false,
+        error: 'Cheffy needs your signer to plan meals. Check your signer app and try again.',
+        code: 'AUTH_REQUIRED'
+      };
+    }
+  } else {
+    return { ok: false, error: 'Log in to plan with Cheffy.', code: 'AUTH_REQUIRED' };
+  }
+
+  try {
+    const resp = await fetch('/api/zappy/meal-plan', {
+      method: 'POST',
+      headers,
+      body: bodyString
+    });
+    const data = await resp.json().catch(() => ({}));
+    if (resp.status === 401) {
+      return { ok: false, error: data.error || 'Authentication required', code: 'AUTH_REQUIRED' };
+    }
+    if (resp.status === 403) {
+      return {
+        ok: false,
+        error: data.error || 'Cheffy is available to Cook+ members.',
+        code: 'NOT_MEMBER'
+      };
+    }
+    if (resp.status === 429) {
+      return {
+        ok: false,
+        error: data.error || 'Cheffy is a little busy. Try again in a bit.',
+        code: 'RATE_LIMITED'
+      };
+    }
+    if (data?.code === 'no-candidates') {
+      return {
+        ok: false,
+        error: data.error || 'No recipes were available to plan with.',
+        code: 'NO_CANDIDATES'
+      };
+    }
+    if (!resp.ok || !data.ok) {
+      return {
+        ok: false,
+        error: data.error || 'Cheffy could not finish that plan. Please try again.',
+        code: 'CHEFFY_FAILED'
+      };
+    }
+
+    const validated = validateGeneratedMealPlan(data.plan, parsed.request);
+    if (!validated.ok) {
+      return { ok: false, error: validated.message, code: 'VALIDATION' };
+    }
+    return { ok: true, plan: validated.plan };
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : 'Cheffy could not finish that plan.';
+    return { ok: false, error: detail, code: 'CHEFFY_FAILED' };
+  }
+}

--- a/src/lib/mealplan/generation.test.ts
+++ b/src/lib/mealplan/generation.test.ts
@@ -1,0 +1,469 @@
+import { describe, it, expect } from 'vitest';
+import { createEmptyMealPlan } from './schema';
+import {
+  cartesianSlots,
+  filterRecipeCandidates,
+  occupiedSlotsFromPlan,
+  parseDurationMinutes,
+  parseExcludeIngredientsInput,
+  parseGenerationRequest,
+  resolveTargetSlots,
+  totalActiveMinutes,
+  validateGeneratedMealPlan,
+  type MealPlanGenerationRequest,
+  type RecipeCandidate
+} from './generation';
+import {
+  eligibleSlotsForRecipe,
+  insufficientSlotCoverageMessage,
+  isRecipeEligibleForSlot,
+  restrictCandidatesToRequestedSlots
+} from './slotEligibility';
+
+function cand(id: string, extra: Partial<RecipeCandidate> = {}): RecipeCandidate {
+  return {
+    a: `30023:pk:${id}`,
+    title: extra.title ?? id,
+    tags: extra.tags ?? [],
+    ingredients: extra.ingredients ?? [],
+    ...extra
+  };
+}
+
+function baseRequest(
+  overrides: Partial<MealPlanGenerationRequest> = {}
+): MealPlanGenerationRequest {
+  return {
+    weekId: '2026-W34',
+    days: ['mon', 'tue'],
+    mealSlots: ['dinner'],
+    preferences: { styles: ['mediterranean'] },
+    strategy: 'fill-empty',
+    candidates: [
+      cand('salmon', { title: 'Mediterranean Salmon', tags: ['mediterranean'] }),
+      cand('pasta', { title: 'Pasta' })
+    ],
+    occupiedSlots: [],
+    ...overrides
+  };
+}
+
+describe('parseDurationMinutes', () => {
+  it('parses minutes, hours, and combined strings', () => {
+    expect(parseDurationMinutes('30 min')).toBe(30);
+    expect(parseDurationMinutes('30 minutes')).toBe(30);
+    expect(parseDurationMinutes('1 hour')).toBe(60);
+    expect(parseDurationMinutes('1h 15m')).toBe(75);
+    expect(parseDurationMinutes('90')).toBe(90);
+    expect(parseDurationMinutes('')).toBeNull();
+    expect(parseDurationMinutes('until golden')).toBeNull();
+  });
+});
+
+describe('totalActiveMinutes', () => {
+  it('sums prep and cook when both parse', () => {
+    expect(totalActiveMinutes('10 min', '20 min')).toBe(30);
+    expect(totalActiveMinutes(undefined, '25 minutes')).toBe(25);
+    expect(totalActiveMinutes('quick', 'fast')).toBeNull();
+  });
+});
+
+describe('filterRecipeCandidates', () => {
+  it('drops recipes that obviously exceed maxMinutes', () => {
+    const out = filterRecipeCandidates(
+      [
+        cand('slow', { prepTime: '20 min', cookTime: '40 min', title: 'Roast' }),
+        cand('fast', { prepTime: '5 min', cookTime: '15 min', title: 'Skillet' }),
+        cand('unknown', { title: 'Mystery' })
+      ],
+      { maxMinutes: 30 }
+    );
+    const ids = out.map((c) => c.a);
+    expect(ids).not.toContain('30023:pk:slow');
+    expect(ids).toContain('30023:pk:fast');
+    expect(ids).toContain('30023:pk:unknown');
+  });
+
+  it('drops recipes whose ingredients obviously match excludes', () => {
+    const out = filterRecipeCandidates(
+      [
+        cand('shrimp', { ingredients: ['1 lb shrimp', 'garlic'], title: 'Garlic Shrimp' }),
+        cand('tofu', { ingredients: ['tofu', 'soy sauce'], title: 'Tofu Stir Fry' })
+      ],
+      { excludeIngredients: ['shellfish', 'shrimp'] }
+    );
+    expect(out.map((c) => c.a)).toEqual(['30023:pk:tofu']);
+  });
+
+  it('drops obvious meat when vegetarian is selected and ingredients are known', () => {
+    const out = filterRecipeCandidates(
+      [
+        cand('steak', { ingredients: ['ribeye steak', 'salt'], title: 'Steak' }),
+        cand('salad', {
+          ingredients: ['chickpeas', 'cucumber'],
+          title: 'Chickpea Salad',
+          tags: ['vegetarian']
+        })
+      ],
+      { styles: ['vegetarian'] }
+    );
+    expect(out.map((c) => c.a)).toEqual(['30023:pk:salad']);
+  });
+
+  it('narrows to style matches when there are enough of them', () => {
+    const many = Array.from({ length: 12 }, (_, i) =>
+      cand(`med-${i}`, { title: `Mediterranean Bowl ${i}`, tags: ['mediterranean'] })
+    );
+    const other = cand('chili', { title: 'Chili', tags: ['spicy'] });
+    const out = filterRecipeCandidates([...many, other], {
+      styles: ['mediterranean'],
+      maxCandidates: 48
+    });
+    expect(out.map((c) => c.a)).not.toContain('30023:pk:chili');
+    expect(out.length).toBe(12);
+  });
+
+  it('caps the candidate set', () => {
+    const many = Array.from({ length: 80 }, (_, i) => cand(`r${i}`, { title: `Recipe ${i}` }));
+    const out = filterRecipeCandidates(many, { maxCandidates: 10 });
+    expect(out).toHaveLength(10);
+  });
+
+  it('omits excluded coordinates used by swap', () => {
+    const out = filterRecipeCandidates([cand('a'), cand('b')], {
+      excludeCoordinates: ['30023:pk:a']
+    });
+    expect(out.map((c) => c.a)).toEqual(['30023:pk:b']);
+  });
+
+  it('keeps breakfast-tagged recipes and drops dinner entrees for breakfast slots', () => {
+    const out = filterRecipeCandidates(
+      [
+        cand('oats', { title: 'Whatever', tags: ['breakfast'] }),
+        cand('chicken', { title: 'Garlic Parmesan Chicken', tags: ['dinner'] })
+      ],
+      { mealSlots: ['breakfast'] }
+    );
+    expect(out.map((c) => c.a)).toEqual(['30023:pk:oats']);
+  });
+
+  it('qualifies a breakfast title when tags are absent', () => {
+    const out = filterRecipeCandidates(
+      [cand('pancakes', { title: 'Blueberry Pancakes' }), cand('stew', { title: 'Beef Stew' })],
+      { mealSlots: ['breakfast'] }
+    );
+    expect(out.map((c) => c.a)).toEqual(['30023:pk:pancakes']);
+  });
+
+  it('does not restrict lunch or dinner to breakfast recipes', () => {
+    const chicken = cand('chicken', { title: 'Garlic Parmesan Chicken', tags: ['dinner'] });
+    const pancakes = cand('pancakes', { title: 'Blueberry Pancakes', tags: ['breakfast'] });
+    expect(
+      filterRecipeCandidates([chicken, pancakes], { mealSlots: ['dinner'] }).map((c) => c.a)
+    ).toEqual(['30023:pk:chicken', '30023:pk:pancakes']);
+    expect(
+      filterRecipeCandidates([chicken, pancakes], { mealSlots: ['lunch'] }).map((c) => c.a)
+    ).toEqual(['30023:pk:chicken', '30023:pk:pancakes']);
+  });
+
+  it('does not pad breakfast with dinner recipes when too few breakfast candidates remain', () => {
+    const breakfasts = [
+      cand('oats', { title: 'Overnight Oats', tags: ['breakfast'] }),
+      cand('yogurt', { title: 'Yogurt Parfait' }),
+      cand('eggs', { title: 'Scrambled Eggs' })
+    ];
+    const dinners = Array.from({ length: 10 }, (_, i) =>
+      cand(`dinner-${i}`, { title: `Roast Chicken ${i}`, tags: ['dinner'] })
+    );
+    const out = filterRecipeCandidates([...breakfasts, ...dinners], { mealSlots: ['breakfast'] });
+    expect(out).toHaveLength(3);
+    expect(out.every((c) => isRecipeEligibleForSlot(c, 'breakfast'))).toBe(true);
+  });
+
+  it('composes breakfast eligibility with max time, excludes, and vegetarian', () => {
+    const out = filterRecipeCandidates(
+      [
+        cand('slow-oats', {
+          title: 'Overnight Oats',
+          tags: ['breakfast', 'vegetarian'],
+          prepTime: '5 min',
+          cookTime: '40 min',
+          ingredients: ['oats', 'milk']
+        }),
+        cand('bacon-eggs', {
+          title: 'Bacon and Eggs',
+          tags: ['breakfast'],
+          prepTime: '5 min',
+          cookTime: '10 min',
+          ingredients: ['bacon', 'eggs']
+        }),
+        cand('yogurt', {
+          title: 'Yogurt Bowl',
+          tags: ['breakfast', 'vegetarian'],
+          prepTime: '5 min',
+          cookTime: '0 min',
+          ingredients: ['yogurt', 'berries']
+        }),
+        cand('tofu-scramble', {
+          title: 'Tofu Scramble',
+          tags: ['breakfast', 'vegetarian'],
+          prepTime: '5 min',
+          cookTime: '10 min',
+          ingredients: ['tofu', 'peanuts']
+        }),
+        cand('salad', {
+          title: 'Chickpea Salad',
+          tags: ['vegetarian', 'lunch'],
+          prepTime: '10 min',
+          cookTime: '0 min',
+          ingredients: ['chickpeas']
+        })
+      ],
+      {
+        mealSlots: ['breakfast'],
+        maxMinutes: 20,
+        styles: ['vegetarian'],
+        excludeIngredients: ['peanuts']
+      }
+    );
+    expect(out.map((c) => c.a)).toEqual(['30023:pk:yogurt']);
+  });
+});
+
+describe('resolveTargetSlots', () => {
+  it('skips occupied slots for fill-empty and keeps them for replace-selected', () => {
+    const occupied = [{ day: 'mon' as const, slot: 'dinner' as const }];
+    const fill = resolveTargetSlots({
+      days: ['mon', 'tue'],
+      mealSlots: ['dinner'],
+      strategy: 'fill-empty',
+      occupiedSlots: occupied
+    });
+    expect(fill).toEqual([{ day: 'tue', slot: 'dinner' }]);
+
+    const replace = resolveTargetSlots({
+      days: ['mon', 'tue'],
+      mealSlots: ['dinner'],
+      strategy: 'replace-selected',
+      occupiedSlots: occupied
+    });
+    expect(replace).toEqual(cartesianSlots(['mon', 'tue'], ['dinner']));
+  });
+
+  it('honors fillSlots for a single-meal swap', () => {
+    const out = resolveTargetSlots({
+      days: ['mon', 'tue'],
+      mealSlots: ['dinner'],
+      strategy: 'fill-empty',
+      fillSlots: [{ day: 'tue', slot: 'dinner' }]
+    });
+    expect(out).toEqual([{ day: 'tue', slot: 'dinner' }]);
+  });
+});
+
+describe('occupiedSlotsFromPlan', () => {
+  it('reports slots that already have a meal', () => {
+    const plan = createEmptyMealPlan('2026-W34');
+    plan.days.mon = { slots: { dinner: { type: 'recipe', a: '30023:pk:x', title: 'X' } } };
+    expect(occupiedSlotsFromPlan(plan, ['mon', 'tue'], ['dinner'])).toEqual([
+      { day: 'mon', slot: 'dinner' }
+    ]);
+  });
+});
+
+describe('parseGenerationRequest', () => {
+  it('accepts a well-formed request and sanitizes candidates', () => {
+    const parsed = parseGenerationRequest({
+      weekId: '2026-W34',
+      days: ['mon', 'mon', 'tue'],
+      mealSlots: ['dinner'],
+      strategy: 'fill-empty',
+      candidates: [cand('salmon', { title: 'Salmon' }), { a: 'nope', title: 'Bad' }]
+    });
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.request.days).toEqual(['mon', 'tue']);
+    expect(parsed.request.candidates).toHaveLength(1);
+  });
+
+  it('rejects missing days, slots, or candidates', () => {
+    expect(parseGenerationRequest({ weekId: 'nope' }).ok).toBe(false);
+    expect(
+      parseGenerationRequest({
+        weekId: '2026-W34',
+        days: [],
+        mealSlots: ['dinner'],
+        strategy: 'fill-empty',
+        candidates: [cand('a')]
+      }).ok
+    ).toBe(false);
+    expect(
+      parseGenerationRequest({
+        weekId: '2026-W34',
+        days: ['mon'],
+        mealSlots: ['dinner'],
+        strategy: 'fill-empty',
+        candidates: []
+      })
+    ).toMatchObject({ ok: false, error: 'no-candidates' });
+  });
+
+  it('rejects fill-empty when every requested slot is occupied', () => {
+    const parsed = parseGenerationRequest({
+      weekId: '2026-W34',
+      days: ['mon'],
+      mealSlots: ['dinner'],
+      strategy: 'fill-empty',
+      occupiedSlots: [{ day: 'mon', slot: 'dinner' }],
+      candidates: [cand('a', { title: 'A' })]
+    });
+    expect(parsed.ok).toBe(false);
+    if (parsed.ok) return;
+    expect(parsed.error).toBe('no-target-slots');
+  });
+});
+
+describe('validateGeneratedMealPlan', () => {
+  it('accepts meals drawn only from the candidate set', () => {
+    const req = baseRequest();
+    const result = validateGeneratedMealPlan(
+      {
+        meals: [
+          { day: 'mon', slot: 'dinner', a: '30023:pk:salmon', title: 'whatever Cheffy said' },
+          { day: 'tue', slot: 'dinner', a: '30023:pk:pasta', title: 'Pasta' }
+        ]
+      },
+      req
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.plan.meals[0].title).toBe('Mediterranean Salmon');
+  });
+
+  it('rejects a hallucinated recipe coordinate', () => {
+    const result = validateGeneratedMealPlan(
+      { meals: [{ day: 'mon', slot: 'dinner', a: '30023:pk:invented', title: 'Ghost Stew' }] },
+      baseRequest()
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe('unknown-recipe');
+  });
+
+  it('rejects days or slots that were not requested', () => {
+    expect(
+      validateGeneratedMealPlan(
+        { meals: [{ day: 'sun', slot: 'dinner', a: '30023:pk:salmon', title: 'S' }] },
+        baseRequest()
+      )
+    ).toMatchObject({ ok: false, error: 'unknown-slot' });
+    expect(
+      validateGeneratedMealPlan(
+        { meals: [{ day: 'mon', slot: 'breakfast', a: '30023:pk:salmon', title: 'S' }] },
+        baseRequest()
+      )
+    ).toMatchObject({ ok: false, error: 'unknown-slot' });
+  });
+
+  it('rejects duplicate slot assignments', () => {
+    const result = validateGeneratedMealPlan(
+      {
+        meals: [
+          { day: 'mon', slot: 'dinner', a: '30023:pk:salmon', title: 'S' },
+          { day: 'mon', slot: 'dinner', a: '30023:pk:pasta', title: 'P' }
+        ]
+      },
+      baseRequest()
+    );
+    expect(result).toMatchObject({ ok: false, error: 'duplicate-slot' });
+  });
+
+  it('rejects fill-empty overwrites of occupied slots', () => {
+    const result = validateGeneratedMealPlan(
+      { meals: [{ day: 'mon', slot: 'dinner', a: '30023:pk:salmon', title: 'S' }] },
+      baseRequest({ occupiedSlots: [{ day: 'mon', slot: 'dinner' }] })
+    );
+    expect(result).toMatchObject({ ok: false, error: 'overwrite-occupied' });
+  });
+
+  it('rejects a breakfast assignment of a dinner entree even if it is in the candidate set', () => {
+    const result = validateGeneratedMealPlan(
+      {
+        meals: [
+          { day: 'mon', slot: 'breakfast', a: '30023:pk:chicken', title: 'Garlic Parmesan Chicken' }
+        ]
+      },
+      baseRequest({
+        mealSlots: ['breakfast', 'dinner'],
+        days: ['mon'],
+        candidates: [
+          cand('chicken', { title: 'Garlic Parmesan Chicken', tags: ['dinner'] }),
+          cand('oats', { title: 'Overnight Oats', tags: ['breakfast'] })
+        ]
+      })
+    );
+    expect(result).toMatchObject({ ok: false, error: 'ineligible-slot' });
+  });
+
+  it('accepts a breakfast-tagged recipe in a breakfast slot', () => {
+    const result = validateGeneratedMealPlan(
+      { meals: [{ day: 'mon', slot: 'breakfast', a: '30023:pk:oats', title: 'Overnight Oats' }] },
+      baseRequest({
+        mealSlots: ['breakfast'],
+        days: ['mon'],
+        candidates: [cand('oats', { title: 'Overnight Oats', tags: ['breakfast'] })]
+      })
+    );
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('slot eligibility', () => {
+  it('treats an explicit breakfast tag as breakfast-eligible', () => {
+    const recipe = cand('oats', { title: 'Savory Bowl', tags: ['breakfast'] });
+    expect(isRecipeEligibleForSlot(recipe, 'breakfast')).toBe(true);
+    expect(eligibleSlotsForRecipe(recipe)).toContain('breakfast');
+  });
+
+  it('does not treat an obvious dinner entree as breakfast', () => {
+    const recipe = cand('chicken', { title: 'Garlic Parmesan Chicken', tags: ['dinner'] });
+    expect(isRecipeEligibleForSlot(recipe, 'breakfast')).toBe(false);
+    expect(isRecipeEligibleForSlot(recipe, 'dinner')).toBe(true);
+    expect(isRecipeEligibleForSlot(recipe, 'lunch')).toBe(true);
+  });
+
+  it('does not match eggplant as eggs', () => {
+    expect(
+      isRecipeEligibleForSlot(cand('eggplant', { title: 'Eggplant Parmesan' }), 'breakfast')
+    ).toBe(false);
+  });
+
+  it('explains a partial breakfast week instead of inventing fillers', () => {
+    expect(
+      insufficientSlotCoverageMessage({ mealSlots: ['breakfast'], found: 3, requested: 7 })
+    ).toBe(
+      'Cheffy found 3 breakfast recipes that match your preferences. Try broadening your preferences to fill the rest of the week.'
+    );
+  });
+
+  it('keeps dinner recipes when breakfast and dinner are both requested', () => {
+    const out = restrictCandidatesToRequestedSlots(
+      [
+        cand('chicken', { title: 'Garlic Parmesan Chicken' }),
+        cand('oats', { title: 'Overnight Oats', tags: ['breakfast'] })
+      ],
+      ['breakfast', 'dinner']
+    );
+    expect(out.map((c) => c.a)).toEqual(['30023:pk:chicken', '30023:pk:oats']);
+  });
+});
+
+describe('parseExcludeIngredientsInput', () => {
+  it('splits comma-separated ingredients', () => {
+    expect(parseExcludeIngredientsInput('shellfish, peanuts; milk')).toEqual([
+      'shellfish',
+      'peanuts',
+      'milk'
+    ]);
+  });
+});

--- a/src/lib/mealplan/generation.ts
+++ b/src/lib/mealplan/generation.ts
@@ -1,0 +1,734 @@
+/**
+ * Cheffy weekly meal-plan generation — types, deterministic filtering,
+ * and validation. Shared by the planner UI and POST /api/zappy/meal-plan.
+ *
+ * Preferences stay here (temporary UI/API state). They are NOT written
+ * into the meal-plan payload — that schema is a frozen Android contract.
+ */
+
+import {
+  DAY_KEYS,
+  SLOT_KEYS,
+  type MealPlan,
+  type MealPlanDayKey,
+  type MealSlotKey
+} from './schema';
+import { isValidWeekId } from './week';
+import { isRecipeEligibleForSlot, restrictCandidatesToRequestedSlots } from './slotEligibility';
+
+export const MEAL_PLAN_STRATEGIES = ['fill-empty', 'replace-selected'] as const;
+export type MealPlanStrategy = (typeof MEAL_PLAN_STRATEGIES)[number];
+
+export const RECIPE_SOURCES = ['my-recipes', 'saved', 'explore', 'all'] as const;
+export type RecipeSource = (typeof RECIPE_SOURCES)[number];
+
+export const PREFERENCE_STYLES = [
+  { id: 'easy', label: 'Easy', tags: ['easy', 'quick', 'simple', 'weeknight'] },
+  {
+    id: 'mediterranean',
+    label: 'Mediterranean',
+    tags: ['mediterranean', 'greek', 'italian', 'levantine']
+  },
+  { id: 'keto', label: 'Keto', tags: ['keto', 'low-carb', 'lowcarb', 'low carb'] },
+  {
+    id: 'high-protein',
+    label: 'High Protein',
+    tags: ['high-protein', 'highprotein', 'protein', 'high protein']
+  },
+  { id: 'vegetarian', label: 'Vegetarian', tags: ['vegetarian', 'vegan', 'plant-based'] },
+  {
+    id: 'family-friendly',
+    label: 'Family Friendly',
+    tags: ['family', 'kid', 'kids', 'family-friendly', 'kid-friendly']
+  },
+  { id: 'budget', label: 'Budget', tags: ['budget', 'cheap', 'affordable', 'inexpensive'] },
+  { id: 'surprise', label: 'Surprise Me', tags: [] }
+] as const;
+
+export type PreferenceStyleId = (typeof PREFERENCE_STYLES)[number]['id'];
+
+export const STYLE_IDS: readonly PreferenceStyleId[] = PREFERENCE_STYLES.map((s) => s.id);
+
+export const MAX_CANDIDATES = 48;
+export const MAX_NOTES_CHARS = 500;
+export const MAX_EXCLUDE_INGREDIENTS = 20;
+export const MAX_INGREDIENTS_PER_CANDIDATE = 12;
+export const MAX_TAGS_PER_CANDIDATE = 8;
+export const MAX_TITLE_CHARS = 120;
+export const MAX_REASON_CHARS = 160;
+
+export interface RecipeCandidate {
+  a: string;
+  title: string;
+  tags: string[];
+  ingredients: string[];
+  prepTime?: string;
+  cookTime?: string;
+  servings?: string;
+}
+
+export interface MealPlanPreferences {
+  styles: PreferenceStyleId[];
+  maxMinutes?: number;
+  servings?: number;
+  excludeIngredients?: string[];
+  notes?: string;
+}
+
+export interface MealSlotRef {
+  day: MealPlanDayKey;
+  slot: MealSlotKey;
+}
+
+export interface MealPlanGenerationRequest {
+  weekId: string;
+  days: MealPlanDayKey[];
+  mealSlots: MealSlotKey[];
+  preferences: MealPlanPreferences;
+  strategy: MealPlanStrategy;
+  candidates: RecipeCandidate[];
+  /** Slots that already have a meal. Required for fill-empty enforcement. */
+  occupiedSlots?: MealSlotRef[];
+  /**
+   * Explicit slots Cheffy should fill. When omitted, the cartesian
+   * product of `days` × `mealSlots` is used (minus occupied slots when
+   * strategy is fill-empty).
+   */
+  fillSlots?: MealSlotRef[];
+  /** Coordinates already used in the preview — avoid repeating them on swap. */
+  excludeCoordinates?: string[];
+}
+
+export interface GeneratedMeal {
+  day: MealPlanDayKey;
+  slot: MealSlotKey;
+  a: string;
+  title: string;
+  reason?: string;
+  /** Client-only preview thumbnail. Never written into the meal-plan schema. */
+  image?: string;
+}
+
+export interface GeneratedMealPlan {
+  meals: GeneratedMeal[];
+}
+
+export type GenerationValidationError =
+  | 'invalid-week'
+  | 'invalid-days'
+  | 'invalid-slots'
+  | 'invalid-strategy'
+  | 'no-candidates'
+  | 'too-many-candidates'
+  | 'no-target-slots'
+  | 'unknown-recipe'
+  | 'unknown-day'
+  | 'unknown-slot'
+  | 'duplicate-slot'
+  | 'overwrite-occupied'
+  | 'ineligible-slot'
+  | 'empty-plan';
+
+export interface ValidationResult {
+  ok: boolean;
+  error?: GenerationValidationError;
+  message?: string;
+}
+
+const DAY_SET = new Set<string>(DAY_KEYS);
+const SLOT_SET = new Set<string>(SLOT_KEYS);
+const STYLE_SET = new Set<string>(STYLE_IDS);
+const STRATEGY_SET = new Set<string>(MEAL_PLAN_STRATEGIES);
+
+const RECIPE_KIND_PREFIX = '30023:';
+
+const VEGETARIAN_BLOCKLIST = [
+  'chicken',
+  'beef',
+  'pork',
+  'lamb',
+  'turkey',
+  'bacon',
+  'sausage',
+  'ham',
+  'steak',
+  'shrimp',
+  'salmon',
+  'tuna',
+  'anchovy',
+  'anchovies',
+  'fish',
+  'seafood',
+  'shellfish',
+  'crab',
+  'lobster',
+  'clam',
+  'mussel',
+  'oyster',
+  'duck',
+  'venison',
+  'pepperoni',
+  'salami',
+  'prosciutto',
+  'pancetta',
+  'chorizo',
+  'meatball',
+  'ground meat',
+  'ground beef'
+];
+
+export function isMealPlanDayKey(value: unknown): value is MealPlanDayKey {
+  return typeof value === 'string' && DAY_SET.has(value);
+}
+
+export function isMealSlotKey(value: unknown): value is MealSlotKey {
+  return typeof value === 'string' && SLOT_SET.has(value);
+}
+
+export function isPreferenceStyleId(value: unknown): value is PreferenceStyleId {
+  return typeof value === 'string' && STYLE_SET.has(value);
+}
+
+export function isMealPlanStrategy(value: unknown): value is MealPlanStrategy {
+  return typeof value === 'string' && STRATEGY_SET.has(value);
+}
+
+export function isRecipeCoordinate(a: unknown): a is string {
+  if (typeof a !== 'string' || !a.startsWith(RECIPE_KIND_PREFIX)) return false;
+  const parts = a.split(':');
+  return parts.length === 3 && parts[1].length > 0 && parts[2].length > 0;
+}
+
+export function slotKey(day: MealPlanDayKey, slot: MealSlotKey): string {
+  return `${day}:${slot}`;
+}
+
+export function cartesianSlots(days: MealPlanDayKey[], mealSlots: MealSlotKey[]): MealSlotRef[] {
+  const out: MealSlotRef[] = [];
+  for (const day of days) {
+    for (const slot of mealSlots) {
+      out.push({ day, slot });
+    }
+  }
+  return out;
+}
+
+export function occupiedSlotSet(occupied: MealSlotRef[] | undefined): Set<string> {
+  const set = new Set<string>();
+  for (const o of occupied || []) {
+    if (isMealPlanDayKey(o.day) && isMealSlotKey(o.slot)) {
+      set.add(slotKey(o.day, o.slot));
+    }
+  }
+  return set;
+}
+
+/** Slots Cheffy is allowed to fill for this request. */
+export function resolveTargetSlots(req: {
+  days: MealPlanDayKey[];
+  mealSlots: MealSlotKey[];
+  strategy: MealPlanStrategy;
+  occupiedSlots?: MealSlotRef[];
+  fillSlots?: MealSlotRef[];
+}): MealSlotRef[] {
+  const occupied = occupiedSlotSet(req.occupiedSlots);
+  const base = req.fillSlots?.length ? req.fillSlots : cartesianSlots(req.days, req.mealSlots);
+  const seen = new Set<string>();
+  const out: MealSlotRef[] = [];
+  for (const ref of base) {
+    if (!isMealPlanDayKey(ref.day) || !isMealSlotKey(ref.slot)) continue;
+    const key = slotKey(ref.day, ref.slot);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    if (req.strategy === 'fill-empty' && occupied.has(key)) continue;
+    out.push({ day: ref.day, slot: ref.slot });
+  }
+  return out;
+}
+
+export function occupiedSlotsFromPlan(
+  plan: MealPlan,
+  days: MealPlanDayKey[],
+  mealSlots: MealSlotKey[]
+): MealSlotRef[] {
+  const out: MealSlotRef[] = [];
+  for (const day of days) {
+    const slots = plan.days[day]?.slots;
+    if (!slots) continue;
+    for (const slot of mealSlots) {
+      if (slots[slot]) out.push({ day, slot });
+    }
+  }
+  return out;
+}
+
+/**
+ * Parse a human cook/prep time into minutes. Returns null when the
+ * string cannot be interpreted — callers must not treat unknown as a
+ * violation.
+ */
+export function parseDurationMinutes(raw: string | undefined | null): number | null {
+  if (!raw || typeof raw !== 'string') return null;
+  const s = raw.trim().toLowerCase();
+  if (!s) return null;
+  if (/^\d+$/.test(s)) {
+    const n = Number(s);
+    return n > 0 ? n : null;
+  }
+
+  let total = 0;
+  const hourMatch = s.match(/(\d+(?:\.\d+)?)\s*(?:hours?|hrs?|h)\b/);
+  const minMatch = s.match(/(\d+(?:\.\d+)?)\s*(?:minutes?|mins?|m)\b/);
+  if (hourMatch) total += parseFloat(hourMatch[1]) * 60;
+  if (minMatch) total += parseFloat(minMatch[1]);
+  if (total > 0) return Math.round(total);
+
+  const firstNum = s.match(/(\d+)/);
+  if (!firstNum) return null;
+  const n = Number(firstNum[1]);
+  return n > 0 ? n : null;
+}
+
+/** Prep + cook when both parse; otherwise whichever is known. */
+export function totalActiveMinutes(prepTime?: string, cookTime?: string): number | null {
+  const prep = parseDurationMinutes(prepTime);
+  const cook = parseDurationMinutes(cookTime);
+  if (prep == null && cook == null) return null;
+  return (prep ?? 0) + (cook ?? 0);
+}
+
+function normalizeNeedle(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function textBlob(parts: Array<string | undefined>): string {
+  return parts
+    .filter((p): p is string => typeof p === 'string' && p.length > 0)
+    .join(' ')
+    .toLowerCase();
+}
+
+function containsAny(haystack: string, needles: string[]): boolean {
+  if (!haystack) return false;
+  return needles.some((n) => n && haystack.includes(n));
+}
+
+function styleMatchers(styles: PreferenceStyleId[]): { tags: string[]; skip: boolean } {
+  const tags: string[] = [];
+  let skip = false;
+  for (const id of styles) {
+    const def = PREFERENCE_STYLES.find((s) => s.id === id);
+    if (!def) continue;
+    if (id === 'surprise') {
+      skip = styles.length === 1;
+      continue;
+    }
+    for (const t of def.tags) tags.push(t.toLowerCase());
+  }
+  return { tags, skip };
+}
+
+function candidateMatchesStyle(c: RecipeCandidate, styleTags: string[]): boolean {
+  if (styleTags.length === 0) return false;
+  const blob = textBlob([c.title, ...(c.tags || [])]);
+  return styleTags.some((t) => blob.includes(t));
+}
+
+function obviouslyNotVegetarian(c: RecipeCandidate): boolean {
+  if (!c.ingredients?.length) return false;
+  const blob = textBlob([c.title, ...c.ingredients]);
+  return containsAny(blob, VEGETARIAN_BLOCKLIST);
+}
+
+function obviouslyContainsExcluded(c: RecipeCandidate, excluded: string[]): boolean {
+  if (excluded.length === 0) return false;
+  if (!c.ingredients?.length && !c.title) return false;
+  const blob = textBlob([c.title, ...(c.ingredients || [])]);
+  return containsAny(blob, excluded);
+}
+
+export interface FilterCandidatesOptions {
+  maxMinutes?: number;
+  excludeIngredients?: string[];
+  styles?: PreferenceStyleId[];
+  excludeCoordinates?: string[];
+  /** Soft-prefer recipes whose tags mention these meal slots. */
+  mealSlots?: MealSlotKey[];
+  maxCandidates?: number;
+}
+
+/**
+ * Deterministic pre-filter. Drops recipes that *obviously* violate hard
+ * constraints; keeps unknowns. Then ranks and caps so Cheffy sees a
+ * useful, bounded set rather than the whole corpus.
+ */
+export function filterRecipeCandidates(
+  candidates: RecipeCandidate[],
+  opts: FilterCandidatesOptions = {}
+): RecipeCandidate[] {
+  const maxMinutes = opts.maxMinutes && opts.maxMinutes > 0 ? opts.maxMinutes : undefined;
+  const excluded = (opts.excludeIngredients || []).map(normalizeNeedle).filter(Boolean);
+  const excludeAs = new Set(opts.excludeCoordinates || []);
+  const styles = (opts.styles || []).filter(isPreferenceStyleId);
+  const vegetarian = styles.includes('vegetarian');
+  const { tags: styleTags, skip: surpriseOnly } = styleMatchers(styles);
+  const mealSlots = opts.mealSlots || [];
+  const cap = opts.maxCandidates ?? MAX_CANDIDATES;
+
+  const hardPassed: RecipeCandidate[] = [];
+  for (const c of candidates) {
+    if (!isRecipeCoordinate(c.a)) continue;
+    if (excludeAs.has(c.a)) continue;
+    if (maxMinutes != null) {
+      const minutes = totalActiveMinutes(c.prepTime, c.cookTime);
+      if (minutes != null && minutes > maxMinutes) continue;
+    }
+    if (obviouslyContainsExcluded(c, excluded)) continue;
+    if (vegetarian && obviouslyNotVegetarian(c)) continue;
+    hardPassed.push(c);
+  }
+
+  const slotEligible =
+    mealSlots.length > 0 ? restrictCandidatesToRequestedSlots(hardPassed, mealSlots) : hardPassed;
+
+  let ranked = slotEligible;
+  if (!surpriseOnly && styleTags.length > 0) {
+    const matched = slotEligible.filter((c) => candidateMatchesStyle(c, styleTags));
+    const unmatched = slotEligible.filter((c) => !candidateMatchesStyle(c, styleTags));
+    // If we have enough style matches to cover a week with extras, drop
+    // the rest. Otherwise keep unmatched as fallback so Cheffy can still plan.
+    ranked = matched.length >= 8 ? matched : [...matched, ...unmatched];
+  } else if (surpriseOnly) {
+    ranked = shuffleInPlace([...slotEligible]);
+  }
+
+  if (mealSlots.length > 0 && !surpriseOnly) {
+    const slotNeedles = mealSlots.map((s) => s.toLowerCase());
+    ranked = [...ranked].sort(
+      (a, b) =>
+        scoreCandidate(b, styleTags, slotNeedles) - scoreCandidate(a, styleTags, slotNeedles)
+    );
+  } else if (styleTags.length > 0 && !surpriseOnly) {
+    ranked = [...ranked].sort(
+      (a, b) => scoreCandidate(b, styleTags, []) - scoreCandidate(a, styleTags, [])
+    );
+  }
+
+  return ranked.slice(0, cap);
+}
+
+function scoreCandidate(c: RecipeCandidate, styleTags: string[], slotNeedles: string[]): number {
+  let score = 0;
+  const blob = textBlob([c.title, ...(c.tags || [])]);
+  if (styleTags.some((t) => blob.includes(t))) score += 3;
+  if (slotNeedles.some((t) => blob.includes(t))) score += 2;
+  if (c.prepTime || c.cookTime) score += 1;
+  if (c.ingredients?.length) score += 1;
+  return score;
+}
+
+function shuffleInPlace<T>(arr: T[]): T[] {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+export function uniqueDays(values: unknown): MealPlanDayKey[] {
+  if (!Array.isArray(values)) return [];
+  const seen = new Set<MealPlanDayKey>();
+  const out: MealPlanDayKey[] = [];
+  for (const v of values) {
+    if (isMealPlanDayKey(v) && !seen.has(v)) {
+      seen.add(v);
+      out.push(v);
+    }
+  }
+  return out;
+}
+
+export function uniqueSlots(values: unknown): MealSlotKey[] {
+  if (!Array.isArray(values)) return [];
+  const seen = new Set<MealSlotKey>();
+  const out: MealSlotKey[] = [];
+  for (const v of values) {
+    if (isMealSlotKey(v) && !seen.has(v)) {
+      seen.add(v);
+      out.push(v);
+    }
+  }
+  return out;
+}
+
+function sanitizeCandidate(raw: unknown): RecipeCandidate | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  if (!isRecipeCoordinate(r.a)) return null;
+  const title = typeof r.title === 'string' ? r.title.trim().slice(0, MAX_TITLE_CHARS) : '';
+  if (!title) return null;
+  const tags = Array.isArray(r.tags)
+    ? r.tags
+        .filter((t): t is string => typeof t === 'string' && t.trim().length > 0)
+        .map((t) => t.trim().slice(0, 40))
+        .slice(0, MAX_TAGS_PER_CANDIDATE)
+    : [];
+  const ingredients = Array.isArray(r.ingredients)
+    ? r.ingredients
+        .filter((t): t is string => typeof t === 'string' && t.trim().length > 0)
+        .map((t) => t.trim().slice(0, 80))
+        .slice(0, MAX_INGREDIENTS_PER_CANDIDATE)
+    : [];
+  const candidate: RecipeCandidate = { a: r.a, title, tags, ingredients };
+  if (typeof r.prepTime === 'string' && r.prepTime.trim()) {
+    candidate.prepTime = r.prepTime.trim().slice(0, 40);
+  }
+  if (typeof r.cookTime === 'string' && r.cookTime.trim()) {
+    candidate.cookTime = r.cookTime.trim().slice(0, 40);
+  }
+  if (typeof r.servings === 'string' && r.servings.trim()) {
+    candidate.servings = r.servings.trim().slice(0, 20);
+  }
+  return candidate;
+}
+
+function sanitizePreferences(raw: unknown): MealPlanPreferences {
+  const src = raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {};
+  const styles = Array.isArray(src.styles)
+    ? src.styles.filter(isPreferenceStyleId).slice(0, STYLE_IDS.length)
+    : [];
+  const prefs: MealPlanPreferences = { styles };
+  if (typeof src.maxMinutes === 'number' && Number.isFinite(src.maxMinutes) && src.maxMinutes > 0) {
+    prefs.maxMinutes = Math.min(Math.round(src.maxMinutes), 24 * 60);
+  }
+  if (typeof src.servings === 'number' && Number.isFinite(src.servings) && src.servings > 0) {
+    prefs.servings = Math.min(Math.round(src.servings), 24);
+  }
+  if (Array.isArray(src.excludeIngredients)) {
+    prefs.excludeIngredients = src.excludeIngredients
+      .filter((s): s is string => typeof s === 'string')
+      .map((s) => s.trim().slice(0, 40))
+      .filter(Boolean)
+      .slice(0, MAX_EXCLUDE_INGREDIENTS);
+  }
+  if (typeof src.notes === 'string') {
+    const notes = src.notes.trim().slice(0, MAX_NOTES_CHARS);
+    if (notes) prefs.notes = notes;
+  }
+  return prefs;
+}
+
+function sanitizeSlotRefs(raw: unknown): MealSlotRef[] {
+  if (!Array.isArray(raw)) return [];
+  const seen = new Set<string>();
+  const out: MealSlotRef[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const r = item as Record<string, unknown>;
+    if (!isMealPlanDayKey(r.day) || !isMealSlotKey(r.slot)) continue;
+    const key = slotKey(r.day, r.slot);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ day: r.day, slot: r.slot });
+  }
+  return out;
+}
+
+/**
+ * Parse and validate a generation request body. Returns a sanitized
+ * request or a validation error — never throws.
+ */
+export function parseGenerationRequest(
+  raw: unknown
+):
+  | { ok: true; request: MealPlanGenerationRequest }
+  | { ok: false; error: GenerationValidationError; message: string } {
+  if (!raw || typeof raw !== 'object') {
+    return { ok: false, error: 'invalid-week', message: 'Request body is required.' };
+  }
+  const body = raw as Record<string, unknown>;
+  if (typeof body.weekId !== 'string' || !isValidWeekId(body.weekId)) {
+    return { ok: false, error: 'invalid-week', message: 'A valid week is required.' };
+  }
+  const days = uniqueDays(body.days);
+  if (days.length === 0) {
+    return { ok: false, error: 'invalid-days', message: 'Select at least one day.' };
+  }
+  const mealSlots = uniqueSlots(body.mealSlots);
+  if (mealSlots.length === 0) {
+    return { ok: false, error: 'invalid-slots', message: 'Select at least one meal.' };
+  }
+  if (!isMealPlanStrategy(body.strategy)) {
+    return {
+      ok: false,
+      error: 'invalid-strategy',
+      message: 'Choose fill-empty or replace-selected.'
+    };
+  }
+  if (!Array.isArray(body.candidates) || body.candidates.length === 0) {
+    return {
+      ok: false,
+      error: 'no-candidates',
+      message: 'No recipes were available to plan with.'
+    };
+  }
+  if (body.candidates.length > MAX_CANDIDATES) {
+    return {
+      ok: false,
+      error: 'too-many-candidates',
+      message: `Too many candidate recipes (max ${MAX_CANDIDATES}).`
+    };
+  }
+
+  const seenA = new Set<string>();
+  const candidates: RecipeCandidate[] = [];
+  for (const rawCandidate of body.candidates) {
+    const c = sanitizeCandidate(rawCandidate);
+    if (!c || seenA.has(c.a)) continue;
+    seenA.add(c.a);
+    candidates.push(c);
+  }
+  if (candidates.length === 0) {
+    return {
+      ok: false,
+      error: 'no-candidates',
+      message: 'No valid recipes were available to plan with.'
+    };
+  }
+
+  const request: MealPlanGenerationRequest = {
+    weekId: body.weekId,
+    days,
+    mealSlots,
+    preferences: sanitizePreferences(body.preferences),
+    strategy: body.strategy,
+    candidates,
+    occupiedSlots: sanitizeSlotRefs(body.occupiedSlots),
+    fillSlots: sanitizeSlotRefs(body.fillSlots),
+    excludeCoordinates: Array.isArray(body.excludeCoordinates)
+      ? body.excludeCoordinates.filter(isRecipeCoordinate).slice(0, MAX_CANDIDATES)
+      : []
+  };
+
+  const targets = resolveTargetSlots(request);
+  if (targets.length === 0) {
+    return {
+      ok: false,
+      error: 'no-target-slots',
+      message:
+        request.strategy === 'fill-empty'
+          ? 'Those slots already have meals. Switch to replace, or pick empty days.'
+          : 'No meal slots to plan.'
+    };
+  }
+
+  return { ok: true, request };
+}
+
+/**
+ * Validate a model-produced plan against the request. Unknown recipe
+ * coordinates are a hard reject — they must never reach the planner.
+ */
+export function validateGeneratedMealPlan(
+  plan: unknown,
+  request: MealPlanGenerationRequest
+):
+  | { ok: true; plan: GeneratedMealPlan }
+  | { ok: false; error: GenerationValidationError; message: string } {
+  if (!plan || typeof plan !== 'object') {
+    return { ok: false, error: 'empty-plan', message: 'Cheffy did not return a meal plan.' };
+  }
+  const mealsRaw = (plan as Record<string, unknown>).meals;
+  if (!Array.isArray(mealsRaw) || mealsRaw.length === 0) {
+    return { ok: false, error: 'empty-plan', message: 'Cheffy did not return any meals.' };
+  }
+
+  const candidateByA = new Map(request.candidates.map((c) => [c.a, c]));
+  const targets = resolveTargetSlots(request);
+  const targetSet = new Set(targets.map((t) => slotKey(t.day, t.slot)));
+  const occupied = occupiedSlotSet(request.occupiedSlots);
+  const seenSlots = new Set<string>();
+  const meals: GeneratedMeal[] = [];
+
+  for (const raw of mealsRaw) {
+    if (!raw || typeof raw !== 'object') continue;
+    const m = raw as Record<string, unknown>;
+    if (!isMealPlanDayKey(m.day)) {
+      return {
+        ok: false,
+        error: 'unknown-day',
+        message: 'Cheffy returned a day that was not requested.'
+      };
+    }
+    if (!isMealSlotKey(m.slot)) {
+      return {
+        ok: false,
+        error: 'unknown-slot',
+        message: 'Cheffy returned a meal that was not requested.'
+      };
+    }
+    const key = slotKey(m.day, m.slot);
+    if (request.strategy === 'fill-empty' && occupied.has(key)) {
+      return {
+        ok: false,
+        error: 'overwrite-occupied',
+        message: 'Cheffy tried to overwrite a meal that is already planned.'
+      };
+    }
+    if (!targetSet.has(key)) {
+      return {
+        ok: false,
+        error: 'unknown-slot',
+        message: 'Cheffy returned a meal slot that was not requested.'
+      };
+    }
+    if (seenSlots.has(key)) {
+      return {
+        ok: false,
+        error: 'duplicate-slot',
+        message: 'Cheffy assigned two recipes to the same slot.'
+      };
+    }
+    seenSlots.add(key);
+    if (!isRecipeCoordinate(m.a) || !candidateByA.has(m.a)) {
+      return {
+        ok: false,
+        error: 'unknown-recipe',
+        message: 'Cheffy returned a recipe that is not in Zap Cooking.'
+      };
+    }
+    const candidate = candidateByA.get(m.a)!;
+    if (!isRecipeEligibleForSlot(candidate, m.slot)) {
+      return {
+        ok: false,
+        error: 'ineligible-slot',
+        message: 'Cheffy assigned a recipe that does not fit that meal.'
+      };
+    }
+    const reason =
+      typeof m.reason === 'string' && m.reason.trim()
+        ? m.reason.trim().slice(0, MAX_REASON_CHARS)
+        : undefined;
+    meals.push({
+      day: m.day,
+      slot: m.slot,
+      a: candidate.a,
+      title: candidate.title,
+      reason
+    });
+  }
+
+  if (meals.length === 0) {
+    return { ok: false, error: 'empty-plan', message: 'Cheffy did not return any meals.' };
+  }
+
+  return { ok: true, plan: { meals } };
+}
+
+export function parseExcludeIngredientsInput(raw: string): string[] {
+  return raw
+    .split(/[,;\n]+/)
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .slice(0, MAX_EXCLUDE_INGREDIENTS);
+}

--- a/src/lib/mealplan/slotEligibility.ts
+++ b/src/lib/mealplan/slotEligibility.ts
@@ -1,0 +1,189 @@
+/**
+ * Meal-slot eligibility for Cheffy planning.
+ *
+ * Internal to meal-plan generation — not part of the shared Android
+ * meal-plan schema. Breakfast (and snack) are hard filters; lunch and
+ * dinner stay permissive.
+ */
+
+import type { MealSlotKey } from './schema';
+
+/** Minimal candidate shape — kept local to avoid a cycle with generation.ts. */
+export interface SlotEligibilityCandidate {
+  title: string;
+  tags: string[];
+}
+
+const BREAKFAST_TAG_NEEDLES = ['breakfast', 'brunch'];
+
+const BREAKFAST_TITLE_PHRASES = [
+  'breakfast',
+  'brunch',
+  'omelet',
+  'omelette',
+  'frittata',
+  'pancake',
+  'pancakes',
+  'waffle',
+  'waffles',
+  'french toast',
+  'oatmeal',
+  'overnight oats',
+  'porridge',
+  'granola',
+  'yogurt',
+  'parfait',
+  'smoothie',
+  'breakfast sandwich',
+  'breakfast burrito',
+  'hash brown',
+  'hashbrowns',
+  'hash browns',
+  'muffin',
+  'muffins',
+  'bagel',
+  'bagels',
+  'cereal',
+  'muesli',
+  'shakshuka',
+  'eggs benedict',
+  'scrambled eggs',
+  'fried eggs',
+  'poached eggs',
+  'avocado toast',
+  'crepe',
+  'crepes',
+  'scone',
+  'scones',
+  'acai'
+];
+
+const BREAKFAST_TITLE_WORDS = ['eggs', 'oats', 'hash'];
+
+const SNACK_TAG_NEEDLES = ['snack', 'snacks'];
+
+const SNACK_TITLE_PHRASES = [
+  'snack',
+  'snacks',
+  'bites',
+  'energy ball',
+  'energy balls',
+  'granola bar',
+  'protein bar',
+  'trail mix',
+  'popcorn',
+  'hummus'
+];
+
+function normalize(value: string): string {
+  return value.toLowerCase().replace(/[_/]+/g, ' ').replace(/-/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function tagMatches(tags: string[], needles: string[]): boolean {
+  for (const tag of tags || []) {
+    const n = normalize(tag);
+    if (!n) continue;
+    for (const needle of needles) {
+      if (n === needle || n.includes(needle)) return true;
+    }
+  }
+  return false;
+}
+
+function titleHasPhrase(title: string, phrases: string[]): boolean {
+  const n = ` ${normalize(title)} `;
+  return phrases.some((phrase) => n.includes(` ${phrase} `) || n.includes(` ${phrase}`));
+}
+
+function titleHasWord(title: string, words: string[]): boolean {
+  const n = normalize(title);
+  if (!n) return false;
+  const tokens = new Set(n.split(' '));
+  return words.some((w) => tokens.has(w));
+}
+
+function hasBreakfastSignal(candidate: SlotEligibilityCandidate): boolean {
+  if (tagMatches(candidate.tags, BREAKFAST_TAG_NEEDLES)) return true;
+  const title = candidate.title || '';
+  if (titleHasPhrase(title, BREAKFAST_TITLE_PHRASES)) return true;
+  if (titleHasWord(title, BREAKFAST_TITLE_WORDS)) return true;
+  return false;
+}
+
+function hasSnackSignal(candidate: SlotEligibilityCandidate): boolean {
+  if (tagMatches(candidate.tags, SNACK_TAG_NEEDLES)) return true;
+  return titleHasPhrase(candidate.title || '', SNACK_TITLE_PHRASES);
+}
+
+/**
+ * Whether a recipe may be assigned to a planner slot.
+ *
+ * Breakfast and snack require a positive signal (tags first, then title).
+ * Lunch and dinner are always eligible — many recipes work for either.
+ */
+export function isRecipeEligibleForSlot(
+  candidate: SlotEligibilityCandidate,
+  slot: MealSlotKey
+): boolean {
+  if (slot === 'lunch' || slot === 'dinner') return true;
+  if (slot === 'breakfast') return hasBreakfastSignal(candidate);
+  if (slot === 'snack') return hasSnackSignal(candidate);
+  return false;
+}
+
+export function eligibleSlotsForRecipe(candidate: SlotEligibilityCandidate): MealSlotKey[] {
+  const slots: MealSlotKey[] = [];
+  if (isRecipeEligibleForSlot(candidate, 'breakfast')) slots.push('breakfast');
+  slots.push('lunch', 'dinner');
+  if (isRecipeEligibleForSlot(candidate, 'snack')) slots.push('snack');
+  return slots;
+}
+
+const HARD_SLOTS: MealSlotKey[] = ['breakfast', 'snack'];
+
+/**
+ * Drop recipes that cannot fill any requested slot. Breakfast-only
+ * (or snack-only) requests keep only matching recipes — dinner entrees
+ * never reach Cheffy as breakfast options. Lunch/dinner requests are
+ * unrestricted.
+ */
+export function restrictCandidatesToRequestedSlots<T extends SlotEligibilityCandidate>(
+  candidates: T[],
+  mealSlots: MealSlotKey[]
+): T[] {
+  if (mealSlots.length === 0) return candidates;
+  const hard = mealSlots.filter((s) => HARD_SLOTS.includes(s));
+  const hasSoft = mealSlots.some((s) => s === 'lunch' || s === 'dinner');
+  if (hard.length === 0) return candidates;
+  if (hasSoft) {
+    return candidates.filter((c) => mealSlots.some((slot) => isRecipeEligibleForSlot(c, slot)));
+  }
+  return candidates.filter((c) => hard.some((slot) => isRecipeEligibleForSlot(c, slot)));
+}
+
+export function insufficientSlotCoverageMessage(opts: {
+  mealSlots: MealSlotKey[];
+  found: number;
+  requested: number;
+}): string | null {
+  if (opts.found >= opts.requested || opts.found <= 0) return null;
+  if (opts.mealSlots.length === 1 && opts.mealSlots[0] === 'breakfast') {
+    const n = opts.found;
+    return `Cheffy found ${n} breakfast ${n === 1 ? 'recipe' : 'recipes'} that match your preferences. Try broadening your preferences to fill the rest of the week.`;
+  }
+  if (opts.mealSlots.length === 1 && opts.mealSlots[0] === 'snack') {
+    const n = opts.found;
+    return `Cheffy found ${n} snack ${n === 1 ? 'recipe' : 'recipes'} that match your preferences. Try broadening your preferences to fill the rest of the week.`;
+  }
+  return `Cheffy found ${opts.found} matching ${opts.found === 1 ? 'recipe' : 'recipes'} — some slots were left empty rather than filled with a poor match.`;
+}
+
+export function noEligibleRecipesMessage(mealSlots: MealSlotKey[]): string {
+  if (mealSlots.length === 1 && mealSlots[0] === 'breakfast') {
+    return 'Cheffy could not find breakfast or brunch recipes that match your preferences. Try another source, or add breakfast recipes.';
+  }
+  if (mealSlots.length === 1 && mealSlots[0] === 'snack') {
+    return 'Cheffy could not find snack recipes that match your preferences. Try another source, or loosen the filters.';
+  }
+  return 'Could not find enough matching recipes. Try another source, or loosen the time and ingredient filters.';
+}

--- a/src/lib/services/recipeDiscoveryService.test.ts
+++ b/src/lib/services/recipeDiscoveryService.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('$app/environment', () => ({ browser: false }));
+vi.mock('$lib/offlineStorage', () => ({
+  offlineStorage: { getRecipes: async () => [], saveRecipeFromEvent: async () => {} }
+}));
+vi.mock('$lib/stores/cookbookStore', () => ({
+  cookbookStore: { load: async () => {} },
+  cookbookLists: {
+    subscribe: (fn: (v: unknown[]) => void) => {
+      fn([]);
+      return () => {};
+    }
+  }
+}));
+vi.mock('$lib/myRecipesPack', () => ({ fetchMyAuthoredRecipeEvents: async () => [] }));
+
+import {
+  attachDiscoveredImages,
+  candidateFromCached,
+  toWireCandidate
+} from './recipeDiscoveryService';
+
+function cached(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '30023:pk:salmon-bowl',
+    title: 'Mediterranean Salmon Bowl',
+    content:
+      '# Salmon Bowl\n\n## Details\n⏲️ Prep time: 10 min\n🍳 Cook time: 15 min\n🍽️ Servings: 2\n\n## Ingredients\n- 1 salmon fillet\n- 1 cup rice\n',
+    ingredients: ['1 salmon fillet', '1 cup rice'],
+    tags: ['zapcooking', 'mediterranean', 'dinner'],
+    authorPubkey: 'pk',
+    createdAt: 1,
+    cachedAt: 1,
+    eventKind: 30023,
+    eventDTag: 'salmon-bowl',
+    eventTags: [],
+    ...overrides
+  } as any;
+}
+
+describe('candidateFromCached', () => {
+  it('drops zapcooking meta tags and keeps useful recipe tags', () => {
+    const c = candidateFromCached(cached());
+    expect(c?.a).toBe('30023:pk:salmon-bowl');
+    expect(c?.title).toBe('Mediterranean Salmon Bowl');
+    expect(c?.tags).toEqual(['mediterranean', 'dinner']);
+    expect(c?.ingredients.length).toBeGreaterThan(0);
+  });
+
+  it('ignores hidden test-recipe coordinates', () => {
+    expect(
+      candidateFromCached(
+        cached({
+          id: '30023:8b739c62ed2a9b76c2836a18a6bc9a480b6f8d902b8f702083dfae20bf6b15b9:pr10-pancakes'
+        })
+      )
+    ).toBeNull();
+  });
+
+  it('toWireCandidate omits image', () => {
+    const discovered = candidateFromCached(cached({ image: 'https://example.com/s.jpg' }));
+    expect(discovered?.image).toBe('https://example.com/s.jpg');
+    expect(toWireCandidate(discovered!)).not.toHaveProperty('image');
+    expect(toWireCandidate(discovered!).a).toBe(discovered!.a);
+  });
+
+  it('attaches discovered images onto generated meals by coordinate', () => {
+    const meals = attachDiscoveredImages(
+      [
+        { a: '30023:pk:salmon-bowl', title: 'Salmon' },
+        { a: '30023:pk:missing', title: 'No photo' }
+      ],
+      [
+        {
+          a: '30023:pk:salmon-bowl',
+          title: 'Salmon',
+          tags: [],
+          ingredients: [],
+          image: 'https://example.com/s.jpg'
+        },
+        { a: '30023:pk:other', title: 'Other', tags: [], ingredients: [] }
+      ]
+    );
+    expect(meals[0].image).toBe('https://example.com/s.jpg');
+    expect(meals[1].image).toBeUndefined();
+  });
+});

--- a/src/lib/services/recipeDiscoveryService.ts
+++ b/src/lib/services/recipeDiscoveryService.ts
@@ -1,0 +1,360 @@
+/**
+ * Discover real Zap Cooking recipes for Cheffy meal planning.
+ *
+ * Reuses the same NDK filters as the planner's RecipePicker and Explore
+ * (`kind:30023` + RECIPE_TAGS). Does not introduce a separate recipe DB.
+ * Candidates are built from event tags plus the existing markdown parser.
+ */
+
+import type NDK from '@nostr-dev-kit/ndk';
+import type { NDKEvent, NDKFilter } from '@nostr-dev-kit/ndk';
+import {
+  RECIPE_TAG_PREFIX_LEGACY,
+  RECIPE_TAG_PREFIX_NEW,
+  RECIPE_TAGS,
+  HIDDEN_RECIPE_COORDINATES,
+  isHiddenRecipeCoordinate
+} from '$lib/consts';
+import { fetchMyAuthoredRecipeEvents } from '$lib/myRecipesPack';
+import { offlineStorage, type CachedRecipe } from '$lib/offlineStorage';
+import { extractRecipeDetails, validateMarkdownTemplate } from '$lib/parser';
+import { parseIngredientsFromRecipe } from '$lib/utils/ingredientParser';
+import { cookbookStore, cookbookLists } from '$lib/stores/cookbookStore';
+import { get } from 'svelte/store';
+import {
+  MAX_INGREDIENTS_PER_CANDIDATE,
+  MAX_TAGS_PER_CANDIDATE,
+  MAX_TITLE_CHARS,
+  isRecipeCoordinate,
+  type RecipeCandidate,
+  type RecipeSource
+} from '$lib/mealplan/generation';
+
+const RECIPE_KIND = 30023;
+const EXPLORE_LIMIT = 150;
+const EXPLORE_TIMEOUT_MS = 8000;
+const FETCH_EVENT_TIMEOUT_MS = 8000;
+
+const META_TAG_SKIP = new Set([RECIPE_TAG_PREFIX_NEW, RECIPE_TAG_PREFIX_LEGACY]);
+
+export interface DiscoveredRecipe extends RecipeCandidate {
+  image?: string;
+}
+
+function hasValidRecipeMarkdown(content: string | undefined): boolean {
+  if (!content) return false;
+  return typeof validateMarkdownTemplate(content) !== 'string';
+}
+
+function aTagFromEvent(event: NDKEvent): string | null {
+  const dTag = event.tags?.find((t) => t[0] === 'd')?.[1] || '';
+  if (!dTag || !event.pubkey) return null;
+  const kind = event.kind || RECIPE_KIND;
+  if (isHiddenRecipeCoordinate(kind, event.pubkey, dTag)) return null;
+  const a = `${kind}:${event.pubkey}:${dTag}`;
+  if (!isRecipeCoordinate(a)) return null;
+  return a;
+}
+
+function tagValue(event: NDKEvent, name: string): string | undefined {
+  const value = event.tags?.find((t) => t[0] === name)?.[1]?.trim();
+  return value || undefined;
+}
+
+function recipeTags(event: NDKEvent): string[] {
+  const tags = (event.tags || [])
+    .filter((t) => t[0] === 't' && t[1] && !META_TAG_SKIP.has(t[1]))
+    .map((t) => t[1].trim())
+    .filter(Boolean);
+  return uniqueTrim(tags, MAX_TAGS_PER_CANDIDATE);
+}
+
+function uniqueTrim(values: string[], cap: number): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of values) {
+    const v = raw.trim();
+    if (!v) continue;
+    const key = v.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(v.slice(0, 80));
+    if (out.length >= cap) break;
+  }
+  return out;
+}
+
+function ingredientNamesFromLines(lines: string[]): string[] {
+  return uniqueTrim(
+    lines.map((line) => {
+      const cleaned = line.replace(/^[-*•]\s+/, '').trim();
+      // Drop a leading quantity so Cheffy sees "chicken" not "2 lbs chicken".
+      return cleaned.replace(
+        /^\d[\d\s/.\-¼½¾⅓⅔⅛⅜⅝⅞]*\s*(?:cups?|tbsp|tsp|oz|lbs?|g|kg|ml|l|cloves?|cans?|slices?)?\s+/i,
+        ''
+      );
+    }),
+    MAX_INGREDIENTS_PER_CANDIDATE
+  );
+}
+
+function ingredientsFromEvent(event: NDKEvent): string[] {
+  const tagged: string[] = [];
+  for (const tag of event.tags || []) {
+    if (tag[0] !== 'ingredient') continue;
+    if (tag.length >= 4) tagged.push(tag[3] || tag[1]);
+    else if (tag.length >= 2) tagged.push(tag[1]);
+  }
+  if (tagged.length > 0) return ingredientNamesFromLines(tagged);
+  if (event.content) {
+    return ingredientNamesFromLines(
+      parseIngredientsFromRecipe(event.content).map((p) => p.name || p.originalText)
+    );
+  }
+  return [];
+}
+
+export function candidateFromEvent(event: NDKEvent): DiscoveredRecipe | null {
+  const a = aTagFromEvent(event);
+  if (!a) return null;
+  const title = (tagValue(event, 'title') || a.split(':')[2] || 'Recipe').slice(0, MAX_TITLE_CHARS);
+  const details = event.content ? extractRecipeDetails(event.content) : null;
+  const candidate: DiscoveredRecipe = {
+    a,
+    title,
+    tags: recipeTags(event),
+    ingredients: ingredientsFromEvent(event),
+    image: tagValue(event, 'image')
+  };
+  const prep = tagValue(event, 'prep_time') || details?.prepTime || undefined;
+  const cook = tagValue(event, 'cook_time') || details?.cookTime || undefined;
+  const servings = tagValue(event, 'servings') || details?.servings || undefined;
+  if (prep) candidate.prepTime = prep;
+  if (cook) candidate.cookTime = cook;
+  if (servings) candidate.servings = servings;
+  return candidate;
+}
+
+export function candidateFromCached(recipe: CachedRecipe): DiscoveredRecipe | null {
+  if (!isRecipeCoordinate(recipe.id) || HIDDEN_RECIPE_COORDINATES.has(recipe.id)) return null;
+  const details = recipe.content ? extractRecipeDetails(recipe.content) : null;
+  const ingredients =
+    recipe.ingredients?.length > 0
+      ? ingredientNamesFromLines(recipe.ingredients)
+      : recipe.content
+        ? ingredientNamesFromLines(
+            parseIngredientsFromRecipe(recipe.content).map((p) => p.name || p.originalText)
+          )
+        : [];
+  const tags = uniqueTrim(
+    (recipe.tags || []).filter((t) => t && !META_TAG_SKIP.has(t)),
+    MAX_TAGS_PER_CANDIDATE
+  );
+  const candidate: DiscoveredRecipe = {
+    a: recipe.id,
+    title: (recipe.title || 'Recipe').slice(0, MAX_TITLE_CHARS),
+    tags,
+    ingredients,
+    image: recipe.image
+  };
+  const prep = recipe.prepTime || details?.prepTime || undefined;
+  const cook = recipe.cookTime || details?.cookTime || undefined;
+  const servings = recipe.servings || details?.servings || undefined;
+  if (prep) candidate.prepTime = prep;
+  if (cook) candidate.cookTime = cook;
+  if (servings) candidate.servings = servings;
+  return candidate;
+}
+
+export function toWireCandidate(recipe: DiscoveredRecipe): RecipeCandidate {
+  const wire: RecipeCandidate = {
+    a: recipe.a,
+    title: recipe.title,
+    tags: recipe.tags,
+    ingredients: recipe.ingredients
+  };
+  if (recipe.prepTime) wire.prepTime = recipe.prepTime;
+  if (recipe.cookTime) wire.cookTime = recipe.cookTime;
+  if (recipe.servings) wire.servings = recipe.servings;
+  return wire;
+}
+
+/** Attach discovered recipe images onto generated meals for the preview only. */
+export function attachDiscoveredImages<T extends { a: string; image?: string }>(
+  meals: T[],
+  recipes: DiscoveredRecipe[]
+): T[] {
+  const images = new Map<string, string>();
+  for (const recipe of recipes) {
+    if (recipe.image) images.set(recipe.a, recipe.image);
+  }
+  return meals.map((meal) => {
+    const image = images.get(meal.a);
+    return image ? { ...meal, image } : meal;
+  });
+}
+
+async function resolveCoordinates(ndk: NDK, aTags: string[]): Promise<DiscoveredRecipe[]> {
+  const unique = [
+    ...new Set(aTags.filter((a) => isRecipeCoordinate(a) && !HIDDEN_RECIPE_COORDINATES.has(a)))
+  ];
+  if (unique.length === 0) return [];
+
+  const byA = new Map<string, DiscoveredRecipe>();
+  const cached = await offlineStorage.getRecipes(unique);
+  for (const c of cached) {
+    const candidate = candidateFromCached(c);
+    if (candidate) byA.set(candidate.a, candidate);
+  }
+
+  const missing = unique.filter((a) => !byA.has(a));
+  if (missing.length > 0 && ndk) {
+    await Promise.all(
+      missing.map(async (aTag) => {
+        const parts = aTag.split(':');
+        if (parts.length !== 3) return;
+        const [kind, pubkey, identifier] = parts;
+        try {
+          const event = await Promise.race([
+            ndk.fetchEvent({
+              kinds: [Number(kind)],
+              '#d': [identifier],
+              authors: [pubkey]
+            }),
+            new Promise<null>((resolve) => setTimeout(() => resolve(null), FETCH_EVENT_TIMEOUT_MS))
+          ]);
+          if (event) {
+            const candidate = candidateFromEvent(event);
+            if (candidate) {
+              byA.set(candidate.a, candidate);
+              offlineStorage.saveRecipeFromEvent(event).catch(() => {});
+            }
+          }
+        } catch (err) {
+          console.warn('[CheffyPlan] Failed to resolve', aTag, err);
+        }
+      })
+    );
+  }
+
+  return unique.map((a) => byA.get(a)).filter((c): c is DiscoveredRecipe => !!c);
+}
+
+async function fetchExploreRecipeEvents(ndk: NDK, limit = EXPLORE_LIMIT): Promise<NDKEvent[]> {
+  const filter: NDKFilter = {
+    kinds: [RECIPE_KIND],
+    '#t': RECIPE_TAGS,
+    limit
+  };
+  const byA = new Map<string, NDKEvent>();
+
+  await new Promise<void>((resolve) => {
+    const subscription = ndk.subscribe(filter, { closeOnEose: true });
+    const finish = () => {
+      try {
+        subscription.stop();
+      } catch {
+        // already stopped
+      }
+      resolve();
+    };
+    const timeout = setTimeout(finish, EXPLORE_TIMEOUT_MS);
+    subscription.on('event', (event: NDKEvent) => {
+      // Same markdown gate Explore / My Recipes use so Cheffy only
+      // sees parseable Zap Cooking recipes, not arbitrary kind:30023.
+      if (!hasValidRecipeMarkdown(event.content)) return;
+      const a = aTagFromEvent(event);
+      if (!a) return;
+      const existing = byA.get(a);
+      if (existing && (existing.created_at || 0) >= (event.created_at || 0)) return;
+      byA.set(a, event);
+    });
+    subscription.on('eose', () => {
+      clearTimeout(timeout);
+      finish();
+    });
+  });
+
+  return [...byA.values()];
+}
+
+async function loadMyRecipes(ndk: NDK, pubkey: string): Promise<DiscoveredRecipe[]> {
+  const events = await fetchMyAuthoredRecipeEvents(ndk, pubkey);
+  const out: DiscoveredRecipe[] = [];
+  for (const event of events) {
+    const candidate = candidateFromEvent(event);
+    if (candidate) {
+      out.push(candidate);
+      offlineStorage.saveRecipeFromEvent(event).catch(() => {});
+    }
+  }
+  return out;
+}
+
+async function loadSavedRecipes(ndk: NDK): Promise<DiscoveredRecipe[]> {
+  const lists = get(cookbookLists);
+  if (!lists.length) {
+    await cookbookStore.load();
+  }
+  const seen = new Set<string>();
+  const aTags: string[] = [];
+  for (const list of get(cookbookLists)) {
+    for (const a of list.recipes) {
+      if (!seen.has(a)) {
+        seen.add(a);
+        aTags.push(a);
+      }
+    }
+  }
+  return resolveCoordinates(ndk, aTags);
+}
+
+async function loadExploreRecipes(ndk: NDK): Promise<DiscoveredRecipe[]> {
+  const events = await fetchExploreRecipeEvents(ndk);
+  const out: DiscoveredRecipe[] = [];
+  for (const event of events) {
+    const candidate = candidateFromEvent(event);
+    if (candidate) {
+      out.push(candidate);
+      offlineStorage.saveRecipeFromEvent(event).catch(() => {});
+    }
+  }
+  return out;
+}
+
+function mergeByA(groups: DiscoveredRecipe[][]): DiscoveredRecipe[] {
+  const byA = new Map<string, DiscoveredRecipe>();
+  for (const group of groups) {
+    for (const recipe of group) {
+      if (!byA.has(recipe.a)) byA.set(recipe.a, recipe);
+    }
+  }
+  return [...byA.values()];
+}
+
+export async function discoverRecipesForPlanning(opts: {
+  ndk: NDK;
+  pubkey: string;
+  source: RecipeSource;
+}): Promise<DiscoveredRecipe[]> {
+  const { ndk, pubkey, source } = opts;
+  if (source === 'my-recipes') return loadMyRecipes(ndk, pubkey);
+  if (source === 'saved') return loadSavedRecipes(ndk);
+  if (source === 'explore') return loadExploreRecipes(ndk);
+
+  const [mine, saved, explore] = await Promise.all([
+    loadMyRecipes(ndk, pubkey).catch((err) => {
+      console.warn('[CheffyPlan] My recipes failed', err);
+      return [] as DiscoveredRecipe[];
+    }),
+    loadSavedRecipes(ndk).catch((err) => {
+      console.warn('[CheffyPlan] Saved recipes failed', err);
+      return [] as DiscoveredRecipe[];
+    }),
+    loadExploreRecipes(ndk).catch((err) => {
+      console.warn('[CheffyPlan] Explore recipes failed', err);
+      return [] as DiscoveredRecipe[];
+    })
+  ]);
+  return mergeByA([mine, saved, explore]);
+}

--- a/src/lib/services/recipeDiscoveryService.ts
+++ b/src/lib/services/recipeDiscoveryService.ts
@@ -180,10 +180,10 @@ export function toWireCandidate(recipe: DiscoveredRecipe): RecipeCandidate {
 }
 
 /** Attach discovered recipe images onto generated meals for the preview only. */
-export function attachDiscoveredImages<T extends { a: string; image?: string }>(
+export function attachDiscoveredImages<T extends { a: string }>(
   meals: T[],
   recipes: DiscoveredRecipe[]
-): T[] {
+): Array<T & { image?: string }> {
   const images = new Map<string, string>();
   for (const recipe of recipes) {
     if (recipe.image) images.set(recipe.a, recipe.image);

--- a/src/lib/stores/plannerStore.test.ts
+++ b/src/lib/stores/plannerStore.test.ts
@@ -250,3 +250,85 @@ describe('dirty-week protection', () => {
     expect(saveMealPlan.mock.calls[0][0].days.mon.slots.dinner.text).toBe('Soup');
   });
 });
+
+describe('applyGeneratedPlan', () => {
+  it('writes every meal in one scheduled save', async () => {
+    await plannerStore.goToWeek(W29);
+
+    expect(
+      plannerStore.applyGeneratedPlan(W29, [
+        { day: 'mon', slot: 'dinner', a: '30023:pk:salmon', title: 'Salmon' },
+        { day: 'tue', slot: 'dinner', a: '30023:pk:pasta', title: 'Pasta' }
+      ])
+    ).toBe(true);
+
+    expect(saveMealPlan).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(saveMealPlan).toHaveBeenCalledTimes(1);
+    const saved = saveMealPlan.mock.calls[0][0];
+    expect(saved.days.mon.slots.dinner).toEqual({
+      type: 'recipe',
+      a: '30023:pk:salmon',
+      title: 'Salmon'
+    });
+    expect(saved.days.tue.slots.dinner).toEqual({
+      type: 'recipe',
+      a: '30023:pk:pasta',
+      title: 'Pasta'
+    });
+  });
+
+  it('fill-empty skips occupied slots and replace-selected overwrites them', async () => {
+    await plannerStore.goToWeek(W29);
+    plannerStore.setSlot(W29, 'mon', 'dinner', { type: 'text', text: 'Leftovers' });
+
+    expect(
+      plannerStore.applyGeneratedPlan(
+        W29,
+        [
+          { day: 'mon', slot: 'dinner', a: '30023:pk:salmon', title: 'Salmon' },
+          { day: 'tue', slot: 'dinner', a: '30023:pk:pasta', title: 'Pasta' }
+        ],
+        'fill-empty'
+      )
+    ).toBe(true);
+
+    let week = get(plannerStore).weeks[W29];
+    expect(week.status).toBe('ok');
+    if (week.status !== 'ok') return;
+    expect(week.plan.days.mon?.slots?.dinner).toEqual({ type: 'text', text: 'Leftovers' });
+    expect(week.plan.days.tue?.slots?.dinner).toEqual({
+      type: 'recipe',
+      a: '30023:pk:pasta',
+      title: 'Pasta'
+    });
+
+    expect(
+      plannerStore.applyGeneratedPlan(
+        W29,
+        [{ day: 'mon', slot: 'dinner', a: '30023:pk:salmon', title: 'Salmon' }],
+        'replace-selected'
+      )
+    ).toBe(true);
+    week = get(plannerStore).weeks[W29];
+    if (week.status !== 'ok') return;
+    expect(week.plan.days.mon?.slots?.dinner).toEqual({
+      type: 'recipe',
+      a: '30023:pk:salmon',
+      title: 'Salmon'
+    });
+  });
+
+  it('returns false when every selected slot is already filled under fill-empty', async () => {
+    await plannerStore.goToWeek(W29);
+    plannerStore.setSlot(W29, 'mon', 'dinner', { type: 'text', text: 'Tacos' });
+
+    expect(
+      plannerStore.applyGeneratedPlan(
+        W29,
+        [{ day: 'mon', slot: 'dinner', a: '30023:pk:salmon', title: 'Salmon' }],
+        'fill-empty'
+      )
+    ).toBe(false);
+  });
+});

--- a/src/lib/stores/plannerStore.ts
+++ b/src/lib/stores/plannerStore.ts
@@ -28,7 +28,14 @@ import {
   deleteMealPlan,
   type MealPlanFetchResult
 } from '$lib/services/plannerService';
-import { createEmptyMealPlan, type MealPlan, type MealPlanDay, type MealPlanDayKey, type MealSlot, type MealSlotKey } from '$lib/mealplan/schema';
+import {
+  createEmptyMealPlan,
+  type MealPlan,
+  type MealPlanDay,
+  type MealPlanDayKey,
+  type MealSlot,
+  type MealSlotKey
+} from '$lib/mealplan/schema';
 import { currentWeekId, isValidWeekId, nextWeekId, prevWeekId } from '$lib/mealplan/week';
 
 export type PlannerWeekState =
@@ -270,6 +277,45 @@ function createPlannerStore() {
       return mutatePlan(weekId, (plan) =>
         withDay(plan, day, (d) => ({ ...d, slots: { ...d.slots, [slot]: entry } }))
       );
+    },
+
+    /**
+     * Apply an approved Cheffy plan in one mutation / one scheduled save.
+     * `fill-empty` skips slots that already have a meal; `replace-selected`
+     * writes every provided slot. Preferences are not stored on the plan.
+     */
+    applyGeneratedPlan(
+      weekId: string,
+      meals: Array<{ day: MealPlanDayKey; slot: MealSlotKey; a: string; title: string }>,
+      strategy: 'fill-empty' | 'replace-selected' = 'fill-empty'
+    ): boolean {
+      if (!meals.length) return false;
+      const weekState = get({ subscribe }).weeks[weekId];
+      if (!weekState || weekState.status !== 'ok' || weekState.readOnly) {
+        return false;
+      }
+
+      const applicable = meals.filter((meal) => {
+        if (strategy === 'fill-empty') {
+          return !weekState.plan.days[meal.day]?.slots?.[meal.slot];
+        }
+        return true;
+      });
+      if (applicable.length === 0) return false;
+
+      return mutatePlan(weekId, (plan) => {
+        let next = plan;
+        for (const meal of applicable) {
+          next = withDay(next, meal.day, (d) => ({
+            ...d,
+            slots: {
+              ...d.slots,
+              [meal.slot]: { type: 'recipe' as const, a: meal.a, title: meal.title }
+            }
+          }));
+        }
+        return next;
+      });
     },
 
     clearSlot(weekId: string, day: MealPlanDayKey, slot: MealSlotKey): boolean {

--- a/src/routes/api/zappy/meal-plan/+server.ts
+++ b/src/routes/api/zappy/meal-plan/+server.ts
@@ -1,0 +1,326 @@
+/**
+ * Cheffy structured meal-planning API.
+ *
+ * POST /api/zappy/meal-plan
+ *
+ * Cheffy selects from the candidate recipes the client already discovered
+ * on Nostr. It does not invent recipes. Unknown coordinates are rejected.
+ *
+ * Requires NIP-98 HTTP auth. Included with any active membership.
+ * Preferences in the request are ephemeral — they are never persisted
+ * into the meal-plan schema.
+ */
+
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import { verifyNip98 } from '$lib/nip98.server';
+import { checkPerIpRateLimit } from '$lib/ipRateLimit.server';
+import { CHEFFY_VOICE_BLOCK } from '$lib/cheffyPrompt.server';
+import { DAY_KEYS, SLOT_KEYS, type MealPlanDayKey } from '$lib/mealplan/schema';
+import {
+  MAX_CANDIDATES,
+  parseGenerationRequest,
+  resolveTargetSlots,
+  validateGeneratedMealPlan,
+  type MealPlanGenerationRequest,
+  type RecipeCandidate
+} from '$lib/mealplan/generation';
+import {
+  isRecipeEligibleForSlot,
+  noEligibleRecipesMessage,
+  restrictCandidatesToRequestedSlots
+} from '$lib/mealplan/slotEligibility';
+
+const PER_HOUR = 10;
+const PER_DAY = 30;
+const MAX_TOKENS = 1200;
+
+const DAY_LABELS: Record<MealPlanDayKey, string> = {
+  mon: 'Monday',
+  tue: 'Tuesday',
+  wed: 'Wednesday',
+  thu: 'Thursday',
+  fri: 'Friday',
+  sat: 'Saturday',
+  sun: 'Sunday'
+};
+
+const SLOT_LABELS: Record<(typeof SLOT_KEYS)[number], string> = {
+  breakfast: 'Breakfast',
+  lunch: 'Lunch',
+  dinner: 'Dinner',
+  snack: 'Snack'
+};
+
+const MEAL_PLAN_SYSTEM = `You are Cheffy, the kitchen companion inside Zap Cooking. You are filling a weekly meal planner using ONLY the candidate recipes supplied in the user message.
+
+${CHEFFY_VOICE_BLOCK}
+
+HARD RULES
+- Select recipes only from the supplied candidate list. Never invent a recipe, title, coordinate, or source.
+- The "a" field in your response MUST be copied exactly from a candidate.
+- Fill each requested day/slot at most once.
+- Every assigned recipe must be appropriate for the requested meal slot. Breakfast slots must contain breakfast- or brunch-appropriate recipes. Do not place normal lunch or dinner entrees into breakfast slots.
+- If a breakfast-eligible list is provided, breakfast slots may use ONLY those coordinates.
+- Prefer variety across the week unless the user asked for repeats or leftovers.
+- Honor excluded ingredients, time limits, servings, style chips, and free-text notes when the candidates allow it.
+- If there are not enough candidates, fill as many requested slots as you reasonably can. Do not pad with invented recipes or with recipes that do not fit the slot.
+- Keep each reason to one short sentence.
+
+You return structured JSON only.`;
+
+function candidateLine(c: RecipeCandidate): string {
+  const bits = [`a=${c.a}`, `title=${c.title}`];
+  if (c.tags.length) bits.push(`tags=${c.tags.join(', ')}`);
+  if (c.prepTime) bits.push(`prep=${c.prepTime}`);
+  if (c.cookTime) bits.push(`cook=${c.cookTime}`);
+  if (c.servings) bits.push(`servings=${c.servings}`);
+  if (c.ingredients.length) bits.push(`ingredients=${c.ingredients.join(', ')}`);
+  return `- ${bits.join(' | ')}`;
+}
+
+function buildUserPrompt(req: MealPlanGenerationRequest): string {
+  const targets = resolveTargetSlots(req);
+  const slots = targets.map((t) => `${DAY_LABELS[t.day]} ${SLOT_LABELS[t.slot]}`).join(', ');
+  const prefs = req.preferences;
+  const lines = [
+    `Week: ${req.weekId}`,
+    `Strategy: ${req.strategy === 'fill-empty' ? 'Fill empty slots only. Do not replace existing meals.' : 'Replace the selected slots.'}`,
+    `Slots to fill: ${slots}`
+  ];
+  if (prefs.styles.length) lines.push(`Styles: ${prefs.styles.join(', ')}`);
+  if (prefs.maxMinutes) lines.push(`Maximum cooking time: ${prefs.maxMinutes} minutes`);
+  if (prefs.servings) lines.push(`Servings: about ${prefs.servings}`);
+  if (prefs.excludeIngredients?.length) {
+    lines.push(`Avoid ingredients: ${prefs.excludeIngredients.join(', ')}`);
+  }
+  if (prefs.notes) lines.push(`Notes: ${prefs.notes}`);
+  if (req.excludeCoordinates?.length) {
+    lines.push(`Do not reuse these coordinates: ${req.excludeCoordinates.join(', ')}`);
+  }
+  const targetSlots = [...new Set(targets.map((t) => t.slot))];
+  if (targetSlots.includes('breakfast')) {
+    const breakfastAs = req.candidates
+      .filter((c) => isRecipeEligibleForSlot(c, 'breakfast'))
+      .map((c) => c.a);
+    lines.push(
+      `Breakfast-eligible coordinates (use ONLY these for breakfast slots): ${
+        breakfastAs.length ? breakfastAs.join(', ') : '(none)'
+      }`
+    );
+  }
+  lines.push(
+    '',
+    `Candidate recipes (${req.candidates.length}):`,
+    ...req.candidates.map(candidateLine)
+  );
+  lines.push('', 'Assign one candidate to each slot you can fill. Copy each coordinate exactly.');
+  return lines.join('\n');
+}
+
+function jsonSchemaFor(days: string[], slots: string[], candidateAs: string[]) {
+  const dayEnum = days.length ? days : [...DAY_KEYS];
+  const slotEnum = slots.length ? slots : [...SLOT_KEYS];
+  const aEnum = candidateAs.slice(0, MAX_CANDIDATES);
+  return {
+    name: 'generated_meal_plan',
+    strict: true,
+    schema: {
+      type: 'object',
+      properties: {
+        meals: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              day: { type: 'string', enum: dayEnum },
+              slot: { type: 'string', enum: slotEnum },
+              a: { type: 'string', enum: aEnum },
+              title: { type: 'string' },
+              reason: { type: 'string' }
+            },
+            required: ['day', 'slot', 'a', 'title', 'reason'],
+            additionalProperties: false
+          }
+        }
+      },
+      required: ['meals'],
+      additionalProperties: false
+    }
+  };
+}
+
+async function callOpenAi(opts: {
+  apiKey: string;
+  userPrompt: string;
+  days: string[];
+  slots: string[];
+  candidateAs: string[];
+}): Promise<{ ok: true; plan: unknown } | { ok: false; error: string }> {
+  const messages = [
+    { role: 'system', content: MEAL_PLAN_SYSTEM },
+    { role: 'user', content: opts.userPrompt }
+  ];
+  const schema = jsonSchemaFor(opts.days, opts.slots, opts.candidateAs);
+
+  const attempt = async (responseFormat: unknown) => {
+    const openaiResponse = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${opts.apiKey}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-4.1-mini',
+        messages,
+        max_tokens: MAX_TOKENS,
+        temperature: 0.4,
+        response_format: responseFormat
+      })
+    });
+    return openaiResponse;
+  };
+
+  let openaiResponse = await attempt({ type: 'json_schema', json_schema: schema });
+  if (!openaiResponse.ok) {
+    const firstErr = await openaiResponse.json().catch(() => ({}));
+    console.warn('[Cheffy meal-plan] json_schema rejected, falling back to json_object', firstErr);
+    openaiResponse = await attempt({ type: 'json_object' });
+  }
+
+  if (!openaiResponse.ok) {
+    const errorData = await openaiResponse.json().catch(() => ({}));
+    console.error('[Cheffy meal-plan] OpenAI API error:', errorData);
+    return { ok: false, error: 'Cheffy could not finish that plan. Please try again.' };
+  }
+
+  const openaiData = await openaiResponse.json();
+  const output = openaiData.choices?.[0]?.message?.content;
+  if (!output || typeof output !== 'string') {
+    return { ok: false, error: 'Cheffy went quiet for a second. Please try again.' };
+  }
+
+  try {
+    return { ok: true, plan: JSON.parse(output) };
+  } catch {
+    return { ok: false, error: 'Cheffy returned a plan that could not be read. Please try again.' };
+  }
+}
+
+export const POST: RequestHandler = async ({ request, getClientAddress, platform }) => {
+  try {
+    const OPENAI_API_KEY = (platform?.env as any)?.OPENAI_API_KEY || env.OPENAI_API_KEY;
+    if (!OPENAI_API_KEY) {
+      return json({ ok: false, error: 'OpenAI API key not configured' }, { status: 500 });
+    }
+
+    let bodyBytes: Uint8Array;
+    try {
+      bodyBytes = new Uint8Array(await request.arrayBuffer());
+    } catch {
+      return json({ ok: false, error: 'Invalid request body' }, { status: 400 });
+    }
+
+    let body: unknown;
+    try {
+      body = JSON.parse(new TextDecoder().decode(bodyBytes));
+    } catch {
+      return json({ ok: false, error: 'Invalid request body' }, { status: 400 });
+    }
+
+    const parsed = parseGenerationRequest(body);
+    if (!parsed.ok) {
+      return json({ ok: false, error: parsed.message, code: parsed.error }, { status: 400 });
+    }
+
+    const verification = await verifyNip98(request, { bodyBytes });
+    if (!verification.ok) {
+      console.warn(`[Cheffy meal-plan] NIP-98 rejected (${verification.reason})`);
+      return json({ ok: false, error: 'Authentication required' }, { status: 401 });
+    }
+    const pubkey = verification.pubkey;
+
+    const MEMBERSHIP_ENABLED = platform?.env?.MEMBERSHIP_ENABLED || env.MEMBERSHIP_ENABLED;
+    if (MEMBERSHIP_ENABLED?.toLowerCase() === 'true') {
+      const API_SECRET = platform?.env?.RELAY_API_SECRET || env.RELAY_API_SECRET;
+      if (API_SECRET) {
+        try {
+          const { hasActiveMembership } = await import('$lib/membershipApi.server');
+          const isActive = await hasActiveMembership(pubkey, API_SECRET);
+          if (!isActive) {
+            return json(
+              { ok: false, error: 'Cheffy is available to Cook+ members.', code: 'NOT_MEMBER' },
+              { status: 403 }
+            );
+          }
+        } catch (err) {
+          console.error('[Cheffy meal-plan] Error checking membership:', err);
+          // Fail open for membership-service outages, matching Cheffy chat/scan.
+          // Unauthenticated callers never get this far (401 above).
+        }
+      }
+    }
+
+    let ip = '127.0.0.1';
+    try {
+      ip = getClientAddress();
+    } catch {
+      // Local dev / missing CF headers.
+    }
+    const kv = platform?.env?.NOURISH_FLAGS;
+    if (!kv) {
+      console.warn('[Cheffy meal-plan] NOURISH_FLAGS KV not bound — rate limiting is disabled');
+    }
+    const rl = await checkPerIpRateLimit(kv, {
+      ip,
+      scope: 'zappy-meal-plan',
+      perHour: PER_HOUR,
+      perDay: PER_DAY
+    });
+    if (rl.limited) {
+      return json(
+        {
+          ok: false,
+          code: 'RATE_LIMITED',
+          error: 'Cheffy is a little busy. Try again in a bit.',
+          retryAfter: rl.body.retryAfter
+        },
+        { status: 429 }
+      );
+    }
+
+    const targets = resolveTargetSlots(parsed.request);
+    const targetSlots = [...new Set(targets.map((t) => t.slot))];
+    const restricted = restrictCandidatesToRequestedSlots(parsed.request.candidates, targetSlots);
+    if (restricted.length === 0) {
+      return json(
+        { ok: false, error: noEligibleRecipesMessage(targetSlots), code: 'no-candidates' },
+        { status: 400 }
+      );
+    }
+    const generationRequest = { ...parsed.request, candidates: restricted };
+
+    const result = await callOpenAi({
+      apiKey: OPENAI_API_KEY,
+      userPrompt: buildUserPrompt(generationRequest),
+      days: [...new Set(targets.map((t) => t.day))],
+      slots: targetSlots,
+      candidateAs: generationRequest.candidates.map((c) => c.a)
+    });
+    if (!result.ok) {
+      return json({ ok: false, error: result.error }, { status: 500 });
+    }
+
+    const validated = validateGeneratedMealPlan(result.plan, generationRequest);
+    if (!validated.ok) {
+      console.warn('[Cheffy meal-plan] Rejected model output:', validated.error);
+      return json({ ok: false, error: validated.message, code: validated.error }, { status: 422 });
+    }
+
+    return json({ ok: true, plan: validated.plan });
+  } catch (error: unknown) {
+    console.error('[Cheffy meal-plan] Error:', error);
+    const message = error instanceof Error ? error.message : 'An unexpected error occurred';
+    return json({ ok: false, error: message }, { status: 500 });
+  }
+};

--- a/src/routes/api/zappy/meal-plan/mealPlan.test.ts
+++ b/src/routes/api/zappy/meal-plan/mealPlan.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Unit tests for POST /api/zappy/meal-plan.
+ *
+ * Auth, membership, and OpenAI are mocked. Request parsing, Cheffy
+ * coordinate validation, fill-empty overwrite rejection, and rate-limit
+ * ordering run for real.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from './+server';
+
+const mocks = vi.hoisted(() => ({
+  verifyNip98: vi.fn(),
+  hasActiveMembership: vi.fn(),
+  checkPerIpRateLimit: vi.fn()
+}));
+
+vi.mock('$lib/nip98.server', () => ({ verifyNip98: mocks.verifyNip98 }));
+vi.mock('$lib/membershipApi.server', () => ({ hasActiveMembership: mocks.hasActiveMembership }));
+vi.mock('$lib/ipRateLimit.server', () => ({ checkPerIpRateLimit: mocks.checkPerIpRateLimit }));
+
+const PUBKEY = 'a'.repeat(64);
+const CLIENT_IP = '203.0.113.7';
+const ENDPOINT = 'https://zap.cooking/api/zappy/meal-plan';
+const fetchMock = vi.fn();
+
+function openaiPlan(meals: unknown[]) {
+  return {
+    ok: true,
+    json: async () => ({
+      choices: [{ message: { content: JSON.stringify({ meals }) } }]
+    })
+  };
+}
+
+function makeEvent(body: unknown, opts: { env?: Record<string, unknown> | null } = {}) {
+  const request = new Request(new URL(ENDPOINT), {
+    method: 'POST',
+    headers: { Authorization: 'Nostr fake' },
+    body: JSON.stringify(body)
+  });
+  const env =
+    opts.env === null
+      ? {}
+      : (opts.env ?? {
+          OPENAI_API_KEY: 'test-key',
+          MEMBERSHIP_ENABLED: 'true',
+          RELAY_API_SECRET: 'secret',
+          NOURISH_FLAGS: { kv: true }
+        });
+  return {
+    request,
+    platform: { env },
+    getClientAddress: () => CLIENT_IP
+  } as any;
+}
+
+async function call(body: unknown, opts: { env?: Record<string, unknown> | null } = {}) {
+  const res = await POST(makeEvent(body, opts));
+  return { res, data: await res.json() };
+}
+
+function validBody(overrides: Record<string, unknown> = {}) {
+  return {
+    weekId: '2026-W34',
+    days: ['mon', 'tue'],
+    mealSlots: ['dinner'],
+    strategy: 'fill-empty',
+    candidates: [
+      {
+        a: '30023:pk:salmon',
+        title: 'Mediterranean Salmon',
+        tags: ['mediterranean'],
+        ingredients: ['salmon']
+      },
+      { a: '30023:pk:pasta', title: 'Lemon Pasta', tags: ['easy'], ingredients: ['pasta'] }
+    ],
+    occupiedSlots: [],
+    ...overrides
+  };
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock);
+  fetchMock.mockReset().mockResolvedValue(
+    openaiPlan([
+      {
+        day: 'mon',
+        slot: 'dinner',
+        a: '30023:pk:salmon',
+        title: 'Mediterranean Salmon',
+        reason: 'Fits the brief.'
+      },
+      {
+        day: 'tue',
+        slot: 'dinner',
+        a: '30023:pk:pasta',
+        title: 'Lemon Pasta',
+        reason: 'Easy Tuesday.'
+      }
+    ])
+  );
+  mocks.verifyNip98.mockReset().mockResolvedValue({ ok: true, pubkey: PUBKEY });
+  mocks.hasActiveMembership.mockReset().mockResolvedValue(true);
+  mocks.checkPerIpRateLimit.mockReset().mockResolvedValue({ limited: false, ipHash: 'x' });
+});
+
+describe('auth and membership', () => {
+  it('rejects an invalid NIP-98 signature before calling OpenAI', async () => {
+    mocks.verifyNip98.mockResolvedValue({ ok: false, reason: 'invalid-signature' });
+    const { res, data } = await call(validBody());
+    expect(res.status).toBe(401);
+    expect(data.ok).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('checks membership against the verified pubkey', async () => {
+    await call(validBody());
+    expect(mocks.hasActiveMembership).toHaveBeenCalledWith(PUBKEY, 'secret');
+  });
+
+  it('returns 403 for a verified non-member', async () => {
+    mocks.hasActiveMembership.mockResolvedValue(false);
+    const { res, data } = await call(validBody());
+    expect(res.status).toBe(403);
+    expect(data.code).toBe('NOT_MEMBER');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rate-limits below the membership gate and above OpenAI', async () => {
+    mocks.checkPerIpRateLimit.mockResolvedValue({
+      limited: true,
+      ipHash: 'x',
+      body: { error: 'rate_limited', retryAfter: 60, scope: 'per-hour' }
+    });
+    const { res, data } = await call(validBody());
+    expect(res.status).toBe(429);
+    expect(data.code).toBe('RATE_LIMITED');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('request validation', () => {
+  it('rejects a request with no candidates before OpenAI', async () => {
+    const { res } = await call(validBody({ candidates: [] }));
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('structured plan validation', () => {
+  it('returns a plan whose titles come from the candidate set', async () => {
+    const { res, data } = await call(validBody());
+    expect(res.status).toBe(200);
+    expect(data.ok).toBe(true);
+    expect(data.plan.meals).toHaveLength(2);
+    expect(data.plan.meals[0].a).toBe('30023:pk:salmon');
+    expect(data.plan.meals[0].title).toBe('Mediterranean Salmon');
+  });
+
+  it('rejects a hallucinated recipe coordinate', async () => {
+    fetchMock.mockResolvedValue(
+      openaiPlan([
+        {
+          day: 'mon',
+          slot: 'dinner',
+          a: '30023:pk:ghost-stew',
+          title: 'Ghost Stew',
+          reason: 'Invented.'
+        }
+      ])
+    );
+    const { res, data } = await call(validBody());
+    expect(res.status).toBe(422);
+    expect(data.ok).toBe(false);
+    expect(data.code).toBe('unknown-recipe');
+  });
+
+  it('rejects fill-empty overwrites of occupied slots', async () => {
+    fetchMock.mockResolvedValue(
+      openaiPlan([
+        {
+          day: 'mon',
+          slot: 'dinner',
+          a: '30023:pk:salmon',
+          title: 'Mediterranean Salmon',
+          reason: 'Nope.'
+        }
+      ])
+    );
+    const { res, data } = await call(
+      validBody({ occupiedSlots: [{ day: 'mon', slot: 'dinner' }], days: ['mon', 'tue'] })
+    );
+    expect(res.status).toBe(422);
+    expect(data.code).toBe('overwrite-occupied');
+  });
+
+  it('rejects a breakfast assignment of a dinner entree that is in the candidate set', async () => {
+    fetchMock.mockResolvedValue(
+      openaiPlan([
+        {
+          day: 'mon',
+          slot: 'breakfast',
+          a: '30023:pk:salmon',
+          title: 'Mediterranean Salmon',
+          reason: 'Protein.'
+        }
+      ])
+    );
+    const { res, data } = await call(
+      validBody({
+        days: ['mon'],
+        mealSlots: ['breakfast', 'dinner'],
+        candidates: [
+          {
+            a: '30023:pk:salmon',
+            title: 'Mediterranean Salmon',
+            tags: ['dinner'],
+            ingredients: ['salmon']
+          },
+          {
+            a: '30023:pk:oats',
+            title: 'Overnight Oats',
+            tags: ['breakfast'],
+            ingredients: ['oats']
+          }
+        ]
+      })
+    );
+    expect(res.status).toBe(422);
+    expect(data.code).toBe('ineligible-slot');
+  });
+
+  it('does not send dinner recipes to the model for a breakfast-only request', async () => {
+    fetchMock.mockResolvedValue(
+      openaiPlan([
+        {
+          day: 'mon',
+          slot: 'breakfast',
+          a: '30023:pk:oats',
+          title: 'Overnight Oats',
+          reason: 'Breakfast.'
+        }
+      ])
+    );
+    const { res, data } = await call(
+      validBody({
+        days: ['mon'],
+        mealSlots: ['breakfast'],
+        candidates: [
+          {
+            a: '30023:pk:salmon',
+            title: 'Mediterranean Salmon',
+            tags: ['dinner'],
+            ingredients: ['salmon']
+          },
+          {
+            a: '30023:pk:oats',
+            title: 'Overnight Oats',
+            tags: ['breakfast'],
+            ingredients: ['oats']
+          }
+        ]
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(data.ok).toBe(true);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    const enumAs =
+      body.response_format?.json_schema?.schema?.properties?.meals?.items?.properties?.a?.enum;
+    expect(enumAs).toEqual(['30023:pk:oats']);
+  });
+});

--- a/src/routes/my-kitchen/planner/+page.svelte
+++ b/src/routes/my-kitchen/planner/+page.svelte
@@ -31,6 +31,7 @@
   import { lazyLoad } from '$lib/lazyLoad';
   import Modal from '../../../components/Modal.svelte';
   import RecipePickerModal from '../../../components/RecipePickerModal.svelte';
+  import CheffyPlanModal from '../../../components/planner/CheffyPlanModal.svelte';
   import { groceryStore } from '$lib/stores/groceryStore';
   import { parseIngredient, parseIngredientsFromRecipe } from '$lib/utils/ingredientParser';
   import {
@@ -48,6 +49,8 @@
   import LockIcon from 'phosphor-svelte/lib/Lock';
   import PlusIcon from 'phosphor-svelte/lib/Plus';
   import NotePencilIcon from 'phosphor-svelte/lib/NotePencil';
+  import CheffyIcon from '../../../components/icons/CheffyIcon.svelte';
+  import { occupiedSlotsFromPlan } from '$lib/mealplan/generation';
   import { addDays, format } from 'date-fns';
 
   const DAY_LABELS: Record<MealPlanDayKey, string> = {
@@ -127,6 +130,7 @@
 
   // ── Recipe picker (PR10) — fills the slot editor's seam ──
   let pickerOpen = false;
+  let cheffyPlanOpen = false;
 
   function openRecipePicker() {
     // Keep editorDay/editorSlot as the target; swap modals
@@ -154,6 +158,8 @@
   } | null = null;
 
   $: weekRecipeSlots = weekPlan ? collectWeekRecipeSlots(weekPlan) : null;
+  $: cheffyOccupiedSlots =
+    weekPlan && !isReadOnly ? occupiedSlotsFromPlan(weekPlan, [...DAY_KEYS], [...SLOT_KEYS]) : [];
 
   function openGenerateConfirm() {
     generationSummary = null;
@@ -423,6 +429,16 @@
         {#if $plannerSaving}
           <span class="text-xs text-caption">Saving…</span>
         {/if}
+        {#if weekPlan && !isReadOnly && !isDecryptFailed}
+          <button
+            type="button"
+            on:click={() => (cheffyPlanOpen = true)}
+            class="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium text-white bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 transition-all"
+          >
+            <CheffyIcon size={20} expression="happy" />
+            <span>Plan with Cheffy</span>
+          </button>
+        {/if}
         {#if weekPlan && weekRecipeSlots}
           <button
             type="button"
@@ -490,7 +506,8 @@
           role="status"
         >
           <LockIcon size={16} class="text-orange-500 flex-shrink-0" />
-          <span>This week was created by a newer version of Zap Cooking and is read-only here.</span>
+          <span>This week was created by a newer version of Zap Cooking and is read-only here.</span
+          >
         </div>
       {/if}
 
@@ -503,7 +520,17 @@
           <h2 class="text-base font-semibold" style="color: var(--color-text-primary);">
             Nothing planned this week
           </h2>
-          <p class="text-sm text-caption max-w-sm">Tap any slot below to plan a meal.</p>
+          <p class="text-sm text-caption max-w-sm">
+            Tap any slot below, or let Cheffy fill the week from real Zap Cooking recipes.
+          </p>
+          <button
+            type="button"
+            on:click={() => (cheffyPlanOpen = true)}
+            class="mt-2 flex items-center gap-1.5 px-4 py-2 rounded-full text-sm font-medium text-white bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 transition-all"
+          >
+            <CheffyIcon size={20} expression="happy" />
+            Plan with Cheffy
+          </button>
         </div>
       {/if}
 
@@ -531,7 +558,9 @@
           {@const isToday = isViewingCurrentWeek && day === todayDayKey()}
           <section
             id="planner-day-{day}"
-            class="rounded-2xl p-3 flex flex-col gap-2 scroll-mt-20 {isToday ? 'planner-today' : ''}"
+            class="rounded-2xl p-3 flex flex-col gap-2 scroll-mt-20 {isToday
+              ? 'planner-today'
+              : ''}"
             style="background-color: var(--color-input-bg); border: 1px solid {isToday
               ? 'rgb(249 115 22 / 0.6)'
               : 'var(--color-input-border)'};"
@@ -715,6 +744,13 @@
   on:select={handleRecipePicked}
 />
 
+<CheffyPlanModal
+  bind:open={cheffyPlanOpen}
+  weekId={$plannerCurrentWeekId}
+  occupiedSlots={cheffyOccupiedSlots}
+  readOnly={isReadOnly}
+/>
+
 <!-- Generate-grocery confirm: pre-generation summary of what will happen -->
 <Modal bind:open={generateConfirmOpen} compact>
   <h1 slot="title">Generate grocery list</h1>
@@ -730,8 +766,8 @@
           : ''}.
       </p>
       <p class="text-xs text-caption">
-        Matching items are combined only when name and quantity are identical. Repeat runs create
-        a new list — existing lists are never changed.
+        Matching items are combined only when name and quantity are identical. Repeat runs create a
+        new list — existing lists are never changed.
       </p>
       {#if generationSummary && generationSummary.unresolved.length > 0}
         <p class="text-xs text-red-500">


### PR DESCRIPTION
## Summary
- Adds **Plan with Cheffy** on My Kitchen → Planner: discover real Nostr recipes, filter them, have Cheffy fill a structured week, preview (with thumbnails), then one bulk write into the planner.
- Breakfast is a hard eligibility rule (tags first, title fallback). Lunch/dinner stay permissive. Too few breakfast matches leaves slots empty instead of filling them with dinner entrees.
- Server validation rejects any breakfast assignment that fails eligibility; the model cannot override that. Shared Android/Web meal-plan schema is unchanged.

## Test plan
- [ ] Plan breakfast only from a mixed library — only breakfast/brunch recipes appear
- [ ] Request 7 breakfasts with ~3 eligible recipes — partial week + “broaden your preferences” copy
- [ ] Confirm lunch/dinner still accept normal entrees
- [ ] Confirm max time, excluded ingredients, and vegetarian still apply on top of breakfast eligibility
- [ ] Preview shows recipe thumbnails; View / Swap / Remove work
- [ ] Approve a preview and confirm one planner write (fill-empty does not overwrite)
- [ ] Confirm grocery list still builds from recipe `a` tags
- [ ] Cook+ gate and NIP-98 auth still required


Made with [Cursor](https://cursor.com)