### PR TITLE
Make pantry useful for cooking, Cheffy, and grocery

### DIFF
--- a/docs/pantry-contract.md
+++ b/docs/pantry-contract.md
@@ -31,6 +31,7 @@ addressable-event rules (newest `created_at` wins).
       "name": "Eggs",
       "normalizedName": "egg",
       "quantity": 8,
+      "isStaple": true,
       "createdAt": 1789000000,
       "updatedAt": 1789000000
     }
@@ -43,11 +44,21 @@ addressable-event rules (newest `created_at` wins).
 `quantity` and `unit` are optional. Absence means “I have this” without tracking
 how much.
 
+`isStaple` is optional. When true, the ingredient is a household staple: it
+stays in the pantry until the user removes it, and grocery generation treats it
+as already owned (presence-only), even if a quantity is also stored.
+
+Optional item fields may be added in schemaVersion 1 as long as they are ignored
+when absent. Unknown fields on items SHOULD be preserved by readers that rewrite
+the pantry, so later clients can add expiration dates, barcodes, and similar
+without a schema bump.
+
 Readers encountering `schemaVersion > 1` MUST treat the pantry as **read-only**.
 
 ## Grocery quantity policy (v1)
 
 - Name match is required.
+- A staple (`isStaple: true`) is presence-only → treated as already owned.
 - A pantry item **without** a quantity is presence-only → treated as already owned.
 - If both sides have a comparable numeric quantity in the **same unit family**,
   compare amounts. Insufficient pantry amount stays on the grocery list.

--- a/docs/pantry-contract.md
+++ b/docs/pantry-contract.md
@@ -1,0 +1,56 @@
+# Pantry Event Contract (v1)
+
+Private ingredients the user already has at home. This contract is **independent**
+of the frozen meal-plan schema (`docs/mealplan-contract.md`) and of grocery lists.
+Do not add pantry fields to meal-plan payloads.
+
+## Event envelope
+
+| Field   | Value                                                             |
+| ------- | ----------------------------------------------------------------- |
+| kind    | `30078` (NIP-78 application-specific data)                        |
+| d-tag   | `pantry` (one replaceable list per user)                          |
+| tags    | `['d', 'pantry']` and `['client', 'Zap Cooking']` only            |
+| content | NIP-44 self-encrypted JSON (encrypted to the author's own pubkey) |
+
+Ingredient names **must not** appear as plaintext Nostr tags.
+
+### Replacement
+
+Saving publishes a new event with the same d-tag. Relays replace per NIP-01
+addressable-event rules (newest `created_at` wins).
+
+## Encrypted payload (schemaVersion 1)
+
+```json
+{
+  "schemaVersion": 1,
+  "items": [
+    {
+      "id": "m5abc-x2k9",
+      "name": "Eggs",
+      "normalizedName": "egg",
+      "quantity": 8,
+      "createdAt": 1789000000,
+      "updatedAt": 1789000000
+    }
+  ],
+  "createdAt": 1789000000,
+  "updatedAt": 1789000123
+}
+```
+
+`quantity` and `unit` are optional. Absence means “I have this” without tracking
+how much.
+
+Readers encountering `schemaVersion > 1` MUST treat the pantry as **read-only**.
+
+## Grocery quantity policy (v1)
+
+- Name match is required.
+- A pantry item **without** a quantity is presence-only → treated as already owned.
+- If both sides have a comparable numeric quantity in the **same unit family**,
+  compare amounts. Insufficient pantry amount stays on the grocery list.
+- Mixed or unparseable units are **uncertain** and stay on the grocery list.
+- Pantry inventory is **never** auto-decremented when meals are planned or
+  groceries are generated.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.713",
+  "version": "4.2.714",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.714",
+  "version": "4.2.715",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.712",
+  "version": "4.2.713",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.715",
+  "version": "4.2.716",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/Recipe/Ingredients.svelte
+++ b/src/components/Recipe/Ingredients.svelte
@@ -2,6 +2,9 @@
   import { onMount } from 'svelte';
   import { browser } from '$app/environment';
   import { scaleIngredientLine } from '$lib/ingredientScaling';
+  import { userPublickey } from '$lib/nostr';
+  import { pantryStore, pantryItems, pantryInitialized } from '$lib/stores/pantryStore';
+  import { findMatchingPantryItem, matchRecipeToPantry, pantryNeededSummary } from '$lib/pantry/matching';
 
   export let items: string[] = [];
   export let recipeId: string;
@@ -24,8 +27,17 @@
   $: checkedStorageKey = `${CHECKED_KEY}${recipeId}`;
   $: scaleStorageKey = `${SCALE_KEY}${recipeId}`;
   $: scaledItems = items.map((item) => scaleIngredientLine(item, scale));
+  $: pantryMatch = matchRecipeToPantry(items, $pantryItems);
+  $: showPantryMarks = $pantryInitialized && $pantryItems.length > 0 && pantryMatch.totalIngredients > 0;
+  $: pantrySummary = showPantryMarks ? pantryNeededSummary(pantryMatch) : '';
+  $: inPantryByIndex = showPantryMarks
+    ? items.map((line) => !!findMatchingPantryItem(line, $pantryItems))
+    : [];
 
   onMount(() => {
+    if (browser && $userPublickey && !$pantryInitialized) {
+      pantryStore.load();
+    }
     if (!browser || !recipeId) return;
     try {
       const storedChecked = localStorage.getItem(checkedStorageKey);
@@ -84,7 +96,12 @@
 {#if items.length > 0}
   <div id="ingredients-section" class="ingredients-section">
     <div class="flex flex-wrap items-baseline justify-between gap-2 mb-3">
-      <h2 class="text-2xl font-bold">Ingredients</h2>
+      <div class="min-w-0">
+        <h2 class="text-2xl font-bold">Ingredients</h2>
+        {#if pantrySummary}
+          <p class="text-xs text-caption mt-0.5">{pantrySummary}</p>
+        {/if}
+      </div>
       <div class="flex items-center gap-2 print:hidden">
         <div
           class="flex items-center rounded-full border overflow-hidden"
@@ -152,7 +169,18 @@
                 </svg>
               {/if}
             </span>
-            <span class="flex-1" class:struck={checked.has(i)}>{item}</span>
+            <span class="flex-1" class:struck={checked.has(i)}>
+              {#if showPantryMarks}
+                <span
+                  class="inline-block w-4 text-xs font-medium mr-1 {inPantryByIndex[i]
+                    ? 'in-pantry'
+                    : 'need-pantry'}"
+                  title={inPantryByIndex[i] ? 'In your pantry' : 'Not in your pantry'}
+                  aria-hidden="true"
+                >{inPantryByIndex[i] ? '✓' : '○'}</span>
+              {/if}
+              {item}
+            </span>
           </button>
         </li>
       {/each}
@@ -167,6 +195,14 @@
 
   .struck {
     text-decoration: line-through;
+    color: var(--color-caption);
+  }
+
+  .in-pantry {
+    color: #16a34a;
+  }
+
+  .need-pantry {
     color: var(--color-caption);
   }
 

--- a/src/components/SectionNav.svelte
+++ b/src/components/SectionNav.svelte
@@ -25,7 +25,7 @@
 </script>
 
 <nav
-  class="inline-flex p-0.5 rounded-full self-start"
+  class="inline-flex flex-wrap p-0.5 rounded-full self-start"
   style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
   aria-label={label}
 >

--- a/src/components/grocery/AddToListModal.svelte
+++ b/src/components/grocery/AddToListModal.svelte
@@ -12,6 +12,8 @@
   import CaretDownIcon from 'phosphor-svelte/lib/CaretDown';
   import CaretUpIcon from 'phosphor-svelte/lib/CaretUp';
   import { groceryStore, groceryLists, groceryInitialized } from '$lib/stores/groceryStore';
+  import { pantryStore, pantryItems, pantryInitialized } from '$lib/stores/pantryStore';
+  import { classifyGroceryRows } from '$lib/pantry/matching';
   import { parseIngredientsFromRecipe, type ParsedIngredient } from '$lib/utils/ingredientParser';
   import { userPublickey } from '$lib/nostr';
 
@@ -33,6 +35,7 @@
   let parsedIngredients: ParsedIngredient[] = [];
   let addingToList = false;
   let successMessage = '';
+  let includeFromPantry: Set<string> = new Set();
 
   // Portal target
   let portalTarget: HTMLElement;
@@ -47,20 +50,48 @@
     selectedListId = null;
     showNewListInput = false;
     successMessage = '';
+    includeFromPantry = new Set();
   }
 
-  // Initialize grocery store if needed
   $: if (open && $userPublickey && !$groceryInitialized) {
     groceryStore.load();
   }
 
-  // Get recipe title
+  $: if (open && $userPublickey && !$pantryInitialized) {
+    pantryStore.load();
+  }
+
   $: recipeTitle = recipeEvent?.tags.find((t) => t[0] === 'title')?.[1] || 
                    recipeEvent?.tags.find((t) => t[0] === 'd')?.[1] ||
                    'Recipe';
 
-  // Get recipe address for linking
   $: recipeAddress = recipeEvent ? buildRecipeAddress(recipeEvent) : null;
+
+  $: classified = classifyGroceryRows(
+    parsedIngredients.map((ingredient) => ({
+      ingredient,
+      recipeId: recipeAddress || ''
+    })),
+    $pantryItems
+  );
+
+  $: toBuyCount =
+    classified.toBuy.length +
+    classified.inPantry.filter((row) => includeFromPantry.has(pantryRowKey(row.ingredient))).length;
+
+  $: pantryReady = !$userPublickey || $pantryInitialized;
+
+  function pantryRowKey(ingredient: ParsedIngredient): string {
+    return `${ingredient.name}|${ingredient.quantity}`;
+  }
+
+  function toggleIncludeFromPantry(ingredient: ParsedIngredient) {
+    const key = pantryRowKey(ingredient);
+    const next = new Set(includeFromPantry);
+    if (next.has(key)) next.delete(key);
+    else next.add(key);
+    includeFromPantry = next;
+  }
 
   function buildRecipeAddress(event: NDKEvent): string {
     const dTag = event.tags.find((t) => t[0] === 'd')?.[1] || '';
@@ -99,29 +130,52 @@
 
   async function addToSelectedList() {
     if (!selectedListId || !recipeAddress || addingToList) return;
-    
+    if (parsedIngredients.length === 0) return;
+
     addingToList = true;
     try {
-      // Add recipe link to the list
       groceryStore.addRecipeLink(selectedListId, recipeAddress);
-      
-      // Add each ingredient as an item
+
       let addedCount = 0;
-      for (const ingredient of parsedIngredients) {
+      for (const row of classified.toBuy) {
         groceryStore.addItem(
           selectedListId,
-          ingredient.name,
-          ingredient.quantity,
-          ingredient.category,
+          row.ingredient.name,
+          row.ingredient.quantity,
+          row.ingredient.category,
           recipeAddress
         );
         addedCount++;
       }
-      
-      successMessage = `Added ${addedCount} ingredients to your list!`;
+      const covered = [];
+      for (const row of classified.inPantry) {
+        if (includeFromPantry.has(pantryRowKey(row.ingredient))) {
+          groceryStore.addItem(
+            selectedListId,
+            row.ingredient.name,
+            row.ingredient.quantity,
+            row.ingredient.category,
+            recipeAddress
+          );
+          addedCount++;
+        } else {
+          covered.push({
+            name: row.ingredient.name,
+            quantity: row.ingredient.quantity,
+            recipeId: recipeAddress
+          });
+        }
+      }
+      if (covered.length > 0) {
+        groceryStore.appendPantryCovered(selectedListId, covered);
+      }
+
+      successMessage =
+        addedCount === 0
+          ? 'Recipe added. Everything was already in your pantry.'
+          : `Added ${addedCount} ingredient${addedCount === 1 ? '' : 's'} to your list!`;
       dispatch('added', { listId: selectedListId, count: addedCount });
-      
-      // Close after a brief delay to show success message
+
       setTimeout(() => {
         close();
       }, 1500);
@@ -203,7 +257,13 @@
                 style="color: var(--color-text-secondary)"
                 on:click={() => showPreview = !showPreview}
               >
-                <span>{parsedIngredients.length} ingredients found</span>
+                <span>
+                  {#if classified.inPantry.length > 0}
+                    {toBuyCount} to buy · {classified.inPantry.length} in pantry
+                  {:else}
+                    {parsedIngredients.length} ingredients found
+                  {/if}
+                </span>
                 {#if showPreview}
                   <CaretUpIcon size={16} />
                 {:else}
@@ -213,22 +273,53 @@
               
               {#if showPreview && parsedIngredients.length > 0}
                 <div 
-                  class="max-h-40 overflow-y-auto rounded-xl p-3 space-y-1"
+                  class="max-h-48 overflow-y-auto rounded-xl p-3 space-y-3"
                   style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
                 >
-                  {#each parsedIngredients as ingredient}
-                    <div class="flex items-center gap-2 text-sm">
-                      <span class={`text-xs px-1.5 py-0.5 rounded ${categoryDisplay[ingredient.category]?.color || 'text-gray-600'}`}>
-                        {categoryDisplay[ingredient.category]?.name || 'Other'}
-                      </span>
-                      <span style="color: var(--color-text-primary)">
-                        {#if ingredient.quantity}
-                          <span class="text-caption">{ingredient.quantity}</span>
-                        {/if}
-                        {ingredient.name}
-                      </span>
+                  {#if classified.toBuy.length > 0}
+                    <div class="space-y-1">
+                      {#if classified.inPantry.length > 0}
+                        <p class="text-xs font-semibold" style="color: var(--color-text-secondary)">Need to buy</p>
+                      {/if}
+                      {#each classified.toBuy as row}
+                        <div class="flex items-center gap-2 text-sm">
+                          <span class={`text-xs px-1.5 py-0.5 rounded ${categoryDisplay[row.ingredient.category]?.color || 'text-gray-600'}`}>
+                            {categoryDisplay[row.ingredient.category]?.name || 'Other'}
+                          </span>
+                          <span style="color: var(--color-text-primary)">
+                            {#if row.ingredient.quantity}
+                              <span class="text-caption">{row.ingredient.quantity}</span>
+                            {/if}
+                            {row.ingredient.name}
+                          </span>
+                        </div>
+                      {/each}
                     </div>
-                  {/each}
+                  {/if}
+                  {#if classified.inPantry.length > 0}
+                    <div class="space-y-1">
+                      <p class="text-xs font-semibold" style="color: var(--color-text-secondary)">Already in pantry</p>
+                      <p class="text-[11px] text-caption">Left off the list. Add any you still need.</p>
+                      {#each classified.inPantry as row}
+                        {@const included = includeFromPantry.has(pantryRowKey(row.ingredient))}
+                        <div class="flex items-center gap-2 text-sm">
+                          <span class="min-w-0 flex-1 {included ? '' : 'text-caption'}" style={included ? 'color: var(--color-text-primary)' : ''}>
+                            {#if row.ingredient.quantity}
+                              <span class="text-caption">{row.ingredient.quantity}</span>
+                            {/if}
+                            {row.ingredient.name}
+                          </span>
+                          <button
+                            type="button"
+                            class="flex-shrink-0 px-2 py-0.5 rounded-full text-xs font-medium border border-green-500/40 text-green-500 hover:bg-green-500/10"
+                            on:click={() => toggleIncludeFromPantry(row.ingredient)}
+                          >
+                            {included ? 'Added' : 'Add'}
+                          </button>
+                        </div>
+                      {/each}
+                    </div>
+                  {/if}
                 </div>
               {/if}
               
@@ -319,7 +410,7 @@
               </button>
               <button
                 on:click={addToSelectedList}
-                disabled={!selectedListId || parsedIngredients.length === 0 || addingToList}
+                disabled={!selectedListId || parsedIngredients.length === 0 || addingToList || !pantryReady}
                 class="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 rounded-full text-sm font-medium text-white bg-gradient-to-r from-green-500 to-emerald-500 hover:from-green-600 hover:to-emerald-600 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
               >
                 {#if addingToList}
@@ -327,7 +418,11 @@
                   Adding...
                 {:else}
                   <PlusIcon size={18} />
-                  Add {parsedIngredients.length} Items
+                  {#if toBuyCount === 0 && classified.inPantry.length > 0}
+                    Add recipe
+                  {:else}
+                    Add {toBuyCount} {toBuyCount === 1 ? 'Item' : 'Items'}
+                  {/if}
                 {/if}
               </button>
             </div>

--- a/src/components/pantry/PantryEditor.svelte
+++ b/src/components/pantry/PantryEditor.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import { pantryStore } from '$lib/stores/pantryStore';
+  import PlusIcon from 'phosphor-svelte/lib/Plus';
+
+  export let disabled = false;
+
+  let name = '';
+  let quantity = '';
+  let nameInput: HTMLInputElement;
+
+  function add() {
+    if (disabled || !name.trim()) return;
+    pantryStore.addItems(name, quantity.trim() || undefined);
+    name = '';
+    quantity = '';
+    nameInput?.focus();
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      add();
+    }
+  }
+</script>
+
+<form
+  on:submit|preventDefault={add}
+  class="flex flex-col gap-3 p-4 rounded-2xl"
+  style="background-color: var(--color-bg-secondary);"
+>
+  <div class="flex flex-col sm:flex-row gap-3">
+    <div class="flex-1">
+      <input
+        bind:this={nameInput}
+        bind:value={name}
+        on:keydown={handleKeydown}
+        type="text"
+        placeholder="Add ingredient… eggs, rice, chicken breast"
+        class="input w-full"
+        autocomplete="off"
+        {disabled}
+        aria-label="Ingredient name"
+      />
+    </div>
+    <div class="w-full sm:w-32">
+      <input
+        bind:value={quantity}
+        on:keydown={handleKeydown}
+        type="text"
+        placeholder="Qty"
+        class="input w-full"
+        autocomplete="off"
+        {disabled}
+        aria-label="Optional quantity"
+      />
+    </div>
+  </div>
+  <p class="text-xs text-caption">
+    Quantity is optional. Comma-separated names add several ingredients at once.
+  </p>
+  <button
+    type="submit"
+    disabled={disabled || !name.trim()}
+    class="flex items-center justify-center gap-2 px-4 py-2 border border-orange-500/40 text-orange-500 hover:bg-orange-500/10 rounded-xl font-medium text-sm transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+  >
+    <PlusIcon size={18} weight="bold" />
+    <span>Add ingredient</span>
+  </button>
+</form>

--- a/src/components/pantry/PantryEditor.svelte
+++ b/src/components/pantry/PantryEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { pantryStore } from '$lib/stores/pantryStore';
+  import { pantryStore, pantryItems } from '$lib/stores/pantryStore';
+  import { suggestPantryIngredients } from '$lib/pantry/catalog';
   import PlusIcon from 'phosphor-svelte/lib/Plus';
 
   export let disabled = false;
@@ -7,16 +8,56 @@
   let name = '';
   let quantity = '';
   let nameInput: HTMLInputElement;
+  let highlight = 0;
+  let open = false;
 
-  function add() {
-    if (disabled || !name.trim()) return;
-    pantryStore.addItems(name, quantity.trim() || undefined);
-    name = '';
-    quantity = '';
+  $: suggestions = suggestPantryIngredients(name, $pantryItems);
+  $: if (suggestions.length === 0) {
+    highlight = 0;
+    open = false;
+  }
+
+  export function focus() {
     nameInput?.focus();
   }
 
+  function add(value = name) {
+    if (disabled || !value.trim()) return;
+    pantryStore.addItems(value, quantity.trim() || undefined);
+    name = '';
+    quantity = '';
+    open = false;
+    highlight = 0;
+    nameInput?.focus();
+  }
+
+  function pick(suggestion: string) {
+    add(suggestion);
+  }
+
   function handleKeydown(e: KeyboardEvent) {
+    if (open && suggestions.length > 0) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        highlight = (highlight + 1) % suggestions.length;
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        highlight = (highlight - 1 + suggestions.length) % suggestions.length;
+        return;
+      }
+      if (e.key === 'Tab' && !e.shiftKey) {
+        e.preventDefault();
+        pick(suggestions[highlight].name);
+        return;
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        open = false;
+        return;
+      }
+    }
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       add();
@@ -25,25 +66,65 @@
 </script>
 
 <form
-  on:submit|preventDefault={add}
+  on:submit|preventDefault={() => add()}
   class="flex flex-col gap-3 p-4 rounded-2xl"
   style="background-color: var(--color-bg-secondary);"
 >
   <div class="flex flex-col sm:flex-row gap-3">
-    <div class="flex-1">
+    <div class="relative flex-1">
       <input
         bind:this={nameInput}
         bind:value={name}
         on:keydown={handleKeydown}
+        on:input={() => {
+          open = true;
+          highlight = 0;
+        }}
+        on:focus={() => {
+          if (suggestions.length) open = true;
+        }}
+        on:blur={() => {
+          // Delay so suggestion mousedown can fire before the list unmounts.
+          setTimeout(() => (open = false), 120);
+        }}
         type="text"
         placeholder="Add ingredient… eggs, rice, chicken breast"
         class="input w-full"
         autocomplete="off"
+        autocorrect="off"
+        spellcheck="false"
         {disabled}
         aria-label="Ingredient name"
+        aria-autocomplete="list"
+        aria-expanded={open && suggestions.length > 0}
+        role="combobox"
       />
+      {#if open && suggestions.length > 0}
+        <ul
+          class="absolute z-20 left-0 right-0 mt-1 max-h-56 overflow-y-auto rounded-xl py-1 shadow-lg"
+          style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+          role="listbox"
+        >
+          {#each suggestions as suggestion, i}
+            <li>
+              <button
+                type="button"
+                class="w-full text-left px-3 py-2.5 text-sm transition-colors"
+                style="color: var(--color-text-primary); {i === highlight
+                  ? 'background-color: var(--color-input-bg);'
+                  : ''}"
+                role="option"
+                aria-selected={i === highlight}
+                on:mousedown|preventDefault={() => pick(suggestion.name)}
+              >
+                {suggestion.name}
+              </button>
+            </li>
+          {/each}
+        </ul>
+      {/if}
     </div>
-    <div class="w-full sm:w-32">
+    <div class="w-full sm:w-28">
       <input
         bind:value={quantity}
         on:keydown={handleKeydown}

--- a/src/components/pantry/PantryItem.svelte
+++ b/src/components/pantry/PantryItem.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+  import { pantryStore } from '$lib/stores/pantryStore';
+  import { formatPantryQuantity, type PantryItem as PantryItemType } from '$lib/pantry/schema';
+  import PencilSimpleIcon from 'phosphor-svelte/lib/PencilSimple';
+  import TrashIcon from 'phosphor-svelte/lib/Trash';
+  import CheckIcon from 'phosphor-svelte/lib/Check';
+  import XIcon from 'phosphor-svelte/lib/X';
+
+  export let item: PantryItemType;
+  export let disabled = false;
+
+  let editing = false;
+  let name = item.name;
+  let quantity = formatPantryQuantity(item);
+  let nameInput: HTMLInputElement;
+
+  $: if (!editing) {
+    name = item.name;
+    quantity = formatPantryQuantity(item);
+  }
+
+  function startEdit() {
+    if (disabled) return;
+    name = item.name;
+    quantity = formatPantryQuantity(item);
+    editing = true;
+    setTimeout(() => nameInput?.focus(), 0);
+  }
+
+  function cancel() {
+    editing = false;
+    name = item.name;
+    quantity = formatPantryQuantity(item);
+  }
+
+  function save() {
+    if (!name.trim()) return;
+    pantryStore.updateItem(item.id, {
+      name: name.trim(),
+      quantityText: quantity.trim()
+    });
+    editing = false;
+  }
+
+  function remove() {
+    pantryStore.removeItem(item.id);
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      save();
+    } else if (e.key === 'Escape') {
+      cancel();
+    }
+  }
+</script>
+
+<li
+  class="flex items-center gap-2 px-3 py-2.5 rounded-xl"
+  style="background-color: var(--color-bg-primary); border: 1px solid var(--color-input-border);"
+>
+  {#if editing}
+    <input
+      bind:this={nameInput}
+      bind:value={name}
+      on:keydown={handleKeydown}
+      class="input flex-1 text-sm"
+      aria-label="Edit ingredient name"
+    />
+    <input
+      bind:value={quantity}
+      on:keydown={handleKeydown}
+      class="input w-24 text-sm"
+      placeholder="Qty"
+      aria-label="Edit quantity"
+    />
+    <button
+      type="button"
+      class="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800"
+      style="color: var(--color-text-secondary);"
+      aria-label="Cancel"
+      on:click={cancel}
+    >
+      <XIcon size={16} weight="bold" />
+    </button>
+    <button
+      type="button"
+      class="p-1.5 rounded-lg bg-green-500 hover:bg-green-600 text-white"
+      aria-label="Save ingredient"
+      on:click={save}
+    >
+      <CheckIcon size={16} weight="bold" />
+    </button>
+  {:else}
+    <div class="min-w-0 flex-1">
+      <p class="text-sm font-medium truncate" style="color: var(--color-text-primary);">
+        {item.name}
+      </p>
+    </div>
+    {#if formatPantryQuantity(item)}
+      <span class="text-sm text-caption flex-shrink-0">{formatPantryQuantity(item)}</span>
+    {/if}
+    <button
+      type="button"
+      class="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800"
+      style="color: var(--color-text-secondary);"
+      aria-label="Edit {item.name}"
+      {disabled}
+      on:click={startEdit}
+    >
+      <PencilSimpleIcon size={16} />
+    </button>
+    <button
+      type="button"
+      class="p-1.5 rounded-lg hover:bg-red-500/10"
+      style="color: var(--color-danger);"
+      aria-label="Remove {item.name}"
+      {disabled}
+      on:click={remove}
+    >
+      <TrashIcon size={16} />
+    </button>
+  {/if}
+</li>

--- a/src/components/pantry/PantryItem.svelte
+++ b/src/components/pantry/PantryItem.svelte
@@ -5,6 +5,7 @@
   import TrashIcon from 'phosphor-svelte/lib/Trash';
   import CheckIcon from 'phosphor-svelte/lib/Check';
   import XIcon from 'phosphor-svelte/lib/X';
+  import StarIcon from 'phosphor-svelte/lib/Star';
 
   export let item: PantryItemType;
   export let disabled = false;
@@ -101,6 +102,18 @@
     {#if formatPantryQuantity(item)}
       <span class="text-sm text-caption flex-shrink-0">{formatPantryQuantity(item)}</span>
     {/if}
+    <button
+      type="button"
+      class="p-1.5 rounded-lg hover:bg-amber-500/10 {item.isStaple ? 'text-amber-500' : ''}"
+      style={item.isStaple ? '' : 'color: var(--color-text-secondary);'}
+      aria-label={item.isStaple ? `Unmark ${item.name} as a staple` : `Mark ${item.name} as a staple`}
+      aria-pressed={!!item.isStaple}
+      title={item.isStaple ? 'Staple — kept until you remove it' : 'Mark as staple'}
+      {disabled}
+      on:click={() => pantryStore.toggleStaple(item.id)}
+    >
+      <StarIcon size={16} weight={item.isStaple ? 'fill' : 'regular'} />
+    </button>
     <button
       type="button"
       class="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800"

--- a/src/components/planner/CheffyPlanModal.svelte
+++ b/src/components/planner/CheffyPlanModal.svelte
@@ -39,6 +39,8 @@
     toWireCandidate,
     type DiscoveredRecipe
   } from '$lib/services/recipeDiscoveryService';
+  import { matchRecipeToPantry, weakPantryPlanNote } from '$lib/pantry/matching';
+  import { pantryStore, pantryItems, pantryInitialized } from '$lib/stores/pantryStore';
   import { THINKING_LINES, pickLine } from '$lib/cheffy';
   import Modal from '../Modal.svelte';
   import Button from '../Button.svelte';
@@ -87,10 +89,12 @@
   let notes = '';
   let source: RecipeSource = 'all';
   let strategy: MealPlanStrategy = 'fill-empty';
+  let prioritizePantry = false;
   let error: string | null = null;
   let statusLine = THINKING_LINES[0];
   let preview: GeneratedMeal[] = [];
   let coverageNote: string | null = null;
+  let pantryNote: string | null = null;
   let discovered: DiscoveredRecipe[] = [];
   let swappingKey: string | null = null;
   let applying = false;
@@ -103,6 +107,9 @@
   onDestroy(unsubMembership);
 
   $: if (open && $userPublickey) queueMembershipLookup($userPublickey);
+  $: if (open && $userPublickey && !$pantryInitialized) {
+    pantryStore.load();
+  }
   $: normalizedPk = String($userPublickey || '')
     .trim()
     .toLowerCase();
@@ -140,8 +147,10 @@
     notes = '';
     source = 'all';
     strategy = 'fill-empty';
+    prioritizePantry = false;
     error = null;
     coverageNote = null;
+    pantryNote = null;
     preview = [];
     discovered = [];
     swappingKey = null;
@@ -177,17 +186,35 @@
     styles = toggleIn(styles, id);
   }
 
+  function wireCandidates() {
+    return discovered.map((recipe) => {
+      const wire = toWireCandidate(recipe);
+      if (prioritizePantry && $pantryItems.length > 0) {
+        const match = matchRecipeToPantry(wire.ingredients, $pantryItems);
+        wire.pantry = {
+          matchedCount: match.matchedCount,
+          totalCount: match.totalIngredients,
+          matchRatio: match.matchRatio,
+          matchedIngredients: match.matchedIngredients,
+          missingIngredients: match.missingIngredients
+        };
+      }
+      return wire;
+    });
+  }
+
   function buildRequest(
     overrides: Partial<MealPlanGenerationRequest> = {}
   ): MealPlanGenerationRequest | null {
     if (!$ndk || !$userPublickey) return null;
     const max = maxMinutes.trim() ? Number(maxMinutes) : undefined;
     const serv = servings.trim() ? Number(servings) : undefined;
-    const filtered = filterRecipeCandidates(discovered.map(toWireCandidate), {
+    const filtered = filterRecipeCandidates(wireCandidates(), {
       maxMinutes: max && Number.isFinite(max) && max > 0 ? max : undefined,
       excludeIngredients: parseExcludeIngredientsInput(excludeText),
       styles,
       mealSlots,
+      prioritizePantry,
       excludeCoordinates: overrides.excludeCoordinates
     });
     if (filtered.length === 0) return null;
@@ -203,6 +230,7 @@
         notes: notes.trim() || undefined
       },
       strategy,
+      prioritizePantry: prioritizePantry || undefined,
       candidates: filtered,
       occupiedSlots,
       ...overrides
@@ -212,6 +240,17 @@
   async function generate(opts: { swap?: GeneratedMeal; regenerate?: boolean } = {}) {
     if (readOnly) return;
     error = null;
+    if (prioritizePantry) {
+      if (!$pantryInitialized) {
+        await pantryStore.load();
+      }
+      if ($pantryItems.length === 0) {
+        error =
+          'Your pantry is empty. Add a few ingredients you already have and Cheffy can build meals around them.';
+        if (!opts.swap && !opts.regenerate) step = 'form';
+        return;
+      }
+    }
     if (!opts.swap && !opts.regenerate) {
       step = 'working';
       statusLine = pickLine(THINKING_LINES, statusLine);
@@ -278,6 +317,7 @@
           found: preview.length,
           requested: requestedSlots
         });
+        pantryNote = prioritizePantry ? weakPantryPlanNote(preview.map((m) => m.pantry)) : null;
         step = 'preview';
       }
     } catch (err) {
@@ -403,8 +443,12 @@
     {#if coverageNote}
       <p class="text-sm text-caption">{coverageNote}</p>
     {/if}
+    {#if pantryNote}
+      <p class="text-sm text-caption">{pantryNote}</p>
+    {/if}
     <GeneratedPlanPreview
       meals={preview}
+      showPantry={prioritizePantry}
       {swappingKey}
       {applying}
       {regenerating}
@@ -427,7 +471,30 @@
     <form class="flex flex-col gap-5" on:submit|preventDefault={handleGenerate}>
       {#if error}
         <p class="text-sm text-red-500">{error}</p>
+        {#if prioritizePantry && $pantryItems.length === 0}
+          <a
+            href="/my-kitchen/pantry"
+            class="text-sm font-medium text-orange-500 hover:underline"
+            on:click={close}
+          >
+            Add ingredients to your pantry
+          </a>
+        {/if}
       {/if}
+
+      <label
+        class="flex items-start gap-3 p-3 rounded-xl"
+        style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border); color: var(--color-text-primary);"
+      >
+        <input type="checkbox" bind:checked={prioritizePantry} class="mt-1" />
+        <span>
+          <span class="font-semibold">Plan with My Pantry</span>
+          <span class="block text-caption text-sm">
+            Prefer meals that use ingredients you already have. Dietary rules and meal type still
+            come first.
+          </span>
+        </span>
+      </label>
 
       <fieldset class="flex flex-col gap-2">
         <legend class="text-sm font-semibold mb-1" style="color: var(--color-text-primary);"
@@ -600,7 +667,7 @@
           class="inline-flex items-center gap-1.5 px-4 py-2 rounded-full text-sm font-medium text-white bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 transition-all disabled:opacity-50"
         >
           <CheffyIcon size={20} expression="happy" />
-          Plan with Cheffy
+          {prioritizePantry ? 'Plan with My Pantry' : 'Plan with Cheffy'}
         </button>
       </div>
     </form>

--- a/src/components/planner/CheffyPlanModal.svelte
+++ b/src/components/planner/CheffyPlanModal.svelte
@@ -52,6 +52,8 @@
   export let weekId: string;
   export let occupiedSlots: MealSlotRef[] = [];
   export let readOnly = false;
+  /** When true, pantry-first planning is on as soon as the modal opens. */
+  export let initialPrioritizePantry = false;
 
   const dispatch = createEventDispatcher<{ close: void; applied: void }>();
 
@@ -147,7 +149,7 @@
     notes = '';
     source = 'all';
     strategy = 'fill-empty';
-    prioritizePantry = false;
+    prioritizePantry = initialPrioritizePantry;
     error = null;
     coverageNote = null;
     pantryNote = null;
@@ -231,6 +233,9 @@
       },
       strategy,
       prioritizePantry: prioritizePantry || undefined,
+      pantryIngredients: prioritizePantry
+        ? $pantryItems.map((item) => item.name).slice(0, 80)
+        : undefined,
       candidates: filtered,
       occupiedSlots,
       ...overrides

--- a/src/components/planner/GeneratedPlanPreview.svelte
+++ b/src/components/planner/GeneratedPlanPreview.svelte
@@ -9,6 +9,7 @@
   import { DAY_KEYS } from '$lib/mealplan/schema';
   import type { GeneratedMeal } from '$lib/mealplan/generation';
   import { slotKey } from '$lib/mealplan/generation';
+  import { pantryMatchSummary } from '$lib/pantry/matching';
   import { getImageOrPlaceholder, getPlaceholderImage } from '$lib/placeholderImages';
   import ArrowsClockwiseIcon from 'phosphor-svelte/lib/ArrowsClockwise';
   import EyeIcon from 'phosphor-svelte/lib/Eye';
@@ -18,6 +19,7 @@
   export let swappingKey: string | null = null;
   export let applying = false;
   export let regenerating = false;
+  export let showPantry = false;
 
   const dispatch = createEventDispatcher<{
     apply: void;
@@ -122,6 +124,19 @@
                   </p>
                   {#if meal.reason}
                     <p class="text-xs text-caption mt-0.5">{meal.reason}</p>
+                  {/if}
+                  {#if showPantry && meal.pantry && meal.pantry.totalCount > 0}
+                    <p class="text-xs mt-0.5" style="color: var(--color-text-secondary);">
+                      ✓ {pantryMatchSummary(meal.pantry)}
+                      {#if meal.pantry.missingIngredients.length}
+                        <span class="text-caption">
+                          · Need: {meal.pantry.missingIngredients.slice(0, 4).join(', ')}{meal
+                            .pantry.missingIngredients.length > 4
+                            ? '…'
+                            : ''}
+                        </span>
+                      {/if}
+                    </p>
                   {/if}
                 </div>
                 <button

--- a/src/lib/mealplan/generation.test.ts
+++ b/src/lib/mealplan/generation.test.ts
@@ -412,6 +412,21 @@ describe('parseGenerationRequest', () => {
     expect(parsed.request.candidates[0].pantry?.missingIngredients).toEqual(['salmon', 'lemon']);
   });
 
+  it('keeps pantryIngredients when prioritizePantry is on', () => {
+    const parsed = parseGenerationRequest({
+      weekId: '2026-W34',
+      days: ['mon'],
+      mealSlots: ['dinner'],
+      strategy: 'fill-empty',
+      prioritizePantry: true,
+      pantryIngredients: ['chicken breast', 'rice', '  ', 'eggs'],
+      candidates: [cand('salmon', { title: 'Salmon' })]
+    });
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.request.pantryIngredients).toEqual(['chicken breast', 'rice', 'eggs']);
+  });
+
   it('rejects missing days, slots, or candidates', () => {
     expect(parseGenerationRequest({ weekId: 'nope' }).ok).toBe(false);
     expect(

--- a/src/lib/mealplan/generation.test.ts
+++ b/src/lib/mealplan/generation.test.ts
@@ -180,6 +180,105 @@ describe('filterRecipeCandidates', () => {
     expect(out.every((c) => isRecipeEligibleForSlot(c, 'breakfast'))).toBe(true);
   });
 
+  it('prefers higher pantry-match recipes when prioritizePantry is on', () => {
+    const high = cand('parm', {
+      title: 'Chicken Parmesan',
+      ingredients: ['chicken breast', 'parmesan', 'egg'],
+      pantry: {
+        matchedCount: 5,
+        totalCount: 7,
+        matchRatio: 5 / 7,
+        matchedIngredients: ['chicken breast', 'parmesan', 'egg', 'olive oil', 'garlic'],
+        missingIngredients: ['breadcrumbs', 'tomato sauce']
+      }
+    });
+    const low = cand('taco', {
+      title: 'Fish Tacos',
+      ingredients: ['fish', 'tortilla'],
+      pantry: {
+        matchedCount: 1,
+        totalCount: 8,
+        matchRatio: 1 / 8,
+        matchedIngredients: ['olive oil'],
+        missingIngredients: ['fish']
+      }
+    });
+    const out = filterRecipeCandidates([low, high], { prioritizePantry: true });
+    expect(out.map((c) => c.a)).toEqual(['30023:pk:parm', '30023:pk:taco']);
+  });
+
+  it('does not let pantry match override vegetarian', () => {
+    const steak = cand('steak', {
+      title: 'Steak',
+      ingredients: ['ribeye steak', 'salt'],
+      pantry: {
+        matchedCount: 2,
+        totalCount: 2,
+        matchRatio: 1,
+        matchedIngredients: ['ribeye steak', 'salt'],
+        missingIngredients: []
+      }
+    });
+    const salad = cand('salad', {
+      title: 'Chickpea Salad',
+      tags: ['vegetarian'],
+      ingredients: ['chickpeas'],
+      pantry: {
+        matchedCount: 0,
+        totalCount: 1,
+        matchRatio: 0,
+        matchedIngredients: [],
+        missingIngredients: ['chickpeas']
+      }
+    });
+    const out = filterRecipeCandidates([steak, salad], {
+      styles: ['vegetarian'],
+      prioritizePantry: true
+    });
+    expect(out.map((c) => c.a)).toEqual(['30023:pk:salad']);
+  });
+
+  it('still drops excluded ingredients when pantry matching is on', () => {
+    const out = filterRecipeCandidates(
+      [
+        cand('shrimp', {
+          ingredients: ['shrimp'],
+          pantry: {
+            matchedCount: 1,
+            totalCount: 1,
+            matchRatio: 1,
+            matchedIngredients: ['shrimp'],
+            missingIngredients: []
+          }
+        }),
+        cand('tofu', { ingredients: ['tofu'] })
+      ],
+      { excludeIngredients: ['shrimp'], prioritizePantry: true }
+    );
+    expect(out.map((c) => c.a)).toEqual(['30023:pk:tofu']);
+  });
+
+  it('keeps breakfast eligibility ahead of pantry ranking', () => {
+    const out = filterRecipeCandidates(
+      [
+        cand('chicken', {
+          title: 'Garlic Parmesan Chicken',
+          tags: ['dinner'],
+          pantry: {
+            matchedCount: 6,
+            totalCount: 6,
+            matchRatio: 1,
+            matchedIngredients: [],
+            missingIngredients: []
+          }
+        }),
+        cand('oats', { title: 'Overnight Oats', tags: ['breakfast'] })
+      ],
+      { mealSlots: ['breakfast'], prioritizePantry: true }
+    );
+    expect(out.map((c) => c.a)).toEqual(['30023:pk:oats']);
+  });
+
   it('composes breakfast eligibility with max time, excludes, and vegetarian', () => {
     const out = filterRecipeCandidates(
       [
@@ -284,6 +383,33 @@ describe('parseGenerationRequest', () => {
     if (!parsed.ok) return;
     expect(parsed.request.days).toEqual(['mon', 'tue']);
     expect(parsed.request.candidates).toHaveLength(1);
+  });
+
+  it('keeps prioritizePantry and candidate pantry match data', () => {
+    const parsed = parseGenerationRequest({
+      weekId: '2026-W34',
+      days: ['mon'],
+      mealSlots: ['dinner'],
+      strategy: 'fill-empty',
+      prioritizePantry: true,
+      candidates: [
+        cand('salmon', {
+          title: 'Salmon',
+          pantry: {
+            matchedCount: 2,
+            totalCount: 4,
+            matchRatio: 0.5,
+            matchedIngredients: ['olive oil', 'garlic'],
+            missingIngredients: ['salmon', 'lemon']
+          }
+        })
+      ]
+    });
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.request.prioritizePantry).toBe(true);
+    expect(parsed.request.candidates[0].pantry?.matchedCount).toBe(2);
+    expect(parsed.request.candidates[0].pantry?.missingIngredients).toEqual(['salmon', 'lemon']);
   });
 
   it('rejects missing days, slots, or candidates', () => {
@@ -403,6 +529,32 @@ describe('validateGeneratedMealPlan', () => {
       })
     );
     expect(result).toMatchObject({ ok: false, error: 'ineligible-slot' });
+  });
+
+  it('copies pantry match data onto generated meals from the candidate', () => {
+    const pantry = {
+      matchedCount: 3,
+      totalCount: 4,
+      matchRatio: 0.75,
+      matchedIngredients: ['egg'],
+      missingIngredients: ['feta']
+    };
+    const result = validateGeneratedMealPlan(
+      { meals: [{ day: 'mon', slot: 'dinner', a: '30023:pk:salmon', title: 'S' }] },
+      baseRequest({
+        days: ['mon'],
+        candidates: [
+          cand('salmon', {
+            title: 'Mediterranean Salmon',
+            tags: ['mediterranean'],
+            pantry
+          })
+        ]
+      })
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.plan.meals[0].pantry).toEqual(pantry);
   });
 
   it('accepts a breakfast-tagged recipe in a breakfast slot', () => {

--- a/src/lib/mealplan/generation.ts
+++ b/src/lib/mealplan/generation.ts
@@ -52,6 +52,7 @@ export const STYLE_IDS: readonly PreferenceStyleId[] = PREFERENCE_STYLES.map((s)
 export const MAX_CANDIDATES = 48;
 export const MAX_NOTES_CHARS = 500;
 export const MAX_EXCLUDE_INGREDIENTS = 20;
+export const MAX_PANTRY_INGREDIENTS = 80;
 export const MAX_INGREDIENTS_PER_CANDIDATE = 12;
 export const MAX_TAGS_PER_CANDIDATE = 8;
 export const MAX_TITLE_CHARS = 120;
@@ -98,6 +99,8 @@ export interface MealPlanGenerationRequest {
   strategy: MealPlanStrategy;
   /** Rank and prompt Cheffy to prefer recipes that use the user's pantry. */
   prioritizePantry?: boolean;
+  /** Display names of pantry ingredients. Prompt-only; never persisted. */
+  pantryIngredients?: string[];
   candidates: RecipeCandidate[];
   /** Slots that already have a meal. Required for fill-empty enforcement. */
   occupiedSlots?: MealSlotRef[];
@@ -669,6 +672,14 @@ export function parseGenerationRequest(
       : []
   };
   if (body.prioritizePantry === true) request.prioritizePantry = true;
+  if (Array.isArray(body.pantryIngredients)) {
+    const pantryIngredients = body.pantryIngredients
+      .filter((s): s is string => typeof s === 'string')
+      .map((s) => s.trim().slice(0, 80))
+      .filter(Boolean)
+      .slice(0, MAX_PANTRY_INGREDIENTS);
+    if (pantryIngredients.length) request.pantryIngredients = pantryIngredients;
+  }
 
   const targets = resolveTargetSlots(request);
   if (targets.length === 0) {

--- a/src/lib/mealplan/generation.ts
+++ b/src/lib/mealplan/generation.ts
@@ -57,6 +57,14 @@ export const MAX_TAGS_PER_CANDIDATE = 8;
 export const MAX_TITLE_CHARS = 120;
 export const MAX_REASON_CHARS = 160;
 
+export interface CandidatePantryMatch {
+  matchedCount: number;
+  totalCount: number;
+  matchRatio: number;
+  matchedIngredients: string[];
+  missingIngredients: string[];
+}
+
 export interface RecipeCandidate {
   a: string;
   title: string;
@@ -65,6 +73,8 @@ export interface RecipeCandidate {
   prepTime?: string;
   cookTime?: string;
   servings?: string;
+  /** Deterministic pantry match. Never invented by Cheffy. */
+  pantry?: CandidatePantryMatch;
 }
 
 export interface MealPlanPreferences {
@@ -86,6 +96,8 @@ export interface MealPlanGenerationRequest {
   mealSlots: MealSlotKey[];
   preferences: MealPlanPreferences;
   strategy: MealPlanStrategy;
+  /** Rank and prompt Cheffy to prefer recipes that use the user's pantry. */
+  prioritizePantry?: boolean;
   candidates: RecipeCandidate[];
   /** Slots that already have a meal. Required for fill-empty enforcement. */
   occupiedSlots?: MealSlotRef[];
@@ -107,6 +119,8 @@ export interface GeneratedMeal {
   reason?: string;
   /** Client-only preview thumbnail. Never written into the meal-plan schema. */
   image?: string;
+  /** Client-only pantry match copied from the candidate. Never persisted. */
+  pantry?: CandidatePantryMatch;
 }
 
 export interface GeneratedMealPlan {
@@ -354,6 +368,8 @@ export interface FilterCandidatesOptions {
   excludeCoordinates?: string[];
   /** Soft-prefer recipes whose tags mention these meal slots. */
   mealSlots?: MealSlotKey[];
+  /** Soft-prefer higher pantry match after hard constraints. */
+  prioritizePantry?: boolean;
   maxCandidates?: number;
 }
 
@@ -391,6 +407,7 @@ export function filterRecipeCandidates(
   const slotEligible =
     mealSlots.length > 0 ? restrictCandidatesToRequestedSlots(hardPassed, mealSlots) : hardPassed;
 
+  const prioritizePantry = !!opts.prioritizePantry;
   let ranked = slotEligible;
   if (!surpriseOnly && styleTags.length > 0) {
     const matched = slotEligible.filter((c) => candidateMatchesStyle(c, styleTags));
@@ -398,32 +415,39 @@ export function filterRecipeCandidates(
     // If we have enough style matches to cover a week with extras, drop
     // the rest. Otherwise keep unmatched as fallback so Cheffy can still plan.
     ranked = matched.length >= 8 ? matched : [...matched, ...unmatched];
-  } else if (surpriseOnly) {
+  } else if (surpriseOnly && !prioritizePantry) {
     ranked = shuffleInPlace([...slotEligible]);
   }
 
-  if (mealSlots.length > 0 && !surpriseOnly) {
-    const slotNeedles = mealSlots.map((s) => s.toLowerCase());
+  const slotNeedles = mealSlots.map((s) => s.toLowerCase());
+  const shouldScore =
+    prioritizePantry || (!surpriseOnly && (styleTags.length > 0 || mealSlots.length > 0));
+  if (shouldScore) {
     ranked = [...ranked].sort(
       (a, b) =>
-        scoreCandidate(b, styleTags, slotNeedles) - scoreCandidate(a, styleTags, slotNeedles)
-    );
-  } else if (styleTags.length > 0 && !surpriseOnly) {
-    ranked = [...ranked].sort(
-      (a, b) => scoreCandidate(b, styleTags, []) - scoreCandidate(a, styleTags, [])
+        scoreCandidate(b, styleTags, slotNeedles, prioritizePantry) -
+        scoreCandidate(a, styleTags, slotNeedles, prioritizePantry)
     );
   }
 
   return ranked.slice(0, cap);
 }
 
-function scoreCandidate(c: RecipeCandidate, styleTags: string[], slotNeedles: string[]): number {
+function scoreCandidate(
+  c: RecipeCandidate,
+  styleTags: string[],
+  slotNeedles: string[],
+  prioritizePantry: boolean
+): number {
   let score = 0;
   const blob = textBlob([c.title, ...(c.tags || [])]);
   if (styleTags.some((t) => blob.includes(t))) score += 3;
   if (slotNeedles.some((t) => blob.includes(t))) score += 2;
   if (c.prepTime || c.cookTime) score += 1;
   if (c.ingredients?.length) score += 1;
+  if (prioritizePantry && c.pantry && c.pantry.totalCount > 0) {
+    score += c.pantry.matchRatio * 5;
+  }
   return score;
 }
 
@@ -489,7 +513,42 @@ function sanitizeCandidate(raw: unknown): RecipeCandidate | null {
   if (typeof r.servings === 'string' && r.servings.trim()) {
     candidate.servings = r.servings.trim().slice(0, 20);
   }
+  const pantry = sanitizeCandidatePantry(r.pantry);
+  if (pantry) candidate.pantry = pantry;
   return candidate;
+}
+
+function sanitizeCandidatePantry(raw: unknown): CandidatePantryMatch | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const p = raw as Record<string, unknown>;
+  const matchedCount =
+    typeof p.matchedCount === 'number' && Number.isFinite(p.matchedCount)
+      ? Math.max(0, Math.round(p.matchedCount))
+      : 0;
+  const totalCount =
+    typeof p.totalCount === 'number' && Number.isFinite(p.totalCount)
+      ? Math.max(0, Math.round(p.totalCount))
+      : 0;
+  const matchRatio =
+    typeof p.matchRatio === 'number' && Number.isFinite(p.matchRatio)
+      ? Math.min(1, Math.max(0, p.matchRatio))
+      : totalCount > 0
+        ? matchedCount / totalCount
+        : 0;
+  const names = (value: unknown) =>
+    Array.isArray(value)
+      ? value
+          .filter((t): t is string => typeof t === 'string' && t.trim().length > 0)
+          .map((t) => t.trim().slice(0, 80))
+          .slice(0, MAX_INGREDIENTS_PER_CANDIDATE)
+      : [];
+  return {
+    matchedCount,
+    totalCount,
+    matchRatio,
+    matchedIngredients: names(p.matchedIngredients),
+    missingIngredients: names(p.missingIngredients)
+  };
 }
 
 function sanitizePreferences(raw: unknown): MealPlanPreferences {
@@ -609,6 +668,7 @@ export function parseGenerationRequest(
       ? body.excludeCoordinates.filter(isRecipeCoordinate).slice(0, MAX_CANDIDATES)
       : []
   };
+  if (body.prioritizePantry === true) request.prioritizePantry = true;
 
   const targets = resolveTargetSlots(request);
   if (targets.length === 0) {
@@ -709,13 +769,15 @@ export function validateGeneratedMealPlan(
       typeof m.reason === 'string' && m.reason.trim()
         ? m.reason.trim().slice(0, MAX_REASON_CHARS)
         : undefined;
-    meals.push({
+    const meal: GeneratedMeal = {
       day: m.day,
       slot: m.slot,
       a: candidate.a,
       title: candidate.title,
       reason
-    });
+    };
+    if (candidate.pantry) meal.pantry = candidate.pantry;
+    meals.push(meal);
   }
 
   if (meals.length === 0) {

--- a/src/lib/mealplan/groceryGeneration.test.ts
+++ b/src/lib/mealplan/groceryGeneration.test.ts
@@ -5,6 +5,7 @@ import {
   collectWeekRecipeSlots,
   dedupeIngredients,
   groceryListTitle,
+  classifyGroceryRows,
   type GenerationRow
 } from './groceryGeneration';
 import { createEmptyMealPlan, type MealPlan } from './schema';
@@ -50,4 +51,40 @@ describe('groceryListTitle', () => {
       expect(groceryListTitle(v.weekId)).toBe(v.expected);
     });
   }
+});
+
+describe('classifyGroceryRows pantry awareness', () => {
+  it('keeps missing ingredients and recognizes pantry items', () => {
+    const rows: GenerationRow[] = [
+      { ingredient: ing('Feta', ''), recipeId: 'a' },
+      { ingredient: ing('Olive oil', ''), recipeId: 'a' },
+      { ingredient: ing('Garlic', ''), recipeId: 'a' }
+    ];
+    const { toBuy, inPantry } = classifyGroceryRows(rows, [
+      { name: 'Olive oil', normalizedName: 'olive oil' },
+      { name: 'Garlic', normalizedName: 'garlic' }
+    ]);
+    expect(inPantry.map((r) => r.ingredient.name)).toEqual(['Olive oil', 'Garlic']);
+    expect(toBuy.map((r) => r.ingredient.name)).toEqual(['Feta']);
+  });
+
+  it('keeps uncertain quantity matches on the grocery list', () => {
+    const rows: GenerationRow[] = [{ ingredient: ing('chicken breast', '2 lb'), recipeId: 'a' }];
+    const { toBuy, inPantry } = classifyGroceryRows(rows, [
+      { name: 'Chicken breast', normalizedName: 'chicken breast', quantity: 1, unit: 'cup' }
+    ]);
+    expect(inPantry).toHaveLength(0);
+    expect(toBuy).toHaveLength(1);
+    expect(toBuy[0].status).toBe('uncertain');
+  });
+
+  it('still generates a full grocery list when pantry is empty', () => {
+    const rows: GenerationRow[] = [
+      { ingredient: ing('Rice', '1 cup'), recipeId: 'a' },
+      { ingredient: ing('Eggs', '6'), recipeId: 'a' }
+    ];
+    const { toBuy, inPantry } = classifyGroceryRows(rows, []);
+    expect(toBuy).toHaveLength(2);
+    expect(inPantry).toHaveLength(0);
+  });
 });

--- a/src/lib/mealplan/groceryGeneration.ts
+++ b/src/lib/mealplan/groceryGeneration.ts
@@ -6,6 +6,12 @@
  * findings: dedupe-without-merge (collapse EXACT (name, quantity)
  * duplicates, first occurrence's recipeId wins; no quantity summing —
  * that's v1.1), text slots skipped and reported.
+ *
+ * Pantry (v1): after dedupe, rows are classified against the user's
+ * pantry. Name matches with no pantry quantity are treated as already
+ * owned (presence-only). If a pantry quantity exists and cannot be
+ * compared reliably to the recipe amount, the ingredient stays on the
+ * grocery list. Pantry inventory is never decremented.
  */
 
 import type { ParsedIngredient } from '$lib/utils/ingredientParser';
@@ -77,3 +83,5 @@ export function dedupeIngredients(rows: GenerationRow[]): GenerationRow[] {
 export function groceryListTitle(weekId: string): string {
   return `Groceries — ${weekDisplayRange(weekId)}`;
 }
+
+export { classifyGroceryRows } from '$lib/pantry/matching';

--- a/src/lib/pantry/catalog.ts
+++ b/src/lib/pantry/catalog.ts
@@ -1,0 +1,221 @@
+/**
+ * Common-ingredient catalog for pantry autocomplete.
+ *
+ * This is a cooking-focused suggestion list, not an inventory ontology.
+ * Users can always enter freeform names when nothing matches.
+ */
+
+import { normalizeIngredientName } from './normalization';
+import { ingredientsMatch } from './matching';
+
+export interface CatalogIngredient {
+  name: string;
+  aliases?: string[];
+}
+
+/** Household staples offered as one-tap adds. */
+export const COMMON_STAPLES: string[] = [
+  'Salt',
+  'Black Pepper',
+  'Olive Oil',
+  'Butter',
+  'All-Purpose Flour',
+  'Sugar',
+  'Garlic',
+  'Onion',
+  'Eggs',
+  'Rice',
+  'Soy Sauce',
+  'Vinegar',
+  'Baking Powder',
+  'Baking Soda',
+  'Paprika',
+  'Cumin',
+  'Oregano',
+  'Cinnamon'
+];
+
+export const INGREDIENT_CATALOG: CatalogIngredient[] = [
+  { name: 'Chicken Breast', aliases: ['chicken', 'chicken breasts'] },
+  { name: 'Chicken Thighs' },
+  { name: 'Ground Chicken' },
+  { name: 'Whole Chicken' },
+  { name: 'Ground Beef', aliases: ['beef', 'hamburger'] },
+  { name: 'Steak' },
+  { name: 'Pork Chops' },
+  { name: 'Bacon' },
+  { name: 'Sausage' },
+  { name: 'Ham' },
+  { name: 'Turkey' },
+  { name: 'Salmon' },
+  { name: 'Tuna' },
+  { name: 'Shrimp' },
+  { name: 'Cod' },
+  { name: 'Tofu' },
+  { name: 'Eggs', aliases: ['egg'] },
+  { name: 'Milk' },
+  { name: 'Heavy Cream', aliases: ['cream'] },
+  { name: 'Half and Half' },
+  { name: 'Butter' },
+  { name: 'Parmesan Cheese', aliases: ['parm', 'parmesan', 'parmigiano'] },
+  { name: 'Cheddar Cheese', aliases: ['cheddar'] },
+  { name: 'Mozzarella' },
+  { name: 'Feta' },
+  { name: 'Cream Cheese' },
+  { name: 'Sour Cream' },
+  { name: 'Yogurt' },
+  { name: 'Greek Yogurt' },
+  { name: 'Onion', aliases: ['onions', 'yellow onion'] },
+  { name: 'Red Onion' },
+  { name: 'Green Onion', aliases: ['scallion', 'spring onion'] },
+  { name: 'Shallot' },
+  { name: 'Garlic' },
+  { name: 'Ginger' },
+  { name: 'Tomato' },
+  { name: 'Cherry Tomatoes' },
+  { name: 'Potato' },
+  { name: 'Sweet Potato' },
+  { name: 'Carrot' },
+  { name: 'Celery' },
+  { name: 'Bell Pepper', aliases: ['pepper'] },
+  { name: 'Jalapeño' },
+  { name: 'Broccoli' },
+  { name: 'Cauliflower' },
+  { name: 'Spinach' },
+  { name: 'Kale' },
+  { name: 'Lettuce' },
+  { name: 'Cabbage' },
+  { name: 'Cucumber' },
+  { name: 'Zucchini' },
+  { name: 'Mushroom' },
+  { name: 'Avocado' },
+  { name: 'Lemon' },
+  { name: 'Lime' },
+  { name: 'Orange' },
+  { name: 'Apple' },
+  { name: 'Banana' },
+  { name: 'Strawberry' },
+  { name: 'Blueberry' },
+  { name: 'Cilantro' },
+  { name: 'Parsley' },
+  { name: 'Basil' },
+  { name: 'Mint' },
+  { name: 'Rice' },
+  { name: 'Brown Rice' },
+  { name: 'Pasta' },
+  { name: 'Spaghetti' },
+  { name: 'Penne' },
+  { name: 'Macaroni' },
+  { name: 'Noodles' },
+  { name: 'Tortillas' },
+  { name: 'Bread' },
+  { name: 'Breadcrumbs' },
+  { name: 'Oats' },
+  { name: 'Quinoa' },
+  { name: 'Couscous' },
+  { name: 'Canned Tomatoes' },
+  { name: 'Tomato Paste' },
+  { name: 'Tomato Sauce' },
+  { name: 'Black Beans' },
+  { name: 'Chickpeas' },
+  { name: 'Chicken Broth' },
+  { name: 'Vegetable Broth' },
+  { name: 'Coconut Milk' },
+  { name: 'Olive Oil', aliases: ['evoo', 'extra virgin olive oil', 'olive'] },
+  { name: 'Vegetable Oil' },
+  { name: 'Sesame Oil' },
+  { name: 'Vinegar' },
+  { name: 'Apple Cider Vinegar' },
+  { name: 'Balsamic Vinegar' },
+  { name: 'Soy Sauce' },
+  { name: 'Hot Sauce' },
+  { name: 'Mustard' },
+  { name: 'Ketchup' },
+  { name: 'Mayonnaise' },
+  { name: 'Salsa' },
+  { name: 'Peanut Butter' },
+  { name: 'All-Purpose Flour', aliases: ['flour'] },
+  { name: 'Sugar' },
+  { name: 'Brown Sugar' },
+  { name: 'Powdered Sugar' },
+  { name: 'Baking Powder' },
+  { name: 'Baking Soda' },
+  { name: 'Yeast' },
+  { name: 'Cocoa Powder' },
+  { name: 'Chocolate Chips' },
+  { name: 'Honey' },
+  { name: 'Maple Syrup' },
+  { name: 'Vanilla Extract', aliases: ['vanilla'] },
+  { name: 'Salt' },
+  { name: 'Black Pepper', aliases: ['pepper'] },
+  { name: 'Paprika' },
+  { name: 'Cumin' },
+  { name: 'Chili Powder' },
+  { name: 'Cayenne' },
+  { name: 'Cinnamon' },
+  { name: 'Oregano' },
+  { name: 'Thyme' },
+  { name: 'Rosemary' },
+  { name: 'Garlic Powder' },
+  { name: 'Onion Powder' },
+  { name: 'Red Pepper Flakes' },
+  { name: 'Italian Seasoning' },
+  { name: 'Frozen Peas' },
+  { name: 'Frozen Corn' },
+  { name: 'Frozen Berries' }
+];
+
+export interface IngredientSuggestion {
+  name: string;
+  /** 0 = strongest match. */
+  score: number;
+}
+
+function catalogSearchBlob(entry: CatalogIngredient): string {
+  return [entry.name, ...(entry.aliases || [])].join(' ').toLowerCase();
+}
+
+/**
+ * Suggest catalog ingredients for a typed query. Already-pantry items are
+ * excluded. Returns [] for empty/comma-separated bulk input so freeform
+ * multi-add is not interrupted.
+ */
+export function suggestPantryIngredients(
+  query: string,
+  existing: Array<{ name: string; normalizedName: string }> = [],
+  limit = 8
+): IngredientSuggestion[] {
+  const q = query.trim().toLowerCase();
+  if (!q || /[,;\n]/.test(query)) return [];
+  if (q.length < 2) return [];
+
+  const scored: IngredientSuggestion[] = [];
+  for (const entry of INGREDIENT_CATALOG) {
+    if (existing.some((item) => ingredientsMatch(entry.name, item.name))) continue;
+
+    const nameLower = entry.name.toLowerCase();
+    const normalized = normalizeIngredientName(entry.name);
+    const aliases = (entry.aliases || []).map((a) => a.toLowerCase());
+    const blob = catalogSearchBlob(entry);
+
+    let score = -1;
+    if (nameLower === q || normalized === q || aliases.includes(q)) score = 0;
+    else if (aliases.some((a) => a.startsWith(q))) score = 1;
+    else if (nameLower.startsWith(q) || normalized.startsWith(q)) score = 2;
+    else if (nameLower.split(' ').some((t) => t.startsWith(q))) score = 3;
+    else if (blob.includes(q)) score = 4;
+
+    if (score >= 0) scored.push({ name: entry.name, score });
+  }
+
+  scored.sort((a, b) => a.score - b.score || a.name.localeCompare(b.name));
+  return scored.slice(0, limit);
+}
+
+export function missingCommonStaples(
+  existing: Array<{ name: string; normalizedName: string }>
+): string[] {
+  return COMMON_STAPLES.filter(
+    (name) => !existing.some((item) => ingredientsMatch(name, item.name))
+  );
+}

--- a/src/lib/pantry/categories.test.ts
+++ b/src/lib/pantry/categories.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { groupPantryItems, inferPantryCategory } from './categories';
+import { missingCommonStaples, suggestPantryIngredients } from './catalog';
+
+describe('inferPantryCategory', () => {
+  it('places common cooking ingredients into the expected aisles', () => {
+    expect(inferPantryCategory('Chicken Breast')).toBe('meat-seafood');
+    expect(inferPantryCategory('Parmesan Cheese')).toBe('dairy-eggs');
+    expect(inferPantryCategory('Eggs')).toBe('dairy-eggs');
+    expect(inferPantryCategory('Broccoli')).toBe('produce');
+    expect(inferPantryCategory('Rice')).toBe('grains-pasta');
+    expect(inferPantryCategory('Olive Oil')).toBe('sauces');
+    expect(inferPantryCategory('All-Purpose Flour')).toBe('baking');
+    expect(inferPantryCategory('Black Pepper')).toBe('spices');
+    expect(inferPantryCategory('Canned Tomatoes')).toBe('canned-jarred');
+    expect(inferPantryCategory('Frozen Peas')).toBe('frozen');
+  });
+
+  it('does not treat black pepper as produce', () => {
+    expect(inferPantryCategory('black pepper')).toBe('spices');
+    expect(inferPantryCategory('bell pepper')).toBe('produce');
+  });
+});
+
+describe('groupPantryItems', () => {
+  it('groups by aisle and sorts staples first', () => {
+    const groups = groupPantryItems([
+      {
+        id: '1',
+        name: 'Broccoli',
+        normalizedName: 'broccoli',
+        createdAt: 1,
+        updatedAt: 1
+      },
+      {
+        id: '2',
+        name: 'Salt',
+        normalizedName: 'salt',
+        isStaple: true,
+        createdAt: 1,
+        updatedAt: 1
+      },
+      {
+        id: '3',
+        name: 'Paprika',
+        normalizedName: 'paprika',
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ]);
+    expect(groups.map((g) => g.category)).toEqual(['produce', 'spices']);
+    expect(groups[1].items.map((i) => i.name)).toEqual(['Salt', 'Paprika']);
+  });
+});
+
+describe('suggestPantryIngredients', () => {
+  it('suggests catalog names from partial input', () => {
+    expect(suggestPantryIngredients('chick').map((s) => s.name)).toContain('Chicken Breast');
+    expect(suggestPantryIngredients('parm').map((s) => s.name)).toContain('Parmesan Cheese');
+    expect(suggestPantryIngredients('olive').map((s) => s.name)).toContain('Olive Oil');
+  });
+
+  it('skips ingredients already in the pantry and ignores bulk input', () => {
+    const existing = [{ name: 'Chicken Breast', normalizedName: 'chicken breast' }];
+    expect(suggestPantryIngredients('chick', existing).map((s) => s.name)).not.toContain(
+      'Chicken Breast'
+    );
+    expect(suggestPantryIngredients('eggs, rice')).toEqual([]);
+  });
+});
+
+describe('missingCommonStaples', () => {
+  it('hides staples the user already has', () => {
+    expect(missingCommonStaples([{ name: 'Salt', normalizedName: 'salt' }])).not.toContain('Salt');
+    expect(missingCommonStaples([])).toContain('Olive Oil');
+  });
+});

--- a/src/lib/pantry/categories.ts
+++ b/src/lib/pantry/categories.ts
@@ -1,0 +1,424 @@
+/**
+ * Automatic pantry categories for presentation.
+ *
+ * Categories are inferred at display time from the ingredient name.
+ * They are not stored on pantry items, so later ontology upgrades do
+ * not require a schema bump or a user-facing recategorize step.
+ */
+
+import { normalizeIngredientName } from './normalization';
+import type { PantryItem } from './schema';
+
+export const PANTRY_CATEGORIES = [
+  'produce',
+  'meat-seafood',
+  'dairy-eggs',
+  'grains-pasta',
+  'canned-jarred',
+  'baking',
+  'spices',
+  'sauces',
+  'frozen',
+  'other'
+] as const;
+
+export type PantryCategory = (typeof PANTRY_CATEGORIES)[number];
+
+export const PANTRY_CATEGORY_LABELS: Record<PantryCategory, string> = {
+  produce: 'Produce',
+  'meat-seafood': 'Meat & Seafood',
+  'dairy-eggs': 'Dairy & Eggs',
+  'grains-pasta': 'Grains & Pasta',
+  'canned-jarred': 'Canned & Jarred',
+  baking: 'Baking',
+  spices: 'Spices & Seasonings',
+  sauces: 'Sauces & Condiments',
+  frozen: 'Frozen',
+  other: 'Other'
+};
+
+const KEYWORDS: Record<Exclude<PantryCategory, 'other'>, string[]> = {
+  frozen: [
+    'frozen',
+    'ice cream',
+    'popsicle',
+    'sorbet',
+    'gelato',
+    'frozen pea',
+    'frozen berry',
+    'frozen fruit',
+    'frozen vegetable'
+  ],
+  'canned-jarred': [
+    'canned',
+    'can of',
+    'jarred',
+    'jar of',
+    'canned tomato',
+    'canned bean',
+    'canned tuna',
+    'canned corn',
+    'tomato paste',
+    'tomato sauce',
+    'crushed tomato',
+    'diced tomato',
+    'coconut milk',
+    'chickpea',
+    'garbanzo',
+    'black bean',
+    'kidney bean',
+    'pinto bean',
+    'cannellini',
+    'refried bean',
+    'broth',
+    'stock',
+    'capers',
+    'olives',
+    'pickle',
+    'sauerkraut',
+    'kimchi',
+    'applesauce'
+  ],
+  spices: [
+    'black pepper',
+    'white pepper',
+    'peppercorn',
+    'kosher salt',
+    'sea salt',
+    'table salt',
+    'salt',
+    'cumin',
+    'paprika',
+    'chili powder',
+    'chilli powder',
+    'cayenne',
+    'turmeric',
+    'cinnamon',
+    'nutmeg',
+    'clove',
+    'allspice',
+    'oregano',
+    'thyme',
+    'rosemary',
+    'basil',
+    'sage',
+    'bay leaf',
+    'bay leaves',
+    'coriander',
+    'cardamom',
+    'fennel seed',
+    'mustard seed',
+    'celery seed',
+    'garlic powder',
+    'onion powder',
+    'chili flake',
+    'red pepper flake',
+    'italian seasoning',
+    'taco seasoning',
+    'curry powder',
+    'garam masala',
+    'zaatar',
+    "za'atar",
+    'sumac',
+    'smoked paprika',
+    'seasoning',
+    'spice',
+    'vanilla extract',
+    'vanilla bean'
+  ],
+  sauces: [
+    'olive oil',
+    'avocado oil',
+    'sesame oil',
+    'vegetable oil',
+    'canola oil',
+    'coconut oil',
+    'neutral oil',
+    'cooking oil',
+    'oil',
+    'vinegar',
+    'soy sauce',
+    'tamari',
+    'fish sauce',
+    'worcestershire',
+    'hot sauce',
+    'sriracha',
+    'ketchup',
+    'mustard',
+    'mayonnaise',
+    'mayo',
+    'bbq sauce',
+    'barbecue sauce',
+    'teriyaki',
+    'hoisin',
+    'oyster sauce',
+    'pesto',
+    'salsa',
+    'hummus',
+    'tahini',
+    'dressing',
+    'marinade',
+    'chili crisp',
+    'chili garlic',
+    'gochujang',
+    'miso',
+    'harissa',
+    'chimichurri',
+    'aioli'
+  ],
+  baking: [
+    'all purpose flour',
+    'all-purpose flour',
+    'bread flour',
+    'cake flour',
+    'whole wheat flour',
+    'almond flour',
+    'coconut flour',
+    'flour',
+    'granulated sugar',
+    'brown sugar',
+    'powdered sugar',
+    'confectioner',
+    'sugar',
+    'baking powder',
+    'baking soda',
+    'yeast',
+    'cocoa',
+    'chocolate chip',
+    'semi sweet chocolate',
+    'dark chocolate',
+    'white chocolate',
+    'cornstarch',
+    'corn starch',
+    'cornmeal',
+    'corn meal',
+    'molasses',
+    'honey',
+    'maple syrup',
+    'vanilla',
+    'shortening',
+    'sprinkles'
+  ],
+  'grains-pasta': [
+    'rice',
+    'pasta',
+    'spaghetti',
+    'penne',
+    'linguine',
+    'fettuccine',
+    'macaroni',
+    'noodle',
+    'lasagna',
+    'orzo',
+    'couscous',
+    'quinoa',
+    'barley',
+    'farro',
+    'bulgur',
+    'oat',
+    'oatmeal',
+    'granola',
+    'cereal',
+    'bread',
+    'tortilla',
+    'pita',
+    'bagel',
+    'bun',
+    'roll',
+    'cracker',
+    'breadcrumb',
+    'panko',
+    'polenta',
+    'grits'
+  ],
+  'dairy-eggs': [
+    'milk',
+    'cream',
+    'half and half',
+    'butter',
+    'ghee',
+    'cheese',
+    'parmesan',
+    'cheddar',
+    'mozzarella',
+    'feta',
+    'ricotta',
+    'goat cheese',
+    'cream cheese',
+    'cottage cheese',
+    'sour cream',
+    'yogurt',
+    'yoghurt',
+    'egg',
+    'buttermilk'
+  ],
+  'meat-seafood': [
+    'chicken',
+    'beef',
+    'steak',
+    'ground beef',
+    'pork',
+    'bacon',
+    'sausage',
+    'ham',
+    'turkey',
+    'duck',
+    'lamb',
+    'veal',
+    'fish',
+    'salmon',
+    'tuna',
+    'cod',
+    'tilapia',
+    'shrimp',
+    'prawn',
+    'crab',
+    'lobster',
+    'scallop',
+    'clam',
+    'mussel',
+    'oyster',
+    'anchovy',
+    'sardine',
+    'tofu',
+    'tempeh',
+    'seitan'
+  ],
+  produce: [
+    'apple',
+    'banana',
+    'orange',
+    'lemon',
+    'lime',
+    'grape',
+    'berry',
+    'strawberry',
+    'blueberry',
+    'raspberry',
+    'mango',
+    'pineapple',
+    'watermelon',
+    'melon',
+    'peach',
+    'pear',
+    'plum',
+    'avocado',
+    'tomato',
+    'lettuce',
+    'spinach',
+    'kale',
+    'arugula',
+    'cabbage',
+    'broccoli',
+    'cauliflower',
+    'carrot',
+    'celery',
+    'cucumber',
+    'zucchini',
+    'squash',
+    'bell pepper',
+    'jalapeno',
+    'jalapeño',
+    'chili',
+    'onion',
+    'shallot',
+    'leek',
+    'garlic',
+    'ginger',
+    'potato',
+    'sweet potato',
+    'yam',
+    'mushroom',
+    'asparagus',
+    'green bean',
+    'pea',
+    'corn',
+    'eggplant',
+    'aubergine',
+    'beet',
+    'radish',
+    'turnip',
+    'cilantro',
+    'parsley',
+    'mint',
+    'basil',
+    'dill',
+    'scallion',
+    'green onion',
+    'chive',
+    'herb',
+    'fruit',
+    'vegetable'
+  ]
+};
+
+const CATEGORY_ORDER: Exclude<PantryCategory, 'other'>[] = [
+  'frozen',
+  'canned-jarred',
+  'spices',
+  'sauces',
+  'baking',
+  'grains-pasta',
+  'dairy-eggs',
+  'meat-seafood',
+  'produce'
+];
+
+function haystackFor(name: string): string {
+  const raw = name.toLowerCase();
+  const normalized = normalizeIngredientName(name);
+  return `${raw} ${normalized}`.trim();
+}
+
+/**
+ * Infer a pantry category. More specific pantry aisles (frozen, canned,
+ * spices, sauces, baking) win over generic produce/protein matches so
+ * "black pepper" is a spice and "bell pepper" is produce.
+ */
+export function inferPantryCategory(name: string): PantryCategory {
+  const haystack = haystackFor(name);
+  if (!haystack) return 'other';
+
+  for (const category of CATEGORY_ORDER) {
+    if (KEYWORDS[category].some((kw) => haystack.includes(kw))) {
+      return category;
+    }
+  }
+  return 'other';
+}
+
+export interface PantryCategoryGroup {
+  category: PantryCategory;
+  label: string;
+  items: PantryItem[];
+}
+
+/**
+ * Group pantry items for display. Staples stay in their aisle and are
+ * sorted to the top of that group so the list stays visually calm.
+ */
+export function groupPantryItems(items: PantryItem[]): PantryCategoryGroup[] {
+  const buckets = new Map<PantryCategory, PantryItem[]>();
+  for (const item of items) {
+    const category = inferPantryCategory(item.name);
+    const list = buckets.get(category);
+    if (list) list.push(item);
+    else buckets.set(category, [item]);
+  }
+
+  const groups: PantryCategoryGroup[] = [];
+  for (const category of PANTRY_CATEGORIES) {
+    const list = buckets.get(category);
+    if (!list?.length) continue;
+    list.sort((a, b) => {
+      if (!!a.isStaple !== !!b.isStaple) return a.isStaple ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+    groups.push({
+      category,
+      label: PANTRY_CATEGORY_LABELS[category],
+      items: list
+    });
+  }
+  return groups;
+}

--- a/src/lib/pantry/matching.ts
+++ b/src/lib/pantry/matching.ts
@@ -1,0 +1,286 @@
+/**
+ * Deterministic pantry ↔ recipe ingredient matching.
+ *
+ * Matching is never delegated to Cheffy. Ranking may use the result;
+ * hard dietary / slot / exclude constraints still win.
+ *
+ * Grocery quantity policy (V1)
+ * - Name match is required.
+ * - If the pantry item has no quantity, treat as presence-only: the user
+ *   said they have it without tracking how much → `have`.
+ * - If both sides have a comparable numeric quantity in the same unit
+ *   family, compare amounts. Insufficient pantry amount → `need`.
+ * - If quantity comparison is uncertain (mixed units, unparseable) →
+ *   `uncertain`, which stays on the grocery list.
+ * - Never auto-decrement pantry inventory.
+ */
+
+import type { ParsedIngredient } from '$lib/utils/ingredientParser';
+import { normalizeIngredientName, parseQuantityInput } from './normalization';
+import type { PantryItem } from './schema';
+
+export interface PantryMatch {
+  matchedIngredients: string[];
+  missingIngredients: string[];
+  totalIngredients: number;
+  matchedCount: number;
+  matchRatio: number;
+}
+
+export type GroceryPantryStatus = 'need' | 'have' | 'uncertain';
+
+export interface ClassifiedGroceryRow {
+  ingredient: ParsedIngredient;
+  recipeId: string;
+  status: GroceryPantryStatus;
+}
+
+/** Headwords too generic to match as a substring/token of a longer name. */
+const GENERIC_HEADS = new Set([
+  'oil',
+  'sauce',
+  'salt',
+  'water',
+  'pepper',
+  'cheese',
+  'milk',
+  'stock',
+  'broth',
+  'flour',
+  'sugar',
+  'juice',
+  'powder',
+  'flake',
+  'extract',
+  'seasoning',
+  'spice',
+  'mix',
+  'blend',
+  'paste',
+  'cream',
+  'butter',
+  'seed',
+  'leaf',
+  'leaves'
+]);
+
+const UNIT_ALIASES: Record<string, string> = {
+  cup: 'cup',
+  cups: 'cup',
+  c: 'cup',
+  tablespoon: 'tbsp',
+  tablespoons: 'tbsp',
+  tbsp: 'tbsp',
+  tbs: 'tbsp',
+  teaspoon: 'tsp',
+  teaspoons: 'tsp',
+  tsp: 'tsp',
+  ounce: 'oz',
+  ounces: 'oz',
+  oz: 'oz',
+  pound: 'lb',
+  pounds: 'lb',
+  lb: 'lb',
+  lbs: 'lb',
+  gram: 'g',
+  grams: 'g',
+  g: 'g',
+  kilogram: 'kg',
+  kilograms: 'kg',
+  kg: 'kg',
+  milliliter: 'ml',
+  milliliters: 'ml',
+  ml: 'ml',
+  liter: 'l',
+  liters: 'l',
+  l: 'l',
+  piece: 'count',
+  pieces: 'count',
+  pc: 'count',
+  pcs: 'count',
+  count: 'count',
+  large: 'count',
+  medium: 'count',
+  small: 'count'
+};
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function hasWholePhrase(haystack: string, needle: string): boolean {
+  if (!haystack || !needle) return false;
+  const re = new RegExp(`(?:^|\\s)${escapeRegExp(needle)}(?:\\s|$)`);
+  return re.test(haystack);
+}
+
+/**
+ * True when two ingredient names refer to the same pantry item.
+ * Uses normalized keys plus whole-token containment. Never matches
+ * `ham` to `hamburger`.
+ */
+export function ingredientsMatch(a: string, b: string): boolean {
+  const na = normalizeIngredientName(a);
+  const nb = normalizeIngredientName(b);
+  if (!na || !nb) return false;
+  if (na === nb) return true;
+
+  const [shorter, longer] = na.length <= nb.length ? [na, nb] : [nb, na];
+  if (shorter.length < 3) return false;
+  if (GENERIC_HEADS.has(shorter)) return false;
+  return hasWholePhrase(longer, shorter);
+}
+
+export function findMatchingPantryItem(
+  ingredientName: string,
+  pantry: Array<Pick<PantryItem, 'name' | 'normalizedName'>>
+): Pick<PantryItem, 'name' | 'normalizedName'> | undefined {
+  return pantry.find(
+    (item) =>
+      ingredientsMatch(ingredientName, item.normalizedName) ||
+      ingredientsMatch(ingredientName, item.name)
+  );
+}
+
+export function matchRecipeToPantry(
+  ingredients: string[],
+  pantry: Array<Pick<PantryItem, 'name' | 'normalizedName'>>
+): PantryMatch {
+  const unique: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of ingredients || []) {
+    const name = (raw || '').trim();
+    if (!name) continue;
+    const key = normalizeIngredientName(name) || name.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(name);
+  }
+
+  if (unique.length === 0) {
+    return {
+      matchedIngredients: [],
+      missingIngredients: [],
+      totalIngredients: 0,
+      matchedCount: 0,
+      matchRatio: 0
+    };
+  }
+
+  if (!pantry.length) {
+    return {
+      matchedIngredients: [],
+      missingIngredients: [...unique],
+      totalIngredients: unique.length,
+      matchedCount: 0,
+      matchRatio: 0
+    };
+  }
+
+  const matchedIngredients: string[] = [];
+  const missingIngredients: string[] = [];
+  for (const name of unique) {
+    if (findMatchingPantryItem(name, pantry)) matchedIngredients.push(name);
+    else missingIngredients.push(name);
+  }
+
+  return {
+    matchedIngredients,
+    missingIngredients,
+    totalIngredients: unique.length,
+    matchedCount: matchedIngredients.length,
+    matchRatio: matchedIngredients.length / unique.length
+  };
+}
+
+function canonicalizeUnit(unit: string | undefined): string | undefined {
+  if (!unit) return 'count';
+  const key = unit.trim().toLowerCase().replace(/\.$/, '');
+  if (!key) return 'count';
+  return UNIT_ALIASES[key] || UNIT_ALIASES[singularizeLoose(key)] || key;
+}
+
+function singularizeLoose(token: string): string {
+  if (token.endsWith('s') && token.length > 2) return token.slice(0, -1);
+  return token;
+}
+
+function parseComparableQuantity(
+  quantityText: string | undefined,
+  explicitQuantity?: number,
+  explicitUnit?: string
+): { amount: number; unit: string } | null {
+  if (explicitQuantity != null && Number.isFinite(explicitQuantity) && explicitQuantity > 0) {
+    return { amount: explicitQuantity, unit: canonicalizeUnit(explicitUnit) || 'count' };
+  }
+  if (!quantityText || !quantityText.trim()) return null;
+  const parsed = parseQuantityInput(quantityText);
+  if (parsed.quantity == null) return null;
+  return { amount: parsed.quantity, unit: canonicalizeUnit(parsed.unit) || 'count' };
+}
+
+/**
+ * Classify a recipe grocery row against pantry.
+ * Uncertain matches stay on the grocery list (`need` is not used for those —
+ * callers put `uncertain` in the to-buy bucket).
+ */
+export function classifyIngredientAgainstPantry(
+  ingredient: ParsedIngredient,
+  pantry: Array<Pick<PantryItem, 'name' | 'normalizedName' | 'quantity' | 'unit'>>
+): GroceryPantryStatus {
+  const item = pantry.find(
+    (p) =>
+      ingredientsMatch(ingredient.name, p.normalizedName) ||
+      ingredientsMatch(ingredient.name, p.name)
+  );
+  if (!item) return 'need';
+
+  const pantryQty = parseComparableQuantity(undefined, item.quantity, item.unit);
+  if (!pantryQty) {
+    // Presence-only pantry entry: user listed the ingredient without an amount.
+    return 'have';
+  }
+
+  const recipeQty = parseComparableQuantity(ingredient.quantity);
+  if (!recipeQty) return 'uncertain';
+  if (pantryQty.unit !== recipeQty.unit) return 'uncertain';
+  return pantryQty.amount + 1e-9 >= recipeQty.amount ? 'have' : 'need';
+}
+
+export function classifyGroceryRows(
+  rows: Array<{ ingredient: ParsedIngredient; recipeId: string }>,
+  pantry: Array<Pick<PantryItem, 'name' | 'normalizedName' | 'quantity' | 'unit'>>
+): { toBuy: ClassifiedGroceryRow[]; inPantry: ClassifiedGroceryRow[] } {
+  const toBuy: ClassifiedGroceryRow[] = [];
+  const inPantry: ClassifiedGroceryRow[] = [];
+  for (const row of rows) {
+    const status = classifyIngredientAgainstPantry(row.ingredient, pantry);
+    const classified = { ...row, status };
+    if (status === 'have') inPantry.push(classified);
+    else toBuy.push(classified);
+  }
+  return { toBuy, inPantry };
+}
+
+export function pantryMatchSummary(match: {
+  matchedCount: number;
+  totalIngredients?: number;
+  totalCount?: number;
+}): string {
+  const total = match.totalIngredients ?? match.totalCount ?? 0;
+  if (total === 0) return '';
+  return `You already have ${match.matchedCount} of ${total} ingredients`;
+}
+
+export function weakPantryPlanNote(
+  matches: Array<{ matchRatio: number; totalIngredients?: number; totalCount?: number } | undefined>
+): string | null {
+  const usable = matches.filter(
+    (m): m is { matchRatio: number; totalIngredients?: number; totalCount?: number } =>
+      !!m && (m.totalIngredients ?? m.totalCount ?? 0) > 0
+  );
+  if (usable.length === 0) return null;
+  const avg = usable.reduce((sum, m) => sum + m.matchRatio, 0) / usable.length;
+  if (avg >= 0.5) return null;
+  return "I couldn't build the whole week from your pantry, but these meals use the ingredients you already have most effectively.";
+}

--- a/src/lib/pantry/matching.ts
+++ b/src/lib/pantry/matching.ts
@@ -6,6 +6,7 @@
  *
  * Grocery quantity policy (V1)
  * - Name match is required.
+ * - A staple is always presence-only → `have`, even if a quantity is stored.
  * - If the pantry item has no quantity, treat as presence-only: the user
  *   said they have it without tracking how much → `have`.
  * - If both sides have a comparable numeric quantity in the same unit
@@ -226,7 +227,7 @@ function parseComparableQuantity(
  */
 export function classifyIngredientAgainstPantry(
   ingredient: ParsedIngredient,
-  pantry: Array<Pick<PantryItem, 'name' | 'normalizedName' | 'quantity' | 'unit'>>
+  pantry: Array<Pick<PantryItem, 'name' | 'normalizedName' | 'quantity' | 'unit' | 'isStaple'>>
 ): GroceryPantryStatus {
   const item = pantry.find(
     (p) =>
@@ -234,6 +235,12 @@ export function classifyIngredientAgainstPantry(
       ingredientsMatch(ingredient.name, p.name)
   );
   if (!item) return 'need';
+
+  if (item.isStaple) {
+    // Staples are always-on-hand; quantity is ignored so grocery lists
+    // do not keep suggesting salt, oil, and similar household items.
+    return 'have';
+  }
 
   const pantryQty = parseComparableQuantity(undefined, item.quantity, item.unit);
   if (!pantryQty) {
@@ -249,7 +256,7 @@ export function classifyIngredientAgainstPantry(
 
 export function classifyGroceryRows(
   rows: Array<{ ingredient: ParsedIngredient; recipeId: string }>,
-  pantry: Array<Pick<PantryItem, 'name' | 'normalizedName' | 'quantity' | 'unit'>>
+  pantry: Array<Pick<PantryItem, 'name' | 'normalizedName' | 'quantity' | 'unit' | 'isStaple'>>
 ): { toBuy: ClassifiedGroceryRow[]; inPantry: ClassifiedGroceryRow[] } {
   const toBuy: ClassifiedGroceryRow[] = [];
   const inPantry: ClassifiedGroceryRow[] = [];
@@ -269,7 +276,22 @@ export function pantryMatchSummary(match: {
 }): string {
   const total = match.totalIngredients ?? match.totalCount ?? 0;
   if (total === 0) return '';
-  return `You already have ${match.matchedCount} of ${total} ingredients`;
+  return `You have ${match.matchedCount} of ${total} ingredients`;
+}
+
+export function pantryNeededSummary(match: {
+  matchedCount: number;
+  totalIngredients?: number;
+  totalCount?: number;
+}): string {
+  const total = match.totalIngredients ?? match.totalCount ?? 0;
+  if (total === 0) return '';
+  const needed = total - match.matchedCount;
+  if (needed === 0) return 'You have every ingredient';
+  if (match.matchedCount === 0) {
+    return `${needed} ingredient${needed === 1 ? '' : 's'} needed`;
+  }
+  return pantryMatchSummary(match);
 }
 
 export function weakPantryPlanNote(

--- a/src/lib/pantry/normalization.test.ts
+++ b/src/lib/pantry/normalization.test.ts
@@ -4,7 +4,8 @@ import {
   classifyIngredientAgainstPantry,
   classifyGroceryRows,
   ingredientsMatch,
-  matchRecipeToPantry
+  matchRecipeToPantry,
+  pantryNeededSummary
 } from './matching';
 import { sanitizePantryItem, validatePantryPayload, formatPantryQuantity } from './schema';
 import type { ParsedIngredient } from '$lib/utils/ingredientParser';
@@ -127,6 +128,18 @@ describe('matchRecipeToPantry', () => {
     expect(match.matchedIngredients).toEqual([]);
     expect(match.missingIngredients).toEqual([]);
   });
+
+  it('summarizes pantry coverage for recipe views', () => {
+    expect(pantryNeededSummary({ matchedCount: 7, totalIngredients: 10 })).toBe(
+      'You have 7 of 10 ingredients'
+    );
+    expect(pantryNeededSummary({ matchedCount: 0, totalIngredients: 3 })).toBe(
+      '3 ingredients needed'
+    );
+    expect(pantryNeededSummary({ matchedCount: 4, totalIngredients: 4 })).toBe(
+      'You have every ingredient'
+    );
+  });
 });
 
 function ing(name: string, quantity = ''): ParsedIngredient {
@@ -182,6 +195,14 @@ describe('classifyIngredientAgainstPantry', () => {
     expect(toBuy.map((r) => r.ingredient.name)).toEqual(['Feta', 'eggs']);
   });
 
+  it('treats staples as already owned even when a recipe needs more quantity', () => {
+    expect(
+      classifyIngredientAgainstPantry(ing('salt', '2 tsp'), [
+        { name: 'Salt', normalizedName: 'salt', quantity: 1, unit: 'tsp', isStaple: true }
+      ])
+    ).toBe('have');
+  });
+
   it('leaves the grocery list unchanged when pantry is empty', () => {
     const rows = [{ ingredient: ing('Rice'), recipeId: 'a' }];
     const { toBuy, inPantry } = classifyGroceryRows(rows, []);
@@ -221,5 +242,19 @@ describe('pantry schema', () => {
       updatedAt: 1
     });
     expect(validated?.readOnly).toBe(true);
+  });
+
+  it('preserves staples and unknown item fields', () => {
+    const item = sanitizePantryItem({
+      id: 'abc',
+      name: 'Salt',
+      normalizedName: 'salt',
+      isStaple: true,
+      expiresAt: 1789000999,
+      createdAt: 1,
+      updatedAt: 1
+    });
+    expect(item?.isStaple).toBe(true);
+    expect((item as { expiresAt?: number }).expiresAt).toBe(1789000999);
   });
 });

--- a/src/lib/pantry/normalization.test.ts
+++ b/src/lib/pantry/normalization.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeIngredientName, parseQuantityInput, singularizeToken } from './normalization';
+import {
+  classifyIngredientAgainstPantry,
+  classifyGroceryRows,
+  ingredientsMatch,
+  matchRecipeToPantry
+} from './matching';
+import { sanitizePantryItem, validatePantryPayload, formatPantryQuantity } from './schema';
+import type { ParsedIngredient } from '$lib/utils/ingredientParser';
+
+describe('normalizeIngredientName', () => {
+  it('normalizes eggs to egg', () => {
+    expect(normalizeIngredientName('Eggs')).toBe('egg');
+    expect(normalizeIngredientName('eggs')).toBe('egg');
+  });
+
+  it('normalizes chicken breasts to chicken breast', () => {
+    expect(normalizeIngredientName('Chicken breasts')).toBe('chicken breast');
+  });
+
+  it('normalizes tomatoes to tomato', () => {
+    expect(normalizeIngredientName('Tomatoes')).toBe('tomato');
+  });
+
+  it('maps EVOO and extra virgin olive oil to olive oil', () => {
+    expect(normalizeIngredientName('EVOO')).toBe('olive oil');
+    expect(normalizeIngredientName('extra virgin olive oil')).toBe('olive oil');
+  });
+
+  it('strips color modifiers from onions', () => {
+    expect(normalizeIngredientName('yellow onion')).toBe('onion');
+    expect(normalizeIngredientName('onions')).toBe('onion');
+  });
+
+  it('strips a leading quantity from a pantry line', () => {
+    expect(normalizeIngredientName('2 large eggs')).toBe('egg');
+  });
+});
+
+describe('singularizeToken', () => {
+  it('handles regular and irregular plurals', () => {
+    expect(singularizeToken('eggs')).toBe('egg');
+    expect(singularizeToken('tomatoes')).toBe('tomato');
+    expect(singularizeToken('breasts')).toBe('breast');
+  });
+});
+
+describe('parseQuantityInput', () => {
+  it('parses optional amounts and units', () => {
+    expect(parseQuantityInput('8')).toEqual({ quantity: 8 });
+    expect(parseQuantityInput('2 lb')).toEqual({ quantity: 2, unit: 'lb' });
+    expect(parseQuantityInput('1 bag')).toEqual({ quantity: 1, unit: 'bag' });
+    expect(parseQuantityInput('')).toEqual({});
+  });
+});
+
+describe('ingredientsMatch', () => {
+  it('matches exact and plural/singular names', () => {
+    expect(ingredientsMatch('eggs', 'egg')).toBe(true);
+    expect(ingredientsMatch('Eggs', 'egg')).toBe(true);
+    expect(ingredientsMatch('chicken breasts', 'chicken breast')).toBe(true);
+    expect(ingredientsMatch('tomatoes', 'tomato')).toBe(true);
+  });
+
+  it('matches normalized variants', () => {
+    expect(ingredientsMatch('yellow onion', 'onion')).toBe(true);
+    expect(ingredientsMatch('olive oil', 'extra virgin olive oil')).toBe(true);
+    expect(ingredientsMatch('EVOO', 'olive oil')).toBe(true);
+  });
+
+  it('does not match unrelated ingredients', () => {
+    expect(ingredientsMatch('eggs', 'flour')).toBe(false);
+    expect(ingredientsMatch('chicken', 'beef')).toBe(false);
+  });
+
+  it('does not match accidental substrings', () => {
+    expect(ingredientsMatch('ham', 'hamburger')).toBe(false);
+    expect(ingredientsMatch('hamburger', 'ham')).toBe(false);
+    expect(ingredientsMatch('egg', 'eggplant')).toBe(false);
+    expect(ingredientsMatch('oil', 'olive oil')).toBe(false);
+  });
+
+  it('matches a more specific cut to a generic pantry protein', () => {
+    expect(ingredientsMatch('chicken', 'chicken breast')).toBe(true);
+  });
+});
+
+describe('matchRecipeToPantry', () => {
+  const pantry = [
+    { name: 'Chicken breast', normalizedName: 'chicken breast' },
+    { name: 'Parmesan', normalizedName: 'parmesan' },
+    { name: 'Eggs', normalizedName: 'egg' },
+    { name: 'Olive oil', normalizedName: 'olive oil' },
+    { name: 'Garlic', normalizedName: 'garlic' }
+  ];
+
+  it('calculates match ratio and lists matched/missing ingredients', () => {
+    const match = matchRecipeToPantry(
+      ['Chicken breast', 'Parmesan', 'Breadcrumbs', 'Egg', 'Tomato sauce', 'Olive oil', 'Garlic'],
+      pantry
+    );
+    expect(match.totalIngredients).toBe(7);
+    expect(match.matchedCount).toBe(5);
+    expect(match.matchRatio).toBeCloseTo(5 / 7);
+    expect(match.matchedIngredients).toEqual([
+      'Chicken breast',
+      'Parmesan',
+      'Egg',
+      'Olive oil',
+      'Garlic'
+    ]);
+    expect(match.missingIngredients).toEqual(['Breadcrumbs', 'Tomato sauce']);
+  });
+
+  it('handles an empty pantry', () => {
+    const match = matchRecipeToPantry(['Eggs', 'Flour'], []);
+    expect(match.matchedCount).toBe(0);
+    expect(match.matchRatio).toBe(0);
+    expect(match.missingIngredients).toEqual(['Eggs', 'Flour']);
+  });
+
+  it('handles a recipe with no parsed ingredients', () => {
+    const match = matchRecipeToPantry([], pantry);
+    expect(match.totalIngredients).toBe(0);
+    expect(match.matchRatio).toBe(0);
+    expect(match.matchedIngredients).toEqual([]);
+    expect(match.missingIngredients).toEqual([]);
+  });
+});
+
+function ing(name: string, quantity = ''): ParsedIngredient {
+  return { name, quantity, category: 'other', originalText: `${quantity} ${name}`.trim() };
+}
+
+describe('classifyIngredientAgainstPantry', () => {
+  it('recognizes pantry ingredients by name', () => {
+    expect(
+      classifyIngredientAgainstPantry(ing('Olive oil'), [
+        { name: 'Olive oil', normalizedName: 'olive oil' }
+      ])
+    ).toBe('have');
+  });
+
+  it('keeps missing ingredients as need', () => {
+    expect(
+      classifyIngredientAgainstPantry(ing('Feta'), [
+        { name: 'Olive oil', normalizedName: 'olive oil' }
+      ])
+    ).toBe('need');
+  });
+
+  it('does not treat 1 egg as enough for 6 eggs', () => {
+    expect(
+      classifyIngredientAgainstPantry(ing('eggs', '6'), [
+        { name: 'Eggs', normalizedName: 'egg', quantity: 1 }
+      ])
+    ).toBe('need');
+  });
+
+  it('treats mixed units as uncertain so they stay on the grocery list', () => {
+    expect(
+      classifyIngredientAgainstPantry(ing('chicken breast', '2 lb'), [
+        { name: 'Chicken breast', normalizedName: 'chicken breast', quantity: 2, unit: 'cups' }
+      ])
+    ).toBe('uncertain');
+  });
+
+  it('classifies grocery rows into to-buy vs in-pantry', () => {
+    const { toBuy, inPantry } = classifyGroceryRows(
+      [
+        { ingredient: ing('Feta'), recipeId: 'a' },
+        { ingredient: ing('Olive oil'), recipeId: 'a' },
+        { ingredient: ing('eggs', '6'), recipeId: 'a' }
+      ],
+      [
+        { name: 'Olive oil', normalizedName: 'olive oil' },
+        { name: 'Eggs', normalizedName: 'egg', quantity: 1 }
+      ]
+    );
+    expect(inPantry.map((r) => r.ingredient.name)).toEqual(['Olive oil']);
+    expect(toBuy.map((r) => r.ingredient.name)).toEqual(['Feta', 'eggs']);
+  });
+
+  it('leaves the grocery list unchanged when pantry is empty', () => {
+    const rows = [{ ingredient: ing('Rice'), recipeId: 'a' }];
+    const { toBuy, inPantry } = classifyGroceryRows(rows, []);
+    expect(toBuy).toHaveLength(1);
+    expect(inPantry).toHaveLength(0);
+  });
+});
+
+describe('pantry schema', () => {
+  it('sanitizes and validates a pantry payload', () => {
+    const item = sanitizePantryItem({
+      id: 'abc',
+      name: 'Eggs',
+      normalizedName: 'egg',
+      quantity: 8,
+      createdAt: 1,
+      updatedAt: 1
+    });
+    expect(item?.name).toBe('Eggs');
+    expect(formatPantryQuantity(item!)).toBe('8');
+
+    const validated = validatePantryPayload({
+      schemaVersion: 1,
+      items: [item],
+      createdAt: 1,
+      updatedAt: 2
+    });
+    expect(validated?.readOnly).toBe(false);
+    expect(validated?.pantry.items).toHaveLength(1);
+  });
+
+  it('treats a newer schemaVersion as read-only', () => {
+    const validated = validatePantryPayload({
+      schemaVersion: 2,
+      items: [],
+      createdAt: 1,
+      updatedAt: 1
+    });
+    expect(validated?.readOnly).toBe(true);
+  });
+});

--- a/src/lib/pantry/normalization.ts
+++ b/src/lib/pantry/normalization.ts
@@ -1,0 +1,208 @@
+/**
+ * Deterministic ingredient normalization for pantry matching.
+ *
+ * V1 is practical, not culinary-complete. The matching layer consumes
+ * `normalizedName`, so a later synonym/ontology upgrade can replace this
+ * file without rewriting Pantry storage or Cheffy ranking.
+ */
+
+const ALIASES: Record<string, string> = {
+  evoo: 'olive oil',
+  'e v o o': 'olive oil',
+  'ev olive oil': 'olive oil',
+  'extra virgin olive oil': 'olive oil',
+  'extra-virgin olive oil': 'olive oil',
+  scallion: 'green onion',
+  scallions: 'green onion',
+  'green onions': 'green onion',
+  'spring onion': 'green onion',
+  'spring onions': 'green onion',
+  cilantro: 'cilantro',
+  coriander: 'cilantro'
+};
+
+const QTY_UNITS = new Set([
+  'cup',
+  'cups',
+  'c',
+  'tablespoon',
+  'tablespoons',
+  'tbsp',
+  'tbs',
+  'tb',
+  'teaspoon',
+  'teaspoons',
+  'tsp',
+  'ts',
+  'ounce',
+  'ounces',
+  'oz',
+  'pound',
+  'pounds',
+  'lb',
+  'lbs',
+  'gram',
+  'grams',
+  'g',
+  'kilogram',
+  'kilograms',
+  'kg',
+  'milliliter',
+  'milliliters',
+  'ml',
+  'liter',
+  'liters',
+  'l',
+  'clove',
+  'cloves',
+  'can',
+  'cans',
+  'bag',
+  'bags',
+  'bunch',
+  'bunches',
+  'package',
+  'packages',
+  'pkg',
+  'pinch',
+  'pinches',
+  'dash',
+  'dashes',
+  'stick',
+  'sticks',
+  'head',
+  'heads',
+  'slice',
+  'slices',
+  'piece',
+  'pieces'
+]);
+
+const MODIFIERS = new Set([
+  'extra',
+  'virgin',
+  'cold-pressed',
+  'coldpressed',
+  'yellow',
+  'white',
+  'red',
+  'green',
+  'sweet',
+  'large',
+  'medium',
+  'small',
+  'fresh',
+  'dried',
+  'frozen',
+  'canned',
+  'ground',
+  'whole',
+  'boneless',
+  'skinless',
+  'organic',
+  'chopped',
+  'diced',
+  'minced',
+  'sliced',
+  'grated',
+  'shredded',
+  'peeled',
+  'cooked',
+  'raw',
+  'unsalted',
+  'unsweetened',
+  'lean',
+  'ripe',
+  'baby',
+  'brown',
+  'russet',
+  'kosher',
+  'crushed',
+  'powdered',
+  'all-purpose',
+  'allpurpose',
+  'low-fat',
+  'lowfat',
+  'fat-free',
+  'fatfree',
+  'free-range',
+  'freerange'
+]);
+
+const IRREGULAR_SINGULARS: Record<string, string> = {
+  tomatoes: 'tomato',
+  potatoes: 'potato',
+  leaves: 'leaf',
+  berries: 'berry',
+  cherries: 'cherry',
+  strawberries: 'strawberry',
+  blueberries: 'blueberry',
+  raspberries: 'raspberry',
+  cloves: 'clove',
+  loaves: 'loaf',
+  geese: 'goose',
+  mice: 'mouse',
+  children: 'child',
+  people: 'person',
+  teeth: 'tooth'
+};
+
+export function parseQuantityInput(raw: string): { quantity?: number; unit?: string } {
+  const s = raw.trim();
+  if (!s) return {};
+  const match = s.match(/^(\d+(?:\.\d+)?)\s*(.*)$/);
+  if (!match) return { unit: s.slice(0, 24) };
+  const quantity = parseFloat(match[1]);
+  if (!Number.isFinite(quantity) || quantity <= 0) return { unit: s.slice(0, 24) };
+  const unit = match[2].trim().slice(0, 24);
+  return unit ? { quantity, unit } : { quantity };
+}
+
+export function singularizeToken(token: string): string {
+  const irregular = IRREGULAR_SINGULARS[token];
+  if (irregular) return irregular;
+  if (token.endsWith('ies') && token.length > 4) return `${token.slice(0, -3)}y`;
+  if (token.endsWith('oes') && token.length > 4) return token.slice(0, -2);
+  if (token.endsWith('sses') || token.endsWith('ss')) return token;
+  if (token.endsWith('s') && !token.endsWith('ss') && token.length > 3) {
+    return token.slice(0, -1);
+  }
+  return token;
+}
+
+function applyAlias(value: string): string {
+  return ALIASES[value] || value;
+}
+
+/**
+ * Collapse a free-text ingredient into a stable matching key.
+ *
+ * Examples:
+ *   "Eggs" → "egg"
+ *   "2 large eggs" → "egg"
+ *   "Chicken breasts" → "chicken breast"
+ *   "extra virgin olive oil" / "EVOO" → "olive oil"
+ *   "yellow onion" → "onion"
+ */
+export function normalizeIngredientName(raw: string): string {
+  if (!raw) return '';
+  let s = raw.toLowerCase().trim();
+  s = s.replace(/\s*\([^)]*\)\s*/g, ' ');
+  s = s.replace(/[^\p{L}\p{N}\s-]+/gu, ' ');
+  s = s.replace(/[-_]+/g, ' ');
+  s = s.replace(/\s+/g, ' ').trim();
+  if (!s) return '';
+
+  s = applyAlias(s);
+
+  const tokens = s
+    .split(' ')
+    .map((t) => t.trim())
+    .filter((t) => t && !MODIFIERS.has(t) && !/^\d+(\.\d+)?$/.test(t) && !QTY_UNITS.has(t))
+    .map(singularizeToken)
+    .filter(Boolean);
+
+  s = tokens.join(' ');
+  s = applyAlias(s);
+  return s.trim();
+}

--- a/src/lib/pantry/schema.ts
+++ b/src/lib/pantry/schema.ts
@@ -29,9 +29,27 @@ export interface PantryItem {
   /** Optional count. Absent means "I have this" without tracking how much. */
   quantity?: number;
   unit?: string;
+  /**
+   * Common household ingredient the user always keeps on hand.
+   * Staples stay in the pantry until explicitly removed and are treated
+   * as already owned when building grocery lists.
+   */
+  isStaple?: boolean;
   createdAt: number;
   updatedAt: number;
 }
+
+/** Keys v1 understands. Unknown item fields are preserved on rewrite. */
+const KNOWN_ITEM_KEYS = new Set([
+  'id',
+  'name',
+  'normalizedName',
+  'quantity',
+  'unit',
+  'isStaple',
+  'createdAt',
+  'updatedAt'
+]);
 
 export interface Pantry {
   schemaVersion: number;
@@ -99,6 +117,14 @@ export function sanitizePantryItem(
   if (quantity != null && quantity > 0) item.quantity = quantity;
   const unit = asTrimmedString(r.unit, 24);
   if (unit) item.unit = unit;
+  if (r.isStaple === true) item.isStaple = true;
+
+  // Preserve unknown fields (expiration, barcode, etc.) so a later
+  // client can adopt them without a schemaVersion bump. V1 ignores them.
+  for (const [key, value] of Object.entries(r)) {
+    if (KNOWN_ITEM_KEYS.has(key) || value === undefined) continue;
+    (item as Record<string, unknown>)[key] = value;
+  }
   return item;
 }
 

--- a/src/lib/pantry/schema.ts
+++ b/src/lib/pantry/schema.ts
@@ -1,0 +1,145 @@
+/**
+ * Pantry event contract (v1)
+ *
+ * Private, user-owned list of ingredients already at home. Independent of
+ * the frozen meal-plan schema (`docs/mealplan-contract.md`) and of grocery
+ * lists. Planning a meal never mutates pantry inventory.
+ *
+ * Event envelope
+ * - kind: 30078 (NIP-78 application-specific data)
+ * - d-tag: `pantry` (one replaceable list per user)
+ * - tags: `['d', 'pantry']` and `['client', 'Zap Cooking']` only
+ * - content: NIP-44 self-encrypted JSON (encrypted to the author's pubkey)
+ *
+ * Ingredient names MUST NOT appear as plaintext Nostr tags.
+ *
+ * Quantity matching (grocery): see `matching.ts`. V1 never auto-decrements
+ * pantry quantities when meals are planned or groceries are generated.
+ */
+
+export const PANTRY_SCHEMA_VERSION = 1;
+export const PANTRY_KIND = 30078;
+export const PANTRY_D_TAG = 'pantry';
+
+export interface PantryItem {
+  id: string;
+  name: string;
+  /** Deterministic matching key. See `normalization.ts`. */
+  normalizedName: string;
+  /** Optional count. Absent means "I have this" without tracking how much. */
+  quantity?: number;
+  unit?: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface Pantry {
+  schemaVersion: number;
+  items: PantryItem[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+export function nowUnixSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+export function generatePantryItemId(): string {
+  const timestamp = Date.now().toString(36);
+  const random = Math.random().toString(36).substring(2, 8);
+  return `${timestamp}-${random}`;
+}
+
+export function createEmptyPantry(now = nowUnixSeconds()): Pantry {
+  return {
+    schemaVersion: PANTRY_SCHEMA_VERSION,
+    items: [],
+    createdAt: now,
+    updatedAt: now
+  };
+}
+
+export function serializePantry(pantry: Pantry): string {
+  return JSON.stringify({
+    schemaVersion: pantry.schemaVersion,
+    items: pantry.items,
+    createdAt: pantry.createdAt,
+    updatedAt: pantry.updatedAt
+  });
+}
+
+function asFiniteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function asTrimmedString(value: unknown, max: number): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim().slice(0, max);
+  return trimmed || undefined;
+}
+
+export function sanitizePantryItem(
+  raw: unknown,
+  fallbackNow = nowUnixSeconds()
+): PantryItem | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  const id = asTrimmedString(r.id, 64);
+  const name = asTrimmedString(r.name, 80);
+  if (!id || !name) return null;
+  const normalizedName = asTrimmedString(r.normalizedName, 80) || name.toLowerCase();
+  const item: PantryItem = {
+    id,
+    name,
+    normalizedName,
+    createdAt: asFiniteNumber(r.createdAt) ?? fallbackNow,
+    updatedAt: asFiniteNumber(r.updatedAt) ?? fallbackNow
+  };
+  const quantity = asFiniteNumber(r.quantity);
+  if (quantity != null && quantity > 0) item.quantity = quantity;
+  const unit = asTrimmedString(r.unit, 24);
+  if (unit) item.unit = unit;
+  return item;
+}
+
+/**
+ * Validate a decrypted pantry payload.
+ * Returns null when the payload is unusable.
+ * schemaVersion > 1 is accepted as read-only so newer clients can extend
+ * the schema without older clients destroying data.
+ */
+export function validatePantryPayload(
+  payload: unknown
+): { pantry: Pantry; readOnly: boolean } | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const p = payload as Record<string, unknown>;
+  const schemaVersion = asFiniteNumber(p.schemaVersion);
+  if (schemaVersion == null || schemaVersion < 1) return null;
+
+  const now = nowUnixSeconds();
+  const itemsRaw = Array.isArray(p.items) ? p.items : [];
+  const seen = new Set<string>();
+  const items: PantryItem[] = [];
+  for (const raw of itemsRaw) {
+    const item = sanitizePantryItem(raw, now);
+    if (!item || seen.has(item.id)) continue;
+    seen.add(item.id);
+    items.push(item);
+  }
+
+  return {
+    pantry: {
+      schemaVersion,
+      items,
+      createdAt: asFiniteNumber(p.createdAt) ?? now,
+      updatedAt: asFiniteNumber(p.updatedAt) ?? now
+    },
+    readOnly: schemaVersion > PANTRY_SCHEMA_VERSION
+  };
+}
+
+export function formatPantryQuantity(item: Pick<PantryItem, 'quantity' | 'unit'>): string {
+  const qty = item.quantity != null ? String(item.quantity) : '';
+  const unit = item.unit?.trim() || '';
+  return `${qty} ${unit}`.trim();
+}

--- a/src/lib/pantry/schema.ts
+++ b/src/lib/pantry/schema.ts
@@ -123,7 +123,7 @@ export function sanitizePantryItem(
   // client can adopt them without a schemaVersion bump. V1 ignores them.
   for (const [key, value] of Object.entries(r)) {
     if (KNOWN_ITEM_KEYS.has(key) || value === undefined) continue;
-    (item as Record<string, unknown>)[key] = value;
+    (item as unknown as Record<string, unknown>)[key] = value;
   }
   return item;
 }

--- a/src/lib/services/groceryService.pantryCovered.test.ts
+++ b/src/lib/services/groceryService.pantryCovered.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('$app/environment', () => ({ browser: false }));
+
+import { sanitizePantryCovered } from './groceryService';
+
+describe('sanitizePantryCovered', () => {
+  it('keeps well-formed rows and drops nulls', () => {
+    expect(
+      sanitizePantryCovered([
+        { name: 'Olive oil', quantity: '', recipeId: '30023:pk:x' },
+        null,
+        { name: '  ', quantity: '1' },
+        { name: 'Eggs', quantity: '8' }
+      ])
+    ).toEqual([
+      { name: 'Olive oil', quantity: '', recipeId: '30023:pk:x' },
+      { name: 'Eggs', quantity: '8' }
+    ]);
+  });
+
+  it('returns undefined for missing or empty payloads', () => {
+    expect(sanitizePantryCovered(undefined)).toBeUndefined();
+    expect(sanitizePantryCovered('nope')).toBeUndefined();
+    expect(sanitizePantryCovered([null, { name: '' }])).toBeUndefined();
+  });
+});

--- a/src/lib/services/groceryService.ts
+++ b/src/lib/services/groceryService.ts
@@ -101,6 +101,27 @@ function dTagToListId(dTag: string): string | null {
   return dTag.slice(GROCERY_D_TAG_PREFIX.length);
 }
 
+/** Drop malformed pantryCovered rows so the grocery UI never reads `.name` on null. */
+export function sanitizePantryCovered(raw: unknown): PantryCoveredItem[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: PantryCoveredItem[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue;
+    const r = entry as Record<string, unknown>;
+    const name = typeof r.name === 'string' ? r.name.trim().slice(0, 80) : '';
+    if (!name) continue;
+    const covered: PantryCoveredItem = {
+      name,
+      quantity: typeof r.quantity === 'string' ? r.quantity.trim().slice(0, 40) : ''
+    };
+    if (typeof r.recipeId === 'string' && r.recipeId.trim()) {
+      covered.recipeId = r.recipeId.trim();
+    }
+    out.push(covered);
+  }
+  return out.length ? out : undefined;
+}
+
 /**
  * Extract recipe links from event tags
  */
@@ -284,7 +305,7 @@ async function decryptGroceryEvent(
       items: payload.items || [],
       recipeLinks,
       notes: payload.notes,
-      pantryCovered: Array.isArray(payload.pantryCovered) ? payload.pantryCovered : undefined,
+      pantryCovered: sanitizePantryCovered(payload.pantryCovered),
       createdAt: payload.createdAt || (event.created_at || Math.floor(Date.now() / 1000)),
       updatedAt: payload.updatedAt || (event.created_at || Math.floor(Date.now() / 1000))
     };

--- a/src/lib/services/groceryService.ts
+++ b/src/lib/services/groceryService.ts
@@ -42,8 +42,20 @@ export interface GroceryList {
   items: GroceryItem[];
   recipeLinks: string[];  // a-tag format references to linked recipes
   notes?: string;
+  /**
+   * Recipe ingredients recognized as already in the user's pantry.
+   * Informational only — not shopping items, and pantry inventory is
+   * not decremented when this list is generated.
+   */
+  pantryCovered?: PantryCoveredItem[];
   createdAt: number;      // Unix timestamp (seconds)
   updatedAt: number;      // Unix timestamp (seconds)
+}
+
+export interface PantryCoveredItem {
+  name: string;
+  quantity: string;
+  recipeId?: string;
 }
 
 export interface GroceryListEvent {
@@ -153,12 +165,11 @@ export async function fetchGroceryLists(): Promise<GroceryListEvent[]> {
     const lists: GroceryListEvent[] = [];
     
     for (const event of events) {
-      // Filter locally: only process events with our client tag or grocery d-tag prefix
-      const clientTag = event.tags.find(t => t[0] === 'client')?.[1];
       const dTag = event.tags.find(t => t[0] === 'd')?.[1];
-      
-      // Accept if it has our client tag OR if d-tag starts with grocery prefix
-      const isOurEvent = clientTag === CLIENT_TAG_IDENTIFIER || dTag?.startsWith(GROCERY_D_TAG_PREFIX);
+
+      // Require the grocery- d-tag prefix so pantry / mealplan kind-30078
+      // events are not decrypted as grocery lists.
+      const isOurEvent = dTag?.startsWith(GROCERY_D_TAG_PREFIX);
       
       if (!isOurEvent) {
         console.log('[GroceryService] Skipping non-grocery event:', dTag);
@@ -273,6 +284,7 @@ async function decryptGroceryEvent(
       items: payload.items || [],
       recipeLinks,
       notes: payload.notes,
+      pantryCovered: Array.isArray(payload.pantryCovered) ? payload.pantryCovered : undefined,
       createdAt: payload.createdAt || (event.created_at || Math.floor(Date.now() / 1000)),
       updatedAt: payload.updatedAt || (event.created_at || Math.floor(Date.now() / 1000))
     };
@@ -340,6 +352,7 @@ export async function saveGroceryList(list: GroceryList): Promise<NDKEvent | nul
     title: listToSave.title,
     items: listToSave.items,
     notes: listToSave.notes,
+    pantryCovered: listToSave.pantryCovered,
     createdAt: listToSave.createdAt,
     updatedAt: listToSave.updatedAt
   });

--- a/src/lib/services/pantryService.ts
+++ b/src/lib/services/pantryService.ts
@@ -72,14 +72,16 @@ export async function fetchPantry(): Promise<PantryFetchResult> {
 
   try {
     const fetchPromise = ndkInstance.fetchEvents(filter, { closeOnEose: true });
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
     const timeoutPromise = new Promise<Set<NDKEvent>>((resolve) => {
-      setTimeout(() => {
+      timeoutId = setTimeout(() => {
         console.log('[PantryService] Fetch timed out, returning empty set');
         resolve(new Set());
       }, FETCH_TIMEOUT_MS);
     });
 
     const events = await Promise.race([fetchPromise, timeoutPromise]);
+    if (timeoutId) clearTimeout(timeoutId);
     if (events.size === 0) return { status: 'empty' };
 
     let newest: NDKEvent | null = null;

--- a/src/lib/services/pantryService.ts
+++ b/src/lib/services/pantryService.ts
@@ -1,0 +1,191 @@
+/**
+ * Pantry Service
+ *
+ * Encrypted pantry storage on kind 30078 (NIP-78) with NIP-44
+ * self-encryption. Independent of grocery lists and the frozen meal-plan
+ * schema. One replaceable event per user (`d` = `pantry`).
+ *
+ * Ingredient names live only inside the encrypted payload — never as
+ * plaintext tags.
+ */
+
+import { browser } from '$app/environment';
+import { get } from 'svelte/store';
+import { ndk, userPublickey, ndkReady } from '$lib/nostr';
+import { NDKEvent, NDKRelaySet, type NDKFilter } from '@nostr-dev-kit/ndk';
+import {
+  encrypt,
+  decrypt,
+  detectEncryptionMethod,
+  type EncryptionMethod
+} from '$lib/encryptionService';
+import { getOutboxRelays } from '$lib/relayListCache';
+import { CLIENT_TAG_IDENTIFIER } from '$lib/consts';
+import {
+  PANTRY_D_TAG,
+  PANTRY_KIND,
+  createEmptyPantry,
+  serializePantry,
+  validatePantryPayload,
+  type Pantry
+} from '$lib/pantry/schema';
+
+const FETCH_TIMEOUT_MS = 10000;
+
+export type PantryFetchResult =
+  | {
+      status: 'ok';
+      pantry: Pantry;
+      readOnly: boolean;
+      event: NDKEvent;
+      encryptionMethod: EncryptionMethod;
+    }
+  | {
+      status: 'decrypt-failed';
+      event: NDKEvent;
+      error: string;
+    }
+  | {
+      status: 'empty';
+    };
+
+export async function fetchPantry(): Promise<PantryFetchResult> {
+  if (!browser) {
+    return { status: 'empty' };
+  }
+
+  const pubkey = get(userPublickey);
+  const ndkInstance = get(ndk);
+
+  if (!pubkey || !ndkInstance) {
+    console.warn('[PantryService] Not logged in or NDK not available');
+    return { status: 'empty' };
+  }
+
+  await ndkReady;
+
+  const filter: NDKFilter = {
+    kinds: [PANTRY_KIND],
+    authors: [pubkey],
+    '#d': [PANTRY_D_TAG]
+  };
+
+  try {
+    const fetchPromise = ndkInstance.fetchEvents(filter, { closeOnEose: true });
+    const timeoutPromise = new Promise<Set<NDKEvent>>((resolve) => {
+      setTimeout(() => {
+        console.log('[PantryService] Fetch timed out, returning empty set');
+        resolve(new Set());
+      }, FETCH_TIMEOUT_MS);
+    });
+
+    const events = await Promise.race([fetchPromise, timeoutPromise]);
+    if (events.size === 0) return { status: 'empty' };
+
+    let newest: NDKEvent | null = null;
+    for (const event of events) {
+      const dTag = event.tags.find((t) => t[0] === 'd')?.[1];
+      if (dTag !== PANTRY_D_TAG) continue;
+      if (!newest || (event.created_at || 0) > (newest.created_at || 0)) {
+        newest = event;
+      }
+    }
+
+    if (!newest) return { status: 'empty' };
+    return decryptPantryEvent(newest, pubkey);
+  } catch (error) {
+    console.error('[PantryService] Failed to fetch pantry:', error);
+    throw error;
+  }
+}
+
+async function decryptPantryEvent(event: NDKEvent, pubkey: string): Promise<PantryFetchResult> {
+  if (!event.content) {
+    return { status: 'decrypt-failed', event, error: 'Event missing content' };
+  }
+
+  try {
+    const method = detectEncryptionMethod(event.content);
+    const plaintext = await decrypt(pubkey, event.content, method);
+    const payload = JSON.parse(plaintext);
+    const validated = validatePantryPayload(payload);
+    if (!validated) {
+      return { status: 'decrypt-failed', event, error: 'Malformed pantry payload' };
+    }
+    return {
+      status: 'ok',
+      pantry: validated.pantry,
+      readOnly: validated.readOnly,
+      event,
+      encryptionMethod: method
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[PantryService] Failed to decrypt/parse pantry:', {
+      message,
+      hasContent: !!event.content,
+      contentLength: event.content?.length || 0
+    });
+    return { status: 'decrypt-failed', event, error: message };
+  }
+}
+
+export async function savePantry(pantry: Pantry): Promise<NDKEvent> {
+  if (!browser) {
+    throw new Error('Cannot save pantry on server');
+  }
+
+  const pubkey = get(userPublickey);
+  const ndkInstance = get(ndk);
+
+  if (!pubkey) {
+    throw new Error('Not logged in');
+  }
+  if (!ndkInstance?.signer) {
+    throw new Error('No signer available. Please log in again.');
+  }
+
+  await ndkReady;
+
+  const now = Math.floor(Date.now() / 1000);
+  const pantryToSave: Pantry = {
+    ...pantry,
+    updatedAt: now,
+    createdAt: pantry.createdAt || now
+  };
+
+  try {
+    const { ciphertext } = await encrypt(pubkey, serializePantry(pantryToSave), 'nip44');
+    const event = new NDKEvent(ndkInstance);
+    event.kind = PANTRY_KIND;
+    event.content = ciphertext;
+    event.tags = [
+      ['d', PANTRY_D_TAG],
+      ['client', CLIENT_TAG_IDENTIFIER]
+    ];
+
+    await event.sign();
+
+    const writeRelays = await getOutboxRelays(pubkey);
+    console.log(
+      '[PantryService] Publishing pantry...',
+      writeRelays.length > 0 ? `(${writeRelays.length} outbox relays)` : '(default relays)'
+    );
+
+    if (writeRelays.length > 0) {
+      const relaySet = NDKRelaySet.fromRelayUrls(writeRelays, ndkInstance);
+      await event.publish(relaySet);
+    } else {
+      await event.publish();
+    }
+
+    console.log('[PantryService] Pantry saved successfully');
+    return event;
+  } catch (error) {
+    console.error('[PantryService] Failed to save pantry:', error);
+    throw error;
+  }
+}
+
+export { createEmptyPantry };
+export type { Pantry };

--- a/src/lib/services/recipeDiscoveryService.test.ts
+++ b/src/lib/services/recipeDiscoveryService.test.ts
@@ -65,6 +65,19 @@ describe('candidateFromCached', () => {
     expect(toWireCandidate(discovered!).a).toBe(discovered!.a);
   });
 
+  it('toWireCandidate keeps pantry match data', () => {
+    const discovered = candidateFromCached(cached());
+    expect(discovered).toBeTruthy();
+    discovered!.pantry = {
+      matchedCount: 1,
+      totalCount: 2,
+      matchRatio: 0.5,
+      matchedIngredients: ['rice'],
+      missingIngredients: ['salmon fillet']
+    };
+    expect(toWireCandidate(discovered!).pantry?.matchedCount).toBe(1);
+  });
+
   it('attaches discovered images onto generated meals by coordinate', () => {
     const meals = attachDiscoveredImages(
       [

--- a/src/lib/services/recipeDiscoveryService.ts
+++ b/src/lib/services/recipeDiscoveryService.ts
@@ -176,6 +176,7 @@ export function toWireCandidate(recipe: DiscoveredRecipe): RecipeCandidate {
   if (recipe.prepTime) wire.prepTime = recipe.prepTime;
   if (recipe.cookTime) wire.cookTime = recipe.cookTime;
   if (recipe.servings) wire.servings = recipe.servings;
+  if (recipe.pantry) wire.pantry = recipe.pantry;
   return wire;
 }
 

--- a/src/lib/stores/groceryStore.ts
+++ b/src/lib/stores/groceryStore.ts
@@ -25,7 +25,8 @@ import {
   type GroceryList,
   type GroceryItem,
   type GroceryCategory,
-  type GroceryListEvent
+  type GroceryListEvent,
+  type PantryCoveredItem
 } from '$lib/services/groceryService';
 
 // ═══════════════════════════════════════════════════════════════
@@ -365,6 +366,26 @@ function createGroceryStore() {
       });
 
       return added;
+    },
+
+    /**
+     * Record recipe ingredients that were skipped because they matched
+     * the pantry. Existing pantryCovered rows are kept.
+     */
+    appendPantryCovered(listId: string, items: PantryCoveredItem[]): void {
+      if (!items.length) return;
+      update((s) => {
+        const lists = s.lists.map((list) => {
+          if (list.id !== listId) return list;
+          return {
+            ...list,
+            pantryCovered: [...(list.pantryCovered || []), ...items],
+            updatedAt: Math.floor(Date.now() / 1000)
+          };
+        });
+        scheduleSave(listId);
+        return { ...s, lists };
+      });
     },
 
     /**

--- a/src/lib/stores/groceryStore.ts
+++ b/src/lib/stores/groceryStore.ts
@@ -243,7 +243,7 @@ function createGroceryStore() {
      */
     updateList(
       listId: string, 
-      updates: Partial<Pick<GroceryList, 'title' | 'notes' | 'recipeLinks'>>
+      updates: Partial<Pick<GroceryList, 'title' | 'notes' | 'recipeLinks' | 'pantryCovered'>>
     ): void {
       update(s => {
         const lists = s.lists.map(list => {
@@ -327,6 +327,44 @@ function createGroceryStore() {
       });
 
       return newItem;
+    },
+
+    /**
+     * Move a pantry-covered ingredient onto the shopping list.
+     * The user decided they don't have enough of it.
+     */
+    addPantryCoveredToList(listId: string, index: number): GroceryItem | null {
+      let added: GroceryItem | null = null;
+
+      update((s) => {
+        const lists = s.lists.map((list) => {
+          if (list.id !== listId) return list;
+          const pantryCovered = [...(list.pantryCovered || [])];
+          const covered = pantryCovered[index];
+          if (!covered) return list;
+
+          const item = createGroceryItem(
+            covered.name,
+            covered.quantity || '',
+            inferCategory(covered.name),
+            covered.recipeId
+          );
+          added = item;
+          pantryCovered.splice(index, 1);
+
+          return {
+            ...list,
+            items: [...list.items, item],
+            pantryCovered: pantryCovered.length ? pantryCovered : undefined,
+            updatedAt: Math.floor(Date.now() / 1000)
+          };
+        });
+
+        if (added) scheduleSave(listId);
+        return { ...s, lists };
+      });
+
+      return added;
     },
 
     /**

--- a/src/lib/stores/pantryStore.test.ts
+++ b/src/lib/stores/pantryStore.test.ts
@@ -112,4 +112,16 @@ describe('pantry persistence', () => {
     await vi.advanceTimersByTimeAsync(2000);
     expect(savePantry).not.toHaveBeenCalled();
   });
+
+  it('marks pantry staples and does not duplicate them', async () => {
+    await pantryStore.load();
+    pantryStore.addItems('Salt');
+    const id = get(pantryStore).pantry.items[0].id;
+    pantryStore.toggleStaple(id);
+    expect(get(pantryStore).pantry.items[0].isStaple).toBe(true);
+
+    expect(pantryStore.addItems('salt', undefined, { isStaple: true })).toEqual([]);
+    expect(get(pantryStore).pantry.items).toHaveLength(1);
+    expect(get(pantryStore).pantry.items[0].isStaple).toBe(true);
+  });
 });

--- a/src/lib/stores/pantryStore.test.ts
+++ b/src/lib/stores/pantryStore.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { writable, get } from 'svelte/store';
+import type { NDKEvent } from '@nostr-dev-kit/ndk';
+import { createEmptyPantry } from '$lib/pantry/schema';
+
+vi.mock('$app/environment', () => ({ browser: true }));
+
+vi.mock('$lib/nostr', async () => {
+  const { writable } = await import('svelte/store');
+  return { userPublickey: writable('a'.repeat(64)) };
+});
+
+vi.mock('$lib/services/pantryService', () => ({
+  fetchPantry: vi.fn(),
+  savePantry: vi.fn()
+}));
+
+import { userPublickey } from '$lib/nostr';
+import * as pantryService from '$lib/services/pantryService';
+import { pantryStore } from './pantryStore';
+
+const mockPubkey = userPublickey as unknown as ReturnType<typeof writable<string>>;
+const fetchPantry = vi.mocked(pantryService.fetchPantry);
+const savePantry = vi.mocked(pantryService.savePantry);
+
+const stubEvent = {} as NDKEvent;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  fetchPantry.mockReset().mockResolvedValue({ status: 'empty' });
+  savePantry.mockReset().mockResolvedValue(stubEvent);
+  mockPubkey.set('a'.repeat(64));
+  pantryStore.clear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('pantry persistence', () => {
+  it('adds pantry items and reloads them from the service', async () => {
+    await pantryStore.load();
+    pantryStore.addItems('Eggs', '8');
+    pantryStore.addItems('Chicken breast', '2 lb');
+
+    const afterAdd = get(pantryStore).pantry.items;
+    expect(afterAdd.map((i) => i.name)).toEqual(['Eggs', 'Chicken breast']);
+    expect(afterAdd[0].normalizedName).toBe('egg');
+    expect(afterAdd[0].quantity).toBe(8);
+    expect(afterAdd[1].unit).toBe('lb');
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(savePantry).toHaveBeenCalledTimes(1);
+
+    const saved = savePantry.mock.calls[0][0];
+    fetchPantry.mockResolvedValue({
+      status: 'ok',
+      pantry: saved,
+      readOnly: false,
+      event: stubEvent,
+      encryptionMethod: 'nip44'
+    });
+
+    pantryStore.clear();
+    await pantryStore.load();
+    expect(get(pantryStore).pantry.items.map((i) => i.name)).toEqual(['Eggs', 'Chicken breast']);
+  });
+
+  it('edits a pantry item', async () => {
+    await pantryStore.load();
+    pantryStore.addItems('Eggs');
+    const id = get(pantryStore).pantry.items[0].id;
+    pantryStore.updateItem(id, { name: 'Large eggs', quantityText: '12' });
+    const item = get(pantryStore).pantry.items[0];
+    expect(item.name).toBe('Large eggs');
+    expect(item.normalizedName).toBe('egg');
+    expect(item.quantity).toBe(12);
+  });
+
+  it('removes a pantry item', async () => {
+    await pantryStore.load();
+    pantryStore.addItems('Eggs, Rice');
+    expect(get(pantryStore).pantry.items).toHaveLength(2);
+    const id = get(pantryStore).pantry.items[0].id;
+    pantryStore.removeItem(id);
+    expect(get(pantryStore).pantry.items.map((i) => i.name)).toEqual(['Rice']);
+  });
+
+  it('creates multiple items from comma-separated input', async () => {
+    await pantryStore.load();
+    pantryStore.addItems('eggs, rice, chicken breast, garlic, onion');
+    expect(get(pantryStore).pantry.items.map((i) => i.normalizedName)).toEqual([
+      'egg',
+      'rice',
+      'chicken breast',
+      'garlic',
+      'onion'
+    ]);
+  });
+
+  it('does not write a read-only newer-schema pantry', async () => {
+    fetchPantry.mockResolvedValue({
+      status: 'ok',
+      pantry: { ...createEmptyPantry(), schemaVersion: 2 },
+      readOnly: true,
+      event: stubEvent,
+      encryptionMethod: 'nip44'
+    });
+    await pantryStore.load();
+    expect(pantryStore.addItems('Eggs')).toEqual([]);
+    expect(get(pantryStore).pantry.items).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(savePantry).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/stores/pantryStore.ts
+++ b/src/lib/stores/pantryStore.ts
@@ -49,6 +49,7 @@ function createPantryStore() {
   let saveTimer: ReturnType<typeof setTimeout> | null = null;
   let saveInFlight = false;
   let pubkeyUnsubscribe: (() => void) | null = null;
+  let lastPubkey: string | null | undefined = undefined;
 
   function scheduleSave(): void {
     if (get({ subscribe }).readOnly) return;
@@ -97,7 +98,8 @@ function createPantryStore() {
   function buildItem(
     name: string,
     quantityText?: string,
-    now = nowUnixSeconds()
+    now = nowUnixSeconds(),
+    isStaple?: boolean
   ): PantryItem | null {
     const trimmed = name.trim().slice(0, 80);
     if (!trimmed) return null;
@@ -111,6 +113,7 @@ function createPantryStore() {
     const parsed = parseQuantityInput(quantityText || '');
     if (parsed.quantity != null) item.quantity = parsed.quantity;
     if (parsed.unit) item.unit = parsed.unit;
+    if (isStaple) item.isStaple = true;
     return item;
   }
 
@@ -121,7 +124,20 @@ function createPantryStore() {
       if (!browser) return;
       if (pubkeyUnsubscribe) pubkeyUnsubscribe();
       pubkeyUnsubscribe = userPublickey.subscribe((pubkey) => {
-        if (!pubkey) this.clear();
+        const next = pubkey || null;
+        if (lastPubkey === undefined) {
+          lastPubkey = next;
+          if (!next) this.clear();
+          return;
+        }
+        if (next === lastPubkey) return;
+        lastPubkey = next;
+        if (!next) {
+          this.clear();
+          return;
+        }
+        this.clear();
+        this.load();
       });
     },
 
@@ -193,8 +209,14 @@ function createPantryStore() {
     /**
      * Add one or more ingredients. Comma-separated input creates multiple
      * items. `quantityText` applies only when a single name is entered.
+     * Re-adding a name that already exists is a no-op, unless `isStaple`
+     * is set — then the existing item is marked as a staple.
      */
-    addItems(rawNames: string, quantityText?: string): PantryItem[] {
+    addItems(
+      rawNames: string,
+      quantityText?: string,
+      options?: { isStaple?: boolean }
+    ): PantryItem[] {
       const parts = rawNames
         .split(/[,;\n]+/)
         .map((s) => s.trim())
@@ -203,35 +225,62 @@ function createPantryStore() {
       const created: PantryItem[] = [];
       const seenNew = new Set<string>();
       for (const part of parts) {
-        const item = buildItem(part, qty);
+        const item = buildItem(part, qty, nowUnixSeconds(), options?.isStaple);
         if (!item || seenNew.has(item.normalizedName)) continue;
         seenNew.add(item.normalizedName);
         created.push(item);
       }
       if (created.length === 0) return [];
 
-      const existing = new Set(get({ subscribe }).pantry.items.map((i) => i.normalizedName));
+      const existingItems = get({ subscribe }).pantry.items;
+      const existing = new Set(existingItems.map((i) => i.normalizedName));
       const toInsert = created.filter((item) => !existing.has(item.normalizedName));
-      if (toInsert.length === 0) return [];
+      const collided = created.filter((item) => existing.has(item.normalizedName));
 
-      const ok = mutate((pantry) => ({
-        ...pantry,
-        items: [...pantry.items, ...toInsert],
-        updatedAt: nowUnixSeconds()
-      }));
+      if (toInsert.length === 0 && !(options?.isStaple && collided.length > 0)) return [];
+
+      const ok = mutate((pantry) => {
+        const now = nowUnixSeconds();
+        let items = pantry.items;
+        if (options?.isStaple && collided.length > 0) {
+          const collideKeys = new Set(collided.map((i) => i.normalizedName));
+          items = items.map((item) =>
+            collideKeys.has(item.normalizedName) && !item.isStaple
+              ? { ...item, isStaple: true, updatedAt: now }
+              : item
+          );
+        }
+        return {
+          ...pantry,
+          items: toInsert.length ? [...items, ...toInsert] : items,
+          updatedAt: now
+        };
+      });
       return ok ? toInsert : [];
     },
 
-    updateItem(itemId: string, updates: { name?: string; quantityText?: string }): boolean {
+    updateItem(
+      itemId: string,
+      updates: { name?: string; quantityText?: string; isStaple?: boolean }
+    ): boolean {
       return mutate((pantry) => {
         const now = nowUnixSeconds();
+        const current = pantry.items.find((i) => i.id === itemId);
+        if (!current) return pantry;
+        const name = updates.name?.trim().slice(0, 80) || current.name;
+        const normalizedName = normalizeIngredientName(name) || name.toLowerCase();
+        if (
+          normalizedName !== current.normalizedName &&
+          pantry.items.some((i) => i.id !== itemId && i.normalizedName === normalizedName)
+        ) {
+          return pantry;
+        }
         const items = pantry.items.map((item) => {
           if (item.id !== itemId) return item;
-          const name = updates.name?.trim().slice(0, 80) || item.name;
           const next: PantryItem = {
             ...item,
             name,
-            normalizedName: normalizeIngredientName(name) || name.toLowerCase(),
+            normalizedName,
             updatedAt: now
           };
           if (updates.quantityText !== undefined) {
@@ -241,10 +290,18 @@ function createPantryStore() {
             if (parsed.quantity != null) next.quantity = parsed.quantity;
             if (parsed.unit) next.unit = parsed.unit;
           }
+          if (updates.isStaple === true) next.isStaple = true;
+          if (updates.isStaple === false) delete next.isStaple;
           return next;
         });
         return { ...pantry, items, updatedAt: now };
       });
+    },
+
+    toggleStaple(itemId: string): boolean {
+      const item = get({ subscribe }).pantry.items.find((i) => i.id === itemId);
+      if (!item) return false;
+      return this.updateItem(itemId, { isStaple: !item.isStaple });
     },
 
     removeItem(itemId: string): boolean {

--- a/src/lib/stores/pantryStore.ts
+++ b/src/lib/stores/pantryStore.ts
@@ -1,0 +1,308 @@
+/**
+ * Pantry Store
+ *
+ * Reactive state over pantryService, mirroring groceryStore / plannerStore:
+ * optimistic local mutations, a single debounced save, and a
+ * userPublickey-watcher logout clear.
+ *
+ * Pantry is one list per user. schemaVersion > 1 is read-only.
+ */
+
+import { writable, derived, get } from 'svelte/store';
+import { browser } from '$app/environment';
+import { userPublickey } from '$lib/nostr';
+import { fetchPantry, savePantry } from '$lib/services/pantryService';
+import { normalizeIngredientName, parseQuantityInput } from '$lib/pantry/normalization';
+import {
+  createEmptyPantry,
+  generatePantryItemId,
+  nowUnixSeconds,
+  type Pantry,
+  type PantryItem
+} from '$lib/pantry/schema';
+
+export interface PantryStoreState {
+  pantry: Pantry;
+  loading: boolean;
+  initialized: boolean;
+  error: string | null;
+  saving: boolean;
+  lastSaved: number | null;
+  readOnly: boolean;
+  decryptFailed: boolean;
+}
+
+const SAVE_DEBOUNCE_MS = 2000;
+
+function createPantryStore() {
+  const { subscribe, set, update } = writable<PantryStoreState>({
+    pantry: createEmptyPantry(),
+    loading: false,
+    initialized: false,
+    error: null,
+    saving: false,
+    lastSaved: null,
+    readOnly: false,
+    decryptFailed: false
+  });
+
+  let saveTimer: ReturnType<typeof setTimeout> | null = null;
+  let saveInFlight = false;
+  let pubkeyUnsubscribe: (() => void) | null = null;
+
+  function scheduleSave(): void {
+    if (get({ subscribe }).readOnly) return;
+    if (saveTimer) clearTimeout(saveTimer);
+    saveTimer = setTimeout(async () => {
+      saveTimer = null;
+      await performSave();
+    }, SAVE_DEBOUNCE_MS);
+  }
+
+  async function performSave(): Promise<void> {
+    if (saveInFlight) return;
+    const state = get({ subscribe });
+    if (state.readOnly || state.decryptFailed) return;
+
+    saveInFlight = true;
+    update((s) => ({ ...s, saving: true }));
+    try {
+      await savePantry(get({ subscribe }).pantry);
+      update((s) => ({ ...s, lastSaved: Date.now(), error: null }));
+      console.log('[PantryStore] Pantry saved');
+    } catch (error) {
+      console.error('[PantryStore] Failed to save pantry:', error);
+      update((s) => ({
+        ...s,
+        error: error instanceof Error ? error.message : 'Failed to save pantry'
+      }));
+    } finally {
+      saveInFlight = false;
+      update((s) => ({ ...s, saving: false }));
+    }
+  }
+
+  function mutate(mutator: (pantry: Pantry) => Pantry): boolean {
+    const state = get({ subscribe });
+    if (state.readOnly || state.decryptFailed) return false;
+    update((s) => ({
+      ...s,
+      pantry: mutator(s.pantry),
+      error: null
+    }));
+    scheduleSave();
+    return true;
+  }
+
+  function buildItem(
+    name: string,
+    quantityText?: string,
+    now = nowUnixSeconds()
+  ): PantryItem | null {
+    const trimmed = name.trim().slice(0, 80);
+    if (!trimmed) return null;
+    const item: PantryItem = {
+      id: generatePantryItemId(),
+      name: trimmed,
+      normalizedName: normalizeIngredientName(trimmed) || trimmed.toLowerCase(),
+      createdAt: now,
+      updatedAt: now
+    };
+    const parsed = parseQuantityInput(quantityText || '');
+    if (parsed.quantity != null) item.quantity = parsed.quantity;
+    if (parsed.unit) item.unit = parsed.unit;
+    return item;
+  }
+
+  return {
+    subscribe,
+
+    init(): void {
+      if (!browser) return;
+      if (pubkeyUnsubscribe) pubkeyUnsubscribe();
+      pubkeyUnsubscribe = userPublickey.subscribe((pubkey) => {
+        if (!pubkey) this.clear();
+      });
+    },
+
+    async load(): Promise<void> {
+      if (!browser) return;
+      const pubkey = get(userPublickey);
+      if (!pubkey) {
+        update((s) => ({
+          ...s,
+          pantry: createEmptyPantry(),
+          initialized: true,
+          loading: false,
+          error: 'Not logged in',
+          decryptFailed: false,
+          readOnly: false
+        }));
+        return;
+      }
+
+      update((s) => ({ ...s, loading: true, error: null }));
+      try {
+        const result = await fetchPantry();
+        if (result.status === 'ok') {
+          update((s) => ({
+            ...s,
+            pantry: result.pantry,
+            loading: false,
+            initialized: true,
+            error: null,
+            readOnly: result.readOnly,
+            decryptFailed: false
+          }));
+        } else if (result.status === 'decrypt-failed') {
+          update((s) => ({
+            ...s,
+            pantry: createEmptyPantry(),
+            loading: false,
+            initialized: true,
+            error: result.error,
+            decryptFailed: true,
+            readOnly: true
+          }));
+        } else {
+          update((s) => ({
+            ...s,
+            pantry: createEmptyPantry(),
+            loading: false,
+            initialized: true,
+            error: null,
+            decryptFailed: false,
+            readOnly: false
+          }));
+        }
+      } catch (error) {
+        console.error('[PantryStore] Failed to load pantry:', error);
+        update((s) => ({
+          ...s,
+          loading: false,
+          initialized: true,
+          error: error instanceof Error ? error.message : 'Failed to load pantry'
+        }));
+      }
+    },
+
+    async refresh(): Promise<void> {
+      return this.load();
+    },
+
+    /**
+     * Add one or more ingredients. Comma-separated input creates multiple
+     * items. `quantityText` applies only when a single name is entered.
+     */
+    addItems(rawNames: string, quantityText?: string): PantryItem[] {
+      const parts = rawNames
+        .split(/[,;\n]+/)
+        .map((s) => s.trim())
+        .filter(Boolean);
+      const qty = parts.length === 1 ? quantityText : undefined;
+      const created: PantryItem[] = [];
+      const seenNew = new Set<string>();
+      for (const part of parts) {
+        const item = buildItem(part, qty);
+        if (!item || seenNew.has(item.normalizedName)) continue;
+        seenNew.add(item.normalizedName);
+        created.push(item);
+      }
+      if (created.length === 0) return [];
+
+      const existing = new Set(get({ subscribe }).pantry.items.map((i) => i.normalizedName));
+      const toInsert = created.filter((item) => !existing.has(item.normalizedName));
+      if (toInsert.length === 0) return [];
+
+      const ok = mutate((pantry) => ({
+        ...pantry,
+        items: [...pantry.items, ...toInsert],
+        updatedAt: nowUnixSeconds()
+      }));
+      return ok ? toInsert : [];
+    },
+
+    updateItem(itemId: string, updates: { name?: string; quantityText?: string }): boolean {
+      return mutate((pantry) => {
+        const now = nowUnixSeconds();
+        const items = pantry.items.map((item) => {
+          if (item.id !== itemId) return item;
+          const name = updates.name?.trim().slice(0, 80) || item.name;
+          const next: PantryItem = {
+            ...item,
+            name,
+            normalizedName: normalizeIngredientName(name) || name.toLowerCase(),
+            updatedAt: now
+          };
+          if (updates.quantityText !== undefined) {
+            delete next.quantity;
+            delete next.unit;
+            const parsed = parseQuantityInput(updates.quantityText);
+            if (parsed.quantity != null) next.quantity = parsed.quantity;
+            if (parsed.unit) next.unit = parsed.unit;
+          }
+          return next;
+        });
+        return { ...pantry, items, updatedAt: now };
+      });
+    },
+
+    removeItem(itemId: string): boolean {
+      return mutate((pantry) => ({
+        ...pantry,
+        items: pantry.items.filter((i) => i.id !== itemId),
+        updatedAt: nowUnixSeconds()
+      }));
+    },
+
+    async saveNow(): Promise<void> {
+      if (saveTimer) {
+        clearTimeout(saveTimer);
+        saveTimer = null;
+      }
+      await performSave();
+    },
+
+    clear(): void {
+      if (saveTimer) {
+        clearTimeout(saveTimer);
+        saveTimer = null;
+      }
+      set({
+        pantry: createEmptyPantry(),
+        loading: false,
+        initialized: false,
+        error: null,
+        saving: false,
+        lastSaved: null,
+        readOnly: false,
+        decryptFailed: false
+      });
+    },
+
+    destroy(): void {
+      if (saveTimer) {
+        clearTimeout(saveTimer);
+        saveTimer = null;
+      }
+      if (pubkeyUnsubscribe) {
+        pubkeyUnsubscribe();
+        pubkeyUnsubscribe = null;
+      }
+    }
+  };
+}
+
+export const pantryStore = createPantryStore();
+
+if (browser) {
+  pantryStore.init();
+}
+
+export const pantryItems = derived(pantryStore, ($s) => $s.pantry.items);
+export const pantryLoading = derived(pantryStore, ($s) => $s.loading);
+export const pantrySaving = derived(pantryStore, ($s) => $s.saving);
+export const pantryError = derived(pantryStore, ($s) => $s.error);
+export const pantryInitialized = derived(pantryStore, ($s) => $s.initialized);
+export const pantryReadOnly = derived(pantryStore, ($s) => $s.readOnly);
+export const pantryDecryptFailed = derived(pantryStore, ($s) => $s.decryptFailed);

--- a/src/routes/api/zappy/meal-plan/+server.ts
+++ b/src/routes/api/zappy/meal-plan/+server.ts
@@ -64,6 +64,7 @@ HARD RULES
 - If a breakfast-eligible list is provided, breakfast slots may use ONLY those coordinates.
 - Prefer variety across the week unless the user asked for repeats or leftovers.
 - Honor excluded ingredients, time limits, servings, style chips, and free-text notes when the candidates allow it.
+- If pantry match data is provided, prefer recipes that use more ingredients the user already has. Do not sacrifice dietary constraints, requested meal type, cooking-time requirements, or other hard constraints merely to improve pantry utilization.
 - If there are not enough candidates, fill as many requested slots as you reasonably can. Do not pad with invented recipes or with recipes that do not fit the slot.
 - Keep each reason to one short sentence.
 
@@ -76,6 +77,14 @@ function candidateLine(c: RecipeCandidate): string {
   if (c.cookTime) bits.push(`cook=${c.cookTime}`);
   if (c.servings) bits.push(`servings=${c.servings}`);
   if (c.ingredients.length) bits.push(`ingredients=${c.ingredients.join(', ')}`);
+  if (c.pantry && c.pantry.totalCount > 0) {
+    bits.push(
+      `pantry=${c.pantry.matchedCount}/${c.pantry.totalCount} (${Math.round(c.pantry.matchRatio * 100)}%)`
+    );
+    if (c.pantry.missingIngredients.length) {
+      bits.push(`need=${c.pantry.missingIngredients.join(', ')}`);
+    }
+  }
   return `- ${bits.join(' | ')}`;
 }
 
@@ -95,6 +104,11 @@ function buildUserPrompt(req: MealPlanGenerationRequest): string {
     lines.push(`Avoid ingredients: ${prefs.excludeIngredients.join(', ')}`);
   }
   if (prefs.notes) lines.push(`Notes: ${prefs.notes}`);
+  if (req.prioritizePantry) {
+    lines.push(
+      'Pantry: Prefer recipes that use more ingredients the user already has. Do not sacrifice dietary constraints, requested meal type, cooking-time requirements, or other hard constraints merely to improve pantry utilization.'
+    );
+  }
   if (req.excludeCoordinates?.length) {
     lines.push(`Do not reuse these coordinates: ${req.excludeCoordinates.join(', ')}`);
   }

--- a/src/routes/api/zappy/meal-plan/+server.ts
+++ b/src/routes/api/zappy/meal-plan/+server.ts
@@ -64,7 +64,7 @@ HARD RULES
 - If a breakfast-eligible list is provided, breakfast slots may use ONLY those coordinates.
 - Prefer variety across the week unless the user asked for repeats or leftovers.
 - Honor excluded ingredients, time limits, servings, style chips, and free-text notes when the candidates allow it.
-- If pantry match data is provided, prefer recipes that use more ingredients the user already has. Do not sacrifice dietary constraints, requested meal type, cooking-time requirements, or other hard constraints merely to improve pantry utilization.
+- If pantry match data or a pantry ingredient list is provided, prefer recipes that use more ingredients the user already has, minimize extra grocery purchases, and reuse pantry ingredients across the week when that still makes a sensible meal. Do not force poor combinations. Do not sacrifice dietary constraints, requested meal type, cooking-time requirements, or other hard constraints merely to improve pantry utilization.
 - If there are not enough candidates, fill as many requested slots as you reasonably can. Do not pad with invented recipes or with recipes that do not fit the slot.
 - Keep each reason to one short sentence.
 
@@ -105,8 +105,11 @@ function buildUserPrompt(req: MealPlanGenerationRequest): string {
   }
   if (prefs.notes) lines.push(`Notes: ${prefs.notes}`);
   if (req.prioritizePantry) {
+    if (req.pantryIngredients?.length) {
+      lines.push(`Pantry ingredients the user already has: ${req.pantryIngredients.join(', ')}`);
+    }
     lines.push(
-      'Pantry: Prefer recipes that use more ingredients the user already has. Do not sacrifice dietary constraints, requested meal type, cooking-time requirements, or other hard constraints merely to improve pantry utilization.'
+      'Pantry: Prefer meals that use these ingredients, minimize additional grocery purchases, and reuse ingredients across the week when it still makes a sensible meal. Do not force poor combinations. Do not sacrifice dietary constraints, requested meal type, cooking-time requirements, or other hard constraints merely to improve pantry utilization.'
     );
   }
   if (req.excludeCoordinates?.length) {

--- a/src/routes/api/zappy/meal-plan/mealPlan.test.ts
+++ b/src/routes/api/zappy/meal-plan/mealPlan.test.ts
@@ -234,6 +234,7 @@ describe('structured plan validation', () => {
     await call(
       validBody({
         prioritizePantry: true,
+        pantryIngredients: ['olive oil', 'garlic', 'rice'],
         candidates: [
           {
             a: '30023:pk:salmon',
@@ -254,7 +255,8 @@ describe('structured plan validation', () => {
     );
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
     const prompt = body.messages.find((m: { role: string }) => m.role === 'user').content as string;
-    expect(prompt).toContain('Pantry: Prefer recipes that use more ingredients');
+    expect(prompt).toContain('Pantry ingredients the user already has: olive oil, garlic, rice');
+    expect(prompt).toContain('Pantry: Prefer meals that use these ingredients');
     expect(prompt).toContain('pantry=1/2 (50%)');
   });
 

--- a/src/routes/api/zappy/meal-plan/mealPlan.test.ts
+++ b/src/routes/api/zappy/meal-plan/mealPlan.test.ts
@@ -230,6 +230,34 @@ describe('structured plan validation', () => {
     expect(data.code).toBe('ineligible-slot');
   });
 
+  it('includes pantry match data in the model prompt when prioritizePantry is set', async () => {
+    await call(
+      validBody({
+        prioritizePantry: true,
+        candidates: [
+          {
+            a: '30023:pk:salmon',
+            title: 'Mediterranean Salmon',
+            tags: ['mediterranean'],
+            ingredients: ['salmon', 'olive oil'],
+            pantry: {
+              matchedCount: 1,
+              totalCount: 2,
+              matchRatio: 0.5,
+              matchedIngredients: ['olive oil'],
+              missingIngredients: ['salmon']
+            }
+          },
+          { a: '30023:pk:pasta', title: 'Lemon Pasta', tags: ['easy'], ingredients: ['pasta'] }
+        ]
+      })
+    );
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    const prompt = body.messages.find((m: { role: string }) => m.role === 'user').content as string;
+    expect(prompt).toContain('Pantry: Prefer recipes that use more ingredients');
+    expect(prompt).toContain('pantry=1/2 (50%)');
+  });
+
   it('does not send dinner recipes to the model for a breakfast-only request', async () => {
     fetchMock.mockResolvedValue(
       openaiPlan([

--- a/src/routes/my-kitchen/+layout.svelte
+++ b/src/routes/my-kitchen/+layout.svelte
@@ -9,6 +9,7 @@
   import BookOpenIcon from 'phosphor-svelte/lib/BookOpen';
   import ShoppingCartIcon from 'phosphor-svelte/lib/ShoppingCart';
   import CalendarBlankIcon from 'phosphor-svelte/lib/CalendarBlank';
+  import BasketIcon from 'phosphor-svelte/lib/Basket';
   import LeafIcon from 'phosphor-svelte/lib/Leaf';
 
   const sections = [
@@ -16,9 +17,21 @@
       href: '/my-kitchen',
       label: 'Recipes',
       icon: BookOpenIcon,
-      // Exact match: child routes (grocery, planner, nourish) must not
+      // Exact match: child routes (grocery, planner, nourish, pantry) must not
       // false-highlight the index section.
       match: (p: string) => p === '/my-kitchen'
+    },
+    {
+      href: '/my-kitchen/planner',
+      label: 'Planner',
+      icon: CalendarBlankIcon,
+      match: (p: string) => p.startsWith('/my-kitchen/planner')
+    },
+    {
+      href: '/my-kitchen/pantry',
+      label: 'Pantry',
+      icon: BasketIcon,
+      match: (p: string) => p.startsWith('/my-kitchen/pantry')
     },
     {
       href: '/my-kitchen/grocery',
@@ -26,12 +39,6 @@
       icon: ShoppingCartIcon,
       // startsWith so the /my-kitchen/grocery/[id] detail keeps the tab active
       match: (p: string) => p.startsWith('/my-kitchen/grocery')
-    },
-    {
-      href: '/my-kitchen/planner',
-      label: 'Planner',
-      icon: CalendarBlankIcon,
-      match: (p: string) => p.startsWith('/my-kitchen/planner')
     },
     {
       href: '/my-kitchen/nourish',

--- a/src/routes/my-kitchen/grocery/[id]/+page.svelte
+++ b/src/routes/my-kitchen/grocery/[id]/+page.svelte
@@ -23,6 +23,7 @@
   import Button from '../../../../components/Button.svelte';
   import SortableGroceryCategory from '../../../../components/grocery/SortableGroceryCategory.svelte';
   import AddItemForm from '../../../../components/grocery/AddItemForm.svelte';
+  import PlusIcon from 'phosphor-svelte/lib/Plus';
 
   // Get list ID from URL params
   $: listId = $page.params.id as string;
@@ -122,6 +123,10 @@
   // Clear checked items
   function clearCheckedItems() {
     groceryStore.clearCheckedItems(listId);
+  }
+
+  function addPantryCoveredToList(index: number) {
+    groceryStore.addPantryCoveredToList(listId, index);
   }
 
   // Calculate stats
@@ -297,6 +302,38 @@
         </div>
       {/if}
     </div>
+
+    {#if list.pantryCovered && list.pantryCovered.length > 0}
+      <div
+        class="flex flex-col gap-2 p-4 rounded-2xl"
+        style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
+      >
+        <h2 class="text-sm font-semibold" style="color: var(--color-text-primary);">
+          Already in Pantry
+        </h2>
+        <p class="text-xs text-caption">
+          These matched your pantry, so they were left off the shopping list. Add any you still need.
+        </p>
+        <ul class="flex flex-col gap-1.5">
+          {#each list.pantryCovered as covered, index (`${covered.name}|${covered.quantity || ''}|${covered.recipeId || ''}|${index}`)}
+            <li class="flex items-center gap-2 text-sm">
+              <span class="min-w-0 flex-1" style="color: var(--color-text-secondary);">
+                {covered.name}{#if covered.quantity}<span class="text-caption"> · {covered.quantity}</span>{/if}
+              </span>
+              <button
+                type="button"
+                class="flex items-center gap-1 flex-shrink-0 px-2.5 py-1 rounded-full text-xs font-medium border border-green-500/40 text-green-500 hover:bg-green-500/10 transition-colors"
+                aria-label="Add {covered.name} to shopping list"
+                on:click={() => addPantryCoveredToList(index)}
+              >
+                <PlusIcon size={12} weight="bold" />
+                Add
+              </button>
+            </li>
+          {/each}
+        </ul>
+      </div>
+    {/if}
 
     <!-- Notes Section -->
     <div class="flex flex-col gap-2 pt-4 border-t" style="border-color: var(--color-input-border);">

--- a/src/routes/my-kitchen/pantry/+page.svelte
+++ b/src/routes/my-kitchen/pantry/+page.svelte
@@ -13,14 +13,19 @@
     pantryDecryptFailed
   } from '$lib/stores/pantryStore';
   import { formatPantryQuantity } from '$lib/pantry/schema';
+  import { groupPantryItems } from '$lib/pantry/categories';
+  import { missingCommonStaples } from '$lib/pantry/catalog';
   import PantryEditor from '../../../components/pantry/PantryEditor.svelte';
   import PantryItem from '../../../components/pantry/PantryItem.svelte';
   import PanLoader from '../../../components/PanLoader.svelte';
   import PullToRefresh from '../../../components/PullToRefresh.svelte';
   import BasketIcon from 'phosphor-svelte/lib/Basket';
   import CircleNotchIcon from 'phosphor-svelte/lib/CircleNotch';
+  import CheffyIcon from '../../../components/icons/CheffyIcon.svelte';
+  import StarIcon from 'phosphor-svelte/lib/Star';
 
   let pullToRefreshEl: PullToRefresh;
+  let editor: PantryEditor;
   let filter = '';
 
   $: filtered = $pantryItems.filter((item) => {
@@ -32,6 +37,8 @@
       formatPantryQuantity(item).toLowerCase().includes(q)
     );
   });
+  $: groups = groupPantryItems(filtered);
+  $: stapleSuggestions = missingCommonStaples($pantryItems).slice(0, 8);
 
   async function handleRefresh() {
     try {
@@ -39,6 +46,14 @@
     } finally {
       pullToRefreshEl?.complete();
     }
+  }
+
+  function focusAdd() {
+    editor?.focus();
+  }
+
+  function addStaple(name: string) {
+    pantryStore.addItems(name, undefined, { isStaple: true });
   }
 
   onMount(async () => {
@@ -75,15 +90,28 @@
         </div>
         <div>
           <h1 class="text-2xl font-bold" style="color: var(--color-text-primary)">Pantry</h1>
-          <p class="text-sm text-caption">Ingredients you already have. Private and encrypted.</p>
+          <p class="text-sm text-caption">
+            Tell Zap what you have. We'll use it to plan meals and skip the grocery extras.
+          </p>
         </div>
       </div>
-      {#if $pantrySaving}
-        <div class="flex items-center gap-1.5 text-sm text-caption">
-          <CircleNotchIcon size={16} class="animate-spin" />
-          <span>Saving…</span>
-        </div>
-      {/if}
+      <div class="flex items-center gap-2 flex-wrap">
+        {#if $pantrySaving}
+          <div class="flex items-center gap-1.5 text-sm text-caption">
+            <CircleNotchIcon size={16} class="animate-spin" />
+            <span>Saving…</span>
+          </div>
+        {/if}
+        {#if $pantryItems.length > 0 && !$pantryReadOnly}
+          <a
+            href="/my-kitchen/planner?planWithPantry=1"
+            class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium text-white bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 transition-all"
+          >
+            <CheffyIcon size={20} expression="happy" />
+            <span>Plan With My Pantry</span>
+          </a>
+        {/if}
+      </div>
     </div>
 
     {#if $pantryError}
@@ -111,9 +139,30 @@
         <PanLoader size="md" />
       </div>
     {:else}
-      <PantryEditor disabled={$pantryReadOnly} />
+      <PantryEditor bind:this={editor} disabled={$pantryReadOnly} />
 
-      {#if $pantryItems.length > 6}
+      {#if stapleSuggestions.length > 0 && !$pantryReadOnly}
+        <div class="flex flex-col gap-2">
+          <p class="text-xs font-medium text-caption flex items-center gap-1.5">
+            <StarIcon size={12} weight="fill" class="text-amber-500" />
+            Pantry staples
+          </p>
+          <div class="flex gap-2 overflow-x-auto scrollbar-hide pb-1">
+            {#each stapleSuggestions as staple}
+              <button
+                type="button"
+                class="flex-shrink-0 px-3 py-1.5 rounded-full text-sm font-medium transition-colors"
+                style="border: 1px solid var(--color-input-border); background-color: var(--color-input-bg); color: var(--color-text-primary);"
+                on:click={() => addStaple(staple)}
+              >
+                {staple}
+              </button>
+            {/each}
+          </div>
+        </div>
+      {/if}
+
+      {#if $pantryItems.length > 0}
         <input
           bind:value={filter}
           type="search"
@@ -124,27 +173,47 @@
       {/if}
 
       {#if $pantryItems.length === 0}
-        <div class="flex flex-col items-center justify-center py-16 px-4">
+        <div class="flex flex-col items-center justify-center py-12 px-4">
           <div
             class="w-20 h-20 rounded-full bg-gradient-to-br from-orange-100 to-amber-100 dark:from-orange-900/30 dark:to-amber-900/30 flex items-center justify-center mb-4"
           >
             <BasketIcon size={40} weight="regular" class="text-orange-500" />
           </div>
           <h2 class="text-xl font-semibold mb-2" style="color: var(--color-text-primary)">
-            Your pantry is empty
+            What's in your kitchen?
           </h2>
-          <p class="text-caption text-center max-w-md">
-            Add a few ingredients you already have and Cheffy can build meals around them.
+          <p class="text-caption text-center max-w-md mb-5">
+            Add ingredients you already have and Zap can use them to help plan meals and simplify
+            your grocery list.
           </p>
+          <button
+            type="button"
+            class="inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium text-white bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 transition-all"
+            on:click={focusAdd}
+          >
+            Add your first ingredient
+          </button>
         </div>
       {:else if filtered.length === 0}
         <p class="text-sm text-caption text-center py-8">No pantry items match that search.</p>
       {:else}
-        <ul class="flex flex-col gap-2">
-          {#each filtered as item (item.id)}
-            <PantryItem {item} disabled={$pantryReadOnly} />
+        <div class="flex flex-col gap-6">
+          {#each groups as group (group.category)}
+            <section class="flex flex-col gap-2">
+              <h2
+                class="text-xs font-semibold uppercase tracking-wide"
+                style="color: var(--color-caption);"
+              >
+                {group.label}
+              </h2>
+              <ul class="flex flex-col gap-2">
+                {#each group.items as item (item.id)}
+                  <PantryItem {item} disabled={$pantryReadOnly} />
+                {/each}
+              </ul>
+            </section>
           {/each}
-        </ul>
+        </div>
       {/if}
     {/if}
   </div>

--- a/src/routes/my-kitchen/pantry/+page.svelte
+++ b/src/routes/my-kitchen/pantry/+page.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { onMount, onDestroy } from 'svelte';
+  import { userPublickey } from '$lib/nostr';
+  import {
+    pantryStore,
+    pantryItems,
+    pantryLoading,
+    pantryError,
+    pantryInitialized,
+    pantrySaving,
+    pantryReadOnly,
+    pantryDecryptFailed
+  } from '$lib/stores/pantryStore';
+  import { formatPantryQuantity } from '$lib/pantry/schema';
+  import PantryEditor from '../../../components/pantry/PantryEditor.svelte';
+  import PantryItem from '../../../components/pantry/PantryItem.svelte';
+  import PanLoader from '../../../components/PanLoader.svelte';
+  import PullToRefresh from '../../../components/PullToRefresh.svelte';
+  import BasketIcon from 'phosphor-svelte/lib/Basket';
+  import CircleNotchIcon from 'phosphor-svelte/lib/CircleNotch';
+
+  let pullToRefreshEl: PullToRefresh;
+  let filter = '';
+
+  $: filtered = $pantryItems.filter((item) => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return true;
+    return (
+      item.name.toLowerCase().includes(q) ||
+      item.normalizedName.includes(q) ||
+      formatPantryQuantity(item).toLowerCase().includes(q)
+    );
+  });
+
+  async function handleRefresh() {
+    try {
+      await pantryStore.load();
+    } finally {
+      pullToRefreshEl?.complete();
+    }
+  }
+
+  onMount(async () => {
+    if (!$userPublickey) {
+      goto('/login?redirect=' + encodeURIComponent('/my-kitchen/pantry'));
+      return;
+    }
+    if (!$pantryInitialized) {
+      await pantryStore.load();
+    }
+  });
+
+  onDestroy(() => {
+    pantryStore.saveNow();
+  });
+</script>
+
+<svelte:head>
+  <title>Pantry - zap.cooking</title>
+  <meta
+    name="description"
+    content="Ingredients you already have at home, private to your kitchen."
+  />
+</svelte:head>
+
+<PullToRefresh bind:this={pullToRefreshEl} on:refresh={handleRefresh}>
+  <div class="flex flex-col gap-6">
+    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div class="flex items-center gap-3">
+        <div
+          class="w-12 h-12 rounded-full bg-gradient-to-br from-orange-500 to-amber-500 flex items-center justify-center flex-shrink-0"
+        >
+          <BasketIcon size={24} weight="fill" class="text-white" />
+        </div>
+        <div>
+          <h1 class="text-2xl font-bold" style="color: var(--color-text-primary)">Pantry</h1>
+          <p class="text-sm text-caption">Ingredients you already have. Private and encrypted.</p>
+        </div>
+      </div>
+      {#if $pantrySaving}
+        <div class="flex items-center gap-1.5 text-sm text-caption">
+          <CircleNotchIcon size={16} class="animate-spin" />
+          <span>Saving…</span>
+        </div>
+      {/if}
+    </div>
+
+    {#if $pantryError}
+      <div
+        class="flex items-center gap-3 px-4 py-3 rounded-xl bg-red-500/10 border border-red-500/30"
+      >
+        <p class="text-sm" style="color: var(--color-text-primary)">
+          {#if $pantryDecryptFailed}
+            Couldn't unlock your pantry. Check your signer and try again.
+          {:else}
+            {$pantryError}
+          {/if}
+        </p>
+      </div>
+    {/if}
+
+    {#if $pantryReadOnly && !$pantryDecryptFailed}
+      <p class="text-sm text-caption">
+        This pantry was saved by a newer app version and is read-only here.
+      </p>
+    {/if}
+
+    {#if $pantryLoading && !$pantryInitialized}
+      <div class="flex justify-center items-center py-16">
+        <PanLoader size="md" />
+      </div>
+    {:else}
+      <PantryEditor disabled={$pantryReadOnly} />
+
+      {#if $pantryItems.length > 6}
+        <input
+          bind:value={filter}
+          type="search"
+          placeholder="Search pantry…"
+          class="input w-full"
+          aria-label="Search pantry"
+        />
+      {/if}
+
+      {#if $pantryItems.length === 0}
+        <div class="flex flex-col items-center justify-center py-16 px-4">
+          <div
+            class="w-20 h-20 rounded-full bg-gradient-to-br from-orange-100 to-amber-100 dark:from-orange-900/30 dark:to-amber-900/30 flex items-center justify-center mb-4"
+          >
+            <BasketIcon size={40} weight="regular" class="text-orange-500" />
+          </div>
+          <h2 class="text-xl font-semibold mb-2" style="color: var(--color-text-primary)">
+            Your pantry is empty
+          </h2>
+          <p class="text-caption text-center max-w-md">
+            Add a few ingredients you already have and Cheffy can build meals around them.
+          </p>
+        </div>
+      {:else if filtered.length === 0}
+        <p class="text-sm text-caption text-center py-8">No pantry items match that search.</p>
+      {:else}
+        <ul class="flex flex-col gap-2">
+          {#each filtered as item (item.id)}
+            <PantryItem {item} disabled={$pantryReadOnly} />
+          {/each}
+        </ul>
+      {/if}
+    {/if}
+  </div>
+</PullToRefresh>

--- a/src/routes/my-kitchen/planner/+page.svelte
+++ b/src/routes/my-kitchen/planner/+page.svelte
@@ -33,8 +33,10 @@
   import RecipePickerModal from '../../../components/RecipePickerModal.svelte';
   import CheffyPlanModal from '../../../components/planner/CheffyPlanModal.svelte';
   import { groceryStore } from '$lib/stores/groceryStore';
+  import { pantryStore, pantryItems, pantryInitialized } from '$lib/stores/pantryStore';
   import { parseIngredient, parseIngredientsFromRecipe } from '$lib/utils/ingredientParser';
   import {
+    classifyGroceryRows,
     collectWeekRecipeSlots,
     dedupeIngredients,
     groceryListTitle,
@@ -229,6 +231,11 @@
       }
       const deduped = dedupeIngredients(rows);
 
+      if (!$pantryInitialized) {
+        await pantryStore.load();
+      }
+      const classified = classifyGroceryRows(deduped, $pantryItems);
+
       // Always a NEW list — never overwrite an existing one. Repeat
       // generations for the same week create additional lists the user
       // can delete; silent merge/overwrite risks destroying manual edits.
@@ -236,7 +243,7 @@
       for (const aTag of resolved) {
         groceryStore.addRecipeLink(list.id, aTag);
       }
-      for (const row of deduped) {
+      for (const row of classified.toBuy) {
         groceryStore.addItem(
           list.id,
           row.ingredient.name,
@@ -245,9 +252,18 @@
           row.recipeId
         );
       }
+      if (classified.inPantry.length > 0) {
+        groceryStore.updateList(list.id, {
+          pantryCovered: classified.inPantry.map((row) => ({
+            name: row.ingredient.name,
+            quantity: row.ingredient.quantity,
+            recipeId: row.recipeId
+          }))
+        });
+      }
 
       generationSummary = {
-        itemCount: deduped.length,
+        itemCount: classified.toBuy.length,
         recipeCount: resolved.length,
         textSkipped: textCount,
         unresolved

--- a/src/routes/my-kitchen/planner/+page.svelte
+++ b/src/routes/my-kitchen/planner/+page.svelte
@@ -8,6 +8,7 @@
    * PR10 via the same slot editor modal (see the "PR10 seam" comment).
    */
   import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
   import { onMount, onDestroy, tick } from 'svelte';
   import { userPublickey, ndk } from '$lib/nostr';
   import { isOnline } from '$lib/connectionMonitor';
@@ -133,6 +134,7 @@
   // ── Recipe picker (PR10) — fills the slot editor's seam ──
   let pickerOpen = false;
   let cheffyPlanOpen = false;
+  let initialPrioritizePantry = false;
 
   function openRecipePicker() {
     // Keep editorDay/editorSlot as the target; swap modals
@@ -396,6 +398,13 @@
     }
     await plannerStore.load();
     await scrollToToday();
+    if ($page.url.searchParams.get('planWithPantry') === '1') {
+      initialPrioritizePantry = true;
+      cheffyPlanOpen = true;
+      const next = new URL($page.url);
+      next.searchParams.delete('planWithPantry');
+      history.replaceState(history.state, '', `${next.pathname}${next.search}${next.hash}`);
+    }
   });
 
   onDestroy(() => {
@@ -765,6 +774,10 @@
   weekId={$plannerCurrentWeekId}
   occupiedSlots={cheffyOccupiedSlots}
   readOnly={isReadOnly}
+  {initialPrioritizePantry}
+  on:close={() => {
+    initialPrioritizePantry = false;
+  }}
 />
 
 <!-- Generate-grocery confirm: pre-generation summary of what will happen -->


### PR DESCRIPTION
## Summary
- Polish My Kitchen Pantry so adding ingredients is fast: autocomplete, automatic categories, search, and an empty state that explains why pantry matters.
- Let users mark household **staples** (salt, olive oil, butter…). Staples stay until explicitly removed and are treated as already owned on grocery lists.
- Connect pantry into Cheffy via **Plan With My Pantry**, which now sends the actual pantry ingredient list and prefers meals that use what is already on hand without forcing poor combinations.
- Show lightweight pantry coverage on recipe ingredient lists (`You have 7 of 10 ingredients`, ✓ / ○), and exclude pantry items when adding a recipe or week plan to a grocery list (with an add-back).

## Test plan
- [ ] My Kitchen → Pantry: add, edit, remove, and search ingredients; confirm autocomplete (`chick` → Chicken Breast) and freeform add both work
- [ ] Mark a few staples and confirm they stay until explicitly removed
- [ ] Refresh / log out and back in: pantry items persist without duplicates
- [ ] Empty pantry shows “What’s in your kitchen?” and **Add your first ingredient**
- [ ] **Plan With My Pantry** opens Cheffy with pantry mode on and generates meals from pantry ingredients
- [ ] Open a recipe: ingredient list shows ✓ / ○ and “You have X of Y ingredients”
- [ ] Add that recipe to a grocery list: pantry items are excluded; add one back from “Already in pantry”
- [ ] Planner → Grocery list still works and still excludes pantry items
- [ ] Existing Plan with Cheffy (without pantry) still works
- [ ] Confirm pantry contents are not published as plaintext Nostr tags (`docs/pantry-contract.md`)