### PR TITLE
fix(branta): harden payment retrieval

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.727",
+  "version": "4.2.728",
   "private": true,
   "scripts": {
     "dev": "vite dev",
@@ -28,7 +28,7 @@
     "node": "22.x"
   },
   "dependencies": {
-    "@branta-ops/branta": "^3.1.2",
+    "@branta-ops/branta": "^3.2.1",
     "@breeztech/breez-sdk-spark": "0.11.0",
     "@capacitor/android": "^8.0.0",
     "@capacitor/app": "^8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
   .:
     dependencies:
       '@branta-ops/branta':
-        specifier: ^3.1.2
-        version: 3.1.3
+        specifier: ^3.2.1
+        version: 3.2.1
       '@breeztech/breez-sdk-spark':
         specifier: 0.11.0
         version: 0.11.0
@@ -342,8 +342,8 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@branta-ops/branta@3.1.3':
-    resolution: {integrity: sha512-rcyDBYnYD+cmvQWylJ+n3JdR65FiHP1tVPtWQMhKLmcXx56czL8Ez7+I9jy7pmLBIVwP6mS1EsUqSrvQi22v1w==}
+  '@branta-ops/branta@3.2.1':
+    resolution: {integrity: sha512-HhgKL8/krQJRYCpJKt/RRtL73KrcAHJUxDoaUWAekGNZgTKXpGU6ZEPWL+w1fhhLsU6zLsBLP1Ddlg8P6yB28w==}
 
   '@breeztech/breez-sdk-spark@0.11.0':
     resolution: {integrity: sha512-wX8ZdFfnXN9t2AuLYlZxslmdHlxqnvkU8kAmIL1GuI3LNV8F7bxMGxLV/WTaQTgd7BGW/pcejpBcNPe7jjCdfA==}
@@ -4095,6 +4095,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prelude-ls@1.2.1:
@@ -5337,7 +5338,7 @@ snapshots:
       css-tree: 3.2.1
     optional: true
 
-  '@branta-ops/branta@3.1.3': {}
+  '@branta-ops/branta@3.2.1': {}
 
   '@breeztech/breez-sdk-spark@0.11.0':
     optionalDependencies:


### PR DESCRIPTION
Upgrades @branta-ops/branta to 3.2.1, which hardens the GET flow used to retrieve and verify payment destinations.