### PR TITLE
fix(wallet): format Spark USDB transactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.734",
+  "version": "4.2.735",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.733",
+  "version": "4.2.734",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.731",
+  "version": "4.2.732",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.729",
+  "version": "4.2.730",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.730",
+  "version": "4.2.731",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.732",
+  "version": "4.2.733",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/wallet/WalletPanel.svelte
+++ b/src/components/wallet/WalletPanel.svelte
@@ -4435,7 +4435,7 @@
                       </div>
                       <div class="flex-1 min-w-0">
                         <div class="font-medium text-primary-color">
-                          {tx.type === 'incoming' ? 'Received' : 'Sent'}
+                          {tx.conversionFrom ? `Converted from ${tx.conversionFrom}` : tx.type === 'incoming' ? 'Received' : 'Sent'}
                         </div>
                         {#if tx.comment}
                           <div class="text-sm text-caption truncate">

--- a/src/components/wallet/WalletPanel.svelte
+++ b/src/components/wallet/WalletPanel.svelte
@@ -2912,7 +2912,7 @@
   {#if errorMessage && portalTarget}
     <div use:portal={portalTarget}>
       <div
-        class="wallet-toast fixed top-4 left-4 right-4 mx-auto p-4 rounded-lg flex items-center gap-3 shadow-xl border z-[9999]"
+        class="wallet-toast fixed top-4 left-4 right-4 mx-auto p-4 rounded-lg flex items-center gap-3 shadow-xl border z-[10002]"
         style="background-color: var(--color-bg-primary); border-color: #ef4444; color: #ef4444;"
       >
         <WarningIcon size={20} class="flex-shrink-0" />
@@ -2928,7 +2928,7 @@
   {#if successMessage && portalTarget}
     <div use:portal={portalTarget}>
       <div
-        class="wallet-toast fixed top-4 left-4 right-4 mx-auto p-4 rounded-lg flex items-center gap-3 shadow-xl border z-[9999]"
+        class="wallet-toast fixed top-4 left-4 right-4 mx-auto p-4 rounded-lg flex items-center gap-3 shadow-xl border z-[10002]"
         style="background-color: var(--color-bg-primary); border-color: #22c55e; color: #22c55e;"
       >
         <CheckCircleIcon size={20} class="flex-shrink-0" />
@@ -3123,14 +3123,14 @@
           >
             <div class="flex-1 min-w-0">
               <div
-                class="inline-block max-w-full rounded-lg transition-colors {!isPanelScrolled
+                class="inline-block max-w-full rounded-lg transition-colors {!isPanelScrolled && !$stableBalance.active
                   ? '-mx-3 px-3 -my-1.5 py-1.5 cursor-pointer select-none hover:bg-white/5'
                   : ''}"
-                role={!isPanelScrolled ? 'button' : undefined}
-                tabindex={!isPanelScrolled ? 0 : -1}
-                aria-label={!isPanelScrolled ? 'Toggle SATS / fiat display' : undefined}
-                on:click={!isPanelScrolled ? handleBalanceAmountTap : undefined}
-                on:keydown={!isPanelScrolled ? handleBalanceAmountKeydown : undefined}
+                role={!isPanelScrolled && !$stableBalance.active ? 'button' : undefined}
+                tabindex={!isPanelScrolled && !$stableBalance.active ? 0 : -1}
+                aria-label={!isPanelScrolled && !$stableBalance.active ? 'Toggle SATS / fiat display' : undefined}
+                on:click={!isPanelScrolled && !$stableBalance.active ? handleBalanceAmountTap : undefined}
+                on:keydown={!isPanelScrolled && !$stableBalance.active ? handleBalanceAmountKeydown : undefined}
               >
                 <div
                   class="balance-amount font-bold text-primary-color flex items-center gap-3 min-w-0"
@@ -3142,7 +3142,15 @@
                     weight="fill"
                     class="text-amber-500 flex-shrink-0"
                   />
-                  {#if $walletBalance === null}
+                  {#if $stableBalance.active}
+                    <span class:balance-refreshing={$walletLoading}>
+                      {#if $balanceVisible}
+                        ${formatStableBalance($stableBalance.balance, $stableBalance.decimals)} {$stableBalance.label}
+                      {:else}
+                        $*** {$stableBalance.label}
+                      {/if}
+                    </span>
+                  {:else if $walletBalance === null}
                     <span
                       class="inline-block w-32 h-9 rounded-lg animate-pulse"
                       style="background: var(--color-input-bg);"
@@ -3162,7 +3170,9 @@
                        invisible placeholder when SATS is primary (preserves
                        card height across toggles). -->
                   <div class="ml-11 text-sm text-caption">
-                    {#if $displayCurrency === 'SATS' || $walletBalance === null}
+                    {#if $stableBalance.active}
+                      Stable balance
+                    {:else if $displayCurrency === 'SATS' || $walletBalance === null}
                       &nbsp;
                     {:else if !$balanceVisible}
                       ***
@@ -3185,7 +3195,7 @@
               {/if}
             </div>
             <div class="flex items-center gap-3 flex-shrink-0">
-              {#if !isPanelScrolled}
+              {#if !isPanelScrolled && !$stableBalance.active}
                 <CurrencySelector compact />
               {/if}
               <button
@@ -3219,14 +3229,8 @@
               {#if $stableBalance.active}
                 <div class="flex items-center justify-between gap-3">
                   <div>
-                    <div class="text-sm font-semibold text-primary-color">USD balance</div>
-                    <div class="text-xs text-caption mt-0.5">
-                      {#if $balanceVisible}
-                        ${formatStableBalance($stableBalance.balance, $stableBalance.decimals)} {$stableBalance.label}
-                      {:else}
-                        $*** {$stableBalance.label}
-                      {/if}
-                    </div>
+                    <div class="text-sm font-semibold text-primary-color">Stable balance active</div>
+                    <div class="text-xs text-caption mt-0.5">Your main balance is shown in {$stableBalance.label}.</div>
                   </div>
                   <button
                     type="button"

--- a/src/components/wallet/WalletPanel.svelte
+++ b/src/components/wallet/WalletPanel.svelte
@@ -109,6 +109,7 @@
   import CloudArrowUpIcon from 'phosphor-svelte/lib/CloudArrowUp';
   import ArrowUpIcon from 'phosphor-svelte/lib/ArrowUp';
   import ArrowDownIcon from 'phosphor-svelte/lib/ArrowDown';
+  import ArrowsLeftRightIcon from 'phosphor-svelte/lib/ArrowsLeftRight';
   import ClockIcon from 'phosphor-svelte/lib/Clock';
   import CloudArrowDownIcon from 'phosphor-svelte/lib/CloudArrowDown';
   import CheckCircleIcon from 'phosphor-svelte/lib/CheckCircle';
@@ -4417,17 +4418,22 @@
                 <!-- Unified transaction history -->
                 {#each completedTxs as tx (tx.id)}
                   {@const isOnchainTx = !!tx.txid || !!tx.isOnchain}
+                  {@const isConversion = !!tx.conversionFrom}
                   <div class="border-b" style="border-color: var(--color-input-border);">
                     <button
                       class="w-full py-4 flex items-center gap-4 text-left"
                       on:click={() => toggleTxDetails(tx.id)}
                     >
                       <div
-                        class="w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 {tx.type === 'incoming'
-                          ? 'bg-green-500/20'
-                          : 'bg-orange-500/20'}"
+                        class="w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 {isConversion
+                          ? 'bg-sky-500/20'
+                          : tx.type === 'incoming'
+                            ? 'bg-green-500/20'
+                            : 'bg-orange-500/20'}"
                       >
-                        {#if tx.type === 'incoming'}
+                        {#if isConversion}
+                          <ArrowsLeftRightIcon size={20} class="text-sky-400" />
+                        {:else if tx.type === 'incoming'}
                           <ArrowDownIcon size={20} class="text-green-500" />
                         {:else}
                           <ArrowUpIcon size={20} class="text-orange-500" />
@@ -4448,14 +4454,16 @@
                       </div>
                       <div class="flex items-center gap-2 flex-shrink-0">
                         <div
-                          class="font-semibold text-right {tx.type === 'incoming'
-                            ? 'text-green-500'
-                            : 'text-orange-500'}"
+                          class="font-semibold text-right {isConversion
+                            ? 'text-sky-400'
+                            : tx.type === 'incoming'
+                              ? 'text-green-500'
+                              : 'text-orange-500'}"
                         >
                           {#if $balanceVisible}
-                            {tx.type === 'incoming' ? '+' : '-'}{formatTransactionAmount(tx)}
+                            {isConversion ? '' : tx.type === 'incoming' ? '+' : '-'}{formatTransactionAmount(tx)}
                           {:else}
-                            {tx.type === 'incoming' ? '+' : '-'}*** {tx.asset?.ticker || 'sats'}
+                            {isConversion ? '' : tx.type === 'incoming' ? '+' : '-'}*** {tx.asset?.ticker || 'sats'}
                           {/if}
                         </div>
                         <CaretDownIcon

--- a/src/components/wallet/WalletPanel.svelte
+++ b/src/components/wallet/WalletPanel.svelte
@@ -677,6 +677,8 @@
   let sendingMaxBalance = false; // Track if user wants to send full balance (fee will be deducted)
   let stableBalanceConfirmation = false;
   let isUpdatingStableBalance = false;
+  $: hasStableBalance = $stableBalance.balance > 0n;
+  $: showStableBalanceAsPrimary = $stableBalance.active || hasStableBalance;
 
   function formatStableBalance(amount: bigint, decimals: number): string {
     const divisor = 10n ** BigInt(decimals);
@@ -3123,14 +3125,14 @@
           >
             <div class="flex-1 min-w-0">
               <div
-                class="inline-block max-w-full rounded-lg transition-colors {!isPanelScrolled && !$stableBalance.active
+                class="inline-block max-w-full rounded-lg transition-colors {!isPanelScrolled && !showStableBalanceAsPrimary
                   ? '-mx-3 px-3 -my-1.5 py-1.5 cursor-pointer select-none hover:bg-white/5'
                   : ''}"
-                role={!isPanelScrolled && !$stableBalance.active ? 'button' : undefined}
-                tabindex={!isPanelScrolled && !$stableBalance.active ? 0 : -1}
-                aria-label={!isPanelScrolled && !$stableBalance.active ? 'Toggle SATS / fiat display' : undefined}
-                on:click={!isPanelScrolled && !$stableBalance.active ? handleBalanceAmountTap : undefined}
-                on:keydown={!isPanelScrolled && !$stableBalance.active ? handleBalanceAmountKeydown : undefined}
+                role={!isPanelScrolled && !showStableBalanceAsPrimary ? 'button' : undefined}
+                tabindex={!isPanelScrolled && !showStableBalanceAsPrimary ? 0 : -1}
+                aria-label={!isPanelScrolled && !showStableBalanceAsPrimary ? 'Toggle SATS / fiat display' : undefined}
+                on:click={!isPanelScrolled && !showStableBalanceAsPrimary ? handleBalanceAmountTap : undefined}
+                on:keydown={!isPanelScrolled && !showStableBalanceAsPrimary ? handleBalanceAmountKeydown : undefined}
               >
                 <div
                   class="balance-amount font-bold text-primary-color flex items-center gap-3 min-w-0"
@@ -3142,7 +3144,7 @@
                     weight="fill"
                     class="text-amber-500 flex-shrink-0"
                   />
-                  {#if $stableBalance.active}
+                  {#if showStableBalanceAsPrimary}
                     <span class:balance-refreshing={$walletLoading}>
                       {#if $balanceVisible}
                         ${formatStableBalance($stableBalance.balance, $stableBalance.decimals)} {$stableBalance.label}
@@ -3170,7 +3172,9 @@
                        invisible placeholder when SATS is primary (preserves
                        card height across toggles). -->
                   <div class="ml-11 text-sm text-caption">
-                    {#if $stableBalance.active}
+                    {#if hasStableBalance && !$stableBalance.active}
+                      USD balance detected
+                    {:else if $stableBalance.active}
                       Stable balance
                     {:else if $displayCurrency === 'SATS' || $walletBalance === null}
                       &nbsp;
@@ -3195,7 +3199,7 @@
               {/if}
             </div>
             <div class="flex items-center gap-3 flex-shrink-0">
-              {#if !isPanelScrolled && !$stableBalance.active}
+              {#if !isPanelScrolled && !showStableBalanceAsPrimary}
                 <CurrencySelector compact />
               {/if}
               <button
@@ -3242,6 +3246,21 @@
                   </button>
                 </div>
                 <p class="mt-2 text-xs text-caption">Bitcoin payments automatically convert from your USD balance when needed.</p>
+              {:else if hasStableBalance}
+                <div class="flex items-center justify-between gap-3">
+                  <div>
+                    <div class="text-sm font-semibold text-primary-color">USD balance detected</div>
+                    <div class="text-xs text-caption mt-0.5">Your USDB funds are available. Resume USD mode to use this balance for payments.</div>
+                  </div>
+                  <button
+                    type="button"
+                    class="text-xs font-medium text-amber-500 hover:text-amber-400 disabled:opacity-50"
+                    on:click={() => updateStableBalance(true)}
+                    disabled={isUpdatingStableBalance}
+                  >
+                    {isUpdatingStableBalance ? 'Updating...' : 'Resume USD'}
+                  </button>
+                </div>
               {:else if stableBalanceConfirmation}
                 <div class="text-sm font-semibold text-primary-color">Enable USD balance?</div>
                 <p class="mt-1 text-xs text-caption">Eligible incoming Bitcoin converts to USDB. Turning this off converts remaining USDB back to Bitcoin. Conversion rates and fees apply.</p>

--- a/src/components/wallet/WalletPanel.svelte
+++ b/src/components/wallet/WalletPanel.svelte
@@ -685,6 +685,19 @@
     return `${whole.toLocaleString()}.${fraction}`;
   }
 
+  function formatTransactionAmount(tx: Transaction): string {
+    if (!tx.asset) return `${tx.amount.toLocaleString()} sats`;
+
+    const amount = BigInt(tx.asset.amount);
+    const divisor = 10n ** BigInt(tx.asset.decimals);
+    const whole = amount / divisor;
+    const fraction = tx.asset.decimals
+      ? `.${(amount % divisor).toString().padStart(tx.asset.decimals, '0').slice(0, 2)}`
+      : '';
+    const prefix = tx.asset.ticker === 'USDB' ? '$' : '';
+    return `${prefix}${whole.toLocaleString()}${fraction} ${tx.asset.ticker}`;
+  }
+
   async function updateStableBalance(enabled: boolean) {
     isUpdatingStableBalance = true;
     try {
@@ -4364,7 +4377,7 @@
                     <div class="text-right">
                       <div class="font-semibold text-amber-500">
                         {#if $balanceVisible}
-                          {tx.type === 'incoming' ? '+' : '-'}{tx.amount.toLocaleString()} sats
+                          {tx.type === 'incoming' ? '+' : '-'}{formatTransactionAmount(tx)}
                         {:else}
                           {tx.type === 'incoming' ? '+' : '-'}*** sats
                         {/if}
@@ -4417,7 +4430,7 @@
                             : 'text-orange-500'}"
                         >
                           {#if $balanceVisible}
-                            {tx.type === 'incoming' ? '+' : '-'}{tx.amount.toLocaleString()} sats
+                            {tx.type === 'incoming' ? '+' : '-'}{formatTransactionAmount(tx)}
                           {:else}
                             {tx.type === 'incoming' ? '+' : '-'}*** sats
                           {/if}
@@ -4447,7 +4460,7 @@
                           style="border-color: var(--color-input-border);"
                         >
                           <span class="text-caption">Type</span>
-                          <span class="text-primary-color">{isOnchainTx ? 'On-chain' : 'Lightning'}</span>
+                          <span class="text-primary-color">{isOnchainTx ? 'On-chain' : tx.asset?.ticker || 'Lightning'}</span>
                         </div>
                         {#if $balanceVisible}
                           <div
@@ -4455,7 +4468,7 @@
                             style="border-color: var(--color-input-border);"
                           >
                             <span class="text-caption">Amount</span>
-                            <span class="text-primary-color">{tx.amount.toLocaleString()} sats</span>
+                            <span class="text-primary-color">{formatTransactionAmount(tx)}</span>
                           </div>
                           {#if tx.fees}
                             <div

--- a/src/components/wallet/WalletPanel.svelte
+++ b/src/components/wallet/WalletPanel.svelte
@@ -4402,7 +4402,7 @@
                         {#if $balanceVisible}
                           {tx.type === 'incoming' ? '+' : '-'}{formatTransactionAmount(tx)}
                         {:else}
-                          {tx.type === 'incoming' ? '+' : '-'}*** sats
+                          {tx.type === 'incoming' ? '+' : '-'}*** {tx.asset?.ticker || 'sats'}
                         {/if}
                       </div>
                     </div>
@@ -4455,7 +4455,7 @@
                           {#if $balanceVisible}
                             {tx.type === 'incoming' ? '+' : '-'}{formatTransactionAmount(tx)}
                           {:else}
-                            {tx.type === 'incoming' ? '+' : '-'}*** sats
+                            {tx.type === 'incoming' ? '+' : '-'}*** {tx.asset?.ticker || 'sats'}
                           {/if}
                         </div>
                         <CaretDownIcon

--- a/src/lib/spark/index.ts
+++ b/src/lib/spark/index.ts
@@ -226,12 +226,17 @@ async function setupEventListener(): Promise<void> {
 async function refreshBalanceInternal(): Promise<void> {
   if (!_sdkInstance) return;
   try {
-    const info = await _sdkInstance.getInfo({ ensureSynced: false });
+    const info = await _sdkInstance.getInfo({ ensureSynced: true });
     const balanceValue =
       info.balanceSats ?? info.balanceSat ?? info.balance_sats ?? info.balance ?? 0;
     walletBalance.set(BigInt(balanceValue));
     const tokenBalances = info.tokenBalances;
-    const balances = tokenBalances instanceof Map ? Array.from(tokenBalances.values()) : [];
+    const balances =
+      tokenBalances instanceof Map
+        ? Array.from(tokenBalances.values())
+        : Array.isArray(tokenBalances)
+          ? tokenBalances
+          : Object.values(tokenBalances || {});
     const usdb = balances.find((entry: any) => entry?.tokenMetadata?.identifier === USDB_TOKEN_IDENTIFIER);
     let active = false;
     try {

--- a/src/lib/spark/index.ts
+++ b/src/lib/spark/index.ts
@@ -226,7 +226,7 @@ async function setupEventListener(): Promise<void> {
 async function refreshBalanceInternal(): Promise<void> {
   if (!_sdkInstance) return;
   try {
-    const info = await _sdkInstance.getInfo({ ensureSynced: true });
+    const info = await _sdkInstance.getInfo({ ensureSynced: false });
     const balanceValue =
       info.balanceSats ?? info.balanceSat ?? info.balance_sats ?? info.balance ?? 0;
     walletBalance.set(BigInt(balanceValue));

--- a/src/lib/wallet/sparkPayment.test.ts
+++ b/src/lib/wallet/sparkPayment.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { extractSparkPaymentAsset } from './sparkPayment';
+import { extractSparkPaymentAsset, extractSparkPaymentSats } from './sparkPayment';
 
 describe('extractSparkPaymentAsset', () => {
   it('uses conversion details for a stable-balance Lightning receive', () => {
@@ -31,5 +31,38 @@ describe('extractSparkPaymentAsset', () => {
         details: { type: 'lightning' }
       })
     ).toBeUndefined();
+  });
+
+  it('uses the token leg even when payment.amount is Lightning sats', () => {
+    const payment = {
+      amount: 23_914n,
+      conversionDetails: {
+        conversions: [
+          {
+            from: { asset: { ticker: 'BTC', decimals: 0 }, amount: '23914' },
+            to: {
+              asset: { identifier: 'usdb-token', ticker: 'USDB', decimals: 6 },
+              amount: '15866330'
+            }
+          }
+        ]
+      }
+    };
+
+    expect(extractSparkPaymentAsset(payment)).toEqual({
+      ticker: 'USDB',
+      amount: '15866330',
+      decimals: 6
+    });
+    expect(extractSparkPaymentSats(payment, true)).toBe(23_914);
+  });
+
+  it('never treats token base units as sats', () => {
+    expect(
+      extractSparkPaymentSats(
+        { amount: 15_866_330n, details: { type: 'token' } },
+        true
+      )
+    ).toBe(0);
   });
 });

--- a/src/lib/wallet/sparkPayment.test.ts
+++ b/src/lib/wallet/sparkPayment.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { extractSparkPaymentAsset, extractSparkPaymentSats } from './sparkPayment';
+import {
+  extractSparkPaymentAsset,
+  extractSparkPaymentConversionFrom,
+  extractSparkPaymentSats
+} from './sparkPayment';
 
 describe('extractSparkPaymentAsset', () => {
   it('uses conversion details for a stable-balance Lightning receive', () => {
@@ -55,6 +59,22 @@ describe('extractSparkPaymentAsset', () => {
       decimals: 6
     });
     expect(extractSparkPaymentSats(payment, true)).toBe(23_914);
+    expect(extractSparkPaymentConversionFrom(payment)).toBe('Bitcoin');
+  });
+
+  it('identifies a conversion from USDB', () => {
+    expect(
+      extractSparkPaymentConversionFrom({
+        conversionDetails: {
+          conversions: [
+            {
+              from: { asset: { identifier: 'usdb-token', ticker: 'USDB' }, amount: '15800000' },
+              to: { asset: { ticker: 'BTC' }, amount: '20339' }
+            }
+          ]
+        }
+      })
+    ).toBe('USDB');
   });
 
   it('never treats token base units as sats', () => {

--- a/src/lib/wallet/sparkPayment.test.ts
+++ b/src/lib/wallet/sparkPayment.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { extractSparkPaymentAsset } from './sparkPayment';
+
+describe('extractSparkPaymentAsset', () => {
+  it('uses conversion details for a stable-balance Lightning receive', () => {
+    expect(
+      extractSparkPaymentAsset({
+        amount: 15_866_330n,
+        method: 'lightning',
+        details: { type: 'lightning' },
+        conversionDetails: {
+          conversions: [
+            {
+              from: { asset: { ticker: 'BTC', decimals: 0 }, amount: '23914' },
+              to: {
+                asset: { identifier: 'usdb-token', ticker: 'USDB', decimals: 6 },
+                amount: '15866330'
+              }
+            }
+          ]
+        }
+      })
+    ).toEqual({ ticker: 'USDB', amount: '15866330', decimals: 6 });
+  });
+
+  it('does not re-denominate ordinary Lightning payments', () => {
+    expect(
+      extractSparkPaymentAsset({
+        amount: 21n,
+        method: 'lightning',
+        details: { type: 'lightning' }
+      })
+    ).toBeUndefined();
+  });
+});

--- a/src/lib/wallet/sparkPayment.ts
+++ b/src/lib/wallet/sparkPayment.ts
@@ -4,6 +4,11 @@ export interface SparkPaymentAsset {
   decimals: number;
 }
 
+function conversionSides(payment: any): any[] {
+  const conversions = payment.conversionDetails?.conversions || payment.conversion_details?.conversions || [];
+  return conversions.flatMap((conversion: any) => [conversion.from, conversion.to].filter(Boolean));
+}
+
 /**
  * Spark keeps the original Lightning method for stable-balance receives. The
  * token amount is instead recorded on the token side of conversionDetails.
@@ -19,16 +24,33 @@ export function extractSparkPaymentAsset(payment: any): SparkPaymentAsset | unde
     };
   }
 
-  const conversions = payment.conversionDetails?.conversions || payment.conversion_details?.conversions || [];
-  const tokenSides = conversions.flatMap((conversion: any) =>
-    [conversion.from, conversion.to].filter((side: any) => side?.asset?.identifier)
-  );
-  const tokenSide = tokenSides.find((side: any) => String(side.amount) === amount);
+  const tokenSide = conversionSides(payment).find((side: any) => side?.asset?.identifier);
   if (!tokenSide) return undefined;
 
   return {
     ticker: tokenSide.asset.ticker || 'Token',
-    amount,
+    amount: String(tokenSide.amount ?? 0),
     decimals: Number(tokenSide.asset.decimals ?? 0)
   };
+}
+
+/**
+ * Transaction.amount is always sats. Token payment payloads may put token
+ * base units in payment.amount, so derive their sat value from the BTC leg.
+ */
+export function extractSparkPaymentSats(payment: any, hasTokenAsset: boolean): number {
+  const explicitSats = payment.amountSat ?? payment.amount_sat;
+  if (explicitSats !== undefined && explicitSats !== null) return Number(explicitSats);
+
+  const amountMsat = payment.amountMsat ?? payment.amount_msat ?? payment.amountMSat;
+  if (amountMsat !== undefined && amountMsat !== null) return Math.floor(Number(amountMsat) / 1000);
+
+  if (hasTokenAsset) {
+    const bitcoinSide = conversionSides(payment).find(
+      (side: any) => side?.asset?.ticker === 'BTC' || side?.asset?.ticker === 'Bitcoin'
+    );
+    return Number(bitcoinSide?.amount ?? 0);
+  }
+
+  return Number(payment.amount ?? 0);
 }

--- a/src/lib/wallet/sparkPayment.ts
+++ b/src/lib/wallet/sparkPayment.ts
@@ -1,0 +1,34 @@
+export interface SparkPaymentAsset {
+  ticker: string;
+  amount: string;
+  decimals: number;
+}
+
+/**
+ * Spark keeps the original Lightning method for stable-balance receives. The
+ * token amount is instead recorded on the token side of conversionDetails.
+ */
+export function extractSparkPaymentAsset(payment: any): SparkPaymentAsset | undefined {
+  const amount = String(payment.amount ?? 0);
+  const directMetadata = payment.details?.type === 'token' ? payment.details.metadata : undefined;
+  if (directMetadata) {
+    return {
+      ticker: directMetadata.ticker || directMetadata.name || 'Token',
+      amount,
+      decimals: Number(directMetadata.decimals ?? 0)
+    };
+  }
+
+  const conversions = payment.conversionDetails?.conversions || payment.conversion_details?.conversions || [];
+  const tokenSides = conversions.flatMap((conversion: any) =>
+    [conversion.from, conversion.to].filter((side: any) => side?.asset?.identifier)
+  );
+  const tokenSide = tokenSides.find((side: any) => String(side.amount) === amount);
+  if (!tokenSide) return undefined;
+
+  return {
+    ticker: tokenSide.asset.ticker || 'Token',
+    amount,
+    decimals: Number(tokenSide.asset.decimals ?? 0)
+  };
+}

--- a/src/lib/wallet/sparkPayment.ts
+++ b/src/lib/wallet/sparkPayment.ts
@@ -54,3 +54,11 @@ export function extractSparkPaymentSats(payment: any, hasTokenAsset: boolean): n
 
   return Number(payment.amount ?? 0);
 }
+
+export function extractSparkPaymentConversionFrom(payment: any): string | undefined {
+  const conversions = payment.conversionDetails?.conversions || payment.conversion_details?.conversions || [];
+  const conversion = conversions.find((item: any) => item?.from?.asset && item?.to?.asset);
+  const ticker = conversion?.from?.asset?.ticker;
+  if (!ticker) return undefined;
+  return ticker === 'BTC' ? 'Bitcoin' : ticker;
+}

--- a/src/lib/wallet/walletManager.ts
+++ b/src/lib/wallet/walletManager.ts
@@ -60,7 +60,7 @@ import {
   recentSparkPayments
 } from '$lib/spark';
 import { userPublickey } from '$lib/nostr';
-import { extractSparkPaymentAsset } from './sparkPayment';
+import { extractSparkPaymentAsset, extractSparkPaymentSats } from './sparkPayment';
 
 /**
  * Connect a new wallet
@@ -724,12 +724,10 @@ function mapSparkPayment(p: any): Transaction {
     paymentType === 'RECEIVED' ||
     paymentType === 'receive' ||
     paymentType === 'incoming';
-  const amountMsat = p.amountMsat || p.amount_msat || p.amountMSat || 0;
-  const amountSat =
-    p.amountSat || p.amount_sat || p.amount || Math.floor(Number(amountMsat) / 1000);
+  const asset = extractSparkPaymentAsset(p);
+  const amountSat = extractSparkPaymentSats(p, !!asset);
   let timestamp = p.createdAt || p.created_at || p.timestamp || p.time || 0;
   if (timestamp > 4102444800) timestamp = Math.floor(timestamp / 1000);
-  const asset = extractSparkPaymentAsset(p);
   const feesMsat = p.feesMsat || p.fees_msat || p.feesMSat || 0;
   const feesSat =
     p.feesSat ||

--- a/src/lib/wallet/walletManager.ts
+++ b/src/lib/wallet/walletManager.ts
@@ -562,7 +562,12 @@ export interface Transaction {
   txid?: string; // On-chain transaction id when available
   isOnchain?: boolean; // True when payment is on-chain (even if txid is unavailable)
   type: 'incoming' | 'outgoing';
-  amount: number; // in sats
+  amount: number; // in sats, unless asset is present
+  asset?: {
+    ticker: string;
+    amount: string; // base units; preserve precision beyond JavaScript's safe integer range
+    decimals: number;
+  };
   description?: string;
   comment?: string; // Zap comment from kind 9734 content field
   timestamp: number; // unix timestamp
@@ -723,6 +728,14 @@ function mapSparkPayment(p: any): Transaction {
     p.amountSat || p.amount_sat || p.amount || Math.floor(Number(amountMsat) / 1000);
   let timestamp = p.createdAt || p.created_at || p.timestamp || p.time || 0;
   if (timestamp > 4102444800) timestamp = Math.floor(timestamp / 1000);
+  const tokenMetadata = p.details?.type === 'token' ? p.details.metadata : undefined;
+  const asset = tokenMetadata
+    ? {
+        ticker: tokenMetadata.ticker || tokenMetadata.name || 'Token',
+        amount: String(p.amount ?? 0),
+        decimals: Number(tokenMetadata.decimals ?? 0)
+      }
+    : undefined;
   const feesMsat = p.feesMsat || p.fees_msat || p.feesMSat || 0;
   const feesSat =
     p.feesSat ||
@@ -833,10 +846,11 @@ function mapSparkPayment(p: any): Transaction {
     isOnchain: isOnchain || undefined,
     type: isIncoming ? 'incoming' : ('outgoing' as 'incoming' | 'outgoing'),
     amount: Number(amountSat),
+    asset,
     description: p.description || p.memo || p.bolt11?.substring(0, 20),
     comment,
     timestamp: timestamp || Math.floor(Date.now() / 1000),
-    fees: feesSat,
+    fees: asset ? undefined : feesSat,
     status,
     pubkey
   };

--- a/src/lib/wallet/walletManager.ts
+++ b/src/lib/wallet/walletManager.ts
@@ -60,7 +60,11 @@ import {
   recentSparkPayments
 } from '$lib/spark';
 import { userPublickey } from '$lib/nostr';
-import { extractSparkPaymentAsset, extractSparkPaymentSats } from './sparkPayment';
+import {
+  extractSparkPaymentAsset,
+  extractSparkPaymentConversionFrom,
+  extractSparkPaymentSats
+} from './sparkPayment';
 
 /**
  * Connect a new wallet
@@ -569,6 +573,7 @@ export interface Transaction {
     amount: string; // base units; preserve precision beyond JavaScript's safe integer range
     decimals: number;
   };
+  conversionFrom?: string;
   description?: string;
   comment?: string; // Zap comment from kind 9734 content field
   timestamp: number; // unix timestamp
@@ -725,6 +730,7 @@ function mapSparkPayment(p: any): Transaction {
     paymentType === 'receive' ||
     paymentType === 'incoming';
   const asset = extractSparkPaymentAsset(p);
+  const conversionFrom = extractSparkPaymentConversionFrom(p);
   const amountSat = extractSparkPaymentSats(p, !!asset);
   let timestamp = p.createdAt || p.created_at || p.timestamp || p.time || 0;
   if (timestamp > 4102444800) timestamp = Math.floor(timestamp / 1000);
@@ -839,6 +845,7 @@ function mapSparkPayment(p: any): Transaction {
     type: isIncoming ? 'incoming' : ('outgoing' as 'incoming' | 'outgoing'),
     amount: Number(amountSat),
     asset,
+    conversionFrom,
     description: p.description || p.memo || p.bolt11?.substring(0, 20),
     comment,
     timestamp: timestamp || Math.floor(Date.now() / 1000),

--- a/src/lib/wallet/walletManager.ts
+++ b/src/lib/wallet/walletManager.ts
@@ -60,6 +60,7 @@ import {
   recentSparkPayments
 } from '$lib/spark';
 import { userPublickey } from '$lib/nostr';
+import { extractSparkPaymentAsset } from './sparkPayment';
 
 /**
  * Connect a new wallet
@@ -728,14 +729,7 @@ function mapSparkPayment(p: any): Transaction {
     p.amountSat || p.amount_sat || p.amount || Math.floor(Number(amountMsat) / 1000);
   let timestamp = p.createdAt || p.created_at || p.timestamp || p.time || 0;
   if (timestamp > 4102444800) timestamp = Math.floor(timestamp / 1000);
-  const tokenMetadata = p.details?.type === 'token' ? p.details.metadata : undefined;
-  const asset = tokenMetadata
-    ? {
-        ticker: tokenMetadata.ticker || tokenMetadata.name || 'Token',
-        amount: String(p.amount ?? 0),
-        decimals: Number(tokenMetadata.decimals ?? 0)
-      }
-    : undefined;
+  const asset = extractSparkPaymentAsset(p);
   const feesMsat = p.feesMsat || p.fees_msat || p.feesMSat || 0;
   const feesSat =
     p.feesSat ||


### PR DESCRIPTION
## Summary
- display Spark token payments using their token decimals instead of treating base units as sats
- label USDB transaction rows and details with the stablecoin amount
- preserve token precision in the wallet transaction model

Follow-up to #659.

## Verification
- `pnpm check` (0 errors; 153 existing warnings)