### PR TITLE
fix(mobile): replace regex lookbehinds (parse error on iOS < 16.4)

### DIFF
--- a/src/components/notifications/NotifText.svelte
+++ b/src/components/notifications/NotifText.svelte
@@ -17,9 +17,11 @@
   const MEDIA_HOST_PATTERN =
     /https?:\/\/(?:i\.)?(?:nostr\.build|imgur\.com|primal\.b-cdn\.net|image\.nostr\.build|void\.cat|m\.primal\.net|cdn\.satellite\.earth|v\.nostr\.build)[^\s]*/gi;
   const URL_PATTERN = /https?:\/\/[^\s]+/g;
-  // Negative lookbehind ensures we don't strip bech32 inside nostr: URIs
+  // The optional nostr: prefix is consumed and re-emitted so bare bech32 is
+  // stripped while nostr: URIs are preserved (no lookbehind: parse-time
+  // SyntaxError on iOS Safari < 16.4, which kills the whole module).
   const BARE_BECH32_PATTERN =
-    /(?<!nostr:)\b(?:note1|nevent1|naddr1|npub1|nprofile1)[023456789ac-hj-np-z]{20,}\b/gi;
+    /(nostr:)?\b(?:note1|nevent1|naddr1|npub1|nprofile1)[023456789ac-hj-np-z]{20,}\b/gi;
 
   function decodePubkey(bech32: string): string | null {
     try {
@@ -37,7 +39,7 @@
     let cleaned = input
       .replace(MEDIA_URL_PATTERN, '')
       .replace(MEDIA_HOST_PATTERN, '')
-      .replace(BARE_BECH32_PATTERN, '')
+      .replace(BARE_BECH32_PATTERN, (match, nostrPrefix) => (nostrPrefix ? match : ''))
       .replace(/\s+/g, ' ')
       .trim();
 

--- a/src/lib/cookbookNormalize.ts
+++ b/src/lib/cookbookNormalize.ts
@@ -77,8 +77,10 @@ export function stripMarkdownFormatting(input: string): string {
 	// Italic (*foo*, _foo_) — restrict to forms unlikely to collide with
 	// regular punctuation usage. Underscore variant only when bordered by
 	// whitespace/start/end so we don't break snake_case identifiers.
-	out = out.replace(/(?<![*\w])\*([^\s*][^*\n]*?[^\s*])\*(?!\w)/g, '$1');
-	out = out.replace(/(?<![\w_])_([^\s_][^_\n]*?[^\s_])_(?!\w)/g, '$1');
+	// The consumed-and-re-emitted border char replaces lookbehind (a
+	// parse-time SyntaxError on iOS Safari < 16.4).
+	out = out.replace(/(^|[^*\w])\*([^\s*][^*\n]*?[^\s*])\*(?!\w)/g, '$1$2');
+	out = out.replace(/(^|[^_\w])_([^\s_][^_\n]*?[^\s_])_(?!\w)/g, '$1$2');
 
 	// Drop links whose destination is localhost/loopback entirely —
 	// label and URL both gone, since the reader can't follow them.

--- a/src/lib/notificationStore.ts
+++ b/src/lib/notificationStore.ts
@@ -438,10 +438,11 @@ function cleanContentForPreview(content: string): string {
     .replace(/https?:\/\/[^\s]+\.(?:jpg|jpeg|png|gif|webp|svg|bmp|avif)(?:\?[^\s]*)?/gi, '')
     .replace(/https?:\/\/(?:i\.)?(?:nostr\.build|imgur\.com|primal\.b-cdn\.net|image\.nostr\.build|void\.cat|m\.primal\.net|cdn\.satellite\.earth)[^\s]*/gi, '')
     // Remove standalone bech32 identifiers (without nostr: prefix) — display layer only resolves nostr: URIs.
-    // The lookbehind keeps `nostr:npub1…` mentions intact; without it the bech32
-    // gets stripped out of the URI, leaving a dangling literal "nostr: " that the
-    // display layer can no longer resolve to a name.
-    .replace(/(?<!nostr:)\b(?:note1|nevent1|naddr1|npub1|nprofile1)[023456789ac-hj-np-z]{20,}\b/gi, ' ')
+    // The consumed-and-re-emitted nostr: prefix keeps `nostr:npub1…` mentions intact; without it
+    // the bech32 gets stripped out of the URI, leaving a dangling literal "nostr: " that the
+    // display layer can no longer resolve to a name. (No lookbehind: parse-time
+    // SyntaxError on iOS Safari < 16.4.)
+    .replace(/(nostr:)?\b(?:note1|nevent1|naddr1|npub1|nprofile1)[023456789ac-hj-np-z]{20,}\b/gi, (match, nostrPrefix) => (nostrPrefix ? match : ' '))
     // Clean up multiple spaces and newlines
     .replace(/\s+/g, ' ')
     .trim();

--- a/src/lib/notificationUtils.ts
+++ b/src/lib/notificationUtils.ts
@@ -33,9 +33,11 @@ const MEDIA_URL_PATTERN =
 const MEDIA_HOST_PATTERN =
   /https?:\/\/(?:i\.)?(?:nostr\.build|imgur\.com|primal\.b-cdn\.net|image\.nostr\.build|void\.cat|m\.primal\.net|cdn\.satellite\.earth|v\.nostr\.build)[^\s]*/gi;
 
-// Negative lookbehind ensures we don't strip bech32 inside nostr: URIs
+// The optional nostr: prefix is consumed and re-emitted so bare bech32 is
+// stripped while nostr: URIs are preserved (no lookbehind: it is a parse-time
+// SyntaxError on iOS Safari < 16.4, which kills the whole module).
 const BARE_BECH32_PATTERN =
-  /(?<!nostr:)(?:note1|nevent1|naddr1|npub1|nprofile1)[023456789ac-hj-np-z]{20,}/gi;
+  /(nostr:)?(?:note1|nevent1|naddr1|npub1|nprofile1)[023456789ac-hj-np-z]{20,}/gi;
 
 /**
  * Strip media URLs, image-host URLs, and bare bech32 identifiers from text.
@@ -46,7 +48,7 @@ export function stripMediaAndBech32(text: string): string {
   return text
     .replace(MEDIA_URL_PATTERN, '')
     .replace(MEDIA_HOST_PATTERN, '')
-    .replace(BARE_BECH32_PATTERN, '')
+    .replace(BARE_BECH32_PATTERN, (match, nostrPrefix) => (nostrPrefix ? match : ''))
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -662,9 +662,14 @@ function extractDirectionsFlexible(markdown: string): Array<{ number: number; te
     const directionsContent = altDirectionsMatch[1].trim();
     const steps: Array<{ number: number; text: string }> = [];
     
-    // Split by periods followed by space or newline, or by newlines
+    // Split by periods followed by space or newline, or by newlines. The
+    // marker dance replaces lookbehind (a parse-time SyntaxError on iOS
+    // Safari < 16.4): sentence boundaries become \u0000, newlines keep
+    // their \n attached to the preceding piece exactly like (?<=\n) did.
     const sentences = directionsContent
-      .split(/(?<=[.!?])\s+(?=[A-Z])|(?<=\n)/)
+      .replace(/([.!?])\s+(?=[A-Z])/g, '$1\u0000')
+      .replace(/\n/g, '\n\u0000')
+      .split('\u0000')
       .map(s => s.trim())
       .filter(s => s.length > 10); // Filter out very short fragments
     


### PR DESCRIPTION
## What

Found during mobile-browser testing. A regex literal containing a **lookbehind is a parse-time `SyntaxError` on iOS Safari < 16.4** (lookbehind shipped in 16.4, March 2023) — the entire module fails to evaluate, not just the function using it. Older iPhones/iPads (incl. every device capped below iOS 16) got:

- a dead notifications subsystem (notificationStore, notificationUtils, NotifText all contain lookbehinds)
- in the parser's case — statically reachable from the layout via CheffyMessenger — **a dead layout chunk**: blank/broken pages on old iOS

All six lookbehind sites rewritten with equivalent constructs:

| site | rewrite |
|---|---|
| bare-bech32 stripping ×3 | optional `nostr:` prefix consumed and re-emitted (bare IDs stripped, `nostr:` URIs preserved) |
| parser directions sentence split | boundary markers (`\u0000`) replace the lookbehind split; newlines stay attached to the preceding piece exactly as `(?<=\n)` had them |
| cookbookNormalize italics/underscores | border character consumed and re-emitted through the replacement |

## Verification

- **110-case equivalence battery** comparing old vs new behavior across prefixed/glued/multiple bech32 identifiers, sentence+newline splits, and markdown-emphasis edge cases — 110/110 identical (including the `_a__b_` and `snake_case` traps)
- repo's own suites for these modules: `vitest src/lib` 93 files / 1323 passing
- `svelte-check` baseline-identical; zero lookbehind regex literals remain in `src/`