### PR TITLE
feat(planner): add Cheffy meal planning modes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.718",
+  "version": "4.2.719",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.719",
+  "version": "4.2.720",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.720",
+  "version": "4.2.721",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/planner/CheffyPlanModal.svelte
+++ b/src/components/planner/CheffyPlanModal.svelte
@@ -5,6 +5,7 @@
    * them, then previews before a single plannerStore.applyGeneratedPlan.
    */
   import { createEventDispatcher, onDestroy } from 'svelte';
+  import { get } from 'svelte/store';
   import { goto } from '$app/navigation';
   import { ndk, userPublickey } from '$lib/nostr';
   import {
@@ -13,6 +14,7 @@
     type MembershipStatus
   } from '$lib/stores/membershipStatus';
   import { plannerStore } from '$lib/stores/plannerStore';
+  import { cookbookLists } from '$lib/stores/cookbookStore';
   import { DAY_KEYS, SLOT_KEYS, type MealPlanDayKey, type MealSlotKey } from '$lib/mealplan/schema';
   import {
     PREFERENCE_STYLES,
@@ -21,6 +23,7 @@
     parseExcludeIngredientsInput,
     resolveTargetSlots,
     slotKey,
+    totalActiveMinutes,
     type GeneratedMeal,
     type MealPlanGenerationRequest,
     type MealPlanStrategy,
@@ -28,6 +31,19 @@
     type PreferenceStyleId,
     type RecipeSource
   } from '$lib/mealplan/generation';
+  import {
+    PLANNING_MODES,
+    familiarCoordinatesFromSources,
+    hasEnabledPlanningMode,
+    loadPlanningModes,
+    savePlanningModes,
+    summarizePlanningModeFeedback,
+    togglePlanningMode,
+    type PlanningModeKey,
+    type PlanningPreferences,
+    type PlanModeFeedback
+  } from '$lib/mealplan/planningModes';
+  import { attachCachedNourish } from '$lib/mealplan/attachNourish';
   import {
     insufficientSlotCoverageMessage,
     noEligibleRecipesMessage
@@ -91,12 +107,13 @@
   let notes = '';
   let source: RecipeSource = 'all';
   let strategy: MealPlanStrategy = 'fill-empty';
-  let prioritizePantry = false;
+  let planningPreferences: PlanningPreferences = loadPlanningModes();
   let error: string | null = null;
   let statusLine = THINKING_LINES[0];
   let preview: GeneratedMeal[] = [];
   let coverageNote: string | null = null;
   let pantryNote: string | null = null;
+  let modeFeedback: PlanModeFeedback | null = null;
   let discovered: DiscoveredRecipe[] = [];
   let swappingKey: string | null = null;
   let applying = false;
@@ -125,6 +142,7 @@
     strategy,
     occupiedSlots
   }).length;
+  $: prioritizePantry = planningPreferences.usePantry;
 
   let wasOpen = false;
   $: {
@@ -149,10 +167,14 @@
     notes = '';
     source = 'all';
     strategy = 'fill-empty';
-    prioritizePantry = initialPrioritizePantry;
+    planningPreferences = loadPlanningModes();
+    if (initialPrioritizePantry) {
+      planningPreferences = { ...planningPreferences, usePantry: true };
+    }
     error = null;
     coverageNote = null;
     pantryNote = null;
+    modeFeedback = null;
     preview = [];
     discovered = [];
     swappingKey = null;
@@ -188,9 +210,35 @@
     styles = toggleIn(styles, id);
   }
 
+  function toggleMode(key: PlanningModeKey) {
+    planningPreferences = togglePlanningMode(planningPreferences, key);
+    savePlanningModes(planningPreferences);
+  }
+
+  function collectFamiliarCoordinates(): string[] {
+    const saved: string[] = [];
+    for (const list of get(cookbookLists)) {
+      for (const a of list.recipes || []) saved.push(a);
+    }
+    const planned: string[] = [];
+    const weeks = get(plannerStore).weeks;
+    for (const state of Object.values(weeks)) {
+      if (state.status !== 'ok') continue;
+      for (const day of Object.values(state.plan.days || {})) {
+        const slots = day?.slots;
+        if (!slots) continue;
+        for (const slot of Object.values(slots)) {
+          if (slot?.type === 'recipe' && slot.a) planned.push(slot.a);
+        }
+      }
+    }
+    return familiarCoordinatesFromSources({ savedAs: saved, plannedAs: planned });
+  }
+
   function wireCandidates() {
+    const attachNourish = planningPreferences.healthy || planningPreferences.highProtein;
     return discovered.map((recipe) => {
-      const wire = toWireCandidate(recipe);
+      let wire = toWireCandidate(recipe);
       if (prioritizePantry && $pantryItems.length > 0) {
         const match = matchRecipeToPantry(wire.ingredients, $pantryItems);
         wire.pantry = {
@@ -201,6 +249,7 @@
           missingIngredients: match.missingIngredients
         };
       }
+      if (attachNourish) wire = attachCachedNourish(wire);
       return wire;
     });
   }
@@ -211,12 +260,17 @@
     if (!$ndk || !$userPublickey) return null;
     const max = maxMinutes.trim() ? Number(maxMinutes) : undefined;
     const serv = servings.trim() ? Number(servings) : undefined;
+    const familiarCoordinates = planningPreferences.adventurous
+      ? collectFamiliarCoordinates()
+      : [];
     const filtered = filterRecipeCandidates(wireCandidates(), {
       maxMinutes: max && Number.isFinite(max) && max > 0 ? max : undefined,
       excludeIngredients: parseExcludeIngredientsInput(excludeText),
       styles,
       mealSlots,
       prioritizePantry,
+      planningPreferences,
+      familiarCoordinates: familiarCoordinates.length ? familiarCoordinates : undefined,
       excludeCoordinates: overrides.excludeCoordinates
     });
     if (filtered.length === 0) return null;
@@ -232,10 +286,14 @@
         notes: notes.trim() || undefined
       },
       strategy,
+      planningPreferences: hasEnabledPlanningMode(planningPreferences)
+        ? planningPreferences
+        : undefined,
       prioritizePantry: prioritizePantry || undefined,
       pantryIngredients: prioritizePantry
         ? $pantryItems.map((item) => item.name).slice(0, 80)
         : undefined,
+      familiarCoordinates: familiarCoordinates.length ? familiarCoordinates : undefined,
       candidates: filtered,
       occupiedSlots,
       ...overrides
@@ -323,6 +381,15 @@
           requested: requestedSlots
         });
         pantryNote = prioritizePantry ? weakPantryPlanNote(preview.map((m) => m.pantry)) : null;
+        modeFeedback = summarizePlanningModeFeedback({
+          preferences: planningPreferences,
+          meals: preview,
+          recipes: discovered.map((recipe) => ({
+            a: recipe.a,
+            ingredients: recipe.ingredients,
+            minutes: totalActiveMinutes(recipe.prepTime, recipe.cookTime)
+          }))
+        });
         step = 'preview';
       }
     } catch (err) {
@@ -451,6 +518,16 @@
     {#if pantryNote}
       <p class="text-sm text-caption">{pantryNote}</p>
     {/if}
+    {#if modeFeedback}
+      <div class="flex flex-col gap-0.5">
+        <p class="text-sm font-medium" style="color: var(--color-text-primary);">
+          Planned with: {modeFeedback.labels.join(' + ')}
+        </p>
+        {#if modeFeedback.summary}
+          <p class="text-sm text-caption">{modeFeedback.summary}</p>
+        {/if}
+      </div>
+    {/if}
     <GeneratedPlanPreview
       meals={preview}
       showPantry={prioritizePantry}
@@ -487,19 +564,29 @@
         {/if}
       {/if}
 
-      <label
-        class="flex items-start gap-3 p-3 rounded-xl"
-        style="background-color: var(--color-input-bg); border: 1px solid var(--color-input-border); color: var(--color-text-primary);"
-      >
-        <input type="checkbox" bind:checked={prioritizePantry} class="mt-1" />
-        <span>
-          <span class="font-semibold">Plan with My Pantry</span>
-          <span class="block text-caption text-sm">
-            Prefer meals that use ingredients you already have. Dietary rules and meal type still
-            come first.
-          </span>
-        </span>
-      </label>
+      <fieldset class="flex flex-col gap-2">
+        <legend class="text-sm font-semibold mb-1" style="color: var(--color-text-primary);"
+          >How should Cheffy plan your week?</legend
+        >
+        <p class="text-xs text-caption -mt-1 mb-1">Pick one or more. Cheffy will weigh them together.</p>
+        <div class="flex flex-wrap gap-2">
+          {#each PLANNING_MODES as mode}
+            <button
+              type="button"
+              class="px-3 py-1.5 rounded-full text-sm font-medium border transition-colors {chipClass(
+                planningPreferences[mode.key]
+              )}"
+              style={planningPreferences[mode.key]
+                ? ''
+                : 'border-color: var(--color-input-border); color: var(--color-text-primary);'}
+              aria-pressed={planningPreferences[mode.key]}
+              on:click={() => toggleMode(mode.key)}
+            >
+              {mode.label}
+            </button>
+          {/each}
+        </div>
+      </fieldset>
 
       <fieldset class="flex flex-col gap-2">
         <legend class="text-sm font-semibold mb-1" style="color: var(--color-text-primary);"

--- a/src/lib/mealplan/attachNourish.test.ts
+++ b/src/lib/mealplan/attachNourish.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { attachCachedNourish } from './attachNourish';
+import type { CandidateNourish } from './planningModes';
 
 const mocks = vi.hoisted(() => ({
   getNourishCache: vi.fn()
@@ -15,7 +16,10 @@ describe('attachCachedNourish', () => {
         protein: { score: 0 }
       }
     });
-    const out = attachCachedNourish({ a: '30023:pk:toast', title: 'Toast' });
+    const out = attachCachedNourish<{ a: string; title: string; nourish?: CandidateNourish }>({
+      a: '30023:pk:toast',
+      title: 'Toast'
+    });
     expect(out.nourish).toEqual({ overall: 0, protein: 0 });
   });
 });

--- a/src/lib/mealplan/attachNourish.test.ts
+++ b/src/lib/mealplan/attachNourish.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest';
+import { attachCachedNourish } from './attachNourish';
+
+const mocks = vi.hoisted(() => ({
+  getNourishCache: vi.fn()
+}));
+
+vi.mock('$lib/nourish/cache', () => ({ getNourishCache: mocks.getNourishCache }));
+
+describe('attachCachedNourish', () => {
+  it('keeps a valid overall score of 0 instead of treating it as missing', () => {
+    mocks.getNourishCache.mockReturnValue({
+      scores: {
+        overall: { score: 0 },
+        protein: { score: 0 }
+      }
+    });
+    const out = attachCachedNourish({ a: '30023:pk:toast', title: 'Toast' });
+    expect(out.nourish).toEqual({ overall: 0, protein: 0 });
+  });
+});

--- a/src/lib/mealplan/attachNourish.ts
+++ b/src/lib/mealplan/attachNourish.ts
@@ -1,0 +1,34 @@
+/**
+ * Attach cached Nourish scores to planner candidates.
+ * Local cache only — never computes or fetches a fresh score.
+ */
+import { getNourishCache } from '$lib/nourish/cache';
+import { NOURISH_PROMPT_VERSION } from '$lib/nourish/types';
+import type { CandidateNourish } from './planningModes';
+
+export function attachCachedNourish<T extends { a: string; nourish?: CandidateNourish }>(
+  candidate: T
+): T {
+  if (candidate.nourish) return candidate;
+  const parts = candidate.a.split(':');
+  if (parts.length !== 3) return candidate;
+  const entry = getNourishCache({
+    recipePubkey: parts[1],
+    recipeDTag: parts[2],
+    promptVersion: NOURISH_PROMPT_VERSION
+  });
+  if (!entry?.scores) return candidate;
+  const nourish: CandidateNourish = {};
+  if (typeof entry.scores.overall?.score === 'number') {
+    nourish.overall = entry.scores.overall.score;
+  }
+  if (typeof entry.scores.protein?.score === 'number') {
+    nourish.protein = entry.scores.protein.score;
+  }
+  const grams = entry.macros?.perServing?.protein_g;
+  if (typeof grams === 'number' && Number.isFinite(grams) && grams > 0) {
+    nourish.proteinGrams = Math.round(grams);
+  }
+  if (!nourish.overall && !nourish.protein && !nourish.proteinGrams) return candidate;
+  return { ...candidate, nourish };
+}

--- a/src/lib/mealplan/attachNourish.ts
+++ b/src/lib/mealplan/attachNourish.ts
@@ -29,6 +29,8 @@ export function attachCachedNourish<T extends { a: string; nourish?: CandidateNo
   if (typeof grams === 'number' && Number.isFinite(grams) && grams > 0) {
     nourish.proteinGrams = Math.round(grams);
   }
-  if (!nourish.overall && !nourish.protein && !nourish.proteinGrams) return candidate;
+  if (nourish.overall == null && nourish.protein == null && nourish.proteinGrams == null) {
+    return candidate;
+  }
   return { ...candidate, nourish };
 }

--- a/src/lib/mealplan/generation.test.ts
+++ b/src/lib/mealplan/generation.test.ts
@@ -327,6 +327,233 @@ describe('filterRecipeCandidates', () => {
     );
     expect(out.map((c) => c.a)).toEqual(['30023:pk:yogurt']);
   });
+
+  it('prefers cheaper recipes when Keep It Cheap is on', () => {
+    const cheap = cand('beans', {
+      title: 'Rice and Beans',
+      ingredients: ['rice', 'black beans', 'onion', 'garlic']
+    });
+    const pricey = cand('surf', {
+      title: 'Truffle Lobster',
+      ingredients: ['lobster', 'truffle', 'saffron', 'crab', 'filet']
+    });
+    const out = filterRecipeCandidates([pricey, cheap], {
+      planningPreferences: {
+        usePantry: false,
+        budgetFriendly: true,
+        healthy: false,
+        highProtein: false,
+        quickMeals: false,
+        lowWaste: false,
+        adventurous: false
+      }
+    });
+    expect(out.map((c) => c.a)).toEqual(['30023:pk:beans', '30023:pk:surf']);
+  });
+
+  it('prefers quicker recipes when Quick Meals is on', () => {
+    const fast = cand('skillet', {
+      title: 'Skillet Eggs',
+      prepTime: '5 min',
+      cookTime: '10 min',
+      ingredients: ['eggs']
+    });
+    const slow = cand('roast', {
+      title: 'Sunday Roast',
+      prepTime: '30 min',
+      cookTime: '3 hours',
+      ingredients: ['beef']
+    });
+    const out = filterRecipeCandidates([slow, fast], {
+      planningPreferences: {
+        usePantry: false,
+        budgetFriendly: false,
+        healthy: false,
+        highProtein: false,
+        quickMeals: true,
+        lowWaste: false,
+        adventurous: false
+      }
+    });
+    expect(out[0].a).toBe('30023:pk:skillet');
+    expect(out.map((c) => c.a)).toContain('30023:pk:roast');
+  });
+
+  it('uses nourish protein when High Protein is on', () => {
+    const high = cand('yogurt', {
+      title: 'Lentil Bowl',
+      ingredients: ['lentils', 'spinach'],
+      nourish: { protein: 9, proteinGrams: 34 }
+    });
+    const low = cand('toast', {
+      title: 'Buttered Toast',
+      ingredients: ['bread', 'butter'],
+      nourish: { protein: 2, proteinGrams: 4 }
+    });
+    const out = filterRecipeCandidates([low, high], {
+      planningPreferences: {
+        usePantry: false,
+        budgetFriendly: false,
+        healthy: false,
+        highProtein: true,
+        quickMeals: false,
+        lowWaste: false,
+        adventurous: false
+      }
+    });
+    expect(out.map((c) => c.a)).toEqual(['30023:pk:yogurt', '30023:pk:toast']);
+  });
+
+  it('uses nourish overall when Healthy Week is on', () => {
+    const strong = cand('bowl', {
+      title: 'Grain Bowl',
+      ingredients: ['quinoa', 'kale'],
+      nourish: { overall: 9 }
+    });
+    const weak = cand('fries', {
+      title: 'Loaded Fries',
+      ingredients: ['potato', 'cheese'],
+      nourish: { overall: 2 }
+    });
+    const out = filterRecipeCandidates([weak, strong], {
+      planningPreferences: {
+        usePantry: false,
+        budgetFriendly: false,
+        healthy: true,
+        highProtein: false,
+        quickMeals: false,
+        lowWaste: false,
+        adventurous: false
+      }
+    });
+    expect(out[0].a).toBe('30023:pk:bowl');
+  });
+
+  it('prefers recipes that share ingredients when Low Waste is on', () => {
+    const sharedA = cand('tacos', {
+      title: 'Chicken Tacos',
+      ingredients: ['chicken', 'spinach', 'tortillas', 'salsa']
+    });
+    const sharedB = cand('quesadilla', {
+      title: 'Spinach Quesadilla',
+      ingredients: ['spinach', 'tortillas', 'cheese']
+    });
+    const odd = cand('sushi', {
+      title: 'Tuna Sushi',
+      ingredients: ['tuna', 'nori', 'rice vinegar', 'wasabi']
+    });
+    const out = filterRecipeCandidates([odd, sharedA, sharedB], {
+      planningPreferences: {
+        usePantry: false,
+        budgetFriendly: false,
+        healthy: false,
+        highProtein: false,
+        quickMeals: false,
+        lowWaste: true,
+        adventurous: false
+      }
+    });
+    expect(out.slice(0, 2).map((c) => c.a).sort()).toEqual([
+      '30023:pk:quesadilla',
+      '30023:pk:tacos'
+    ]);
+  });
+
+  it('deprioritizes familiar recipes when Try Something New is on', () => {
+    const usual = cand('usual', { title: 'Usual Chili', tags: ['american'] });
+    const fresh = cand('fresh', { title: 'Thai Basil Stir Fry', tags: ['thai'] });
+    const thinHistory = filterRecipeCandidates([usual, fresh], {
+      familiarCoordinates: ['30023:pk:usual'],
+      planningPreferences: {
+        usePantry: false,
+        budgetFriendly: false,
+        healthy: false,
+        highProtein: false,
+        quickMeals: false,
+        lowWaste: false,
+        adventurous: true
+      }
+    });
+    expect(thinHistory.map((c) => c.a)).toContain('30023:pk:fresh');
+    expect(thinHistory).toHaveLength(2);
+
+    const withHistory = filterRecipeCandidates([usual, fresh], {
+      familiarCoordinates: ['30023:pk:usual', '30023:pk:other1', '30023:pk:other2'],
+      planningPreferences: {
+        usePantry: false,
+        budgetFriendly: false,
+        healthy: false,
+        highProtein: false,
+        quickMeals: false,
+        lowWaste: false,
+        adventurous: true
+      }
+    });
+    expect(withHistory[0].a).toBe('30023:pk:fresh');
+  });
+
+  it('still returns candidates when conflicting modes are combined', () => {
+    const out = filterRecipeCandidates(
+      [
+        cand('beans', {
+          title: 'Rice and Beans',
+          tags: ['budget'],
+          prepTime: '10 min',
+          cookTime: '20 min',
+          ingredients: ['rice', 'black beans', 'eggs'],
+          nourish: { overall: 7, protein: 6, proteinGrams: 22 }
+        }),
+        cand('fancy', {
+          title: 'Saffron Scallops',
+          prepTime: '20 min',
+          cookTime: '15 min',
+          ingredients: ['scallops', 'saffron'],
+          nourish: { overall: 8, protein: 8, proteinGrams: 28 }
+        })
+      ],
+      {
+        planningPreferences: {
+          usePantry: false,
+          budgetFriendly: true,
+          healthy: false,
+          highProtein: true,
+          quickMeals: true,
+          lowWaste: false,
+          adventurous: true
+        },
+        familiarCoordinates: ['30023:pk:beans']
+      }
+    );
+    expect(out.length).toBe(2);
+  });
+
+  it('keeps breakfast eligibility when planning modes are on', () => {
+    const out = filterRecipeCandidates(
+      [
+        cand('chicken', {
+          title: 'Garlic Parmesan Chicken',
+          tags: ['dinner'],
+          nourish: { protein: 10, proteinGrams: 45 },
+          prepTime: '10 min',
+          cookTime: '15 min'
+        }),
+        cand('oats', { title: 'Overnight Oats', tags: ['breakfast'] })
+      ],
+      {
+        mealSlots: ['breakfast'],
+        planningPreferences: {
+          usePantry: false,
+          budgetFriendly: true,
+          healthy: true,
+          highProtein: true,
+          quickMeals: true,
+          lowWaste: true,
+          adventurous: true
+        }
+      }
+    );
+    expect(out.map((c) => c.a)).toEqual(['30023:pk:oats']);
+  });
 });
 
 describe('resolveTargetSlots', () => {
@@ -410,6 +637,47 @@ describe('parseGenerationRequest', () => {
     expect(parsed.request.prioritizePantry).toBe(true);
     expect(parsed.request.candidates[0].pantry?.matchedCount).toBe(2);
     expect(parsed.request.candidates[0].pantry?.missingIngredients).toEqual(['salmon', 'lemon']);
+  });
+
+  it('keeps planningPreferences and maps usePantry onto prioritizePantry', () => {
+    const parsed = parseGenerationRequest({
+      weekId: '2026-W34',
+      days: ['mon'],
+      mealSlots: ['dinner'],
+      strategy: 'fill-empty',
+      planningPreferences: {
+        usePantry: true,
+        budgetFriendly: true,
+        healthy: false,
+        highProtein: true,
+        quickMeals: false,
+        lowWaste: true,
+        adventurous: false
+      },
+      familiarCoordinates: ['30023:pk:usual', 'not-a-coord'],
+      candidates: [
+        cand('salmon', {
+          title: 'Salmon',
+          nourish: { overall: 8, protein: 7, proteinGrams: 31 }
+        })
+      ]
+    });
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.request.prioritizePantry).toBe(true);
+    expect(parsed.request.planningPreferences).toMatchObject({
+      usePantry: true,
+      budgetFriendly: true,
+      highProtein: true,
+      lowWaste: true,
+      adventurous: false
+    });
+    expect(parsed.request.familiarCoordinates).toEqual(['30023:pk:usual']);
+    expect(parsed.request.candidates[0].nourish).toEqual({
+      overall: 8,
+      protein: 7,
+      proteinGrams: 31
+    });
   });
 
   it('keeps pantryIngredients when prioritizePantry is on', () => {

--- a/src/lib/mealplan/generation.ts
+++ b/src/lib/mealplan/generation.ts
@@ -15,6 +15,26 @@ import {
 } from './schema';
 import { isValidWeekId } from './week';
 import { isRecipeEligibleForSlot, restrictCandidatesToRequestedSlots } from './slotEligibility';
+import {
+  QUICK_SOFT_MAX_MINUTES,
+  buildIngredientFrequency,
+  collectFamiliarCuisines,
+  hasEnabledPlanningMode,
+  normalizePlanningPreferences,
+  sanitizePlanningPreferences,
+  scorePlanningModes,
+  type PlanningPreferences,
+  type CandidateNourish
+} from './planningModes';
+
+export type { PlanningPreferences, PlanningModeKey, CandidateNourish } from './planningModes';
+export {
+  PLANNING_MODES,
+  PLANNING_MODE_KEYS,
+  emptyPlanningPreferences,
+  hasEnabledPlanningMode,
+  normalizePlanningPreferences
+} from './planningModes';
 
 export const MEAL_PLAN_STRATEGIES = ['fill-empty', 'replace-selected'] as const;
 export type MealPlanStrategy = (typeof MEAL_PLAN_STRATEGIES)[number];
@@ -76,6 +96,8 @@ export interface RecipeCandidate {
   servings?: string;
   /** Deterministic pantry match. Never invented by Cheffy. */
   pantry?: CandidatePantryMatch;
+  /** Cached Nourish signals only. Never invented or computed here. */
+  nourish?: CandidateNourish;
 }
 
 export interface MealPlanPreferences {
@@ -101,6 +123,17 @@ export interface MealPlanGenerationRequest {
   prioritizePantry?: boolean;
   /** Display names of pantry ingredients. Prompt-only; never persisted. */
   pantryIngredients?: string[];
+  /**
+   * Weighted planning modes (pantry, cheap, healthy, …). Prompt-only;
+   * never persisted into the meal-plan schema. Extensible — add keys
+   * in planningModes.ts without changing the planner contract.
+   */
+  planningPreferences?: PlanningPreferences;
+  /**
+   * Recipe coordinates the user has already saved or planned.
+   * Used by Try Something New. Prompt-only; never persisted.
+   */
+  familiarCoordinates?: string[];
   candidates: RecipeCandidate[];
   /** Slots that already have a meal. Required for fill-empty enforcement. */
   occupiedSlots?: MealSlotRef[];
@@ -373,6 +406,8 @@ export interface FilterCandidatesOptions {
   mealSlots?: MealSlotKey[];
   /** Soft-prefer higher pantry match after hard constraints. */
   prioritizePantry?: boolean;
+  planningPreferences?: PlanningPreferences;
+  familiarCoordinates?: string[];
   maxCandidates?: number;
 }
 
@@ -410,7 +445,8 @@ export function filterRecipeCandidates(
   const slotEligible =
     mealSlots.length > 0 ? restrictCandidatesToRequestedSlots(hardPassed, mealSlots) : hardPassed;
 
-  const prioritizePantry = !!opts.prioritizePantry;
+  const modes = normalizePlanningPreferences(opts.planningPreferences, opts.prioritizePantry);
+  const prioritizePantry = modes.usePantry;
   let ranked = slotEligible;
   if (!surpriseOnly && styleTags.length > 0) {
     const matched = slotEligible.filter((c) => candidateMatchesStyle(c, styleTags));
@@ -418,18 +454,40 @@ export function filterRecipeCandidates(
     // If we have enough style matches to cover a week with extras, drop
     // the rest. Otherwise keep unmatched as fallback so Cheffy can still plan.
     ranked = matched.length >= 8 ? matched : [...matched, ...unmatched];
-  } else if (surpriseOnly && !prioritizePantry) {
+  } else if (surpriseOnly && !hasEnabledPlanningMode(modes)) {
     ranked = shuffleInPlace([...slotEligible]);
   }
 
+  if (modes.quickMeals) {
+    const quickEnough = ranked.filter((c) => {
+      const minutes = totalActiveMinutes(c.prepTime, c.cookTime);
+      return minutes == null || minutes <= QUICK_SOFT_MAX_MINUTES;
+    });
+    if (quickEnough.length >= 8) ranked = quickEnough;
+  }
+
   const slotNeedles = mealSlots.map((s) => s.toLowerCase());
+  const familiarCoordinates = new Set(opts.familiarCoordinates || []);
+  const familiarCuisines = collectFamiliarCuisines(ranked, familiarCoordinates);
+  const ingredientFrequency = buildIngredientFrequency(ranked);
   const shouldScore =
-    prioritizePantry || (!surpriseOnly && (styleTags.length > 0 || mealSlots.length > 0));
+    hasEnabledPlanningMode(modes) ||
+    (!surpriseOnly && (styleTags.length > 0 || mealSlots.length > 0));
   if (shouldScore) {
     ranked = [...ranked].sort(
       (a, b) =>
-        scoreCandidate(b, styleTags, slotNeedles, prioritizePantry) -
-        scoreCandidate(a, styleTags, slotNeedles, prioritizePantry)
+        scoreCandidate(b, styleTags, slotNeedles, modes, {
+          minutes: totalActiveMinutes(b.prepTime, b.cookTime),
+          ingredientFrequency,
+          familiarCoordinates,
+          familiarCuisines
+        }) -
+        scoreCandidate(a, styleTags, slotNeedles, modes, {
+          minutes: totalActiveMinutes(a.prepTime, a.cookTime),
+          ingredientFrequency,
+          familiarCoordinates,
+          familiarCuisines
+        })
     );
   }
 
@@ -440,7 +498,13 @@ function scoreCandidate(
   c: RecipeCandidate,
   styleTags: string[],
   slotNeedles: string[],
-  prioritizePantry: boolean
+  modes: PlanningPreferences,
+  modeCtx: {
+    minutes: number | null;
+    ingredientFrequency: Map<string, number>;
+    familiarCoordinates: Set<string>;
+    familiarCuisines: Set<string>;
+  }
 ): number {
   let score = 0;
   const blob = textBlob([c.title, ...(c.tags || [])]);
@@ -448,9 +512,7 @@ function scoreCandidate(
   if (slotNeedles.some((t) => blob.includes(t))) score += 2;
   if (c.prepTime || c.cookTime) score += 1;
   if (c.ingredients?.length) score += 1;
-  if (prioritizePantry && c.pantry && c.pantry.totalCount > 0) {
-    score += c.pantry.matchRatio * 5;
-  }
+  score += scorePlanningModes(c, modes, modeCtx);
   return score;
 }
 
@@ -518,7 +580,25 @@ function sanitizeCandidate(raw: unknown): RecipeCandidate | null {
   }
   const pantry = sanitizeCandidatePantry(r.pantry);
   if (pantry) candidate.pantry = pantry;
+  const nourish = sanitizeCandidateNourish(r.nourish);
+  if (nourish) candidate.nourish = nourish;
   return candidate;
+}
+
+function sanitizeCandidateNourish(raw: unknown): CandidateNourish | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const n = raw as Record<string, unknown>;
+  const out: CandidateNourish = {};
+  if (typeof n.overall === 'number' && Number.isFinite(n.overall)) {
+    out.overall = Math.min(10, Math.max(0, Math.round(n.overall)));
+  }
+  if (typeof n.protein === 'number' && Number.isFinite(n.protein)) {
+    out.protein = Math.min(10, Math.max(0, Math.round(n.protein)));
+  }
+  if (typeof n.proteinGrams === 'number' && Number.isFinite(n.proteinGrams) && n.proteinGrams > 0) {
+    out.proteinGrams = Math.min(200, Math.round(n.proteinGrams));
+  }
+  return out.overall != null || out.protein != null || out.proteinGrams != null ? out : undefined;
 }
 
 function sanitizeCandidatePantry(raw: unknown): CandidatePantryMatch | undefined {
@@ -671,7 +751,16 @@ export function parseGenerationRequest(
       ? body.excludeCoordinates.filter(isRecipeCoordinate).slice(0, MAX_CANDIDATES)
       : []
   };
-  if (body.prioritizePantry === true) request.prioritizePantry = true;
+  const planningPreferences = normalizePlanningPreferences(
+    sanitizePlanningPreferences(body.planningPreferences),
+    body.prioritizePantry === true
+  );
+  if (hasEnabledPlanningMode(planningPreferences)) {
+    request.planningPreferences = planningPreferences;
+  }
+  if (planningPreferences.usePantry || body.prioritizePantry === true) {
+    request.prioritizePantry = true;
+  }
   if (Array.isArray(body.pantryIngredients)) {
     const pantryIngredients = body.pantryIngredients
       .filter((s): s is string => typeof s === 'string')
@@ -679,6 +768,12 @@ export function parseGenerationRequest(
       .filter(Boolean)
       .slice(0, MAX_PANTRY_INGREDIENTS);
     if (pantryIngredients.length) request.pantryIngredients = pantryIngredients;
+  }
+  if (Array.isArray(body.familiarCoordinates)) {
+    const familiarCoordinates = body.familiarCoordinates
+      .filter(isRecipeCoordinate)
+      .slice(0, MAX_CANDIDATES * 2);
+    if (familiarCoordinates.length) request.familiarCoordinates = familiarCoordinates;
   }
 
   const targets = resolveTargetSlots(request);

--- a/src/lib/mealplan/planningModes.test.ts
+++ b/src/lib/mealplan/planningModes.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest';
+import {
+  costHint,
+  emptyPlanningPreferences,
+  familiarCoordinatesFromSources,
+  hasEnabledPlanningMode,
+  normalizePlanningPreferences,
+  overlappingIngredientHints,
+  planningModePromptLines,
+  planningPreferencesFromKeys,
+  sanitizePlanningPreferences,
+  scorePlanningModes,
+  summarizePlanningModeFeedback,
+  togglePlanningMode
+} from './planningModes';
+
+describe('sanitizePlanningPreferences', () => {
+  it('defaults every mode off and ignores unknown keys', () => {
+    expect(sanitizePlanningPreferences(undefined)).toEqual(emptyPlanningPreferences());
+    expect(
+      sanitizePlanningPreferences({ usePantry: true, notAMode: true, healthy: 'yes' })
+    ).toEqual({
+      ...emptyPlanningPreferences(),
+      usePantry: true
+    });
+  });
+
+  it('treats prioritizePantry as Use My Pantry', () => {
+    const prefs = normalizePlanningPreferences(undefined, true);
+    expect(prefs.usePantry).toBe(true);
+    expect(hasEnabledPlanningMode(prefs)).toBe(true);
+  });
+});
+
+describe('togglePlanningMode', () => {
+  it('toggles a single mode without clearing others', () => {
+    const start = planningPreferencesFromKeys(['healthy']);
+    const next = togglePlanningMode(start, 'quickMeals');
+    expect(next.healthy).toBe(true);
+    expect(next.quickMeals).toBe(true);
+    expect(togglePlanningMode(next, 'healthy').healthy).toBe(false);
+  });
+});
+
+describe('scorePlanningModes', () => {
+  const emptyCtx = {
+    minutes: null as number | null,
+    ingredientFrequency: new Map<string, number>(),
+    familiarCoordinates: new Set<string>(),
+    familiarCuisines: new Set<string>()
+  };
+
+  it('scores budget vs pricey without inventing prices', () => {
+    const cheap = scorePlanningModes(
+      {
+        a: '30023:pk:beans',
+        title: 'Rice and Beans',
+        tags: [],
+        ingredients: ['rice', 'black beans', 'onion']
+      },
+      { ...emptyPlanningPreferences(), budgetFriendly: true },
+      emptyCtx
+    );
+    const pricey = scorePlanningModes(
+      {
+        a: '30023:pk:surf',
+        title: 'Truffle Lobster',
+        tags: [],
+        ingredients: ['lobster', 'truffle', 'saffron']
+      },
+      { ...emptyPlanningPreferences(), budgetFriendly: true },
+      emptyCtx
+    );
+    expect(costHint({ a: 'x', title: 'Rice and Beans', tags: [], ingredients: ['rice', 'beans'] })).toBe(
+      'budget'
+    );
+    expect(cheap).toBeGreaterThan(pricey);
+  });
+
+  it('uses nourish protein grams ahead of title keywords', () => {
+    const withMacros = scorePlanningModes(
+      {
+        a: '30023:pk:a',
+        title: 'Salad',
+        tags: [],
+        ingredients: ['lettuce'],
+        nourish: { proteinGrams: 40, protein: 8 }
+      },
+      { ...emptyPlanningPreferences(), highProtein: true },
+      emptyCtx
+    );
+    const keywordsOnly = scorePlanningModes(
+      {
+        a: '30023:pk:b',
+        title: 'Chicken Chicken',
+        tags: ['protein'],
+        ingredients: ['chicken']
+      },
+      { ...emptyPlanningPreferences(), highProtein: true },
+      emptyCtx
+    );
+    expect(withMacros).toBeGreaterThan(keywordsOnly);
+  });
+});
+
+describe('planningModePromptLines', () => {
+  it('emits an explicit instruction per enabled mode', () => {
+    const lines = planningModePromptLines({
+      ...emptyPlanningPreferences(),
+      usePantry: true,
+      budgetFriendly: true,
+      quickMeals: true
+    });
+    const text = lines.join('\n');
+    expect(text).toContain('Use My Pantry:');
+    expect(text).toContain('Keep It Cheap:');
+    expect(text).toContain('Quick Meals:');
+    expect(text).not.toContain('Make this healthy and cheap');
+    expect(text).toContain('weighted preferences');
+  });
+
+  it('returns nothing when no modes are on', () => {
+    expect(planningModePromptLines(emptyPlanningPreferences())).toEqual([]);
+  });
+});
+
+describe('summarizePlanningModeFeedback', () => {
+  it('only reports pantry and reuse counts that can be counted', () => {
+    const feedback = summarizePlanningModeFeedback({
+      preferences: {
+        ...emptyPlanningPreferences(),
+        usePantry: true,
+        lowWaste: true,
+        budgetFriendly: true
+      },
+      meals: [
+        {
+          a: '30023:pk:tacos',
+          pantry: { matchedIngredients: ['chicken', 'spinach'] }
+        },
+        {
+          a: '30023:pk:quesadilla',
+          pantry: { matchedIngredients: ['spinach'] }
+        }
+      ],
+      recipes: [
+        { a: '30023:pk:tacos', ingredients: ['chicken', 'spinach', 'tortillas', 'salt'] },
+        { a: '30023:pk:quesadilla', ingredients: ['spinach', 'tortillas', 'cheese'] }
+      ]
+    });
+    expect(feedback?.labels).toEqual(['Pantry', 'Cheap', 'Low Waste']);
+    expect(feedback?.summary).toContain('2 pantry ingredients used');
+    expect(feedback?.summary).toContain('2 ingredients reused across meals');
+    expect(feedback?.summary).not.toMatch(/\$|saved|calories/);
+  });
+
+  it('mentions 30 minutes only when most meals have known short times', () => {
+    const feedback = summarizePlanningModeFeedback({
+      preferences: { ...emptyPlanningPreferences(), quickMeals: true },
+      meals: [{ a: '30023:pk:a' }, { a: '30023:pk:b' }],
+      recipes: [
+        { a: '30023:pk:a', minutes: 20 },
+        { a: '30023:pk:b', minutes: 25 }
+      ]
+    });
+    expect(feedback?.summary).toBe('Most meals are ready in about 30 minutes.');
+  });
+});
+
+describe('overlappingIngredientHints', () => {
+  it('lists ingredients that appear in more than one recipe', () => {
+    expect(
+      overlappingIngredientHints([
+        { ingredients: ['chicken', 'spinach', 'salt'] },
+        { ingredients: ['spinach', 'tortillas'] },
+        { ingredients: ['tuna'] }
+      ])
+    ).toEqual(['spinach']);
+  });
+});
+
+describe('familiarCoordinatesFromSources', () => {
+  it('dedupes saved and planned coordinates', () => {
+    expect(
+      familiarCoordinatesFromSources({
+        savedAs: ['30023:pk:a', '30023:pk:b'],
+        plannedAs: ['30023:pk:b', '30023:pk:c']
+      })
+    ).toEqual(['30023:pk:a', '30023:pk:b', '30023:pk:c']);
+  });
+});

--- a/src/lib/mealplan/planningModes.ts
+++ b/src/lib/mealplan/planningModes.ts
@@ -1,0 +1,655 @@
+/**
+ * Cheffy meal-planning modes — weighted preferences on the existing
+ * planner, not separate planners. Types, ranking signals, prompt copy,
+ * and lightweight plan feedback live here so we can add modes later
+ * without redesigning generation.
+ */
+
+import { normalizeIngredientName } from '$lib/pantry/normalization';
+
+export const PLANNING_MODE_KEYS = [
+  'usePantry',
+  'budgetFriendly',
+  'healthy',
+  'highProtein',
+  'quickMeals',
+  'lowWaste',
+  'adventurous'
+] as const;
+
+export type PlanningModeKey = (typeof PLANNING_MODE_KEYS)[number];
+
+export interface PlanningPreferences {
+  usePantry: boolean;
+  budgetFriendly: boolean;
+  healthy: boolean;
+  highProtein: boolean;
+  quickMeals: boolean;
+  lowWaste: boolean;
+  adventurous: boolean;
+}
+
+export interface CandidateNourish {
+  /** Nourish overall, 0–10. Omitted when no cached score exists. */
+  overall?: number;
+  /** Nourish protein dimension, 0–10. */
+  protein?: number;
+  /** Estimated grams of protein per serving, when macros exist. */
+  proteinGrams?: number;
+}
+
+export interface ModeScorable {
+  a: string;
+  title: string;
+  tags: string[];
+  ingredients: string[];
+  pantry?: { matchRatio: number; totalCount: number };
+  nourish?: CandidateNourish;
+}
+
+export const PLANNING_MODES: readonly {
+  key: PlanningModeKey;
+  label: string;
+  shortLabel: string;
+}[] = [
+  { key: 'usePantry', label: 'Use My Pantry', shortLabel: 'Pantry' },
+  { key: 'budgetFriendly', label: 'Keep It Cheap', shortLabel: 'Cheap' },
+  { key: 'healthy', label: 'Healthy Week', shortLabel: 'Healthy' },
+  { key: 'highProtein', label: 'High Protein', shortLabel: 'High Protein' },
+  { key: 'quickMeals', label: 'Quick Meals', shortLabel: 'Quick' },
+  { key: 'lowWaste', label: 'Low Waste', shortLabel: 'Low Waste' },
+  { key: 'adventurous', label: 'Try Something New', shortLabel: 'New' }
+] as const;
+
+export const QUICK_TARGET_MINUTES = 30;
+export const QUICK_SOFT_MAX_MINUTES = 45;
+export const QUICK_OBVIOUS_LONG_MINUTES = 90;
+
+const STORAGE_KEY = 'zap.cheffy.planningModes';
+const MODE_KEY_SET = new Set<string>(PLANNING_MODE_KEYS);
+
+const CHEAP_SIGNALS = [
+  'bean',
+  'lentil',
+  'chickpea',
+  'egg',
+  'tofu',
+  'rice',
+  'pasta',
+  'noodle',
+  'oat',
+  'potato',
+  'onion',
+  'carrot',
+  'cabbage',
+  'tomato',
+  'garlic',
+  'chicken',
+  'turkey',
+  'tuna',
+  'sardine',
+  'peanut',
+  'black bean',
+  'pinto',
+  'kidney bean'
+];
+
+const PRICEY_SIGNALS = [
+  'lobster',
+  'scallop',
+  'filet',
+  'fillet mignon',
+  'ribeye',
+  'wagyu',
+  'truffle',
+  'saffron',
+  'prosciutto',
+  'pine nut',
+  'crab',
+  'oyster',
+  'caviar',
+  'foie',
+  'veal',
+  'lamb chop',
+  'duck breast',
+  'halibut',
+  'sea bass',
+  'shrimp',
+  'prawn',
+  'asparagus',
+  'artichoke',
+  'goat cheese',
+  'manchego',
+  'pecorino'
+];
+
+const PROTEIN_SIGNALS = [
+  'chicken',
+  'turkey',
+  'beef',
+  'pork',
+  'tofu',
+  'tempeh',
+  'egg',
+  'yogurt',
+  'greek yogurt',
+  'cottage cheese',
+  'lentil',
+  'bean',
+  'chickpea',
+  'salmon',
+  'tuna',
+  'cod',
+  'shrimp',
+  'fish',
+  'steak',
+  'protein'
+];
+
+const HEALTHY_SIGNALS = [
+  'vegetable',
+  'salad',
+  'grain',
+  'bowl',
+  'lentil',
+  'bean',
+  'broccoli',
+  'spinach',
+  'kale',
+  'quinoa',
+  'oat',
+  'yogurt',
+  'berry',
+  'avocado',
+  'nourish',
+  'healthy',
+  'whole grain'
+];
+
+const CUISINE_TAGS = [
+  'italian',
+  'mexican',
+  'tex-mex',
+  'thai',
+  'indian',
+  'japanese',
+  'korean',
+  'chinese',
+  'mediterranean',
+  'greek',
+  'french',
+  'vietnamese',
+  'spanish',
+  'middle eastern',
+  'lebanese',
+  'moroccan',
+  'ethiopian',
+  'caribbean',
+  'cajun',
+  'american',
+  'southern',
+  'german',
+  'peruvian',
+  'brazilian',
+  'filipino',
+  'indonesian',
+  'turkish',
+  'persian'
+];
+
+/** Salt / water / plain oil — reuse is real but not a useful user metric. */
+const FEEDBACK_STAPLES = new Set([
+  'salt',
+  'pepper',
+  'black pepper',
+  'water',
+  'oil',
+  'olive oil',
+  'vegetable oil',
+  'cooking spray'
+]);
+
+const PROTEIN_VARIETY_SOURCES = [
+  'chicken',
+  'turkey',
+  'beef',
+  'pork',
+  'fish',
+  'salmon',
+  'tuna',
+  'shrimp',
+  'tofu',
+  'tempeh',
+  'egg',
+  'lentil',
+  'bean',
+  'yogurt'
+];
+
+export function emptyPlanningPreferences(): PlanningPreferences {
+  return {
+    usePantry: false,
+    budgetFriendly: false,
+    healthy: false,
+    highProtein: false,
+    quickMeals: false,
+    lowWaste: false,
+    adventurous: false
+  };
+}
+
+export function isPlanningModeKey(value: unknown): value is PlanningModeKey {
+  return typeof value === 'string' && MODE_KEY_SET.has(value);
+}
+
+export function sanitizePlanningPreferences(raw: unknown): PlanningPreferences {
+  const prefs = emptyPlanningPreferences();
+  if (!raw || typeof raw !== 'object') return prefs;
+  const src = raw as Record<string, unknown>;
+  for (const key of PLANNING_MODE_KEYS) {
+    if (src[key] === true) prefs[key] = true;
+  }
+  return prefs;
+}
+
+/** Merge wire prefs with the older prioritizePantry flag. */
+export function normalizePlanningPreferences(
+  raw?: Partial<PlanningPreferences> | null,
+  prioritizePantry?: boolean
+): PlanningPreferences {
+  const prefs = sanitizePlanningPreferences(raw ?? {});
+  if (prioritizePantry) prefs.usePantry = true;
+  return prefs;
+}
+
+export function hasEnabledPlanningMode(prefs: PlanningPreferences): boolean {
+  return PLANNING_MODE_KEYS.some((key) => prefs[key]);
+}
+
+export function enabledPlanningModeKeys(prefs: PlanningPreferences): PlanningModeKey[] {
+  return PLANNING_MODE_KEYS.filter((key) => prefs[key]);
+}
+
+export function togglePlanningMode(
+  prefs: PlanningPreferences,
+  key: PlanningModeKey
+): PlanningPreferences {
+  return { ...prefs, [key]: !prefs[key] };
+}
+
+export function planningPreferencesFromKeys(keys: Iterable<string>): PlanningPreferences {
+  const prefs = emptyPlanningPreferences();
+  for (const key of keys) {
+    if (isPlanningModeKey(key)) prefs[key] = true;
+  }
+  return prefs;
+}
+
+export function planningModeLabel(key: PlanningModeKey): string {
+  return PLANNING_MODES.find((m) => m.key === key)?.label ?? key;
+}
+
+export function planningModeShortLabel(key: PlanningModeKey): string {
+  return PLANNING_MODES.find((m) => m.key === key)?.shortLabel ?? key;
+}
+
+function canUseLocalStorage(): boolean {
+  try {
+    return typeof localStorage !== 'undefined';
+  } catch {
+    return false;
+  }
+}
+
+export function loadPlanningModes(): PlanningPreferences {
+  if (!canUseLocalStorage()) return emptyPlanningPreferences();
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return emptyPlanningPreferences();
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return planningPreferencesFromKeys(parsed);
+    return sanitizePlanningPreferences(parsed);
+  } catch {
+    return emptyPlanningPreferences();
+  }
+}
+
+export function savePlanningModes(prefs: PlanningPreferences): void {
+  if (!canUseLocalStorage()) return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(enabledPlanningModeKeys(prefs)));
+  } catch {
+    // private mode / quota — skip
+  }
+}
+
+function textBlob(parts: Array<string | undefined>): string {
+  return parts
+    .filter((p): p is string => typeof p === 'string' && p.length > 0)
+    .join(' ')
+    .toLowerCase();
+}
+
+function containsAny(haystack: string, needles: string[]): boolean {
+  return needles.some((n) => n && haystack.includes(n));
+}
+
+function countHits(haystack: string, needles: string[]): number {
+  let n = 0;
+  for (const needle of needles) {
+    if (needle && haystack.includes(needle)) n += 1;
+  }
+  return n;
+}
+
+export function cuisineTagsOf(c: { title: string; tags: string[] }): string[] {
+  const blob = textBlob([c.title, ...(c.tags || [])]);
+  return CUISINE_TAGS.filter((tag) => blob.includes(tag));
+}
+
+export function collectFamiliarCuisines(
+  candidates: Array<{ a: string; title: string; tags: string[] }>,
+  familiar: Set<string>
+): Set<string> {
+  const out = new Set<string>();
+  for (const c of candidates) {
+    if (!familiar.has(c.a)) continue;
+    for (const tag of cuisineTagsOf(c)) out.add(tag);
+  }
+  return out;
+}
+
+export function uniqueNormalizedIngredients(ingredients: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of ingredients || []) {
+    const name = normalizeIngredientName(raw);
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    out.push(name);
+  }
+  return out;
+}
+
+export function buildIngredientFrequency(
+  candidates: Array<{ ingredients: string[] }>
+): Map<string, number> {
+  const freq = new Map<string, number>();
+  for (const c of candidates) {
+    for (const name of uniqueNormalizedIngredients(c.ingredients || [])) {
+      freq.set(name, (freq.get(name) ?? 0) + 1);
+    }
+  }
+  return freq;
+}
+
+/** Shared ingredients that appear in 2+ candidates — a Low Waste hint. */
+export function overlappingIngredientHints(
+  candidates: Array<{ ingredients: string[] }>,
+  cap = 16
+): string[] {
+  const freq = buildIngredientFrequency(candidates);
+  return [...freq.entries()]
+    .filter(([name, count]) => count >= 2 && !FEEDBACK_STAPLES.has(name))
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, cap)
+    .map(([name]) => name);
+}
+
+export function costHint(c: ModeScorable): 'budget' | 'pricey' | 'typical' {
+  const blob = textBlob([c.title, ...(c.tags || []), ...(c.ingredients || [])]);
+  const cheap = countHits(blob, CHEAP_SIGNALS);
+  const pricey = countHits(blob, PRICEY_SIGNALS);
+  if (pricey >= 2 || (pricey >= 1 && cheap === 0 && (c.ingredients?.length ?? 0) > 8)) {
+    return 'pricey';
+  }
+  if (cheap >= 2 && pricey === 0) return 'budget';
+  if (pricey >= 1 && cheap === 0) return 'pricey';
+  return 'typical';
+}
+
+function proteinSourceCount(blob: string): number {
+  return countHits(blob, PROTEIN_VARIETY_SOURCES);
+}
+
+export interface ModeScoreContext {
+  minutes: number | null;
+  ingredientFrequency: Map<string, number>;
+  familiarCoordinates: Set<string>;
+  familiarCuisines: Set<string>;
+}
+
+/**
+ * Soft score for enabled modes. Hard constraints (allergies, vegetarian,
+ * breakfast eligibility, explicit time limits) are applied elsewhere.
+ */
+export function scorePlanningModes(
+  c: ModeScorable,
+  prefs: PlanningPreferences,
+  ctx: ModeScoreContext
+): number {
+  let score = 0;
+  const blob = textBlob([c.title, ...(c.tags || []), ...(c.ingredients || [])]);
+
+  if (prefs.usePantry && c.pantry && c.pantry.totalCount > 0) {
+    score += c.pantry.matchRatio * 5;
+  }
+
+  if (prefs.budgetFriendly) {
+    const hint = costHint(c);
+    if (hint === 'budget') score += 3;
+    else if (hint === 'pricey') score -= 3;
+    const extras = Math.max(0, (c.ingredients?.length ?? 0) - 8);
+    score -= extras * 0.25;
+  }
+
+  if (prefs.healthy) {
+    if (typeof c.nourish?.overall === 'number') {
+      score += (c.nourish.overall / 10) * 4;
+    } else {
+      score += Math.min(2, countHits(blob, HEALTHY_SIGNALS) * 0.6);
+    }
+  }
+
+  if (prefs.highProtein) {
+    if (typeof c.nourish?.proteinGrams === 'number' && c.nourish.proteinGrams > 0) {
+      score += Math.min(4, c.nourish.proteinGrams / 10);
+    } else if (typeof c.nourish?.protein === 'number') {
+      score += (c.nourish.protein / 10) * 4;
+    } else {
+      score += Math.min(2.5, countHits(blob, PROTEIN_SIGNALS) * 0.7);
+    }
+    // Variety: a second protein family is a small plus; chicken-only is enough.
+    if (proteinSourceCount(blob) >= 2) score += 0.4;
+  }
+
+  if (prefs.quickMeals) {
+    if (ctx.minutes != null) {
+      if (ctx.minutes <= QUICK_TARGET_MINUTES) score += 4;
+      else if (ctx.minutes <= QUICK_SOFT_MAX_MINUTES) score += 2;
+      else if (ctx.minutes <= QUICK_OBVIOUS_LONG_MINUTES) score -= 2;
+      else score -= 4;
+    }
+  }
+
+  if (prefs.lowWaste) {
+    const names = uniqueNormalizedIngredients(c.ingredients || []);
+    let overlap = 0;
+    for (const name of names) {
+      if (FEEDBACK_STAPLES.has(name)) continue;
+      const freq = ctx.ingredientFrequency.get(name) ?? 0;
+      if (freq >= 2) overlap += 1;
+    }
+    score += Math.min(4, overlap * 0.7);
+  }
+
+  if (prefs.adventurous) {
+    if (ctx.familiarCoordinates.size >= 3) {
+      if (ctx.familiarCoordinates.has(c.a)) score -= 2.5;
+      else score += 1.5;
+      const cuisines = cuisineTagsOf(c);
+      if (cuisines.some((tag) => !ctx.familiarCuisines.has(tag))) score += 1.5;
+    } else if (cuisineTagsOf(c).length > 0) {
+      score += 0.8;
+    }
+  }
+
+  return score;
+}
+
+export function planningModePromptLines(prefs: PlanningPreferences): string[] {
+  if (!hasEnabledPlanningMode(prefs)) return [];
+  const labels = enabledPlanningModeKeys(prefs).map(planningModeLabel);
+  const lines = [
+    `Planning modes (weighted preferences, not hard requirements): ${labels.join(', ')}`,
+    'Dietary exclusions, vegetarian requests, breakfast eligibility, and explicit cooking-time limits still win over planning modes. If modes conflict, pick the best overall fit. Do not fail the request or leave slots empty because modes disagree.'
+  ];
+
+  if (prefs.usePantry) {
+    lines.push(
+      'Use My Pantry: Prefer recipes that naturally use ingredients the user already has. Minimize extra grocery purchases. Allow missing ingredients when they make the meal better. Do not force a poor recipe just to use pantry items.'
+    );
+  }
+  if (prefs.budgetFriendly) {
+    lines.push(
+      'Keep It Cheap: Prefer inexpensive proteins (beans, eggs, chicken, tofu), rice, pasta, and common produce. Favor recipes with fewer specialty ingredients and reuse ingredients across the week. Avoid premium cuts and one-off specialty items unless nothing else fits. Do not invent dollar amounts or prices.'
+    );
+  }
+  if (prefs.healthy) {
+    lines.push(
+      'Healthy Week: Prefer meals with stronger overall nutritional balance — protein, fiber, vegetables, and reasonable calorie density. Use Nourish overall scores when present on a candidate. This is not a medical or restrictive diet. Do not invent nutrition numbers.'
+    );
+  }
+  if (prefs.highProtein) {
+    lines.push(
+      'High Protein: Prefer meals with meaningful protein. Use Nourish protein scores or protein grams when present; otherwise use recipe-level signals (eggs, yogurt, legumes, fish, poultry, tofu). Keep variety — do not fill the week with the same chicken recipe. Do not invent precise macros.'
+    );
+  }
+  if (prefs.quickMeals) {
+    lines.push(
+      `Quick Meals: Prefer recipes that are about ${QUICK_TARGET_MINUTES} minutes or less of active cooking when timing is known. Avoid obviously long-cook meals (braises, all-day roasts, multi-hour projects). If timing is missing, use the recipe title and tags conservatively.`
+    );
+  }
+  if (prefs.lowWaste) {
+    lines.push(
+      'Low Waste: Intentionally reuse ingredients across the week — produce, herbs, proteins, dairy, sauces, and pantry staples. Overlap ingredients, not meals. The week should feel varied while sharing a shopping basket. Do not repeat the same recipe to create reuse.'
+    );
+  }
+  if (prefs.adventurous) {
+    lines.push(
+      'Try Something New: Prefer recipes the user has not already saved or planned, and a broader mix of cuisines and styles. Introduce variety without becoming random or overly exotic. If history is thin, still favor a wider mix. Never block planning because history is missing.'
+    );
+  }
+  return lines;
+}
+
+export function candidateModeBits(
+  c: ModeScorable & { prepTime?: string; cookTime?: string },
+  prefs: PlanningPreferences,
+  familiarCoordinates?: Set<string>
+): string[] {
+  const bits: string[] = [];
+  if (prefs.budgetFriendly) bits.push(`cost=${costHint(c)}`);
+  if ((prefs.healthy || prefs.highProtein) && c.nourish) {
+    const n: string[] = [];
+    if (typeof c.nourish.overall === 'number') n.push(`overall ${c.nourish.overall}/10`);
+    if (typeof c.nourish.protein === 'number') n.push(`protein ${c.nourish.protein}/10`);
+    if (typeof c.nourish.proteinGrams === 'number') n.push(`${c.nourish.proteinGrams}g protein`);
+    if (n.length) bits.push(`nourish=${n.join(', ')}`);
+  }
+  if (prefs.adventurous && familiarCoordinates?.has(c.a)) {
+    bits.push('familiar=yes');
+  }
+  return bits;
+}
+
+export interface PlanModeFeedback {
+  labels: string[];
+  summary: string | null;
+}
+
+export function summarizePlanningModeFeedback(opts: {
+  preferences: PlanningPreferences;
+  meals: Array<{ a: string; pantry?: { matchedIngredients?: string[] } }>;
+  recipes: Array<{
+    a: string;
+    ingredients?: string[];
+    prepTime?: string;
+    cookTime?: string;
+    minutes?: number | null;
+  }>;
+}): PlanModeFeedback | null {
+  const { preferences: prefs, meals, recipes } = opts;
+  if (!hasEnabledPlanningMode(prefs) || meals.length === 0) return null;
+
+  const labels = enabledPlanningModeKeys(prefs).map(planningModeShortLabel);
+  const byA = new Map(recipes.map((r) => [r.a, r]));
+  const metrics: string[] = [];
+
+  if (prefs.usePantry) {
+    const used = new Set<string>();
+    for (const meal of meals) {
+      for (const name of meal.pantry?.matchedIngredients || []) {
+        const key = normalizeIngredientName(name) || name.toLowerCase();
+        if (key) used.add(key);
+      }
+    }
+    if (used.size > 0) {
+      metrics.push(`${used.size} pantry ingredient${used.size === 1 ? '' : 's'} used`);
+    }
+  }
+
+  if (prefs.lowWaste) {
+    const freq = new Map<string, number>();
+    for (const meal of meals) {
+      const recipe = byA.get(meal.a);
+      for (const name of uniqueNormalizedIngredients(recipe?.ingredients || [])) {
+        if (FEEDBACK_STAPLES.has(name)) continue;
+        freq.set(name, (freq.get(name) ?? 0) + 1);
+      }
+    }
+    const reused = [...freq.values()].filter((n) => n >= 2).length;
+    if (reused > 0) {
+      metrics.push(`${reused} ingredient${reused === 1 ? '' : 's'} reused across meals`);
+    }
+  }
+
+  if (prefs.quickMeals) {
+    const times: number[] = [];
+    for (const meal of meals) {
+      const recipe = byA.get(meal.a);
+      if (typeof recipe?.minutes === 'number') {
+        times.push(recipe.minutes);
+        continue;
+      }
+    }
+    if (times.length >= Math.ceil(meals.length / 2)) {
+      const quick = times.filter((m) => m <= QUICK_SOFT_MAX_MINUTES).length;
+      if (quick >= times.length * 0.6) {
+        metrics.push(`Most meals are ready in about ${QUICK_TARGET_MINUTES} minutes.`);
+      }
+    }
+  }
+
+  return {
+    labels,
+    summary: metrics.length ? metrics.join(' · ') : null
+  };
+}
+
+export function familiarCoordinatesFromSources(opts: {
+  savedAs?: Iterable<string>;
+  plannedAs?: Iterable<string>;
+}): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const group of [opts.savedAs, opts.plannedAs]) {
+    if (!group) continue;
+    for (const a of group) {
+      if (typeof a !== 'string' || !a || seen.has(a)) continue;
+      seen.add(a);
+      out.push(a);
+    }
+  }
+  return out;
+}

--- a/src/lib/services/recipeDiscoveryService.ts
+++ b/src/lib/services/recipeDiscoveryService.ts
@@ -177,6 +177,7 @@ export function toWireCandidate(recipe: DiscoveredRecipe): RecipeCandidate {
   if (recipe.cookTime) wire.cookTime = recipe.cookTime;
   if (recipe.servings) wire.servings = recipe.servings;
   if (recipe.pantry) wire.pantry = recipe.pantry;
+  if (recipe.nourish) wire.nourish = recipe.nourish;
   return wire;
 }
 

--- a/src/routes/api/zappy/meal-plan/+server.ts
+++ b/src/routes/api/zappy/meal-plan/+server.ts
@@ -152,12 +152,13 @@ function buildUserPrompt(req: MealPlanGenerationRequest): string {
       }`
     );
   }
+  const familiar = req.familiarCoordinates?.length
+    ? new Set(req.familiarCoordinates)
+    : undefined;
   lines.push(
     '',
     `Candidate recipes (${req.candidates.length}):`,
-    ...req.candidates.map((c) =>
-      candidateLine(c, modes, new Set(req.familiarCoordinates || []))
-    )
+    ...req.candidates.map((c) => candidateLine(c, modes, familiar))
   );
   lines.push('', 'Assign one candidate to each slot you can fill. Copy each coordinate exactly.');
   return lines.join('\n');

--- a/src/routes/api/zappy/meal-plan/+server.ts
+++ b/src/routes/api/zappy/meal-plan/+server.ts
@@ -26,6 +26,13 @@ import {
   type RecipeCandidate
 } from '$lib/mealplan/generation';
 import {
+  candidateModeBits,
+  emptyPlanningPreferences,
+  normalizePlanningPreferences,
+  overlappingIngredientHints,
+  planningModePromptLines
+} from '$lib/mealplan/planningModes';
+import {
   isRecipeEligibleForSlot,
   noEligibleRecipesMessage,
   restrictCandidatesToRequestedSlots
@@ -33,7 +40,7 @@ import {
 
 const PER_HOUR = 10;
 const PER_DAY = 30;
-const MAX_TOKENS = 1200;
+const MAX_TOKENS = 1800;
 
 const DAY_LABELS: Record<MealPlanDayKey, string> = {
   mon: 'Monday',
@@ -64,13 +71,18 @@ HARD RULES
 - If a breakfast-eligible list is provided, breakfast slots may use ONLY those coordinates.
 - Prefer variety across the week unless the user asked for repeats or leftovers.
 - Honor excluded ingredients, time limits, servings, style chips, and free-text notes when the candidates allow it.
+- Treat planning modes as weighted preferences, not absolute requirements. Dietary exclusions, vegetarian requests, breakfast eligibility, and explicit cooking-time limits still win. If modes conflict, pick the best overall fit — never fail the request.
 - If pantry match data or a pantry ingredient list is provided, prefer recipes that use more ingredients the user already has, minimize extra grocery purchases, and reuse pantry ingredients across the week when that still makes a sensible meal. Do not force poor combinations. Do not sacrifice dietary constraints, requested meal type, cooking-time requirements, or other hard constraints merely to improve pantry utilization.
 - If there are not enough candidates, fill as many requested slots as you reasonably can. Do not pad with invented recipes or with recipes that do not fit the slot.
 - Keep each reason to one short sentence.
 
 You return structured JSON only.`;
 
-function candidateLine(c: RecipeCandidate): string {
+function candidateLine(
+  c: RecipeCandidate,
+  prefs = emptyPlanningPreferences(),
+  familiar?: Set<string>
+): string {
   const bits = [`a=${c.a}`, `title=${c.title}`];
   if (c.tags.length) bits.push(`tags=${c.tags.join(', ')}`);
   if (c.prepTime) bits.push(`prep=${c.prepTime}`);
@@ -85,6 +97,7 @@ function candidateLine(c: RecipeCandidate): string {
       bits.push(`need=${c.pantry.missingIngredients.join(', ')}`);
     }
   }
+  bits.push(...candidateModeBits(c, prefs, familiar));
   return `- ${bits.join(' | ')}`;
 }
 
@@ -104,12 +117,25 @@ function buildUserPrompt(req: MealPlanGenerationRequest): string {
     lines.push(`Avoid ingredients: ${prefs.excludeIngredients.join(', ')}`);
   }
   if (prefs.notes) lines.push(`Notes: ${prefs.notes}`);
-  if (req.prioritizePantry) {
+  const modes = normalizePlanningPreferences(req.planningPreferences, req.prioritizePantry);
+  if (modes.usePantry || req.prioritizePantry) {
     if (req.pantryIngredients?.length) {
       lines.push(`Pantry ingredients the user already has: ${req.pantryIngredients.join(', ')}`);
     }
     lines.push(
       'Pantry: Prefer meals that use these ingredients, minimize additional grocery purchases, and reuse ingredients across the week when it still makes a sensible meal. Do not force poor combinations. Do not sacrifice dietary constraints, requested meal type, cooking-time requirements, or other hard constraints merely to improve pantry utilization.'
+    );
+  }
+  lines.push(...planningModePromptLines(modes));
+  if (modes.lowWaste) {
+    const overlap = overlappingIngredientHints(req.candidates);
+    if (overlap.length) {
+      lines.push(`Ingredients that appear in multiple candidates (prefer reuse): ${overlap.join(', ')}`);
+    }
+  }
+  if (modes.adventurous && req.familiarCoordinates?.length) {
+    lines.push(
+      `Recipes the user has already saved or planned (prefer others when a good alternative exists): ${req.familiarCoordinates.join(', ')}`
     );
   }
   if (req.excludeCoordinates?.length) {
@@ -129,7 +155,9 @@ function buildUserPrompt(req: MealPlanGenerationRequest): string {
   lines.push(
     '',
     `Candidate recipes (${req.candidates.length}):`,
-    ...req.candidates.map(candidateLine)
+    ...req.candidates.map((c) =>
+      candidateLine(c, modes, new Set(req.familiarCoordinates || []))
+    )
   );
   lines.push('', 'Assign one candidate to each slot you can fill. Copy each coordinate exactly.');
   return lines.join('\n');

--- a/src/routes/api/zappy/meal-plan/mealPlan.test.ts
+++ b/src/routes/api/zappy/meal-plan/mealPlan.test.ts
@@ -260,6 +260,50 @@ describe('structured plan validation', () => {
     expect(prompt).toContain('pantry=1/2 (50%)');
   });
 
+  it('includes explicit planning-mode instructions in the model prompt', async () => {
+    await call(
+      validBody({
+        planningPreferences: {
+          usePantry: false,
+          budgetFriendly: true,
+          healthy: true,
+          highProtein: false,
+          quickMeals: true,
+          lowWaste: true,
+          adventurous: true
+        },
+        familiarCoordinates: ['30023:pk:pasta'],
+        candidates: [
+          {
+            a: '30023:pk:salmon',
+            title: 'Mediterranean Salmon',
+            tags: ['mediterranean'],
+            ingredients: ['salmon', 'spinach'],
+            nourish: { overall: 8, protein: 7 }
+          },
+          {
+            a: '30023:pk:pasta',
+            title: 'Lemon Pasta',
+            tags: ['easy'],
+            ingredients: ['pasta', 'spinach']
+          }
+        ]
+      })
+    );
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    const prompt = body.messages.find((m: { role: string }) => m.role === 'user').content as string;
+    expect(prompt).toContain('Keep It Cheap:');
+    expect(prompt).toContain('Healthy Week:');
+    expect(prompt).toContain('Quick Meals:');
+    expect(prompt).toContain('Low Waste:');
+    expect(prompt).toContain('Try Something New:');
+    expect(prompt).toContain('weighted preferences, not hard requirements');
+    expect(prompt).toContain('Ingredients that appear in multiple candidates (prefer reuse): spinach');
+    expect(prompt).toContain('cost=');
+    expect(prompt).toContain('nourish=overall 8/10');
+    expect(prompt).not.toContain('Make this healthy and cheap');
+  });
+
   it('does not send dinner recipes to the model for a breakfast-only request', async () => {
     fetchMock.mockResolvedValue(
       openaiPlan([


### PR DESCRIPTION
## Summary
- Add selectable Cheffy planning modes (Use My Pantry, Keep It Cheap, Healthy Week, High Protein, Quick Meals, Low Waste, Try Something New) as chips on the existing planner, not as separate planners.
- Pass selected modes as weighted `planningPreferences` on the structured meal-plan request, with explicit prompt instructions and candidate ranking. Hard constraints (allergies, vegetarian, breakfast eligibility, time limits) still win; conflicting modes do not fail generation.
- Show lightweight post-plan feedback only for metrics we can count (pantry ingredients used, reused ingredients, ~30-minute meals). Grocery consolidation and pantry exclusions stay in Grocery Planner.

## Test plan
- [ ] Open Plan with Cheffy and select one or more mode chips; confirm the last selection is remembered on reopen
- [ ] **Use My Pantry**: pantry ingredients influence recipe selection; empty pantry still blocks with a link to add items
- [ ] **Low Waste**: several recipes share useful ingredients without repeating the same meal
- [ ] **Quick Meals + High Protein**: meals are reasonably fast and protein-forward, with variety
- [ ] **Keep It Cheap + Use My Pantry**: fewer specialty one-off purchases
- [ ] **Healthy Week + Try Something New**: variety without ignoring nutritional quality
- [ ] Generate → preview → apply still works; breakfast-only plans stay breakfast-appropriate
- [ ] Add Week to Grocery List still consolidates ingredients and excludes pantry items
- [ ] Conflicting modes (cheap + new + quick + high protein) still generate a plan


Made with [Cursor](https://cursor.com)