### PR TITLE
fix(reads): re-render mention names when their lookups land

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.743",
+  "version": "4.2.744",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/CheffyMessenger.svelte
+++ b/src/components/CheffyMessenger.svelte
@@ -20,7 +20,7 @@
     queueMembershipLookup,
     type MembershipStatus
   } from '$lib/stores/membershipStatus';
-  import { parseMarkdown } from '$lib/parser';
+  import { parseMarkdown, mentionNamesVersion } from '$lib/parser';
   import { PROMPT_PLACEHOLDERS, SCAN_ERROR_LINE, photoFormatLine } from '$lib/cheffy';
   import { fileToBase64, identifyPhotoFile, PHOTO_MAX_BYTES } from '$lib/photoAsk';
   import { scanFridgePhoto } from '$lib/photoScan';
@@ -648,8 +648,10 @@
                   {:else}
                     <div class="cheffy-text prose dark:prose-invert max-w-none">
                       <!-- Sanitized via parseMarkdown → sanitizeHTML. -->
+                      <!-- $mentionNamesVersion re-renders when a queued
+                           mention-name lookup lands. -->
                       <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-                      {@html parseMarkdown(m.content)}
+                      {@html parseMarkdown(m.content, $mentionNamesVersion)}
                     </div>
                   {/if}
 

--- a/src/components/Recipe/Recipe.svelte
+++ b/src/components/Recipe/Recipe.svelte
@@ -26,7 +26,8 @@
     parseMarkdown,
     extractAndGroupDirections,
     extractRecipeDetails,
-    parseMarkdownForEditing
+    parseMarkdownForEditing,
+    mentionNamesVersion
   } from '$lib/parser';
   import { sanitizeHTML } from '$lib/sanitize';
   import { goto } from '$app/navigation';
@@ -726,9 +727,16 @@
 
   let parsedBeforeDirections = '';
   let parsedAfterDirections = '';
-  // Parse markdown once and reuse in template (avoids 3x redundant parsing per section)
-  $: parsedBeforeDirections = markdownBeforeDirections ? parseMarkdown(markdownBeforeDirections) : '';
-  $: parsedAfterDirections = markdownAfterDirections ? parseMarkdown(markdownAfterDirections) : '';
+  // Parse markdown once and reuse in template (avoids 3x redundant parsing per section).
+  // $mentionNamesVersion is a dependency so profile mentions re-render
+  // with real names when their queued lookups land — the first parse
+  // renders shortened npubs, and without this the article never re-parsed.
+  $: parsedBeforeDirections = markdownBeforeDirections
+    ? parseMarkdown(markdownBeforeDirections, $mentionNamesVersion)
+    : '';
+  $: parsedAfterDirections = markdownAfterDirections
+    ? parseMarkdown(markdownAfterDirections, $mentionNamesVersion)
+    : '';
 </script>
 
 <svelte:window on:keydown={handleImageModalKeydown} />

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -332,7 +332,12 @@ export function parseMarkdownToEditorHtml(
   return root.innerHTML;
 }
 
-export function parseMarkdown(markdown: string) {
+export function parseMarkdown(markdown: string, mentionNamesRevision?: number) {
+  // `mentionNamesRevision` is ignored on purpose: callers pass
+  // $mentionNamesVersion purely so their reactive statements re-run when
+  // a queued mention-name lookup lands — the re-parse then renders real
+  // names instead of the shortened npubs the first pass showed.
+  void mentionNamesRevision;
   const parsedMarkdown = md.render(markdown);
   const sanitized = sanitizeHTML(parsedMarkdown);
   return enhanceContent(sanitized);

--- a/src/lib/profileResolver.batch.test.ts
+++ b/src/lib/profileResolver.batch.test.ts
@@ -65,7 +65,7 @@ describe('profileResolver batching', () => {
     expect(fetchEventsMock.mock.calls[0][0].authors).toEqual(pubkeys);
     expect(fetchEventsMock.mock.calls[0][0].kinds).toEqual([0]);
     for (const profile of results) {
-      expect(profile?.name).toBe(`name-${profile.pubkey}`);
+      expect(profile?.name).toBe(`name-${profile?.pubkey}`);
     }
   });
 


### PR DESCRIPTION
## What

Article mentions (`nostr:npub1…` / `nostr:nprofile1…`) render through `parseMarkdown`, which links them as anchors showing a **shortened npub** and queues a background name lookup. When the lookup lands, `mentionNamesVersion` is bumped so "reactive callers can re-render with the real name" — but **nothing in the article reader depended on that store**, so the first parse's shortened npubs stayed forever. (The longform *editor preview* has the dependency; the reader never got it.)

The recipe/article reader's parse statements and the Cheffy message renderer now reference `$mentionNamesVersion` — `parseMarkdown` accepts an (ignored) revision argument so callers can express the reactive dependency explicitly.

## Verification (live, both directions)

On the article from the original report ("Nostr Forever", 9 `nostr:nprofile1` mentions):

| state | rendered mentions |
|---|---|
| **with fix** | `@Cody`, `@Breez ⚡️`, `@Sidecar 🍸`, `@fiatjaf`, `@PlebLab`, `@Zap Cooking`, `@Seth`, … |
| **without (control)** | `@npub1syjmj…f6wl`, `@npub1jugar…fc28`, … — never upgrade |

- `vitest src/lib`: 103 files / 1405 passing; `svelte-check` baseline-identical (this also fixes a null-safety type error the profileResolver batch test left on main)

Rides on top of the batched profile fetcher (#687) — mentions now resolve in one `authors:[]` REQ for the whole article.