### PR TITLE
perf(feed): read engagement snapshot at menu-open, not per list render

### DIFF
--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -5094,15 +5094,6 @@
               <!-- Glow/animation disabled on community feed to reduce bandwidth -->
               <!-- {@const isZapAnimating = zapAnimatingNotes.has(event.id)} -->
               <!-- {@const zapGlowTier = engagementInfo.zapGlowTier} -->
-              {@const engagementStoreValue = get(getEngagementStore(event.id))}
-              {@const engagementData = {
-                zaps: {
-                  totalAmount: engagementStoreValue.zaps.totalAmount,
-                  count: engagementStoreValue.zaps.count
-                },
-                reactions: { count: engagementStoreValue.reactions.count },
-                comments: { count: engagementStoreValue.comments.count }
-              }}
               <!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->
               <article
                 class="w-full cursor-pointer"
@@ -5182,7 +5173,6 @@
                   <div class="flex-shrink-0 ml-2">
                     <PostActionsMenu
                       {event}
-                      {engagementData}
                       on:copy={(e) => {
                         selectedEvent = event;
                         handlePostCopy(e);

--- a/src/components/PostActionsMenu.svelte
+++ b/src/components/PostActionsMenu.svelte
@@ -15,9 +15,17 @@
   import CheffyIcon from './icons/CheffyIcon.svelte';
   import CheffyNoteReview from './CheffyNoteReview.svelte';
   import { extractImageUrls } from '$lib/imageUrls';
+  import { get } from 'svelte/store';
+  import { getEngagementStore } from '$lib/engagementCache';
 
   export let event: NDKEvent;
-  export let engagementData: {
+
+  // Engagement snapshot for the share-image flow, read from the engagement
+  // store when the menu opens. Reading it at render time from the feed's
+  // list markup put a per-note store read (plus a first-touch localStorage
+  // parse) on every list re-render; opening a menu is the only moment the
+  // data is actually needed, and this snapshot is fresher anyway.
+  let engagementData: {
     zaps: { totalAmount: number; count: number };
     reactions: { count: number };
     comments: { count: number };
@@ -45,8 +53,28 @@
 
   let copyTimeout: ReturnType<typeof setTimeout> | null = null;
 
+  function refreshEngagementSnapshot() {
+    if (!browser || !event?.id) {
+      engagementData = null;
+      return;
+    }
+    const value = get(getEngagementStore(event.id));
+    // Pages that never initialize engagement (polls, thread views) keep
+    // the share-image item hidden — same as the old null-prop behavior.
+    if (value.loading) {
+      engagementData = null;
+      return;
+    }
+    engagementData = {
+      zaps: { totalAmount: value.zaps.totalAmount, count: value.zaps.count },
+      reactions: { count: value.reactions.count },
+      comments: { count: value.comments.count }
+    };
+  }
+
   function toggleMenu() {
     menuOpen = !menuOpen;
+    if (menuOpen) refreshEngagementSnapshot();
   }
 
   function closeMenu() {


### PR DESCRIPTION
## What

From the perf audit: the feed's card markup ran `get(getEngagementStore(event.id))` plus an object build inside `{@const}` **per note, on every invalidation of the list block** — and the first touch per note pays a synchronous localStorage read + parse. All of that existed only to hand `PostActionsMenu` a snapshot of zap/reaction/comment counts, captured at render time and stale by the time anyone opens the menu.

`PostActionsMenu` now reads the snapshot from the engagement store **when the menu opens** (the only moment it's needed):

- off the feed's hot re-render path entirely
- the snapshot is current at the moment of use instead of at render time
- the `downloadImage` dispatch contract is unchanged (still carries engagementData)
- polls/thread pages (which never passed the prop) keep the Save Image item hidden via the store's loading state — same visible behavior as before

## Verification

- `vitest src/lib`: 93 files / 1323 passing; `svelte-check` baseline-identical
- Live browser test on `/community`: opened a note's actions menu — full item list renders including Save Image (snapshot self-served from the loaded store), zero non-HMR console errors