### PR TITLE
feat(reads): share button on articles with automatic short link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.742",
+  "version": "4.2.743",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/routes/reads/[naddr]/+page.svelte
+++ b/src/routes/reads/[naddr]/+page.svelte
@@ -7,15 +7,22 @@
   import { onMount } from 'svelte';
   import Recipe from '../../../components/Recipe/Recipe.svelte';
   import PanLoader from '../../../components/PanLoader.svelte';
+  import ShareModal from '../../../components/ShareModal.svelte';
   import { RECIPE_TAGS } from '$lib/consts';
   import { validateMarkdownTemplate } from '$lib/parser';
   import ArrowLeftIcon from 'phosphor-svelte/lib/ArrowLeft';
+  import ShareFatIcon from 'phosphor-svelte/lib/ShareFat';
   import { stripTrackingParams } from '$lib/utils/stripTrackingParams';
 
   let event: NDKEvent | null = null;
   let naddr: string = '';
   let loading = true;
   let error: string | null = null;
+  let shareModalOpen = false;
+
+  // Production origin (matching og:url): the shortener only accepts
+  // zap.cooking URLs, and social platforms reject localhost anyway.
+  $: articleShareUrl = `https://zap.cooking/reads/${$page.params.naddr}`;
 
   onMount(() => stripTrackingParams($page.url));
 
@@ -170,8 +177,8 @@
   <meta name="twitter:image" content={og_image} />
 </svelte:head>
 
-<!-- Back to Reads link -->
-<div class="mb-4">
+<!-- Back to Reads / Share bar -->
+<div class="mb-4 flex items-center justify-between gap-2">
   <a
     href="/reads"
     class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium transition-colors hover:bg-accent-gray"
@@ -180,6 +187,16 @@
     <ArrowLeftIcon size={16} weight="bold" />
     <span>Back to Reads</span>
   </a>
+  <button
+    type="button"
+    aria-label="Share article"
+    class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium transition-colors hover:bg-accent-gray"
+    style="color: var(--color-text-secondary);"
+    on:click={() => (shareModalOpen = true)}
+  >
+    <ShareFatIcon size={16} weight="bold" />
+    <span>Share</span>
+  </button>
 </div>
 
 {#if loading}
@@ -212,3 +229,12 @@
     <PanLoader />
   </div>
 {/if}
+
+<!-- ShareModal mints a zap.cooking/s/<code> short link for the article
+     URL automatically when opened. -->
+<ShareModal
+  bind:open={shareModalOpen}
+  url={articleShareUrl}
+  title={fullPageTitle || og_title || 'Article'}
+  imageUrl={og_image}
+/>


### PR DESCRIPTION
## What

Articles had no share affordance at all — sharing meant copying the ~200-character `/reads/naddr1…` URL from the address bar. The shortlink system (`/api/shorten` + KV + `/s/<code>` redirects + ShareModal) already served recipes, packs, and notes; the article page just never wired in.

A **Share** button now sits next to "Back to Reads" and opens the existing ShareModal, which automatically mints a **`zap.cooking/s/<code>`** short link and offers copy, native share, and the branded QR.

## Verification

- End-to-end on the production build (wrangler pages dev, local KV): opened a real article (`SiteSignal…` fetched from nos.lol), clicked Share → modal displayed the auto-minted `https://zap.cooking/s/bxxbkw`; the `/s/<code>` route 302-redirects back to the canonical `/reads/<naddr>` URL; `POST /api/shorten` round-trip verified
- `vitest src/lib`: 101 files / 1398 passing; `svelte-check` baseline-identical

Companion follow-up (separate PR): premium vanity URLs — `zap.cooking/<handle>/<slug>` resolving via NIP-05 handles.