### PR TITLE
fix(wallet): show Spark recovery phrase modal

### DIFF
--- a/src/components/wallet/WalletPanel.svelte
+++ b/src/components/wallet/WalletPanel.svelte
@@ -5058,11 +5058,12 @@
 
   <!-- Mnemonic Display Modal removed - replaced by backup reminder banner -->
 
-  <!-- Reveal Mnemonic Modal - higher z-index to appear above other modals -->
+  <!-- This portal sits alongside the parent wallet modal at <body> level.
+       It must clear Modal.svelte's z-[10000] backdrop. -->
   {#if revealedMnemonic && portalTarget}
     <div use:portal={portalTarget}>
       <div
-        class="fixed inset-0 bg-black/50 flex z-[60] p-4"
+        class="fixed inset-0 bg-black/50 flex z-[10001] p-4"
         style="display: flex; align-items: center; justify-content: center;"
       >
         <div


### PR DESCRIPTION
## Summary
- Raise the body-ported Spark recovery phrase overlay above the wallet modal backdrop.
- Keep the phrase dialog visible and interactive from the wallet backup flow.
- Include the repository-managed version bump to 4.2.724.

## Verification
- git diff --check
- corepack pnpm check (fails on a pre-existing TypeScript error in src/routes/api/stripe/webhook/renewalRetry.test.ts; this change introduces no diagnostics)