### PR TITLE
fix(spark): reconcile stale pending payments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.727",
+  "version": "4.2.728",
   "private": true,
   "scripts": {
     "dev": "vite dev",
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@branta-ops/branta": "^3.1.2",
-    "@breeztech/breez-sdk-spark": "0.11.0",
+    "@breeztech/breez-sdk-spark": "0.23.1",
     "@capacitor/android": "^8.0.0",
     "@capacitor/app": "^8.0.0",
     "@capacitor/cli": "^8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^3.1.2
         version: 3.1.3
       '@breeztech/breez-sdk-spark':
-        specifier: 0.11.0
-        version: 0.11.0
+        specifier: 0.23.1
+        version: 0.23.1
       '@capacitor/android':
         specifier: ^8.0.0
         version: 8.0.0(@capacitor/core@8.0.0)
@@ -345,8 +345,8 @@ packages:
   '@branta-ops/branta@3.1.3':
     resolution: {integrity: sha512-rcyDBYnYD+cmvQWylJ+n3JdR65FiHP1tVPtWQMhKLmcXx56czL8Ez7+I9jy7pmLBIVwP6mS1EsUqSrvQi22v1w==}
 
-  '@breeztech/breez-sdk-spark@0.11.0':
-    resolution: {integrity: sha512-wX8ZdFfnXN9t2AuLYlZxslmdHlxqnvkU8kAmIL1GuI3LNV8F7bxMGxLV/WTaQTgd7BGW/pcejpBcNPe7jjCdfA==}
+  '@breeztech/breez-sdk-spark@0.23.1':
+    resolution: {integrity: sha512-oEORfCAsRVlWFLcyF7pYMQR7AY1rWUVFUWo0YPAOF2gL6XWRlzh5DEtnAnXtKbj2eolJvatIbX42wEU9BzkdbQ==}
     engines: {node: '>=22'}
 
   '@capacitor/android@8.0.0':
@@ -4095,6 +4095,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prelude-ls@1.2.1:
@@ -5339,7 +5340,7 @@ snapshots:
 
   '@branta-ops/branta@3.1.3': {}
 
-  '@breeztech/breez-sdk-spark@0.11.0':
+  '@breeztech/breez-sdk-spark@0.23.1':
     optionalDependencies:
       better-sqlite3: 12.6.2
       pg: 8.20.0
@@ -9214,7 +9215,7 @@ snapshots:
 
   prebuild-install@7.1.3:
     dependencies:
-      detect-libc: 2.0.4
+      detect-libc: 2.1.2
       expand-template: 2.0.3
       github-from-package: 0.0.0
       minimist: 1.2.8

--- a/src/lib/spark/index.ts
+++ b/src/lib/spark/index.ts
@@ -350,7 +350,6 @@ export async function initializeSdk(
     const config = defaultConfig('mainnet');
     config.apiKey = apiKey;
     config.privateEnabledDefault = true;
-    config.supportLnurlVerify = true; // Enable NIP-57 zap receipt metadata on received payments
 
     // Use sats.zap.cooking (subdomain) in production, breez.tips for local development
     // Strategy A: Subdomain approach - uses CNAME sats -> breez.tips in Cloudflare


### PR DESCRIPTION
Upgrades Breez Spark SDK from 0.11.0 to 0.23.1. This includes upstream pending-payment reconciliation during wallet sync, correcting Lightning payments that were received but remained pending in local history. Removes the retired supportLnurlVerify config assignment; NIP-57 metadata remains provided by current SDK bindings.