### PR TITLE
feat(share): prefer the author's verified vanity URL when sharing articles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.744",
+  "version": "4.2.745",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/ShareModal.svelte
+++ b/src/components/ShareModal.svelte
@@ -28,6 +28,9 @@
   export let imageName: string = 'zap-cooking-note.png';
   export let isGeneratingImage: boolean = false;
   export let onGenerateImage: (() => Promise<void>) | null = null;
+  /** Verified vanity URL (zap.cooking/<handle>/<slug>) — preferred over
+   * minting a short link when the caller has resolved one for the author. */
+  export let vanityUrl = '';
 
   let copied = false;
   let copyTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -66,11 +69,13 @@
     return url;
   })();
 
-  // Short link is the primary share URL when available
-  $: effectiveShareUrl = shortUrlResult?.shortUrl ?? displayUrl;
+  // Vanity URL (verified author handle) is the primary share URL; the
+  // minted short link is the fallback for authors without handles.
+  $: effectiveShareUrl = vanityUrl || (shortUrlResult?.shortUrl ?? displayUrl);
 
-  // Auto-fetch short link when share modal opens
-  $: if (browser && open && displayUrl && !shortUrlResult && !loadingShort && !shortError) {
+  // Auto-fetch short link when share modal opens (skipped when a vanity
+  // URL is present — there's nothing to mint).
+  $: if (browser && open && displayUrl && !vanityUrl && !shortUrlResult && !loadingShort && !shortError) {
     getShortLink();
   }
 

--- a/src/routes/reads/[naddr]/+page.svelte
+++ b/src/routes/reads/[naddr]/+page.svelte
@@ -77,6 +77,11 @@
           }
           event = e;
           loading = false;
+          // Premium share URL: zap.cooking/<handle>/<slug> when the author
+          // has a handle that verifies back to their pubkey. Background —
+          // the share modal falls back to a minted /s/ code until (or
+          // unless) this resolves.
+          void resolveVanityShareUrl(e);
         } else {
           loading = false;
           error = 'Article not found';
@@ -91,10 +96,41 @@
     }
   }
 
+  /**
+   * Resolve the author's @zap.cooking handle (premium NIP-05) from the
+   * site's verified directory and, when the author is in it, expose
+   * zap.cooking/<handle>/<d-tag> as the preferred share URL. The
+   * directory is the source of truth — an author's own profile nip05 may
+   * point elsewhere (e.g. a personal domain) while they still hold a
+   * zap.cooking handle, so the profile is not consulted at all.
+   */
+  let vanityShareUrl = '';
+
+  async function resolveVanityShareUrl(e: NDKEvent) {
+    vanityShareUrl = '';
+    if (!browser) return;
+    const dTag = e.tags.find((t) => t[0] === 'd')?.[1];
+    if (!dTag) return;
+
+    try {
+      const res = await fetch('/.well-known/nostr.json');
+      if (!res.ok) return;
+      const names = (await res.json())?.names;
+      if (!names || typeof names !== 'object') return;
+      for (const [handle, pubkey] of Object.entries(names)) {
+        if (pubkey === e.pubkey && /^[a-z0-9-_.]{1,30}$/.test(handle)) {
+          vanityShareUrl = `https://zap.cooking/${handle}/${dTag}`;
+          return;
+        }
+      }
+    } catch {
+      // Keep the minted-short-link default.
+    }
+  }
+
   // OG/meta derived entirely from the client-fetched NDK event, with static
   // defaults until it loads. No server load — see <svelte:head>.
-  $: pageHeading = event
-    ? event.tags.find((e) => e[0] == 'title')?.[1] || event.tags.find((e) => e[0] == 'd')?.[1] || '...'
+  $: pageHeading = event    ? event.tags.find((e) => e[0] == 'title')?.[1] || event.tags.find((e) => e[0] == 'd')?.[1] || '...'
     : 'Article';
 
   $: metaTitleBase = event
@@ -231,10 +267,13 @@
 {/if}
 
 <!-- ShareModal mints a zap.cooking/s/<code> short link for the article
-     URL automatically when opened. -->
+     URL automatically when opened — unless the author's verified handle
+     resolves, in which case the vanity URL (zap.cooking/<handle>/<slug>)
+     is shared instead. -->
 <ShareModal
   bind:open={shareModalOpen}
   url={articleShareUrl}
+  vanityUrl={vanityShareUrl}
   title={fullPageTitle || og_title || 'Article'}
   imageUrl={og_image}
 />


### PR DESCRIPTION
## What

Completes the vanity-URL story from #693: the article **share modal now shares `zap.cooking/<handle>/<slug>`** when the author holds a handle in the site's verified directory, instead of minting a `zap.cooking/s/<code>`.

- the directory (`/.well-known/nostr.json` — static names + pantry members) is **reverse-looked-up by the article author's pubkey**. It is the source of truth: an author's own profile `nip05` may point at a personal domain while they still hold a zap.cooking handle (exactly the case that motivated this — `daniel`'s profile declares `daniel@sidecar.top`)
- `ShareModal` gains a `vanityUrl` prop: when present it becomes the effective share URL (copy / native share / QR all follow) and the short-link minting is skipped entirely; authors without handles keep the minted short link unchanged
- resolution runs in the background after the article loads — the modal falls back to the short link until/unless the handle resolves

## Verification

Live on the motivating article (logged out): share modal displays **`https://zap.cooking/daniel/nostr-forever`** as the share URL with **no `/s/` code minted**; the vanity URL itself 302-resolves to the canonical article (verified on production). `vitest src/lib`: 103 files / 1405 passing; `svelte-check` baseline-identical.