### PR TITLE
perf(messages): batch historical backfill into addMessages calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.742",
+  "version": "4.2.743",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/stores/messages.ts
+++ b/src/lib/stores/messages.ts
@@ -309,24 +309,29 @@ export async function initMessageSubscription(ndkInstance: NDK, userPubkey: stri
 
 		// 3. Load historical messages in background
 		const historicalPromises: Promise<void>[] = [];
+		const historyBatcher = createHistoryBatcher(userPubkey);
 
 		// NIP-17 historical
 		if (bestMethod === 'nip44') {
 			historicalPromises.push(
 				fetchHistoricalMessages(ndkInstance, userPubkey, (message) => {
-					addMessage(message, userPubkey);
+					historyBatcher.add(message);
 				}).then(() => {})
 			);
 		}
 
 		// NIP-04 historical
 		historicalPromises.push(
-			fetchHistoricalNip04Messages(ndkInstance, userPubkey).then(() => {})
+			fetchHistoricalNip04Messages(ndkInstance, userPubkey, (message) => {
+				historyBatcher.add(message);
+			}).then(() => {})
 		);
 
 		Promise.all(historicalPromises)
 			.catch(() => {})
 			.finally(() => {
+				// Apply anything still sitting in the batch window.
+				historyBatcher.flush();
 				messagesLoading.set(false);
 			});
 	} catch {
@@ -339,7 +344,8 @@ export async function initMessageSubscription(ndkInstance: NDK, userPubkey: stri
  */
 async function fetchHistoricalNip04Messages(
 	ndkInstance: NDK,
-	userPubkey: string
+	userPubkey: string,
+	onMessage?: (message: DecryptedMessage) => void
 ): Promise<DecryptedMessage[]> {
 	const sinceTimestamp = Math.round(Date.now() / 1000) - 3 * 24 * 60 * 60;
 
@@ -382,7 +388,11 @@ async function fetchHistoricalNip04Messages(
 			const message = await decryptNip04Event(event, userPubkey);
 			if (message) {
 				messages.push(message);
-				addMessage(message, userPubkey);
+				if (onMessage) {
+					onMessage(message);
+				} else {
+					addMessage(message, userPubkey);
+				}
 			}
 		} catch {
 			// Individual failures don't stop the rest
@@ -393,6 +403,37 @@ async function fetchHistoricalNip04Messages(
 }
 
 /** Stop the active message subscriptions. */
+/**
+ * Collects historical backfill messages and inserts them in batched
+ * addMessages calls (~one per 250ms of decryption). Historical backfill
+ * used addMessage per decrypted message — each paying a full Map copy +
+ * per-conversation sort — which made loading N days of history O(N²)
+ * store work on the main thread, right when a /messages deep link is
+ * already busy with sequential signer decrypts.
+ */
+function createHistoryBatcher(userPubkey: string, flushMs = 250) {
+	let batch: DecryptedMessage[] = [];
+	let timer: ReturnType<typeof setTimeout> | null = null;
+
+	function flush() {
+		timer = null;
+		if (batch.length === 0) return;
+		const pending = batch;
+		batch = [];
+		addMessages(pending, userPubkey);
+	}
+
+	return {
+		add(message: DecryptedMessage) {
+			batch.push(message);
+			if (timer === null) {
+				timer = setTimeout(flush, flushMs);
+			}
+		},
+		flush
+	};
+}
+
 export function stopMessageSubscription() {
 	if (activeSub) {
 		activeSub.stop();


### PR DESCRIPTION
## What

From the deep-link freeze memory scan. Deep-linking `/messages` decrypts 3 days of NIP-17 + NIP-04 history sequentially (necessary — browser signers handle one request at a time), but each decrypted message then ran `addMessage` individually: a **full conversations Map copy + per-conversation sort per message — O(N²)** store work stacked on an already-busy deep link.

Both backfills now feed a 250ms batching collector that inserts via the existing `addMessages` (one Map copy + sort per batch — its first real caller; it was written for exactly this and never wired in), with a final flush when backfill completes. Realtime incoming messages keep the immediate `addMessage` path.

**Behavior note (deliberate, flagging for review):** the batched history path does not increment unread counts (`addMessages`' semantics), so backfilled history no longer lights up the notification bell as unread — realtime messages still do. If backfill-as-unread was intended, this PR changes it; it matches how every other history load in the app behaves.

## Verification

- `vitest src/lib`: 101 files / 1398 passing; `svelte-check` baseline-identical
- No messages-store tests existed; the batcher mirrors the comments/notification buffering patterns from #674/#675