### PR TITLE
fix(wallet): show USDB in mini wallet balance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.735",
+  "version": "4.2.736",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.729",
+  "version": "4.2.730",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/WalletBalance.svelte
+++ b/src/components/WalletBalance.svelte
@@ -48,6 +48,7 @@
   import DenominatedBalance from './DenominatedBalance.svelte';
   import { displayCurrency, getPreferredFiat } from '$lib/currencyStore';
   import { stableBalance } from '$lib/spark';
+  import { formatStableBalance } from '$lib/spark/format';
 
   function onPillKeydown(e: KeyboardEvent) {
     if (e.key === 'Enter' || e.key === ' ') {
@@ -60,14 +61,10 @@
   // Recomputed reactively when the active currency changes so the
   // label always describes what the next click will switch to.
   $: cycleTarget = $displayCurrency === 'SATS' ? getPreferredFiat() : 'SATS';
-  $: showStableBalance = $activeWallet?.kind === 4 && $stableBalance.balance > 0n;
-
-  function formatStableBalance(amount: bigint, decimals: number): string {
-    const divisor = 10n ** BigInt(decimals);
-    const whole = amount / divisor;
-    const fraction = (amount % divisor).toString().padStart(decimals, '0').slice(0, 2);
-    return `${whole.toLocaleString()}.${fraction}`;
-  }
+  // Mirror WalletPanel's showStableBalanceAsPrimary: USDB is the primary balance
+  // when the user has enabled it (even at $0.00) or when any USDB is held.
+  $: showStableBalance =
+    $activeWallet?.kind === 4 && ($stableBalance.active || $stableBalance.balance > 0n);
 
   let dropdownActive = false;
   let showRemoveBitcoinConnectModal = false;

--- a/src/components/WalletBalance.svelte
+++ b/src/components/WalletBalance.svelte
@@ -47,6 +47,7 @@
   import BitcoinConnectLogo from './icons/BitcoinConnectLogo.svelte';
   import DenominatedBalance from './DenominatedBalance.svelte';
   import { displayCurrency, getPreferredFiat } from '$lib/currencyStore';
+  import { stableBalance } from '$lib/spark';
 
   function onPillKeydown(e: KeyboardEvent) {
     if (e.key === 'Enter' || e.key === ' ') {
@@ -59,6 +60,14 @@
   // Recomputed reactively when the active currency changes so the
   // label always describes what the next click will switch to.
   $: cycleTarget = $displayCurrency === 'SATS' ? getPreferredFiat() : 'SATS';
+  $: showStableBalance = $activeWallet?.kind === 4 && $stableBalance.balance > 0n;
+
+  function formatStableBalance(amount: bigint, decimals: number): string {
+    const divisor = 10n ** BigInt(decimals);
+    const whole = amount / divisor;
+    const fraction = (amount % divisor).toString().padStart(decimals, '0').slice(0, 2);
+    return `${whole.toLocaleString()}.${fraction}`;
+  }
 
   let dropdownActive = false;
   let showRemoveBitcoinConnectModal = false;
@@ -349,12 +358,20 @@
       on:keydown={onPillKeydown}
     >
       <LightningIcon size={16} weight="fill" class="text-amber-500" />
-      <span class="balance-text min-w-[3.5rem] text-right">
-        <DenominatedBalance
-          sats={$walletBalance}
-          visible={$balanceVisible}
-          loading={$walletLoading}
-        />
+      <span class="balance-text min-w-[3.5rem] text-right whitespace-nowrap">
+        {#if showStableBalance}
+          {#if $balanceVisible}
+            ${formatStableBalance($stableBalance.balance, $stableBalance.decimals)} {$stableBalance.label}
+          {:else}
+            $*** {$stableBalance.label}
+          {/if}
+        {:else}
+          <DenominatedBalance
+            sats={$walletBalance}
+            visible={$balanceVisible}
+            loading={$walletLoading}
+          />
+        {/if}
       </span>
 
       <CaretDownIcon size={12} class="text-caption ml-0.5" />
@@ -419,13 +436,15 @@
           {/if}
 
           <!-- Actions -->
-          <button
-            class="flex items-center gap-2 text-sm hover:text-primary transition-colors cursor-pointer"
-            on:click={() => displayCurrency.cycleSatsFiat()}
-          >
-            <ArrowsLeftRightIcon size={18} weight="bold" />
-            Switch to {cycleTarget}
-          </button>
+          {#if !showStableBalance}
+            <button
+              class="flex items-center gap-2 text-sm hover:text-primary transition-colors cursor-pointer"
+              on:click={() => displayCurrency.cycleSatsFiat()}
+            >
+              <ArrowsLeftRightIcon size={18} weight="bold" />
+              Switch to {cycleTarget}
+            </button>
+          {/if}
 
           <button
             class="flex items-center gap-2 text-sm hover:text-primary transition-colors cursor-pointer"

--- a/src/components/wallet/WalletPanel.svelte
+++ b/src/components/wallet/WalletPanel.svelte
@@ -91,6 +91,7 @@
     type ClaimDepositResult,
     type RefundDepositResult
   } from '$lib/spark';
+  import { formatStableBalance } from '$lib/spark/format';
   import {
     hasEncryptionSupport,
     encrypt as encryptionServiceEncrypt,
@@ -680,13 +681,6 @@
   let isUpdatingStableBalance = false;
   $: hasStableBalance = $stableBalance.balance > 0n;
   $: showStableBalanceAsPrimary = $stableBalance.active || hasStableBalance;
-
-  function formatStableBalance(amount: bigint, decimals: number): string {
-    const divisor = 10n ** BigInt(decimals);
-    const whole = amount / divisor;
-    const fraction = (amount % divisor).toString().padStart(decimals, '0').slice(0, 2);
-    return `${whole.toLocaleString()}.${fraction}`;
-  }
 
   function formatTransactionAmount(tx: Transaction): string {
     if (!tx.asset) return `${tx.amount.toLocaleString()} sats`;

--- a/src/lib/spark/format.test.ts
+++ b/src/lib/spark/format.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { formatStableBalance } from './format';
+
+describe('formatStableBalance', () => {
+  it('formats a zero balance', () => {
+    expect(formatStableBalance(0n, 6)).toBe('0.00');
+  });
+
+  it('formats whole and fractional parts with two decimals', () => {
+    expect(formatStableBalance(12_345_678n, 6)).toBe('12.34');
+  });
+
+  it('pads small fractional amounts', () => {
+    expect(formatStableBalance(5_000n, 6)).toBe('0.00');
+    expect(formatStableBalance(50_000n, 6)).toBe('0.05');
+  });
+
+  it('truncates rather than rounds', () => {
+    expect(formatStableBalance(1_999_999n, 6)).toBe('1.99');
+  });
+
+  it('respects the token decimals', () => {
+    expect(formatStableBalance(1_234n, 2)).toBe('12.34');
+  });
+
+  it('locale-formats the whole part', () => {
+    expect(formatStableBalance(1_234_567_000_000n, 6)).toBe((1_234_567n).toLocaleString() + '.00');
+  });
+});

--- a/src/lib/spark/format.ts
+++ b/src/lib/spark/format.ts
@@ -1,0 +1,16 @@
+/**
+ * Format a Spark stable-balance token amount (e.g. USDB) for display.
+ *
+ * `amount` is the raw integer token amount and `decimals` is the token's
+ * precision. The result is truncated (not rounded) to two decimal places and
+ * the whole part is locale-formatted, e.g. 1234567n / 6 → "1.23".
+ *
+ * Shared by the mini wallet pill and the wallet panel so both render the
+ * balance identically.
+ */
+export function formatStableBalance(amount: bigint, decimals: number): string {
+  const divisor = 10n ** BigInt(decimals);
+  const whole = amount / divisor;
+  const fraction = (amount % divisor).toString().padStart(decimals, '0').slice(0, 2);
+  return `${whole.toLocaleString()}.${fraction}`;
+}


### PR DESCRIPTION
## Summary
- show the held USDB balance in the Spark mini-wallet pill
- hide the sats/fiat switch while USDB is the active balance

## Dependency
- Depends on #662 and should merge after it.

## Verification
- pnpm check: 0 errors