### PR TITLE
feat(wallet): add opt-in USDB balance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.728",
+  "version": "4.2.729",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.727",
+  "version": "4.2.728",
   "private": true,
   "scripts": {
     "dev": "vite dev",
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@branta-ops/branta": "^3.1.2",
-    "@breeztech/breez-sdk-spark": "0.11.0",
+    "@breeztech/breez-sdk-spark": "0.23.1",
     "@capacitor/android": "^8.0.0",
     "@capacitor/app": "^8.0.0",
     "@capacitor/cli": "^8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^3.1.2
         version: 3.1.3
       '@breeztech/breez-sdk-spark':
-        specifier: 0.11.0
-        version: 0.11.0
+        specifier: 0.23.1
+        version: 0.23.1
       '@capacitor/android':
         specifier: ^8.0.0
         version: 8.0.0(@capacitor/core@8.0.0)
@@ -345,8 +345,8 @@ packages:
   '@branta-ops/branta@3.1.3':
     resolution: {integrity: sha512-rcyDBYnYD+cmvQWylJ+n3JdR65FiHP1tVPtWQMhKLmcXx56czL8Ez7+I9jy7pmLBIVwP6mS1EsUqSrvQi22v1w==}
 
-  '@breeztech/breez-sdk-spark@0.11.0':
-    resolution: {integrity: sha512-wX8ZdFfnXN9t2AuLYlZxslmdHlxqnvkU8kAmIL1GuI3LNV8F7bxMGxLV/WTaQTgd7BGW/pcejpBcNPe7jjCdfA==}
+  '@breeztech/breez-sdk-spark@0.23.1':
+    resolution: {integrity: sha512-oEORfCAsRVlWFLcyF7pYMQR7AY1rWUVFUWo0YPAOF2gL6XWRlzh5DEtnAnXtKbj2eolJvatIbX42wEU9BzkdbQ==}
     engines: {node: '>=22'}
 
   '@capacitor/android@8.0.0':
@@ -4095,6 +4095,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prelude-ls@1.2.1:
@@ -5339,7 +5340,7 @@ snapshots:
 
   '@branta-ops/branta@3.1.3': {}
 
-  '@breeztech/breez-sdk-spark@0.11.0':
+  '@breeztech/breez-sdk-spark@0.23.1':
     optionalDependencies:
       better-sqlite3: 12.6.2
       pg: 8.20.0
@@ -9214,7 +9215,7 @@ snapshots:
 
   prebuild-install@7.1.3:
     dependencies:
-      detect-libc: 2.0.4
+      detect-libc: 2.1.2
       expand-template: 2.0.3
       github-from-package: 0.0.0
       minimist: 1.2.8

--- a/src/components/wallet/WalletPanel.svelte
+++ b/src/components/wallet/WalletPanel.svelte
@@ -80,6 +80,8 @@
     claimDeposit,
     claimDepositWithNetworkFee,
     refundDeposit,
+    stableBalance,
+    setStableBalanceEnabled,
     isBitcoinAddress,
     type SparkWalletBackup,
     type SparkBackupEntry,
@@ -673,6 +675,28 @@
   let isSendingOnchain = false;
   let showOnchainConfirmation = false; // Show address verification step before sending
   let sendingMaxBalance = false; // Track if user wants to send full balance (fee will be deducted)
+  let stableBalanceConfirmation = false;
+  let isUpdatingStableBalance = false;
+
+  function formatStableBalance(amount: bigint, decimals: number): string {
+    const divisor = 10n ** BigInt(decimals);
+    const whole = amount / divisor;
+    const fraction = (amount % divisor).toString().padStart(decimals, '0').slice(0, 2);
+    return `${whole.toLocaleString()}.${fraction}`;
+  }
+
+  async function updateStableBalance(enabled: boolean) {
+    isUpdatingStableBalance = true;
+    try {
+      await setStableBalanceEnabled(enabled);
+      stableBalanceConfirmation = false;
+      await refreshAll();
+    } catch (error) {
+      errorMessage = error instanceof Error ? error.message : 'Unable to update USD balance';
+    } finally {
+      isUpdatingStableBalance = false;
+    }
+  }
 
   // QR scan state
   let showQrCamera = false;
@@ -3176,6 +3200,49 @@
               </button>
             </div>
           </div>
+
+          {#if $activeWallet?.kind === 4 && !isPanelScrolled}
+            <div class="mt-4 p-3 rounded-lg border" style="border-color: var(--color-input-border); background: var(--color-input-bg);">
+              {#if $stableBalance.active}
+                <div class="flex items-center justify-between gap-3">
+                  <div>
+                    <div class="text-sm font-semibold text-primary-color">USD balance</div>
+                    <div class="text-xs text-caption mt-0.5">
+                      {#if $balanceVisible}
+                        ${formatStableBalance($stableBalance.balance, $stableBalance.decimals)} {$stableBalance.label}
+                      {:else}
+                        $*** {$stableBalance.label}
+                      {/if}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    class="text-xs font-medium text-amber-500 hover:text-amber-400 disabled:opacity-50"
+                    on:click={() => updateStableBalance(false)}
+                    disabled={isUpdatingStableBalance}
+                  >
+                    {isUpdatingStableBalance ? 'Updating...' : 'Use Bitcoin'}
+                  </button>
+                </div>
+                <p class="mt-2 text-xs text-caption">Bitcoin payments automatically convert from your USD balance when needed.</p>
+              {:else if stableBalanceConfirmation}
+                <div class="text-sm font-semibold text-primary-color">Enable USD balance?</div>
+                <p class="mt-1 text-xs text-caption">Eligible incoming Bitcoin converts to USDB. Turning this off converts remaining USDB back to Bitcoin. Conversion rates and fees apply.</p>
+                <div class="mt-3 flex gap-2">
+                  <button type="button" class="flex-1 py-2 text-sm text-caption border border-input rounded-lg" on:click={() => (stableBalanceConfirmation = false)}>Not now</button>
+                  <button type="button" class="flex-1 py-2 text-sm font-medium bg-amber-500 text-white rounded-lg disabled:opacity-50" on:click={() => updateStableBalance(true)} disabled={isUpdatingStableBalance}>{isUpdatingStableBalance ? 'Enabling...' : 'Enable USD'}</button>
+                </div>
+              {:else}
+                <div class="flex items-center justify-between gap-3">
+                  <div>
+                    <div class="text-sm font-semibold text-primary-color">USD balance</div>
+                    <div class="text-xs text-caption mt-0.5">Protect future wallet value from Bitcoin price movement.</div>
+                  </div>
+                  <button type="button" class="text-xs font-medium text-amber-500 hover:text-amber-400" on:click={() => (stableBalanceConfirmation = true)}>Enable</button>
+                </div>
+              {/if}
+            </div>
+          {/if}
 
           <!-- Send/Receive buttons - only for NWC and Spark wallets, hidden
                in compact mode and while a send/receive view is active. -->
@@ -5868,6 +5935,11 @@
           {/if}
         {:else}
           <!-- Lightning payment button -->
+          {#if $activeWallet?.kind === 4 && $stableBalance.active}
+            <div class="p-3 rounded-lg text-xs text-caption" style="background: var(--color-input-bg);">
+              This payment may convert USDB to Bitcoin. The final rate and conversion fee are determined by Spark before settlement.
+            </div>
+          {/if}
           <button
             class="w-full py-3 px-4 rounded-xl bg-amber-500 hover:bg-amber-600 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium transition-colors flex items-center justify-center gap-2"
             on:click={handleSend}

--- a/src/lib/spark/index.ts
+++ b/src/lib/spark/index.ts
@@ -350,7 +350,6 @@ export async function initializeSdk(
     const config = defaultConfig('mainnet');
     config.apiKey = apiKey;
     config.privateEnabledDefault = true;
-    config.supportLnurlVerify = true; // Enable NIP-57 zap receipt metadata on received payments
 
     // Use sats.zap.cooking (subdomain) in production, breez.tips for local development
     // Strategy A: Subdomain approach - uses CNAME sats -> breez.tips in Cloudflare

--- a/src/lib/spark/index.ts
+++ b/src/lib/spark/index.ts
@@ -108,6 +108,19 @@ function createPersistentLightningAddress() {
 export const lightningAddress = createPersistentLightningAddress();
 
 export const walletBalance = writable<bigint | null>(null);
+export const USDB_TOKEN_IDENTIFIER = 'btkn1xgrvjwey5ngcagvap2dzzvsy4uk8ua9x69k82dwvt5e7ef9drm9qztux87';
+export interface StableBalanceState {
+  active: boolean;
+  label: string;
+  balance: bigint;
+  decimals: number;
+}
+export const stableBalance = writable<StableBalanceState>({
+  active: false,
+  label: 'USDB',
+  balance: 0n,
+  decimals: 6
+});
 export const walletInitialized = writable<boolean>(false);
 export const sparkLoading = writable<boolean>(false);
 export const sparkSyncing = writable<boolean>(false); // True while explicit sync is in progress
@@ -217,7 +230,30 @@ async function refreshBalanceInternal(): Promise<void> {
     const balanceValue =
       info.balanceSats ?? info.balanceSat ?? info.balance_sats ?? info.balance ?? 0;
     walletBalance.set(BigInt(balanceValue));
+    const tokenBalances = info.tokenBalances;
+    const balances = tokenBalances instanceof Map ? Array.from(tokenBalances.values()) : [];
+    const usdb = balances.find((entry: any) => entry?.tokenMetadata?.identifier === USDB_TOKEN_IDENTIFIER);
+    let active = false;
+    try {
+      const settings = await _sdkInstance.getUserSettings();
+      active = settings?.stableBalanceActiveLabel === 'USDB';
+    } catch {}
+    stableBalance.set({
+      active,
+      label: usdb?.tokenMetadata?.ticker || 'USDB',
+      balance: BigInt(usdb?.balance ?? 0),
+      decimals: Number(usdb?.tokenMetadata?.decimals ?? 6)
+    });
   } catch {}
+}
+
+export async function setStableBalanceEnabled(enabled: boolean): Promise<void> {
+  if (!_sdkInstance) throw new Error('Spark SDK is not initialized');
+  await _sdkInstance.updateUserSettings({
+    stableBalanceActiveLabel: enabled ? { type: 'set', label: 'USDB' } : { type: 'unset' }
+  });
+  await _sdkInstance.syncWallet({});
+  await refreshBalanceInternal();
 }
 
 /**
@@ -350,6 +386,9 @@ export async function initializeSdk(
     const config = defaultConfig('mainnet');
     config.apiKey = apiKey;
     config.privateEnabledDefault = true;
+    config.stableBalanceConfig = {
+      tokens: [{ label: 'USDB', tokenIdentifier: USDB_TOKEN_IDENTIFIER }]
+    };
 
     // Use sats.zap.cooking (subdomain) in production, breez.tips for local development
     // Strategy A: Subdomain approach - uses CNAME sats -> breez.tips in Cloudflare
@@ -535,6 +574,7 @@ export async function disconnectWallet(): Promise<void> {
     breezSdk.set(null);
     lightningAddress.set(null);
     walletBalance.set(null);
+    stableBalance.set({ active: false, label: 'USDB', balance: 0n, decimals: 6 });
     walletInitialized.set(false);
     sparkSyncing.set(false);
     _sdkInstance = null;


### PR DESCRIPTION
Adds an opt-in USD balance backed by Spark USDB. Users can enable or disable Stable Balance directly in the Spark wallet; the SDK handles the associated Bitcoin-to-USDB and USDB-to-Bitcoin conversions. The wallet displays the USDB balance and discloses when a Bitcoin send may trigger a conversion. Includes the Spark SDK 0.23.1 prerequisite from #657 because Stable Balance requires the newer SDK APIs.