### PR TITLE
perf(sw): cap the static-asset cache at 400 entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.742",
+  "version": "4.2.743",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,8 +1,30 @@
 // Service Worker to intercept __data.json requests and cache app assets for offline support
 // This handles requests that Capacitor's native layer can't serve and enables offline functionality
 
-const CACHE_NAME = 'zapcooking-v2';
+// v3: one-time reset of the previously unbounded cache; going forward
+// the static-asset cache is capped (see MAX_STATIC_CACHE_ENTRIES).
+const CACHE_NAME = 'zapcooking-v3';
 const APP_ORIGIN = self.location.origin;
+
+// The cache-first static-asset store (images, fonts) grows without
+// bound otherwise — until this file's CACHE_NAME is manually bumped,
+// which is not a quota strategy. Entries beyond the cap are evicted
+// oldest-first (Cache keys iterate in insertion order).
+const MAX_STATIC_CACHE_ENTRIES = 400;
+
+async function trimStaticCache(cache) {
+  try {
+    const keys = await cache.keys();
+    const excess = keys.length - MAX_STATIC_CACHE_ENTRIES;
+    if (excess > 0) {
+      for (const key of keys.slice(0, excess)) {
+        await cache.delete(key);
+      }
+    }
+  } catch (e) {
+    // Non-fatal — trimming is best-effort
+  }
+}
 
 // Assets that should be cached (app code, styles, fonts, etc.)
 const ASSET_PATTERNS = [
@@ -163,7 +185,9 @@ self.addEventListener('fetch', (event) => {
               .then((networkResponse) => {
                 if (networkResponse.status === 200) {
                   const responseClone = networkResponse.clone();
-                  cache.put(event.request, responseClone);
+                  cache
+                    .put(event.request, responseClone)
+                    .then(() => trimStaticCache(cache));
                 }
                 return networkResponse;
               })


### PR DESCRIPTION
## What

From the perf audit (assets pass). The service worker cached images and fonts **cache-first with no eviction** — storage grew until someone manually bumped `CACHE_NAME`, which is not a quota strategy. Avatars and note media flow through this cache continuously.

- static-asset entries capped at **400**, evicted oldest-first after each cache-first put (`Cache.keys()` iterates in insertion order)
- `CACHE_NAME` bumps v2 → v3: existing clients get a one-time reset of their accumulated cache, then stay bounded forever
- app-code entries are untouched (immutable per-deploy artifacts, network-first)

## Verification

Functional browser test of the shipped `sw.js`: pre-filled the SW's cache with 450 entries from the page, triggered one real cache-first fetch → **450 → 400**, oldest entry evicted, newest kept, the fetched asset cached. Plus `node --check`, full `vitest src/lib` (1398 passing), `svelte-check` baseline-identical.