### PR TITLE
feat(routes): vanity article URLs for premium handles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.742",
+  "version": "4.2.743",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/handleDirectory.server.ts
+++ b/src/lib/handleDirectory.server.ts
@@ -1,0 +1,73 @@
+/**
+ * Server-side zap.cooking handle directory.
+ *
+ * Premium members get verified @zap.cooking NIP-05 identifiers; the
+ * mapping lives in the pantry's nostr.json (dynamic members) plus a few
+ * static names. Shared by /.well-known/nostr.json and the vanity-URL
+ * routes (`zap.cooking/<handle>/<slug>`), with a short in-isolate cache
+ * so vanity resolutions don't hammer the pantry.
+ */
+
+export const STATIC_NAMES: Record<string, string> = {
+  jack: 'c5fb6ecc876e0458e3eca9918e370cbcd376901c58460512fe537a46e58c38bb',
+  _: '319ad3e790634dbe86f14db9c2995b26ee3c6228be55f89c4c7fea9acc01d50a',
+  seth: 'a723805cda67251191c8786f4da58f797e6977582301354ba8e91bcb0342dc9c',
+  daniel: 'ee6ea13ab9fe5c4a68eaf9b1a34fe014a66b40117c50ee2a614f4cda959b6e74'
+};
+
+const PANTRY_NOSTR_JSON = 'https://pantry.zap.cooking/.well-known/nostr.json';
+const DIRECTORY_TTL_MS = 5 * 60 * 1000;
+
+let directory: { names: Record<string, string>; fetchedAt: number } | null = null;
+let directoryInFlight: Promise<Record<string, string>> | null = null;
+
+async function fetchDirectory(): Promise<Record<string, string>> {
+  try {
+    const res = await fetch(PANTRY_NOSTR_JSON, {
+      method: 'GET',
+      headers: { Accept: 'application/json' }
+    });
+    if (!res.ok) return {};
+    const data = await res.json();
+    if (data?.names && typeof data.names === 'object') {
+      return data.names as Record<string, string>;
+    }
+  } catch {
+    // Pantry unreachable — static names still resolve below.
+  }
+  return {};
+}
+
+/** Load the merged handle directory (dynamic members + static names). */
+export async function loadHandleDirectory(): Promise<Record<string, string>> {
+  if (directory && Date.now() - directory.fetchedAt < DIRECTORY_TTL_MS) {
+    return directory.names;
+  }
+  if (directoryInFlight) return directoryInFlight;
+
+  directoryInFlight = fetchDirectory().then((dynamic) => {
+    // Static names take precedence, mirroring /.well-known/nostr.json.
+    directory = { names: { ...dynamic, ...STATIC_NAMES }, fetchedAt: Date.now() };
+    directoryInFlight = null;
+    return directory.names;
+  });
+  return directoryInFlight;
+}
+
+/**
+ * Resolve a zap.cooking handle (NIP-05 name) to a pubkey. Lowercases the
+ * handle (NIP-05 names are case-insensitive by convention). Returns null
+ * for unknown handles — never throws.
+ */
+export async function resolveHandlePubkey(handle: string): Promise<string | null> {
+  const normalized = handle.trim().toLowerCase();
+  if (!normalized) return null;
+
+  // Static names resolve without touching the network.
+  const staticPubkey = STATIC_NAMES[normalized];
+  if (staticPubkey) return staticPubkey;
+
+  const names = await loadHandleDirectory();
+  const pubkey = names[normalized];
+  return typeof pubkey === 'string' && /^[0-9a-f]{64}$/.test(pubkey) ? pubkey : null;
+}

--- a/src/routes/.well-known/nostr.json/+server.ts
+++ b/src/routes/.well-known/nostr.json/+server.ts
@@ -1,11 +1,11 @@
 /**
  * NIP-05 nostr.json endpoint
- * 
+ *
  * Serves the NIP-05 mapping file at /.well-known/nostr.json
  * Fetches dynamic NIP-05 mappings from pantry.zap.cooking and merges with static names
- * 
+ *
  * GET /.well-known/nostr.json
- * 
+ *
  * Returns:
  * {
  *   names: {
@@ -16,14 +16,7 @@
  */
 
 import { json, type RequestHandler } from '@sveltejs/kit';
-
-// Static names that should always be included
-const STATIC_NAMES: Record<string, string> = {
-  "jack": "c5fb6ecc876e0458e3eca9918e370cbcd376901c58460512fe537a46e58c38bb",
-  "_": "319ad3e790634dbe86f14db9c2995b26ee3c6228be55f89c4c7fea9acc01d50a",
-  "seth": "a723805cda67251191c8786f4da58f797e6977582301354ba8e91bcb0342dc9c",
-  "daniel": "ee6ea13ab9fe5c4a68eaf9b1a34fe014a66b40117c50ee2a614f4cda959b6e74"
-};
+import { STATIC_NAMES, loadHandleDirectory } from '$lib/handleDirectory.server';
 
 export const GET: RequestHandler = async ({ setHeaders }) => {
   // Set CORS headers for NIP-05 compliance
@@ -33,48 +26,8 @@ export const GET: RequestHandler = async ({ setHeaders }) => {
     'Cache-Control': 'public, max-age=300' // Cache for 5 minutes
   });
 
-  try {
-    // Fetch dynamic NIP-05 mappings from pantry.zap.cooking
-    const membersRes = await fetch('https://pantry.zap.cooking/.well-known/nostr.json', {
-      method: 'GET',
-      headers: {
-        'Accept': 'application/json'
-      }
-    });
-
-    let dynamicNames: Record<string, string> = {};
-
-    if (membersRes.ok) {
-      try {
-        const membersData = await membersRes.json();
-        if (membersData.names && typeof membersData.names === 'object') {
-          dynamicNames = membersData.names;
-        }
-      } catch (e) {
-        console.error('[NIP-05] Error parsing members nostr.json:', e);
-        // Continue with static names only if fetch fails
-      }
-    } else {
-      console.warn('[NIP-05] Members API returned non-OK status:', membersRes.status);
-      // Continue with static names only if fetch fails
-    }
-
-    // Merge static names with dynamic names (static names take precedence)
-    const mergedNames = {
-      ...dynamicNames,
-      ...STATIC_NAMES
-    };
-
-    return json({
-      names: mergedNames
-    });
-
-  } catch (error: any) {
-    console.error('[NIP-05] Error fetching nostr.json:', error);
-    
-    // Fallback to static names only if fetch fails
-    return json({
-      names: STATIC_NAMES
-    });
-  }
+  // Static names take precedence over dynamic member names (see
+  // loadHandleDirectory); on pantry failure the static names still serve.
+  const names = await loadHandleDirectory();
+  return json({ names });
 };

--- a/src/routes/[handle]/[slug]/+page.server.ts
+++ b/src/routes/[handle]/[slug]/+page.server.ts
@@ -1,0 +1,62 @@
+/**
+ * Vanity article URLs for premium members: zap.cooking/<handle>/<slug>
+ *
+ * The handle must be the author's verified @zap.cooking NIP-05 name
+ * (premium benefit). The slug is the article's `d` identifier. Resolves
+ * handle → pubkey via the handle directory, then the article via the
+ * same raw-WebSocket relay race the OG path uses, and 302-redirects to
+ * the canonical /reads/<naddr> URL (which carries OG tags, the share
+ * short-link flow, and all client behavior unchanged).
+ *
+ * A 302 rather than a 301 because the handle→pubkey mapping is mutable:
+ * memberships lapse and handles get reassigned, so crawlers must keep
+ * re-resolving. Unknown handles and unknown slugs return a real 404 —
+ * this route is the last-resort match for two-segment paths, so junk
+ * URLs must not soft-redirect somewhere.
+ */
+
+import { error, redirect } from '@sveltejs/kit';
+import { nip19 } from 'nostr-tools';
+import { resolveHandlePubkey } from '$lib/handleDirectory.server';
+import { raceRelays } from '$lib/recipePackOg.server';
+
+/** NIP-05 name characters, lowercased. */
+const HANDLE_RE = /^[a-z0-9-_.]{1,30}$/;
+/** Nostr `d` identifier characters (case-sensitive match). */
+const SLUG_RE = /^[a-zA-Z0-9-_.]{1,80}$/;
+
+const RESOLVE_TIMEOUT_MS = 5000;
+const ARTICLE_KIND = 30023;
+
+function withTimeout<T>(promise: Promise<T>): Promise<T | null> {
+  return Promise.race([
+    promise,
+    new Promise<null>((resolve) => setTimeout(() => resolve(null), RESOLVE_TIMEOUT_MS))
+  ]);
+}
+
+export const load = async ({ params }: { params: { handle: string; slug: string } }) => {
+  const handle = params.handle.toLowerCase();
+  const slug = params.slug;
+
+  if (!HANDLE_RE.test(handle) || !SLUG_RE.test(slug)) {
+    throw error(404, 'Not found');
+  }
+
+  const pubkey = await withTimeout(resolveHandlePubkey(handle));
+  if (!pubkey) {
+    throw error(404, `No zap.cooking handle “${handle}”`);
+  }
+
+  const event = await withTimeout(
+    raceRelays({ kinds: [ARTICLE_KIND], authors: [pubkey], '#d': [slug] })
+  );
+  if (!event) {
+    throw error(404, `No article “${slug}” by @${handle}`);
+  }
+
+  throw redirect(
+    302,
+    `/reads/${nip19.naddrEncode({ kind: ARTICLE_KIND, pubkey, identifier: slug })}`
+  );
+};

--- a/src/routes/[handle]/[slug]/+page.svelte
+++ b/src/routes/[handle]/[slug]/+page.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  // This page never renders — the load function always redirects to the
+  // canonical article URL or throws a 404. Kept minimal for that reason.
+</script>
+
+<div class="flex justify-center items-center page-loader">
+  <p style="color: var(--color-text-secondary)">Resolving…</p>
+</div>


### PR DESCRIPTION
## What

Implements `zap.cooking/<handle>/<slug>` for members with a verified **@zap.cooking** NIP-05 identifier (the premium benefit):

1. **handle → pubkey** via a new shared `handleDirectory.server.ts` (pantry member nostr.json + static names, 5-minute in-isolate cache). The `/.well-known/nostr.json` endpoint now serves from the same module instead of duplicating the logic.
2. **slug → article** via the article's `d` identifier, resolved with the same raw-WebSocket `raceRelays` the OG path uses (production-proven, NDK-free).
3. **302-redirect** to the canonical `/reads/<naddr>` URL — OG tags, the share/short-link flow (#692), and all client behavior stay in one place. 302 not 301 because handle mappings are mutable (memberships lapse, handles reassign).

Unknown handles and unknown slugs return **real 404s** (this route is the last-resort two-segment match — junk URLs must not soft-redirect). Static routes (`/reads/x`, `/recipe/x`, `/user/x`, …) always take precedence over the catch-all.

## Verification (production build via wrangler, live relay data)

| request | result |
|---|---|
| `/daniel/nostr-forever` | **302 → `/reads/naddr1qvzqqqr4gupzpmnw5yatnlj…`** — the exact article from the "URL too ugly to paste" example |
| `/nobody-here/nostr-forever` | 404 |
| `/daniel/not-a-real-slug-xyz` | 404 |
| `/reads/<naddr>` (existing route) | 200 — no interception |
| `/.well-known/nostr.json` | serves merged names via the shared module |

- `vitest src/lib`: 101 files / 1398 passing; `svelte-check` baseline-identical

## Future (not in this PR)

Recipes (incl. gated premium kinds) could resolve the same way; case-insensitive slug fallback; showing the vanity URL in the article share modal once authors have handles.