### PR TITLE
perf(engagement): batch per-event store updates and cache writes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.741",
+  "version": "4.2.742",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/engagementCache.batching.test.ts
+++ b/src/lib/engagementCache.batching.test.ts
@@ -1,0 +1,592 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+/**
+ * Engagement batching — externally observable behaviour of the per-note
+ * event queue: counts, loading state, cache persistence and lifecycle.
+ * Store updates and cache writes are counted through a store subscriber
+ * and a localStorage spy; relays are a mocked NDK subscription; time is
+ * fake so the ~250ms flush and the 5s/10s completion timeouts are driven
+ * explicitly.
+ */
+
+vi.mock('$app/environment', () => ({ browser: true }));
+vi.mock('@nostr-dev-kit/ndk', () => ({
+  default: class NDK {},
+  NDKRelaySet: { fromRelayUrls: () => ({}) }
+}));
+const countQuery = vi.hoisted(() => ({
+  pending: null as null | { resolve: (v: unknown) => void },
+  getEngagementCounts: vi.fn(
+    () =>
+      new Promise((resolve) => {
+        countQuery.pending = { resolve };
+      })
+  ),
+  batchFetchFromServerAPI: vi.fn(async () => new Map())
+}));
+vi.mock('./countQuery', () => ({
+  getEngagementCounts: countQuery.getEngagementCounts,
+  batchFetchFromServerAPI: countQuery.batchFetchFromServerAPI
+}));
+
+import {
+  fetchEngagement,
+  batchFetchEngagement,
+  getEngagementStore,
+  cleanupEngagement,
+  clearAllEngagementCaches,
+  getEngagementStats,
+  trackOptimisticReaction,
+  trackOptimisticRepost,
+  optimisticZapUpdate,
+  type EngagementData
+} from './engagementCache';
+
+// ── localStorage stub whose entries are enumerable own properties, so
+// clearAllEngagementCaches' Object.keys(localStorage) scan works.
+const writes: Array<{ key: string; value: string; at: number }> = [];
+function makeStorage() {
+  const store: Record<string, string> = {};
+  const define = (name: string, fn: (...a: string[]) => unknown) =>
+    Object.defineProperty(store, name, { value: fn, enumerable: false, writable: true });
+  define('getItem', (k) => (k in store ? store[k] : null));
+  define('setItem', (k, v) => {
+    store[k] = String(v);
+    writes.push({ key: k, value: String(v), at: Date.now() });
+  });
+  define('removeItem', (k) => {
+    delete store[k];
+  });
+  define('clear', () => {
+    for (const k of Object.keys(store)) delete store[k];
+  });
+  return store;
+}
+const cacheWrites = (id: string) => writes.filter((w) => w.key === `engagement_${id}`);
+const persisted = (id: string) => {
+  const w = cacheWrites(id);
+  return w.length ? (JSON.parse(w[w.length - 1].value) as {
+    reactions: { count: number; groups: Array<{ emoji: string; count: number }> };
+    comments: number;
+    reposts: number;
+    zaps: { amount: number; count: number };
+    timestamp: number;
+  }) : null;
+};
+
+// ── mocked NDK subscriptions
+type Handler = (...args: unknown[]) => void;
+function makeSub() {
+  const handlers = new Map<string, Handler[]>();
+  return {
+    on(name: string, cb: Handler) {
+      handlers.set(name, [...(handlers.get(name) ?? []), cb]);
+    },
+    emit(name: string, ...args: unknown[]) {
+      for (const cb of handlers.get(name) ?? []) cb(...args);
+    },
+    stop: vi.fn()
+  };
+}
+type FakeSub = ReturnType<typeof makeSub>;
+let subs: FakeSub[] = [];
+const ndk = {
+  pool: { getRelay: () => ({ connectivity: { status: 1 }, connect: async () => {} }) },
+  explicitRelayUrls: [] as string[],
+  subscribe: vi.fn((filter: unknown, opts: unknown) => {
+    const s = makeSub();
+    (s as FakeSub & { filter: unknown; opts: unknown }).filter = filter;
+    (s as FakeSub & { filter: unknown; opts: unknown }).opts = opts;
+    subs.push(s);
+    return s;
+  })
+} as never;
+
+// ── event factories (NDKEvent-shaped plain objects)
+const USER = 'user-pubkey';
+let seq = 0;
+const nextId = (p = 'ev') => `${p}-${++seq}`;
+const reaction = (target: string, pubkey: string, content = '+', id = nextId('r')) => ({
+  id, kind: 7, pubkey, content, created_at: 1_700_000_000, tags: [['e', target], ['p', 'author']]
+});
+const repost = (target: string, pubkey: string, id = nextId('rp')) => ({
+  id, kind: 6, pubkey, content: '', created_at: 1_700_000_000, tags: [['e', target]]
+});
+const comment = (target: string, pubkey: string, id = nextId('c')) => ({
+  id, kind: 1, pubkey, content: 'nice', created_at: 1_700_000_000, tags: [['e', target]]
+});
+const zap = (target: string, zapper: string, sats: number, id = nextId('z')) => ({
+  id, kind: 9735, pubkey: 'lnurl-service', content: '', created_at: 1_700_000_000,
+  tags: [
+    ['e', target],
+    ['description', JSON.stringify({ pubkey: zapper, content: 'zap!', tags: [['amount', String(sats * 1000)]] })]
+  ]
+});
+
+// ── store observation
+function observe(id: string) {
+  const store = getEngagementStore(id);
+  let updates = -1; // subscribe() fires once immediately
+  const unsub = store.subscribe(() => updates++);
+  return {
+    get updates() {
+      return updates;
+    },
+    get data(): EngagementData {
+      return get(store);
+    },
+    unsub
+  };
+}
+
+const emitAll = (sub: FakeSub, events: object[]) => events.forEach((e) => sub.emit('event', e));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-09-05T12:00:00Z'));
+  vi.stubGlobal('localStorage', makeStorage());
+  writes.length = 0;
+  subs = [];
+  seq = 0;
+  countQuery.pending = null;
+  clearAllEngagementCaches();
+  writes.length = 0;
+  vi.spyOn(console, 'debug').mockImplementation(() => {});
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => {
+  clearAllEngagementCaches();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('single-note subscription (fetchEngagement)', () => {
+  it('a burst of 100 unique events plus duplicate deliveries: one periodic update/write, one completion update/write', async () => {
+    const id = 'note-a';
+    const obs = observe(id);
+    await fetchEngagement(ndk, id, USER);
+    expect(subs).toHaveLength(1);
+    const sub = subs[0];
+    const updatesBefore = obs.updates;
+    writes.length = 0;
+
+    const burst = Array.from({ length: 100 }, (_, i) => reaction(id, `pk-${i}`, '+'));
+    emitAll(sub, burst);
+    emitAll(sub, burst.slice(0, 20)); // relay re-delivers the same ids
+    // same users, same emoji, new ids: reaction-pair dedup
+    emitAll(sub, Array.from({ length: 5 }, (_, i) => reaction(id, `pk-${i}`, '+')));
+
+    // Nothing applied synchronously; the UI is not re-rendered per event.
+    expect(obs.updates - updatesBefore).toBe(0);
+    expect(obs.data.reactions.count).toBe(0);
+    expect(cacheWrites(id)).toHaveLength(0);
+
+    vi.advanceTimersByTime(250);
+    expect(obs.updates - updatesBefore).toBe(1);
+    expect(cacheWrites(id)).toHaveLength(1);
+    expect(obs.data.reactions.count).toBe(100);
+    expect(obs.data.reactions.groups).toEqual([{ emoji: '❤️', count: 100, userReacted: false }]);
+    expect(obs.data.loading).toBe(true);
+
+    vi.advanceTimersByTime(100);
+    sub.emit('eose');
+    expect(obs.updates - updatesBefore).toBe(2);
+    expect(cacheWrites(id)).toHaveLength(2);
+    expect(obs.data.loading).toBe(false);
+    expect(obs.data.lastFetched).toBe(Date.now());
+    const saved = persisted(id)!;
+    expect(saved.reactions.count).toBe(100);
+    expect(saved.timestamp).toBe(Date.now());
+    expect(saved.timestamp).toBeGreaterThan(cacheWrites(id)[0].at);
+
+    // The persistent subscription stays open after EOSE.
+    expect(sub.stop).not.toHaveBeenCalled();
+    expect(getEngagementStats().persistentSubscriptionCount).toBe(1);
+    obs.unsub();
+  });
+
+  it('EOSE before the periodic flush: correct final counts with exactly one update and one write', async () => {
+    const id = 'note-b';
+    const obs = observe(id);
+    await fetchEngagement(ndk, id, USER);
+    const sub = subs[0];
+    const before = obs.updates;
+    writes.length = 0;
+
+    emitAll(sub, Array.from({ length: 100 }, (_, i) => reaction(id, `pk-${i}`, i % 2 ? '🔥' : '+')));
+    sub.emit('eose');
+
+    expect(obs.updates - before).toBe(1);
+    expect(cacheWrites(id)).toHaveLength(1);
+    expect(obs.data.reactions.count).toBe(100);
+    expect(obs.data.loading).toBe(false);
+    expect(persisted(id)!.reactions.count).toBe(100);
+
+    // The queue is empty: the timer tick must not update or write again.
+    vi.advanceTimersByTime(1000);
+    expect(obs.updates - before).toBe(1);
+    expect(cacheWrites(id)).toHaveLength(1);
+    obs.unsub();
+  });
+
+  it('mixed reactions, reposts, comments and zap receipts are counted correctly', async () => {
+    const id = 'note-c';
+    const obs = observe(id);
+    await fetchEngagement(ndk, id, USER);
+    const sub = subs[0];
+
+    emitAll(sub, [
+      reaction(id, 'p1', '+'),
+      reaction(id, 'p2', '🔥'),
+      reaction(id, 'p2', '🔥'), // same user + emoji, new id → pair dedup
+      reaction(id, 'p3', ':custom:'), // unrenderable shortcode → skipped
+      repost(id, 'p1'),
+      repost(id, 'p4'),
+      comment(id, 'p5'),
+      comment('some-other-note', 'p6'), // not a reply to this note
+      zap(id, 'p7', 21),
+      zap(id, 'p8', 100),
+      zap(id, 'p7', 9) // same zapper again → aggregated
+    ]);
+    sub.emit('eose');
+
+    const d = obs.data;
+    expect(d.reactions.count).toBe(2);
+    expect(d.reactions.groups.map((g) => [g.emoji, g.count])).toEqual([['❤️', 1], ['🔥', 1]]);
+    expect(d.reposts.count).toBe(2);
+    expect(d.comments.count).toBe(1);
+    expect(d.zaps.count).toBe(3);
+    expect(d.zaps.totalAmount).toBe(130_000); // millisats
+    expect(d.zaps.topZappers.map((z) => [z.pubkey, z.amount])).toEqual([['p8', 100], ['p7', 30]]);
+    const saved = persisted(id)!;
+    expect([saved.reactions.count, saved.reposts, saved.comments, saved.zaps.count, saved.zaps.amount]).toEqual([
+      2, 2, 1, 3, 130_000
+    ]);
+    obs.unsub();
+  });
+
+  it('optimistic reaction/repost/zap are reconciled when the relay echoes them back', async () => {
+    const id = 'note-d';
+    const obs = observe(id);
+    await fetchEngagement(ndk, id, USER);
+    const sub = subs[0];
+    const before = obs.updates;
+
+    // Optimistic zap updates the UI immediately (not queued) and persists.
+    optimisticZapUpdate(id, 21_000, USER, 'great');
+    expect(obs.updates - before).toBe(1);
+    expect(obs.data.zaps).toMatchObject({ count: 1, totalAmount: 21_000, userZapped: true });
+    expect(persisted(id)!.zaps.count).toBe(1);
+
+    trackOptimisticReaction(id, '❤️', USER);
+    trackOptimisticRepost(id, USER);
+
+    emitAll(sub, [
+      reaction(id, USER, '+'), // echo of our optimistic reaction → not counted
+      repost(id, USER), // echo of our optimistic repost → not counted
+      zap(id, USER, 21), // real receipt for the optimistic zap → replaces, no double count
+      reaction(id, 'other', '+'),
+      zap(id, 'other', 5)
+    ]);
+    sub.emit('eose');
+
+    const d = obs.data;
+    expect(d.reactions.count).toBe(1);
+    expect(d.reposts.count).toBe(0);
+    expect(d.zaps.count).toBe(2);
+    expect(d.zaps.totalAmount).toBe(26_000);
+    expect(d.zaps.userZapped).toBe(true);
+    expect(persisted(id)!.zaps).toMatchObject({ count: 2, amount: 26_000 });
+    obs.unsub();
+  });
+
+  it('timeout without EOSE after the queue was already flushed still finalizes and persists once', async () => {
+    const id = 'note-e';
+    const obs = observe(id);
+    await fetchEngagement(ndk, id, USER);
+    const sub = subs[0];
+    const before = obs.updates;
+    writes.length = 0;
+
+    emitAll(sub, [reaction(id, 'p1'), comment(id, 'p2'), zap(id, 'p3', 10)]);
+    vi.advanceTimersByTime(250); // periodic flush empties the queue
+    expect(obs.updates - before).toBe(1);
+    expect(cacheWrites(id)).toHaveLength(1);
+    const periodicTs = persisted(id)!.timestamp;
+    expect(obs.data.loading).toBe(true);
+
+    vi.advanceTimersByTime(5000 - 250); // subscription timeout, no EOSE
+    expect(obs.updates - before).toBe(2);
+    expect(cacheWrites(id)).toHaveLength(2);
+    const d = obs.data;
+    expect(d.loading).toBe(false);
+    expect(d.lastFetched).toBe(Date.now());
+    const saved = persisted(id)!;
+    expect(saved.timestamp).toBeGreaterThan(periodicTs);
+    expect(saved.timestamp).toBe(Date.now());
+    expect([saved.reactions.count, saved.comments, saved.zaps.count]).toEqual([
+      d.reactions.count, d.comments.count, d.zaps.count
+    ]);
+
+    // Late EOSE after the timeout: no second finalization.
+    sub.emit('eose');
+    vi.advanceTimersByTime(1000);
+    expect(obs.updates - before).toBe(2);
+    expect(cacheWrites(id)).toHaveLength(2);
+    obs.unsub();
+  });
+
+  it('EOSE cancels the timeout fallback so it cannot finalize a second time', async () => {
+    const id = 'note-f';
+    const obs = observe(id);
+    await fetchEngagement(ndk, id, USER);
+    const before = obs.updates;
+    writes.length = 0;
+    subs[0].emit('eose');
+    expect(obs.updates - before).toBe(1);
+    vi.advanceTimersByTime(10_000);
+    expect(obs.updates - before).toBe(1);
+    expect(cacheWrites(id)).toHaveLength(1);
+    obs.unsub();
+  });
+
+  it('realtime arrivals after completion are applied on the next flush and persisted', async () => {
+    const id = 'note-g';
+    const obs = observe(id);
+    await fetchEngagement(ndk, id, USER);
+    const sub = subs[0];
+    sub.emit('eose');
+    const before = obs.updates;
+    writes.length = 0;
+
+    sub.emit('event', zap(id, 'late', 42));
+    sub.emit('event', reaction(id, 'late', '+'));
+    expect(obs.updates - before).toBe(0);
+    vi.advanceTimersByTime(250);
+    expect(obs.updates - before).toBe(1);
+    expect(cacheWrites(id)).toHaveLength(1);
+    expect(obs.data.zaps).toMatchObject({ count: 1, totalAmount: 42_000 });
+    expect(obs.data.reactions.count).toBe(1);
+    expect(obs.data.loading).toBe(false);
+    expect(persisted(id)!.zaps.amount).toBe(42_000);
+    obs.unsub();
+  });
+
+  it('NIP-45 counts that arrive while the subscription is still counting are ignored', async () => {
+    const id = 'note-h';
+    const obs = observe(id);
+    await fetchEngagement(ndk, id, USER);
+    const sub = subs[0];
+    emitAll(sub, [reaction(id, 'p1'), reaction(id, 'p2')]);
+    vi.advanceTimersByTime(250);
+    expect(obs.data.reactions.count).toBe(2);
+
+    countQuery.pending!.resolve({ reactions: 999, comments: 999, reposts: 999, zaps: 999 });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(obs.data.reactions.count).toBe(2);
+    expect(obs.data.comments.count).toBe(0);
+    obs.unsub();
+  });
+});
+
+describe('batch subscription (batchFetchEngagement)', () => {
+  it('a burst across two notes: one completion update and write per note at EOSE', async () => {
+    const a = 'batch-a';
+    const b = 'batch-b';
+    const oa = observe(a);
+    const ob = observe(b);
+    await batchFetchEngagement(ndk, [a, b], USER);
+    expect(subs).toHaveLength(1);
+    const sub = subs[0];
+    expect((sub as FakeSub & { opts: { closeOnEose: boolean } }).opts.closeOnEose).toBe(true);
+    const beforeA = oa.updates;
+    const beforeB = ob.updates;
+    writes.length = 0;
+
+    const eventsA = Array.from({ length: 100 }, (_, i) => reaction(a, `pk-${i}`, '+'));
+    const eventsB = [repost(b, 'p1'), zap(b, 'p2', 7), comment(b, 'p3')];
+    emitAll(sub, eventsA);
+    emitAll(sub, eventsB);
+    emitAll(sub, eventsA.slice(0, 30)); // duplicates
+    sub.emit('eose');
+
+    expect(oa.updates - beforeA).toBe(1);
+    expect(ob.updates - beforeB).toBe(1);
+    expect(cacheWrites(a)).toHaveLength(1);
+    expect(cacheWrites(b)).toHaveLength(1);
+    expect(oa.data.reactions.count).toBe(100);
+    expect(oa.data.loading).toBe(false);
+    expect(ob.data).toMatchObject({ reposts: { count: 1 }, comments: { count: 1 }, loading: false });
+    expect(ob.data.zaps).toMatchObject({ count: 1, totalAmount: 7_000 });
+    expect(persisted(a)!.reactions.count).toBe(100);
+    expect(persisted(b)!.zaps.amount).toBe(7_000);
+
+    vi.advanceTimersByTime(1000);
+    expect(oa.updates - beforeA).toBe(1);
+    expect(cacheWrites(a)).toHaveLength(1);
+    oa.unsub();
+    ob.unsub();
+  });
+
+  it('batch timeout without EOSE persists the finalized counts, including a note whose queue is already empty', async () => {
+    const a = 'batch-c';
+    const b = 'batch-d';
+    const oa = observe(a);
+    const ob = observe(b);
+    await batchFetchEngagement(ndk, [a, b], USER);
+    const sub = subs[0];
+    writes.length = 0;
+    const beforeA = oa.updates;
+    const beforeB = ob.updates;
+
+    emitAll(sub, [reaction(a, 'p1'), reaction(a, 'p2')]);
+    vi.advanceTimersByTime(250); // a flushed periodically; b never received anything
+    expect(cacheWrites(a)).toHaveLength(1);
+    expect(cacheWrites(b)).toHaveLength(0);
+    const periodicTs = persisted(a)!.timestamp;
+
+    vi.advanceTimersByTime(10_000 - 250); // batch timeout
+    expect(oa.updates - beforeA).toBe(2);
+    expect(ob.updates - beforeB).toBe(1);
+    expect(cacheWrites(a)).toHaveLength(2);
+    expect(cacheWrites(b)).toHaveLength(1);
+    expect(oa.data.loading).toBe(false);
+    expect(ob.data.loading).toBe(false);
+    expect(persisted(a)).toMatchObject({ reactions: { count: 2 }, timestamp: Date.now() });
+    expect(persisted(a)!.timestamp).toBeGreaterThan(periodicTs);
+    expect(persisted(b)).toMatchObject({ reactions: { count: 0 }, timestamp: Date.now() });
+
+    sub.emit('eose'); // late EOSE after timeout
+    expect(oa.updates - beforeA).toBe(2);
+    expect(cacheWrites(a)).toHaveLength(2);
+    oa.unsub();
+    ob.unsub();
+  });
+});
+
+describe('overlapping subscriptions and lifecycle', () => {
+  it('single-note and batch subscriptions receiving the same events count each once', async () => {
+    const a = 'shared-a';
+    const b = 'shared-b';
+    const oa = observe(a);
+    await fetchEngagement(ndk, a, USER);
+    await batchFetchEngagement(ndk, [a, b], USER);
+    expect(subs).toHaveLength(2);
+    const [single, batch] = subs;
+
+    const events = Array.from({ length: 10 }, (_, i) => reaction(a, `pk-${i}`, '+'));
+    emitAll(single, events);
+    emitAll(batch, events);
+    emitAll(batch, [zap(a, 'z', 3)]);
+    emitAll(single, [zap(a, 'z', 3, 'z-dup')]); // different id, same zapper → aggregated, not a dup
+    vi.advanceTimersByTime(250);
+    expect(oa.data.reactions.count).toBe(10);
+    expect(oa.data.zaps.count).toBe(2);
+
+    single.emit('eose');
+    batch.emit('eose');
+    expect(oa.data.reactions.count).toBe(10);
+    expect(oa.data.loading).toBe(false);
+    expect(persisted(a)!.reactions.count).toBe(10);
+    oa.unsub();
+  });
+
+  it('rapid repeated fetches for one note share one dedup set and never double count', async () => {
+    const id = 'rapid';
+    const obs = observe(id);
+    await fetchEngagement(ndk, id, USER);
+    await fetchEngagement(ndk, id, USER); // second component mounts
+    await fetchEngagement(ndk, id, USER);
+    const events = [reaction(id, 'p1'), reaction(id, 'p2'), repost(id, 'p3')];
+    for (const s of subs) emitAll(s, events);
+    for (const s of subs) s.emit('eose');
+    vi.advanceTimersByTime(250);
+    expect(obs.data.reactions.count).toBe(2);
+    expect(obs.data.reposts.count).toBe(1);
+    expect(obs.data.loading).toBe(false);
+    obs.unsub();
+  });
+
+  it('cleanupEngagement discards queued work; a stale timeout cannot finalize a replacement subscription', async () => {
+    const id = 'cleanup';
+    const obs = observe(id);
+    await fetchEngagement(ndk, id, USER);
+    const oldSub = subs[0];
+    vi.advanceTimersByTime(1000); // old timeout is due at t+5000
+    emitAll(oldSub, [reaction(id, 'p1'), reaction(id, 'p2')]); // queued, not yet flushed
+
+    cleanupEngagement(id);
+    expect(oldSub.stop).toHaveBeenCalled();
+    writes.length = 0;
+    const before = obs.updates;
+
+    vi.advanceTimersByTime(250); // periodic flush: the queued events were discarded
+    expect(obs.updates - before).toBe(0);
+    expect(obs.data.reactions.count).toBe(0);
+    expect(cacheWrites(id)).toHaveLength(0);
+
+    // Replacement subscription for the same note (its timeout is due at t+6250).
+    await fetchEngagement(ndk, id, USER);
+    const newSub = subs[1];
+    const afterStart = obs.updates;
+    expect(obs.data.loading).toBe(true);
+
+    vi.advanceTimersByTime(4000); // old subscription's timeout fires (stale)
+    expect(obs.data.loading).toBe(true); // the replacement is still counting
+    expect(obs.updates - afterStart).toBe(0);
+    expect(cacheWrites(id)).toHaveLength(0);
+
+    emitAll(newSub, [reaction(id, 'p9')]);
+    newSub.emit('eose');
+    expect(obs.data.loading).toBe(false);
+    expect(obs.data.reactions.count).toBe(1);
+    expect(cacheWrites(id)).toHaveLength(1);
+    obs.unsub();
+  });
+
+  it('a stale EOSE from a cleaned-up subscription cannot finalize the replacement', async () => {
+    const id = 'cleanup-eose';
+    const obs = observe(id);
+    await fetchEngagement(ndk, id, USER);
+    const oldSub = subs[0];
+    cleanupEngagement(id);
+    await fetchEngagement(ndk, id, USER);
+    const afterStart = obs.updates;
+    writes.length = 0;
+
+    oldSub.emit('event', reaction(id, 'stale'));
+    oldSub.emit('eose');
+    vi.advanceTimersByTime(250);
+    expect(obs.data.loading).toBe(true);
+    expect(obs.updates - afterStart).toBe(0);
+    expect(cacheWrites(id)).toHaveLength(0);
+
+    subs[1].emit('eose');
+    expect(obs.data.loading).toBe(false);
+    expect(cacheWrites(id)).toHaveLength(1);
+    obs.unsub();
+  });
+
+  it('clearAllEngagementCaches cancels pending work and old callbacks do not recreate stores', async () => {
+    const id = 'cleared';
+    observe(id).unsub();
+    await fetchEngagement(ndk, id, USER);
+    const sub = subs[0];
+    emitAll(sub, [reaction(id, 'p1'), zap(id, 'p2', 5)]);
+
+    clearAllEngagementCaches();
+    writes.length = 0;
+    expect(getEngagementStats().storeCount).toBe(0);
+    expect(sub.stop).toHaveBeenCalled();
+
+    vi.advanceTimersByTime(250);
+    sub.emit('event', reaction(id, 'p3'));
+    sub.emit('eose');
+    vi.advanceTimersByTime(10_000);
+    expect(getEngagementStats().storeCount).toBe(0);
+    expect(writes).toHaveLength(0);
+  });
+});

--- a/src/lib/engagementCache.ts
+++ b/src/lib/engagementCache.ts
@@ -197,6 +197,146 @@ function saveToCache(eventId: string, engagement: EngagementData): void {
   }
 }
 
+// ═══════════════════════════════════════════════════════════════
+// EVENT BATCHING
+// Applying one store.update per incoming engagement event (plus a
+// synchronous localStorage write per event) stalls the main thread
+// during a busy note's initial EOSE burst — hundreds of historical
+// reactions/zaps arrive back-to-back. Events are queued per target id
+// and applied in a single update per flush cycle instead. Per-id
+// dedup still happens at enqueue time; ordering within an id is
+// arrival order — both exactly as before batching.
+//
+// Two flush modes share one code path so a note never pays for two
+// back-to-back store updates + cache writes:
+// - periodic: the ~250ms timer applies whatever is queued for each
+//   dirty note (one update + one cache write per dirty note, nothing
+//   for notes with an empty queue). Browser scheduling can delay the
+//   timer beyond 250ms; the interval is approximate.
+// - complete: EOSE or the timeout fallback applies anything still
+//   queued AND finalizes the note (reaction-count reconciliation,
+//   loading=false, lastFetched, counting flag cleared) in that same
+//   update, then persists once with a fresh cache timestamp — even
+//   when a periodic flush already emptied the queue.
+// ═══════════════════════════════════════════════════════════════
+
+const ENGAGEMENT_FLUSH_MS = 250;
+const pendingEngagementEvents = new Map<string, { userPubkey: string; events: NDKEvent[] }>();
+let engagementFlushTimer: ReturnType<typeof setTimeout> | null = null;
+
+// Fetch generations: every subscription started for a note gets a token;
+// completion callbacks (EOSE / timeout) only finalize if their token is
+// still the note's current one. cleanupEngagement and
+// clearAllEngagementCaches invalidate the token, so an old callback can
+// neither recreate a torn-down store nor mark a replacement subscription
+// complete before it has actually finished counting.
+const fetchGenerations = new Map<string, number>();
+let fetchGenerationCounter = 0;
+
+function beginFetchGeneration(targetEventId: string): number {
+  const generation = ++fetchGenerationCounter;
+  fetchGenerations.set(targetEventId, generation);
+  return generation;
+}
+
+function applyEngagementEvent(
+  data: EngagementData,
+  event: NDKEvent,
+  userPubkey: string,
+  targetEventId: string
+): void {
+  switch (event.kind) {
+    case 7: // Reaction
+      processReaction(data, event, userPubkey, targetEventId);
+      break;
+    case 6: // Repost
+      processRepost(data, event, userPubkey, targetEventId);
+      break;
+    case 9735: // Zap
+      processZap(data, event, userPubkey, targetEventId);
+      break;
+    case 1: // Comment
+      // Only count as comment if it's replying to this event
+      if (event.tags.some(t => t[0] === 'e' && t[1] === targetEventId)) {
+        data.comments.count++;
+      }
+      break;
+  }
+}
+
+function queueEngagementEvent(targetEventId: string, event: NDKEvent, userPubkey: string): void {
+  let entry = pendingEngagementEvents.get(targetEventId);
+  if (!entry) {
+    entry = { userPubkey, events: [] };
+    pendingEngagementEvents.set(targetEventId, entry);
+  }
+  entry.events.push(event);
+  if (engagementFlushTimer === null) {
+    engagementFlushTimer = setTimeout(flushAllEngagementEvents, ENGAGEMENT_FLUSH_MS);
+  }
+}
+
+/**
+ * Apply everything queued for one note in a single store update with a
+ * single cache write. In 'complete' mode the same update also finalizes
+ * the note (see the section comment above); the update and write happen
+ * even if the queue is already empty. In 'periodic' mode an empty queue
+ * is a no-op.
+ */
+function flushEngagementEvents(targetEventId: string, mode: 'periodic' | 'complete' = 'periodic'): void {
+  const entry = pendingEngagementEvents.get(targetEventId);
+  if (entry) pendingEngagementEvents.delete(targetEventId);
+  if (mode === 'periodic' && !entry) return;
+
+  if (mode === 'complete') {
+    // Initial count is complete: NIP-45 counts may apply again.
+    subscriptionCountingInProgress.delete(targetEventId);
+  }
+
+  // Never recreate a store here: the note may have been torn down
+  // (cleanupEngagement / clearAllEngagementCaches) while events sat in
+  // the queue or while a completion timer was pending.
+  const store = engagementStores.get(targetEventId);
+  if (!store) return;
+
+  store.update(s => {
+    const updated = { ...s };
+    if (entry) {
+      for (const event of entry.events) {
+        applyEngagementEvent(updated, event, entry.userPubkey, targetEventId);
+      }
+    }
+    if (mode === 'complete') {
+      // Recalculate reaction count from groups to ensure accuracy
+      const sumOfGroups = updated.reactions.groups.reduce((sum, g) => sum + g.count, 0);
+      if (sumOfGroups > 0 && sumOfGroups !== updated.reactions.count) {
+        updated.reactions.count = sumOfGroups;
+      }
+      updated.loading = false;
+      updated.lastFetched = Date.now();
+    }
+    saveToCache(targetEventId, updated);
+    return updated;
+  });
+}
+
+/**
+ * Finalize a note for the subscription identified by `generation`. A
+ * stale generation (the note was cleaned up, all caches were cleared, or
+ * a newer subscription replaced this one) is ignored entirely.
+ */
+function completeEngagementFetch(targetEventId: string, generation: number): void {
+  if (fetchGenerations.get(targetEventId) !== generation) return;
+  flushEngagementEvents(targetEventId, 'complete');
+}
+
+function flushAllEngagementEvents(): void {
+  engagementFlushTimer = null;
+  for (const id of [...pendingEngagementEvents.keys()]) {
+    flushEngagementEvents(id, 'periodic');
+  }
+}
+
 // Get or create engagement store for an event
 export function getEngagementStore(eventId: string): Writable<EngagementData> {
   if (!engagementStores.has(eventId)) {
@@ -361,7 +501,6 @@ export async function fetchEngagement(
   if (!processedReactionPairs.has(eventId)) {
     processedReactionPairs.set(eventId, new Set());
   }
-  const processed = processedEventIds.get(eventId)!;
 
   // Stop any old-style subscriptions
   const existingSubs = activeSubscriptions.get(eventId);
@@ -431,6 +570,8 @@ export async function fetchEngagement(
   
   // Mark that subscription counting is in progress (prevents NIP-45 race condition)
   subscriptionCountingInProgress.add(eventId);
+  // This call's completion token (see fetchGenerations).
+  const generation = beginFetchGeneration(eventId);
   
   // Create persistent subscription for all engagement types
   const filter = {
@@ -439,6 +580,7 @@ export async function fetchEngagement(
   };
 
   let eoseReceived = false;
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
 
   // Pre-connect aggregator relays before subscribing.
   // NDKRelaySet.fromRelayUrls creates temporary relays that connect asynchronously,
@@ -475,84 +617,42 @@ export async function fetchEngagement(
     persistentSubscriptions.set(eventId, { sub, lastActivity: Date.now() });
     
     sub.on('event', (event: NDKEvent) => {
-      if (!event.id || processed.has(event.id)) return;
+      // A subscription that cleanupEngagement stopped, or that a newer
+      // fetch replaced, must not feed events into the replacement's
+      // counts. The shared dedup Set is looked up live for the same
+      // reason (cleanup evicts it; the replacement recreates it).
+      if (persistentSubscriptions.get(eventId)?.sub !== sub) return;
+      const processed = processedEventIds.get(eventId);
+      if (!processed || !event.id || processed.has(event.id)) return;
       processed.add(event.id);
-      
+
       // Mark subscription as active on new events
       touchEngagementSubscription(eventId);
-      
-      store.update(s => {
-        const updated = { ...s };
-        
-        switch (event.kind) {
-          case 7: // Reaction
-            processReaction(updated, event, userPublickey, eventId);
-            break;
-          case 6: // Repost
-            processRepost(updated, event, userPublickey, eventId);
-            break;
-          case 9735: // Zap
-            processZap(updated, event, userPublickey, eventId);
-            break;
-          case 1: // Comment
-            // Only count as comment if it's replying to this event
-            if (event.tags.some(t => t[0] === 'e' && t[1] === eventId)) {
-              updated.comments.count++;
-            }
-            break;
-        }
-        
-        // Save to cache on each update for persistence
-        saveToCache(eventId, updated);
-        
-        return updated;
-      });
+
+      queueEngagementEvent(eventId, event, userPublickey);
     });
-    
+
+    // EOSE and the timeout fallback finalize through the same path
+    // exactly once per subscription: queued events are applied, counts
+    // reconciled, loading cleared and the result persisted in a single
+    // store update + cache write (see flushEngagementEvents).
     sub.on('eose', () => {
-      if (!eoseReceived) {
-        eoseReceived = true;
-        // Clear counting flag - subscription initial count is complete
-        subscriptionCountingInProgress.delete(eventId);
-        
-        store.update(s => {
-          const updated = { ...s, loading: false, lastFetched: Date.now() };
-          
-          // Recalculate reaction count from groups to ensure accuracy
-          const sumOfGroups = updated.reactions.groups.reduce((sum, g) => sum + g.count, 0);
-          if (sumOfGroups > 0 && sumOfGroups !== updated.reactions.count) {
-            updated.reactions.count = sumOfGroups;
-          }
-          
-          // Save to cache after initial fetch
-          saveToCache(eventId, updated);
-          return updated;
-        });
-        
-        console.debug('[Engagement] EOSE received, subscription stays open for', eventId);
+      if (eoseReceived) return;
+      eoseReceived = true;
+      if (timeoutHandle !== null) {
+        clearTimeout(timeoutHandle);
+        timeoutHandle = null;
       }
+      completeEngagementFetch(eventId, generation);
+      console.debug('[Engagement] EOSE received, subscription stays open for', eventId);
     });
     
     // Timeout fallback - mark as loaded after timeout even if EOSE didn't arrive
-    setTimeout(() => {
-      if (!eoseReceived) {
-        eoseReceived = true;
-        // Clear counting flag on timeout too
-        subscriptionCountingInProgress.delete(eventId);
-        
-        store.update(s => {
-          const updated = { ...s, loading: false, lastFetched: Date.now() };
-          
-          // Recalculate reaction count from groups to ensure accuracy
-          const sumOfGroups = updated.reactions.groups.reduce((sum, g) => sum + g.count, 0);
-          if (sumOfGroups > 0 && sumOfGroups !== updated.reactions.count) {
-            updated.reactions.count = sumOfGroups;
-          }
-          
-          saveToCache(eventId, updated);
-          return updated;
-        });
-      }
+    timeoutHandle = setTimeout(() => {
+      timeoutHandle = null;
+      if (eoseReceived) return;
+      eoseReceived = true;
+      completeEngagementFetch(eventId, generation);
     }, 5000);
     
     // Also keep in activeSubscriptions for backward compatibility
@@ -815,6 +915,14 @@ export function clearOptimisticRepost(targetEventId: string, userPubkey: string)
 
 // Cleanup function for when a note is removed from view
 export function cleanupEngagement(eventId: string): void {
+  // Drop any queued-but-unapplied events: the dedup Sets for this id are
+  // wiped below, and flushing queued events against a fresh Set would
+  // double-count them when a future subscription re-delivers them.
+  pendingEngagementEvents.delete(eventId);
+  // Invalidate any pending EOSE/timeout completion for this note so it
+  // can't finalize a store or subscription created after this cleanup.
+  fetchGenerations.delete(eventId);
+
   // Clean up persistent subscription
   const persistent = persistentSubscriptions.get(eventId);
   if (persistent) {
@@ -1098,6 +1206,8 @@ export async function batchFetchEngagement(
   }
   
   // FULL PATH: NDK subscription for accurate counts + user state
+  // Completion tokens for this batch, one per note (see fetchGenerations).
+  const generations = new Map<string, number>();
   // Init-if-absent on the dedup Sets — never wipe them here. The batch
   // subscription shares `processedEventIds` with any per-event subscription
   // that fetchEngagement may have already opened for the same eventId.
@@ -1123,6 +1233,7 @@ export async function batchFetchEngagement(
 
     // Mark that subscription counting is in progress
     subscriptionCountingInProgress.add(id);
+    generations.set(id, beginFetchGeneration(id));
 
     if (isFirstInit) {
       const store = getEngagementStore(id);
@@ -1148,6 +1259,7 @@ export async function batchFetchEngagement(
   };
   
   let eoseReceived = false;
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
   
   try {
     const sub = ndk.subscribe(filter, { closeOnEose: true });
@@ -1156,81 +1268,34 @@ export async function batchFetchEngagement(
       // Find which target event this is for
       const targetEventId = event.tags.find(t => t[0] === 'e' && toFetch.includes(t[1]))?.[1];
       if (!targetEventId) return;
-      
+
       const processed = processedEventIds.get(targetEventId);
       if (!processed || !event.id || processed.has(event.id)) return;
       processed.add(event.id);
-      
-      const store = getEngagementStore(targetEventId);
-      
-      store.update(s => {
-        const updated = { ...s };
-        
-        switch (event.kind) {
-          case 7:
-            processReaction(updated, event, userPublickey, targetEventId);
-            break;
-          case 6:
-            processRepost(updated, event, userPublickey, targetEventId);
-            break;
-          case 9735:
-            processZap(updated, event, userPublickey, targetEventId);
-            break;
-          case 1:
-            if (event.tags.some(t => t[0] === 'e' && t[1] === targetEventId)) {
-              updated.comments.count++;
-            }
-            break;
-        }
-        
-        return updated;
-      });
+
+      queueEngagementEvent(targetEventId, event, userPublickey);
     });
-    
+
+    // EOSE and the timeout fallback finalize every note in the batch
+    // through the same path exactly once: queued events applied, counts
+    // reconciled, loading cleared and the result persisted in a single
+    // store update + cache write per note (see flushEngagementEvents).
     sub.on('eose', () => {
-      if (!eoseReceived) {
-        eoseReceived = true;
-        
-        // Mark all stores as loaded and clear counting flags
-        toFetch.forEach(id => {
-          subscriptionCountingInProgress.delete(id);
-          const store = getEngagementStore(id);
-          store.update(s => {
-            const updated = { ...s, loading: false, lastFetched: Date.now() };
-            
-            // Recalculate reaction count from groups to ensure accuracy
-            const sumOfGroups = updated.reactions.groups.reduce((sum, g) => sum + g.count, 0);
-            if (sumOfGroups > 0 && sumOfGroups !== updated.reactions.count) {
-              updated.reactions.count = sumOfGroups;
-            }
-            
-            saveToCache(id, updated);
-            return updated;
-          });
-        });
+      if (eoseReceived) return;
+      eoseReceived = true;
+      if (timeoutHandle !== null) {
+        clearTimeout(timeoutHandle);
+        timeoutHandle = null;
       }
+      toFetch.forEach(id => completeEngagementFetch(id, generations.get(id)!));
     });
     
     // Timeout fallback
-    setTimeout(() => {
-      if (!eoseReceived) {
-        eoseReceived = true;
-        toFetch.forEach(id => {
-          subscriptionCountingInProgress.delete(id);
-          const store = getEngagementStore(id);
-          store.update(s => {
-            const updated = { ...s, loading: false, lastFetched: Date.now() };
-            
-            // Recalculate reaction count from groups to ensure accuracy
-            const sumOfGroups = updated.reactions.groups.reduce((sum, g) => sum + g.count, 0);
-            if (sumOfGroups > 0 && sumOfGroups !== updated.reactions.count) {
-              updated.reactions.count = sumOfGroups;
-            }
-            
-            return updated;
-          });
-        });
-      }
+    timeoutHandle = setTimeout(() => {
+      timeoutHandle = null;
+      if (eoseReceived) return;
+      eoseReceived = true;
+      toFetch.forEach(id => completeEngagementFetch(id, generations.get(id)!));
     }, 10000);
     
   } catch (error) {
@@ -1279,7 +1344,16 @@ export function clearAllEngagementCaches(): void {
   // Stop legacy subscriptions
   activeSubscriptions.forEach(subs => subs.forEach(sub => sub.stop()));
   activeSubscriptions.clear();
-  
+
+  // Drop queued events and stop the flush timer
+  pendingEngagementEvents.clear();
+  if (engagementFlushTimer !== null) {
+    clearTimeout(engagementFlushTimer);
+    engagementFlushTimer = null;
+  }
+  // Pending EOSE/timeout completions must not recreate cleared stores
+  fetchGenerations.clear();
+
   // Clear stores
   engagementStores.clear();
   processedEventIds.clear();


### PR DESCRIPTION
## What

This is the main-thread freeze driver from the perf audit. Every incoming engagement event (reaction/repost/zap/comment) ran its own `store.update` **plus a synchronous `JSON.stringify` + `localStorage.setItem` inside the update callback**. A busy note's initial EOSE burst delivers hundreds of historical events back-to-back: hundreds of sequential store updates (each re-rendering all subscribers) and cache writes stall the page.

Events now queue per target note and apply in **one store update per note per flush cycle**, with one cache write per dirty note and no writes for empty queues. Both subscription paths (`fetchEngagement`'s persistent per-note sub and `batchFetchEngagement`) route through the same queue. The periodic flush runs on a ~250 ms timer; browser scheduling can delay the callback beyond that, so the interval is approximate.

**Flushing and completion are one code path.** `flushEngagementEvents(id, 'periodic' | 'complete')` applies queued events in arrival order and, in `complete` mode (EOSE and the timeout fallback, on both paths), also reconciles reaction counts from groups, clears the NIP-45 counting flag, sets `loading=false` / `lastFetched`, and persists the normalized counts with a refreshed cache timestamp — all in a single `store.update` and a single `saveToCache`. Completion persists even when a periodic flush already emptied the queue (this also fixes the batch-timeout path, which previously never wrote the cache). EOSE clears the timeout, so a request can never finalize twice.

**Lifecycle.** Every subscription gets a per-note fetch generation. Stale EOSE/timeout callbacks — after `cleanupEngagement`, `clearAllEngagementCaches`, or a replacement subscription — are ignored and never recreate a torn-down store or mark a replacement complete early. Events from a stopped or replaced single-note subscription are dropped. `cleanupEngagement` discards the note's queued events together with its dedup sets; `clearAllEngagementCaches` cancels queued work and the flush timer.

Preserved unchanged: enqueue-time event-id dedup, the dedup set shared across single-note and batch subscriptions, reaction-pair dedup, optimistic reaction/repost/zap reconciliation, the NIP-45/count-query race guard, immediate (unqueued) optimistic UI updates, and the persistent single-note subscription receiving realtime events after EOSE.

## Relation to #670

This branch is now **main + one commit** (93fdf3d2). The service-worker fix (7ca6faa7) that the reviewed branch carried before the engagement commit stays in #670; `static/sw.js` here is identical to main. Version bumped to 4.2.742.

## Measured (100-event burst per note, mocked relay, fake timers)

| path | scenario | store updates per note | cache writes |
|---|---|---|---|
| single note | main | 101 | 101 |
| single note | this PR, EOSE before first flush | **1** | **1** |
| single note | this PR, one periodic flush then EOSE | **2** | **2** |
| batch (3 notes) | main | 101 each | 1 per note (at EOSE) |
| batch (3 notes) | this PR, EOSE before first flush | **1 each** | 1 per note |
| batch (3 notes) | this PR, one periodic flush then EOSE | **2 each** | 2 per note |

The batch path already wrote the cache once at EOSE on main, so its win is the store updates (101 → 1–2 per note); cache writes there stay at one per note at completion plus one per note for each periodic flush that had events. The single-note path wins on both.

## Verification

- `pnpm test`: 115 files / 1601 tests passing. New `engagementCache.batching.test.ts` (15) uses fake timers, mocked NDK subscriptions and a localStorage spy to assert counts, loading state, persisted values/timestamps and lifecycle: 100-event burst + duplicate deliveries (single and batch), overlapping single+batch subscriptions on the same events, mixed reactions/reposts/comments/zaps, optimistic updates then relay confirmation, EOSE before the periodic flush (one update/write), timeout without EOSE with an already-empty queue, late EOSE after timeout, EOSE cancelling the timeout, realtime arrivals after completion, NIP-45 counts ignored mid-count, rapid repeated fetches, cleanup then stale timeout/EOSE against a replacement subscription, and clearAll then advancing timers and invoking old callbacks.
- `svelte-check`: identical to main (1 pre-existing error in `src/lib/spark/index.ts`).
- Production build passes.
- Smoke test on `/community` (headless Chrome against `vite preview` of this build): 6 feed notes rendered; all 6 engagement cache entries written with non-zero counts; 15 cache writes total over 27 s (2.5 per note, max 3: cached/API fast-path, periodic flush, completion), completion writes landing together at ~12.6 s (batch timeout, since the sandbox relays never sent EOSE); no non-environmental console errors. True realtime relay traffic could not be forced from the sandbox; the post-completion path is covered by the "realtime arrivals after completion" test.

## Cloudflare "Workers Builds" checks

Both fail on every PR-branch head today (#666, #667, #669, #671, #672, #679) while every `main` commit today passes them, so the failure is the Workers integration's branch/preview build configuration, not this PR's content. The build logs need the Cloudflare dashboard (the local wrangler token has expired and no API token is set), so the exact error message remains unread. "Cloudflare Pages" is the deploying check.
