### PR TITLE
fix(recipes): enforce the hidden-recipe list on every surface, with d-tag prefix matching

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.726",
+  "version": "4.2.727",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.725",
+  "version": "4.2.726",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/BoostedRecipeCard.svelte
+++ b/src/components/BoostedRecipeCard.svelte
@@ -5,6 +5,7 @@
   import { goto } from '$app/navigation';
   import { getImageOrPlaceholder } from '$lib/placeholderImages';
   import { lazyLoad } from '$lib/lazyLoad';
+  import { isHiddenRecipeEvent } from '$lib/consts';
 
   // Accept either an NDKEvent or pre-resolved props
   export let event: NDKEvent | null = null;
@@ -19,7 +20,9 @@
   let resolvedAuthorPubkey: string | null = null;
 
   $: {
-    if (event && event.tags) {
+    if (event && isHiddenRecipeEvent(event)) {
+      resolvedLink = '';
+    } else if (event && event.tags) {
       // Derive from NDKEvent (same logic as TrendingRecipeCard)
       const d = event.tags.find((t) => Array.isArray(t) && t[0] == 'd')?.[1];
       if (d && event.author?.pubkey) {

--- a/src/components/Feed.svelte
+++ b/src/components/Feed.svelte
@@ -19,6 +19,7 @@
   import type { NDKEvent } from '@nostr-dev-kit/ndk';
   import RecipeCard from './RecipeCard.svelte';
   import { validateMarkdownTemplate } from '$lib/parser';
+  import { isHiddenRecipeEvent } from '$lib/consts';
 
   export let events: NDKEvent[];
   export let hideHide = false;
@@ -45,12 +46,14 @@
     // Perform validation checks
     const hasContent = Boolean(e.content && e.content.trim() !== '');
     const notDeleted = !e.tags.some((t) => t[0] === 'deleted');
+    // Site-wide hide list (applies to lists too, so no `lists` bypass)
+    const notHidden = !isHiddenRecipeEvent(e);
 
     // For lists, skip markdown validation
     // For recipes, validate markdown structure
     const validStructure = lists || typeof validateMarkdownTemplate(e.content) !== 'string';
 
-    const isValid: boolean = hasContent && notDeleted && validStructure;
+    const isValid: boolean = hasContent && notDeleted && notHidden && validStructure;
 
     // Cache the result
     if (eventId) {

--- a/src/components/NoteEmbed.svelte
+++ b/src/components/NoteEmbed.svelte
@@ -4,6 +4,7 @@
   import { browser } from '$app/environment';
   import { ndk } from '$lib/nostr';
   import { mutedPubkeys } from '$lib/muteListStore';
+  import { isHiddenRecipeEvent } from '$lib/consts';
   import CustomAvatar from './CustomAvatar.svelte';
   import AuthorName from './AuthorName.svelte';
   import { formatDistanceToNow } from 'date-fns';
@@ -126,6 +127,7 @@
       let resolved = false;
 
       subscription.on('event', (receivedEvent: NDKEvent) => {
+        if (isHiddenRecipeEvent(receivedEvent)) return;
         if (!event) {
           event = receivedEvent;
           loading = false;

--- a/src/components/TagsSearchAutocomplete.svelte
+++ b/src/components/TagsSearchAutocomplete.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
-  import { recipeTags, type recipeTagSimple, RECIPE_TAGS } from '$lib/consts';
+  import { recipeTags, type recipeTagSimple, RECIPE_TAGS, isHiddenRecipeEvent } from '$lib/consts';
   import { ndk, userPublickey } from '$lib/nostr';
   import { nip19 } from 'nostr-tools';
   import { NDKRelaySet, type NDKEvent } from '@nostr-dev-kit/ndk';
@@ -130,6 +130,7 @@
       if (cachedEvents && cachedEvents.length > 0) {
         const map = new Map<string, (typeof recipeCache)[0]>();
         for (const event of cachedEvents) {
+          if (isHiddenRecipeEvent(event)) continue;
           const title = event.tags.find((t) => t[0] === 'title')?.[1] || 'Untitled';
           const summary = event.tags.find((t) => t[0] === 'summary')?.[1] || '';
           const d = event.tags.find((t) => t[0] === 'd')?.[1] || '';
@@ -165,6 +166,7 @@
       const tempMap = new Map<string, (typeof recipeCache)[0]>();
 
       recipeSubscription.on('event', (event: any) => {
+        if (isHiddenRecipeEvent(event)) return;
         const title = event.tags.find((t: any) => t[0] === 'title')?.[1] || 'Untitled';
         const summary = event.tags.find((t: any) => t[0] === 'summary')?.[1] || '';
         const d = event.tags.find((t: any) => t[0] === 'd')?.[1] || '';
@@ -349,6 +351,7 @@
       const d = event.tags.find((t: string[]) => t[0] === 'd')?.[1];
       const title = event.tags.find((t: string[]) => t[0] === 'title')?.[1];
       if (!d || !title) return;
+      if (isHiddenRecipeEvent(event)) return;
 
       const naddr = nip19.naddrEncode({ kind: 30023, pubkey: event.pubkey, identifier: d });
       if (searchResults.recipes.some((r) => r.naddr === naddr)) return;

--- a/src/lib/consts.test.ts
+++ b/src/lib/consts.test.ts
@@ -24,6 +24,14 @@ describe('isHiddenRecipeCoordinate', () => {
   it('hides any pubkey whose d-tag matches a listed prefix', () => {
     expect(isHiddenRecipeCoordinate(30023, 'f'.repeat(64), 'ios-2.3-live-publish-0001')).toBe(true);
     expect(isHiddenRecipeCoordinate(30023, 'a'.repeat(64), 'ios-2.3-live-publish-')).toBe(true);
+    // premium recipe kind is prefix-matched too
+    expect(isHiddenRecipeCoordinate(35000, 'f'.repeat(64), 'ios-2.3-live-publish-1')).toBe(true);
+  });
+
+  it('limits prefix matching to recipe kinds', () => {
+    // a kind-30001 cookbook list with a colliding d-tag is not swallowed
+    expect(isHiddenRecipeCoordinate(30001, 'f'.repeat(64), 'ios-2.3-live-publish-1')).toBe(false);
+    expect(isHiddenRecipeCoordinate(30078, 'f'.repeat(64), 'ios-2.3-live-publish-1')).toBe(false);
   });
 
   it('does not hide normal recipes', () => {

--- a/src/lib/consts.test.ts
+++ b/src/lib/consts.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import {
+  HIDDEN_RECIPE_COORDINATES,
+  isHiddenRecipeCoordinate,
+  isHiddenRecipeEvent,
+  isHiddenRecipeATag
+} from './consts';
+
+const LISTED = '30023:8b739c62ed2a9b76c2836a18a6bc9a480b6f8d902b8f702083dfae20bf6b15b9:zc-pr11-test-bravo';
+const [LISTED_KIND, LISTED_PUBKEY, LISTED_DTAG] = [30023, LISTED.split(':')[1], 'zc-pr11-test-bravo'];
+
+describe('isHiddenRecipeCoordinate', () => {
+  it('hides exact listed coordinates', () => {
+    expect(isHiddenRecipeCoordinate(LISTED_KIND, LISTED_PUBKEY, LISTED_DTAG)).toBe(true);
+  });
+
+  it('hides every coordinate on the exact list', () => {
+    for (const coord of HIDDEN_RECIPE_COORDINATES) {
+      const [kind, pubkey, ...d] = coord.split(':');
+      expect(isHiddenRecipeCoordinate(Number(kind), pubkey, d.join(':'))).toBe(true);
+    }
+  });
+
+  it('hides any pubkey whose d-tag matches a listed prefix', () => {
+    expect(isHiddenRecipeCoordinate(30023, 'f'.repeat(64), 'ios-2.3-live-publish-0001')).toBe(true);
+    expect(isHiddenRecipeCoordinate(30023, 'a'.repeat(64), 'ios-2.3-live-publish-')).toBe(true);
+  });
+
+  it('does not hide normal recipes', () => {
+    expect(isHiddenRecipeCoordinate(30023, 'f'.repeat(64), 'grandmas-lasagna')).toBe(false);
+    // prefix must match the start, not the middle
+    expect(isHiddenRecipeCoordinate(30023, 'f'.repeat(64), 'my-ios-2.3-live-publish-copy')).toBe(
+      false
+    );
+  });
+
+  it('does not hide a listed d-tag under a different pubkey unless prefix-matched', () => {
+    expect(isHiddenRecipeCoordinate(30023, 'f'.repeat(64), LISTED_DTAG)).toBe(false);
+  });
+
+  it('returns false for missing parts', () => {
+    expect(isHiddenRecipeCoordinate(null, LISTED_PUBKEY, LISTED_DTAG)).toBe(false);
+    expect(isHiddenRecipeCoordinate(LISTED_KIND, '', LISTED_DTAG)).toBe(false);
+    expect(isHiddenRecipeCoordinate(LISTED_KIND, LISTED_PUBKEY, null)).toBe(false);
+  });
+});
+
+describe('isHiddenRecipeEvent', () => {
+  it('hides an event with a prefix-matched d-tag', () => {
+    expect(
+      isHiddenRecipeEvent({
+        kind: 30023,
+        pubkey: 'f'.repeat(64),
+        tags: [['d', 'ios-2.3-live-publish-42'], ['title', 'junk']]
+      })
+    ).toBe(true);
+  });
+
+  it('does not hide a normal event', () => {
+    expect(
+      isHiddenRecipeEvent({ kind: 30023, pubkey: 'f'.repeat(64), tags: [['d', 'real-recipe']] })
+    ).toBe(false);
+  });
+
+  it('does not hide an event without a d tag', () => {
+    expect(isHiddenRecipeEvent({ kind: 30023, pubkey: 'f'.repeat(64), tags: [] })).toBe(false);
+  });
+});
+
+describe('isHiddenRecipeATag', () => {
+  it('hides exact listed a-tags', () => {
+    expect(isHiddenRecipeATag(LISTED)).toBe(true);
+  });
+
+  it('hides prefix-matched a-tags', () => {
+    expect(isHiddenRecipeATag(`30023:${'f'.repeat(64)}:ios-2.3-live-publish-9`)).toBe(true);
+  });
+
+  it('handles d-tags containing colons', () => {
+    expect(isHiddenRecipeATag(`30023:${'f'.repeat(64)}:ios-2.3-live-publish-a:b`)).toBe(true);
+  });
+
+  it('does not hide normal a-tags or malformed input', () => {
+    expect(isHiddenRecipeATag(`30023:${'f'.repeat(64)}:grandmas-lasagna`)).toBe(false);
+    expect(isHiddenRecipeATag('')).toBe(false);
+    expect(isHiddenRecipeATag(null)).toBe(false);
+    expect(isHiddenRecipeATag('not-a-coordinate')).toBe(false);
+  });
+});

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -32,9 +32,24 @@ export const RECIPE_TAG_PREFIX_LEGACY = 'nostrcooking';
 export const RECIPE_TAGS = [RECIPE_TAG_PREFIX_NEW, RECIPE_TAG_PREFIX_LEGACY]; // For filtering (supports both)
 
 /**
- * Dev / e2e test recipes that should never surface on /recipes.
+ * Dev / e2e test recipes that should never surface anywhere on the site.
  * Coordinates are NIP-01 addressable keys `kind:pubkey:d-tag` (not event ids),
  * so later replaceable revisions stay hidden too.
+ *
+ * These entries are artifacts of a process failure that has now happened
+ * twice: live-write test gates (first an Android build, then the iOS 2.3
+ * live-publish gate) published test recipes to production relays and then
+ * discarded the ephemeral signing keys before cleaning up, making NIP-09
+ * deletion impossible. If you are here to add another coordinate, stop and
+ * fix the test instead — live-publish tests must publish, verify, and
+ * DELETE with the same key before discarding it. This list is damage
+ * control, not the normal fix.
+ *
+ * This list is duplicated across three codebases with no shared package.
+ * Any change here must be mirrored in:
+ *   Android: app/src/main/kotlin/cooking/zap/app/nostr/HiddenRecipes.kt
+ *   iOS:     HiddenRecipes.swift
+ * Drift means a recipe hidden on one client stays visible on another.
  *
  * Source naddrs (19): zc-pr11 / pr10 / pr11-ghost / pr10-zero-parse* / e2e-*.
  */
@@ -60,14 +75,42 @@ export const HIDDEN_RECIPE_COORDINATES: ReadonlySet<string> = new Set([
   '30023:dd7e9c53ae4509aba878370c7285395e5d61b98e8eabdb33afa4deb6b6f68c13:e2e-curry'
 ]);
 
-/** True when a recipe coordinate is on the permanent /recipes hide list. */
+/**
+ * d-tag prefixes that mark junk test recipes regardless of pubkey. The iOS
+ * 2.3 live-publish gate spread nine recipes across eight ephemeral pubkeys,
+ * so an exact-coordinate (or pubkey) list would grow with every future gate
+ * run; the shared d-tag prefix is the stable identifier. Mirror changes in
+ * the Android/iOS files listed above.
+ */
+export const HIDDEN_RECIPE_DTAG_PREFIXES = ['ios-2.3-live-publish-'] as const;
+
+/** True when a recipe coordinate is on the permanent site-wide hide list. */
 export function isHiddenRecipeCoordinate(
   kind: number | undefined | null,
   pubkey: string | undefined | null,
   dTag: string | undefined | null
 ): boolean {
   if (kind == null || !pubkey || !dTag) return false;
-  return HIDDEN_RECIPE_COORDINATES.has(`${kind}:${pubkey}:${dTag}`);
+  if (HIDDEN_RECIPE_COORDINATES.has(`${kind}:${pubkey}:${dTag}`)) return true;
+  return HIDDEN_RECIPE_DTAG_PREFIXES.some((prefix) => dTag.startsWith(prefix));
+}
+
+/** True when a nostr event (NDKEvent-shaped) is on the site-wide hide list. */
+export function isHiddenRecipeEvent(event: {
+  kind?: number | null;
+  pubkey?: string;
+  tags?: readonly (readonly string[])[];
+}): boolean {
+  const dTag = event.tags?.find((t) => t[0] === 'd')?.[1];
+  return isHiddenRecipeCoordinate(event.kind, event.pubkey, dTag);
+}
+
+/** True when an addressable coordinate string (`kind:pubkey:d-tag`) is hidden. */
+export function isHiddenRecipeATag(aTag: string | undefined | null): boolean {
+  if (!aTag) return false;
+  const [kind, pubkey, ...dParts] = aTag.split(':');
+  // d-tags may themselves contain ':', so rejoin the tail.
+  return isHiddenRecipeCoordinate(Number(kind), pubkey, dParts.join(':'));
 }
 
 // Gated/Premium recipe kind (addressable event in 30000-39999 range)

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -92,6 +92,9 @@ export function isHiddenRecipeCoordinate(
 ): boolean {
   if (kind == null || !pubkey || !dTag) return false;
   if (HIDDEN_RECIPE_COORDINATES.has(`${kind}:${pubkey}:${dTag}`)) return true;
+  // Prefix matching is recipe-only so a non-recipe addressable event (e.g. a
+  // kind-30001 cookbook list) with a colliding d-tag is never swallowed.
+  if (kind !== 30023 && kind !== GATED_RECIPE_KIND) return false;
   return HIDDEN_RECIPE_DTAG_PREFIXES.some((prefix) => dTag.startsWith(prefix));
 }
 

--- a/src/lib/exploreUtils.ts
+++ b/src/lib/exploreUtils.ts
@@ -5,7 +5,12 @@ import { validateMarkdownTemplate } from './parser';
 import { profileCacheManager } from './profileCache';
 import { logger } from './logger';
 import { markOnce } from './perf/explorePerf';
-import { RECIPE_TAGS, RECIPE_TAG_PREFIX_NEW, RECIPE_TAG_PREFIX_LEGACY } from './consts';
+import {
+  RECIPE_TAGS,
+  RECIPE_TAG_PREFIX_NEW,
+  RECIPE_TAG_PREFIX_LEGACY,
+  isHiddenRecipeEvent
+} from './consts';
 
 export type Collection = {
   id: string;
@@ -227,7 +232,11 @@ async function fetchPopularCooksFresh(limit: number): Promise<PopularCook[]> {
           markOnce('t3_explore_first_live_event_received');
         }
         eventCount++;
-        if (typeof validateMarkdownTemplate(event.content) !== 'string' && event.author?.pubkey) {
+        if (
+          typeof validateMarkdownTemplate(event.content) !== 'string' &&
+          event.author?.pubkey &&
+          !isHiddenRecipeEvent(event)
+        ) {
           const count = authorCounts.get(event.author.pubkey) || 0;
           authorCounts.set(event.author.pubkey, count + 1);
         }
@@ -337,7 +346,11 @@ export async function fetchCollectionImage(tag: string): Promise<string | undefi
       }, 3000); // Shorter timeout for collection images
 
       subscription.on('event', (event: NDKEvent) => {
-        if (typeof validateMarkdownTemplate(event.content) !== 'string' && !imageUrl) {
+        if (
+          typeof validateMarkdownTemplate(event.content) !== 'string' &&
+          !isHiddenRecipeEvent(event) &&
+          !imageUrl
+        ) {
           // Find first image tag
           const imageTag = event.tags.find((t) => Array.isArray(t) && t[0] === 'image');
           if (imageTag && Array.isArray(imageTag) && imageTag[1]) {
@@ -484,7 +497,11 @@ export async function fetchTrendingRecipes(limit: number = 12): Promise<NDKEvent
       }, 5000); // 5 second timeout for faster UX
 
       subscription.on('event', (event: NDKEvent) => {
-        if (typeof validateMarkdownTemplate(event.content) !== 'string' && event.author?.pubkey) {
+        if (
+          typeof validateMarkdownTemplate(event.content) !== 'string' &&
+          event.author?.pubkey &&
+          !isHiddenRecipeEvent(event)
+        ) {
           recipes.push(event);
         }
       });
@@ -747,7 +764,7 @@ export async function fetchDiscoverRecipes(
         }
 
         // Filter: must have valid markdown and author (image is preferred but not required if we don't have enough)
-        if (hasValidMarkdown && hasAuthor) {
+        if (hasValidMarkdown && hasAuthor && !isHiddenRecipeEvent(event)) {
           validCount++;
           allRecipes.push(event);
 

--- a/src/lib/mesh/meshData.ts
+++ b/src/lib/mesh/meshData.ts
@@ -9,7 +9,8 @@ import {
   CURATED_TAG_SECTIONS,
   TAG_ALIASES,
   recipeTags,
-  GATED_RECIPE_KIND
+  GATED_RECIPE_KIND,
+  isHiddenRecipeEvent
 } from '$lib/consts';
 import { getImageOrPlaceholder } from '$lib/placeholderImages';
 import { nip19 } from 'nostr-tools';
@@ -65,7 +66,11 @@ export async function fetchMeshRecipes(): Promise<NDKEvent[]> {
     const timeout = setTimeout(finalize, 8000);
 
     subscription.on('event', (event: NDKEvent) => {
-      if (typeof validateMarkdownTemplate(event.content) !== 'string' && event.author?.pubkey) {
+      if (
+        typeof validateMarkdownTemplate(event.content) !== 'string' &&
+        event.author?.pubkey &&
+        !isHiddenRecipeEvent(event)
+      ) {
         recipes.push(event);
       }
       if (recipes.length >= 150) {

--- a/src/lib/myRecipesPack.ts
+++ b/src/lib/myRecipesPack.ts
@@ -17,7 +17,7 @@
 import type NDK from '@nostr-dev-kit/ndk';
 import type { NDKEvent, NDKFilter } from '@nostr-dev-kit/ndk';
 import { validateMarkdownTemplate } from '$lib/parser';
-import { RECIPE_TAGS } from '$lib/consts';
+import { RECIPE_TAGS, isHiddenRecipeCoordinate } from '$lib/consts';
 
 export interface MyRecipeForPack {
   /** Addressable a-tag in `kind:pubkey:dTag` form, ready to drop into a Recipe Pack event. */
@@ -93,6 +93,7 @@ export async function fetchMyAuthoredRecipeEvents(ndk: NDK, pubkey: string): Pro
       if (typeof validation === 'string') return;
       const dTag = event.tags.find((t) => t[0] === 'd')?.[1];
       if (!dTag) return;
+      if (isHiddenRecipeCoordinate(RECIPE_KIND, pubkey, dTag)) return;
       const aTag = `${RECIPE_KIND}:${pubkey}:${dTag}`;
       const existing = byATag.get(aTag);
       if (existing && (existing.created_at || 0) >= (event.created_at || 0)) return;

--- a/src/lib/nourish/nourishDiscovery.ts
+++ b/src/lib/nourish/nourishDiscovery.ts
@@ -29,6 +29,7 @@ import { NDKRelaySet } from '@nostr-dev-kit/ndk';
 import { NOURISH_SERVICE_PUBKEY, NOURISH_LABEL_NAMESPACE } from './types';
 import type { NourishLabel, NourishScores } from './types';
 import { parseNourishEvent, type NourishRelayResult } from './nourishRelay';
+import { isHiddenRecipeATag } from '$lib/consts';
 
 const PANTRY_RELAY = 'wss://pantry.zap.cooking';
 const FETCH_TIMEOUT_MS = 8000;
@@ -429,6 +430,7 @@ function parseAnalyses(nourishEvents: Iterable<NDKEvent>): AnalysisRow[] {
     const aTag = event.tags.find((t) => t[0] === 'a')?.[1] || '';
     const parts = aTag.split(':');
     if (parts.length < 3 || parts[0] !== '30023') continue;
+    if (isHiddenRecipeATag(aTag)) continue;
 
     const recipePubkey = parts[1];
     const recipeDTag = parts.slice(2).join(':');

--- a/src/lib/offlineStorage.ts
+++ b/src/lib/offlineStorage.ts
@@ -6,6 +6,7 @@
  */
 
 import { browser } from '$app/environment';
+import { isHiddenRecipeATag } from '$lib/consts';
 
 // Database configuration
 const DB_NAME = 'zapcooking-offline';
@@ -556,6 +557,7 @@ class OfflineStorageManager {
 
     const dTag = event.tags?.find((t: string[]) => t[0] === 'd')?.[1] || '';
     const aTag = `${event.kind}:${event.pubkey}:${dTag}`;
+    if (isHiddenRecipeATag(aTag)) return;
     console.log('[OfflineStorage] Saving recipe:', aTag, '- Title:', event.tags?.find((t: string[]) => t[0] === 'title')?.[1]);
 
     // Parse ingredients from tags
@@ -597,6 +599,7 @@ class OfflineStorageManager {
    * Get a cached recipe by its a-tag
    */
   async getRecipe(aTag: string): Promise<CachedRecipe | null> {
+    if (isHiddenRecipeATag(aTag)) return null;
     await this.ready();
     if (!this.db) {
       console.warn('[OfflineStorage] getRecipe: DB not ready');
@@ -653,7 +656,10 @@ class OfflineStorageManager {
       const store = transaction.objectStore(RECIPES_STORE);
       const request = store.getAll();
 
-      request.onsuccess = () => resolve(request.result || []);
+      request.onsuccess = () =>
+        resolve(
+          ((request.result || []) as CachedRecipe[]).filter((r) => !isHiddenRecipeATag(r.id))
+        );
       request.onerror = () => reject(request.error);
     });
   }

--- a/src/lib/recipeOg.server.ts
+++ b/src/lib/recipeOg.server.ts
@@ -14,7 +14,7 @@
 
 import { nip19 } from 'nostr-tools';
 import { raceRelays } from './recipePackOg.server';
-import { GATED_RECIPE_KIND } from './consts';
+import { GATED_RECIPE_KIND, isHiddenRecipeCoordinate, isHiddenRecipeEvent } from './consts';
 import type { OgEventLike } from './recipeOgMeta';
 
 /** Hard ceiling on the whole resolve so a wedged relay can never delay the
@@ -49,6 +49,8 @@ async function resolveEvent(slug: string): Promise<OgEventLike | null> {
 
     // Support both regular recipes (30023) and premium recipes (GATED_RECIPE_KIND).
     const recipeKind = pointer.kind === GATED_RECIPE_KIND ? GATED_RECIPE_KIND : 30023;
+    // Hidden recipes get no OG card — skip the relay race entirely.
+    if (isHiddenRecipeCoordinate(recipeKind, pointer.pubkey, pointer.identifier)) return null;
     const evt = await raceRelays({
       kinds: [recipeKind],
       authors: [pointer.pubkey],
@@ -60,7 +62,9 @@ async function resolveEvent(slug: string): Promise<OgEventLike | null> {
   // Raw hex event id.
   if (!/^[0-9a-f]{64}$/i.test(slug)) return null;
   const evt = await raceRelays({ ids: [slug] });
-  return toOgEvent(evt);
+  const ogEvent = toOgEvent(evt);
+  if (ogEvent && isHiddenRecipeEvent(ogEvent)) return null;
+  return ogEvent;
 }
 
 /**

--- a/src/lib/recipePackOg.server.ts
+++ b/src/lib/recipePackOg.server.ts
@@ -8,6 +8,8 @@
  * OG meta and the card image generator.
  */
 
+import { isHiddenRecipeATag } from './consts';
+
 const RELAYS = [
 	'wss://relay.primal.net',
 	'wss://nos.lol'
@@ -185,7 +187,10 @@ export async function fetchPackMetadata(
 	const title = find('title') || find('d') || '';
 	const description = find('description') || '';
 	const image = find('image') || '';
-	const recipeATags = tags.filter((t) => t[0] === 'a' && typeof t[1] === 'string').map((t) => t[1]);
+	const recipeATags = tags
+		.filter((t) => t[0] === 'a' && typeof t[1] === 'string')
+		.map((t) => t[1])
+		.filter((a) => !isHiddenRecipeATag(a));
 
 	return {
 		title,

--- a/src/lib/services/recipeDiscoveryService.ts
+++ b/src/lib/services/recipeDiscoveryService.ts
@@ -12,7 +12,7 @@ import {
   RECIPE_TAG_PREFIX_LEGACY,
   RECIPE_TAG_PREFIX_NEW,
   RECIPE_TAGS,
-  HIDDEN_RECIPE_COORDINATES,
+  isHiddenRecipeATag,
   isHiddenRecipeCoordinate
 } from '$lib/consts';
 import { fetchMyAuthoredRecipeEvents } from '$lib/myRecipesPack';
@@ -136,7 +136,7 @@ export function candidateFromEvent(event: NDKEvent): DiscoveredRecipe | null {
 }
 
 export function candidateFromCached(recipe: CachedRecipe): DiscoveredRecipe | null {
-  if (!isRecipeCoordinate(recipe.id) || HIDDEN_RECIPE_COORDINATES.has(recipe.id)) return null;
+  if (!isRecipeCoordinate(recipe.id) || isHiddenRecipeATag(recipe.id)) return null;
   const details = recipe.content ? extractRecipeDetails(recipe.content) : null;
   const ingredients =
     recipe.ingredients?.length > 0
@@ -198,7 +198,7 @@ export function attachDiscoveredImages<T extends { a: string }>(
 
 async function resolveCoordinates(ndk: NDK, aTags: string[]): Promise<DiscoveredRecipe[]> {
   const unique = [
-    ...new Set(aTags.filter((a) => isRecipeCoordinate(a) && !HIDDEN_RECIPE_COORDINATES.has(a)))
+    ...new Set(aTags.filter((a) => isRecipeCoordinate(a) && !isHiddenRecipeATag(a)))
   ];
   if (unique.length === 0) return [];
 

--- a/src/lib/stores/cookbookStore.ts
+++ b/src/lib/stores/cookbookStore.ts
@@ -12,7 +12,7 @@ import { writable, derived, get } from 'svelte/store';
 import { ndk, userPublickey, ensureNdkConnected } from '$lib/nostr';
 import { NDKEvent, type NDKFilter, type NDKSubscription } from '@nostr-dev-kit/ndk';
 import { nip19 } from 'nostr-tools';
-import { RECIPE_TAGS, RECIPE_TAG_PREFIX_NEW } from '$lib/consts';
+import { RECIPE_TAGS, RECIPE_TAG_PREFIX_NEW, isHiddenRecipeATag } from '$lib/consts';
 import { offlineStorage, type SyncOperation, type OfflineCookbook, type SerializedCookbookData } from '$lib/offlineStorage';
 import { isCurrentlyOnline, onConnect } from '$lib/connectionMonitor';
 
@@ -1278,7 +1278,10 @@ function eventToList(event: NDKEvent, userPubkey: string): CookbookList | null {
   const summary = event.tags.find(t => t[0] === 'summary')?.[1];
   const imageTag = event.tags.find(t => t[0] === 'image')?.[1];
   const coverRecipeId = event.tags.find(t => t[0] === 'cover')?.[1];
-  const recipes = event.tags.filter(t => t[0] === 'a').map(t => t[1]);
+  const recipes = event.tags
+    .filter(t => t[0] === 'a')
+    .map(t => t[1])
+    .filter(a => !isHiddenRecipeATag(a));
   const isDefault = dTag === DEFAULT_LIST_ID;
   
   const image = imageTag;

--- a/src/lib/tagUtils.ts
+++ b/src/lib/tagUtils.ts
@@ -4,7 +4,8 @@ import {
   TAG_ALIASES,
   RECIPE_TAGS,
   RECIPE_TAG_PREFIX_NEW,
-  RECIPE_TAG_PREFIX_LEGACY
+  RECIPE_TAG_PREFIX_LEGACY,
+  isHiddenRecipeEvent
 } from './consts';
 import { ndk, ndkConnected } from './nostr';
 import { get } from 'svelte/store';
@@ -93,6 +94,7 @@ export async function computePopularTags(limit: number = 8): Promise<TagWithCoun
           markOnce('t3_explore_first_live_event_received');
         }
         eventCount++;
+        if (isHiddenRecipeEvent(event)) return;
         // Extract tags from the event (support both legacy and new prefixes)
         const tags = event.tags.filter(
           (t) =>

--- a/src/routes/fork/[slug]/+page.svelte
+++ b/src/routes/fork/[slug]/+page.svelte
@@ -3,7 +3,7 @@
   import { ndk, userPublickey } from '$lib/nostr';
   import { createMarkdown, validateMarkdownTemplate } from '$lib/parser';
   import { NDKEvent } from '@nostr-dev-kit/ndk';
-  import { recipeTags, type recipeTagSimple } from '$lib/consts';
+  import { recipeTags, type recipeTagSimple, isHiddenRecipeEvent } from '$lib/consts';
   import FeedItem from '../../../components/RecipeCard.svelte';
   import { browser } from '$app/environment';
   import { onMount } from 'svelte';
@@ -80,6 +80,10 @@
           goto(`/fork/${c}`);
         }
       }
+    }
+    if (event && isHiddenRecipeEvent(event)) {
+      resultMessage = 'Recipe not found.';
+      return;
     }
     if (event) {
       const va = validateMarkdownTemplate(event.content);

--- a/src/routes/pack/[naddr]/+page.svelte
+++ b/src/routes/pack/[naddr]/+page.svelte
@@ -34,6 +34,7 @@
   import { lazyLoad } from '$lib/lazyLoad';
   import { getImageOrPlaceholder } from '$lib/placeholderImages';
   import { offlineStorage } from '$lib/offlineStorage';
+  import { isHiddenRecipeATag } from '$lib/consts';
   import { isOnline } from '$lib/connectionMonitor';
   import { cookbookStore, cookbookLists } from '$lib/stores/cookbookStore';
   import { buildPackUrl } from '$lib/recipePack';
@@ -129,7 +130,10 @@
         return;
       }
       packEvent = found;
-      const tags = found.tags.filter((t) => t[0] === 'a').map((t) => t[1]);
+      const tags = found.tags
+        .filter((t) => t[0] === 'a')
+        .map((t) => t[1])
+        .filter((a) => !isHiddenRecipeATag(a));
       loaded = true; // header can render now
       await resolveRecipes(tags);
     } catch (err) {

--- a/src/routes/packs/+page.svelte
+++ b/src/routes/packs/+page.svelte
@@ -6,7 +6,7 @@
   import { nip19 } from 'nostr-tools';
   import { ndk, userPublickey, ensureNdkConnected } from '$lib/nostr';
   import { NDKEvent, NDKRelaySet } from '@nostr-dev-kit/ndk';
-  import { standardRelays } from '$lib/consts';
+  import { standardRelays, isHiddenRecipeATag } from '$lib/consts';
   import { RECIPE_PACK_KIND, RECIPE_PACK_TAG, ZAP_COOKING_TAG } from '$lib/recipePack';
   import { savedPacksStore, savedPackATags } from '$lib/savedPacksStore';
   import RecipePackCard from '../../components/RecipePackCard.svelte';
@@ -364,7 +364,8 @@
     const title = find('title') || find('d') || 'Recipe Pack';
     const description = find('description') || '';
     const image = find('image') || undefined;
-    const recipeCount = e.tags?.filter((t) => t[0] === 'a').length || 0;
+    const recipeCount =
+      e.tags?.filter((t) => t[0] === 'a' && !isHiddenRecipeATag(t[1])).length || 0;
     const dTag = find('d') || '';
     let viewUrl = '';
     if (dTag && e.pubkey) {

--- a/src/routes/packs/+page.svelte
+++ b/src/routes/packs/+page.svelte
@@ -365,7 +365,9 @@
     const description = find('description') || '';
     const image = find('image') || undefined;
     const recipeCount =
-      e.tags?.filter((t) => t[0] === 'a' && !isHiddenRecipeATag(t[1])).length || 0;
+      e.tags?.filter(
+        (t) => t[0] === 'a' && typeof t[1] === 'string' && t[1] !== '' && !isHiddenRecipeATag(t[1])
+      ).length || 0;
     const dTag = find('d') || '';
     let viewUrl = '';
     if (dTag && e.pubkey) {

--- a/src/routes/r/[naddr]/+page.svelte
+++ b/src/routes/r/[naddr]/+page.svelte
@@ -7,7 +7,7 @@
   import { onMount } from 'svelte';
   import Recipe from '../../../components/Recipe/Recipe.svelte';
   import PanLoader from '../../../components/PanLoader.svelte';
-  import { GATED_RECIPE_KIND, RECIPE_TAGS } from '$lib/consts';
+  import { GATED_RECIPE_KIND, RECIPE_TAGS, isHiddenRecipeCoordinate } from '$lib/consts';
   import { getRecipeOgMeta } from '$lib/recipeOgMeta';
   import ArrowLeftIcon from 'phosphor-svelte/lib/ArrowLeft';
   import { stripTrackingParams } from '$lib/utils/stripTrackingParams';
@@ -43,6 +43,13 @@
 
         // Support both regular recipes (30023) and premium recipes (35000)
         const recipeKind = b.kind === GATED_RECIPE_KIND ? GATED_RECIPE_KIND : 30023;
+
+        // Site-wide hidden coordinates 404 without hitting relays
+        if (isHiddenRecipeCoordinate(recipeKind, b.pubkey, b.identifier)) {
+          loading = false;
+          error = 'Recipe not found';
+          return;
+        }
 
         naddr = nip19.naddrEncode({
           identifier: b.identifier,

--- a/src/routes/recipe/[slug]/+page.svelte
+++ b/src/routes/recipe/[slug]/+page.svelte
@@ -10,7 +10,12 @@
   import PanLoader from '../../../components/PanLoader.svelte';
   import RightRail from '../../../components/RightRail.svelte';
   import RailCard from '../../../components/RailCard.svelte';
-  import { GATED_RECIPE_KIND, RECIPE_TAGS } from '$lib/consts';
+  import {
+    GATED_RECIPE_KIND,
+    RECIPE_TAGS,
+    isHiddenRecipeCoordinate,
+    isHiddenRecipeEvent
+  } from '$lib/consts';
   import { getRecipeOgMeta } from '$lib/recipeOgMeta';
   import { stripTrackingParams } from '$lib/utils/stripTrackingParams';
 
@@ -40,6 +45,7 @@
       const items: { naddr: string; title: string; image: string }[] = [];
       for (const ev of events) {
         if (ev.id === current.id) continue;
+        if (isHiddenRecipeEvent(ev)) continue;
         const isRecipe = ev.tags.some(
           (t) => t[0] === 't' && RECIPE_TAGS.includes((t[1] || '').toLowerCase())
         );
@@ -94,6 +100,13 @@
         // Support both regular recipes (30023) and premium recipes (35000)
         const recipeKind = b.kind === GATED_RECIPE_KIND ? GATED_RECIPE_KIND : 30023;
 
+        // Site-wide hidden coordinates 404 without hitting relays
+        if (isHiddenRecipeCoordinate(recipeKind, b.pubkey, b.identifier)) {
+          loading = false;
+          error = 'Recipe not found';
+          return;
+        }
+
         naddr = nip19.naddrEncode({
           identifier: b.identifier,
           pubkey: b.pubkey,
@@ -133,6 +146,11 @@
 
         const e = await Promise.race<NDKEvent | null>([fetchPromise, timeoutPromise]);
         if (e) {
+          if (isHiddenRecipeEvent(e)) {
+            loading = false;
+            error = 'Recipe not found';
+            return;
+          }
           event = e;
           const id = e.tags.find((z: any) => z[0] == 'd')?.[1];
           if (!id || !e.kind) {


### PR DESCRIPTION
## The finding that shaped this PR

`recipeDiscoveryService` — the only module besides `/recipes` that filtered hidden recipes at all — did raw `HIDDEN_RECIPE_COORDINATES.has()` set lookups in two spots (`candidateFromCached`, `resolveCoordinates`) instead of calling `isHiddenRecipeCoordinate`. Extending the helper with prefix matching would have left both lookups blind to the new rule: the Cheffy planner's explore/saved candidate paths would have kept surfacing the nine `ios-2.3-live-publish-*` recipes even after the "fix" shipped. That is the same class of bug as the original leak — filtering logic duplicated at a call site instead of routed through the shared check — and the reason a helper-only change would have looked correct and shipped broken. Both lookups now go through the helper.

## What this fixes

The hidden-recipe list (19 junk test recipes from a discarded-key Android live gate) was only enforced on `/recipes` and in the Cheffy planner. Every other surface rendered them. A second identical process failure — the iOS 2.3 live-publish gate — added nine more junk recipes across **eight** ephemeral pubkeys, so an exact-coordinate (or pubkey) list no longer scales.

### 1. Prefix matching

- `HIDDEN_RECIPE_DTAG_PREFIXES = ['ios-2.3-live-publish-']` — the shared d-tag prefix is the stable identifier across all eight pubkeys.
- `isHiddenRecipeCoordinate` returns true on exact-set match OR d-tag prefix match.
- New shared wrappers: `isHiddenRecipeEvent(event)` and `isHiddenRecipeATag('kind:pubkey:d')` (colon-safe d-tag rejoin).
- The comment above the list documents the twice-repeated process failure (the real fix is publish-verify-delete in the test gate, not another coordinate) and names the mirrored lists in Android (`app/src/main/kotlin/cooking/zap/app/nostr/HiddenRecipes.kt`) and iOS (`HiddenRecipes.swift`). Matching PRs are in flight on both.

### 2. Site-wide enforcement

There is no single choke point — recipes enter through five independent pipelines — but six wiring points each cover a whole family:

| Wiring point | Surfaces covered |
|---|---|
| `Feed.svelte` `isValidEvent` | every recipe grid: /recipes, /tag/[slug], /user recipes tab, /my-kitchen/[naddr], /list/[slug], ProfileLists |
| `cookbookStore.eventToList` | all cookbook-list a-tags → my-kitchen home, planner, RecipePickerModal saved tab, grocery |
| `offlineStorage` save + read | the IndexedDB recipe cache all my-kitchen/planner/grocery/pack surfaces resolve through; read-side filter also purges already-cached entries |
| `myRecipesPack.fetchMyAuthoredRecipeEvents` | my-kitchen Published tab, RecipePickerModal published tab, Share-My-Recipes pack |
| `recipeOg.server` + `recipePackOg.server` | crawler OG for /recipe, /r, /reads, and pack OG + OG-image endpoint |
| individual sites | exploreUtils (trending/discover/popular-cooks/collection covers — the homepage redirects to /explore), TagsSearchAutocomplete (cache + live sub + NIP-50), popular-tag chips, mesh graph, nourish explore, /packs counts, /pack/[naddr], /recipe/[slug] (404 pre-fetch on naddr, post-fetch on hex id, chef rail), **/r/[naddr] (404, no carve-out)**, /fork/[slug], NoteEmbed, BoostedRecipeCard |

Deliberately not wired: publishing/draft paths (render nothing), counts/membership/pantry-stats endpoints (numbers, not recipes), /admin/nourish-flags (moderation tool), the /boost purchase flow (operator-curated; the rendering card is filtered), /reads (excludes recipe-shaped events by design), /premium detail (kind 35000 only).

## Related

The investigation also found always-true markdown-validation dead code on /recipes, /tag, and /user — page-level checks that look like filtering and aren't. Filed separately as #654; not touched here.

## Verification

- New `src/lib/consts.test.ts`: exact-list coverage, prefix matching under arbitrary pubkeys, no-false-positive cases (mid-string prefix, same d-tag under a different pubkey), colon-containing d-tags.
- `pnpm test` (1534 tests), `pnpm run check` (0 errors), `pnpm build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gokf3z7Bs77ktcDiR869HT