### PR TITLE
chore(deps): drop svelte-qrcode, render login QR via @svelte-put/qr

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "phosphor-svelte": "^1.4.2",
     "qrcode-generator": "^1.4.4",
     "stripe": "^20.1.0",
-    "svelte-qrcode": "^1.0.0",
     "syllable": "^5.0.1",
     "timeago.js": "^4.0.2",
     "turndown": "^7.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,9 +185,6 @@ importers:
       stripe:
         specifier: ^20.1.0
         version: 20.1.0(@types/node@18.19.64)
-      svelte-qrcode:
-        specifier: ^1.0.0
-        version: 1.0.1
       syllable:
         specifier: ^5.0.1
         version: 5.0.1
@@ -4193,9 +4190,6 @@ packages:
   qrcode-generator@1.4.4:
     resolution: {integrity: sha512-HM7yY8O2ilqhmULxGMpcHSF1EhJJ9yBj8gvDEuZ6M+KGJ0YY2hKpnXvRD+hZPLrDVck3ExIGhmPtSdcjC+guuw==}
 
-  qrious@4.0.2:
-    resolution: {integrity: sha512-xWPJIrK1zu5Ypn898fBp8RHkT/9ibquV2Kv24S/JY9VYEhMBMKur1gHVsOiNUh7PHP9uCgejjpZUHUIXXKoU/g==}
-
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
@@ -4646,9 +4640,6 @@ packages:
         optional: true
       typescript:
         optional: true
-
-  svelte-qrcode@1.0.1:
-    resolution: {integrity: sha512-l1RcxDWkQqtBWUkolYee/IHGVKSgm1I2PdF8yVoIRqzKCc3kXpCXSVsMfrMSavWW2/BXvKu5Orv+JGbrO5onsw==}
 
   svelte@4.2.20:
     resolution: {integrity: sha512-eeEgGc2DtiUil5ANdtd8vPwt9AgaMdnuUFnPft9F5oMvU/FHu5IHFic+p1dR/UOB7XU2mX2yHW+NcTch4DCh5Q==}
@@ -9304,8 +9295,6 @@ snapshots:
 
   qrcode-generator@1.4.4: {}
 
-  qrious@4.0.2: {}
-
   qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
@@ -9836,10 +9825,6 @@ snapshots:
       postcss: 8.5.25
       postcss-load-config: 4.0.2(postcss@8.5.25)(ts-node@10.9.2(@types/node@18.19.64)(typescript@5.6.3))
       typescript: 5.6.3
-
-  svelte-qrcode@1.0.1:
-    dependencies:
-      qrious: 4.0.2
 
   svelte@4.2.20:
     dependencies:

--- a/src/components/LoginOverlay.svelte
+++ b/src/components/LoginOverlay.svelte
@@ -7,7 +7,7 @@
   import Modal from './Modal.svelte';
   import CloseIcon from 'phosphor-svelte/lib/XCircle';
   import ProfileReadyIcon from './icons/ProfileReadyIcon.svelte';
-  import QRCode from 'svelte-qrcode';
+  import { qr } from '@svelte-put/qr/svg';
 
   import { nip19 } from 'nostr-tools';
   import { createAuthManager, VaultConflictError, type AuthState } from '$lib/authManager';
@@ -997,7 +997,7 @@
         {#if nip46PairingUri}
           <div class="flex flex-col items-center gap-4">
             <div class="bg-white rounded-lg qr-container" style="--qr-size: 280px; --qr-padding: 16px;">
-              <QRCode value={nip46PairingUri} size={248} padding={null} />
+              <svg use:qr={{ data: nip46PairingUri }} width="248" height="248" />
             </div>
             <div class="text-center">
               <p class="text-sm font-medium mb-1" style="color: var(--color-text-primary)">{nip46PairingStatus}</p>


### PR DESCRIPTION
## What

Perf-audit follow-up: three QR libraries shipped simultaneously (`@svelte-put/qr`, `svelte-qrcode`, `qrcode-generator`). The NIP-46 pairing QR in `LoginOverlay` was the **only** `svelte-qrcode` consumer — and `LoginOverlay` is statically imported in the root layout, so its QR lib rode along app-wide.

It now uses the same `use:qr` action from `@svelte-put/qr/svg` already used by the footer, wallet panel, and share surfaces — same 248×248 output in the same `bg-white` container.

`qrcode-generator` stays a direct dependency: `ShareModal` paints its branded share QR from the raw module matrix (canvas + logo), and `@svelte-put/qr` itself depends on it — so it adds no bundle weight either way.

## Verification

- `vitest src/lib`: 93 files / 1323 passing; `svelte-check` baseline-identical
- Live browser test on `/login`: opened the scan-QR / universal-pairing flow — QR renders at 248×248 with full module grid (3,891 elements) in the pairing modal, zero non-HMR console errors