### PR TITLE
fix(qr): explicit module fills so QR codes stay black in dark mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.745",
+  "version": "4.2.746",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/LoginOverlay.svelte
+++ b/src/components/LoginOverlay.svelte
@@ -997,7 +997,19 @@
         {#if nip46PairingUri}
           <div class="flex flex-col items-center gap-4">
             <div class="bg-white rounded-lg qr-container" style="--qr-size: 280px; --qr-padding: 16px;">
-              <svg use:qr={{ data: nip46PairingUri }} width="248" height="248" />
+              <svg
+                use:qr={{
+                  data: nip46PairingUri,
+                  // Explicit dark fills: the default is currentColor,
+                  // which washes the modules out against the white card
+                  // in dark mode (the theme's text color is light).
+                  moduleFill: '#000000',
+                  anchorOuterFill: '#000000',
+                  anchorInnerFill: '#000000'
+                }}
+                width="248"
+                height="248"
+              />
             </div>
             <div class="text-center">
               <p class="text-sm font-medium mb-1" style="color: var(--color-text-primary)">{nip46PairingStatus}</p>

--- a/src/components/ShareModal.svelte
+++ b/src/components/ShareModal.svelte
@@ -536,7 +536,15 @@
           >
             <div class="relative flex-shrink-0" style="width: 200px; height: 200px;">
               <svg
-                use:qr={{ data: effectiveShareUrl }}
+                use:qr={{
+                  data: effectiveShareUrl,
+                  // Explicit dark fills: the default is currentColor,
+                  // which washes the modules out against the white card
+                  // whenever the theme's text color is light (dark mode).
+                  moduleFill: '#000000',
+                  anchorOuterFill: '#000000',
+                  anchorInnerFill: '#000000'
+                }}
                 class="absolute inset-0 w-full h-full"
                 style="left: 0; top: 0;"
                 aria-hidden="true"


### PR DESCRIPTION
## What

User-reported: the share modal's QR washes out in dark mode. The on-screen QRs (share modal, NIP-46 pairing) left `@svelte-put/qr` module colors at their `currentColor` default — and since their cards are white in both themes, dark mode's light text color rendered pale, unscannable modules. The footer QR already guards against this exact trap with explicit fills; these two now do too.

The saved/copied branded QR image was already correct (canvas-painted black on white) — only the on-screen rendering was affected.

## Verification

Dark-mode browser test on the article share modal: all 590 QR path/rect elements carry explicit `fill=\"#000000\"` (previously inherit/CSS-driven). `vitest src/lib`: 103 files / 1405 passing; `svelte-check` baseline-identical.