### PR TITLE
feat(grocery): build one consolidated list from the meal plan

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.716",
+  "version": "4.2.717",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.717",
+  "version": "4.2.718",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/grocery/AddItemForm.svelte
+++ b/src/components/grocery/AddItemForm.svelte
@@ -1,26 +1,23 @@
 <script lang="ts">
-  import { groceryStore, inferCategory, type GroceryCategory } from '$lib/stores/groceryStore';
+  import { groceryStore, inferGroceryCategory } from '$lib/stores/groceryStore';
+  import {
+    GROCERY_CATEGORIES,
+    GROCERY_CATEGORY_EMOJI,
+    GROCERY_CATEGORY_LABELS,
+    type GroceryAisle
+  } from '$lib/grocery/categories';
   import PlusIcon from 'phosphor-svelte/lib/Plus';
 
   export let listId: string;
 
   let itemName = '';
   let itemQuantity = '';
-  let itemCategory: GroceryCategory = 'other';
+  let itemCategory: GroceryAisle = 'other';
   let nameInput: HTMLInputElement;
+  let categoryTouched = false;
 
-  const categories: { value: GroceryCategory; label: string; emoji: string }[] = [
-    { value: 'produce', label: 'Produce', emoji: '🥬' },
-    { value: 'protein', label: 'Protein', emoji: '🥩' },
-    { value: 'dairy', label: 'Dairy', emoji: '🧀' },
-    { value: 'pantry', label: 'Pantry', emoji: '🥫' },
-    { value: 'frozen', label: 'Frozen', emoji: '🧊' },
-    { value: 'other', label: 'Other', emoji: '📦' }
-  ];
-
-  // Auto-infer category when name changes, but only while using the default category
-  $: if (itemName && itemCategory === 'other') {
-    itemCategory = inferCategory(itemName);
+  $: if (itemName && !categoryTouched) {
+    itemCategory = inferGroceryCategory(itemName);
   }
 
   function addItem() {
@@ -33,12 +30,10 @@
       itemCategory
     );
 
-    // Clear form
     itemName = '';
     itemQuantity = '';
     itemCategory = 'other';
-
-    // Refocus input for quick entry
+    categoryTouched = false;
     nameInput?.focus();
   }
 
@@ -56,7 +51,6 @@
   style="background-color: var(--color-bg-secondary);"
 >
   <div class="flex flex-col sm:flex-row gap-3">
-    <!-- Item name -->
     <div class="flex-1">
       <input
         bind:this={nameInput}
@@ -69,7 +63,6 @@
       />
     </div>
 
-    <!-- Quantity -->
     <div class="w-full sm:w-32">
       <input
         bind:value={itemQuantity}
@@ -81,24 +74,23 @@
       />
     </div>
 
-    <!-- Category dropdown -->
-    <div class="w-full sm:w-40">
+    <div class="w-full sm:w-52">
       <select
         bind:value={itemCategory}
+        on:change={() => (categoryTouched = true)}
         class="input w-full cursor-pointer"
       >
-        {#each categories as cat}
-          <option value={cat.value}>{cat.emoji} {cat.label}</option>
+        {#each GROCERY_CATEGORIES as cat}
+          <option value={cat}>{GROCERY_CATEGORY_EMOJI[cat]} {GROCERY_CATEGORY_LABELS[cat]}</option>
         {/each}
       </select>
     </div>
   </div>
 
-  <!-- Add button -->
   <button
     type="submit"
     disabled={!itemName.trim()}
-    class="flex items-center justify-center gap-2 px-4 py-2 border border-green-500/40 text-green-500 hover:bg-green-500/10 rounded-xl font-medium text-sm transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+    class="flex items-center justify-center gap-2 px-4 py-2.5 border border-green-500/40 text-green-500 hover:bg-green-500/10 rounded-xl font-medium text-sm transition-all disabled:opacity-50 disabled:cursor-not-allowed"
   >
     <PlusIcon size={18} weight="bold" />
     <span>Add Item</span>

--- a/src/components/grocery/AddToListModal.svelte
+++ b/src/components/grocery/AddToListModal.svelte
@@ -13,9 +13,10 @@
   import CaretUpIcon from 'phosphor-svelte/lib/CaretUp';
   import { groceryStore, groceryLists, groceryInitialized } from '$lib/stores/groceryStore';
   import { pantryStore, pantryItems, pantryInitialized } from '$lib/stores/pantryStore';
-  import { classifyGroceryRows } from '$lib/pantry/matching';
   import { parseIngredientsFromRecipe, type ParsedIngredient } from '$lib/utils/ingredientParser';
   import { userPublickey } from '$lib/nostr';
+  import { buildGrocerySnapshot } from '$lib/mealplan/groceryGeneration';
+  import { GROCERY_CATEGORY_LABELS, canonicalizeGroceryCategory } from '$lib/grocery/categories';
 
   export let open = false;
   export let recipeEvent: NDKEvent | null = null;
@@ -67,29 +68,38 @@
 
   $: recipeAddress = recipeEvent ? buildRecipeAddress(recipeEvent) : null;
 
-  $: classified = classifyGroceryRows(
-    parsedIngredients.map((ingredient) => ({
-      ingredient,
-      recipeId: recipeAddress || ''
-    })),
-    $pantryItems
-  );
+  $: pantryMatches = recipeAddress
+    ? buildGrocerySnapshot(
+        parsedIngredients.map((ingredient) => ({
+          ingredient: { name: ingredient.name, quantity: ingredient.quantity },
+          recipeId: recipeAddress,
+          recipeTitle,
+          occurrenceId: `recipe:${recipeAddress}`
+        })),
+        $pantryItems
+      ).inPantry
+    : [];
 
-  $: toBuyCount =
-    classified.toBuy.length +
-    classified.inPantry.filter((row) => includeFromPantry.has(pantryRowKey(row.ingredient))).length;
+  $: snapshot = recipeAddress
+    ? buildGrocerySnapshot(
+        parsedIngredients.map((ingredient) => ({
+          ingredient: { name: ingredient.name, quantity: ingredient.quantity },
+          recipeId: recipeAddress,
+          recipeTitle,
+          occurrenceId: `recipe:${recipeAddress}`
+        })),
+        $pantryItems,
+        { pantryOverrides: [...includeFromPantry] }
+      )
+    : { toBuy: [], inPantry: [], stats: { totalIngredients: 0, pantryCoveredCount: 0, addedCount: 0 }, recipeLinks: [] };
 
+  $: toBuyCount = snapshot.toBuy.length;
   $: pantryReady = !$userPublickey || $pantryInitialized;
 
-  function pantryRowKey(ingredient: ParsedIngredient): string {
-    return `${ingredient.name}|${ingredient.quantity}`;
-  }
-
-  function toggleIncludeFromPantry(ingredient: ParsedIngredient) {
-    const key = pantryRowKey(ingredient);
+  function toggleIncludeFromPantry(normalizedName: string) {
     const next = new Set(includeFromPantry);
-    if (next.has(key)) next.delete(key);
-    else next.add(key);
+    if (next.has(normalizedName)) next.delete(normalizedName);
+    else next.add(normalizedName);
     includeFromPantry = next;
   }
 
@@ -134,47 +144,14 @@
 
     addingToList = true;
     try {
+      groceryStore.mergeRequirements(selectedListId, snapshot.toBuy, snapshot.inPantry);
       groceryStore.addRecipeLink(selectedListId, recipeAddress);
 
-      let addedCount = 0;
-      for (const row of classified.toBuy) {
-        groceryStore.addItem(
-          selectedListId,
-          row.ingredient.name,
-          row.ingredient.quantity,
-          row.ingredient.category,
-          recipeAddress
-        );
-        addedCount++;
-      }
-      const covered = [];
-      for (const row of classified.inPantry) {
-        if (includeFromPantry.has(pantryRowKey(row.ingredient))) {
-          groceryStore.addItem(
-            selectedListId,
-            row.ingredient.name,
-            row.ingredient.quantity,
-            row.ingredient.category,
-            recipeAddress
-          );
-          addedCount++;
-        } else {
-          covered.push({
-            name: row.ingredient.name,
-            quantity: row.ingredient.quantity,
-            recipeId: recipeAddress
-          });
-        }
-      }
-      if (covered.length > 0) {
-        groceryStore.appendPantryCovered(selectedListId, covered);
-      }
-
       successMessage =
-        addedCount === 0
+        toBuyCount === 0
           ? 'Recipe added. Everything was already in your pantry.'
-          : `Added ${addedCount} ingredient${addedCount === 1 ? '' : 's'} to your list!`;
-      dispatch('added', { listId: selectedListId, count: addedCount });
+          : `Added ${toBuyCount} ingredient${toBuyCount === 1 ? '' : 's'} to your list!`;
+      dispatch('added', { listId: selectedListId, count: toBuyCount });
 
       setTimeout(() => {
         close();
@@ -189,16 +166,6 @@
   function selectList(listId: string) {
     selectedListId = listId;
   }
-
-  // Category display names and colors
-  const categoryDisplay: Record<string, { name: string; color: string }> = {
-    produce: { name: 'Produce', color: 'text-green-600' },
-    protein: { name: 'Protein', color: 'text-red-600' },
-    dairy: { name: 'Dairy', color: 'text-blue-600' },
-    pantry: { name: 'Pantry', color: 'text-amber-600' },
-    frozen: { name: 'Frozen', color: 'text-cyan-600' },
-    other: { name: 'Other', color: 'text-gray-600' }
-  };
 </script>
 
 {#if open && portalTarget}
@@ -258,10 +225,10 @@
                 on:click={() => showPreview = !showPreview}
               >
                 <span>
-                  {#if classified.inPantry.length > 0}
-                    {toBuyCount} to buy · {classified.inPantry.length} in pantry
+                  {#if pantryMatches.length > 0}
+                    {toBuyCount} to buy · {pantryMatches.length} in My Kitchen
                   {:else}
-                    {parsedIngredients.length} ingredients found
+                    {snapshot.stats.totalIngredients || parsedIngredients.length} ingredients found
                   {/if}
                 </span>
                 {#if showPreview}
@@ -276,45 +243,45 @@
                   class="max-h-48 overflow-y-auto rounded-xl p-3 space-y-3"
                   style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
                 >
-                  {#if classified.toBuy.length > 0}
+                  {#if snapshot.toBuy.filter((row) => !row.pantryOverride).length > 0}
                     <div class="space-y-1">
-                      {#if classified.inPantry.length > 0}
+                      {#if pantryMatches.length > 0}
                         <p class="text-xs font-semibold" style="color: var(--color-text-secondary)">Need to buy</p>
                       {/if}
-                      {#each classified.toBuy as row}
+                      {#each snapshot.toBuy.filter((row) => !row.pantryOverride) as row}
                         <div class="flex items-center gap-2 text-sm">
-                          <span class={`text-xs px-1.5 py-0.5 rounded ${categoryDisplay[row.ingredient.category]?.color || 'text-gray-600'}`}>
-                            {categoryDisplay[row.ingredient.category]?.name || 'Other'}
+                          <span class="text-xs px-1.5 py-0.5 rounded text-caption">
+                            {GROCERY_CATEGORY_LABELS[canonicalizeGroceryCategory(row.category, row.name)]}
                           </span>
                           <span style="color: var(--color-text-primary)">
-                            {#if row.ingredient.quantity}
-                              <span class="text-caption">{row.ingredient.quantity}</span>
+                            {#if row.quantity}
+                              <span class="text-caption">{row.quantity}</span>
                             {/if}
-                            {row.ingredient.name}
+                            {row.name}
                           </span>
                         </div>
                       {/each}
                     </div>
                   {/if}
-                  {#if classified.inPantry.length > 0}
+                  {#if pantryMatches.length > 0}
                     <div class="space-y-1">
-                      <p class="text-xs font-semibold" style="color: var(--color-text-secondary)">Already in pantry</p>
-                      <p class="text-[11px] text-caption">Left off the list. Add any you still need.</p>
-                      {#each classified.inPantry as row}
-                        {@const included = includeFromPantry.has(pantryRowKey(row.ingredient))}
+                      <p class="text-xs font-semibold" style="color: var(--color-text-secondary)">Already in My Kitchen</p>
+                      <p class="text-[11px] text-caption">Left off the list unless you still need them.</p>
+                      {#each pantryMatches as row}
+                        {@const included = includeFromPantry.has(row.normalizedName)}
                         <div class="flex items-center gap-2 text-sm">
                           <span class="min-w-0 flex-1 {included ? '' : 'text-caption'}" style={included ? 'color: var(--color-text-primary)' : ''}>
-                            {#if row.ingredient.quantity}
-                              <span class="text-caption">{row.ingredient.quantity}</span>
+                            {#if row.quantity}
+                              <span class="text-caption">{row.quantity}</span>
                             {/if}
-                            {row.ingredient.name}
+                            {row.name}
                           </span>
                           <button
                             type="button"
-                            class="flex-shrink-0 px-2 py-0.5 rounded-full text-xs font-medium border border-green-500/40 text-green-500 hover:bg-green-500/10"
-                            on:click={() => toggleIncludeFromPantry(row.ingredient)}
+                            class="flex-shrink-0 px-2 py-1 rounded-full text-xs font-medium border border-green-500/40 text-green-500 hover:bg-green-500/10"
+                            on:click={() => toggleIncludeFromPantry(row.normalizedName)}
                           >
-                            {included ? 'Added' : 'Add'}
+                            {included ? 'Added' : 'I still need this'}
                           </button>
                         </div>
                       {/each}
@@ -418,7 +385,7 @@
                   Adding...
                 {:else}
                   <PlusIcon size={18} />
-                  {#if toBuyCount === 0 && classified.inPantry.length > 0}
+                  {#if toBuyCount === 0 && pantryMatches.length > 0}
                     Add recipe
                   {:else}
                     Add {toBuyCount} {toBuyCount === 1 ? 'Item' : 'Items'}

--- a/src/components/grocery/GroceryItemRow.svelte
+++ b/src/components/grocery/GroceryItemRow.svelte
@@ -44,6 +44,10 @@
   function toggleSources() {
     sourcesOpen = !sourcesOpen;
   }
+
+  function returnToPantry() {
+    groceryStore.returnPantryOverride(listId, item.id);
+  }
 </script>
 
 <div
@@ -117,6 +121,17 @@
           {/each}
         </ul>
       {/if}
+    {/if}
+
+    {#if item.pantryOverride}
+      <button
+        type="button"
+        on:click={returnToPantry}
+        class="mt-1.5 inline-flex items-center px-3 py-1 rounded-full text-xs font-medium border border-green-500/40 text-green-500 hover:bg-green-500/10 transition-colors"
+        aria-label="I have {item.name}"
+      >
+        I have this
+      </button>
     {/if}
   </div>
 

--- a/src/components/grocery/GroceryItemRow.svelte
+++ b/src/components/grocery/GroceryItemRow.svelte
@@ -3,6 +3,8 @@
   import CheckIcon from 'phosphor-svelte/lib/Check';
   import TrashIcon from 'phosphor-svelte/lib/Trash';
   import DotsSixVerticalIcon from 'phosphor-svelte/lib/DotsSixVertical';
+  import CaretDownIcon from 'phosphor-svelte/lib/CaretDown';
+  import CaretUpIcon from 'phosphor-svelte/lib/CaretUp';
 
   export let item: GroceryItem;
   export let listId: string;
@@ -15,12 +17,32 @@
   export let onDragEnd: () => void = () => {};
   export let onDragLeave: () => void = () => {};
 
+  let sourcesOpen = false;
+
+  $: recipeTitles = uniqueRecipeTitles(item);
+
+  function uniqueRecipeTitles(current: GroceryItem): string[] {
+    const titles = new Map<string, string>();
+    for (const source of current.sources || []) {
+      const label = source.recipeTitle || source.recipeId.split(':').slice(2).join(':');
+      if (label && !titles.has(source.recipeId)) titles.set(source.recipeId, label);
+    }
+    if (titles.size === 0 && current.recipeId) {
+      titles.set(current.recipeId, current.recipeId.split(':').slice(2).join(':'));
+    }
+    return [...titles.values()];
+  }
+
   function toggleItem() {
     groceryStore.toggleItem(listId, item.id);
   }
 
   function removeItem() {
     groceryStore.removeItem(listId, item.id);
+  }
+
+  function toggleSources() {
+    sourcesOpen = !sourcesOpen;
   }
 </script>
 
@@ -32,55 +54,79 @@
   on:drop|preventDefault={(e) => onDrop(e, index)}
   on:dragend={onDragEnd}
   on:dragleave={onDragLeave}
-  class="group flex items-center gap-3 p-3 rounded-xl transition-all
+  class="group flex items-start gap-2 sm:gap-3 p-3 rounded-xl transition-all
     {item.checked ? 'opacity-60' : ''}
     {isDragged ? 'opacity-50' : ''}
     {isDragOver ? 'ring-2 ring-primary' : ''}"
   style="background-color: var(--color-bg-secondary);"
 >
-  <!-- Drag handle -->
   <div
-    class="cursor-grab active:cursor-grabbing text-caption hover:text-primary flex-shrink-0 touch-none mr-1"
+    class="hidden sm:flex cursor-grab active:cursor-grabbing text-caption hover:text-primary flex-shrink-0 touch-none mt-1"
     title="Drag to reorder"
     aria-label="Drag to reorder"
     role="img"
   >
-    <DotsSixVerticalIcon size={20} weight="bold" />
+    <DotsSixVerticalIcon size={18} weight="bold" />
   </div>
-
-  <!-- Checkbox -->
   <button
+    type="button"
     on:click={toggleItem}
-    class="w-6 h-6 rounded-full border-2 flex items-center justify-center flex-shrink-0 transition-all {item.checked
+    class="mt-0.5 w-7 h-7 rounded-full border-2 flex items-center justify-center flex-shrink-0 transition-all {item.checked
       ? 'bg-green-500 border-green-500'
       : 'border-gray-400 dark:border-gray-400 hover:border-green-400'}"
     aria-label={item.checked ? 'Uncheck item' : 'Check item'}
   >
     {#if item.checked}
-      <CheckIcon size={14} weight="bold" class="text-white" />
+      <CheckIcon size={16} weight="bold" class="text-white" />
     {/if}
   </button>
 
-  <!-- Item details -->
   <div class="flex-1 min-w-0">
-    <span 
-      class="block {item.checked ? 'line-through' : ''}"
-      style="color: var(--color-text-primary)"
+    <button
+      type="button"
+      on:click={toggleItem}
+      class="flex w-full text-left gap-2 items-baseline min-h-[28px]"
     >
-      {item.name}
-    </span>
-    <span class="text-sm text-caption">
-      {item.quantity || '1'}
-    </span>
+      <span
+        class="font-medium {item.checked ? 'line-through' : ''}"
+        style="color: var(--color-text-primary)"
+      >
+        {item.name}{#if item.quantity}<span class="font-normal text-caption"> — {item.quantity}</span>{/if}
+      </span>
+    </button>
+
+    {#if recipeTitles.length > 0}
+      <button
+        type="button"
+        on:click={toggleSources}
+        class="mt-1 flex items-center gap-1 text-xs text-caption hover:opacity-80"
+        aria-expanded={sourcesOpen}
+      >
+        {#if sourcesOpen}
+          <CaretUpIcon size={12} />
+        {:else}
+          <CaretDownIcon size={12} />
+        {/if}
+        Used in {recipeTitles.length}
+        {recipeTitles.length === 1 ? 'recipe' : 'recipes'}
+      </button>
+      {#if sourcesOpen}
+        <ul class="mt-1 pl-4 text-xs text-caption list-disc">
+          {#each recipeTitles as title}
+            <li>{title}</li>
+          {/each}
+        </ul>
+      {/if}
+    {/if}
   </div>
 
-  <!-- Delete button -->
   <button
+    type="button"
     on:click={removeItem}
-    class="p-1.5 rounded-lg opacity-0 group-hover:opacity-100 transition-all hover:bg-red-500/10"
+    class="p-2 rounded-lg sm:opacity-0 sm:group-hover:opacity-100 transition-all hover:bg-red-500/10 flex-shrink-0"
     style="color: var(--color-danger)"
     aria-label="Remove item"
   >
-    <TrashIcon size={16} />
+    <TrashIcon size={18} />
   </button>
 </div>

--- a/src/lib/grocery/categories.test.ts
+++ b/src/lib/grocery/categories.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('$app/environment', () => ({ browser: false }));
+
+import { canonicalizeGroceryCategory, inferGroceryCategory } from './categories';
+
+describe('inferGroceryCategory', () => {
+  it('uses pantry aisles and grocery-specific bakery/beverage/snack groups', () => {
+    expect(inferGroceryCategory('Broccoli')).toBe('produce');
+    expect(inferGroceryCategory('Chicken Breast')).toBe('meat-seafood');
+    expect(inferGroceryCategory('Eggs')).toBe('dairy-eggs');
+    expect(inferGroceryCategory('Sourdough bread')).toBe('bakery');
+    expect(inferGroceryCategory('Rice')).toBe('grains-pasta');
+    expect(inferGroceryCategory('Olive oil')).toBe('sauces');
+    expect(inferGroceryCategory('Black pepper')).toBe('spices');
+    expect(inferGroceryCategory('Sparkling water')).toBe('beverages');
+    expect(inferGroceryCategory('Potato chips')).toBe('snacks');
+  });
+});
+
+describe('canonicalizeGroceryCategory', () => {
+  it('maps legacy grocery categories', () => {
+    expect(canonicalizeGroceryCategory('protein', 'chicken')).toBe('meat-seafood');
+    expect(canonicalizeGroceryCategory('dairy', 'milk')).toBe('dairy-eggs');
+    expect(canonicalizeGroceryCategory('pantry', 'flour')).toBe('baking');
+  });
+});

--- a/src/lib/grocery/categories.ts
+++ b/src/lib/grocery/categories.ts
@@ -1,0 +1,161 @@
+/**
+ * Store-oriented grocery aisles.
+ *
+ * Reuses pantry category inference and adds bakery / beverages / snacks.
+ * Legacy grocery values (`protein`, `dairy`, `pantry`) are accepted on
+ * read and canonicalized at display time so older lists keep working.
+ */
+
+import { inferPantryCategory, type PantryCategory } from '$lib/pantry/categories';
+import { normalizeIngredientName } from '$lib/pantry/normalization';
+
+export const GROCERY_CATEGORIES = [
+  'produce',
+  'meat-seafood',
+  'dairy-eggs',
+  'bakery',
+  'grains-pasta',
+  'canned-jarred',
+  'sauces',
+  'spices',
+  'baking',
+  'frozen',
+  'beverages',
+  'snacks',
+  'other'
+] as const;
+
+export type GroceryAisle = (typeof GROCERY_CATEGORIES)[number];
+
+/** Includes legacy persisted values from earlier grocery lists. */
+export type GroceryCategory = GroceryAisle | 'protein' | 'dairy' | 'pantry';
+
+export const GROCERY_CATEGORY_LABELS: Record<GroceryAisle, string> = {
+  produce: 'Produce',
+  'meat-seafood': 'Meat & Seafood',
+  'dairy-eggs': 'Dairy & Eggs',
+  bakery: 'Bakery',
+  'grains-pasta': 'Grains, Pasta & Rice',
+  'canned-jarred': 'Canned & Jarred',
+  sauces: 'Sauces & Condiments',
+  spices: 'Spices & Seasonings',
+  baking: 'Baking',
+  frozen: 'Frozen',
+  beverages: 'Beverages',
+  snacks: 'Snacks',
+  other: 'Other'
+};
+
+export const GROCERY_CATEGORY_EMOJI: Record<GroceryAisle, string> = {
+  produce: '🥬',
+  'meat-seafood': '🥩',
+  'dairy-eggs': '🧀',
+  bakery: '🍞',
+  'grains-pasta': '🍝',
+  'canned-jarred': '🥫',
+  sauces: '🫙',
+  spices: '🧂',
+  baking: '🧁',
+  frozen: '🧊',
+  beverages: '🥤',
+  snacks: '🍿',
+  other: '📦'
+};
+
+const AISLE_SET = new Set<string>(GROCERY_CATEGORIES);
+
+const BAKERY_KEYWORDS = [
+  'baguette',
+  'bagel',
+  'brioche',
+  'croissant',
+  'english muffin',
+  'sourdough',
+  'bread',
+  'bun',
+  'roll',
+  'loaf',
+  'baguette'
+];
+
+const BEVERAGE_KEYWORDS = [
+  'coffee',
+  'espresso',
+  'sparkling water',
+  'seltzer',
+  'kombucha',
+  'soda',
+  'cola',
+  'beer',
+  'wine',
+  'tea bags',
+  'black tea',
+  'green tea',
+  'iced tea'
+];
+
+const SNACK_KEYWORDS = [
+  'potato chip',
+  'tortilla chip',
+  'chips',
+  'pretzel',
+  'popcorn',
+  'candy',
+  'cookie',
+  'granola bar',
+  'protein bar',
+  'crackers'
+];
+
+function haystackFor(name: string): string {
+  const raw = name.toLowerCase();
+  const normalized = normalizeIngredientName(name);
+  return `${raw} ${normalized}`.trim();
+}
+
+function matchesKeyword(haystack: string, keywords: string[]): boolean {
+  return keywords.some((kw) => haystack.includes(kw));
+}
+
+const PANTRY_TO_GROCERY: Record<PantryCategory, GroceryAisle> = {
+  produce: 'produce',
+  'meat-seafood': 'meat-seafood',
+  'dairy-eggs': 'dairy-eggs',
+  'grains-pasta': 'grains-pasta',
+  'canned-jarred': 'canned-jarred',
+  baking: 'baking',
+  spices: 'spices',
+  sauces: 'sauces',
+  frozen: 'frozen',
+  other: 'other'
+};
+
+/**
+ * Infer a grocery aisle from an item name. Bakery / beverages / snacks
+ * win over the pantry mapping so "bread" is Bakery, not Grains.
+ */
+export function inferGroceryCategory(name: string): GroceryAisle {
+  const haystack = haystackFor(name);
+  if (!haystack) return 'other';
+  if (matchesKeyword(haystack, BEVERAGE_KEYWORDS)) return 'beverages';
+  if (matchesKeyword(haystack, SNACK_KEYWORDS)) return 'snacks';
+  if (matchesKeyword(haystack, BAKERY_KEYWORDS)) return 'bakery';
+  return PANTRY_TO_GROCERY[inferPantryCategory(name)];
+}
+
+export function canonicalizeGroceryCategory(
+  category: string | undefined,
+  name?: string
+): GroceryAisle {
+  if (category === 'protein') return 'meat-seafood';
+  if (category === 'dairy') return 'dairy-eggs';
+  if (category === 'pantry') {
+    return name ? inferGroceryCategory(name) : 'other';
+  }
+  if (category && AISLE_SET.has(category)) return category as GroceryAisle;
+  return name ? inferGroceryCategory(name) : 'other';
+}
+
+export function groceryCategoryLabel(category: string, name?: string): string {
+  return GROCERY_CATEGORY_LABELS[canonicalizeGroceryCategory(category, name)];
+}

--- a/src/lib/grocery/consolidation.test.ts
+++ b/src/lib/grocery/consolidation.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('$app/environment', () => ({ browser: false }));
+
+import { consolidateIngredients, groceryConsolidationKey } from './consolidation';
+
+function row(name: string, quantity: string, recipeId: string, occurrenceId = `${recipeId}:slot`) {
+  return {
+    ingredient: { name, quantity },
+    recipeId,
+    recipeTitle: recipeId,
+    occurrenceId
+  };
+}
+
+describe('groceryConsolidationKey', () => {
+  it('singularizes and aliases obvious variants', () => {
+    expect(groceryConsolidationKey('onions')).toBe('onion');
+    expect(groceryConsolidationKey('tomatoes')).toBe('tomato');
+    expect(groceryConsolidationKey('chicken breasts')).toBe('chicken breast');
+    expect(groceryConsolidationKey('parmesan cheese')).toBe('parmesan');
+    expect(groceryConsolidationKey('Parmesan')).toBe('parmesan');
+  });
+
+  it('keeps distinguishing colors and forms', () => {
+    expect(groceryConsolidationKey('yellow onion')).toBe('yellow onion');
+    expect(groceryConsolidationKey('red onion')).toBe('red onion');
+    expect(groceryConsolidationKey('green onion')).toBe('green onion');
+    expect(groceryConsolidationKey('ground beef')).toBe('ground beef');
+  });
+});
+
+describe('consolidateIngredients', () => {
+  it('merges yellow onions with generic onion and sums counts', () => {
+    const out = consolidateIngredients([
+      row('yellow onion', '1', 'A'),
+      row('yellow onions', '2', 'B'),
+      row('onion', '1', 'C')
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].normalizedName).toBe('yellow onion');
+    expect(out[0].quantity).toBe('4');
+    expect(out[0].sources).toHaveLength(3);
+  });
+
+  it('keeps red, yellow, and green onions distinct', () => {
+    const out = consolidateIngredients([
+      row('red onion', '1', 'A'),
+      row('yellow onion', '1', 'B'),
+      row('green onion', '1', 'C')
+    ]);
+    expect(out.map((item) => item.normalizedName).sort()).toEqual([
+      'green onion',
+      'red onion',
+      'yellow onion'
+    ]);
+  });
+
+  it('does not merge generic onion when both red and yellow are present', () => {
+    const out = consolidateIngredients([
+      row('red onion', '1', 'A'),
+      row('yellow onion', '1', 'B'),
+      row('onion', '1', 'C')
+    ]);
+    expect(out).toHaveLength(3);
+  });
+
+  it('combines compatible quantities and keeps recipe sources', () => {
+    const out = consolidateIngredients([
+      row('chicken broth', '1 cup', 'A', 'mon:dinner'),
+      row('chicken broth', '2 cups', 'B', 'tue:dinner')
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].quantity).toBe('3 cups');
+    expect(out[0].sources.map((s) => s.recipeId).sort()).toEqual(['A', 'B']);
+  });
+
+  it('does not double the same occurrence', () => {
+    const out = consolidateIngredients([
+      row('rice', '1 cup', 'A', 'mon:dinner'),
+      row('rice', '1 cup', 'A', 'mon:dinner')
+    ]);
+    expect(out[0].sources).toHaveLength(1);
+    expect(out[0].quantity).toBe('1 cup');
+  });
+});

--- a/src/lib/grocery/consolidation.ts
+++ b/src/lib/grocery/consolidation.ts
@@ -1,0 +1,283 @@
+/**
+ * Conservative grocery ingredient consolidation.
+ *
+ * Merges obvious duplicates (onion/onions, chicken breast/breasts,
+ * parmesan/parmesan cheese) and keeps meaningfully distinct items
+ * (red vs yellow vs green onion) separate. Quantity combining is
+ * delegated to `units.ts`.
+ */
+
+import { singularizeToken } from '$lib/pantry/normalization';
+import { combineQuantities } from './units';
+import { inferGroceryCategory, type GroceryAisle } from './categories';
+
+export interface GroceryItemSource {
+  recipeId: string;
+  recipeTitle?: string;
+  /** Meal-plan slot (`mon:dinner`) or `recipe:<a-tag>` for recipe-page adds. */
+  occurrenceId: string;
+  quantity: string;
+  originalName?: string;
+}
+
+export interface ConsolidationRow {
+  ingredient: { name: string; quantity: string };
+  recipeId: string;
+  recipeTitle?: string;
+  occurrenceId: string;
+}
+
+export interface ConsolidatedIngredient {
+  name: string;
+  normalizedName: string;
+  quantity: string;
+  amount?: number;
+  unit?: string;
+  category: GroceryAisle;
+  sources: GroceryItemSource[];
+}
+
+const PREP_STRIP = new Set([
+  'chopped',
+  'diced',
+  'minced',
+  'sliced',
+  'grated',
+  'shredded',
+  'peeled',
+  'cooked',
+  'packed',
+  'sifted',
+  'softened',
+  'melted',
+  'beaten',
+  'divided',
+  'optional',
+  'fresh',
+  'organic',
+  'ripe',
+  'lean',
+  'large',
+  'medium',
+  'small',
+  'extra',
+  'virgin'
+]);
+
+/** Color / form words that distinguish grocery items. */
+const DISTINGUISHING = new Set([
+  'yellow',
+  'white',
+  'red',
+  'green',
+  'brown',
+  'purple',
+  'ground',
+  'whole',
+  'dried',
+  'frozen',
+  'canned',
+  'boneless',
+  'skinless'
+]);
+
+const DEFAULT_VARIETY = new Set(['yellow', 'white']);
+
+const NAME_ALIASES: Record<string, string> = {
+  'parmesan cheese': 'parmesan',
+  parmigiano: 'parmesan',
+  'parmigiano reggiano': 'parmesan',
+  'cheddar cheese': 'cheddar',
+  'mozzarella cheese': 'mozzarella',
+  'swiss cheese': 'swiss',
+  'provolone cheese': 'provolone',
+  'asiago cheese': 'asiago',
+  'pecorino cheese': 'pecorino',
+  'romano cheese': 'romano',
+  scallion: 'green onion',
+  scallions: 'green onion',
+  'spring onion': 'green onion',
+  'spring onions': 'green onion',
+  evoo: 'olive oil',
+  'extra virgin olive oil': 'olive oil'
+};
+
+function applyAlias(value: string): string {
+  return NAME_ALIASES[value] || value;
+}
+
+/**
+ * Matching key for grocery consolidation. Keeps distinguishing modifiers
+ * (color, ground, dried) that pantry matching may strip.
+ */
+export function groceryConsolidationKey(raw: string): string {
+  if (!raw) return '';
+  let s = raw.toLowerCase().trim();
+  s = s.replace(/\s*\([^)]*\)\s*/g, ' ');
+  s = s.replace(/[^\p{L}\p{N}\s-]+/gu, ' ');
+  s = s.replace(/[-_]+/g, ' ');
+  s = s.replace(/\s+/g, ' ').trim();
+  s = s.replace(/\s+to taste$/i, '').trim();
+  if (!s) return '';
+  s = applyAlias(s);
+
+  const tokens = s
+    .split(' ')
+    .map((t) => t.trim())
+    .filter((t) => t && !PREP_STRIP.has(t) && !/^\d+(\.\d+)?$/.test(t))
+    .map(singularizeToken)
+    .filter(Boolean);
+
+  s = applyAlias(tokens.join(' '));
+  return s.trim();
+}
+
+export function titleCaseIngredient(name: string): string {
+  return name
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
+}
+
+function pickDisplayName(originalNames: string[], key: string): string {
+  const cleaned = originalNames
+    .map((n) => n.replace(/\s*\([^)]*\)\s*/g, ' ').replace(/\s+/g, ' ').trim())
+    .filter(Boolean);
+  const specific = cleaned.reduce((best, name) => (name.length > best.length ? name : best), '');
+  if (specific && specific.length >= key.length && !/^[A-Z0-9]{2,}$/.test(specific)) {
+    return titleCaseIngredient(specific);
+  }
+  return titleCaseIngredient(key);
+}
+
+export function grocerySourceKey(source: Pick<GroceryItemSource, 'occurrenceId' | 'recipeId'>): string {
+  return `${source.occurrenceId}|${source.recipeId}`;
+}
+
+function mergeSources(groups: ConsolidatedIngredient[]): GroceryItemSource[] {
+  const map = new Map<string, GroceryItemSource>();
+  for (const group of groups) {
+    for (const source of group.sources) {
+      map.set(grocerySourceKey(source), source);
+    }
+  }
+  return [...map.values()];
+}
+
+/**
+ * Absorb a generic headword ("onion") into a single default-variety
+ * specific group ("yellow onion") when that merge is unambiguous.
+ * Red / green onion stay distinct; generic "onion" is not merged into
+ * them, and is left separate when more than one default variety exists.
+ */
+function absorbGenericVarieties(groups: Map<string, ConsolidatedIngredient>): void {
+  for (const [key, generic] of [...groups.entries()]) {
+    if (key.includes(' ')) continue;
+    const defaultMatches: string[] = [];
+    const otherMatches: string[] = [];
+    for (const candidate of groups.keys()) {
+      if (candidate === key) continue;
+      const tokens = candidate.split(' ');
+      if (tokens.length === 2 && tokens[1] === key) {
+        if (DEFAULT_VARIETY.has(tokens[0])) defaultMatches.push(candidate);
+        else if (DISTINGUISHING.has(tokens[0])) otherMatches.push(candidate);
+      }
+    }
+    if (defaultMatches.length === 1 && otherMatches.length === 0) {
+      const target = groups.get(defaultMatches[0]);
+      if (!target) continue;
+      const merged = mergeConsolidated([target, generic]);
+      groups.set(defaultMatches[0], merged);
+      groups.delete(key);
+    }
+  }
+}
+
+function mergeConsolidated(items: ConsolidatedIngredient[]): ConsolidatedIngredient {
+  const sources = mergeSources(items);
+  const combined = combineQuantities(sources.map((s) => s.quantity));
+  const names = items.flatMap((item) => [
+    item.name,
+    ...item.sources.map((s) => s.originalName || item.name)
+  ]);
+  const key = items[0].normalizedName;
+  return {
+    name: pickDisplayName(names, key),
+    normalizedName: key,
+    quantity: combined.display,
+    amount: combined.amount,
+    unit: combined.unit,
+    category: items[0].category,
+    sources
+  };
+}
+
+export function consolidateIngredients(rows: ConsolidationRow[]): ConsolidatedIngredient[] {
+  const groups = new Map<string, ConsolidatedIngredient>();
+
+  for (const row of rows) {
+    const key = groceryConsolidationKey(row.ingredient.name);
+    if (!key) continue;
+    const source: GroceryItemSource = {
+      recipeId: row.recipeId,
+      recipeTitle: row.recipeTitle,
+      occurrenceId: row.occurrenceId,
+      quantity: row.ingredient.quantity || '',
+      originalName: row.ingredient.name
+    };
+    const existing = groups.get(key);
+    if (!existing) {
+      const combined = combineQuantities([source.quantity]);
+      groups.set(key, {
+        name: pickDisplayName([row.ingredient.name], key),
+        normalizedName: key,
+        quantity: combined.display,
+        amount: combined.amount,
+        unit: combined.unit,
+        category: inferGroceryCategory(row.ingredient.name),
+        sources: [source]
+      });
+      continue;
+    }
+    groups.set(
+      key,
+      mergeConsolidated([
+        existing,
+        {
+          name: row.ingredient.name,
+          normalizedName: key,
+          quantity: source.quantity,
+          category: existing.category,
+          sources: [source]
+        }
+      ])
+    );
+  }
+
+  absorbGenericVarieties(groups);
+
+  return [...groups.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function recombineFromSources(
+  name: string,
+  normalizedName: string,
+  sources: GroceryItemSource[],
+  category: GroceryAisle
+): ConsolidatedIngredient {
+  const combined = combineQuantities(sources.map((s) => s.quantity));
+  return {
+    name: pickDisplayName(
+      [name, ...sources.map((s) => s.originalName || name)],
+      normalizedName
+    ),
+    normalizedName,
+    quantity: combined.display,
+    amount: combined.amount,
+    unit: combined.unit,
+    category,
+    sources
+  };
+}

--- a/src/lib/grocery/export.ts
+++ b/src/lib/grocery/export.ts
@@ -1,0 +1,60 @@
+/**
+ * Provider-ready grocery export.
+ *
+ * Zap owns the normalized shopping list. A future adapter (Instacart,
+ * Walmart, etc.) should consume this shape rather than grocery-list
+ * persistence or any retailer-specific fields. No adapters are
+ * implemented here.
+ */
+
+import { canonicalizeGroceryCategory, type GroceryAisle } from './categories';
+import { groceryConsolidationKey, type GroceryItemSource } from './consolidation';
+import { isManualGroceryItem, type SnapshotListItem } from './requirements';
+
+export interface NormalizedGroceryExportItem {
+  name: string;
+  normalizedName: string;
+  quantity: string;
+  quantityValue?: number;
+  unit?: string;
+  category: GroceryAisle;
+  recipeSources: Array<{ recipeId: string; recipeTitle?: string }>;
+  pantryStatus: 'need' | 'have' | 'overridden';
+  userOverride: boolean;
+  origin: 'manual' | 'recipe';
+}
+
+function uniqueRecipeSources(sources: GroceryItemSource[] | undefined, recipeId?: string) {
+  const map = new Map<string, { recipeId: string; recipeTitle?: string }>();
+  for (const source of sources || []) {
+    if (!map.has(source.recipeId)) {
+      map.set(source.recipeId, {
+        recipeId: source.recipeId,
+        recipeTitle: source.recipeTitle
+      });
+    }
+  }
+  if (recipeId && !map.has(recipeId)) {
+    map.set(recipeId, { recipeId });
+  }
+  return [...map.values()];
+}
+
+export function toProviderItem(item: SnapshotListItem): NormalizedGroceryExportItem {
+  const origin = isManualGroceryItem(item) ? 'manual' : 'recipe';
+  return {
+    name: item.name,
+    normalizedName: item.normalizedName || groceryConsolidationKey(item.name),
+    quantity: item.quantity,
+    unit: item.unit,
+    category: canonicalizeGroceryCategory(item.category, item.name),
+    recipeSources: uniqueRecipeSources(item.sources, item.recipeId),
+    pantryStatus: item.pantryOverride ? 'overridden' : 'need',
+    userOverride: !!item.pantryOverride,
+    origin
+  };
+}
+
+export function toProviderList(items: SnapshotListItem[]): NormalizedGroceryExportItem[] {
+  return items.filter((item) => !item.checked).map(toProviderItem);
+}

--- a/src/lib/grocery/hooks.ts
+++ b/src/lib/grocery/hooks.ts
@@ -1,0 +1,20 @@
+/**
+ * Decoupled meal-plan → grocery sync hook.
+ *
+ * plannerStore notifies here after slot mutations. groceryStore
+ * registers the handler so the two stores do not import each other.
+ */
+
+import type { MealPlan } from '$lib/mealplan/schema';
+
+type MealPlanSyncHandler = (weekId: string, plan: MealPlan) => void;
+
+let handler: MealPlanSyncHandler | null = null;
+
+export function registerMealPlanGrocerySync(fn: MealPlanSyncHandler | null): void {
+  handler = fn;
+}
+
+export function notifyMealPlanMutated(weekId: string, plan: MealPlan): void {
+  handler?.(weekId, plan);
+}

--- a/src/lib/grocery/requirements.test.ts
+++ b/src/lib/grocery/requirements.test.ts
@@ -8,6 +8,10 @@ import {
   buildGrocerySnapshot,
   dropStaleSourcesFromList,
   isManualGroceryItem,
+  movePantryCoveredToList,
+  removeGroceryItemFromList,
+  returnOverrideToPantry,
+  unresolvedRecipeSources,
   type SnapshotList
 } from './requirements';
 import type { ConsolidationRow } from './consolidation';
@@ -89,7 +93,7 @@ describe('applySnapshotToList', () => {
     expect(second.items.filter((item) => item.normalizedName === 'chicken breast')).toHaveLength(1);
   });
 
-  it('preserves manual items and checked state', () => {
+  it('preserves manual items when the week is recalculated', () => {
     const list: SnapshotList = {
       ...emptyList(),
       items: [
@@ -98,7 +102,7 @@ describe('applySnapshotToList', () => {
           name: 'Paper towels',
           quantity: '1',
           category: 'other',
-          checked: false,
+          checked: true,
           addedAt: 1,
           origin: 'manual'
         },
@@ -130,13 +134,198 @@ describe('applySnapshotToList', () => {
       []
     );
     const next = applySnapshotToList(list, snapshot);
-    expect(next.items.some((item) => item.name === 'Paper towels' && isManualGroceryItem(item))).toBe(
-      true
-    );
+    const towels = next.items.find((item) => item.name === 'Paper towels');
+    expect(towels && isManualGroceryItem(towels)).toBe(true);
+    expect(towels?.checked).toBe(true);
     const chicken = next.items.find((item) => item.normalizedName === 'chicken breast');
-    expect(chicken?.checked).toBe(true);
     expect(chicken?.id).toBe('recipe-1');
     expect(chicken?.quantity).toBe('4');
+    expect(chicken?.checked).toBe(false);
+  });
+});
+
+describe('checked state vs requirement changes', () => {
+  function withChickenChecked(list: SnapshotList): SnapshotList {
+    return {
+      ...list,
+      items: list.items.map((item) =>
+        item.normalizedName === 'chicken breast' ? { ...item, checked: true } : item
+      )
+    };
+  }
+
+  it('keeps a checked item checked when the requirement is unchanged', () => {
+    const snapshot = buildGrocerySnapshot([row('chicken breast', '2 lb', 'parm', 'mon:dinner')], []);
+    const checked = withChickenChecked(applySnapshotToList(emptyList(), snapshot));
+    const next = applySnapshotToList(checked, snapshot);
+    const chicken = next.items.find((item) => item.normalizedName === 'chicken breast');
+    expect(chicken?.quantity).toBe('2 lb');
+    expect(chicken?.checked).toBe(true);
+  });
+
+  it('unchecks when quantity increases', () => {
+    const first = buildGrocerySnapshot([row('chicken breast', '2 lb', 'parm', 'mon:dinner')], []);
+    const checked = withChickenChecked(applySnapshotToList(emptyList(), first));
+    const next = applySnapshotToList(
+      checked,
+      buildGrocerySnapshot(
+        [
+          row('chicken breast', '2 lb', 'parm', 'mon:dinner'),
+          row('chicken breast', '2 lb', 'tacos', 'tue:dinner')
+        ],
+        []
+      )
+    );
+    const chicken = next.items.find((item) => item.normalizedName === 'chicken breast');
+    expect(chicken?.quantity).toBe('4 lb');
+    expect(chicken?.checked).toBe(false);
+  });
+
+  it('unchecks when recipe sources change at the same quantity', () => {
+    const first = buildGrocerySnapshot([row('chicken breast', '2 lb', 'parm', 'mon:dinner')], []);
+    const checked = withChickenChecked(applySnapshotToList(emptyList(), first));
+    const next = applySnapshotToList(
+      checked,
+      buildGrocerySnapshot([row('chicken breast', '2 lb', 'tacos', 'tue:dinner')], [])
+    );
+    const chicken = next.items.find((item) => item.normalizedName === 'chicken breast');
+    expect(chicken?.quantity).toBe('2 lb');
+    expect(chicken?.checked).toBe(false);
+  });
+
+  it('unchecks remaining quantity after a meal is removed', () => {
+    const snapshot = buildGrocerySnapshot(
+      [
+        row('chicken breast', '2 lb', 'parm', 'mon:dinner'),
+        row('chicken breast', '2 lb', 'tacos', 'tue:dinner')
+      ],
+      []
+    );
+    const list = applySnapshotToList(emptyList(), snapshot);
+    const checked = {
+      ...list,
+      items: list.items.map((item) =>
+        item.normalizedName === 'chicken breast' ? { ...item, checked: true } : item
+      )
+    };
+    const plan = createEmptyMealPlan('2026-W29');
+    plan.days.tue = {
+      slots: {
+        dinner: { type: 'recipe', a: 'tacos', title: 'Chicken Tacos' }
+      }
+    };
+    const next = dropStaleSourcesFromList(checked, plan);
+    const chicken = next.items.find((item) => item.normalizedName === 'chicken breast');
+    expect(chicken?.quantity).toBe('2 lb');
+    expect(chicken?.checked).toBe(false);
+  });
+});
+
+describe('unresolved recipe sources', () => {
+  it('retains unresolved recipes on the generated list and retry rebuilds without duplicating', () => {
+    const occurrences = [
+      { a: 'parm', title: 'Chicken Parm' },
+      { a: 'tacos', title: 'Chicken Tacos' }
+    ];
+    const unresolved = unresolvedRecipeSources(occurrences, ['parm']);
+    expect(unresolved).toEqual([{ a: 'tacos', title: 'Chicken Tacos' }]);
+
+    const partial = buildGrocerySnapshot([row('chicken breast', '2 lb', 'parm', 'mon:dinner')], [], {
+      unresolvedRecipes: unresolved,
+      sourceWeekId: '2026-W29'
+    });
+    expect(partial.toBuy).toHaveLength(1);
+    expect(partial.unresolvedRecipes).toEqual([{ a: 'tacos', title: 'Chicken Tacos' }]);
+
+    const list = applySnapshotToList(emptyList(), partial);
+    expect(list.unresolvedRecipes).toHaveLength(1);
+    expect(list.items.filter((item) => item.normalizedName === 'chicken breast')).toHaveLength(1);
+
+    const resolved = buildGrocerySnapshot(
+      [
+        row('chicken breast', '2 lb', 'parm', 'mon:dinner'),
+        row('chicken breast', '2 lb', 'tacos', 'tue:dinner')
+      ],
+      [],
+      { sourceWeekId: '2026-W29', unresolvedRecipes: [] }
+    );
+    const retried = applySnapshotToList(list, resolved);
+    expect(retried.unresolvedRecipes).toBeUndefined();
+    const chicken = retried.items.filter((item) => item.normalizedName === 'chicken breast');
+    expect(chicken).toHaveLength(1);
+    expect(chicken[0].quantity).toBe('4 lb');
+  });
+
+  it('drops unresolved recipes that are no longer on the meal plan', () => {
+    const list = applySnapshotToList(
+      emptyList(),
+      buildGrocerySnapshot([row('chicken breast', '2 lb', 'parm', 'mon:dinner')], [], {
+        unresolvedRecipes: [{ a: 'tacos', title: 'Chicken Tacos' }]
+      })
+    );
+    const plan = createEmptyMealPlan('2026-W29');
+    plan.days.mon = {
+      slots: {
+        dinner: { type: 'recipe', a: 'parm', title: 'Chicken Parm' }
+      }
+    };
+    const next = dropStaleSourcesFromList(list, plan);
+    expect(next.unresolvedRecipes).toBeUndefined();
+  });
+});
+
+describe('pantry override reversal', () => {
+  it('includes after I still need this, excludes after I have this, and stays excluded on rebuild', () => {
+    const pantry = [{ name: 'Olive oil', normalizedName: 'olive oil' }];
+    const oliveRow = row('olive oil', '', 'parm', 'mon:dinner');
+
+    const initial = applySnapshotToList(emptyList(), buildGrocerySnapshot([oliveRow], pantry));
+    expect(initial.items).toHaveLength(0);
+    expect(initial.pantryCovered?.map((item) => item.normalizedName)).toEqual(['olive oil']);
+
+    const overridden = movePantryCoveredToList(initial, 0);
+    expect(overridden.added?.pantryOverride).toBe(true);
+    expect(overridden.list.items).toHaveLength(1);
+    expect(overridden.list.pantryCovered).toBeUndefined();
+    expect(overridden.list.pantryOverrides).toEqual(['olive oil']);
+
+    const included = applySnapshotToList(
+      overridden.list,
+      buildGrocerySnapshot([oliveRow], pantry, { pantryOverrides: overridden.list.pantryOverrides })
+    );
+    expect(included.items).toHaveLength(1);
+    expect(included.items[0].pantryOverride).toBe(true);
+    expect(included.pantryOverrides).toEqual(['olive oil']);
+
+    const reversed = returnOverrideToPantry(included, included.items[0].id);
+    expect(reversed.items).toHaveLength(0);
+    expect(reversed.pantryCovered?.map((item) => item.normalizedName)).toEqual(['olive oil']);
+    expect(reversed.pantryOverrides).toBeUndefined();
+
+    const rebuilt = applySnapshotToList(
+      reversed,
+      buildGrocerySnapshot([oliveRow], pantry, { pantryOverrides: reversed.pantryOverrides })
+    );
+    expect(rebuilt.items).toHaveLength(0);
+    expect(rebuilt.pantryCovered?.map((item) => item.normalizedName)).toEqual(['olive oil']);
+    expect(rebuilt.pantryOverrides).toBeUndefined();
+  });
+
+  it('does not resurrect an override after the grocery item is removed', () => {
+    const pantry = [{ name: 'Olive oil', normalizedName: 'olive oil' }];
+    const oliveRow = row('olive oil', '', 'parm', 'mon:dinner');
+    const initial = applySnapshotToList(emptyList(), buildGrocerySnapshot([oliveRow], pantry));
+    const overridden = movePantryCoveredToList(initial, 0);
+    const removed = removeGroceryItemFromList(overridden.list, overridden.added!.id);
+    expect(removed.items).toHaveLength(0);
+    expect(removed.pantryOverrides).toBeUndefined();
+
+    const rebuilt = applySnapshotToList(
+      removed,
+      buildGrocerySnapshot([oliveRow], pantry, { pantryOverrides: removed.pantryOverrides })
+    );
+    expect(rebuilt.items).toHaveLength(0);
+    expect(rebuilt.pantryCovered?.map((item) => item.normalizedName)).toEqual(['olive oil']);
   });
 });
 

--- a/src/lib/grocery/requirements.test.ts
+++ b/src/lib/grocery/requirements.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('$app/environment', () => ({ browser: false }));
+
+import { createEmptyMealPlan } from '$lib/mealplan/schema';
+import {
+  applySnapshotToList,
+  buildGrocerySnapshot,
+  dropStaleSourcesFromList,
+  isManualGroceryItem,
+  type SnapshotList
+} from './requirements';
+import type { ConsolidationRow } from './consolidation';
+
+function row(name: string, quantity: string, recipeId: string, occurrenceId: string): ConsolidationRow {
+  return {
+    ingredient: { name, quantity },
+    recipeId,
+    recipeTitle: recipeId,
+    occurrenceId
+  };
+}
+
+function emptyList(): SnapshotList {
+  return {
+    id: 'list-1',
+    title: 'Groceries',
+    items: [],
+    recipeLinks: [],
+    createdAt: 1,
+    updatedAt: 1
+  };
+}
+
+describe('buildGrocerySnapshot', () => {
+  it('excludes pantry matches and keeps missing items', () => {
+    const snapshot = buildGrocerySnapshot(
+      [
+        row('chicken breast', '1 lb', 'parm', 'mon:dinner'),
+        row('rice', '1 cup', 'parm', 'mon:dinner'),
+        row('broccoli', '1 head', 'parm', 'mon:dinner'),
+        row('olive oil', '', 'parm', 'mon:dinner'),
+        row('garlic', '3 cloves', 'parm', 'mon:dinner')
+      ],
+      [
+        { name: 'Chicken breast', normalizedName: 'chicken breast' },
+        { name: 'Rice', normalizedName: 'rice' },
+        { name: 'Olive oil', normalizedName: 'olive oil' }
+      ]
+    );
+    expect(snapshot.toBuy.map((i) => i.normalizedName).sort()).toEqual(['broccoli', 'garlic']);
+    expect(snapshot.inPantry.map((i) => i.normalizedName).sort()).toEqual([
+      'chicken breast',
+      'olive oil',
+      'rice'
+    ]);
+    expect(snapshot.stats).toEqual({
+      totalIngredients: 5,
+      pantryCoveredCount: 3,
+      addedCount: 2
+    });
+  });
+
+  it('honors pantry overrides', () => {
+    const snapshot = buildGrocerySnapshot(
+      [row('rice', '1 cup', 'a', 'mon:dinner')],
+      [{ name: 'Rice', normalizedName: 'rice' }],
+      { pantryOverrides: ['rice'] }
+    );
+    expect(snapshot.toBuy).toHaveLength(1);
+    expect(snapshot.toBuy[0].pantryOverride).toBe(true);
+    expect(snapshot.inPantry).toHaveLength(0);
+  });
+});
+
+describe('applySnapshotToList', () => {
+  it('does not double quantities when the same week is applied twice', () => {
+    const snapshot = buildGrocerySnapshot(
+      [
+        row('chicken breast', '2', 'parm', 'mon:dinner'),
+        row('chicken breast', '2', 'tacos', 'tue:dinner')
+      ],
+      []
+    );
+    const first = applySnapshotToList(emptyList(), snapshot);
+    const second = applySnapshotToList(first, snapshot);
+    const chicken = second.items.find((item) => item.normalizedName === 'chicken breast');
+    expect(chicken?.quantity).toBe('4');
+    expect(second.items.filter((item) => item.normalizedName === 'chicken breast')).toHaveLength(1);
+  });
+
+  it('preserves manual items and checked state', () => {
+    const list: SnapshotList = {
+      ...emptyList(),
+      items: [
+        {
+          id: 'manual-1',
+          name: 'Paper towels',
+          quantity: '1',
+          category: 'other',
+          checked: false,
+          addedAt: 1,
+          origin: 'manual'
+        },
+        {
+          id: 'recipe-1',
+          name: 'Chicken Breast',
+          quantity: '2',
+          category: 'meat-seafood',
+          checked: true,
+          addedAt: 1,
+          origin: 'recipe',
+          normalizedName: 'chicken breast',
+          sources: [
+            {
+              recipeId: 'parm',
+              occurrenceId: 'mon:dinner',
+              quantity: '2',
+              recipeTitle: 'parm'
+            }
+          ]
+        }
+      ]
+    };
+    const snapshot = buildGrocerySnapshot(
+      [
+        row('chicken breast', '2', 'parm', 'mon:dinner'),
+        row('chicken breast', '2', 'tacos', 'tue:dinner')
+      ],
+      []
+    );
+    const next = applySnapshotToList(list, snapshot);
+    expect(next.items.some((item) => item.name === 'Paper towels' && isManualGroceryItem(item))).toBe(
+      true
+    );
+    const chicken = next.items.find((item) => item.normalizedName === 'chicken breast');
+    expect(chicken?.checked).toBe(true);
+    expect(chicken?.id).toBe('recipe-1');
+    expect(chicken?.quantity).toBe('4');
+  });
+});
+
+describe('dropStaleSourcesFromList', () => {
+  it('recalculates remaining quantities when a meal is removed', () => {
+    const snapshot = buildGrocerySnapshot(
+      [
+        row('chicken breast', '2', 'parm', 'mon:dinner'),
+        row('chicken breast', '2', 'tacos', 'tue:dinner')
+      ],
+      []
+    );
+    const list = applySnapshotToList(emptyList(), snapshot);
+    const plan = createEmptyMealPlan('2026-W29');
+    plan.days.tue = {
+      slots: {
+        dinner: { type: 'recipe', a: 'tacos', title: 'Chicken Tacos' }
+      }
+    };
+
+    const next = dropStaleSourcesFromList(list, plan);
+    const chicken = next.items.find((item) => item.normalizedName === 'chicken breast');
+    expect(chicken?.quantity).toBe('2');
+    expect(chicken?.sources).toHaveLength(1);
+    expect(chicken?.sources?.[0].recipeId).toBe('tacos');
+  });
+
+  it('removes a grocery item when no recipes still need it', () => {
+    const snapshot = buildGrocerySnapshot(
+      [row('broccoli', '1 head', 'parm', 'mon:dinner')],
+      []
+    );
+    const list = applySnapshotToList(emptyList(), snapshot);
+    const next = dropStaleSourcesFromList(list, createEmptyMealPlan('2026-W29'));
+    expect(next.items).toHaveLength(0);
+  });
+});

--- a/src/lib/grocery/requirements.ts
+++ b/src/lib/grocery/requirements.ts
@@ -1,0 +1,429 @@
+/**
+ * Build a pantry-aware grocery snapshot from consolidated recipe
+ * requirements, and apply it to an existing list without duplicating
+ * quantities or disturbing manual items.
+ */
+
+import { classifyIngredientAgainstPantry } from '$lib/pantry/matching';
+import type { PantryItem } from '$lib/pantry/schema';
+import {
+  canonicalizeGroceryCategory,
+  inferGroceryCategory,
+  type GroceryAisle
+} from './categories';
+import {
+  consolidateIngredients,
+  groceryConsolidationKey,
+  grocerySourceKey,
+  recombineFromSources,
+  type ConsolidatedIngredient,
+  type ConsolidationRow,
+  type GroceryItemSource
+} from './consolidation';
+import { DAY_KEYS, SLOT_KEYS, type MealPlan } from '$lib/mealplan/schema';
+
+export type GroceryItemOrigin = 'manual' | 'recipe';
+
+export interface GroceryRequirement {
+  name: string;
+  normalizedName: string;
+  quantity: string;
+  amount?: number;
+  unit?: string;
+  category: GroceryAisle;
+  sources: GroceryItemSource[];
+  pantryOverride?: boolean;
+}
+
+export interface GrocerySnapshot {
+  toBuy: GroceryRequirement[];
+  inPantry: GroceryRequirement[];
+  stats: {
+    totalIngredients: number;
+    pantryCoveredCount: number;
+    addedCount: number;
+  };
+  recipeLinks: string[];
+  sourceWeekId?: string;
+}
+
+export interface SnapshotListItem {
+  id: string;
+  name: string;
+  quantity: string;
+  category: string;
+  checked: boolean;
+  recipeId?: string;
+  addedAt: number;
+  normalizedName?: string;
+  unit?: string;
+  origin?: GroceryItemOrigin;
+  sources?: GroceryItemSource[];
+  pantryOverride?: boolean;
+}
+
+export interface SnapshotList {
+  id: string;
+  title: string;
+  items: SnapshotListItem[];
+  recipeLinks: string[];
+  notes?: string;
+  pantryCovered?: GroceryRequirement[];
+  pantryOverrides?: string[];
+  sourceWeekId?: string;
+  stats?: GrocerySnapshot['stats'];
+  createdAt: number;
+  updatedAt: number;
+}
+
+const MEAL_OCCURRENCE_RE =
+  /^(mon|tue|wed|thu|fri|sat|sun):(breakfast|lunch|dinner|snack)$/;
+
+export function isMealPlanOccurrence(occurrenceId: string): boolean {
+  return MEAL_OCCURRENCE_RE.test(occurrenceId);
+}
+
+export function isManualGroceryItem(item: Pick<SnapshotListItem, 'origin' | 'recipeId' | 'sources'>): boolean {
+  if (item.origin === 'manual') return true;
+  if (item.origin === 'recipe') return false;
+  if (item.recipeId || (item.sources && item.sources.length > 0)) return false;
+  return true;
+}
+
+function requirementFromConsolidated(
+  item: ConsolidatedIngredient,
+  pantryOverride = false
+): GroceryRequirement {
+  return {
+    name: item.name,
+    normalizedName: item.normalizedName,
+    quantity: item.quantity,
+    amount: item.amount,
+    unit: item.unit,
+    category: item.category,
+    sources: item.sources,
+    pantryOverride: pantryOverride || undefined
+  };
+}
+
+function toParsedIngredient(item: ConsolidatedIngredient) {
+  return {
+    name: item.name,
+    quantity: item.quantity,
+    category: 'other' as const,
+    originalText: `${item.quantity} ${item.name}`.trim()
+  };
+}
+
+export function buildGrocerySnapshot(
+  rows: ConsolidationRow[],
+  pantry: Array<Pick<PantryItem, 'name' | 'normalizedName' | 'quantity' | 'unit' | 'isStaple'>>,
+  options?: { pantryOverrides?: string[]; sourceWeekId?: string }
+): GrocerySnapshot {
+  const consolidated = consolidateIngredients(rows);
+  const overrides = new Set(
+    (options?.pantryOverrides || []).map((n) => groceryConsolidationKey(n) || n)
+  );
+
+  const toBuy: GroceryRequirement[] = [];
+  const inPantry: GroceryRequirement[] = [];
+
+  for (const item of consolidated) {
+    const status = classifyIngredientAgainstPantry(toParsedIngredient(item), pantry);
+    const overridden = overrides.has(item.normalizedName);
+    if (status === 'have' && !overridden) {
+      inPantry.push(requirementFromConsolidated(item));
+    } else {
+      toBuy.push(requirementFromConsolidated(item, overridden && status === 'have'));
+    }
+  }
+
+  const recipeLinks = [
+    ...new Set(consolidated.flatMap((item) => item.sources.map((s) => s.recipeId)))
+  ];
+
+  return {
+    toBuy,
+    inPantry,
+    stats: {
+      totalIngredients: consolidated.length,
+      pantryCoveredCount: inPantry.length,
+      addedCount: toBuy.length
+    },
+    recipeLinks,
+    sourceWeekId: options?.sourceWeekId
+  };
+}
+
+function itemFromRequirement(
+  req: GroceryRequirement,
+  existing?: SnapshotListItem
+): SnapshotListItem {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    id: existing?.id || createLocalId(),
+    name: req.name,
+    quantity: req.quantity,
+    category: req.category,
+    checked: existing?.checked ?? false,
+    recipeId: req.sources[0]?.recipeId,
+    addedAt: existing?.addedAt ?? now,
+    normalizedName: req.normalizedName,
+    unit: req.unit,
+    origin: 'recipe',
+    sources: req.sources,
+    pantryOverride: req.pantryOverride
+  };
+}
+
+function createLocalId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).substring(2, 8)}`;
+}
+
+function recipeItemKey(item: SnapshotListItem): string {
+  return item.normalizedName || groceryConsolidationKey(item.name);
+}
+
+/**
+ * Replace recipe-derived items with the snapshot. Manual items, checked
+ * state, and item ids (matched by normalized name) are preserved.
+ */
+export function applySnapshotToList(list: SnapshotList, snapshot: GrocerySnapshot): SnapshotList {
+  const manual = list.items.filter((item) => isManualGroceryItem(item));
+  const existingRecipe = list.items.filter((item) => !isManualGroceryItem(item));
+  const existingByKey = new Map(existingRecipe.map((item) => [recipeItemKey(item), item]));
+
+  const recipeItems = snapshot.toBuy.map((req) =>
+    itemFromRequirement(req, existingByKey.get(req.normalizedName))
+  );
+
+  const overrides = [
+    ...new Set([
+      ...(list.pantryOverrides || []),
+      ...snapshot.toBuy.filter((r) => r.pantryOverride).map((r) => r.normalizedName)
+    ])
+  ];
+
+  return {
+    ...list,
+    items: [...recipeItems, ...manual],
+    recipeLinks: snapshot.recipeLinks,
+    pantryCovered: snapshot.inPantry.length ? snapshot.inPantry : undefined,
+    pantryOverrides: overrides.length ? overrides : undefined,
+    sourceWeekId: snapshot.sourceWeekId ?? list.sourceWeekId,
+    stats: snapshot.stats,
+    updatedAt: Math.floor(Date.now() / 1000)
+  };
+}
+
+/**
+ * Merge recipe requirements into a list without dropping unrelated
+ * recipe items. Same occurrence+recipe sources replace rather than add.
+ */
+export function mergeRequirementsIntoList(
+  list: SnapshotList,
+  requirements: GroceryRequirement[],
+  pantryCovered: GroceryRequirement[] = []
+): SnapshotList {
+  const items = [...list.items];
+  const recipeItems = items.filter((item) => !isManualGroceryItem(item));
+  const manual = items.filter((item) => isManualGroceryItem(item));
+  const byKey = new Map(recipeItems.map((item) => [recipeItemKey(item), item]));
+
+  for (const req of requirements) {
+    const existing = byKey.get(req.normalizedName);
+    if (!existing) {
+      const created = itemFromRequirement(req);
+      byKey.set(req.normalizedName, created);
+      continue;
+    }
+    const sourceMap = new Map(
+      (existing.sources || []).map((s) => [grocerySourceKey(s), s])
+    );
+    for (const source of req.sources) {
+      sourceMap.set(grocerySourceKey(source), source);
+    }
+    const sources = [...sourceMap.values()];
+    const recombined = recombineFromSources(
+      req.name,
+      req.normalizedName,
+      sources,
+      req.category
+    );
+    byKey.set(req.normalizedName, {
+      ...existing,
+      name: recombined.name,
+      quantity: recombined.quantity,
+      unit: recombined.unit,
+      category: recombined.category,
+      sources,
+      recipeId: sources[0]?.recipeId,
+      origin: 'recipe',
+      pantryOverride: existing.pantryOverride || req.pantryOverride
+    });
+  }
+
+  const covered = [...(list.pantryCovered || [])];
+  for (const item of pantryCovered) {
+    const alreadyOnList = byKey.has(item.normalizedName);
+    const alreadyCovered = covered.some((c) => c.normalizedName === item.normalizedName);
+    if (!alreadyOnList && !alreadyCovered) covered.push(item);
+  }
+
+  const nextRecipe = [...byKey.values()];
+  const recipeLinks = [
+    ...new Set([
+      ...list.recipeLinks,
+      ...nextRecipe.flatMap((item) => (item.sources || []).map((s) => s.recipeId))
+    ])
+  ];
+
+  return {
+    ...list,
+    items: [...nextRecipe, ...manual],
+    recipeLinks,
+    pantryCovered: covered.length ? covered : undefined,
+    updatedAt: Math.floor(Date.now() / 1000)
+  };
+}
+
+export function liveMealPlanSourceKeys(plan: MealPlan): Set<string> {
+  const keys = new Set<string>();
+  for (const day of DAY_KEYS) {
+    const slots = plan.days[day]?.slots;
+    if (!slots) continue;
+    for (const slot of SLOT_KEYS) {
+      const entry = slots[slot];
+      if (entry?.type === 'recipe') {
+        keys.add(`${day}:${slot}|${entry.a}`);
+      }
+    }
+  }
+  return keys;
+}
+
+function dropStaleFromSources(
+  sources: GroceryItemSource[] | undefined,
+  liveKeys: Set<string>
+): GroceryItemSource[] {
+  return (sources || []).filter((source) => {
+    if (!isMealPlanOccurrence(source.occurrenceId)) return true;
+    return liveKeys.has(grocerySourceKey(source));
+  });
+}
+
+/**
+ * Drop meal-plan sources that are no longer on the plan and recombine
+ * remaining recipe quantities. Manual items are untouched.
+ */
+export function dropStaleSourcesFromList(list: SnapshotList, plan: MealPlan): SnapshotList {
+  const liveKeys = liveMealPlanSourceKeys(plan);
+  const nextItems: SnapshotListItem[] = [];
+
+  for (const item of list.items) {
+    if (isManualGroceryItem(item)) {
+      nextItems.push(item);
+      continue;
+    }
+    const sources = dropStaleFromSources(item.sources, liveKeys);
+    if (sources.length === 0) {
+      if (item.recipeId && !item.sources?.length) {
+        // Legacy single-recipeId item: drop when that recipe is gone.
+        const stillLinked = [...liveKeys].some((k) => k.endsWith(`|${item.recipeId}`));
+        if (stillLinked) nextItems.push(item);
+      }
+      continue;
+    }
+    const normalizedName = item.normalizedName || groceryConsolidationKey(item.name);
+    const category = canonicalizeGroceryCategory(item.category, item.name);
+    const recombined = recombineFromSources(item.name, normalizedName, sources, category);
+    nextItems.push({
+      ...item,
+      name: recombined.name,
+      quantity: recombined.quantity,
+      unit: recombined.unit,
+      category: recombined.category,
+      sources,
+      recipeId: sources[0]?.recipeId,
+      normalizedName
+    });
+  }
+
+  const pantryCovered = (list.pantryCovered || [])
+    .map((covered) => {
+      const sources = dropStaleFromSources(covered.sources, liveKeys);
+      if (covered.sources?.length && sources.length === 0) return null;
+      if (!sources.length) return covered;
+      const recombined = recombineFromSources(
+        covered.name,
+        covered.normalizedName,
+        sources,
+        covered.category
+      );
+      return {
+        ...covered,
+        name: recombined.name,
+        quantity: recombined.quantity,
+        unit: recombined.unit,
+        sources
+      };
+    })
+    .filter((item): item is GroceryRequirement => item != null);
+
+  const recipeLinks = [
+    ...new Set(nextItems.flatMap((item) => (item.sources || []).map((s) => s.recipeId).filter(Boolean)))
+  ];
+
+  const recipeCount = nextItems.filter((item) => !isManualGroceryItem(item)).length;
+
+  return {
+    ...list,
+    items: nextItems,
+    recipeLinks,
+    pantryCovered: pantryCovered.length ? pantryCovered : undefined,
+    stats: list.stats
+      ? {
+          ...list.stats,
+          addedCount: recipeCount,
+          pantryCoveredCount: pantryCovered.length,
+          totalIngredients: recipeCount + pantryCovered.length
+        }
+      : undefined,
+    updatedAt: Math.floor(Date.now() / 1000)
+  };
+}
+
+export function movePantryCoveredToList(
+  list: SnapshotList,
+  index: number
+): { list: SnapshotList; added: SnapshotListItem | null } {
+  const pantryCovered = [...(list.pantryCovered || [])];
+  const covered = pantryCovered[index];
+  if (!covered) return { list, added: null };
+
+  pantryCovered.splice(index, 1);
+  const key = covered.normalizedName || groceryConsolidationKey(covered.name);
+  const overrides = [...new Set([...(list.pantryOverrides || []), key])];
+  const req: GroceryRequirement = {
+    ...covered,
+    normalizedName: key,
+    category: covered.category || inferGroceryCategory(covered.name),
+    pantryOverride: true
+  };
+
+  const merged = mergeRequirementsIntoList(
+    { ...list, pantryCovered: pantryCovered.length ? pantryCovered : undefined, pantryOverrides: overrides },
+    [req],
+    []
+  );
+
+  const added =
+    merged.items.find((item) => (item.normalizedName || groceryConsolidationKey(item.name)) === key) ||
+    null;
+
+  return { list: { ...merged, pantryOverrides: overrides }, added };
+}
+
+export function overrideKeysFromList(list: SnapshotList): string[] {
+  return list.pantryOverrides || [];
+}

--- a/src/lib/grocery/requirements.ts
+++ b/src/lib/grocery/requirements.ts
@@ -35,6 +35,11 @@ export interface GroceryRequirement {
   pantryOverride?: boolean;
 }
 
+export interface UnresolvedRecipeSource {
+  a: string;
+  title?: string;
+}
+
 export interface GrocerySnapshot {
   toBuy: GroceryRequirement[];
   inPantry: GroceryRequirement[];
@@ -45,6 +50,8 @@ export interface GrocerySnapshot {
   };
   recipeLinks: string[];
   sourceWeekId?: string;
+  /** Recipe a-tags that could not be loaded when this snapshot was built. */
+  unresolvedRecipes?: UnresolvedRecipeSource[];
 }
 
 export interface SnapshotListItem {
@@ -72,6 +79,7 @@ export interface SnapshotList {
   pantryOverrides?: string[];
   sourceWeekId?: string;
   stats?: GrocerySnapshot['stats'];
+  unresolvedRecipes?: UnresolvedRecipeSource[];
   createdAt: number;
   updatedAt: number;
 }
@@ -115,10 +123,57 @@ function toParsedIngredient(item: ConsolidatedIngredient) {
   };
 }
 
+export function unresolvedRecipeSources(
+  occurrences: Array<{ a: string; title?: string }>,
+  resolvedATags: Iterable<string>
+): UnresolvedRecipeSource[] {
+  const resolved = new Set(resolvedATags);
+  const seen = new Set<string>();
+  const out: UnresolvedRecipeSource[] = [];
+  for (const occ of occurrences) {
+    if (resolved.has(occ.a) || seen.has(occ.a)) continue;
+    seen.add(occ.a);
+    out.push({ a: occ.a, title: occ.title });
+  }
+  return out;
+}
+
+function sourceSignature(sources?: GroceryItemSource[]): string {
+  return (sources || [])
+    .map((source) => `${grocerySourceKey(source)}|${(source.quantity || '').trim()}`)
+    .sort()
+    .join('\n');
+}
+
+/** Stable identity for a shopping requirement — used to decide checked-state reuse. */
+export function groceryRequirementSignature(item: {
+  quantity: string;
+  unit?: string;
+  sources?: GroceryItemSource[];
+}): string {
+  return [
+    item.quantity.trim(),
+    (item.unit || '').trim().toLowerCase(),
+    sourceSignature(item.sources)
+  ].join('||');
+}
+
+export function shouldPreserveChecked(
+  existing: { checked?: boolean; quantity: string; unit?: string; sources?: GroceryItemSource[] } | undefined,
+  next: { quantity: string; unit?: string; sources?: GroceryItemSource[] }
+): boolean {
+  if (!existing?.checked) return false;
+  return groceryRequirementSignature(existing) === groceryRequirementSignature(next);
+}
+
 export function buildGrocerySnapshot(
   rows: ConsolidationRow[],
   pantry: Array<Pick<PantryItem, 'name' | 'normalizedName' | 'quantity' | 'unit' | 'isStaple'>>,
-  options?: { pantryOverrides?: string[]; sourceWeekId?: string }
+  options?: {
+    pantryOverrides?: string[];
+    sourceWeekId?: string;
+    unresolvedRecipes?: UnresolvedRecipeSource[];
+  }
 ): GrocerySnapshot {
   const consolidated = consolidateIngredients(rows);
   const overrides = new Set(
@@ -151,7 +206,8 @@ export function buildGrocerySnapshot(
       addedCount: toBuy.length
     },
     recipeLinks,
-    sourceWeekId: options?.sourceWeekId
+    sourceWeekId: options?.sourceWeekId,
+    unresolvedRecipes: options?.unresolvedRecipes?.length ? options.unresolvedRecipes : undefined
   };
 }
 
@@ -165,7 +221,7 @@ function itemFromRequirement(
     name: req.name,
     quantity: req.quantity,
     category: req.category,
-    checked: existing?.checked ?? false,
+    checked: shouldPreserveChecked(existing, req),
     recipeId: req.sources[0]?.recipeId,
     addedAt: existing?.addedAt ?? now,
     normalizedName: req.normalizedName,
@@ -185,8 +241,9 @@ function recipeItemKey(item: SnapshotListItem): string {
 }
 
 /**
- * Replace recipe-derived items with the snapshot. Manual items, checked
- * state, and item ids (matched by normalized name) are preserved.
+ * Replace recipe-derived items with the snapshot. Manual items and item
+ * ids (matched by normalized name) are preserved. Checked state is kept
+ * only when quantity, unit, and recipe sources are unchanged.
  */
 export function applySnapshotToList(list: SnapshotList, snapshot: GrocerySnapshot): SnapshotList {
   const manual = list.items.filter((item) => isManualGroceryItem(item));
@@ -197,11 +254,14 @@ export function applySnapshotToList(list: SnapshotList, snapshot: GrocerySnapsho
     itemFromRequirement(req, existingByKey.get(req.normalizedName))
   );
 
+  // Only persist overrides that are still applied on a shopping item.
+  // Stale keys (removed item / "I have this") must not survive a rebuild.
   const overrides = [
-    ...new Set([
-      ...(list.pantryOverrides || []),
-      ...snapshot.toBuy.filter((r) => r.pantryOverride).map((r) => r.normalizedName)
-    ])
+    ...new Set(
+      recipeItems
+        .filter((item) => item.pantryOverride && item.normalizedName)
+        .map((item) => item.normalizedName as string)
+    )
   ];
 
   return {
@@ -212,6 +272,7 @@ export function applySnapshotToList(list: SnapshotList, snapshot: GrocerySnapsho
     pantryOverrides: overrides.length ? overrides : undefined,
     sourceWeekId: snapshot.sourceWeekId ?? list.sourceWeekId,
     stats: snapshot.stats,
+    unresolvedRecipes: snapshot.unresolvedRecipes?.length ? snapshot.unresolvedRecipes : undefined,
     updatedAt: Math.floor(Date.now() / 1000)
   };
 }
@@ -259,7 +320,12 @@ export function mergeRequirementsIntoList(
       sources,
       recipeId: sources[0]?.recipeId,
       origin: 'recipe',
-      pantryOverride: existing.pantryOverride || req.pantryOverride
+      pantryOverride: existing.pantryOverride || req.pantryOverride,
+      checked: shouldPreserveChecked(existing, {
+        quantity: recombined.quantity,
+        unit: recombined.unit,
+        sources
+      })
     });
   }
 
@@ -345,7 +411,12 @@ export function dropStaleSourcesFromList(list: SnapshotList, plan: MealPlan): Sn
       category: recombined.category,
       sources,
       recipeId: sources[0]?.recipeId,
-      normalizedName
+      normalizedName,
+      checked: shouldPreserveChecked(item, {
+        quantity: recombined.quantity,
+        unit: recombined.unit,
+        sources
+      })
     });
   }
 
@@ -375,12 +446,15 @@ export function dropStaleSourcesFromList(list: SnapshotList, plan: MealPlan): Sn
   ];
 
   const recipeCount = nextItems.filter((item) => !isManualGroceryItem(item)).length;
+  const liveATags = new Set([...liveKeys].map((key) => key.slice(key.indexOf('|') + 1)));
+  const unresolvedRecipes = (list.unresolvedRecipes || []).filter((source) => liveATags.has(source.a));
 
   return {
     ...list,
     items: nextItems,
     recipeLinks,
     pantryCovered: pantryCovered.length ? pantryCovered : undefined,
+    unresolvedRecipes: unresolvedRecipes.length ? unresolvedRecipes : undefined,
     stats: list.stats
       ? {
           ...list.stats,
@@ -426,4 +500,79 @@ export function movePantryCoveredToList(
 
 export function overrideKeysFromList(list: SnapshotList): string[] {
   return list.pantryOverrides || [];
+}
+
+function overrideKey(item: Pick<SnapshotListItem, 'normalizedName' | 'name'>): string {
+  return item.normalizedName || groceryConsolidationKey(item.name);
+}
+
+function dropOverrideKey(overrides: string[] | undefined, key: string): string[] | undefined {
+  const next = (overrides || []).filter(
+    (value) => value !== key && groceryConsolidationKey(value) !== key
+  );
+  return next.length ? next : undefined;
+}
+
+/**
+ * Reverse "I still need this": drop the override and return the item
+ * to Already in My Kitchen. Pantry inventory is unchanged.
+ */
+export function returnOverrideToPantry(list: SnapshotList, itemId: string): SnapshotList {
+  const item = list.items.find((entry) => entry.id === itemId);
+  if (!item?.pantryOverride) return list;
+
+  const key = overrideKey(item);
+  const existingCovered = list.pantryCovered || [];
+  const pantryCovered: GroceryRequirement[] = existingCovered.some((entry) => entry.normalizedName === key)
+    ? existingCovered
+    : [
+        ...existingCovered,
+        {
+          name: item.name,
+          normalizedName: key,
+          quantity: item.quantity,
+          unit: item.unit,
+          category: canonicalizeGroceryCategory(item.category, item.name),
+          sources: item.sources || []
+        }
+      ];
+  const items = list.items.filter((entry) => entry.id !== itemId);
+  const recipeCount = items.filter((entry) => !isManualGroceryItem(entry)).length;
+
+  return {
+    ...list,
+    items,
+    pantryCovered,
+    pantryOverrides: dropOverrideKey(list.pantryOverrides, key),
+    stats: list.stats
+      ? {
+          ...list.stats,
+          addedCount: recipeCount,
+          pantryCoveredCount: pantryCovered.length,
+          totalIngredients: recipeCount + pantryCovered.length
+        }
+      : undefined,
+    updatedAt: Math.floor(Date.now() / 1000)
+  };
+}
+
+/**
+ * Remove a grocery item and drop its pantry override so a later
+ * recalculation cannot resurrect it.
+ */
+export function removeGroceryItemFromList(list: SnapshotList, itemId: string): SnapshotList {
+  const item = list.items.find((entry) => entry.id === itemId);
+  if (!item) return list;
+
+  const items = list.items.filter((entry) => entry.id !== itemId);
+  const pantryOverrides = item.pantryOverride
+    ? dropOverrideKey(list.pantryOverrides, overrideKey(item))
+    : list.pantryOverrides;
+
+  return {
+    ...list,
+    items,
+    pantryOverrides,
+    updatedAt: Math.floor(Date.now() / 1000)
+  };
 }

--- a/src/lib/grocery/units.test.ts
+++ b/src/lib/grocery/units.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { combineQuantities, parseGroceryQuantity } from './units';
+
+describe('parseGroceryQuantity', () => {
+  it('parses unitless counts, cups, and fractions', () => {
+    expect(parseGroceryQuantity('2')).toEqual({ amount: 2, unit: '', family: 'count' });
+    expect(parseGroceryQuantity('2 cups')).toMatchObject({ amount: 2, unit: 'cup', family: 'volume' });
+    expect(parseGroceryQuantity('2 cup')).toMatchObject({ amount: 2, unit: 'cup', family: 'volume' });
+    expect(parseGroceryQuantity('1/2 tsp')).toMatchObject({ amount: 0.5, unit: 'tsp', family: 'volume' });
+    expect(parseGroceryQuantity('1 1/2 cups')).toMatchObject({ amount: 1.5, unit: 'cup', family: 'volume' });
+    expect(parseGroceryQuantity('8 oz')).toMatchObject({ amount: 8, unit: 'oz', family: 'weight' });
+    expect(parseGroceryQuantity('8 fl oz')).toMatchObject({ amount: 8, unit: 'fl oz', family: 'volume' });
+    expect(parseGroceryQuantity('3 cloves')).toMatchObject({ amount: 3, unit: 'clove', family: 'other' });
+  });
+});
+
+describe('combineQuantities', () => {
+  it('sums matching units', () => {
+    expect(combineQuantities(['1 cup', '2 cups']).display).toBe('3 cups');
+    expect(combineQuantities(['8 oz', '8 oz']).display).toBe('16 oz');
+    expect(combineQuantities(['2', '3']).display).toBe('5');
+  });
+
+  it('converts compatible volume and weight units', () => {
+    expect(combineQuantities(['1 cup', '8 fl oz']).display).toBe('2 cups');
+    expect(combineQuantities(['1 lb', '8 oz']).display).toBe('1 1/2 lb');
+    expect(combineQuantities(['3 tsp', '1 tbsp']).display).toBe('2 tbsp');
+  });
+
+  it('keeps incompatible units instead of inventing a conversion', () => {
+    expect(combineQuantities(['3 cloves', '1 head']).display).toBe('3 cloves + 1 head');
+  });
+});

--- a/src/lib/grocery/units.ts
+++ b/src/lib/grocery/units.ts
@@ -1,0 +1,313 @@
+/**
+ * Conservative grocery quantity parsing and combining.
+ *
+ * Only converts units that are unambiguously in the same family
+ * (volume, weight, or count). Mixed units such as cloves vs heads
+ * are preserved side-by-side instead of inventing a number.
+ */
+
+export type QuantityFamily = 'volume' | 'weight' | 'count' | 'other';
+
+const FRACTION_MAP: Record<string, string> = {
+  '½': '1/2',
+  '⅓': '1/3',
+  '⅔': '2/3',
+  '¼': '1/4',
+  '¾': '3/4',
+  '⅕': '1/5',
+  '⅖': '2/5',
+  '⅗': '3/5',
+  '⅘': '4/5',
+  '⅙': '1/6',
+  '⅚': '5/6',
+  '⅛': '1/8',
+  '⅜': '3/8',
+  '⅝': '5/8',
+  '⅞': '7/8'
+};
+
+function normalizeFraction(text: string): string {
+  let result = text;
+  for (const [fraction, replacement] of Object.entries(FRACTION_MAP)) {
+    result = result.replace(new RegExp(fraction, 'g'), replacement);
+  }
+  return result;
+}
+
+export interface ParsedGroceryQuantity {
+  amount: number;
+  unit: string;
+  family: QuantityFamily;
+}
+
+export interface CombinedQuantity {
+  display: string;
+  parts: ParsedGroceryQuantity[];
+  /** Present when the combined result is a single comparable amount. */
+  amount?: number;
+  unit?: string;
+}
+
+interface UnitDef {
+  aliases: string[];
+  canon: string;
+  family: QuantityFamily;
+  /** Size in the family's base unit (tsp for volume, oz for weight). */
+  factor?: number;
+}
+
+const UNITS: UnitDef[] = [
+  {
+    aliases: ['fluid ounces', 'fluid ounce', 'fl. oz', 'fl oz', 'floz'],
+    canon: 'fl oz',
+    family: 'volume',
+    factor: 6
+  },
+  {
+    aliases: ['tablespoons', 'tablespoon', 'tbsps', 'tbsp', 'tbs', 'tb'],
+    canon: 'tbsp',
+    family: 'volume',
+    factor: 3
+  },
+  {
+    aliases: ['teaspoons', 'teaspoon', 'tsps', 'tsp', 'ts'],
+    canon: 'tsp',
+    family: 'volume',
+    factor: 1
+  },
+  { aliases: ['cups', 'cup', 'c'], canon: 'cup', family: 'volume', factor: 48 },
+  { aliases: ['pints', 'pint', 'pt'], canon: 'pint', family: 'volume', factor: 96 },
+  { aliases: ['quarts', 'quart', 'qt'], canon: 'quart', family: 'volume', factor: 192 },
+  { aliases: ['milliliters', 'milliliter', 'mls', 'ml'], canon: 'ml', family: 'volume', factor: 0.202884 },
+  { aliases: ['liters', 'liter', 'l'], canon: 'l', family: 'volume', factor: 202.884 },
+  { aliases: ['pounds', 'pound', 'lbs', 'lb'], canon: 'lb', family: 'weight', factor: 16 },
+  { aliases: ['ounces', 'ounce', 'oz'], canon: 'oz', family: 'weight', factor: 1 },
+  { aliases: ['kilograms', 'kilogram', 'kgs', 'kg'], canon: 'kg', family: 'weight', factor: 35.27396 },
+  { aliases: ['grams', 'gram', 'gs', 'g'], canon: 'g', family: 'weight', factor: 0.03527396 },
+  { aliases: ['pieces', 'piece', 'pcs', 'pc', 'count'], canon: '', family: 'count' },
+  { aliases: ['large', 'medium', 'small'], canon: '', family: 'count' },
+  { aliases: ['cloves', 'clove'], canon: 'clove', family: 'other' },
+  { aliases: ['heads', 'head', 'bulb', 'bulbs'], canon: 'head', family: 'other' },
+  { aliases: ['bunches', 'bunch'], canon: 'bunch', family: 'other' },
+  { aliases: ['cans', 'can'], canon: 'can', family: 'other' },
+  { aliases: ['jars', 'jar'], canon: 'jar', family: 'other' },
+  { aliases: ['bags', 'bag'], canon: 'bag', family: 'other' },
+  { aliases: ['packages', 'package', 'pkgs', 'pkg'], canon: 'package', family: 'other' },
+  { aliases: ['sticks', 'stick'], canon: 'stick', family: 'other' },
+  { aliases: ['slices', 'slice'], canon: 'slice', family: 'other' },
+  { aliases: ['sprigs', 'sprig'], canon: 'sprig', family: 'other' },
+  { aliases: ['stalks', 'stalk'], canon: 'stalk', family: 'other' },
+  { aliases: ['pinches', 'pinch'], canon: 'pinch', family: 'other' },
+  { aliases: ['dashes', 'dash'], canon: 'dash', family: 'other' }
+];
+
+const ALIAS_LOOKUP: Array<{ alias: string; def: UnitDef }> = UNITS.flatMap((def) =>
+  def.aliases
+    .slice()
+    .sort((a, b) => b.length - a.length)
+    .map((alias) => ({ alias, def }))
+).sort((a, b) => b.alias.length - a.alias.length);
+
+const NUMBER_RE = /^(\d+\s+\d+\/\d+|\d+\/\d+|\d+(?:\.\d+)?)/;
+
+function parseNumberToken(raw: string): number | null {
+  const text = raw.trim();
+  const mixed = text.match(/^(\d+)\s+(\d+)\/(\d+)$/);
+  if (mixed) {
+    const whole = Number(mixed[1]);
+    const num = Number(mixed[2]);
+    const den = Number(mixed[3]);
+    if (den === 0) return null;
+    return whole + num / den;
+  }
+  const frac = text.match(/^(\d+)\/(\d+)$/);
+  if (frac) {
+    const den = Number(frac[2]);
+    if (den === 0) return null;
+    return Number(frac[1]) / den;
+  }
+  const n = Number(text);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+function matchUnit(raw: string): { def: UnitDef; rest: string } | null {
+  const text = raw.trim().toLowerCase().replace(/\.$/, '');
+  if (!text) return null;
+  for (const { alias, def } of ALIAS_LOOKUP) {
+    if (text === alias || text.startsWith(`${alias} `) || text.startsWith(`${alias}s`)) {
+      return { def, rest: text.slice(alias.length).trim() };
+    }
+    if (text.endsWith('s') && text.slice(0, -1) === alias) {
+      return { def, rest: '' };
+    }
+  }
+  return null;
+}
+
+export function parseGroceryQuantity(raw: string): ParsedGroceryQuantity | null {
+  const text = normalizeFraction((raw || '').trim());
+  if (!text) return null;
+  const numMatch = text.match(NUMBER_RE);
+  if (!numMatch) return null;
+  const amount = parseNumberToken(numMatch[1]);
+  if (amount == null) return null;
+  const rest = text.slice(numMatch[0].length).trim();
+  if (!rest) return { amount, unit: '', family: 'count' };
+  const matched = matchUnit(rest);
+  if (!matched) {
+    const unit = rest.slice(0, 24);
+    return { amount, unit, family: 'other' };
+  }
+  return { amount, unit: matched.def.canon, family: matched.def.family };
+}
+
+function unitFactor(unit: string, family: QuantityFamily): number | undefined {
+  if (family === 'count') return 1;
+  const def = UNITS.find((u) => u.canon === unit && u.family === family);
+  return def?.factor;
+}
+
+function canConvert(a: ParsedGroceryQuantity, b: ParsedGroceryQuantity): boolean {
+  if (a.family !== b.family) return false;
+  if (a.family === 'other') return a.unit === b.unit;
+  if (a.family === 'count') return true;
+  return unitFactor(a.unit, a.family) != null && unitFactor(b.unit, b.family) != null;
+}
+
+function toBase(q: ParsedGroceryQuantity): number | null {
+  if (q.family === 'count') return q.amount;
+  if (q.family === 'other') return q.amount;
+  const factor = unitFactor(q.unit, q.family);
+  if (factor == null) return null;
+  return q.amount * factor;
+}
+
+const VOLUME_PREFERENCE = ['cup', 'tbsp', 'tsp', 'fl oz', 'pint', 'quart', 'ml', 'l'];
+const WEIGHT_PREFERENCE = ['lb', 'oz', 'kg', 'g'];
+
+function pickDisplayUnit(family: QuantityFamily, unitsUsed: string[], baseAmount: number): string {
+  if (family === 'count') return '';
+  if (family === 'other') return unitsUsed[0] || '';
+
+  const preference = family === 'volume' ? VOLUME_PREFERENCE : WEIGHT_PREFERENCE;
+  const uniqueUsed = [...new Set(unitsUsed.filter(Boolean))];
+  if (uniqueUsed.length === 1) return uniqueUsed[0];
+
+  for (const unit of preference) {
+    const factor = unitFactor(unit, family);
+    if (factor == null) continue;
+    const converted = baseAmount / factor;
+    if (converted >= 1 && uniqueUsed.includes(unit)) return unit;
+  }
+  for (const unit of preference) {
+    const factor = unitFactor(unit, family);
+    if (factor == null) continue;
+    const converted = baseAmount / factor;
+    if (converted >= 1) return unit;
+  }
+  return uniqueUsed[0] || preference[preference.length - 1];
+}
+
+function formatAmount(amount: number): string {
+  const rounded = Math.round(amount * 1000) / 1000;
+  const nearest = Math.round(rounded);
+  if (Math.abs(rounded - nearest) < 0.001) return String(nearest);
+
+  const fractions: Array<[number, string]> = [
+    [0.25, '1/4'],
+    [1 / 3, '1/3'],
+    [0.5, '1/2'],
+    [2 / 3, '2/3'],
+    [0.75, '3/4']
+  ];
+  const whole = Math.floor(rounded);
+  const frac = rounded - whole;
+  for (const [value, label] of fractions) {
+    if (Math.abs(frac - value) < 0.02) {
+      return whole > 0 ? `${whole} ${label}` : label;
+    }
+  }
+  return String(Math.round(rounded * 100) / 100);
+}
+
+export function formatGroceryQuantity(amount: number, unit: string): string {
+  const amountText = formatAmount(amount);
+  if (!unit) return amountText;
+  const plural =
+    Math.abs(amount - 1) > 0.001 &&
+    !['oz', 'lb', 'g', 'kg', 'ml', 'l', 'tsp', 'tbsp', 'fl oz'].includes(unit) &&
+    !unit.endsWith('s')
+      ? `${unit}s`
+      : unit;
+  return `${amountText} ${plural}`;
+}
+
+function combineGroup(group: ParsedGroceryQuantity[]): ParsedGroceryQuantity | null {
+  if (group.length === 0) return null;
+  if (group.length === 1) return group[0];
+  const family = group[0].family;
+  let base = 0;
+  for (const part of group) {
+    const value = toBase(part);
+    if (value == null) return null;
+    base += value;
+  }
+  const unit = pickDisplayUnit(
+    family,
+    group.map((p) => p.unit),
+    base
+  );
+  const factor = family === 'count' || family === 'other' ? 1 : unitFactor(unit, family);
+  if (factor == null) return null;
+  return { amount: base / factor, unit, family };
+}
+
+/**
+ * Combine quantity strings. Compatible units are summed; incompatible
+ * units become a joined display like "3 cloves + 1 head".
+ */
+export function combineQuantities(quantityTexts: string[]): CombinedQuantity {
+  const parsed: ParsedGroceryQuantity[] = [];
+  const unparsed: string[] = [];
+  for (const text of quantityTexts) {
+    const trimmed = (text || '').trim();
+    if (!trimmed) continue;
+    const qty = parseGroceryQuantity(trimmed);
+    if (qty) parsed.push(qty);
+    else unparsed.push(trimmed);
+  }
+
+  if (parsed.length === 0 && unparsed.length === 0) {
+    return { display: '', parts: [] };
+  }
+
+  const groups: ParsedGroceryQuantity[][] = [];
+  for (const qty of parsed) {
+    const existing = groups.find((g) => canConvert(g[0], qty));
+    if (existing) existing.push(qty);
+    else groups.push([qty]);
+  }
+
+  const combinedParts: ParsedGroceryQuantity[] = [];
+  for (const group of groups) {
+    const combined = combineGroup(group);
+    if (combined) combinedParts.push(combined);
+    else combinedParts.push(...group);
+  }
+
+  const displayParts = [
+    ...combinedParts.map((p) => formatGroceryQuantity(p.amount, p.unit)),
+    ...unparsed
+  ];
+  const display = displayParts.join(' + ');
+
+  if (combinedParts.length === 1 && unparsed.length === 0) {
+    return {
+      display,
+      parts: combinedParts,
+      amount: combinedParts[0].amount,
+      unit: combinedParts[0].unit
+    };
+  }
+  return { display, parts: combinedParts };
+}

--- a/src/lib/grocery/weekGenerate.ts
+++ b/src/lib/grocery/weekGenerate.ts
@@ -1,0 +1,125 @@
+/**
+ * Shared week grocery generation used by Meal Planner and Grocery
+ * Planner retry. Recipe fetch stays here so requirements.ts remains
+ * a pure snapshot/apply module.
+ */
+
+import { get } from 'svelte/store';
+import { ndk } from '$lib/nostr';
+import { isOnline } from '$lib/connectionMonitor';
+import { offlineStorage } from '$lib/offlineStorage';
+import { parseIngredientsFromRecipe } from '$lib/utils/ingredientParser';
+import { groceryStore, groceryInitialized } from '$lib/stores/groceryStore';
+import { plannerStore } from '$lib/stores/plannerStore';
+import { pantryStore, pantryItems, pantryInitialized } from '$lib/stores/pantryStore';
+import {
+  collectWeekRecipeOccurrences,
+  rowsFromRecipeLines
+} from '$lib/mealplan/groceryGeneration';
+import {
+  buildGrocerySnapshot,
+  unresolvedRecipeSources,
+  type GrocerySnapshot,
+  type UnresolvedRecipeSource
+} from './requirements';
+
+export interface WeekGroceryGeneration {
+  snapshot: GrocerySnapshot;
+  textSkipped: number;
+  resolvedRecipeCount: number;
+  unresolved: UnresolvedRecipeSource[];
+}
+
+export async function loadRecipeLinesByATag(aTags: string[]): Promise<Map<string, string[]>> {
+  const linesByATag = new Map<string, string[]>();
+  if (aTags.length === 0) return linesByATag;
+
+  const cached = await offlineStorage.getRecipes(aTags);
+  for (const recipe of cached) {
+    if (recipe.ingredients?.length) {
+      linesByATag.set(recipe.id, recipe.ingredients);
+    } else if (recipe.content) {
+      linesByATag.set(
+        recipe.id,
+        parseIngredientsFromRecipe(recipe.content).map((parsed) => parsed.originalText)
+      );
+    }
+  }
+
+  const missing = aTags.filter((a) => !linesByATag.has(a));
+  const ndkInstance = get(ndk);
+  if (missing.length === 0 || !get(isOnline) || !ndkInstance) {
+    return linesByATag;
+  }
+
+  await Promise.all(
+    missing.map(async (aTag) => {
+      const parts = aTag.split(':');
+      if (parts.length !== 3) return;
+      const [kind, pubkey, identifier] = parts;
+      try {
+        const event = await ndkInstance.fetchEvent({
+          kinds: [Number(kind)],
+          '#d': [identifier],
+          authors: [pubkey]
+        });
+        if (!event?.content) return;
+        linesByATag.set(
+          aTag,
+          parseIngredientsFromRecipe(event.content).map((parsed) => parsed.originalText)
+        );
+        try {
+          await offlineStorage.saveRecipeFromEvent(event);
+        } catch {
+          // Cache write is best-effort; the in-memory lines are enough.
+        }
+      } catch (error) {
+        console.warn('[Grocery generate] Failed to fetch', aTag, error);
+      }
+    })
+  );
+
+  return linesByATag;
+}
+
+export async function generateWeekGrocerySnapshot(
+  weekId: string
+): Promise<WeekGroceryGeneration | null> {
+  if (!get(groceryInitialized)) {
+    await groceryStore.load();
+  }
+  if (!get(pantryInitialized)) {
+    await pantryStore.load();
+  }
+
+  await plannerStore.ensureWeek(weekId);
+  const week = get(plannerStore).weeks[weekId];
+  if (!week || week.status !== 'ok') return null;
+
+  const collected = collectWeekRecipeOccurrences(week.plan);
+  const linesByATag = await loadRecipeLinesByATag(collected.aTags);
+  const resolvedOccurrences = collected.occurrences.filter((occ) => linesByATag.has(occ.a));
+  const rows = rowsFromRecipeLines(
+    resolvedOccurrences.map((occ) => ({
+      a: occ.a,
+      title: occ.title,
+      occurrenceId: occ.occurrenceId,
+      lines: linesByATag.get(occ.a) || []
+    }))
+  );
+
+  const existing = groceryStore.findListForWeek(weekId);
+  const unresolved = unresolvedRecipeSources(collected.occurrences, linesByATag.keys());
+  const snapshot = buildGrocerySnapshot(rows, get(pantryItems), {
+    pantryOverrides: existing?.pantryOverrides,
+    sourceWeekId: weekId,
+    unresolvedRecipes: unresolved
+  });
+
+  return {
+    snapshot,
+    textSkipped: collected.textCount,
+    resolvedRecipeCount: new Set(resolvedOccurrences.map((occ) => occ.a)).size,
+    unresolved
+  };
+}

--- a/src/lib/mealplan/groceryGeneration.test.ts
+++ b/src/lib/mealplan/groceryGeneration.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 vi.mock('$app/environment', () => ({ browser: false }));
 import {
   collectWeekRecipeSlots,
+  collectWeekRecipeOccurrences,
   dedupeIngredients,
   groceryListTitle,
   classifyGroceryRows,
@@ -27,6 +28,19 @@ describe('collectWeekRecipeSlots', () => {
       expect(collectWeekRecipeSlots(plan)).toEqual(v.expected);
     });
   }
+});
+
+describe('collectWeekRecipeOccurrences', () => {
+  it('counts repeated recipes as separate meals', () => {
+    const plan = planWith({
+      mon: { slots: { dinner: { type: 'recipe', a: '30023:pk:curry', title: 'Curry' } } },
+      wed: { slots: { dinner: { type: 'recipe', a: '30023:pk:curry', title: 'Curry' } } }
+    });
+    const collected = collectWeekRecipeOccurrences(plan);
+    expect(collected.aTags).toEqual(['30023:pk:curry']);
+    expect(collected.occurrences).toHaveLength(2);
+    expect(collected.recipeSlotCount).toBe(2);
+  });
 });
 
 describe('dedupeIngredients (approved v1: exact-match collapse, no merging)', () => {

--- a/src/lib/mealplan/groceryGeneration.ts
+++ b/src/lib/mealplan/groceryGeneration.ts
@@ -1,22 +1,21 @@
 /**
- * Grocery generation from a week's meal plan (Phase 3.3, PR11).
+ * Grocery generation from a week's meal plan.
  *
- * Pure helpers — the relay/store side (groceryStore.addList/addItem)
- * stays in the planner page. Approved v1 behavior per the Phase 3
- * findings: dedupe-without-merge (collapse EXACT (name, quantity)
- * duplicates, first occurrence's recipeId wins; no quantity summing —
- * that's v1.1), text slots skipped and reported.
+ * Pure helpers — persistence stays in groceryStore. Ingredients are
+ * consolidated (names + safe quantities) and classified against pantry
+ * after combining, so a pantry amount is compared to the week's total.
  *
- * Pantry (v1): after dedupe, rows are classified against the user's
- * pantry. Name matches with no pantry quantity are treated as already
- * owned (presence-only). If a pantry quantity exists and cannot be
- * compared reliably to the recipe amount, the ingredient stays on the
- * grocery list. Pantry inventory is never decremented.
+ * `dedupeIngredients` is the original exact-match collapse and remains
+ * for the shared Android fixture contract. The planner uses
+ * `collectWeekRecipeOccurrences` + `buildGrocerySnapshot`.
  */
 
 import type { ParsedIngredient } from '$lib/utils/ingredientParser';
+import { parseIngredient } from '$lib/utils/ingredientParser';
 import { DAY_KEYS, SLOT_KEYS, type MealPlan } from '$lib/mealplan/schema';
 import { weekDisplayRange } from '$lib/mealplan/week';
+import type { ConsolidationRow } from '$lib/grocery/consolidation';
+import { buildGrocerySnapshot } from '$lib/grocery/requirements';
 
 export interface WeekRecipeSlots {
   /** Unique recipe coordinates in day/slot order. */
@@ -27,10 +26,31 @@ export interface WeekRecipeSlots {
   recipeSlotCount: number;
 }
 
-/** Walk the plan's days/slots and collect what generation operates on. */
+export interface WeekRecipeOccurrence {
+  a: string;
+  title?: string;
+  occurrenceId: string;
+}
+
+export interface WeekRecipeOccurrences extends WeekRecipeSlots {
+  occurrences: WeekRecipeOccurrence[];
+}
+
+/** Walk the plan's days/slots and collect unique recipe coordinates. */
 export function collectWeekRecipeSlots(plan: MealPlan): WeekRecipeSlots {
+  const collected = collectWeekRecipeOccurrences(plan);
+  return {
+    aTags: collected.aTags,
+    textCount: collected.textCount,
+    recipeSlotCount: collected.recipeSlotCount
+  };
+}
+
+/** Include every planned recipe slot so repeated meals count twice. */
+export function collectWeekRecipeOccurrences(plan: MealPlan): WeekRecipeOccurrences {
   const seen = new Set<string>();
   const aTags: string[] = [];
+  const occurrences: WeekRecipeOccurrence[] = [];
   let textCount = 0;
   let recipeSlotCount = 0;
 
@@ -44,6 +64,11 @@ export function collectWeekRecipeSlots(plan: MealPlan): WeekRecipeSlots {
         textCount++;
       } else if (entry.type === 'recipe') {
         recipeSlotCount++;
+        occurrences.push({
+          a: entry.a,
+          title: entry.title,
+          occurrenceId: `${day}:${slotKey}`
+        });
         if (!seen.has(entry.a)) {
           seen.add(entry.a);
           aTags.push(entry.a);
@@ -52,13 +77,15 @@ export function collectWeekRecipeSlots(plan: MealPlan): WeekRecipeSlots {
     }
   }
 
-  return { aTags, textCount, recipeSlotCount };
+  return { aTags, textCount, recipeSlotCount, occurrences };
 }
 
 export interface GenerationRow {
   ingredient: ParsedIngredient;
   /** Source recipe coordinate (becomes GroceryItem.recipeId). */
   recipeId: string;
+  recipeTitle?: string;
+  occurrenceId?: string;
 }
 
 /**
@@ -79,9 +106,28 @@ export function dedupeIngredients(rows: GenerationRow[]): GenerationRow[] {
   return out;
 }
 
+export function rowsFromRecipeLines(
+  recipes: Array<{ a: string; title?: string; occurrenceId: string; lines: string[] }>
+): ConsolidationRow[] {
+  const rows: ConsolidationRow[] = [];
+  for (const recipe of recipes) {
+    for (const line of recipe.lines) {
+      const ingredient = parseIngredient(line);
+      rows.push({
+        ingredient: { name: ingredient.name, quantity: ingredient.quantity },
+        recipeId: recipe.a,
+        recipeTitle: recipe.title,
+        occurrenceId: recipe.occurrenceId
+      });
+    }
+  }
+  return rows;
+}
+
 /** "Groceries — Week 29 (Jul 13–19)" — reuses the PR7 display helper. */
 export function groceryListTitle(weekId: string): string {
   return `Groceries — ${weekDisplayRange(weekId)}`;
 }
 
 export { classifyGroceryRows } from '$lib/pantry/matching';
+export { buildGrocerySnapshot };

--- a/src/lib/services/groceryService.ts
+++ b/src/lib/services/groceryService.ts
@@ -19,13 +19,26 @@ import { NDKEvent, NDKRelaySet, type NDKFilter } from '@nostr-dev-kit/ndk';
 import { encrypt, decrypt, detectEncryptionMethod, type EncryptionMethod } from '$lib/encryptionService';
 import { getOutboxRelays, getInboxRelays } from '$lib/relayListCache';
 import { CLIENT_TAG_IDENTIFIER } from '$lib/consts';
+import {
+  canonicalizeGroceryCategory,
+  type GroceryCategory
+} from '$lib/grocery/categories';
+import type { GroceryItemSource } from '$lib/grocery/consolidation';
+
+export type { GroceryCategory } from '$lib/grocery/categories';
+export type { GroceryItemSource } from '$lib/grocery/consolidation';
+
+export type GroceryItemOrigin = 'manual' | 'recipe';
 
 // ═══════════════════════════════════════════════════════════════
 // TYPES
 // ═══════════════════════════════════════════════════════════════
 
-export type GroceryCategory = 'produce' | 'protein' | 'dairy' | 'pantry' | 'frozen' | 'other';
-
+/**
+ * Grocery list item. Persistence is Zap-owned and retailer-agnostic.
+ * A future grocery provider adapter should consume `toProviderList`
+ * from `$lib/grocery/export` rather than this event payload.
+ */
 export interface GroceryItem {
   id: string;
   name: string;
@@ -34,6 +47,13 @@ export interface GroceryItem {
   checked: boolean;
   recipeId?: string;  // a-tag format: "30023:pubkey:slug"
   addedAt: number;    // Unix timestamp (seconds)
+  /** Consolidation key. Optional on lists written before grocery v1.1. */
+  normalizedName?: string;
+  unit?: string;
+  origin?: GroceryItemOrigin;
+  sources?: GroceryItemSource[];
+  /** User chose "I still need this" for a pantry-matched ingredient. */
+  pantryOverride?: boolean;
 }
 
 export interface GroceryList {
@@ -48,6 +68,18 @@ export interface GroceryList {
    * not decremented when this list is generated.
    */
   pantryCovered?: PantryCoveredItem[];
+  /**
+   * Normalized names the user forced onto the shopping list after a
+   * pantry match. Survives meal-plan recalculation.
+   */
+  pantryOverrides?: string[];
+  /** Meal-plan week this list was generated from, e.g. `2026-W29`. */
+  sourceWeekId?: string;
+  stats?: {
+    totalIngredients: number;
+    pantryCoveredCount: number;
+    addedCount: number;
+  };
   createdAt: number;      // Unix timestamp (seconds)
   updatedAt: number;      // Unix timestamp (seconds)
 }
@@ -56,6 +88,10 @@ export interface PantryCoveredItem {
   name: string;
   quantity: string;
   recipeId?: string;
+  normalizedName?: string;
+  unit?: string;
+  category?: GroceryCategory;
+  sources?: GroceryItemSource[];
 }
 
 export interface GroceryListEvent {
@@ -101,6 +137,67 @@ function dTagToListId(dTag: string): string | null {
   return dTag.slice(GROCERY_D_TAG_PREFIX.length);
 }
 
+function asTrimmed(value: unknown, max: number): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim().slice(0, max);
+  return trimmed || undefined;
+}
+
+function sanitizeSources(raw: unknown): GroceryItemSource[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: GroceryItemSource[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue;
+    const r = entry as Record<string, unknown>;
+    const recipeId = asTrimmed(r.recipeId, 200);
+    const occurrenceId = asTrimmed(r.occurrenceId, 80);
+    if (!recipeId || !occurrenceId) continue;
+    const source: GroceryItemSource = {
+      recipeId,
+      occurrenceId,
+      quantity: asTrimmed(r.quantity, 80) || ''
+    };
+    const recipeTitle = asTrimmed(r.recipeTitle, 120);
+    if (recipeTitle) source.recipeTitle = recipeTitle;
+    const originalName = asTrimmed(r.originalName, 80);
+    if (originalName) source.originalName = originalName;
+    out.push(source);
+  }
+  return out.length ? out : undefined;
+}
+
+function sanitizeGroceryItem(raw: unknown, fallbackNow: number): GroceryItem | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  const id = asTrimmed(r.id, 64);
+  const name = asTrimmed(r.name, 80);
+  if (!id || !name) return null;
+  const origin = r.origin === 'manual' || r.origin === 'recipe' ? r.origin : undefined;
+  const item: GroceryItem = {
+    id,
+    name,
+    quantity: asTrimmed(r.quantity, 80) || '',
+    category: canonicalizeGroceryCategory(
+      typeof r.category === 'string' ? r.category : undefined,
+      name
+    ),
+    checked: r.checked === true,
+    addedAt: typeof r.addedAt === 'number' && Number.isFinite(r.addedAt) ? r.addedAt : fallbackNow
+  };
+  const recipeId = asTrimmed(r.recipeId, 200);
+  if (recipeId) item.recipeId = recipeId;
+  const normalizedName = asTrimmed(r.normalizedName, 80);
+  if (normalizedName) item.normalizedName = normalizedName;
+  const unit = asTrimmed(r.unit, 24);
+  if (unit) item.unit = unit;
+  if (origin) item.origin = origin;
+  else item.origin = recipeId ? 'recipe' : 'manual';
+  const sources = sanitizeSources(r.sources);
+  if (sources) item.sources = sources;
+  if (r.pantryOverride === true) item.pantryOverride = true;
+  return item;
+}
+
 /** Drop malformed pantryCovered rows so the grocery UI never reads `.name` on null. */
 export function sanitizePantryCovered(raw: unknown): PantryCoveredItem[] | undefined {
   if (!Array.isArray(raw)) return undefined;
@@ -117,10 +214,39 @@ export function sanitizePantryCovered(raw: unknown): PantryCoveredItem[] | undef
     if (typeof r.recipeId === 'string' && r.recipeId.trim()) {
       covered.recipeId = r.recipeId.trim();
     }
+    const normalizedName = asTrimmed(r.normalizedName, 80);
+    if (normalizedName) covered.normalizedName = normalizedName;
+    const unit = asTrimmed(r.unit, 24);
+    if (unit) covered.unit = unit;
+    if (typeof r.category === 'string') {
+      covered.category = canonicalizeGroceryCategory(r.category, name);
+    }
+    const sources = sanitizeSources(r.sources);
+    if (sources) covered.sources = sources;
     out.push(covered);
   }
   return out.length ? out : undefined;
 }
+
+function sanitizePantryOverrides(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out = raw
+    .filter((value): value is string => typeof value === 'string')
+    .map((value) => value.trim().slice(0, 80))
+    .filter(Boolean);
+  return out.length ? [...new Set(out)] : undefined;
+}
+
+function sanitizeStats(raw: unknown): GroceryList['stats'] | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const r = raw as Record<string, unknown>;
+  const totalIngredients = typeof r.totalIngredients === 'number' ? r.totalIngredients : undefined;
+  const pantryCoveredCount = typeof r.pantryCoveredCount === 'number' ? r.pantryCoveredCount : undefined;
+  const addedCount = typeof r.addedCount === 'number' ? r.addedCount : undefined;
+  if (totalIngredients == null || pantryCoveredCount == null || addedCount == null) return undefined;
+  return { totalIngredients, pantryCoveredCount, addedCount };
+}
+
 
 /**
  * Extract recipe links from event tags
@@ -298,16 +424,31 @@ async function decryptGroceryEvent(
     // Extract recipe links from event tags
     const recipeLinks = extractRecipeLinks(event);
 
-    // Build GroceryList object
+    const now = event.created_at || Math.floor(Date.now() / 1000);
+    const itemsRaw = Array.isArray(payload.items) ? payload.items : [];
+    const items: GroceryItem[] = [];
+    for (const raw of itemsRaw) {
+      const item = sanitizeGroceryItem(raw, now);
+      if (item) items.push(item);
+    }
+
+    const sourceWeekId =
+      typeof payload.sourceWeekId === 'string' && /^\d{4}-W\d{2}$/.test(payload.sourceWeekId)
+        ? payload.sourceWeekId
+        : undefined;
+
     const list: GroceryList = {
       id: payload.id || listId,
       title: payload.title || 'Untitled List',
-      items: payload.items || [],
+      items,
       recipeLinks,
       notes: payload.notes,
       pantryCovered: sanitizePantryCovered(payload.pantryCovered),
-      createdAt: payload.createdAt || (event.created_at || Math.floor(Date.now() / 1000)),
-      updatedAt: payload.updatedAt || (event.created_at || Math.floor(Date.now() / 1000))
+      pantryOverrides: sanitizePantryOverrides(payload.pantryOverrides),
+      sourceWeekId,
+      stats: sanitizeStats(payload.stats),
+      createdAt: payload.createdAt || now,
+      updatedAt: payload.updatedAt || now
     };
 
     return {
@@ -374,6 +515,9 @@ export async function saveGroceryList(list: GroceryList): Promise<NDKEvent | nul
     items: listToSave.items,
     notes: listToSave.notes,
     pantryCovered: listToSave.pantryCovered,
+    pantryOverrides: listToSave.pantryOverrides,
+    sourceWeekId: listToSave.sourceWeekId,
+    stats: listToSave.stats,
     createdAt: listToSave.createdAt,
     updatedAt: listToSave.updatedAt
   });
@@ -502,13 +646,18 @@ export async function deleteGroceryList(
 /**
  * Create a new empty grocery list
  */
-export function createEmptyList(title: string = 'New List'): GroceryList {
+export function createEmptyList(
+  title: string = 'New List',
+  extras?: Partial<Pick<GroceryList, 'sourceWeekId' | 'notes'>>
+): GroceryList {
   const now = Math.floor(Date.now() / 1000);
   return {
     id: generateListId(),
     title,
     items: [],
     recipeLinks: [],
+    sourceWeekId: extras?.sourceWeekId,
+    notes: extras?.notes,
     createdAt: now,
     updatedAt: now
   };
@@ -521,8 +670,13 @@ export function createGroceryItem(
   name: string,
   quantity: string = '',
   category: GroceryCategory = 'other',
-  recipeId?: string
+  recipeId?: string,
+  extras?: Partial<
+    Pick<GroceryItem, 'normalizedName' | 'unit' | 'origin' | 'sources' | 'pantryOverride'>
+  >
 ): GroceryItem {
+  const origin = extras?.origin || (recipeId ? 'recipe' : 'manual');
+  const { origin: _ignoredOrigin, ...rest } = extras || {};
   return {
     id: generateListId(),
     name,
@@ -530,7 +684,9 @@ export function createGroceryItem(
     category,
     checked: false,
     recipeId,
-    addedAt: Math.floor(Date.now() / 1000)
+    addedAt: Math.floor(Date.now() / 1000),
+    origin,
+    ...rest
   };
 }
 

--- a/src/lib/services/groceryService.ts
+++ b/src/lib/services/groceryService.ts
@@ -30,6 +30,11 @@ export type { GroceryItemSource } from '$lib/grocery/consolidation';
 
 export type GroceryItemOrigin = 'manual' | 'recipe';
 
+export interface UnresolvedRecipeSource {
+  a: string;
+  title?: string;
+}
+
 // ═══════════════════════════════════════════════════════════════
 // TYPES
 // ═══════════════════════════════════════════════════════════════
@@ -80,6 +85,8 @@ export interface GroceryList {
     pantryCoveredCount: number;
     addedCount: number;
   };
+  /** Planned recipes that could not be loaded when this list was generated. */
+  unresolvedRecipes?: UnresolvedRecipeSource[];
   createdAt: number;      // Unix timestamp (seconds)
   updatedAt: number;      // Unix timestamp (seconds)
 }
@@ -245,6 +252,22 @@ function sanitizeStats(raw: unknown): GroceryList['stats'] | undefined {
   const addedCount = typeof r.addedCount === 'number' ? r.addedCount : undefined;
   if (totalIngredients == null || pantryCoveredCount == null || addedCount == null) return undefined;
   return { totalIngredients, pantryCoveredCount, addedCount };
+}
+
+export function sanitizeUnresolvedRecipes(raw: unknown): UnresolvedRecipeSource[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: UnresolvedRecipeSource[] = [];
+  const seen = new Set<string>();
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue;
+    const r = entry as Record<string, unknown>;
+    const a = typeof r.a === 'string' ? r.a.trim() : '';
+    if (!a.includes(':') || seen.has(a)) continue;
+    seen.add(a);
+    const title = asTrimmed(r.title, 120);
+    out.push(title ? { a, title } : { a });
+  }
+  return out.length ? out : undefined;
 }
 
 
@@ -447,6 +470,7 @@ async function decryptGroceryEvent(
       pantryOverrides: sanitizePantryOverrides(payload.pantryOverrides),
       sourceWeekId,
       stats: sanitizeStats(payload.stats),
+      unresolvedRecipes: sanitizeUnresolvedRecipes(payload.unresolvedRecipes),
       createdAt: payload.createdAt || now,
       updatedAt: payload.updatedAt || now
     };
@@ -518,6 +542,7 @@ export async function saveGroceryList(list: GroceryList): Promise<NDKEvent | nul
     pantryOverrides: listToSave.pantryOverrides,
     sourceWeekId: listToSave.sourceWeekId,
     stats: listToSave.stats,
+    unresolvedRecipes: listToSave.unresolvedRecipes,
     createdAt: listToSave.createdAt,
     updatedAt: listToSave.updatedAt
   });

--- a/src/lib/stores/groceryStore.ts
+++ b/src/lib/stores/groceryStore.ts
@@ -21,13 +21,25 @@ import {
   deleteGroceryList,
   createEmptyList,
   createGroceryItem,
-  inferCategory,
   type GroceryList,
   type GroceryItem,
   type GroceryCategory,
-  type GroceryListEvent,
   type PantryCoveredItem
 } from '$lib/services/groceryService';
+import { canonicalizeGroceryCategory, GROCERY_CATEGORIES, type GroceryAisle } from '$lib/grocery/categories';
+import { groceryConsolidationKey } from '$lib/grocery/consolidation';
+import {
+  applySnapshotToList,
+  dropStaleSourcesFromList,
+  mergeRequirementsIntoList,
+  movePantryCoveredToList,
+  type GrocerySnapshot,
+  type GroceryRequirement,
+  type SnapshotList
+} from '$lib/grocery/requirements';
+import { registerMealPlanGrocerySync } from '$lib/grocery/hooks';
+import { weekDisplayRange } from '$lib/mealplan/week';
+import type { MealPlan } from '$lib/mealplan/schema';
 
 // ═══════════════════════════════════════════════════════════════
 // TYPES
@@ -40,6 +52,41 @@ export interface GroceryStoreState {
   error: string | null;
   saving: boolean;
   lastSaved: number | null;
+}
+
+function toSnapshot(list: GroceryList): SnapshotList {
+  return {
+    ...list,
+    pantryCovered: list.pantryCovered?.map((item) => ({
+      name: item.name,
+      quantity: item.quantity,
+      normalizedName: item.normalizedName || groceryConsolidationKey(item.name),
+      category: canonicalizeGroceryCategory(item.category, item.name),
+      unit: item.unit,
+      sources: item.sources || (item.recipeId
+        ? [{
+            recipeId: item.recipeId,
+            occurrenceId: `recipe:${item.recipeId}`,
+            quantity: item.quantity,
+            originalName: item.name
+          }]
+        : [])
+    }))
+  };
+}
+
+function fromSnapshot(snapshot: SnapshotList, previous: GroceryList): GroceryList {
+  return {
+    ...previous,
+    ...snapshot,
+    items: snapshot.items as GroceryItem[],
+    recipeLinks: snapshot.recipeLinks,
+    pantryCovered: snapshot.pantryCovered,
+    pantryOverrides: snapshot.pantryOverrides,
+    sourceWeekId: snapshot.sourceWeekId,
+    stats: snapshot.stats,
+    updatedAt: snapshot.updatedAt
+  };
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -244,7 +291,7 @@ function createGroceryStore() {
      */
     updateList(
       listId: string, 
-      updates: Partial<Pick<GroceryList, 'title' | 'notes' | 'recipeLinks' | 'pantryCovered'>>
+      updates: Partial<Pick<GroceryList, 'title' | 'notes' | 'recipeLinks' | 'pantryCovered' | 'pantryOverrides' | 'sourceWeekId' | 'stats'>>
     ): void {
       update(s => {
         const lists = s.lists.map(list => {
@@ -305,8 +352,11 @@ function createGroceryStore() {
       category?: GroceryCategory,
       recipeId?: string
     ): GroceryItem {
-      const inferredCategory = category || inferCategory(name);
-      const newItem = createGroceryItem(name, quantity, inferredCategory, recipeId);
+      const inferredCategory = canonicalizeGroceryCategory(category, name);
+      const newItem = createGroceryItem(name, quantity, inferredCategory, recipeId, {
+        origin: recipeId ? 'recipe' : 'manual',
+        normalizedName: groceryConsolidationKey(name)
+      });
 
       update(s => {
         const lists = s.lists.map(list => {
@@ -340,28 +390,13 @@ function createGroceryStore() {
       update((s) => {
         const lists = s.lists.map((list) => {
           if (list.id !== listId) return list;
-          const pantryCovered = [...(list.pantryCovered || [])];
-          const covered = pantryCovered[index];
-          if (!covered) return list;
-
-          const item = createGroceryItem(
-            covered.name,
-            covered.quantity || '',
-            inferCategory(covered.name),
-            covered.recipeId
-          );
-          added = item;
-          pantryCovered.splice(index, 1);
-
-          return {
-            ...list,
-            items: [...list.items, item],
-            pantryCovered: pantryCovered.length ? pantryCovered : undefined,
-            updatedAt: Math.floor(Date.now() / 1000)
-          };
+          const result = movePantryCoveredToList(toSnapshot(list), index);
+          added = result.added as GroceryItem | null;
+          if (!added) return list;
+          scheduleSave(listId);
+          return fromSnapshot(result.list, list);
         });
 
-        if (added) scheduleSave(listId);
         return { ...s, lists };
       });
 
@@ -480,13 +515,15 @@ function createGroceryStore() {
     reorderItem(listId: string, category: GroceryCategory, oldIndex: number, newIndex: number): void {
       if (oldIndex === newIndex) return;
 
+      const aisle = canonicalizeGroceryCategory(category);
+
       update(s => {
         const lists = s.lists.map(list => {
           if (list.id !== listId) return list;
 
           const categoryItemIndices: number[] = [];
           list.items.forEach((item, idx) => {
-            if (item.category === category) {
+            if (canonicalizeGroceryCategory(item.category, item.name) === aisle) {
               categoryItemIndices.push(idx);
             }
           });
@@ -595,6 +632,108 @@ function createGroceryStore() {
     },
 
     /**
+     * Replace recipe-derived items from a meal-plan snapshot. Manual
+     * items and checked state are preserved. Adding the same week twice
+     * updates the existing list instead of doubling quantities.
+     */
+    applySnapshot(listId: string, snapshot: GrocerySnapshot): void {
+      update((s) => {
+        const lists = s.lists.map((list) => {
+          if (list.id !== listId) return list;
+          const next = fromSnapshot(applySnapshotToList(toSnapshot(list), snapshot), list);
+          scheduleSave(listId);
+          return next;
+        });
+        return { ...s, lists };
+      });
+    },
+
+    /**
+     * Find the grocery list generated for a meal-plan week, if any.
+     */
+    findListForWeek(weekId: string): GroceryList | undefined {
+      const state = get({ subscribe });
+      return (
+        state.lists.find((list) => list.sourceWeekId === weekId) ||
+        state.lists.find((list) => list.title === `Groceries — ${weekDisplayRange(weekId)}`)
+      );
+    },
+
+    /**
+     * Create or update the grocery list for a planned week.
+     */
+    async applyOrCreateWeekList(weekId: string, snapshot: GrocerySnapshot): Promise<GroceryList> {
+      const existing = this.findListForWeek(weekId);
+      if (existing) {
+        this.applySnapshot(existing.id, { ...snapshot, sourceWeekId: weekId });
+        const updated = get({ subscribe }).lists.find((list) => list.id === existing.id);
+        return updated || existing;
+      }
+
+      const newList = createEmptyList(`Groceries — ${weekDisplayRange(weekId)}`, { sourceWeekId: weekId });
+      const populated = fromSnapshot(
+        applySnapshotToList(toSnapshot(newList), { ...snapshot, sourceWeekId: weekId }),
+        newList
+      );
+
+      update((s) => ({
+        ...s,
+        lists: [populated, ...s.lists],
+        error: null
+      }));
+
+      try {
+        await saveGroceryList(populated);
+        update((s) => ({ ...s, lastSaved: Date.now() }));
+      } catch (error) {
+        console.error('[GroceryStore] Failed to save week grocery list:', error);
+        update((s) => ({
+          ...s,
+          error: error instanceof Error ? error.message : 'Failed to create grocery list'
+        }));
+      }
+
+      return populated;
+    },
+
+    mergeRequirements(
+      listId: string,
+      requirements: GroceryRequirement[],
+      pantryCovered: GroceryRequirement[] = []
+    ): void {
+      update((s) => {
+        const lists = s.lists.map((list) => {
+          if (list.id !== listId) return list;
+          const next = fromSnapshot(
+            mergeRequirementsIntoList(toSnapshot(list), requirements, pantryCovered),
+            list
+          );
+          scheduleSave(listId);
+          return next;
+        });
+        return { ...s, lists };
+      });
+    },
+
+    /**
+     * Recalculate recipe-derived quantities after the meal plan changes.
+     * Manual items are not touched.
+     */
+    syncMealPlanSources(weekId: string, plan: MealPlan): void {
+      update((s) => {
+        let changed = false;
+        const lists = s.lists.map((list) => {
+          if (list.sourceWeekId !== weekId) return list;
+          const next = fromSnapshot(dropStaleSourcesFromList(toSnapshot(list), plan), list);
+          changed = true;
+          scheduleSave(list.id);
+          return next;
+        });
+        return changed ? { ...s, lists } : s;
+      });
+    },
+
+    /**
      * Force save all pending changes immediately
      */
     async saveNow(): Promise<void> {
@@ -635,6 +774,10 @@ function createGroceryStore() {
           this.clear();
         }
       });
+
+      registerMealPlanGrocerySync((weekId, plan) => {
+        this.syncMealPlanSources(weekId, plan);
+      });
     },
 
     /**
@@ -642,6 +785,7 @@ function createGroceryStore() {
      */
     destroy(): void {
       clearAllTimers();
+      registerMealPlanGrocerySync(null);
       if (pubkeyUnsubscribe) {
         pubkeyUnsubscribe();
         pubkeyUnsubscribe = null;
@@ -737,13 +881,14 @@ export function getGroceryItems(listId: string, category?: GroceryCategory) {
 export function getGroceryItemsByCategory(listId: string) {
   return derived(groceryStore, $store => {
     const list = $store.lists.find(l => l.id === listId);
-    if (!list) return new Map<GroceryCategory, GroceryItem[]>();
+    if (!list) return new Map<GroceryAisle, GroceryItem[]>();
     
-    const grouped = new Map<GroceryCategory, GroceryItem[]>();
-    const categories: GroceryCategory[] = ['produce', 'protein', 'dairy', 'pantry', 'frozen', 'other'];
+    const grouped = new Map<GroceryAisle, GroceryItem[]>();
     
-    for (const category of categories) {
-      const items = list.items.filter(item => item.category === category);
+    for (const category of GROCERY_CATEGORIES) {
+      const items = list.items.filter(
+        (item) => canonicalizeGroceryCategory(item.category, item.name) === category
+      );
       if (items.length > 0) {
         grouped.set(category, items);
       }
@@ -759,3 +904,4 @@ export function getGroceryItemsByCategory(listId: string) {
 
 export type { GroceryList, GroceryItem, GroceryCategory } from '$lib/services/groceryService';
 export { inferCategory, createGroceryItem } from '$lib/services/groceryService';
+export { inferGroceryCategory } from '$lib/grocery/categories';

--- a/src/lib/stores/groceryStore.ts
+++ b/src/lib/stores/groceryStore.ts
@@ -33,6 +33,8 @@ import {
   dropStaleSourcesFromList,
   mergeRequirementsIntoList,
   movePantryCoveredToList,
+  removeGroceryItemFromList,
+  returnOverrideToPantry,
   type GrocerySnapshot,
   type GroceryRequirement,
   type SnapshotList
@@ -85,6 +87,7 @@ function fromSnapshot(snapshot: SnapshotList, previous: GroceryList): GroceryLis
     pantryOverrides: snapshot.pantryOverrides,
     sourceWeekId: snapshot.sourceWeekId,
     stats: snapshot.stats,
+    unresolvedRecipes: snapshot.unresolvedRecipes,
     updatedAt: snapshot.updatedAt
   };
 }
@@ -291,7 +294,7 @@ function createGroceryStore() {
      */
     updateList(
       listId: string, 
-      updates: Partial<Pick<GroceryList, 'title' | 'notes' | 'recipeLinks' | 'pantryCovered' | 'pantryOverrides' | 'sourceWeekId' | 'stats'>>
+      updates: Partial<Pick<GroceryList, 'title' | 'notes' | 'recipeLinks' | 'pantryCovered' | 'pantryOverrides' | 'sourceWeekId' | 'stats' | 'unresolvedRecipes'>>
     ): void {
       update(s => {
         const lists = s.lists.map(list => {
@@ -404,6 +407,22 @@ function createGroceryStore() {
     },
 
     /**
+     * Reverse a pantry override: take the item off the shopping list
+     * and put it back under Already in My Kitchen.
+     */
+    returnPantryOverride(listId: string, itemId: string): void {
+      update((s) => {
+        const lists = s.lists.map((list) => {
+          if (list.id !== listId) return list;
+          const next = fromSnapshot(returnOverrideToPantry(toSnapshot(list), itemId), list);
+          scheduleSave(listId);
+          return next;
+        });
+        return { ...s, lists };
+      });
+    },
+
+    /**
      * Record recipe ingredients that were skipped because they matched
      * the pantry. Existing pantryCovered rows are kept.
      */
@@ -492,17 +511,9 @@ function createGroceryStore() {
       update(s => {
         const lists = s.lists.map(list => {
           if (list.id !== listId) return list;
-          
-          const updatedList: GroceryList = {
-            ...list,
-            items: list.items.filter(item => item.id !== itemId),
-            updatedAt: Math.floor(Date.now() / 1000)
-          };
-          
-          // Schedule debounced save
-          scheduleSave(updatedList.id);
-          
-          return updatedList;
+          const next = fromSnapshot(removeGroceryItemFromList(toSnapshot(list), itemId), list);
+          scheduleSave(listId);
+          return next;
         });
 
         return { ...s, lists };

--- a/src/lib/stores/plannerStore.ts
+++ b/src/lib/stores/plannerStore.ts
@@ -37,6 +37,7 @@ import {
   type MealSlotKey
 } from '$lib/mealplan/schema';
 import { currentWeekId, isValidWeekId, nextWeekId, prevWeekId } from '$lib/mealplan/week';
+import { notifyMealPlanMutated } from '$lib/grocery/hooks';
 
 export type PlannerWeekState =
   | { status: 'ok'; plan: MealPlan; readOnly: boolean }
@@ -198,14 +199,16 @@ function createPlannerStore() {
       return false;
     }
 
+    const nextPlan = mutate(weekState.plan);
     update((s) => ({
       ...s,
       weeks: {
         ...s.weeks,
-        [weekId]: { status: 'ok', plan: mutate(weekState.plan), readOnly: false }
+        [weekId]: { status: 'ok', plan: nextPlan, readOnly: false }
       }
     }));
     scheduleSave(weekId);
+    notifyMealPlanMutated(weekId, nextPlan);
     return true;
   }
 
@@ -269,6 +272,12 @@ function createPlannerStore() {
 
     async goToCurrentWeek(): Promise<void> {
       await this.goToWeek(currentWeekId());
+    },
+
+    /** Load a week without changing the visible planner week. */
+    async ensureWeek(weekId: string): Promise<void> {
+      if (!isValidWeekId(weekId)) return;
+      await loadWeeks([weekId]);
     },
 
     // ── Mutations (PR9 API). All return false when rejected. ──
@@ -370,6 +379,7 @@ function createPlannerStore() {
           },
           error: null
         }));
+        notifyMealPlanMutated(weekId, createEmptyMealPlan(weekId));
       } catch (error) {
         console.error('[PlannerStore] Failed to delete week:', error);
         update((s) => ({

--- a/src/routes/my-kitchen/grocery/+page.svelte
+++ b/src/routes/my-kitchen/grocery/+page.svelte
@@ -111,19 +111,28 @@
         <ShoppingCartIcon size={40} weight="regular" class="text-green-500" />
       </div>
       <h2 class="text-xl font-semibold mb-2" style="color: var(--color-text-primary)">
-        No Grocery Lists Yet
+        Your grocery list is empty
       </h2>
       <p class="text-caption text-center max-w-md mb-6">
-        Create a grocery list to keep track of items you need. Your lists are private and encrypted.
+        Add ingredients manually or build a meal plan and Zap will create your grocery list automatically.
       </p>
-      <button
-        on:click={createNewList}
-        disabled={isCreating}
-        class="flex items-center gap-2 px-5 py-2.5 bg-gradient-to-r from-green-500 to-emerald-500 hover:from-green-600 hover:to-emerald-600 text-white rounded-full font-medium transition-all disabled:opacity-50"
-      >
-        <PlusIcon size={18} weight="bold" />
-        {isCreating ? 'Creating...' : 'Create Your First List'}
-      </button>
+      <div class="flex flex-col sm:flex-row items-center gap-3">
+        <a
+          href="/my-kitchen/planner"
+          class="flex items-center gap-2 px-5 py-2.5 rounded-full font-medium transition-all"
+          style="color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+        >
+          Plan Meals
+        </a>
+        <button
+          on:click={createNewList}
+          disabled={isCreating}
+          class="flex items-center gap-2 px-5 py-2.5 bg-gradient-to-r from-green-500 to-emerald-500 hover:from-green-600 hover:to-emerald-600 text-white rounded-full font-medium transition-all disabled:opacity-50"
+        >
+          <PlusIcon size={18} weight="bold" />
+          {isCreating ? 'Creating...' : 'Add Item'}
+        </button>
+      </div>
     </div>
   {:else}
     <!-- Lists Grid -->

--- a/src/routes/my-kitchen/grocery/[id]/+page.svelte
+++ b/src/routes/my-kitchen/grocery/[id]/+page.svelte
@@ -2,28 +2,34 @@
   import { page } from '$app/stores';
   import { goto } from '$app/navigation';
   import { onMount, onDestroy } from 'svelte';
+  import { get } from 'svelte/store';
   import { userPublickey } from '$lib/nostr';
   import { 
     groceryStore, 
     getGroceryList, 
     getGroceryItemsByCategory,
     grocerySaving,
-    groceryInitialized,
-    type GroceryCategory
+    groceryInitialized
   } from '$lib/stores/groceryStore';
+  import { plannerStore } from '$lib/stores/plannerStore';
+  import {
+    GROCERY_CATEGORIES,
+    GROCERY_CATEGORY_EMOJI,
+    GROCERY_CATEGORY_LABELS
+  } from '$lib/grocery/categories';
+  import { isManualGroceryItem } from '$lib/grocery/requirements';
   import ArrowLeftIcon from 'phosphor-svelte/lib/ArrowLeft';
   import TrashIcon from 'phosphor-svelte/lib/Trash';
   import CheckIcon from 'phosphor-svelte/lib/Check';
   import XIcon from 'phosphor-svelte/lib/X';
   import PencilSimpleIcon from 'phosphor-svelte/lib/PencilSimple';
-  import FloppyDiskIcon from 'phosphor-svelte/lib/FloppyDisk';
   import CircleNotchIcon from 'phosphor-svelte/lib/CircleNotch';
   import PanLoader from '../../../../components/PanLoader.svelte';
   import Modal from '../../../../components/Modal.svelte';
   import Button from '../../../../components/Button.svelte';
   import SortableGroceryCategory from '../../../../components/grocery/SortableGroceryCategory.svelte';
   import AddItemForm from '../../../../components/grocery/AddItemForm.svelte';
-  import PlusIcon from 'phosphor-svelte/lib/Plus';
+  import CalendarBlankIcon from 'phosphor-svelte/lib/CalendarBlank';
 
   // Get list ID from URL params
   $: listId = $page.params.id as string;
@@ -36,18 +42,7 @@
   $: itemsByCategoryStore = getGroceryItemsByCategory(listId);
   $: itemsByCategory = $itemsByCategoryStore;
 
-  // Category display info
-  const categoryInfo: Record<GroceryCategory, { label: string; emoji: string }> = {
-    produce: { label: 'Produce', emoji: '🥬' },
-    protein: { label: 'Protein', emoji: '🥩' },
-    dairy: { label: 'Dairy', emoji: '🧀' },
-    pantry: { label: 'Pantry', emoji: '🥫' },
-    frozen: { label: 'Frozen', emoji: '🧊' },
-    other: { label: 'Other', emoji: '📦' }
-  };
-
-  // Category order for display
-  const categoryOrder: GroceryCategory[] = ['produce', 'protein', 'dairy', 'pantry', 'frozen', 'other'];
+  const categoryOrder = GROCERY_CATEGORIES;
 
   // UI state
   let isEditingTitle = false;
@@ -129,10 +124,12 @@
     groceryStore.addPantryCoveredToList(listId, index);
   }
 
-  // Calculate stats
   $: totalItems = list?.items.length ?? 0;
   $: checkedItems = list?.items.filter(item => item.checked).length ?? 0;
   $: hasCheckedItems = checkedItems > 0;
+  $: recipeItemCount = list?.items.filter((item) => !isManualGroceryItem(item)).length ?? 0;
+  $: pantryCoveredCount = list?.pantryCovered?.length ?? 0;
+  $: plannedIngredientCount = recipeItemCount + pantryCoveredCount;
 
   onMount(async () => {
     if (!$userPublickey) {
@@ -143,6 +140,15 @@
     // Only load if not already initialized (to preserve locally created lists)
     if (!$groceryInitialized) {
       await groceryStore.load();
+    }
+
+    const currentList = get(groceryStore).lists.find((entry) => entry.id === listId);
+    if (currentList?.sourceWeekId) {
+      await plannerStore.ensureWeek(currentList.sourceWeekId);
+      const week = get(plannerStore).weeks[currentList.sourceWeekId];
+      if (week?.status === 'ok') {
+        groceryStore.syncMealPlanSources(currentList.sourceWeekId, week.plan);
+      }
     }
   });
 
@@ -244,24 +250,35 @@
       </div>
 
       <!-- Stats bar -->
-      <div class="flex items-center justify-between">
-        <p class="text-sm text-caption">
-          {#if totalItems === 0}
-            No items yet
-          {:else}
-            {checkedItems}/{totalItems} items checked
-          {/if}
-        </p>
+      <div class="flex flex-col gap-1">
+        <div class="flex items-center justify-between">
+          <p class="text-sm text-caption">
+            {#if totalItems === 0}
+              No items yet
+            {:else}
+              {checkedItems}/{totalItems} items checked
+            {/if}
+          </p>
 
-        {#if hasCheckedItems}
-          <button
-            on:click={clearCheckedItems}
-            class="text-sm font-medium transition-colors hover:opacity-80"
-            style="color: var(--color-primary)"
-            aria-label="Clear checked items"
-          >
-            Clear checked
-          </button>
+          {#if hasCheckedItems}
+            <button
+              on:click={clearCheckedItems}
+              class="text-sm font-medium transition-colors hover:opacity-80"
+              style="color: var(--color-primary)"
+              aria-label="Clear checked items"
+            >
+              Clear checked
+            </button>
+          {/if}
+        </div>
+        {#if plannedIngredientCount > 0}
+          <p class="text-xs text-caption">
+            {plannedIngredientCount} ingredient{plannedIngredientCount === 1 ? '' : 's'} needed
+            {#if pantryCoveredCount > 0}
+              · {pantryCoveredCount} already in My Kitchen
+              · {recipeItemCount} added to Grocery List
+            {/if}
+          </p>
         {/if}
       </div>
 
@@ -290,15 +307,27 @@
             {listId}
             {category}
             {items}
-            categoryLabel={categoryInfo[category].label}
-            categoryEmoji={categoryInfo[category].emoji}
+            categoryLabel={GROCERY_CATEGORY_LABELS[category]}
+            categoryEmoji={GROCERY_CATEGORY_EMOJI[category]}
           />
         {/if}
       {/each}
 
       {#if totalItems === 0}
-        <div class="text-center py-8">
-          <p class="text-caption">Add items using the form above</p>
+        <div class="text-center py-10 px-4">
+          <h2 class="text-lg font-semibold mb-2" style="color: var(--color-text-primary)">
+            Your grocery list is empty
+          </h2>
+          <p class="text-caption max-w-md mx-auto mb-5">
+            Add ingredients manually or build a meal plan and Zap will create your grocery list automatically.
+          </p>
+          <a
+            href="/my-kitchen/planner"
+            class="inline-flex items-center gap-2 px-4 py-2.5 rounded-full text-sm font-medium text-white bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 transition-all"
+          >
+            <CalendarBlankIcon size={16} />
+            Plan Meals
+          </a>
         </div>
       {/if}
     </div>
@@ -309,25 +338,24 @@
         style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border);"
       >
         <h2 class="text-sm font-semibold" style="color: var(--color-text-primary);">
-          Already in Pantry
+          Already in My Kitchen
         </h2>
         <p class="text-xs text-caption">
-          These matched your pantry, so they were left off the shopping list. Add any you still need.
+          These matched your pantry, so they were left off the shopping list.
         </p>
         <ul class="flex flex-col gap-1.5">
           {#each list.pantryCovered as covered, index (`${covered.name}|${covered.quantity || ''}|${covered.recipeId || ''}|${index}`)}
-            <li class="flex items-center gap-2 text-sm">
+            <li class="flex items-center gap-2 text-sm min-h-[40px]">
               <span class="min-w-0 flex-1" style="color: var(--color-text-secondary);">
                 {covered.name}{#if covered.quantity}<span class="text-caption"> · {covered.quantity}</span>{/if}
               </span>
               <button
                 type="button"
-                class="flex items-center gap-1 flex-shrink-0 px-2.5 py-1 rounded-full text-xs font-medium border border-green-500/40 text-green-500 hover:bg-green-500/10 transition-colors"
-                aria-label="Add {covered.name} to shopping list"
+                class="flex items-center gap-1 flex-shrink-0 px-3 py-1.5 rounded-full text-xs font-medium border border-green-500/40 text-green-500 hover:bg-green-500/10 transition-colors"
+                aria-label="I still need {covered.name}"
                 on:click={() => addPantryCoveredToList(index)}
               >
-                <PlusIcon size={12} weight="bold" />
-                Add
+                I still need this
               </button>
             </li>
           {/each}

--- a/src/routes/my-kitchen/grocery/[id]/+page.svelte
+++ b/src/routes/my-kitchen/grocery/[id]/+page.svelte
@@ -30,6 +30,8 @@
   import SortableGroceryCategory from '../../../../components/grocery/SortableGroceryCategory.svelte';
   import AddItemForm from '../../../../components/grocery/AddItemForm.svelte';
   import CalendarBlankIcon from 'phosphor-svelte/lib/CalendarBlank';
+  import WarningIcon from 'phosphor-svelte/lib/Warning';
+  import { generateWeekGrocerySnapshot } from '$lib/grocery/weekGenerate';
 
   // Get list ID from URL params
   $: listId = $page.params.id as string;
@@ -122,6 +124,24 @@
 
   function addPantryCoveredToList(index: number) {
     groceryStore.addPantryCoveredToList(listId, index);
+  }
+
+  let retryingUnresolved = false;
+
+  async function retryUnresolvedRecipes() {
+    if (!list?.sourceWeekId || !list.unresolvedRecipes?.length || retryingUnresolved) return;
+    retryingUnresolved = true;
+    try {
+      const result = await generateWeekGrocerySnapshot(list.sourceWeekId);
+      if (result) {
+        groceryStore.applySnapshot(listId, result.snapshot);
+        await groceryStore.saveNow();
+      }
+    } catch (error) {
+      console.error('[Grocery] Failed to retry unresolved recipes', error);
+    } finally {
+      retryingUnresolved = false;
+    }
   }
 
   $: totalItems = list?.items.length ?? 0;
@@ -294,6 +314,33 @@
         </div>
       {/if}
     </div>
+
+    {#if list.unresolvedRecipes && list.unresolvedRecipes.length > 0}
+      <div
+        class="flex items-start gap-3 p-3 rounded-xl border border-amber-500/30 bg-amber-500/10"
+        role="status"
+      >
+        <WarningIcon size={20} class="text-amber-500 flex-shrink-0 mt-0.5" weight="fill" />
+        <div class="flex-1 min-w-0">
+          <p class="text-sm font-semibold" style="color: var(--color-text-primary)">
+            Some ingredients may be missing
+          </p>
+          <p class="text-xs text-caption mt-0.5">
+            {list.unresolvedRecipes.length}
+            {list.unresolvedRecipes.length === 1 ? 'recipe' : 'recipes'}
+            couldn't be loaded while building this grocery list.
+          </p>
+        </div>
+        <button
+          type="button"
+          disabled={retryingUnresolved}
+          on:click={retryUnresolvedRecipes}
+          class="flex-shrink-0 px-3 py-1.5 rounded-full text-xs font-medium text-white bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 transition-all disabled:opacity-50"
+        >
+          {retryingUnresolved ? 'Retrying…' : 'Retry'}
+        </button>
+      </div>
+    {/if}
 
     <!-- Add Item Form -->
     <AddItemForm {listId} />

--- a/src/routes/my-kitchen/planner/+page.svelte
+++ b/src/routes/my-kitchen/planner/+page.svelte
@@ -33,15 +33,14 @@
   import Modal from '../../../components/Modal.svelte';
   import RecipePickerModal from '../../../components/RecipePickerModal.svelte';
   import CheffyPlanModal from '../../../components/planner/CheffyPlanModal.svelte';
-  import { groceryStore } from '$lib/stores/groceryStore';
+  import { groceryStore, groceryInitialized } from '$lib/stores/groceryStore';
   import { pantryStore, pantryItems, pantryInitialized } from '$lib/stores/pantryStore';
-  import { parseIngredient, parseIngredientsFromRecipe } from '$lib/utils/ingredientParser';
+  import { parseIngredientsFromRecipe } from '$lib/utils/ingredientParser';
   import {
-    classifyGroceryRows,
-    collectWeekRecipeSlots,
-    dedupeIngredients,
+    collectWeekRecipeOccurrences,
     groceryListTitle,
-    type GenerationRow
+    rowsFromRecipeLines,
+    buildGrocerySnapshot
   } from '$lib/mealplan/groceryGeneration';
   import ShoppingCartIcon from 'phosphor-svelte/lib/ShoppingCart';
   import Button from '../../../components/Button.svelte';
@@ -161,7 +160,7 @@
     unresolved: string[];
   } | null = null;
 
-  $: weekRecipeSlots = weekPlan ? collectWeekRecipeSlots(weekPlan) : null;
+  $: weekRecipeSlots = weekPlan ? collectWeekRecipeOccurrences(weekPlan) : null;
   $: cheffyOccupiedSlots =
     weekPlan && !isReadOnly ? occupiedSlotsFromPlan(weekPlan, [...DAY_KEYS], [...SLOT_KEYS]) : [];
 
@@ -174,11 +173,8 @@
     if (!weekPlan || !weekRecipeSlots || generating) return;
     generating = true;
     try {
-      const { aTags, textCount } = weekRecipeSlots;
+      const { aTags, textCount, occurrences } = weekRecipeSlots;
 
-      // Resolve each recipe's ingredient LINES, cache-first.
-      // CachedRecipe.ingredients (pre-extracted lines) skips markdown
-      // re-extraction; uncached coordinates fetch + full-parse.
       const linesByATag = new Map<string, string[]>();
       const cached = await offlineStorage.getRecipes(aTags);
       for (const c of cached) {
@@ -220,59 +216,40 @@
         );
       }
 
-      // Unresolvable coordinates are REPORTED, not silently dropped
       const unresolved = aTags.filter((a) => !linesByATag.has(a));
-      const resolved = aTags.filter((a) => linesByATag.has(a));
+      const resolvedOccurrences = occurrences.filter((occ) => linesByATag.has(occ.a));
 
-      // Parse + approved v1 dedupe (exact (name, quantity) collapse)
-      const rows: GenerationRow[] = [];
-      for (const aTag of resolved) {
-        for (const line of linesByATag.get(aTag) || []) {
-          rows.push({ ingredient: parseIngredient(line), recipeId: aTag });
-        }
+      const rows = rowsFromRecipeLines(
+        resolvedOccurrences.map((occ) => ({
+          a: occ.a,
+          title: occ.title,
+          occurrenceId: occ.occurrenceId,
+          lines: linesByATag.get(occ.a) || []
+        }))
+      );
+
+      if (!$groceryInitialized) {
+        await groceryStore.load();
       }
-      const deduped = dedupeIngredients(rows);
-
       if (!$pantryInitialized) {
         await pantryStore.load();
       }
-      const classified = classifyGroceryRows(deduped, $pantryItems);
 
-      // Always a NEW list — never overwrite an existing one. Repeat
-      // generations for the same week create additional lists the user
-      // can delete; silent merge/overwrite risks destroying manual edits.
-      const list = await groceryStore.addList(groceryListTitle($plannerCurrentWeekId));
-      for (const aTag of resolved) {
-        groceryStore.addRecipeLink(list.id, aTag);
-      }
-      for (const row of classified.toBuy) {
-        groceryStore.addItem(
-          list.id,
-          row.ingredient.name,
-          row.ingredient.quantity,
-          row.ingredient.category,
-          row.recipeId
-        );
-      }
-      if (classified.inPantry.length > 0) {
-        groceryStore.updateList(list.id, {
-          pantryCovered: classified.inPantry.map((row) => ({
-            name: row.ingredient.name,
-            quantity: row.ingredient.quantity,
-            recipeId: row.recipeId
-          }))
-        });
-      }
+      const existing = groceryStore.findListForWeek($plannerCurrentWeekId);
+      const snapshot = buildGrocerySnapshot(rows, $pantryItems, {
+        pantryOverrides: existing?.pantryOverrides,
+        sourceWeekId: $plannerCurrentWeekId
+      });
+
+      const list = await groceryStore.applyOrCreateWeekList($plannerCurrentWeekId, snapshot);
 
       generationSummary = {
-        itemCount: classified.toBuy.length,
-        recipeCount: resolved.length,
+        itemCount: snapshot.stats.addedCount,
+        recipeCount: new Set(resolvedOccurrences.map((occ) => occ.a)).size,
         textSkipped: textCount,
         unresolved
       };
 
-      // Flush the coalesced item save before leaving the page, then land
-      // on the new list.
       await groceryStore.saveNow();
       goto(`/my-kitchen/grocery/${list.id}`);
     } catch (err) {
@@ -473,10 +450,11 @@
             style="background-color: var(--color-input-bg); color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
             title={weekRecipeSlots.aTags.length === 0
               ? 'Add recipes to this week to generate a grocery list'
-              : 'Generate a grocery list from this week'}
+              : 'Add this week to your grocery list'}
           >
             <ShoppingCartIcon size={16} />
-            <span>Grocery list</span>
+            <span class="hidden sm:inline">Add Week to Grocery List</span>
+            <span class="sm:hidden">Add Week</span>
           </button>
         {/if}
         {#if !isViewingCurrentWeek}
@@ -782,21 +760,23 @@
 
 <!-- Generate-grocery confirm: pre-generation summary of what will happen -->
 <Modal bind:open={generateConfirmOpen} compact>
-  <h1 slot="title">Generate grocery list</h1>
+  <h1 slot="title">Add Week to Grocery List</h1>
   <div class="flex flex-col gap-3">
     {#if weekRecipeSlots}
       <p class="text-sm" style="color: var(--color-text-primary);">
-        Creates a new list "{groceryListTitle($plannerCurrentWeekId)}" from
-        {weekRecipeSlots.aTags.length}
-        {weekRecipeSlots.aTags.length === 1 ? 'recipe' : 'recipes'}{weekRecipeSlots.textCount > 0
+        Builds "{groceryListTitle($plannerCurrentWeekId)}" from
+        {weekRecipeSlots.occurrences.length}
+        {weekRecipeSlots.occurrences.length === 1 ? 'meal' : 'meals'}
+        ({weekRecipeSlots.aTags.length}
+        {weekRecipeSlots.aTags.length === 1 ? 'recipe' : 'recipes'}){weekRecipeSlots.textCount > 0}
           ? ` · ${weekRecipeSlots.textCount} text ${
               weekRecipeSlots.textCount === 1 ? 'entry' : 'entries'
             } skipped`
           : ''}.
       </p>
       <p class="text-xs text-caption">
-        Matching items are combined only when name and quantity are identical. Repeat runs create a
-        new list — existing lists are never changed.
+        Duplicate ingredients are combined, pantry items stay off the list unless you add them back,
+        and running this again updates the same list instead of doubling it.
       </p>
       {#if generationSummary && generationSummary.unresolved.length > 0}
         <p class="text-xs text-red-500">
@@ -813,7 +793,7 @@
           on:click={generateGroceryList}
           class="px-4 py-2 rounded-full text-sm font-medium text-white bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 transition-all disabled:opacity-50"
         >
-          {generating ? 'Generating…' : 'Generate'}
+          {generating ? 'Adding…' : 'Add Week'}
         </button>
       </div>
     {/if}

--- a/src/routes/my-kitchen/planner/+page.svelte
+++ b/src/routes/my-kitchen/planner/+page.svelte
@@ -33,15 +33,12 @@
   import Modal from '../../../components/Modal.svelte';
   import RecipePickerModal from '../../../components/RecipePickerModal.svelte';
   import CheffyPlanModal from '../../../components/planner/CheffyPlanModal.svelte';
-  import { groceryStore, groceryInitialized } from '$lib/stores/groceryStore';
-  import { pantryStore, pantryItems, pantryInitialized } from '$lib/stores/pantryStore';
-  import { parseIngredientsFromRecipe } from '$lib/utils/ingredientParser';
+  import { groceryStore } from '$lib/stores/groceryStore';
   import {
     collectWeekRecipeOccurrences,
-    groceryListTitle,
-    rowsFromRecipeLines,
-    buildGrocerySnapshot
+    groceryListTitle
   } from '$lib/mealplan/groceryGeneration';
+  import { generateWeekGrocerySnapshot } from '$lib/grocery/weekGenerate';
   import ShoppingCartIcon from 'phosphor-svelte/lib/ShoppingCart';
   import Button from '../../../components/Button.svelte';
   import PullToRefresh from '../../../components/PullToRefresh.svelte';
@@ -173,81 +170,19 @@
     if (!weekPlan || !weekRecipeSlots || generating) return;
     generating = true;
     try {
-      const { aTags, textCount, occurrences } = weekRecipeSlots;
-
-      const linesByATag = new Map<string, string[]>();
-      const cached = await offlineStorage.getRecipes(aTags);
-      for (const c of cached) {
-        if (c.ingredients?.length) {
-          linesByATag.set(c.id, c.ingredients);
-        } else if (c.content) {
-          linesByATag.set(
-            c.id,
-            parseIngredientsFromRecipe(c.content).map((p) => p.originalText)
-          );
-        }
-      }
-      const missing = aTags.filter((a) => !linesByATag.has(a));
-      if (missing.length > 0 && $isOnline && $ndk) {
-        await Promise.all(
-          missing.map(async (aTag) => {
-            const parts = aTag.split(':');
-            if (parts.length !== 3) return;
-            const [kind, pubkey, identifier] = parts;
-            try {
-              const e = await $ndk.fetchEvent({
-                kinds: [Number(kind)],
-                '#d': [identifier],
-                authors: [pubkey]
-              });
-              if (e?.content) {
-                linesByATag.set(
-                  aTag,
-                  parseIngredientsFromRecipe(e.content).map((p) => p.originalText)
-                );
-                try {
-                  await offlineStorage.saveRecipeFromEvent(e);
-                } catch {}
-              }
-            } catch (err) {
-              console.warn('[Planner generate] Failed to fetch', aTag, err);
-            }
-          })
-        );
+      const result = await generateWeekGrocerySnapshot($plannerCurrentWeekId);
+      if (!result) {
+        generationSummary = { itemCount: 0, recipeCount: 0, textSkipped: 0, unresolved: [] };
+        return;
       }
 
-      const unresolved = aTags.filter((a) => !linesByATag.has(a));
-      const resolvedOccurrences = occurrences.filter((occ) => linesByATag.has(occ.a));
-
-      const rows = rowsFromRecipeLines(
-        resolvedOccurrences.map((occ) => ({
-          a: occ.a,
-          title: occ.title,
-          occurrenceId: occ.occurrenceId,
-          lines: linesByATag.get(occ.a) || []
-        }))
-      );
-
-      if (!$groceryInitialized) {
-        await groceryStore.load();
-      }
-      if (!$pantryInitialized) {
-        await pantryStore.load();
-      }
-
-      const existing = groceryStore.findListForWeek($plannerCurrentWeekId);
-      const snapshot = buildGrocerySnapshot(rows, $pantryItems, {
-        pantryOverrides: existing?.pantryOverrides,
-        sourceWeekId: $plannerCurrentWeekId
-      });
-
-      const list = await groceryStore.applyOrCreateWeekList($plannerCurrentWeekId, snapshot);
+      const list = await groceryStore.applyOrCreateWeekList($plannerCurrentWeekId, result.snapshot);
 
       generationSummary = {
-        itemCount: snapshot.stats.addedCount,
-        recipeCount: new Set(resolvedOccurrences.map((occ) => occ.a)).size,
-        textSkipped: textCount,
-        unresolved
+        itemCount: result.snapshot.stats.addedCount,
+        recipeCount: result.resolvedRecipeCount,
+        textSkipped: result.textSkipped,
+        unresolved: result.unresolved.map((source) => source.a)
       };
 
       await groceryStore.saveNow();


### PR DESCRIPTION
## Summary
- Derive a single grocery list from the planned week: merge obvious duplicate ingredients, combine compatible quantities, and keep recipe-source provenance so removing a meal recalculates remaining amounts instead of deleting the item.
- Skip pantry matches by default, with an **I still need this** override and a reversible **I have this** action that returns the item to Already in My Kitchen without changing pantry inventory.
- Group items into store aisles, keep manual items intact, and leave the normalized list retailer-agnostic for a future grocery-provider adapter.

### Edge-case polish
- Persist unresolved recipe sources and show a non-blocking **Some ingredients may be missing** warning on Grocery Planner, with **Retry** that rebuilds the same week without duplicating items.
- Preserve checked state only when quantity, unit, and recipe sources are unchanged; a requirement change unchecks the item.
- Clean up pantry overrides when the user chooses **I have this** or removes the overridden item, so they do not reappear on the next weekly rebuild.

This branch also includes the earlier pantry work it builds on (My Kitchen pantry matching, Cheffy pantry ranking, and pantry-aware grocery classification).

## Test plan
- [ ] Add pantry items in My Kitchen, plan several meals, then use **Add Week to Grocery List**
- [ ] Confirm obvious duplicates merge (onion/onions) while distinct items stay separate (red vs yellow vs green onion)
- [ ] Confirm compatible quantities combine (cups, tsp/tbsp, lb/oz) and incompatible ones stay side-by-side (cloves + head)
- [ ] Confirm pantry matches are excluded and **I still need this** adds them back without deleting pantry
- [ ] Choose **I have this** on an overridden item and confirm it returns to Already in My Kitchen and stays excluded after rebuild
- [ ] Run **Add Week to Grocery List** twice and confirm quantities do not double
- [ ] Remove one planned meal and confirm grocery quantities recalculate from remaining recipes
- [ ] Add a manual item, then change the meal plan — the manual item remains
- [ ] Check an item off, then change its required quantity via the meal plan — it becomes unchecked
- [ ] Force or simulate one recipe load failure, confirm the incomplete-list warning, retry, and confirm it clears without duplicating quantities
- [ ] Confirm empty grocery states offer **Plan Meals** / **Add Item**
- [ ] Spot-check Pantry, Meal Planner, Cheffy, and recipe add-to-list still work

Made with [Cursor](https://cursor.com)