### PR TITLE
fix(reads): render profile mentions as links, and preview what will publish

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -286,6 +286,19 @@ html.dark .image-placeholder::before {
   -webkit-touch-callout: none;
 }
 
+/* Profile mentions inside rendered markdown. Global rather than scoped to
+   one component: the same parseMarkdown output is rendered by the article
+   view, the recipe view, both editor previews and the print sheet. */
+a.nostr-mention {
+  color: var(--color-primary);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+a.nostr-mention:hover {
+  text-decoration: underline;
+}
+
 /* Print styles for #print-recipe */
 #print-recipe {
   display: none;

--- a/src/components/reads/ArticleMetadata.svelte
+++ b/src/components/reads/ArticleMetadata.svelte
@@ -2,9 +2,11 @@
 	import { ndk } from '$lib/nostr';
 	import { NDKEvent } from '@nostr-dev-kit/ndk';
 	import { Fetch } from 'hurdak';
+	import { isImageUrl } from '$lib/imageUrls';
 	import XIcon from 'phosphor-svelte/lib/X';
 	import ImageIcon from 'phosphor-svelte/lib/Image';
 	import UploadIcon from 'phosphor-svelte/lib/UploadSimple';
+	import LinkIcon from 'phosphor-svelte/lib/Link';
 	import ArrowsClockwiseIcon from 'phosphor-svelte/lib/ArrowsClockwise';
 
 	export let title: string = '';
@@ -17,6 +19,10 @@
 	let tagInput = '';
 	let isDragging = false;
 	let uploadError = '';
+	let coverUrlInput = '';
+	let isCheckingCoverUrl = false;
+	let coverUrlError = '';
+	let coverUrlWarning = '';
 
 	// Upload to nostr.build
 	async function uploadToNostrBuild(file: File): Promise<string | null> {
@@ -128,6 +134,85 @@
 
 	function removeCover() {
 		coverImage = '';
+		coverUrlWarning = '';
+	}
+
+	/**
+	 * Accepting a pasted cover URL.
+	 *
+	 * The scheme is checked rather than just `new URL()` parsing, which
+	 * happily accepts `javascript:` and `data:` - this string ends up in
+	 * an `<img src>` here and in the event's `image` tag for every other
+	 * client that renders the article.
+	 */
+	function isHttpUrl(value: string): boolean {
+		try {
+			const { protocol } = new URL(value);
+			return protocol === 'http:' || protocol === 'https:';
+		} catch {
+			return false;
+		}
+	}
+
+	const COVER_PROBE_TIMEOUT_MS = 10000;
+
+	/** Loads the URL to confirm it really is an image the browser renders. */
+	function loadsAsImage(url: string): Promise<boolean> {
+		return new Promise((resolve) => {
+			const img = new Image();
+			const done = (result: boolean) => {
+				clearTimeout(timer);
+				img.onload = null;
+				img.onerror = null;
+				resolve(result);
+			};
+			const timer = setTimeout(() => done(false), COVER_PROBE_TIMEOUT_MS);
+			img.onload = () => done(true);
+			img.onerror = () => done(false);
+			img.src = url;
+		});
+	}
+
+	async function applyCoverUrl() {
+		const url = coverUrlInput.trim();
+		coverUrlError = '';
+		coverUrlWarning = '';
+		if (!url) return;
+
+		if (!isHttpUrl(url)) {
+			coverUrlError = 'Enter an image URL starting with http:// or https://';
+			return;
+		}
+
+		isCheckingCoverUrl = true;
+		const loaded = await loadsAsImage(url);
+		isCheckingCoverUrl = false;
+
+		if (loaded) {
+			coverImage = url;
+			coverUrlInput = '';
+			return;
+		}
+
+		// Some hosts block hotlinking or need a referrer, so a failed probe
+		// doesn't prove the URL is bad. If it still looks like an image,
+		// take it and say the preview couldn't be confirmed rather than
+		// refusing a URL that may well work for readers.
+		if (isImageUrl(url)) {
+			coverImage = url;
+			coverUrlInput = '';
+			coverUrlWarning = "Couldn't load a preview from that host. Check the cover looks right before publishing.";
+			return;
+		}
+
+		coverUrlError = "That URL didn't load as an image.";
+	}
+
+	function handleCoverUrlKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter') {
+			e.preventDefault();
+			applyCoverUrl();
+		}
 	}
 
 	// Tag management
@@ -202,6 +287,9 @@
 					Cover
 				</div>
 			</div>
+			{#if coverUrlWarning}
+				<p class="upload-warning">{coverUrlWarning}</p>
+			{/if}
 		{:else}
 			<button
 				type="button"
@@ -223,6 +311,37 @@
 			</button>
 			{#if uploadError}
 				<p class="upload-error">{uploadError}</p>
+			{/if}
+
+			<!-- Or point at an image that's already hosted somewhere. -->
+			<div class="cover-url-row">
+				<label class="cover-url-label" for="cover-url">or paste an image URL</label>
+				<div class="cover-url-controls">
+					<div class="cover-url-field">
+						<LinkIcon size={16} />
+						<input
+							id="cover-url"
+							type="url"
+							bind:value={coverUrlInput}
+							on:keydown={handleCoverUrlKeydown}
+							placeholder="https://example.com/image.jpg"
+							autocomplete="off"
+							spellcheck="false"
+							class="cover-url-input"
+						/>
+					</div>
+					<button
+						type="button"
+						class="cover-url-submit"
+						on:click={applyCoverUrl}
+						disabled={!coverUrlInput.trim() || isCheckingCoverUrl}
+					>
+						{isCheckingCoverUrl ? 'Checking...' : 'Use'}
+					</button>
+				</div>
+			</div>
+			{#if coverUrlError}
+				<p class="upload-error">{coverUrlError}</p>
 			{/if}
 		{/if}
 	</div>
@@ -393,6 +512,88 @@
 		font-size: 0.875rem;
 		color: #dc2626;
 		margin-top: 0.5rem;
+	}
+
+	.upload-warning {
+		font-size: 0.875rem;
+		color: #b45309;
+		margin-top: 0.5rem;
+	}
+
+	/* Cover image by URL */
+	.cover-url-row {
+		display: flex;
+		flex-direction: column;
+		gap: 0.375rem;
+		margin-top: 0.75rem;
+	}
+
+	.cover-url-label {
+		font-size: 0.75rem;
+		color: var(--color-text-secondary);
+	}
+
+	.cover-url-controls {
+		display: flex;
+		gap: 0.5rem;
+	}
+
+	.cover-url-field {
+		flex: 1;
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0 0.625rem;
+		border: 1px solid var(--color-input-border);
+		border-radius: 0.5rem;
+		background: var(--color-input-bg);
+		color: var(--color-text-secondary);
+		min-width: 0;
+	}
+
+	.cover-url-field:focus-within {
+		border-color: var(--color-primary);
+	}
+
+	.cover-url-input {
+		flex: 1;
+		min-width: 0;
+		border: none;
+		background: transparent;
+		color: var(--color-text-primary);
+		font-size: 0.875rem;
+		padding: 0.5rem 0;
+	}
+
+	.cover-url-input:focus {
+		outline: none;
+	}
+
+	.cover-url-input::placeholder {
+		color: var(--color-text-secondary);
+		opacity: 0.6;
+	}
+
+	.cover-url-submit {
+		padding: 0.5rem 1rem;
+		border-radius: 0.5rem;
+		background: var(--color-input-bg);
+		border: 1px solid var(--color-input-border);
+		color: var(--color-text-primary);
+		font-size: 0.875rem;
+		font-weight: 500;
+		white-space: nowrap;
+		transition: all 0.15s ease;
+	}
+
+	.cover-url-submit:hover:not(:disabled) {
+		border-color: var(--color-primary);
+		color: var(--color-primary);
+	}
+
+	.cover-url-submit:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
 	}
 
 	/* Tags */

--- a/src/components/reads/LongformEditorModal.svelte
+++ b/src/components/reads/LongformEditorModal.svelte
@@ -11,7 +11,7 @@
 	import { getOutboxRelays } from '$lib/relayListCache';
 	import { addClientTagToEvent } from '$lib/nip89';
 	import TurndownService from 'turndown';
-	import { sanitizeHTML } from '$lib/sanitize';
+	import { parseMarkdown, mentionNamesVersion } from '$lib/parser';
 	import XIcon from 'phosphor-svelte/lib/X';
 	import FloppyDiskIcon from 'phosphor-svelte/lib/FloppyDisk';
 	import CloudCheckIcon from 'phosphor-svelte/lib/CloudCheck';
@@ -72,6 +72,10 @@
 		codeBlockStyle: 'fenced'
 	});
 
+	const NPUB_MENTION_RE = /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58})/g;
+	const ANY_MENTION_RE =
+		/nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)/g;
+
 	// Custom rule: convert mention spans to nostr:npub1... format
 	turndownService.addRule('mention', {
 		filter: (node: HTMLElement) => {
@@ -96,6 +100,16 @@
 	}
 
 	// Computed values
+	// The preview renders the *published* markdown, not the editor's HTML.
+	// Rendering the editor HTML showed mentions as inert text and hashtags
+	// and YouTube links unprocessed, so the preview promised less than
+	// publishing delivers. Going through the same turndown + parseMarkdown
+	// path the reader gets makes it accurate in both directions, including
+	// anything turndown drops. `$mentionNamesVersion` is a dependency so a
+	// mention re-renders once its display name resolves.
+	$: previewHtml = showPreview
+		? renderPreview(localDraft.content, $mentionNamesVersion)
+		: '';
 	$: wordCount = getWordCount(localDraft.content);
 	$: readingTime = getReadingTime(wordCount);
 	$: statusText = getStatusText($draftStatus);
@@ -228,6 +242,60 @@
 		if (!html) return '';
 		return turndownService.turndown(html);
 	}
+
+	/**
+	 * Rewrites `nostr:npub1…` mentions as `nostr:nprofile1…` with relay
+	 * hints, which is the form NIP-27 shows in its own example.
+	 *
+	 * A bare npub carries no clue where the profile lives, so a reader
+	 * that has never seen this person has nothing to fetch and falls back
+	 * to displaying the bech32 string. Hints give it somewhere to look, so
+	 * the mention resolves to a name in clients that don't already follow
+	 * the mentioned account.
+	 *
+	 * Best-effort: a mention whose relay list can't be fetched keeps its
+	 * npub, which is still valid NIP-27.
+	 */
+	async function addRelayHintsToMentions(markdown: string): Promise<string> {
+		const matches = [...markdown.matchAll(NPUB_MENTION_RE)];
+		if (matches.length === 0) return markdown;
+
+		const npubs = [...new Set(matches.map((m) => m[1]))];
+		const replacements = new Map<string, string>();
+
+		await Promise.all(
+			npubs.map(async (npub) => {
+				try {
+					const decoded = nip19.decode(npub);
+					if (decoded.type !== 'npub') return;
+					const relays = await getOutboxRelays(decoded.data);
+					if (!relays || relays.length === 0) return;
+					// Two hints is the customary ceiling - enough to find
+					// the profile without bloating every mention.
+					replacements.set(
+						npub,
+						nip19.nprofileEncode({ pubkey: decoded.data, relays: relays.slice(0, 2) })
+					);
+				} catch {
+					// Leave this mention as a bare npub.
+				}
+			})
+		);
+
+		if (replacements.size === 0) return markdown;
+		return markdown.replace(NPUB_MENTION_RE, (full, npub) => {
+			const nprofile = replacements.get(npub);
+			return nprofile ? `nostr:${nprofile}` : full;
+		});
+	}
+
+	// `namesVersion` is unused: it's a reactivity dependency only, so the
+	// preview re-renders when a mentioned profile's name arrives.
+	function renderPreview(html: string, namesVersion: number): string {
+		void namesVersion;
+		if (!html) return '';
+		return parseMarkdown(htmlToMarkdown(html));
+	}
 	
 	// Generate a URL-friendly identifier from the title
 	// Note: In NIP-23, reusing the same identifier updates the article (by design)
@@ -277,7 +345,7 @@
 		
 		try {
 			// Convert HTML content to Markdown
-			const markdownContent = htmlToMarkdown(localDraft.content);
+			const markdownContent = await addRelayHintsToMentions(htmlToMarkdown(localDraft.content));
 			
 			if (!markdownContent.trim()) {
 				publishError = 'Article content cannot be empty';
@@ -310,10 +378,16 @@
 			}
 			
 			if (localDraft.coverImage && localDraft.coverImage.trim()) {
-				// Basic URL validation
+				// `new URL()` alone is not enough: it parses `javascript:` and
+				// `data:` URLs happily, and this value is republished as the
+				// article's `image` tag for every other client to render.
 				try {
-					new URL(localDraft.coverImage);
-					event.tags.push(['image', localDraft.coverImage]);
+					const { protocol } = new URL(localDraft.coverImage);
+					if (protocol === 'http:' || protocol === 'https:') {
+						event.tags.push(['image', localDraft.coverImage]);
+					} else {
+						console.warn('Cover image URL is not http(s), skipping');
+					}
 				} catch {
 					console.warn('Invalid cover image URL, skipping');
 				}
@@ -337,16 +411,20 @@
 			// Add NIP-89 client tag
 			addClientTagToEvent(event);
 
-			// Extract mentioned pubkeys from content and add p tags (NIP-23/NIP-27)
-			const mentionMatches = markdownContent.match(/nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58})/g);
+			// Extract mentioned pubkeys from content and add p tags (NIP-23/NIP-27).
+			// Both mention forms count: relay hints turn npub mentions into
+			// nprofile, and matching only npub would drop the p tag - and with
+			// it the notification - for every hinted mention.
+			const mentionMatches = markdownContent.match(ANY_MENTION_RE);
 			if (mentionMatches) {
 				const mentionedPubkeys = new Set<string>();
 				for (const match of mentionMatches) {
 					try {
-						const npub = match.replace('nostr:', '');
-						const decoded = nip19.decode(npub);
+						const decoded = nip19.decode(match.replace('nostr:', ''));
 						if (decoded.type === 'npub') {
 							mentionedPubkeys.add(decoded.data);
+						} else if (decoded.type === 'nprofile') {
+							mentionedPubkeys.add(decoded.data.pubkey);
 						}
 					} catch {}
 				}
@@ -623,7 +701,7 @@
 							{/if}
 
 							<div class="preview-body prose">
-								{@html sanitizeHTML(localDraft.content)}
+								{@html previewHtml}
 							</div>
 						</article>
 					</div>

--- a/src/lib/nip37DraftService.ts
+++ b/src/lib/nip37DraftService.ts
@@ -22,7 +22,7 @@ import { getOutboxRelays } from '$lib/relayListCache';
 import type { RecipeDraft } from '$lib/draftStore';
 import type { ArticleDraft } from '$lib/articleEditor';
 import TurndownService from 'turndown';
-import { parseMarkdown } from '$lib/parser';
+import { parseMarkdownToEditorHtml } from '$lib/parser';
 
 // ═══════════════════════════════════════════════════════════════
 // CONSTANTS
@@ -456,9 +456,11 @@ function parseArticleToDraft(eventData: { kind: number; content: string; tags: s
     .filter(t => t[0] === 't' && t[1] !== 'zapreads')
     .map(t => t[1] || '');
 
-  // Convert markdown back to HTML for Tiptap
-  // Drafts store HTML, so we need to convert the markdown from NIP-37
-  const htmlContent = parseMarkdown(content);
+  // Convert markdown back to HTML for Tiptap. Drafts store HTML, so the
+  // markdown from NIP-37 has to be rendered back - via the editor
+  // variant, which restores mention spans instead of reader-facing
+  // anchors and leaves hashtags and video links as text.
+  const htmlContent = parseMarkdownToEditorHtml(content);
 
   const timestamp = (eventData.created_at || Math.floor(Date.now() / 1000)) * 1000;
 

--- a/src/lib/parser.mentions.test.ts
+++ b/src/lib/parser.mentions.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from 'vitest';
+import { nip19 } from 'nostr-tools';
+
+// The mention pass resolves display names lazily through the NDK
+// singleton. Neither is needed to assert the markup, and importing
+// `$lib/nostr` for real would open relay connections in the test run.
+vi.mock('$lib/nostr', () => ({ ndk: { subscribe: vi.fn() } }));
+vi.mock('$lib/profileResolver', () => ({
+  resolveProfileByPubkey: vi.fn().mockResolvedValue(null)
+}));
+
+import { parseMarkdown, parseMarkdownToEditorHtml } from './parser';
+
+const PUBKEY = '79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
+const NPUB = nip19.npubEncode(PUBKEY);
+const NPROFILE = nip19.nprofileEncode({ pubkey: PUBKEY, relays: ['wss://relay.example'] });
+
+describe('parseMarkdown profile mentions', () => {
+  it('links a bare nostr:npub mention to the profile page', () => {
+    const html = parseMarkdown(`Thanks nostr:${NPUB} for the recipe`);
+    expect(html).toContain(`href="/user/${NPUB}"`);
+    expect(html).toContain('class="nostr-mention"');
+    // Unresolved profiles show a shortened npub, never the raw URI.
+    expect(html).not.toContain(`nostr:${NPUB}`);
+  });
+
+  it('links an nprofile mention to the same profile page', () => {
+    const html = parseMarkdown(`Thanks nostr:${NPROFILE} for the recipe`);
+    expect(html).toContain(`href="/user/${NPUB}"`);
+    expect(html).not.toContain(`nostr:${NPROFILE}`);
+  });
+
+  it('keeps the surrounding text intact', () => {
+    const html = parseMarkdown(`before nostr:${NPUB} after`);
+    expect(html).toContain('before ');
+    expect(html).toContain(' after');
+  });
+
+  it('leaves a malformed mention as written', () => {
+    const written = 'nostr:npub1notrealbech32';
+    expect(parseMarkdown(written)).toContain(written);
+  });
+
+  it('does not treat a mention as a hashtag target', () => {
+    const html = parseMarkdown(`nostr:${NPUB} #brunch`);
+    // The hashtag still links, and the mention anchor is not nested in one.
+    expect(html).toContain('href="/tag/brunch"');
+    expect(html).not.toContain('hashtag-link"><a');
+  });
+
+  it('renders an unresolved mention as a shortened npub, not an invented name', () => {
+    const html = parseMarkdown(`nostr:${NPUB}`);
+    expect(html).toContain(`@${NPUB.slice(0, 10)}`);
+    expect(html).toContain(NPUB.slice(-4));
+  });
+});
+
+describe('parseMarkdownToEditorHtml', () => {
+  it('restores a mention as a Tiptap mention span, not a reader anchor', () => {
+    const html = parseMarkdownToEditorHtml(`Thanks nostr:${NPUB} for the recipe`);
+    expect(html).toContain('data-type="mention"');
+    expect(html).toContain(`data-id="${NPUB}"`);
+    expect(html).not.toContain('nostr-mention');
+    expect(html).not.toContain('href=');
+  });
+
+  it('normalizes an nprofile mention to an npub in data-id', () => {
+    // Publishing re-adds relay hints, and the turndown rule emits
+    // `nostr:${data-id}` verbatim, so the id has to be an npub.
+    const html = parseMarkdownToEditorHtml(`Thanks nostr:${NPROFILE}`);
+    expect(html).toContain(`data-id="${NPUB}"`);
+  });
+
+  it('uses a supplied display name as the label', () => {
+    const html = parseMarkdownToEditorHtml(
+      `nostr:${NPUB}`,
+      new Map([[PUBKEY, 'alice']])
+    );
+    expect(html).toContain('data-label="alice"');
+    expect(html).toContain('@alice');
+  });
+
+  it('leaves hashtags as text so the editor does not gain stray links', () => {
+    const html = parseMarkdownToEditorHtml('a #brunch post');
+    expect(html).toContain('#brunch');
+    expect(html).not.toContain('/tag/brunch');
+  });
+
+  it('does not embed videos into the editor', () => {
+    const html = parseMarkdownToEditorHtml('https://youtu.be/dQw4w9WgXcQ');
+    expect(html).not.toContain('<iframe');
+  });
+});

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -1,4 +1,6 @@
 import MarkdownIt from 'markdown-it';
+import { get, writable } from 'svelte/store';
+import { nip19 } from 'nostr-tools';
 import { sanitizeHTML } from '$lib/sanitize';
 
 const md = new MarkdownIt({ linkify: true });
@@ -74,6 +76,123 @@ function linkHashtagsInElement(root: Element, doc: Document): void {
   }
 }
 
+/**
+ * Inline profile mentions, per NIP-27: the author's content holds a bare
+ * `nostr:npub1…` / `nostr:nprofile1…` URI and the reader is responsible
+ * for turning it into a name and a link. Without this pass a mention
+ * renders as the raw bech32 string - markdown-it's linkify doesn't know
+ * the `nostr:` scheme, so it passes straight through as text.
+ *
+ * Names come from a module-level cache. A miss renders a shortened npub
+ * immediately and queues a lookup; `mentionNamesVersion` is bumped when
+ * one lands so reactive callers can re-render with the real name. Nothing
+ * here awaits, so a cold cache never blocks the article body.
+ */
+const NOSTR_MENTION_RE =
+  /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]{58}|nprofile1[023456789acdefghjklmnpqrstuvwxyz]+)/g;
+
+/** Bumped whenever a mentioned profile's name resolves. */
+export const mentionNamesVersion = writable(0);
+
+const mentionNames = new Map<string, string>();
+const mentionLookupsInFlight = new Set<string>();
+
+/**
+ * Fetches a mentioned profile's name in the background. `profileResolver`
+ * is imported lazily: `parser.ts` is used in SSR paths and pulling the
+ * NDK singleton in at module load would drag a relay connection with it.
+ */
+function queueMentionLookup(pubkey: string): void {
+  if (typeof window === 'undefined') return;
+  if (mentionNames.has(pubkey) || mentionLookupsInFlight.has(pubkey)) return;
+  mentionLookupsInFlight.add(pubkey);
+
+  (async () => {
+    try {
+      const [{ resolveProfileByPubkey }, { ndk }] = await Promise.all([
+        import('$lib/profileResolver'),
+        import('$lib/nostr')
+      ]);
+      const profile = await resolveProfileByPubkey(pubkey, get(ndk));
+      // Deliberately not getUsername(): its anon-name fallback would
+      // dress an unresolvable mention up as a real handle. A shortened
+      // npub is the honest answer for a profile we never found.
+      const name = profile?.display_name || profile?.name;
+      if (name) {
+        mentionNames.set(pubkey, name);
+        mentionNamesVersion.update((n) => n + 1);
+      }
+    } catch {
+      // A mention that can't be resolved keeps its shortened npub.
+    } finally {
+      mentionLookupsInFlight.delete(pubkey);
+    }
+  })();
+}
+
+function shortNpub(npub: string): string {
+  return npub.length <= 16 ? npub : `${npub.slice(0, 10)}…${npub.slice(-4)}`;
+}
+
+/** Resolves a mention URI to the pubkey and npub it points at. */
+function decodeMention(identifier: string): { pubkey: string; npub: string } | null {
+  try {
+    const decoded = nip19.decode(identifier);
+    if (decoded.type === 'npub') {
+      return { pubkey: decoded.data, npub: identifier };
+    }
+    if (decoded.type === 'nprofile') {
+      return { pubkey: decoded.data.pubkey, npub: nip19.npubEncode(decoded.data.pubkey) };
+    }
+  } catch {
+    // Malformed bech32: leave the text as the author wrote it.
+  }
+  return null;
+}
+
+function linkMentionsInElement(root: Element, doc: Document): void {
+  const textNodes: Text[] = [];
+  collectTextNodes(root, textNodes);
+  for (const node of textNodes) {
+    const text = node.textContent || '';
+    NOSTR_MENTION_RE.lastIndex = 0;
+    if (!NOSTR_MENTION_RE.test(text)) continue;
+    NOSTR_MENTION_RE.lastIndex = 0;
+
+    const fragment = doc.createDocumentFragment();
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+    let replaced = false;
+    while ((match = NOSTR_MENTION_RE.exec(text)) !== null) {
+      const target = decodeMention(match[1]);
+      if (!target) continue;
+
+      if (match.index > lastIndex) {
+        fragment.appendChild(doc.createTextNode(text.slice(lastIndex, match.index)));
+      }
+
+      const name = mentionNames.get(target.pubkey);
+      if (!name) queueMentionLookup(target.pubkey);
+
+      const a = doc.createElement('a');
+      a.setAttribute('href', `/user/${target.npub}`);
+      a.className = 'nostr-mention';
+      // textContent, not innerHTML: the name is profile metadata from a
+      // relay and is not to be trusted as markup.
+      a.textContent = `@${name || shortNpub(target.npub)}`;
+      fragment.appendChild(a);
+
+      lastIndex = match.index + match[0].length;
+      replaced = true;
+    }
+    if (!replaced) continue;
+    if (lastIndex < text.length) {
+      fragment.appendChild(doc.createTextNode(text.slice(lastIndex)));
+    }
+    node.parentNode?.replaceChild(fragment, node);
+  }
+}
+
 function buildYoutubeEmbed(id: string, doc: Document): HTMLElement {
   const wrapper = doc.createElement('div');
   wrapper.className = 'youtube-embed';
@@ -128,7 +247,88 @@ function enhanceContent(html: string): string {
   const root = doc.body.firstElementChild as HTMLElement | null;
   if (!root) return html;
   embedYoutubeInElement(root, doc);
+  linkMentionsInElement(root, doc);
   linkHashtagsInElement(root, doc);
+  return root.innerHTML;
+}
+
+/**
+ * Renders markdown for the *editor*, not for reading.
+ *
+ * Differs from `parseMarkdown` in two ways that matter when the output is
+ * going back into Tiptap and will be turned back into markdown on save:
+ *
+ * - Profile mentions become Tiptap mention spans, so they survive the
+ *   round-trip as `nostr:` URIs. Rendering them as reader-facing anchors
+ *   instead would come back through turndown as `[@name](/user/npub…)`
+ *   markdown links, quietly demoting a real Nostr mention to a relative
+ *   web link.
+ * - No hashtag links and no YouTube embeds. Those are reading
+ *   affordances; an iframe has no business inside a text editor.
+ *
+ * `mentionLabels` supplies display names by pubkey where they're known.
+ * The label is cosmetic - `data-id` is what publishing reads - so an
+ * unresolved mention falls back to a shortened npub without affecting
+ * what gets saved.
+ */
+export function parseMarkdownToEditorHtml(
+  markdown: string,
+  mentionLabels?: Map<string, string>
+): string {
+  const sanitized = sanitizeHTML(md.render(markdown || ''));
+  if (!sanitized || typeof DOMParser === 'undefined') return sanitized;
+
+  const doc = new DOMParser().parseFromString(`<div>${sanitized}</div>`, 'text/html');
+  const root = doc.body.firstElementChild as HTMLElement | null;
+  if (!root) return sanitized;
+
+  const textNodes: Text[] = [];
+  collectTextNodes(root, textNodes);
+  for (const node of textNodes) {
+    const text = node.textContent || '';
+    NOSTR_MENTION_RE.lastIndex = 0;
+    if (!NOSTR_MENTION_RE.test(text)) continue;
+    NOSTR_MENTION_RE.lastIndex = 0;
+
+    const fragment = doc.createDocumentFragment();
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+    let replaced = false;
+    while ((match = NOSTR_MENTION_RE.exec(text)) !== null) {
+      const target = decodeMention(match[1]);
+      if (!target) continue;
+
+      if (match.index > lastIndex) {
+        fragment.appendChild(doc.createTextNode(text.slice(lastIndex, match.index)));
+      }
+
+      const label =
+        mentionLabels?.get(target.pubkey) ||
+        mentionNames.get(target.pubkey) ||
+        shortNpub(target.npub);
+
+      // Matches what Tiptap's Mention extension renders, so the editor
+      // picks it up as a mention node rather than loose markup.
+      const span = doc.createElement('span');
+      span.className = 'mention';
+      span.setAttribute('data-type', 'mention');
+      // Always an npub: publishing re-adds relay hints, and the turndown
+      // rule emits `nostr:${data-id}` verbatim.
+      span.setAttribute('data-id', target.npub);
+      span.setAttribute('data-label', label);
+      span.textContent = `@${label}`;
+      fragment.appendChild(span);
+
+      lastIndex = match.index + match[0].length;
+      replaced = true;
+    }
+    if (!replaced) continue;
+    if (lastIndex < text.length) {
+      fragment.appendChild(doc.createTextNode(text.slice(lastIndex)));
+    }
+    node.parentNode?.replaceChild(fragment, node);
+  }
+
   return root.innerHTML;
 }
 


### PR DESCRIPTION
Longform mentions were never rendered. The editor writes them correctly as `nostr:npub1…` per NIP-27 and adds a `p` tag for each mentioned pubkey, but nothing on the reading side turned them back into names — markdown-it's linkify doesn't know the `nostr:` scheme, so the raw bech32 string went straight to the page. Articles written in other clients had the same problem here, and the editor preview looked equally inert, which is what made me go looking.

## Rendering

`parser.ts` now links mentions in the shared markdown pass, alongside the existing hashtag and YouTube passes, so every surface gets it at once: articles, recipes, both editor previews and the print sheet.

Names resolve in the background. A cache miss renders a shortened npub immediately and upgrades in place when the profile arrives, so a cold cache never blocks the article body. An unresolvable mention keeps the shortened npub rather than borrowing `getUsername()`'s anon-name fallback, which would dress an unknown pubkey up as a real handle.

## The preview now shows what will publish

It was rendering the Tiptap HTML. It now renders the markdown that actually gets published, so mentions, hashtags, video embeds — and anything turndown drops on the way to markdown — are all visible before publishing rather than after.

## Relay hints on mentions

`nostr:npub1…` is rewritten to `nostr:nprofile1…` with up to two relays from the mentioned person's outbox list. A bare npub says who but not where, so a client that has never seen that account has nothing to fetch and falls back to printing bech32. Best-effort: a mention whose relay list can't be fetched stays a bare npub, which is still valid NIP-27.

`p` tag extraction had to learn nprofile at the same time — matching only npub would have silently dropped the tag, and the notification with it, for every hinted mention.

## NIP-37 draft round-trips

Remote drafts get a separate editor-side renderer. Feeding reader HTML back into Tiptap would return through turndown as `[@name](/user/npub…)`, demoting a Nostr mention to a relative web link, and it was already putting YouTube iframes inside the text editor.

## Cover images by URL

The cover can now be given as a URL as well as uploaded. The URL is verified by actually loading it; a host that blocks hotlinking is accepted with a warning rather than refused outright. Both the entry point and the publish path check the scheme now — `new URL()` alone accepts `javascript:` and `data:`, and this value lands in an `<img src>` here and in the article's `image` tag everywhere else.

## Verification

- 11 new tests on the two renderers: both mention forms, malformed bech32 left as written, no hashtag/mention nesting, the shortened-npub fallback, and the editor round-trip (mention spans, npub-normalized `data-id`, no iframes)
- `pnpm test` — 1551 passing
- `pnpm check` — 153 existing warnings, plus one pre-existing error unrelated to this change: `src/routes/api/stripe/webhook/renewalRetry.test.ts:94` has a `delete` on a non-optional property, from e2b5b8b2
- Checked a published article renders correctly in Jumble and Yakihonne as well as here
