### PR TITLE
fix(engagement): actually run engagement cleanup, and stop sub churn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.742",
+  "version": "4.2.743",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -95,6 +95,7 @@
     batchFetchEngagement,
     getEngagementStore,
     fetchEngagement,
+    cleanupEngagement,
     type EngagementData
   } from '$lib/engagementCache';
 
@@ -4355,6 +4356,12 @@
             if (!visibleNotes.has(eventId)) {
               unsubscribeFromEngagement(eventId);
               engagementGlowCache.delete(eventId);
+              // Release the note's persistent relay subscription and its
+              // engagement dedupe sets — without this they grew for the
+              // whole session, one set of structures per note ever
+              // rendered (the module's designed eviction path, previously
+              // never called).
+              cleanupEngagement(eventId);
             }
           }, 30000); // 30 second grace period
           pendingCleanupTimers.set(eventId, timer);
@@ -4743,8 +4750,14 @@
     pendingCleanupTimers.forEach((timer) => clearTimeout(timer));
     pendingCleanupTimers.clear();
 
-    // Unsubscribe all engagement store subscriptions
-    engagementSubscriptions.forEach((unsub) => unsub());
+    // Unsubscribe all engagement store subscriptions, and release every
+    // note's persistent engagement subscription and dedupe sets (the
+    // 5-min idle reaper would eventually catch some of these; don't
+    // keep streaming until then).
+    for (const eventId of [...engagementSubscriptions.keys()]) {
+      engagementSubscriptions.get(eventId)?.();
+      cleanupEngagement(eventId);
+    }
     engagementSubscriptions.clear();
 
     cleanupInfiniteScroll();

--- a/src/lib/engagementCache.ts
+++ b/src/lib/engagementCache.ts
@@ -95,8 +95,15 @@ const CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours - persist across page reloads
 // Keep subscriptions alive for real-time engagement updates
 // ═══════════════════════════════════════════════════════════════
 
-const persistentSubscriptions = new Map<string, { sub: NDKSubscription; lastActivity: number }>();
+const persistentSubscriptions = new Map<string, { sub: NDKSubscription; lastActivity: number; createdAt: number }>();
 const SUBSCRIPTION_IDLE_TIMEOUT = 5 * 60 * 1000; // 5 minutes - close idle subscriptions
+// A young persistent subscription is reused even without zap-amount data.
+// Five-plus components call fetchEngagement per note on mount, and most
+// notes have no zaps at all — refreshing the subscription on every call
+// (the old behavior) meant several stop+re-REQ cycles per note across
+// every relay, re-delivering and re-deduping the note's whole engagement
+// history each time.
+const SUBSCRIPTION_REFRESH_INTERVAL = 60 * 1000;
 let subscriptionCleanupInterval: ReturnType<typeof setInterval> | null = null;
 
 // Start cleanup interval for idle subscriptions
@@ -456,15 +463,20 @@ export async function fetchEngagement(
   const existingPersistent = persistentSubscriptions.get(eventId);
   const latestData = get(store);
   const hasAmountData = latestData.zaps.totalAmount > 0 || latestData.zaps.topZappers.length > 0;
-  
-  if (existingPersistent && hasAmountData) {
-    // Only reuse if we already have amount data
+  const subIsYoung =
+    existingPersistent !== undefined && Date.now() - existingPersistent.createdAt < SUBSCRIPTION_REFRESH_INTERVAL;
+
+  if (existingPersistent && (hasAmountData || subIsYoung)) {
+    // Reuse: we already have amount data (a refresh would find nothing
+    // more), or the subscription is young enough that the zap aggregator
+    // relays have had a fair chance already.
     existingPersistent.lastActivity = Date.now();
     store.update(s => ({ ...s, loading: false }));
     return;
   }
-  
-  // If we have a subscription but no amount data, close it and create a fresh one.
+
+  // If we have a stale subscription but still no amount data, close it
+  // and create a fresh one.
   // Note: we intentionally do NOT wipe processedEventIds / processedReactionPairs
   // here — those dedup Sets must persist across sub close+reopen so any
   // events the prior sub already counted aren't re-counted by the new sub
@@ -472,7 +484,7 @@ export async function fetchEngagement(
   // The Sets are only evicted by `cleanupEngagement(eventId)` when the
   // event goes off-screen.
   if (existingPersistent && !hasAmountData) {
-    console.debug('[Engagement] Subscription exists but no amount data, refreshing for', eventId);
+    console.debug('[Engagement] Stale subscription with no amount data, refreshing for', eventId);
     existingPersistent.sub.stop();
     persistentSubscriptions.delete(eventId);
   }
@@ -614,7 +626,7 @@ export async function fetchEngagement(
     const sub = ndk.subscribe(filter, { closeOnEose: false }, relaySet);
     
     // Register in persistent subscriptions map
-    persistentSubscriptions.set(eventId, { sub, lastActivity: Date.now() });
+    persistentSubscriptions.set(eventId, { sub, lastActivity: Date.now(), createdAt: Date.now() });
     
     sub.on('event', (event: NDKEvent) => {
       // A subscription that cleanupEngagement stopped, or that a newer

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -72,7 +72,7 @@
   import { prewarmOutboxCache } from '$lib/followOutbox';
   // Refresh engagement counts when the tab returns from background
   import { tabVisibleAfterHide } from '$lib/tabVisibility';
-  import { refreshActiveEngagement } from '$lib/engagementCache';
+  import { refreshActiveEngagement, clearAllEngagementCaches } from '$lib/engagementCache';
   import { scrollActiveSurfaceToTop } from '$lib/activeScrollSurface';
 
   // ── Lazy-loaded overlays ──────────────────────────────────────────
@@ -461,6 +461,10 @@
           clearUnwrapCache();
           stopGroupSubscription();
           clearGroups();
+          // Release every note's engagement subscriptions/dedupe sets and
+          // wipe the engagement localStorage cache — the next user must
+          // not inherit any of it.
+          clearAllEngagementCaches();
           disconnectSparkWallet().catch(() => {});
           clearAllWallets();
           clearAllSparkWallets();


### PR DESCRIPTION
## What

From the deep-link freeze memory scan. The engagement cache's designed eviction was **dead code in production**: `cleanupEngagement` had zero callers, `clearAllEngagementCaches` was never invoked. Every note ever rendered retained, for the whole session:

- its persistent relay subscription (until the 5-min idle reaper — and busy notes never idle)
- its dedupe Sets — one entry **per engagement event received** (~75KB for a popular note)
- its `engagement_*` localStorage cache entry

Three wirings:

1. the feed's existing off-screen cleanup (30s grace, already unsubscribing store subscriptions) now also calls `cleanupEngagement` — persistent sub + Sets released when a note leaves the viewport for good; scrolling back recreates from the localStorage cache
2. the feed's `onDestroy` releases every note it managed, instead of streaming until the idle reaper while the user reads another page
3. **logout** calls `clearAllEngagementCaches` — the next user inherits nothing (subs, Sets, or cached counts)

Plus the **zap-less churn loop**: `fetchEngagement` refreshed the persistent subscription on *every* call when a note had no zap-amount data — true forever for zap-less notes (most of the feed), with 5+ components calling per note on mount — so each note did several stop+re-REQ cycles across all relays, re-delivering and re-deduping its whole engagement history. A subscription younger than 60s is now reused.

## Verification

- `vitest src/lib`: 101 files / 1398 passing; `svelte-check` baseline-identical
- Live browser test on `/community`: feed renders, engagement data populates through the batched path exactly as before (5 notes, 5 cache entries), zero non-HMR console errors
- Companion to #694 (thread reply-sub leak) from the same scan

Note for reviewers: `cleanupEngagement` intentionally does **not** delete the engagement store objects (Svelte writables have no subscriber count — a note visible in a thread while off-feed must keep its live store). The heavyweight per-event growth was the dedupe Sets + subscriptions, both released now.