### PR TITLE
perf(recipe): lazy-load the browser translator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.736",
+  "version": "4.2.737",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.737",
+  "version": "4.2.738",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/translation.ts
+++ b/src/lib/translation.ts
@@ -10,9 +10,9 @@ export async function translate(
   string: string
 ): Promise<TranslationResult | ''> {
   if (translateOption.option == 'google') {
-    // Lazy-load the translator (~50KB gz with its language tables) so it
-    // only downloads when a user actually translates something, instead
-    // of riding along on every recipe page load.
+    // Lazy-load the translator so it only downloads when a user actually
+    // translates something, instead of riding along on every recipe page
+    // load.
     const { translate: googletranslate } = await import('google-translate-api-browser');
     const e = await googletranslate(string, {
       corsUrl: translateOption.data,

--- a/src/lib/translation.ts
+++ b/src/lib/translation.ts
@@ -1,6 +1,4 @@
-import { translate as googletranslate } from 'google-translate-api-browser';
 import type { TranslateOption } from './state';
-//import { translate as libretranslate } from 'libretranslate';
 
 type TranslationResult = {
   text: string;
@@ -12,20 +10,16 @@ export async function translate(
   string: string
 ): Promise<TranslationResult | ''> {
   if (translateOption.option == 'google') {
+    // Lazy-load the translator (~50KB gz with its language tables) so it
+    // only downloads when a user actually translates something, instead
+    // of riding along on every recipe page load.
+    const { translate: googletranslate } = await import('google-translate-api-browser');
     const e = await googletranslate(string, {
       corsUrl: translateOption.data,
       to: translateOption.lang
     });
     return e;
   }
-  /*if (translateOption.option == 'libretranslate') {
-    const e = await libretranslate({
-        query: string,
-        target: translateOption.lang,
-        apiurl: translateOption.data,
-    });
-    return e;
-  }*/
 
   return '';
 }


### PR DESCRIPTION
## What

`translation.ts` (used by the recipe page) statically imported `google-translate-api-browser`, which bundled the translator and its tables into the recipe route chunk. Translation only runs when the user explicitly asks for it, so the lib now lazy-loads inside `translate()` on first use.

Also removes the dead commented-out `libretranslate` fallback (package already removed from deps in #668).

## Impact

The `translate.google*` code moved from a 180KB raw / 53.5KB gz route chunk to a dedicated 5.3KB raw / 2.8KB gz lazy chunk, referenced only via `await import(...)` (verified in the built chunk graph).

## Verification

- `vitest src/lib`: 93 files / 1323 tests passing
- production build passes