### PR TITLE
fix(build): bundle @capacitor/* instead of externalizing as bare specifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.736",
+  "version": "4.2.737",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,13 +52,6 @@ export default defineConfig({
   },
   build: {
     rollupOptions: {
-      external: (id) => {
-        // Externalize Capacitor modules for web builds (they're only available in mobile)
-        if (id.startsWith('@capacitor/')) {
-          return true;
-        }
-        return false;
-      },
       onwarn(warning, warn) {
         // Suppress warnings about Svelte 5 functions (untrack, fork, settled) 
         // that SvelteKit 2.49.5 references but aren't available in Svelte 4 SSR


### PR DESCRIPTION
## What

Found during mobile-browser testing (investigating reported page-load failures). The rollup `external` list shipped every `@capacitor/*` import as a **bare module specifier** — and nothing resolves those on the web deployment (no importmap, no Capacitor bridge):

1. notification init, layout listener setup, and the Capacitor probes all `import('@capacitor/core')` → fails **on every web page load** (verified live on production: `Failed to resolve module specifier '@capacitor/core'`, `[Notifications] isNativePlatform: Error importing Capacitor`)
2. Vite surfaces each failed dynamic import as a `vite:preloadError` → the layout's stale-deploy recovery handler fires `location.reload()` — **a spurious full-page reload every web session** (production console shows recovery errors #2–#5 per session as the probes re-fire). On mobile this reads as "page load failure."
3. The native app is affected too: the bridge injects `window.Capacitor` but **not** plugin globals, so the `@capacitor/local-notifications` / `@capacitor/app` fallback imports are equally unresolvable there — native notifications silently no-op.

The externalization came from ac48a392 ("Prevents build failures in web/Cloudflare environment"). The current toolchain **builds cleanly without it** — verified with both the Cloudflare and static adapters. Bundling is standard Capacitor usage: `@capacitor/core`'s ESM build no-ops on web (`isNativePlatform() → false`) and works natively.

## Measured impact

`@capacitor/core` lands as a 3.4KB gz **lazy** chunk. No other chunk sizes change.

## Verification

- Production (before): 5+ `vite:preloadError` events + recovery reload per session, console error spam — captured on iPhone emulation
- This branch, full Cloudflare build served via `wrangler pages dev`, fresh iPhone-emulated session: `[Capacitor] Not a native platform, skipping listener setup` (clean graceful skip), `[Notifications] isNativePlatform: Imported successfully, platform = web, isNative = false`, **zero** preloadError/recovery events, zero console errors
- Static/mobile build (`build:mobile`): no bare specifiers in output; prerendered explore page loads clean under iPhone emulation (only expected API-404 warnings from serving without a backend)
- `vitest src/lib`: 93 files / 1323 passing; `svelte-check` baseline-identical