### PR TITLE
feat(grocery): bulk-delete lists from the feed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.721",
+  "version": "4.2.722",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.722",
+  "version": "4.2.723",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/grocery/GroceryListCard.svelte
+++ b/src/components/grocery/GroceryListCard.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
+  import { createEventDispatcher } from 'svelte';
   import type { GroceryList } from '$lib/stores/groceryStore';
   import { formatDistanceToNow } from 'date-fns';
   import ShoppingCartIcon from 'phosphor-svelte/lib/ShoppingCart';
   import CheckIcon from 'phosphor-svelte/lib/Check';
 
   export let list: GroceryList;
+  export let selectable = false;
+  export let selected = false;
+
+  const dispatch = createEventDispatcher<{ toggle: void }>();
 
   // Calculate item counts
   $: totalItems = list.items.length;
@@ -16,70 +21,146 @@
 
   // Progress percentage
   $: progress = totalItems > 0 ? (checkedItems / totalItems) * 100 : 0;
+
+  $: selectedStyle = selected
+    ? 'rgb(34 197 94)'
+    : 'var(--color-input-border)';
 </script>
 
-<a
-  href="/my-kitchen/grocery/{list.id}"
-  class="group block p-4 rounded-2xl transition-all duration-200 hover:scale-[1.02] hover:shadow-lg"
-  style="background-color: var(--color-bg-secondary); border: 1px solid var(--color-input-border);"
->
-  <div class="flex flex-col gap-3">
-    <!-- Header -->
-    <div class="flex items-start justify-between gap-2">
-      <div class="flex items-center gap-3 min-w-0 flex-1">
-        <div class="w-10 h-10 rounded-full bg-gradient-to-br from-green-500 to-emerald-500 flex items-center justify-center flex-shrink-0">
-          <ShoppingCartIcon size={20} weight="fill" class="text-white" />
-        </div>
-        <div class="min-w-0 flex-1">
-          <h3 class="font-semibold truncate" style="color: var(--color-text-primary)">
-            {list.title}
-          </h3>
-          <p class="text-xs text-caption">
-            Updated {lastUpdated}
-          </p>
+{#if selectable}
+  <button
+    type="button"
+    class="group w-full text-left p-4 rounded-2xl transition-all duration-200 cursor-pointer {selected
+      ? 'ring-2 ring-green-500'
+      : ''}"
+    style="background-color: var(--color-bg-secondary); border: 1px solid {selectedStyle};"
+    aria-pressed={selected}
+    aria-label="{selected ? 'Deselect' : 'Select'} {list.title}"
+    on:click={() => dispatch('toggle')}
+  >
+    <div class="flex flex-col gap-3">
+      <div class="flex items-start justify-between gap-2">
+        <div class="flex items-center gap-3 min-w-0 flex-1">
+          <span
+            class="w-7 h-7 rounded-full border-2 flex items-center justify-center flex-shrink-0 transition-all {selected
+              ? 'bg-green-500 border-green-500'
+              : 'border-gray-400 dark:border-gray-400'}"
+            aria-hidden="true"
+          >
+            {#if selected}
+              <CheckIcon size={16} weight="bold" class="text-white" />
+            {/if}
+          </span>
+          <div class="min-w-0 flex-1">
+            <h3 class="font-semibold truncate" style="color: var(--color-text-primary)">
+              {list.title}
+            </h3>
+            <p class="text-xs text-caption">
+              Updated {lastUpdated}
+            </p>
+          </div>
         </div>
       </div>
-    </div>
 
-    <!-- Item Count -->
-    <div class="flex items-center gap-2">
-      {#if totalItems === 0}
-        <span class="text-sm text-caption">No items yet</span>
-      {:else}
-        <div class="flex items-center gap-1.5">
-          <CheckIcon size={16} weight="bold" class="text-green-500" />
-          <span class="text-sm" style="color: var(--color-text-primary)">
-            {checkedItems}/{totalItems} items
-          </span>
-        </div>
-        
-        {#if uncheckedItems > 0}
-          <span class="text-sm text-caption">
-            ({uncheckedItems} remaining)
-          </span>
+      <div class="flex items-center gap-2">
+        {#if totalItems === 0}
+          <span class="text-sm text-caption">No items yet</span>
         {:else}
-          <span class="text-sm text-green-500 font-medium">
-            Complete!
-          </span>
+          <div class="flex items-center gap-1.5">
+            <CheckIcon size={16} weight="bold" class="text-green-500" />
+            <span class="text-sm" style="color: var(--color-text-primary)">
+              {checkedItems}/{totalItems} items
+            </span>
+          </div>
+
+          {#if uncheckedItems > 0}
+            <span class="text-sm text-caption">
+              ({uncheckedItems} remaining)
+            </span>
+          {:else}
+            <span class="text-sm text-green-500 font-medium">
+              Complete!
+            </span>
+          {/if}
         {/if}
+      </div>
+
+      {#if totalItems > 0}
+        <div class="h-1.5 rounded-full overflow-hidden" style="background-color: var(--color-input-bg);">
+          <div
+            class="h-full rounded-full transition-all duration-300 bg-gradient-to-r from-green-500 to-emerald-500"
+            style="width: {progress}%"
+          />
+        </div>
+      {/if}
+
+      {#if list.recipeLinks.length > 0}
+        <p class="text-xs text-caption">
+          Linked to {list.recipeLinks.length} {list.recipeLinks.length === 1 ? 'recipe' : 'recipes'}
+        </p>
       {/if}
     </div>
-
-    <!-- Progress Bar -->
-    {#if totalItems > 0}
-      <div class="h-1.5 rounded-full overflow-hidden" style="background-color: var(--color-input-bg);">
-        <div 
-          class="h-full rounded-full transition-all duration-300 bg-gradient-to-r from-green-500 to-emerald-500"
-          style="width: {progress}%"
-        />
+  </button>
+{:else}
+  <a
+    href="/my-kitchen/grocery/{list.id}"
+    class="group block p-4 rounded-2xl transition-all duration-200 hover:scale-[1.02] hover:shadow-lg"
+    style="background-color: var(--color-bg-secondary); border: 1px solid var(--color-input-border);"
+  >
+    <div class="flex flex-col gap-3">
+      <div class="flex items-start justify-between gap-2">
+        <div class="flex items-center gap-3 min-w-0 flex-1">
+          <div class="w-10 h-10 rounded-full bg-gradient-to-br from-green-500 to-emerald-500 flex items-center justify-center flex-shrink-0">
+            <ShoppingCartIcon size={20} weight="fill" class="text-white" />
+          </div>
+          <div class="min-w-0 flex-1">
+            <h3 class="font-semibold truncate" style="color: var(--color-text-primary)">
+              {list.title}
+            </h3>
+            <p class="text-xs text-caption">
+              Updated {lastUpdated}
+            </p>
+          </div>
+        </div>
       </div>
-    {/if}
 
-    <!-- Recipe Links (if any) -->
-    {#if list.recipeLinks.length > 0}
-      <p class="text-xs text-caption">
-        Linked to {list.recipeLinks.length} {list.recipeLinks.length === 1 ? 'recipe' : 'recipes'}
-      </p>
-    {/if}
-  </div>
-</a>
+      <div class="flex items-center gap-2">
+        {#if totalItems === 0}
+          <span class="text-sm text-caption">No items yet</span>
+        {:else}
+          <div class="flex items-center gap-1.5">
+            <CheckIcon size={16} weight="bold" class="text-green-500" />
+            <span class="text-sm" style="color: var(--color-text-primary)">
+              {checkedItems}/{totalItems} items
+            </span>
+          </div>
+
+          {#if uncheckedItems > 0}
+            <span class="text-sm text-caption">
+              ({uncheckedItems} remaining)
+            </span>
+          {:else}
+            <span class="text-sm text-green-500 font-medium">
+              Complete!
+            </span>
+          {/if}
+        {/if}
+      </div>
+
+      {#if totalItems > 0}
+        <div class="h-1.5 rounded-full overflow-hidden" style="background-color: var(--color-input-bg);">
+          <div
+            class="h-full rounded-full transition-all duration-300 bg-gradient-to-r from-green-500 to-emerald-500"
+            style="width: {progress}%"
+          />
+        </div>
+      {/if}
+
+      {#if list.recipeLinks.length > 0}
+        <p class="text-xs text-caption">
+          Linked to {list.recipeLinks.length} {list.recipeLinks.length === 1 ? 'recipe' : 'recipes'}
+        </p>
+      {/if}
+    </div>
+  </a>
+{/if}

--- a/src/lib/services/groceryService.ts
+++ b/src/lib/services/groceryService.ts
@@ -611,7 +611,7 @@ export async function deleteGroceryLists(
   if (uniqueIds.length === 0) return null;
 
   if (!browser) {
-    throw new Error('Cannot delete grocery list on server');
+    throw new Error('Cannot delete grocery lists on server');
   }
 
   const pubkey = get(userPublickey);
@@ -681,7 +681,8 @@ export async function deleteGroceryList(
   listId: string,
   eventId?: string
 ): Promise<NDKEvent | null> {
-  return deleteGroceryLists(listId ? [listId] : [], eventId ? { [listId]: eventId } : undefined);
+  if (!listId) return null;
+  return deleteGroceryLists([listId], eventId ? { [listId]: eventId } : undefined);
 }
 
 // ═══════════════════════════════════════════════════════════════

--- a/src/lib/services/groceryService.ts
+++ b/src/lib/services/groceryService.ts
@@ -596,16 +596,20 @@ export async function saveGroceryList(list: GroceryList): Promise<NDKEvent | nul
 // ═══════════════════════════════════════════════════════════════
 
 /**
- * Delete a grocery list by publishing a kind 5 deletion event
- * 
- * @param listId - The ID of the list to delete
- * @param eventId - Optional: the event ID to reference in deletion
- * @returns The deletion event, or null on failure
+ * Delete one or more grocery lists by publishing a kind 5 deletion event.
+ * NIP-09 allows multiple `a` tags on a single deletion request.
+ *
+ * @param listIds - List IDs to delete
+ * @param eventIds - Optional map of list ID → event ID for `e` tags
+ * @returns The deletion event, or null if there is nothing to delete
  */
-export async function deleteGroceryList(
-  listId: string,
-  eventId?: string
+export async function deleteGroceryLists(
+  listIds: string[],
+  eventIds?: Record<string, string>
 ): Promise<NDKEvent | null> {
+  const uniqueIds = [...new Set(listIds.filter(Boolean))];
+  if (uniqueIds.length === 0) return null;
+
   if (!browser) {
     throw new Error('Cannot delete grocery list on server');
   }
@@ -624,44 +628,60 @@ export async function deleteGroceryList(
   await ndkReady;
 
   try {
-    // Create deletion event (kind 5 per NIP-09)
     const deleteEvent = new NDKEvent(ndkInstance);
     deleteEvent.kind = 5;
-    deleteEvent.content = 'Deleted grocery list';
-    
-    // Reference the addressable event with an 'a' tag
-    const aTag = `${GROCERY_KIND}:${pubkey}:${listIdToDTag(listId)}`;
-    deleteEvent.tags = [
-      ['a', aTag]
-    ];
+    deleteEvent.content =
+      uniqueIds.length === 1
+        ? 'Deleted grocery list'
+        : `Deleted ${uniqueIds.length} grocery lists`;
+    deleteEvent.tags = uniqueIds.map((listId) => [
+      'a',
+      `${GROCERY_KIND}:${pubkey}:${listIdToDTag(listId)}`
+    ]);
 
-    // If we have the specific event ID, also add an 'e' tag
-    if (eventId) {
-      deleteEvent.tags.push(['e', eventId]);
+    for (const listId of uniqueIds) {
+      const eventId = eventIds?.[listId];
+      if (eventId) {
+        deleteEvent.tags.push(['e', eventId]);
+      }
     }
 
-    // Sign and publish
     await deleteEvent.sign();
-    
-    // Get user's write relays for publishing
+
     const writeRelays = await getOutboxRelays(pubkey);
-    
-    console.log('[GroceryService] Publishing deletion event...', writeRelays.length > 0 ? `(${writeRelays.length} outbox relays)` : '(default relays)');
-    
-    // Publish to user's outbox relays if available, otherwise use default relay set
+
+    console.log(
+      '[GroceryService] Publishing deletion event...',
+      writeRelays.length > 0 ? `(${writeRelays.length} outbox relays)` : '(default relays)'
+    );
+
     if (writeRelays.length > 0) {
       const relaySet = NDKRelaySet.fromRelayUrls(writeRelays, ndkInstance);
       await deleteEvent.publish(relaySet);
     } else {
       await deleteEvent.publish();
     }
-    
-    console.log('[GroceryService] Grocery list deleted successfully');
+
+    console.log('[GroceryService] Grocery list(s) deleted successfully');
     return deleteEvent;
   } catch (error) {
-    console.error('[GroceryService] Failed to delete grocery list:', error);
+    console.error('[GroceryService] Failed to delete grocery list(s):', error);
     throw error;
   }
+}
+
+/**
+ * Delete a grocery list by publishing a kind 5 deletion event
+ *
+ * @param listId - The ID of the list to delete
+ * @param eventId - Optional: the event ID to reference in deletion
+ * @returns The deletion event, or null on failure
+ */
+export async function deleteGroceryList(
+  listId: string,
+  eventId?: string
+): Promise<NDKEvent | null> {
+  return deleteGroceryLists(listId ? [listId] : [], eventId ? { [listId]: eventId } : undefined);
 }
 
 // ═══════════════════════════════════════════════════════════════

--- a/src/lib/stores/groceryStore.ts
+++ b/src/lib/stores/groceryStore.ts
@@ -18,7 +18,7 @@ import { userPublickey } from '$lib/nostr';
 import {
   fetchGroceryLists,
   saveGroceryList,
-  deleteGroceryList,
+  deleteGroceryLists,
   createEmptyList,
   createGroceryItem,
   type GroceryList,
@@ -317,32 +317,41 @@ function createGroceryStore() {
     },
 
     /**
-     * Delete a grocery list
+     * Delete one or more grocery lists
      */
-    async deleteList(listId: string): Promise<boolean> {
-      // Cancel any pending save for this list
-      const timer = saveTimers.get(listId);
-      if (timer) {
-        clearTimeout(timer);
-        saveTimers.delete(listId);
+    async deleteLists(listIds: string[]): Promise<boolean> {
+      const uniqueIds = [...new Set(listIds.filter(Boolean))];
+      if (uniqueIds.length === 0) return true;
+
+      for (const listId of uniqueIds) {
+        const timer = saveTimers.get(listId);
+        if (timer) {
+          clearTimeout(timer);
+          saveTimers.delete(listId);
+        }
       }
 
-      // Remove from local state immediately
+      const idSet = new Set(uniqueIds);
       update(s => ({
         ...s,
-        lists: s.lists.filter(l => l.id !== listId)
+        lists: s.lists.filter(l => !idSet.has(l.id))
       }));
 
-      // Delete from Nostr
       try {
-        await deleteGroceryList(listId);
+        await deleteGroceryLists(uniqueIds);
         return true;
       } catch (error) {
-        console.error('[GroceryStore] Failed to delete list:', error);
-        // Reload to restore state if delete failed
+        console.error('[GroceryStore] Failed to delete lists:', error);
         this.load();
         return false;
       }
+    },
+
+    /**
+     * Delete a grocery list
+     */
+    async deleteList(listId: string): Promise<boolean> {
+      return this.deleteLists([listId]);
     },
 
     /**

--- a/src/lib/stores/groceryStore.ts
+++ b/src/lib/stores/groceryStore.ts
@@ -332,6 +332,7 @@ function createGroceryStore() {
       }
 
       const idSet = new Set(uniqueIds);
+      const previousLists = get({ subscribe }).lists;
       update(s => ({
         ...s,
         lists: s.lists.filter(l => !idSet.has(l.id))
@@ -342,7 +343,8 @@ function createGroceryStore() {
         return true;
       } catch (error) {
         console.error('[GroceryStore] Failed to delete lists:', error);
-        this.load();
+        update(s => ({ ...s, lists: previousLists }));
+        void this.load();
         return false;
       }
     },

--- a/src/routes/my-kitchen/grocery/+page.svelte
+++ b/src/routes/my-kitchen/grocery/+page.svelte
@@ -31,7 +31,7 @@
   $: selectedCount = selectedIds.size;
   $: selectedLists = $groceryLists.filter((list) => selectedIds.has(list.id));
 
-  $: if (isEditing && $groceryLists.length === 0) {
+  $: if (isEditing && !isDeleting && $groceryLists.length === 0) {
     isEditing = false;
     selectedIds = new Set();
     deleteConfirmOpen = false;

--- a/src/routes/my-kitchen/grocery/+page.svelte
+++ b/src/routes/my-kitchen/grocery/+page.svelte
@@ -11,18 +11,39 @@
   } from '$lib/stores/groceryStore';
   import PlusIcon from 'phosphor-svelte/lib/Plus';
   import ShoppingCartIcon from 'phosphor-svelte/lib/ShoppingCart';
+  import TrashIcon from 'phosphor-svelte/lib/Trash';
   import PanLoader from '../../../components/PanLoader.svelte';
   import GroceryListCard from '../../../components/grocery/GroceryListCard.svelte';
   import PullToRefresh from '../../../components/PullToRefresh.svelte';
+  import Modal from '../../../components/Modal.svelte';
+  import Button from '../../../components/Button.svelte';
 
   // Pull-to-refresh ref
   let pullToRefreshEl: PullToRefresh;
 
   let isCreating = false;
+  let isEditing = false;
+  let selectedIds = new Set<string>();
+  let deleteConfirmOpen = false;
+  let isDeleting = false;
+
+  $: allSelected = $groceryLists.length > 0 && selectedIds.size === $groceryLists.length;
+  $: selectedCount = selectedIds.size;
+  $: selectedLists = $groceryLists.filter((list) => selectedIds.has(list.id));
+
+  $: if (isEditing && $groceryLists.length === 0) {
+    isEditing = false;
+    selectedIds = new Set();
+    deleteConfirmOpen = false;
+  }
 
   async function handleRefresh() {
     try {
       await groceryStore.load();
+      if (isEditing) {
+        const validIds = new Set($groceryLists.map((list) => list.id));
+        selectedIds = new Set([...selectedIds].filter((id) => validIds.has(id)));
+      }
     } finally {
       pullToRefreshEl?.complete();
     }
@@ -46,7 +67,7 @@
   });
 
   async function createNewList() {
-    if (isCreating) return;
+    if (isCreating || isEditing) return;
     
     isCreating = true;
     try {
@@ -57,6 +78,50 @@
       console.error('Failed to create list:', error);
     } finally {
       isCreating = false;
+    }
+  }
+
+  function enterEditMode() {
+    isEditing = true;
+    selectedIds = new Set();
+  }
+
+  function exitEditMode() {
+    isEditing = false;
+    selectedIds = new Set();
+    deleteConfirmOpen = false;
+  }
+
+  function toggleSelect(listId: string) {
+    const next = new Set(selectedIds);
+    if (next.has(listId)) {
+      next.delete(listId);
+    } else {
+      next.add(listId);
+    }
+    selectedIds = next;
+  }
+
+  function toggleSelectAll() {
+    selectedIds = allSelected
+      ? new Set()
+      : new Set($groceryLists.map((list) => list.id));
+  }
+
+  async function deleteSelected() {
+    if (selectedIds.size === 0 || isDeleting) return;
+
+    isDeleting = true;
+    try {
+      const success = await groceryStore.deleteLists([...selectedIds]);
+      if (success) {
+        exitEditMode();
+      }
+    } catch (error) {
+      console.error('Failed to delete grocery lists:', error);
+    } finally {
+      isDeleting = false;
+      deleteConfirmOpen = false;
     }
   }
 </script>
@@ -80,17 +145,74 @@
       </div>
     </div>
     
-    <!-- New List Button -->
-    <button
-      on:click={createNewList}
-      disabled={isCreating}
-      class="flex items-center gap-2 px-4 py-1.5 bg-gradient-to-r from-green-500 to-emerald-500 hover:from-green-600 hover:to-emerald-600 text-white rounded-full font-medium transition-all text-sm disabled:opacity-50"
-      aria-label="Create new grocery list"
-    >
-      <PlusIcon size={18} weight="bold" />
-      <span>{isCreating ? 'Creating...' : 'New List'}</span>
-    </button>
+    <div class="flex items-center gap-2">
+      {#if $groceryLists.length > 0}
+        {#if isEditing}
+          <button
+            type="button"
+            on:click={exitEditMode}
+            class="flex items-center gap-2 px-4 py-1.5 rounded-full font-medium transition-all text-sm"
+            style="color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+          >
+            Done
+          </button>
+        {:else}
+          <button
+            type="button"
+            on:click={enterEditMode}
+            class="flex items-center gap-2 px-4 py-1.5 rounded-full font-medium transition-all text-sm"
+            style="color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+          >
+            Edit
+          </button>
+        {/if}
+      {/if}
+
+      {#if !isEditing}
+        <button
+          on:click={createNewList}
+          disabled={isCreating}
+          class="flex items-center gap-2 px-4 py-1.5 bg-gradient-to-r from-green-500 to-emerald-500 hover:from-green-600 hover:to-emerald-600 text-white rounded-full font-medium transition-all text-sm disabled:opacity-50"
+          aria-label="Create new grocery list"
+        >
+          <PlusIcon size={18} weight="bold" />
+          <span>{isCreating ? 'Creating...' : 'New List'}</span>
+        </button>
+      {/if}
+    </div>
   </div>
+
+  {#if isEditing}
+    <div
+      class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between px-4 py-3 rounded-2xl"
+      style="background-color: var(--color-bg-secondary); border: 1px solid var(--color-input-border);"
+    >
+      <p class="text-sm font-medium" style="color: var(--color-text-primary)">
+        {selectedCount === 0
+          ? 'Select lists to delete'
+          : `${selectedCount} ${selectedCount === 1 ? 'list' : 'lists'} selected`}
+      </p>
+      <div class="flex items-center gap-2">
+        <button
+          type="button"
+          on:click={toggleSelectAll}
+          class="px-3 py-1.5 rounded-full text-sm font-medium transition-all"
+          style="color: var(--color-text-primary); border: 1px solid var(--color-input-border);"
+        >
+          {allSelected ? 'Clear' : 'Select all'}
+        </button>
+        <button
+          type="button"
+          on:click={() => (deleteConfirmOpen = true)}
+          disabled={selectedCount === 0}
+          class="flex items-center gap-1.5 px-3 py-1.5 bg-red-500 hover:bg-red-600 text-white rounded-full text-sm font-medium transition-colors disabled:opacity-40"
+        >
+          <TrashIcon size={16} />
+          Delete
+        </button>
+      </div>
+    </div>
+  {/if}
 
   <!-- Error Banner -->
   {#if $groceryError}
@@ -138,9 +260,54 @@
     <!-- Lists Grid -->
     <div class="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
       {#each $groceryLists as list (list.id)}
-        <GroceryListCard {list} />
+        <GroceryListCard
+          {list}
+          selectable={isEditing}
+          selected={selectedIds.has(list.id)}
+          on:toggle={() => toggleSelect(list.id)}
+        />
       {/each}
     </div>
   {/if}
 </div>
 </PullToRefresh>
+
+<Modal cleanup={() => (deleteConfirmOpen = false)} open={deleteConfirmOpen}>
+  <h1 slot="title">{selectedCount === $groceryLists.length ? 'Delete All Lists' : selectedCount === 1 ? 'Delete List' : 'Delete Lists'}</h1>
+
+  <div class="flex flex-col gap-4">
+    <p style="color: var(--color-text-primary)">
+      {#if selectedCount === 1}
+        Are you sure you want to delete "<strong>{selectedLists[0]?.title}</strong>"?
+        This cannot be undone.
+      {:else if selectedCount === $groceryLists.length}
+        Are you sure you want to delete all {selectedCount} grocery lists?
+        This cannot be undone.
+      {:else}
+        Are you sure you want to delete {selectedCount} grocery lists?
+        This cannot be undone.
+      {/if}
+    </p>
+
+    <div class="flex justify-end gap-2">
+      <Button on:click={() => (deleteConfirmOpen = false)} primary={false} disabled={isDeleting}>
+        Cancel
+      </Button>
+      <button
+        on:click={deleteSelected}
+        disabled={isDeleting}
+        class="px-4 py-2 bg-red-500 hover:bg-red-600 text-white rounded-full font-semibold transition-colors disabled:opacity-50"
+      >
+        {#if isDeleting}
+          Deleting...
+        {:else if selectedCount === $groceryLists.length}
+          Delete All
+        {:else if selectedCount === 1}
+          Delete List
+        {:else}
+          Delete {selectedCount} Lists
+        {/if}
+      </button>
+    </div>
+  </div>
+</Modal>


### PR DESCRIPTION
## Summary
- Add an Edit mode on `/my-kitchen/grocery` so lists can be selected with checkboxes, including Select all
- Confirm and delete one, several, or every list from the feed without opening each one
- Publish a single NIP-09 deletion event for the selected lists

## Test plan
- [ ] Open Grocery with at least two lists and confirm **Edit** appears next to **New List**
- [ ] Tap **Edit** and confirm cards show checkboxes and no longer navigate into a list
- [ ] Select one list, tap **Delete**, cancel the modal, and confirm the list is still there
- [ ] Delete one list and confirm it disappears and remaining cards open normally after **Done**
- [ ] Use **Select all** then **Delete All** and confirm the empty state returns
- [ ] Confirm single-list delete from a list detail page still works


Made with [Cursor](https://cursor.com)