### PR TITLE
perf(recipe): fetch zap receipts through the NDK pool, not raw sockets

### DIFF
--- a/src/components/Recipe/TopZappers.svelte
+++ b/src/components/Recipe/TopZappers.svelte
@@ -3,7 +3,7 @@
   import { userPublickey } from '$lib/nostr';
   import type { NDKEvent } from '@nostr-dev-kit/ndk';
   import { formatAmount } from '$lib/utils';
-  import { extractZapAmountSats } from '$lib/zapAmount';
+  import { fetchZapTally } from '$lib/recipeZaps';
   import CustomAvatar from '../CustomAvatar.svelte';
   import LightningIcon from 'phosphor-svelte/lib/Lightning';
 
@@ -17,99 +17,14 @@
 
   let topZappers: ZapperInfo[] = [];
   let loading = true;
-  let activeWebSockets: WebSocket[] = [];
-
-  const AGGREGATOR_RELAYS = [
-    'wss://nos.lol',
-    'wss://relay.primal.net',
-    'wss://nostr.wine',
-    'wss://offchain.pub',
-    'wss://relay.snort.social'
-  ];
 
   const MAX_VISIBLE = 5;
 
   async function fetchTopZappers(eventId: string): Promise<ZapperInfo[]> {
-    const zapperMap = new Map<string, number>();
-    const processedIds = new Set<string>();
-    const zapEvents: any[] = [];
-
-    const relayPromises = AGGREGATOR_RELAYS.map((relayUrl) => {
-      return new Promise<void>((resolve) => {
-        try {
-          const ws = new WebSocket(relayUrl);
-          activeWebSockets.push(ws);
-
-          const timeout = setTimeout(() => {
-            ws.close();
-            resolve();
-          }, 6000);
-
-          ws.onopen = () => {
-            const req = JSON.stringify([
-              'REQ',
-              'zaps',
-              { kinds: [9735], '#e': [eventId], limit: 500 }
-            ]);
-            ws.send(req);
-          };
-
-          ws.onmessage = (msg) => {
-            try {
-              const data = JSON.parse(msg.data);
-              if (data[0] === 'EVENT' && data[2]?.kind === 9735) {
-                zapEvents.push(data[2]);
-              } else if (data[0] === 'EOSE') {
-                clearTimeout(timeout);
-                ws.close();
-                resolve();
-              }
-            } catch (e) {
-              // Ignore parse errors
-            }
-          };
-
-          ws.onerror = () => {
-            clearTimeout(timeout);
-            resolve();
-          };
-
-          ws.onclose = () => {
-            activeWebSockets = activeWebSockets.filter((w) => w !== ws);
-          };
-        } catch (e) {
-          resolve();
-        }
-      });
-    });
-
-    await Promise.all(relayPromises);
-
-    // Process zap events and aggregate by sender
-    for (const zapEvent of zapEvents) {
-      if (!zapEvent.id || processedIds.has(zapEvent.id)) continue;
-      processedIds.add(zapEvent.id);
-
-      const { sats: amountSats } = extractZapAmountSats(zapEvent);
-      if (amountSats <= 0) continue;
-
-      // Extract sender from description tag
-      const descTag = zapEvent.tags?.find((t: string[]) => t[0] === 'description');
-      if (descTag?.[1]) {
-        try {
-          const zapRequest = JSON.parse(descTag[1]);
-          if (zapRequest.pubkey) {
-            const current = zapperMap.get(zapRequest.pubkey) || 0;
-            zapperMap.set(zapRequest.pubkey, current + amountSats);
-          }
-        } catch (e) {
-          // Ignore parse errors
-        }
-      }
-    }
-
-    // Convert to array and sort by amount (highest first)
-    return Array.from(zapperMap.entries())
+    // Zap receipts come from the aggregator relays via the shared NDK
+    // pool (used to be five dedicated raw WebSockets per mount).
+    const tally = await fetchZapTally(eventId);
+    return Array.from(tally.satsByZapper.entries())
       .map(([pubkey, totalSats]) => ({ pubkey, totalSats }))
       .sort((a, b) => b.totalSats - a.totalSats);
   }
@@ -139,14 +54,8 @@
   }
 
   onDestroy(() => {
-    activeWebSockets.forEach((ws) => {
-      try {
-        ws.close();
-      } catch (e) {
-        /* ignore */
-      }
-    });
-    activeWebSockets = [];
+    // Nothing to tear down — the tally fetch runs through the shared
+    // NDK pool with closeOnEose.
   });
 
   $: visibleZappers = topZappers.slice(0, MAX_VISIBLE);

--- a/src/components/Recipe/TotalZaps.svelte
+++ b/src/components/Recipe/TotalZaps.svelte
@@ -4,6 +4,7 @@
   import { onMount, onDestroy } from 'svelte';
   import { formatAmount } from '$lib/utils';
   import { extractZapAmountSats } from '$lib/zapAmount';
+  import { fetchZapTally } from '$lib/recipeZaps';
   import LightningIcon from 'phosphor-svelte/lib/Lightning';
   import { browser } from '$app/environment';
 
@@ -14,100 +15,6 @@
   let hasUserZapped = false;
   let subscription: NDKSubscription | null = null;
   let mounted = false;
-  let activeWebSockets: WebSocket[] = [];
-
-  // Aggregator relays known to have good zap data
-  // Tested for response time (<800ms) and zap coverage
-  const AGGREGATOR_RELAYS = [
-    'wss://nos.lol',
-    'wss://relay.primal.net',
-    'wss://nostr.wine',
-    'wss://offchain.pub',
-    'wss://relay.snort.social'
-  ];
-
-  // Fetch zaps directly from relays using raw WebSocket (similar to Habla.news approach)
-  async function fetchZapsFromRelays(eventId: string): Promise<{ totalSats: number; zapCount: number; zapperPubkeys: string[] }> {
-    const result = { totalSats: 0, zapCount: 0, zapperPubkeys: [] as string[] };
-    const zapEvents: any[] = [];
-
-    // Query all aggregator relays in parallel
-    const relayPromises = AGGREGATOR_RELAYS.map((relayUrl) => {
-      return new Promise<void>((resolve) => {
-        try {
-          const ws = new WebSocket(relayUrl);
-          activeWebSockets.push(ws);
-
-          const timeout = setTimeout(() => {
-            ws.close();
-            resolve();
-          }, 6000);
-
-          ws.onopen = () => {
-            // Query for zaps by #e tag (event ID)
-            const req = JSON.stringify(['REQ', 'zaps', { kinds: [9735], '#e': [eventId], limit: 500 }]);
-            ws.send(req);
-          };
-
-          ws.onmessage = (msg) => {
-            try {
-              const data = JSON.parse(msg.data);
-              if (data[0] === 'EVENT' && data[2]?.kind === 9735) {
-                zapEvents.push(data[2]);
-              } else if (data[0] === 'EOSE') {
-                clearTimeout(timeout);
-                ws.close();
-                resolve();
-              }
-            } catch (e) {
-              // Ignore parse errors
-            }
-          };
-
-          ws.onerror = () => {
-            clearTimeout(timeout);
-            resolve();
-          };
-
-          ws.onclose = () => {
-            activeWebSockets = activeWebSockets.filter(w => w !== ws);
-          };
-        } catch (e) {
-          resolve();
-        }
-      });
-    });
-
-    // Wait for all relays to respond (or timeout)
-    await Promise.all(relayPromises);
-
-    // Process all collected zap events
-    for (const zapEvent of zapEvents) {
-      if (!zapEvent.id || processedZapIds.has(zapEvent.id)) continue;
-      processedZapIds.add(zapEvent.id);
-
-      const { sats } = extractZapAmountSats(zapEvent);
-      if (sats <= 0) continue;
-
-      result.totalSats += sats;
-      result.zapCount++;
-
-      // Extract sender from description tag (contains zap request)
-      const descTag = zapEvent.tags?.find((t: string[]) => t[0] === 'description');
-      if (descTag?.[1]) {
-        try {
-          const zapRequest = JSON.parse(descTag[1]);
-          if (zapRequest.pubkey) {
-            result.zapperPubkeys.push(zapRequest.pubkey);
-          }
-        } catch (e) {
-          // Ignore parse errors
-        }
-      }
-    }
-
-    return result;
-  }
 
   async function loadZaps() {
     if (!event?.id || !mounted) return;
@@ -118,13 +25,14 @@
     hasUserZapped = false;
 
     try {
-      // Fetch zaps directly from aggregator relays (Habla.news approach)
-      const relayResult = await fetchZapsFromRelays(event.id);
+      // Zap receipts come from the aggregator relays via the shared NDK
+      // pool (used to be five dedicated raw WebSockets per mount).
+      const tally = await fetchZapTally(event.id);
 
-      totalZapAmount = relayResult.totalSats;
+      totalZapAmount = tally.totalSats;
 
       // Check if current user zapped
-      if ($userPublickey && relayResult.zapperPubkeys.includes($userPublickey)) {
+      if ($userPublickey && tally.satsByZapper.has($userPublickey)) {
         hasUserZapped = true;
       }
 
@@ -171,11 +79,6 @@
       subscription.stop();
     }
     subscription = null;
-    // Close any active WebSocket connections
-    activeWebSockets.forEach(ws => {
-      try { ws.close(); } catch (e) { /* ignore */ }
-    });
-    activeWebSockets = [];
   });
 </script>
 

--- a/src/lib/recipeZaps.ts
+++ b/src/lib/recipeZaps.ts
@@ -1,0 +1,87 @@
+/**
+ * Zap receipt fetching for recipe pages
+ *
+ * Both TotalZaps and TopZappers need the kind:9735 receipts for a
+ * recipe event. They used to open five dedicated raw WebSockets per
+ * page mount (one per aggregator relay) — duplicated fan-out, sockets
+ * not shared with anything else in the app. Fetching through the NDK
+ * pool with an explicit relay set gets the same coverage while reusing
+ * already-connected pool relays (nos.lol, relay.primal.net, nostr.wine
+ * are in the default pool) and deduping the rest.
+ */
+
+import { get } from 'svelte/store';
+import { ndk } from '$lib/nostr';
+import type { NDKEvent } from '@nostr-dev-kit/ndk';
+import { extractZapAmountSats } from '$lib/zapAmount';
+
+// Aggregator relays known to have good zap data (tested for response
+// time and zap coverage).
+export const ZAP_AGGREGATOR_RELAYS = [
+  'wss://nos.lol',
+  'wss://relay.primal.net',
+  'wss://nostr.wine',
+  'wss://offchain.pub',
+  'wss://relay.snort.social'
+];
+
+export interface ZapTally {
+  totalSats: number;
+  zapCount: number;
+  /** Sender pubkey -> summed sats (senders with 0-sats receipts omitted). */
+  satsByZapper: Map<string, number>;
+}
+
+/**
+ * Fetch and tally zap receipts for an event from the aggregator relays.
+ * Never throws — returns whatever arrived before the timeout.
+ */
+export async function fetchZapTally(
+  eventId: string,
+  limit = 500,
+  timeoutMs = 6000
+): Promise<ZapTally> {
+  const tally: ZapTally = { totalSats: 0, zapCount: 0, satsByZapper: new Map() };
+  const $ndk = get(ndk);
+  if (!$ndk) return tally;
+
+  try {
+    const { NDKRelaySet } = await import('@nostr-dev-kit/ndk');
+    const relaySet = NDKRelaySet.fromRelayUrls(ZAP_AGGREGATOR_RELAYS, $ndk, true);
+    const events = await Promise.race([
+      $ndk.fetchEvents({ kinds: [9735], '#e': [eventId], limit }, { closeOnEose: true }, relaySet),
+      new Promise<Set<NDKEvent>>((resolve) => setTimeout(() => resolve(new Set()), timeoutMs))
+    ]);
+
+    for (const zapEvent of events) {
+      if (!zapEvent.id) continue;
+
+      const { sats } = extractZapAmountSats(zapEvent);
+      if (sats <= 0) continue;
+
+      tally.totalSats += sats;
+      tally.zapCount++;
+
+      // Sender pubkey lives in the zap request (description tag), not on
+      // the receipt itself.
+      const descTag = zapEvent.tags.find((t) => t[0] === 'description');
+      if (descTag?.[1]) {
+        try {
+          const zapRequest = JSON.parse(descTag[1]);
+          if (zapRequest.pubkey) {
+            tally.satsByZapper.set(
+              zapRequest.pubkey,
+              (tally.satsByZapper.get(zapRequest.pubkey) || 0) + sats
+            );
+          }
+        } catch {
+          // Ignore malformed description tags
+        }
+      }
+    }
+  } catch (error) {
+    console.debug('[RecipeZaps] Fetch failed, keeping partial tally:', error);
+  }
+
+  return tally;
+}


### PR DESCRIPTION
## What

From the perf audit (connection sprawl). `Recipe/TotalZaps` and `Recipe/TopZappers` each opened **five dedicated raw WebSockets per recipe page mount** (nos.lol, relay.primal.net, nostr.wine, offchain.pub, relay.snort.social) with hand-rolled REQ/EOSE/timeout bookkeeping and manual teardown — duplicated in both components, sockets shared with nothing else in the app.

Both now use one shared helper (`$lib/recipeZaps` → `fetchZapTally`) that runs the same `{kinds:[9735], #e:[id], limit:500}` filter over an `NDKRelaySet` of the same relays with `closeOnEose` and the same 6-second bound:

- **three of the five relays are already in the default NDK pool** — those connections are reused, no new sockets
- only offchain.pub and relay.snort.social dial fresh, as temporary NDK relays (auto-cleanup, same pattern the app uses elsewhere)
- receipt tallying (sats extraction, sender from the description tag) unchanged, now in one place instead of two

## Verification

- `vitest src/lib`: 93 files / 1323 passing; `svelte-check` baseline-identical; no `new WebSocket` remains in either component
- Live browser test: loaded a recipe page — engagement counts render through the pool fetch, zero non-HMR console errors