### PR TITLE
chore: restore console.log after NDK connect window; gate dev routes in prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.742",
+  "version": "4.2.743",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/nostr.ts
+++ b/src/lib/nostr.ts
@@ -478,9 +478,12 @@ if (browser) {
     ndkReadyResolve(); // Resolve anyway so components don't hang
   }).finally(() => {
     setTimeout(() => {
-      // Initial connection window has passed — restore console.error.
+      // Initial connection window has passed — restore both patched
+      // methods. Leaving console.log wrapped for the whole session taxed
+      // every log call with an args.join + substring scan.
       errorSuppressionActive = false;
       console.error = originalError;
+      console.log = originalLog;
     }, 3000);
   });
 } else {

--- a/src/routes/debug/+page.svelte
+++ b/src/routes/debug/+page.svelte
@@ -1,3 +1,12 @@
+<script context="module" lang="ts">
+  // Dev-only tooling — redirect away in production builds. (Checked via
+  // PROD so the branch survives DEV being inlined+eliminated at build.)
+  import { redirect } from '@sveltejs/kit';
+  if (import.meta.env.PROD) {
+    throw redirect(307, '/');
+  }
+</script>
+
 <script lang="ts">
   import { onMount } from 'svelte';
   import { ndk } from '$lib/nostr';

--- a/src/routes/dev/avatar-rings/+page.svelte
+++ b/src/routes/dev/avatar-rings/+page.svelte
@@ -1,3 +1,12 @@
+<script context="module" lang="ts">
+  // Dev-only tooling — redirect away in production builds. (Checked via
+  // PROD so the branch survives DEV being inlined+eliminated at build.)
+  import { redirect } from '@sveltejs/kit';
+  if (import.meta.env.PROD) {
+    throw redirect(307, '/');
+  }
+</script>
+
 <script lang="ts">
   import Avatar from '../../../components/Avatar.svelte';
 


### PR DESCRIPTION
## What

Two small hygiene items from the perf audit:

1. **console.log stayed monkey-patched all session.** The NDK boot path rewraps `console.error` and `console.log` to quiet connection noise, but only `console.error` was restored after the 3s window — every `console.log` call for the rest of the session paid an `args.join(' ')` + substring scan. Both restore together now.
2. **`/debug` (relay speed tester) and `/dev/avatar-rings` (component demo) shipped ungated** in the production route tree. Both now `redirect(307, '/')` in production builds via a module-level `import.meta.env.PROD` guard (PROD, not `!DEV`, so the branch survives DEV being inlined and eliminated). Dev servers keep both pages.

## Verification

- `vitest src/lib`: 101 files / 1398 passing; `svelte-check` baseline-identical; production build passes
- Served the production build via wrangler: `/debug` → **307 → /**, `/dev/avatar-rings` → **307 → /**, `/explore` → 200