### PR TITLE
feat(create): name the missing fields blocking Publish on both recipe forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.724",
+  "version": "4.2.725",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/recipeValidation.test.ts
+++ b/src/lib/recipeValidation.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { getMissingFields, type RecipeRequiredFields } from './recipeValidation';
+
+function complete(): RecipeRequiredFields {
+  return {
+    title: 'Beef Wellington',
+    tags: [{ title: 'beef' }],
+    ingredients: ['1 lb beef tenderloin'],
+    directions: ['Sear the beef on all sides'],
+    images: ['https://example.com/wellington.jpg']
+  };
+}
+
+describe('getMissingFields', () => {
+  it('returns an empty list when every field is present', () => {
+    expect(getMissingFields(complete())).toEqual([]);
+  });
+
+  it('reports a missing title', () => {
+    expect(getMissingFields({ ...complete(), title: '' })).toEqual(['a title']);
+  });
+
+  it('treats a whitespace-only title as missing', () => {
+    // Previously a truthy check let "   " through, producing a d tag of
+    // pure dashes. Behavior change: trim before counting the title.
+    expect(getMissingFields({ ...complete(), title: '   ' })).toEqual(['a title']);
+  });
+
+  it('reports missing tags', () => {
+    expect(getMissingFields({ ...complete(), tags: [] })).toEqual(['at least one tag']);
+  });
+
+  it('reports missing ingredients', () => {
+    expect(getMissingFields({ ...complete(), ingredients: [] })).toEqual(['ingredients']);
+  });
+
+  it('reports missing directions', () => {
+    expect(getMissingFields({ ...complete(), directions: [] })).toEqual(['directions']);
+  });
+
+  it('reports a missing photo', () => {
+    expect(getMissingFields({ ...complete(), images: [] })).toEqual(['a photo']);
+  });
+
+  it('reports several missing fields in stable order', () => {
+    expect(
+      getMissingFields({ ...complete(), tags: [], directions: [], images: [] })
+    ).toEqual(['at least one tag', 'directions', 'a photo']);
+  });
+
+  it('reports all five fields for an empty form', () => {
+    expect(
+      getMissingFields({ title: '', tags: [], ingredients: [], directions: [], images: [] })
+    ).toEqual(['a title', 'at least one tag', 'ingredients', 'directions', 'a photo']);
+  });
+});

--- a/src/lib/recipeValidation.ts
+++ b/src/lib/recipeValidation.ts
@@ -1,0 +1,29 @@
+/**
+ * The five fields a recipe must have before it can be published.
+ * Shared by /create and /create/gated so both forms gate (and explain)
+ * the publish button the same way.
+ */
+export interface RecipeRequiredFields {
+  title: string;
+  tags: readonly unknown[];
+  ingredients: readonly unknown[];
+  directions: readonly unknown[];
+  images: readonly unknown[];
+}
+
+/**
+ * Returns human-readable names of the required fields that are still
+ * empty, in a stable order suitable for a "Still needed: ..." hint.
+ * A whitespace-only title counts as missing — it would otherwise
+ * produce a `d` tag of pure dashes.
+ */
+export function getMissingFields(fields: RecipeRequiredFields): string[] {
+  const { title, tags, ingredients, directions, images } = fields;
+  return [
+    !title.trim() && 'a title',
+    tags.length === 0 && 'at least one tag',
+    ingredients.length === 0 && 'ingredients',
+    directions.length === 0 && 'directions',
+    images.length === 0 && 'a photo'
+  ].filter((f): f is string => Boolean(f));
+}

--- a/src/routes/create/+page.svelte
+++ b/src/routes/create/+page.svelte
@@ -17,6 +17,7 @@
   import MarkdownEditor from '../../components/MarkdownEditor.svelte';
   import { onMount, onDestroy, tick } from 'svelte';
   import { RECIPE_TAG_PREFIX_NEW } from '$lib/consts';
+  import { getMissingFields } from '$lib/recipeValidation';
   import {
     saveDraft,
     getDraft,
@@ -310,13 +311,16 @@
     });
   }
 
-  // Check if all required fields are filled (for enabling publish button)
-  $: canPublish =
-    $images.length > 0 &&
-    title &&
-    $selectedTags.length > 0 &&
-    $directionsArray.length > 0 &&
-    $ingredientsArray.length > 0;
+  // Which required fields are still empty — drives the publish gate and
+  // the "Still needed" hint next to the action buttons
+  $: missingFields = getMissingFields({
+    title,
+    tags: $selectedTags,
+    ingredients: $ingredientsArray,
+    directions: $directionsArray,
+    images: $images
+  });
+  $: canPublish = missingFields.length === 0;
 
   async function publishRecipe() {
     formatStringArrays();
@@ -634,6 +638,12 @@
     <span class="text-caption">First image will be your cover photo</span>
     <MediaUploader uploadedImages={images} />
   </div>
+
+  {#if missingFields.length > 0}
+    <p class="text-sm text-caption text-right">
+      Still needed: {missingFields.join(', ')}
+    </p>
+  {/if}
 
   <div class="flex justify-end items-center gap-2">
     {#if draftSaveMessage}

--- a/src/routes/create/gated/+page.svelte
+++ b/src/routes/create/gated/+page.svelte
@@ -18,6 +18,7 @@
   import MarkdownEditor from '../../../components/MarkdownEditor.svelte';
   import { onMount, onDestroy } from 'svelte';
   import { RECIPE_TAG_PREFIX_NEW, GATED_RECIPE_KIND, GATED_RECIPE_TAG } from '$lib/consts';
+  import { getMissingFields } from '$lib/recipeValidation';
   import { saveDraft, getDraft, deleteDraft } from '$lib/draftStore';
   import FloppyDiskIcon from 'phosphor-svelte/lib/FloppyDisk';
   import GateRecipeToggle from '../../../components/GateRecipeToggle.svelte';
@@ -160,7 +161,20 @@
   }
 
   // Check if all required fields are filled (for enabling publish button)
-  $: canPublish = $images.length > 0 && title && $selectedTags.length > 0 && $directionsArray.length > 0 && $ingredientsArray.length > 0 && gateCostSats > 0;
+  // Which required fields are still empty — drives the publish gate and
+  // the "Still needed" hint. The gate cost is specific to this page, so
+  // it's appended after the five shared recipe fields.
+  $: missingFields = [
+    ...getMissingFields({
+      title,
+      tags: $selectedTags,
+      ingredients: $ingredientsArray,
+      directions: $directionsArray,
+      images: $images
+    }),
+    ...(gateCostSats > 0 ? [] : ['a gate cost'])
+  ];
+  $: canPublish = missingFields.length === 0;
 
   async function publishRecipe() {
     formatStringArrays();
@@ -445,6 +459,12 @@
         </div>
       {/if}
     </div>
+
+    {#if missingFields.length > 0}
+      <p class="text-sm text-caption text-right">
+        Still needed: {missingFields.join(', ')}
+      </p>
+    {/if}
 
     <div class="flex justify-end items-center gap-2">
       {#if draftSaveMessage}


### PR DESCRIPTION
## What

The Publish button on `/create` (and `/create/gated`) is disabled until five required fields are filled, but nothing tells the user which field is missing — the page reads as broken, especially since Save Draft works. This PR makes both recipe forms say what's missing.

- New `src/lib/recipeValidation.ts` exporting a pure `getMissingFields({ title, tags, ingredients, directions, images })` returning an ordered `string[]`.
- `/create` and `/create/gated` both derive `missingFields` from it and compute `canPublish = missingFields.length === 0`; the gated page appends its page-specific `gateCostSats > 0` requirement as `'a gate cost'` so its hint stays complete.
- A neutral, comma-joined hint renders beside the action buttons on both forms, e.g. **Still needed: at least one tag, directions**.

## Behavior change (intentional)

The title check tightens from truthy to `.trim()`: a whitespace-only title previously passed the gate and produced a `d` tag of pure dashes (`title.toLowerCase().replaceAll(' ', '-')` at `src/routes/create/+page.svelte:343`). It now counts as missing.

## Out of scope

`publishRecipe`, `disablePublishButton`, and the draft/auto-save machinery are untouched. The disabled-cursor styling is PR #650.

## Testing

- New `src/lib/recipeValidation.test.ts` (9 tests): each field missing individually, several at once, all present, whitespace-only title, and full-empty-form ordering.
- Full vitest suite green (1534 tests), `svelte-check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBSGj2JUAf3G9WxmuCtjCA
