### PR TITLE
perf(comments): buffer comment arrivals into one store update

### DIFF
--- a/src/lib/comments/subscription.ts
+++ b/src/lib/comments/subscription.ts
@@ -96,13 +96,36 @@ export function createCommentSubscription(
   const filter = createCommentFilter(root);
   const subscription: NDKSubscription = ndk.subscribe(filter, { closeOnEose });
 
+  // Buffer arrivals so a busy thread's initial EOSE burst (or a burst of
+  // realtime replies) applies as ONE store update + sort instead of a
+  // growing-array copy + sort per event.
+  const BUFFER_FLUSH_MS = 200;
+  const pendingEvents: NDKEvent[] = [];
+  let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function flushPending() {
+    flushTimer = null;
+    if (pendingEvents.length === 0) return;
+    const batch = pendingEvents.splice(0, pendingEvents.length);
+    rawEvents.update((list) => sortChronological([...list, ...batch]));
+  }
+
   subscription.on('event', (ev: NDKEvent) => {
     if (processedIds.has(ev.id)) return;
     processedIds.add(ev.id);
-    rawEvents.update((list) => sortChronological([...list, ev]));
+    pendingEvents.push(ev);
+    if (flushTimer === null) {
+      flushTimer = setTimeout(flushPending, BUFFER_FLUSH_MS);
+    }
   });
 
   subscription.on('eose', () => {
+    // Apply everything that arrived during the initial burst before
+    // flagging EOSE, so "eosed" implies the full history is in the store.
+    if (flushTimer !== null) {
+      clearTimeout(flushTimer);
+      flushPending();
+    }
     eosedStore.set(true);
   });
 
@@ -118,6 +141,7 @@ export function createCommentSubscription(
   function addLocal(ev: NDKEvent): void {
     if (!ev.id || processedIds.has(ev.id)) return;
     processedIds.add(ev.id);
+    // Optimistic UI: applied immediately rather than buffered.
     rawEvents.update((list) => sortChronological([...list, ev]));
   }
 
@@ -128,6 +152,11 @@ export function createCommentSubscription(
       subscription.stop();
     } catch {
       // NDK subscriptions can throw on repeated stop; swallow.
+    }
+    // Don't drop events that were still queued for a flush.
+    if (flushTimer !== null) {
+      clearTimeout(flushTimer);
+      flushPending();
     }
   }
 


### PR DESCRIPTION
## What

From the perf audit (rendering pass): each incoming comment event ran its own `rawEvents.update` with a full array copy + chronological re-sort — O(n log n) per event, re-rendering thread subscribers each time. Busy threads deliver their whole history in the initial EOSE burst, so a 100-comment thread paid 100 growing sorts on open.

Events now buffer ~200ms and apply as one update + one sort:

- **EOSE flushes synchronously before setting `eosed`**, so `eosed === true` still implies the full history is in the store (the documented contract consumers rely on to distinguish "loading" from "empty thread")
- `stop()` flushes so queued events are never dropped
- `addLocal()` (optimistic UI for your own just-posted comment) stays immediate

Note: the audit also flagged `addMessage` in the messages store, but investigation showed its only caller is the user's own send echo (one per explicit action) — history loading already goes through the batched `addMessages`. Nothing to fix there; scoped this PR to comments only.

## Verification

- `vitest src/lib`: 93 files / 1323 passing; `svelte-check` baseline-identical
- Live browser test: opened a note thread page — subscription EOSE'd cleanly through the buffered path ("No replies yet" state renders), zero non-HMR console errors