### PR TITLE
fix(ui): add not-allowed cursor to disabled Button variants

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.724",
+  "version": "4.2.725",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/Button.svelte
+++ b/src/components/Button.svelte
@@ -18,12 +18,12 @@
     primary === false ? 'secondary' : primary === true ? 'primary' : variant;
 
   const variantClasses: Record<ButtonVariant, string> = {
-    primary: 'bg-primary text-white hover:opacity-80 disabled:bg-primary/50',
-    secondary: 'bg-gray-700 text-white hover:bg-gray-600 disabled:bg-gray-700/50',
+    primary: 'bg-primary text-white hover:opacity-80 disabled:bg-primary/50 disabled:cursor-not-allowed',
+    secondary: 'bg-gray-700 text-white hover:bg-gray-600 disabled:bg-gray-700/50 disabled:cursor-not-allowed',
     outline:
-      'bg-transparent border border-primary text-primary hover:bg-primary/10 disabled:opacity-50',
+      'bg-transparent border border-primary text-primary hover:bg-primary/10 disabled:opacity-50 disabled:cursor-not-allowed',
     ghost:
-      'bg-transparent text-primary hover:bg-primary/10 disabled:opacity-50'
+      'bg-transparent text-primary hover:bg-primary/10 disabled:opacity-50 disabled:cursor-not-allowed'
   };
 </script>
 


### PR DESCRIPTION
## What

Adds `disabled:cursor-not-allowed` to each of the four variant strings in `src/components/Button.svelte`. Every variant already dims when disabled (`disabled:bg-*` / `disabled:opacity-50`), but the cursor gave no signal, so disabled buttons read as broken rather than unavailable — most visibly the Publish Recipe button on /create.

## Scope

- Pure CSS addition inside the variant strings; no behavior or API change.
- All ~77 `<Button ... disabled>` call sites across 30 files pick this up for free. Since the variant string is interpolated into the component's own `class` attribute (which wins over `$$restProps`), no caller class is displaced.
- Two callers already added the cursor themselves (`LoginOverlay.svelte:1333`, `feed-post/+page.svelte:150`) — now redundant with the same value, intentionally left alone.
- Raw `<button>` elements that mimic Button styling are out of scope.

## Testing

Full vitest suite green (111 files, 1525 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBSGj2JUAf3G9WxmuCtjCA
