### PR TITLE
fix(sw): stop mocking __data.json when the server can serve it

### DIFF
--- a/static/sw.js
+++ b/static/sw.js
@@ -36,7 +36,7 @@ function shouldCache(request) {
   if (request.method && request.method !== 'GET') {
     return false;
   }
-  
+
   const urlString = request.url || (typeof request === 'string' ? request : request.toString());
   
   // Only cache same-origin requests
@@ -66,6 +66,29 @@ function shouldCache(request) {
   return false;
 }
 
+// Empty SvelteKit devalue payload for __data.json requests in packaged
+// static/Capacitor builds, which have no server to answer them. Mirrors
+// the isPackagedStatic mocks in app.html and hooks.client.ts (the SW
+// can't read window.Capacitor, so the caller decides when to use it).
+function mockDataResponse() {
+  const mockData = {
+    type: 'data',
+    nodes: [
+      null, // layout data
+      {
+        type: 'data',
+        data: [{ ogMeta: 1 }, null], // devalue-encoded { ogMeta: null }
+        uses: {}
+      }
+    ]
+  };
+
+  return new Response(JSON.stringify(mockData), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' }
+  });
+}
+
 self.addEventListener('install', (event) => {
   console.log('[SW] Installing service worker');
   self.skipWaiting();
@@ -92,28 +115,24 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('fetch', (event) => {
   const url = event.request.url;
   
-  // Intercept __data.json requests that don't exist in static builds
+  // __data.json exists only on the SSR web deployment. Serve the real
+  // response whenever the network provides one; fall back to the mock
+  // when it doesn't (packaged static builds have no server — a fetch
+  // there fails, 404s, or returns the SPA index.html, none of which is
+  // usable data). This used to mock unconditionally, which starved web
+  // clients of real +page.server.ts data on client-side navigations.
   if (url.includes('__data.json')) {
-    console.log('[SW] Intercepting __data.json request:', url);
-    
-    // Return mock SvelteKit data response
-    const mockData = {
-      type: 'data',
-      nodes: [
-        null, // layout data
-        {
-          type: 'data',
-          data: [{ ogMeta: 1 }, null], // devalue-encoded { ogMeta: null }
-          uses: {}
-        }
-      ]
-    };
-    
     event.respondWith(
-      new Response(JSON.stringify(mockData), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' }
-      })
+      fetch(event.request)
+        .then((response) => {
+          const contentType = response.headers.get('content-type') || '';
+          if (response.ok && contentType.includes('application/json')) {
+            return response;
+          }
+          console.debug('[SW] __data.json not served as JSON, using mock for:', url);
+          return mockDataResponse();
+        })
+        .catch(() => mockDataResponse())
     );
     return;
   }


### PR DESCRIPTION
## What

`sw.js` intercepted **every** `__data.json` request and returned a canned empty devalue payload. That mock exists for packaged static/Capacitor builds, which have no server to answer those requests — the other two interceptors (`app.html`, `hooks.client.ts`) are properly gated on `isPackagedStatic`, but the SW can't read `window.Capacitor` and was left unconditional. Net effect on the **SSR web deployment**: with the SW active, client-side navigations got `{ ogMeta: null }` instead of real `+page.server.ts` data.

Fix: network-first with a strict fallback —

- response is 200 **and** `application/json` → pass the real server data through
- network failure / non-200 / non-JSON (e.g. the SPA `index.html` a packaged build returns for unknown paths) → serve the mock

This keeps packaged-static behavior identical (their fetches fail/404/HTML → mock) while web clients always get real data.

## Verification

Functional test of the shipped `sw.js` in a real browser against a local static server:

| request | before | after |
|---|---|---|
| real `__data.json` (200, JSON) | mocked | **real server payload passed through** |
| missing `__data.json` (404) | mocked | mocked (unchanged) |
| non-JSON response (`text/plain`) | mocked | mocked (guard against SPA-fallback HTML) |

Plus `node --check`, full `vitest src/lib` suite (1323 passing).

Found in the perf audit (startup/data layer pass).