### PR TITLE
test(mealplan): pin Cheffy slot eligibility for Android parity

### DIFF
--- a/docs/mealplan-contract.md
+++ b/docs/mealplan-contract.md
@@ -123,12 +123,18 @@ hashes below. Unilateral edits on either side fail the Android checksum drift te
 | `week.vectors.json` | `de5c75e648548f0fe38ebe021a03da17a1f3a977ec7b103642bbf0fd066faf30` |
 | `mealplan-schema.vectors.json` | `d8a34927d30a8a636bbc84ed3a384ee5f975d65827ae3302aceffb0239373e18` |
 | `grocery-generation.vectors.json` | `090faff2b486886c0c14fe83e3a4fe48f2b3de8ddff375f18f1e5c1d125508d0` |
+| `mealplan-eligibility.vectors.json` | `36e19caaa2ecc7df9005c1dc6f342a92a7cbe4b685faa3461c236fd3c39f531d` |
 
 Notes:
 
 - `ingredient-parser.vectors.json` pins quirks (plural singularization `"2 cups"` → `"2 cup"`,
   comma-suffix retention `"eggs, beaten"`) — they are the contract, not bugs to "fix" on one
   platform.
+- `mealplan-eligibility.vectors.json` pins Cheffy meal-slot eligibility
+  (`src/lib/mealplan/slotEligibility.ts`). Android's port must checksum-match this file. The
+  `category-tag-zapcooking-breakfast` case is deliberate: `normalize()` turns `-` into a space and
+  `tagMatches` uses contains, so category-prefixed tags still carry the breakfast/snack signal and
+  must not be prefix-stripped.
 - `mealplan-schema.vectors.json` case `default-missing-fields` asserts `createdAt > 0` (wall
   clock), not a fixed timestamp.
 - After editing any fixture file, recompute sha256 (`shasum -a 256`) and update this table **and**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.723",
+  "version": "4.2.724",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/mealplan/slotEligibility.test.ts
+++ b/src/lib/mealplan/slotEligibility.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isRecipeEligibleForSlot,
+  eligibleSlotsForRecipe,
+  restrictCandidatesToRequestedSlots,
+  insufficientSlotCoverageMessage,
+  noEligibleRecipesMessage
+} from './slotEligibility';
+import type { MealSlotKey } from './schema';
+import fixtures from '../../test/fixtures/mealplan-eligibility.vectors.json';
+
+/**
+ * Fixture-driven slot-eligibility tests. Expectations live in
+ * src/test/fixtures/mealplan-eligibility.vectors.json (cross-platform contract).
+ * Vectors record current Cheffy behavior, including quirks.
+ */
+
+const FIXTURE_CASE_ARRAYS = [
+  'isRecipeEligibleForSlot',
+  'eligibleSlotsForRecipe',
+  'restrictCandidatesToRequestedSlots',
+  'insufficientSlotCoverageMessage',
+  'noEligibleRecipesMessage'
+] as const;
+
+describe('mealplan-eligibility fixtures', () => {
+  it('executes every case array in the fixture', () => {
+    const keys = Object.keys(fixtures)
+      .filter((k) => k !== 'description')
+      .sort();
+    expect(keys).toEqual([...FIXTURE_CASE_ARRAYS].sort());
+  });
+});
+
+describe('isRecipeEligibleForSlot', () => {
+  for (const c of fixtures.isRecipeEligibleForSlot) {
+    it(c.id, () => {
+      expect(isRecipeEligibleForSlot({ title: c.title, tags: c.tags }, c.slot as MealSlotKey)).toBe(
+        c.expected
+      );
+    });
+  }
+});
+
+describe('eligibleSlotsForRecipe', () => {
+  for (const c of fixtures.eligibleSlotsForRecipe) {
+    it(c.id, () => {
+      expect(eligibleSlotsForRecipe({ title: c.title, tags: c.tags })).toEqual(c.expected);
+    });
+  }
+});
+
+describe('restrictCandidatesToRequestedSlots', () => {
+  for (const c of fixtures.restrictCandidatesToRequestedSlots) {
+    it(c.id, () => {
+      const surviving = restrictCandidatesToRequestedSlots(
+        c.candidates,
+        c.mealSlots as MealSlotKey[]
+      );
+      expect(surviving.map((row) => row.id)).toEqual(c.expected);
+    });
+  }
+});
+
+describe('insufficientSlotCoverageMessage', () => {
+  for (const c of fixtures.insufficientSlotCoverageMessage) {
+    it(c.id, () => {
+      expect(
+        insufficientSlotCoverageMessage({
+          mealSlots: c.mealSlots as MealSlotKey[],
+          found: c.found,
+          requested: c.requested
+        })
+      ).toBe(c.expected);
+    });
+  }
+});
+
+describe('noEligibleRecipesMessage', () => {
+  for (const c of fixtures.noEligibleRecipesMessage) {
+    it(c.id, () => {
+      expect(noEligibleRecipesMessage(c.mealSlots as MealSlotKey[])).toBe(c.expected);
+    });
+  }
+});

--- a/src/test/fixtures/mealplan-eligibility.vectors.json
+++ b/src/test/fixtures/mealplan-eligibility.vectors.json
@@ -1,0 +1,453 @@
+{
+  "description": "Cross-platform Cheffy meal-slot eligibility vectors. Source: src/lib/mealplan/slotEligibility.ts. Vectors record current behavior, including quirks.",
+  "isRecipeEligibleForSlot": [
+    {
+      "id": "tag-breakfast",
+      "title": "Roast Chicken",
+      "tags": ["breakfast"],
+      "slot": "breakfast",
+      "expected": true
+    },
+    {
+      "id": "category-tag-zapcooking-breakfast",
+      "title": "Roast Chicken",
+      "tags": ["zapcooking-breakfast"],
+      "slot": "breakfast",
+      "expected": true
+    },
+    {
+      "id": "tag-brunch-case",
+      "title": "Roast Chicken",
+      "tags": ["Brunch"],
+      "slot": "breakfast",
+      "expected": true
+    },
+    {
+      "id": "tag-brunch-whitespace",
+      "title": "Roast Chicken",
+      "tags": ["  brunch  "],
+      "slot": "breakfast",
+      "expected": true
+    },
+    {
+      "id": "title-pancakes",
+      "title": "Blueberry Pancakes",
+      "tags": [],
+      "slot": "breakfast",
+      "expected": true
+    },
+    {
+      "id": "title-french-toast",
+      "title": "French Toast",
+      "tags": [],
+      "slot": "breakfast",
+      "expected": true
+    },
+    {
+      "id": "title-overnight-oats",
+      "title": "Overnight Oats",
+      "tags": [],
+      "slot": "breakfast",
+      "expected": true
+    },
+    {
+      "id": "title-shakshuka",
+      "title": "Shakshuka",
+      "tags": [],
+      "slot": "breakfast",
+      "expected": true
+    },
+    {
+      "id": "title-avocado-toast",
+      "title": "Avocado Toast",
+      "tags": [],
+      "slot": "breakfast",
+      "expected": true
+    },
+    {
+      "id": "title-acai",
+      "title": "Acai Bowl",
+      "tags": [],
+      "slot": "breakfast",
+      "expected": true
+    },
+    {
+      "id": "title-muffins-plural-prefix",
+      "title": "Blueberry Muffins",
+      "tags": [],
+      "slot": "breakfast",
+      "expected": true
+    },
+    {
+      "id": "title-word-corned-beef-hash",
+      "title": "Corned Beef Hash",
+      "tags": [],
+      "slot": "breakfast",
+      "expected": true
+    },
+    {
+      "id": "title-word-eggplant-not-eggs",
+      "title": "Eggplant Parmesan",
+      "tags": [],
+      "slot": "breakfast",
+      "expected": false
+    },
+    {
+      "id": "title-word-hash-brown-casserole",
+      "title": "Hash Brown Casserole",
+      "tags": [],
+      "slot": "breakfast",
+      "expected": true
+    },
+    {
+      "id": "hyphen-title-french-toast",
+      "title": "French-Toast",
+      "tags": [],
+      "slot": "breakfast",
+      "expected": true
+    },
+    {
+      "id": "underscore-title-overnight-oats",
+      "title": "overnight_oats",
+      "tags": [],
+      "slot": "breakfast",
+      "expected": true
+    },
+    {
+      "id": "slash-title-avocado-toast",
+      "title": "avocado/toast",
+      "tags": [],
+      "slot": "breakfast",
+      "expected": true
+    },
+    {
+      "id": "hyphen-tag-breakfast-food",
+      "title": "Roast Chicken",
+      "tags": ["breakfast-food"],
+      "slot": "breakfast",
+      "expected": true
+    },
+    {
+      "id": "underscore-tag-breakfast",
+      "title": "Roast Chicken",
+      "tags": ["breakfast_club"],
+      "slot": "breakfast",
+      "expected": true
+    },
+    {
+      "id": "slash-tag-brunch",
+      "title": "Roast Chicken",
+      "tags": ["brunch/morning"],
+      "slot": "breakfast",
+      "expected": true
+    },
+    {
+      "id": "negative-braised-short-ribs",
+      "title": "Braised Short Ribs",
+      "tags": [],
+      "slot": "breakfast",
+      "expected": false
+    },
+    {
+      "id": "substring-trap-no-leading-boundary",
+      "title": "Blueberrypancakes",
+      "tags": [],
+      "slot": "breakfast",
+      "expected": false
+    },
+    {
+      "id": "snack-tag-snacks",
+      "title": "Roast Chicken",
+      "tags": ["snacks"],
+      "slot": "snack",
+      "expected": true
+    },
+    {
+      "id": "snack-title-popcorn",
+      "title": "Popcorn",
+      "tags": [],
+      "slot": "snack",
+      "expected": true
+    },
+    {
+      "id": "snack-title-energy-balls",
+      "title": "Energy Balls",
+      "tags": [],
+      "slot": "snack",
+      "expected": true
+    },
+    {
+      "id": "snack-title-hummus",
+      "title": "Hummus",
+      "tags": [],
+      "slot": "snack",
+      "expected": true
+    },
+    {
+      "id": "snack-hyphen-energy-balls",
+      "title": "energy-balls",
+      "tags": [],
+      "slot": "snack",
+      "expected": true
+    },
+    {
+      "id": "snack-negative-beef-stew",
+      "title": "Beef Stew",
+      "tags": [],
+      "slot": "snack",
+      "expected": false
+    },
+    {
+      "id": "lunch-always-snack-recipe",
+      "title": "Popcorn",
+      "tags": ["snacks"],
+      "slot": "lunch",
+      "expected": true
+    },
+    {
+      "id": "dinner-always-snack-recipe",
+      "title": "Popcorn",
+      "tags": ["snacks"],
+      "slot": "dinner",
+      "expected": true
+    },
+    {
+      "id": "lunch-empty-title-no-tags",
+      "title": "",
+      "tags": [],
+      "slot": "lunch",
+      "expected": true
+    },
+    {
+      "id": "dinner-empty-title-no-tags",
+      "title": "",
+      "tags": [],
+      "slot": "dinner",
+      "expected": true
+    },
+    {
+      "id": "breakfast-empty-title-no-tags",
+      "title": "",
+      "tags": [],
+      "slot": "breakfast",
+      "expected": false
+    },
+    {
+      "id": "quirk-tag-substring-unbreakfast",
+      "title": "Roast Chicken",
+      "tags": ["unbreakfast"],
+      "slot": "breakfast",
+      "expected": true
+    },
+    {
+      "id": "quirk-title-prefix-pancakeland",
+      "title": "Pancakeland",
+      "tags": [],
+      "slot": "breakfast",
+      "expected": true
+    },
+    {
+      "id": "quirk-hashbrown-compact-false",
+      "title": "Hashbrown",
+      "tags": [],
+      "slot": "breakfast",
+      "expected": false
+    }
+  ],
+  "eligibleSlotsForRecipe": [
+    {
+      "id": "breakfast-recipe",
+      "title": "Overnight Oats",
+      "tags": ["breakfast"],
+      "expected": ["breakfast", "lunch", "dinner"]
+    },
+    {
+      "id": "snack-recipe",
+      "title": "Popcorn",
+      "tags": [],
+      "expected": ["lunch", "dinner", "snack"]
+    },
+    {
+      "id": "plain-dinner",
+      "title": "Braised Short Ribs",
+      "tags": [],
+      "expected": ["lunch", "dinner"]
+    },
+    {
+      "id": "breakfast-and-snack",
+      "title": "Yogurt Parfait",
+      "tags": ["snacks"],
+      "expected": ["breakfast", "lunch", "dinner", "snack"]
+    }
+  ],
+  "restrictCandidatesToRequestedSlots": [
+    {
+      "id": "breakfast-only",
+      "candidates": [
+        { "id": "breakfast-tag", "title": "Weeknight Pasta", "tags": ["breakfast"] },
+        { "id": "snack-title", "title": "Popcorn", "tags": [] },
+        { "id": "plain-dinner", "title": "Braised Short Ribs", "tags": [] },
+        { "id": "both", "title": "Yogurt Parfait", "tags": ["snacks"] }
+      ],
+      "mealSlots": ["breakfast"],
+      "expected": ["breakfast-tag", "both"]
+    },
+    {
+      "id": "snack-only",
+      "candidates": [
+        { "id": "breakfast-tag", "title": "Weeknight Pasta", "tags": ["breakfast"] },
+        { "id": "snack-title", "title": "Popcorn", "tags": [] },
+        { "id": "plain-dinner", "title": "Braised Short Ribs", "tags": [] },
+        { "id": "both", "title": "Yogurt Parfait", "tags": ["snacks"] }
+      ],
+      "mealSlots": ["snack"],
+      "expected": ["snack-title", "both"]
+    },
+    {
+      "id": "breakfast-and-dinner",
+      "candidates": [
+        { "id": "breakfast-tag", "title": "Weeknight Pasta", "tags": ["breakfast"] },
+        { "id": "snack-title", "title": "Popcorn", "tags": [] },
+        { "id": "plain-dinner", "title": "Braised Short Ribs", "tags": [] },
+        { "id": "both", "title": "Yogurt Parfait", "tags": ["snacks"] }
+      ],
+      "mealSlots": ["breakfast", "dinner"],
+      "expected": ["breakfast-tag", "snack-title", "plain-dinner", "both"]
+    },
+    {
+      "id": "lunch-and-dinner",
+      "candidates": [
+        { "id": "breakfast-tag", "title": "Weeknight Pasta", "tags": ["breakfast"] },
+        { "id": "snack-title", "title": "Popcorn", "tags": [] },
+        { "id": "plain-dinner", "title": "Braised Short Ribs", "tags": [] },
+        { "id": "both", "title": "Yogurt Parfait", "tags": ["snacks"] }
+      ],
+      "mealSlots": ["lunch", "dinner"],
+      "expected": ["breakfast-tag", "snack-title", "plain-dinner", "both"]
+    },
+    {
+      "id": "empty-slots",
+      "candidates": [
+        { "id": "breakfast-tag", "title": "Weeknight Pasta", "tags": ["breakfast"] },
+        { "id": "snack-title", "title": "Popcorn", "tags": [] },
+        { "id": "plain-dinner", "title": "Braised Short Ribs", "tags": [] },
+        { "id": "both", "title": "Yogurt Parfait", "tags": ["snacks"] }
+      ],
+      "mealSlots": [],
+      "expected": ["breakfast-tag", "snack-title", "plain-dinner", "both"]
+    }
+  ],
+  "insufficientSlotCoverageMessage": [
+    {
+      "id": "breakfast-singular",
+      "mealSlots": ["breakfast"],
+      "found": 1,
+      "requested": 7,
+      "expected": "Cheffy found 1 breakfast recipe that match your preferences. Try broadening your preferences to fill the rest of the week."
+    },
+    {
+      "id": "breakfast-plural",
+      "mealSlots": ["breakfast"],
+      "found": 3,
+      "requested": 7,
+      "expected": "Cheffy found 3 breakfast recipes that match your preferences. Try broadening your preferences to fill the rest of the week."
+    },
+    {
+      "id": "breakfast-found-eq-requested",
+      "mealSlots": ["breakfast"],
+      "found": 7,
+      "requested": 7,
+      "expected": null
+    },
+    {
+      "id": "breakfast-found-zero",
+      "mealSlots": ["breakfast"],
+      "found": 0,
+      "requested": 7,
+      "expected": null
+    },
+    {
+      "id": "breakfast-found-gt-requested",
+      "mealSlots": ["breakfast"],
+      "found": 8,
+      "requested": 7,
+      "expected": null
+    },
+    {
+      "id": "snack-singular",
+      "mealSlots": ["snack"],
+      "found": 1,
+      "requested": 7,
+      "expected": "Cheffy found 1 snack recipe that match your preferences. Try broadening your preferences to fill the rest of the week."
+    },
+    {
+      "id": "snack-plural",
+      "mealSlots": ["snack"],
+      "found": 2,
+      "requested": 7,
+      "expected": "Cheffy found 2 snack recipes that match your preferences. Try broadening your preferences to fill the rest of the week."
+    },
+    {
+      "id": "snack-found-zero",
+      "mealSlots": ["snack"],
+      "found": 0,
+      "requested": 7,
+      "expected": null
+    },
+    {
+      "id": "generic-singular",
+      "mealSlots": ["lunch"],
+      "found": 1,
+      "requested": 7,
+      "expected": "Cheffy found 1 matching recipe — some slots were left empty rather than filled with a poor match."
+    },
+    {
+      "id": "generic-plural",
+      "mealSlots": ["lunch", "dinner"],
+      "found": 4,
+      "requested": 7,
+      "expected": "Cheffy found 4 matching recipes — some slots were left empty rather than filled with a poor match."
+    },
+    {
+      "id": "generic-when-breakfast-not-alone",
+      "mealSlots": ["breakfast", "dinner"],
+      "found": 3,
+      "requested": 7,
+      "expected": "Cheffy found 3 matching recipes — some slots were left empty rather than filled with a poor match."
+    },
+    {
+      "id": "generic-found-eq-requested",
+      "mealSlots": ["dinner"],
+      "found": 7,
+      "requested": 7,
+      "expected": null
+    }
+  ],
+  "noEligibleRecipesMessage": [
+    {
+      "id": "breakfast-only",
+      "mealSlots": ["breakfast"],
+      "expected": "Cheffy could not find breakfast or brunch recipes that match your preferences. Try another source, or add breakfast recipes."
+    },
+    {
+      "id": "snack-only",
+      "mealSlots": ["snack"],
+      "expected": "Cheffy could not find snack recipes that match your preferences. Try another source, or loosen the filters."
+    },
+    {
+      "id": "generic-lunch",
+      "mealSlots": ["lunch"],
+      "expected": "Could not find enough matching recipes. Try another source, or loosen the time and ingredient filters."
+    },
+    {
+      "id": "generic-when-breakfast-not-alone",
+      "mealSlots": ["breakfast", "dinner"],
+      "expected": "Could not find enough matching recipes. Try another source, or loosen the time and ingredient filters."
+    },
+    {
+      "id": "generic-empty-slots",
+      "mealSlots": [],
+      "expected": "Could not find enough matching recipes. Try another source, or loosen the time and ingredient filters."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- This is a **parity artifact**, not ordinary test coverage. Android's Cheffy meal-planning port (frontend PR #644) must reproduce `src/lib/mealplan/slotEligibility.ts` exactly: breakfast/snack are hard filters, and the server re-validates model output via `validateGeneratedMealPlan` → `isRecipeEligibleForSlot` (422 `ineligible-slot`). An Android-only fixture with an Android-only hash proves nothing; the vectors originate here so `ContractFixtureChecksumTest` can checksum against the sha256 table in `docs/mealplan-contract.md`.
- Adds `src/test/fixtures/mealplan-eligibility.vectors.json` and the first Vitest suite for `slotEligibility.ts`. No runtime code changes — vectors record current behavior, including quirks.
- Registers the fixture in the cross-platform sha256 table. **Paired Android PR:** copy this file verbatim into `app/src/test/resources/fixtures/` and add the hash below to `ContractFixtureChecksumTest.EXPECTED`.

The pre-commit version hook also bumped `package.json` `4.2.723` → `4.2.724` (repo convention on every commit). Intentional diff is the fixture, the test, and the contract table + Notes bullet.

## Vector count

Every case in every array is executed (plus one meta-test that the fixture has no unread arrays). **62 vectors**, 63 tests.

| Case array | Count |
|---|---|
| `isRecipeEligibleForSlot` | 36 |
| `eligibleSlotsForRecipe` | 4 |
| `restrictCandidatesToRequestedSlots` | 5 |
| `insufficientSlotCoverageMessage` | 12 |
| `noEligibleRecipesMessage` | 5 |

**sha256** (`shasum -a 256 src/test/fixtures/mealplan-eligibility.vectors.json`):

```
36e19caaa2ecc7df9005c1dc6f342a92a7cbe4b685faa3461c236fd3c39f531d
```

## Observed, not changed

Recorded as vectors; left `slotEligibility.ts` alone.

- **`titleHasPhrase` is a leading-boundary prefix match**, not a whole-phrase match. The ` ${phrase} ` check is redundant with ` ${phrase}`, so "Pancakeland" is breakfast-eligible (`quirk-title-prefix-pancakeland`).
- **`tagMatches` uses untokenized `includes`**, so a tag of `"unbreakfast"` is breakfast-eligible (`quirk-tag-substring-unbreakfast`). This is the same contains-after-hyphen-to-space behavior that makes `zapcooking-breakfast` load-bearing — Android must not prefix-strip category tags.
- **Compact `"Hashbrown"` is not breakfast** (`quirk-hashbrown-compact-false`): the phrase list has `hashbrowns` / `hash brown` / `hash browns`, not `hashbrown`. `"Hash Brown Casserole"` and `"Corned Beef Hash"` still match.
- **Singular coverage copy is ungrammatical:** `found === 1` yields `"Cheffy found 1 breakfast recipe that match your preferences..."` (plural verb). Same for snack.
- **Breakfast/snack-specific copy only fires when `mealSlots` has exactly one entry.** `["breakfast", "dinner"]` uses the generic message (`generic-when-breakfast-not-alone`).
- **Lunch and dinner are unconditionally eligible**, so `restrictCandidatesToRequestedSlots` with `["breakfast", "dinner"]` keeps every candidate (dinner is permissive).

## Test plan

- [x] `vitest run src/lib/mealplan/slotEligibility.test.ts` — 63 passed
- [x] full `vitest run` — 1512 passed (107 files), including the new suite
- [x] `svelte-check` — 0 errors (`it.each` is missing from svelte-check's vitest typings, so the suite uses the existing `for` + `it(id)` fixture pattern)
- [x] sha256 recomputed after the final JSON edit; table row matches the committed file byte-for-byte
- [ ] Paired Android PR copies the fixture verbatim and adds the hash to `ContractFixtureChecksumTest.EXPECTED`