### PR TITLE
perf(cache): bound the NDK Dexie cache (sized warm-up + daily cap)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "buffer": "^6.0.3",
     "d3-force": "^3.0.0",
     "date-fns": "^3.6.0",
+    "dexie": "^4.0.8",
     "dompurify": "^3.4.12",
     "dotenv": "^17.2.3",
     "emoji-picker-element": "^1.28.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       date-fns:
         specifier: ^3.6.0
         version: 3.6.0
+      dexie:
+        specifier: ^4.0.8
+        version: 4.0.10
       dompurify:
         specifier: ^3.4.12
         version: 3.4.13

--- a/src/lib/ndkCacheMaintenance.ts
+++ b/src/lib/ndkCacheMaintenance.ts
@@ -1,0 +1,85 @@
+/**
+ * NDK Dexie cache maintenance
+ *
+ * ndk-cache-dexie has no pruning path: its in-memory LRUs only bound
+ * memory, while the on-disk tables grow forever. This module caps the
+ * cache once a day — when the events table exceeds MAX_CACHED_EVENTS it
+ * is cleared wholesale (together with its tag index) and repopulates
+ * over subsequent use.
+ *
+ * Why clear instead of deleting the oldest rows: the events table has no
+ * created_at index, so age-based pruning would have to deserialize every
+ * row on the main thread. A cache reset is two cheap IndexedDB
+ * operations. The app keeps its own feed hydration cache separately, so
+ * the user-visible cost of a reset is modest.
+ */
+
+import { browser } from '$app/environment';
+import Dexie from 'dexie';
+
+const MAINTENANCE_KEY = 'zc_ndk_cache_maintenance_v1';
+const DAY_MS = 24 * 60 * 60 * 1000;
+const MAX_CACHED_EVENTS = 50_000;
+const PRUNE_DELAY_MS = 60_000;
+
+// Same stores and version ndk-cache-dexie declares (Database.version(15)).
+// This is a second connection to the same database, used only for
+// counting and clearing.
+class NdkCacheDb extends Dexie {
+  events!: Dexie.Table<{ id: string; createdAt?: number }, string>;
+  eventTags!: Dexie.Table<{ tagValue: string; eventId: string }, string>;
+
+  constructor() {
+    super('zapcooking-ndk-cache-db');
+    this.version(15).stores({
+      events: '&id, kind',
+      eventTags: '&tagValue'
+    });
+  }
+}
+
+/** Run the cache cap check at most once per day, after startup settles. */
+export function scheduleNdkCacheMaintenance(): void {
+  if (!browser) return;
+
+  let last = 0;
+  try {
+    last = Number(localStorage.getItem(MAINTENANCE_KEY) || 0);
+  } catch {
+    return; // private mode / storage disabled — nothing to do
+  }
+  if (Date.now() - last < DAY_MS) return;
+  try {
+    localStorage.setItem(MAINTENANCE_KEY, String(Date.now()));
+  } catch {
+    return;
+  }
+
+  // Past the adapter warm-up and the first minute of session churn. The
+  // check itself is one IDB count; a reset is two cheap clears.
+  setTimeout(() => {
+    pruneNdkCache().catch((e) => {
+      // Version drift in ndk-cache-dexie (schema bump) surfaces here as
+      // a VersionError — fail silent; the adapter still works.
+      console.debug('[NdkCache] Maintenance skipped:', e);
+    });
+  }, PRUNE_DELAY_MS);
+}
+
+async function pruneNdkCache(): Promise<void> {
+  const db = new NdkCacheDb();
+  try {
+    const count = await db.events.count();
+    if (count <= MAX_CACHED_EVENTS) return;
+
+    await db.transaction('rw', db.events, db.eventTags, async () => {
+      await db.events.clear();
+      await db.eventTags.clear();
+    });
+    console.info(
+      `[NdkCache] Reset ${count} cached events (cap ${MAX_CACHED_EVENTS}); the cache will repopulate`
+    );
+  } finally {
+    db.close();
+  }
+}

--- a/src/lib/nostr.ts
+++ b/src/lib/nostr.ts
@@ -4,13 +4,28 @@ import NDKCacheAdapterDexie from '@nostr-dev-kit/ndk-cache-dexie';
 import { writable, get, type Writable } from 'svelte/store';
 import { standardRelays } from './consts';
 import { createConnectionManager, getConnectionManager, resetConnectionManagerSingleton } from './connectionManager';
+import { scheduleNdkCacheMaintenance } from './ndkCacheMaintenance';
 
 // Storage keys
 const RELAYS_STORAGE_KEY = 'nostrcooking_relays';
 const RELAY_SET_STORAGE_KEY = 'zap_active_relay_set';
 
 // Only create Dexie adapter in browser (IndexedDB not available in SSR)
-const dexieAdapter = browser ? new NDKCacheAdapterDexie({ dbName: 'zapcooking-ndk-cache-db' }) : undefined;
+const dexieAdapter = browser ? new NDKCacheAdapterDexie({
+  dbName: 'zapcooking-ndk-cache-db',
+  // Bound the in-memory LRUs — and with them the startup warm-up, which
+  // reads up to each maxSize rows from IndexedDB before the first NDK
+  // query can run. Library defaults are 50k events / 100k profiles /
+  // 100k event tags (~250k row reads every launch); these caps cover
+  // real usage with room to spare, and misses fall back to the on-disk
+  // tables anyway (getWithFallback).
+  eventCacheSize: 15_000,
+  profileCacheSize: 15_000,
+  eventTagsCacheSize: 15_000
+}) : undefined;
+
+// Cap the on-disk tables (the adapter never prunes them) — once a day.
+if (browser) scheduleNdkCacheMaintenance();
 
 // Default outbox relays (used in standard/default mode)
 const DEFAULT_OUTBOX_RELAY_URLS = ["wss://purplepag.es", "wss://nos.lol"];


### PR DESCRIPTION
## What

From the perf audit (startup/data layer — top remaining priority). The NDK Dexie cache adapter was created with library defaults only:

1. **Startup:** its warm-up reads up to `maxSize` rows per table from IndexedDB into in-memory LRUs — defaults are **50k events + 100k profiles + 100k event tags (~250k row reads every launch)** — and every first NDK query `await`s the warm-up (the adapter logs `"froze query for X ms"`). Now sized explicitly: 15k / 15k / 15k. Misses beyond the LRU fall back to on-disk reads (`getWithFallback`), so correctness is unchanged.
2. **Unbounded growth:** the adapter has **no pruning path at all** — on-disk tables grow for the life of the browser profile. New `ndkCacheMaintenance.ts` runs once a day, 60s after load: if the events table exceeds 50k rows, clear it (and its tag index). It's a pure cache; it repopulates. Clear-instead-of-age-prune because the events table has no `created_at` index — an age scan would deserialize every row on the main thread.

`dexie` is added as a direct dependency (^4.0.8 — the same major `ndk-cache-dexie` already resolves) for the maintenance's second connection, which declares the adapter's exact schema/version.

## Verification

- `vitest src/lib`: 93 files / 1323 passing; `svelte-check` baseline-identical
- Live browser test: app boots with the sized adapter, feed + engagement all load; verified the maintenance connection opens the real database (`zapcooking-ndk-cache-db`, Dexie v150, all 7 stores) without schema/VersionError, ran the scheduled maintenance live (below cap → silent no-op), zero non-HMR console errors