### PR TITLE
perf(feed): lazy-load html2canvas for share-image generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.736",
+  "version": "4.2.737",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.737",
+  "version": "4.2.738",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/shareNoteImage.ts
+++ b/src/lib/shareNoteImage.ts
@@ -717,13 +717,14 @@ async function generateNoteImageInternal(
       }
     }
 
-    // Generate canvas with Safari-specific options
+    // Generate canvas with html2canvas. Safari never reaches this point: it
+    // returned early above via generateSafariImage (simple canvas drawing).
     console.log('[ShareImage] Generating canvas with html2canvas...');
 
     // Lazy-load html2canvas (~48KB gz) so it only downloads when a share
     // image is actually generated instead of riding along in the feed
-    // route chunks. Imported here rather than at the top of the function
-    // so Safari's simple-canvas fallback path never fetches it at all.
+    // route chunks. Imported here rather than at the top of the module so
+    // the Safari early-return path above never fetches it at all.
     const { default: html2canvas } = await import('html2canvas');
 
     const canvas = await html2canvas(container, {

--- a/src/lib/shareNoteImage.ts
+++ b/src/lib/shareNoteImage.ts
@@ -4,7 +4,6 @@
  * Generates shareable PNG images from Nostr notes using html2canvas
  */
 
-import html2canvas from 'html2canvas';
 import { browser } from '$app/environment';
 import type { NDKEvent } from '@nostr-dev-kit/ndk';
 import { nip19 } from 'nostr-tools';
@@ -720,6 +719,12 @@ async function generateNoteImageInternal(
 
     // Generate canvas with Safari-specific options
     console.log('[ShareImage] Generating canvas with html2canvas...');
+
+    // Lazy-load html2canvas (~48KB gz) so it only downloads when a share
+    // image is actually generated instead of riding along in the feed
+    // route chunks. Imported here rather than at the top of the function
+    // so Safari's simple-canvas fallback path never fetches it at all.
+    const { default: html2canvas } = await import('html2canvas');
 
     const canvas = await html2canvas(container, {
       width,


### PR DESCRIPTION
## What

`shareNoteImage.ts` statically imported html2canvas, putting ~48KB gz into every feed route chunk load. It's only needed when a user explicitly taps "share as image". Now imported at the single call site, inside the non-Safari branch (Safari's simple-canvas path never downloads it).

Interesting find: jspdf's ESM build has its own internal dynamic import of html2canvas (for its `.html()` API), so Vite keeps one shared lazy chunk for the library — both cookbook export and share-image now load it on demand, nothing eagerly.

## Impact

Feed route chunks (community/kitchen/profile) no longer statically reference the 202KB raw / 47.7KB gz html2canvas chunk — verified in the built chunk graph: the reference changed from a static import to `await import(...)`.

## Verification

- `svelte-check`: no new issues (1 pre-existing error on base)
- `vitest src/lib`: 93 files / 1323 tests, all passing
- Production build passes