### PR TITLE
feat(share): namespaced vanity short links for premium members' posts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.746",
+  "version": "4.2.748",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/FoodstrFeedOptimized.svelte
+++ b/src/components/FoodstrFeedOptimized.svelte
@@ -5550,6 +5550,9 @@
   imageName={shareImageName}
   isGeneratingImage={isGeneratingShareImage}
   onGenerateImage={shareModalEvent ? generateShareModalImage : null}
+  authorPubkey={shareModalEvent
+    ? shareModalEvent.author?.hexpubkey || shareModalEvent.pubkey
+    : ''}
 />
 
 <!-- Image generation loading overlay -->

--- a/src/components/PostActionsMenu.svelte
+++ b/src/components/PostActionsMenu.svelte
@@ -6,6 +6,7 @@
   import CopyIcon from 'phosphor-svelte/lib/Copy';
   import CheckIcon from 'phosphor-svelte/lib/Check';
   import LinkIcon from 'phosphor-svelte/lib/Link';
+  import ShareIcon from 'phosphor-svelte/lib/ShareFat';
   import UserIcon from 'phosphor-svelte/lib/User';
   import TextAlignLeftIcon from 'phosphor-svelte/lib/TextAlignLeft';
   import BracketsCurlyIcon from 'phosphor-svelte/lib/BracketsCurly';
@@ -35,6 +36,8 @@
     /** The copied NIP-21 URI (`nostr:nevent1…`). */
     copy: { noteUri: string };
     downloadImage: { event: NDKEvent; engagementData: any };
+    /** Open the share modal for this note. */
+    share: { url: string; event: NDKEvent };
   }>();
 
   let menuOpen = false;
@@ -112,6 +115,22 @@
 
   let linkCopied = false;
   let linkCopyTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  /** Production-origin share URL for the share modal / short links —
+   *  social platforms and the shortener API both reject localhost. */
+  function shareUrl(): string {
+    const noteId = nip19.neventEncode({
+      id: event.id,
+      author: event.pubkey,
+      kind: event.kind
+    });
+    return `https://zap.cooking/${noteId}`;
+  }
+
+  function handleShare() {
+    closeMenu();
+    dispatch('share', { url: shareUrl(), event });
+  }
 
   async function handleCopyLink() {
     if (!browser) return;
@@ -238,6 +257,14 @@
           <CopyIcon size={16} class="text-caption" />
           <span>Copy Note URI</span>
         {/if}
+      </button>
+      <button
+        on:click={handleShare}
+        class="w-full px-4 py-2 text-left text-sm hover:bg-accent-gray flex items-center gap-2"
+        style="color: var(--color-text-primary);"
+      >
+        <ShareIcon size={16} class="text-caption" />
+        <span>Share…</span>
       </button>
       <button
         on:click={handleCopyLink}

--- a/src/components/ShareModal.svelte
+++ b/src/components/ShareModal.svelte
@@ -31,6 +31,10 @@
   /** Verified vanity URL (zap.cooking/<handle>/<slug>) — preferred over
    * minting a short link when the caller has resolved one for the author. */
   export let vanityUrl = '';
+  /** Author's pubkey of the thing being shared. When the author holds a
+   * verified zap.cooking handle, the minted short link is namespaced
+   * under it (zap.cooking/<handle>/<code>) instead of /s/<code>. */
+  export let authorPubkey = '';
 
   let copied = false;
   let copyTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -188,16 +192,45 @@
     }
   }
 
+  // Author pubkey -> verified zap.cooking handle (directory reverse
+  // lookup), for namespaced short links. Session-cached: the modal can
+  // open repeatedly while scrolling someone's posts.
+  let namespaceForAuthor = '';
+
+  async function resolveNamespace(): Promise<string> {
+    if (!browser || !authorPubkey) return '';
+    if (namespaceForAuthor) return namespaceForAuthor;
+    try {
+      const res = await fetch('/.well-known/nostr.json');
+      if (!res.ok) return '';
+      const names = (await res.json())?.names;
+      if (!names || typeof names !== 'object') return '';
+      for (const [handle, pubkey] of Object.entries(names)) {
+        if (pubkey === authorPubkey && /^[a-z0-9-_.]{1,30}$/.test(handle)) {
+          namespaceForAuthor = handle;
+          return handle;
+        }
+      }
+    } catch {
+      // Fall back to a plain /s/ code.
+    }
+    return '';
+  }
+
   async function getShortLink() {
     if (!browser || !displayUrl) return;
     loadingShort = true;
     shortError = null;
     shortUrlResult = null;
     try {
+      const namespace = await resolveNamespace();
       const res = await fetch('/api/shorten', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url: displayUrl })
+        body: JSON.stringify({
+          url: displayUrl,
+          ...(namespace ? { namespace, authorPubkey } : {})
+        })
       });
       const data = await res.json();
       if (!res.ok) {

--- a/src/routes/[handle]/[slug]/+page.server.ts
+++ b/src/routes/[handle]/[slug]/+page.server.ts
@@ -24,9 +24,16 @@ import { raceRelays } from '$lib/recipePackOg.server';
 const HANDLE_RE = /^[a-z0-9-_.]{1,30}$/;
 /** Nostr `d` identifier characters (case-sensitive match). */
 const SLUG_RE = /^[a-zA-Z0-9-_.]{1,80}$/;
+/** Namespaced short-code shape (base62, same as /s/ codes). */
+const SHORTCODE_RE = /^[0-9a-z]{4,12}$/;
 
 const RESOLVE_TIMEOUT_MS = 5000;
 const ARTICLE_KIND = 30023;
+
+interface NamespacedShortLink {
+  target: string;
+  createdAt: number;
+}
 
 function withTimeout<T>(promise: Promise<T>): Promise<T | null> {
   return Promise.race([
@@ -35,7 +42,13 @@ function withTimeout<T>(promise: Promise<T>): Promise<T | null> {
   ]);
 }
 
-export const load = async ({ params }: { params: { handle: string; slug: string } }) => {
+export const load = async ({
+  params,
+  platform
+}: {
+  params: { handle: string; slug: string };
+  platform?: App.Platform;
+}) => {
   const handle = params.handle.toLowerCase();
   const slug = params.slug;
 
@@ -51,12 +64,25 @@ export const load = async ({ params }: { params: { handle: string; slug: string 
   const event = await withTimeout(
     raceRelays({ kinds: [ARTICLE_KIND], authors: [pubkey], '#d': [slug] })
   );
-  if (!event) {
-    throw error(404, `No article “${slug}” by @${handle}`);
+
+  if (event) {
+    throw redirect(
+      302,
+      `/reads/${nip19.naddrEncode({ kind: ARTICLE_KIND, pubkey, identifier: slug })}`
+    );
   }
 
-  throw redirect(
-    302,
-    `/reads/${nip19.naddrEncode({ kind: ARTICLE_KIND, pubkey, identifier: slug })}`
-  );
+  // Not an article slug — maybe a namespaced short code
+  // (zap.cooking/<handle>/<code> → the author's post).
+  if (SHORTCODE_RE.test(slug)) {
+    const kv = platform?.env?.SHORTLINKS;
+    const record = kv
+      ? ((await withTimeout(kv.get(`ns/${handle}/${slug}`, 'json'))) as NamespacedShortLink | null)
+      : null;
+    if (record?.target && record.target.startsWith('/')) {
+      throw redirect(302, record.target);
+    }
+  }
+
+  throw error(404, `No article “${slug}” by @${handle}`);
 };

--- a/src/routes/api/shorten/+server.ts
+++ b/src/routes/api/shorten/+server.ts
@@ -43,6 +43,86 @@ function getShortUrl(code: string): string {
   return `${SITE_ORIGIN}/s/${code}`;
 }
 
+const NAMESPACE_RE = /^[a-z0-9-_.]{1,30}$/;
+const NAMESPACE_TARGET_RE = /^\/(?:note1|nevent1|naddr1|npub1|r\/|reads\/|pack\/)[a-z0-9/?=-]*$/i;
+
+interface NamespacedRecord {
+  target: string;
+  createdAt: number;
+}
+
+/**
+ * Mint zap.cooking/<handle>/<code> short links (premium members' posts).
+ * The handle must be the author's verified zap.cooking handle: the
+ * directory (pantry members + static names) must map namespace →
+ * authorPubkey. Targets are restricted to internal note/article paths —
+ * this endpoint must never become an open redirector.
+ */
+async function mintNamespacedShortLink(
+  kv: NonNullable<App.Platform['env']>['SHORTLINKS'] | undefined,
+  namespace: string,
+  authorPubkey: string | undefined,
+  rawUrl: string
+): Promise<Response> {
+  if (!kv) {
+    return json({ success: false, error: 'Short links are not configured' }, { status: 503 });
+  }
+  const handle = namespace.trim().toLowerCase();
+  if (!NAMESPACE_RE.test(handle)) {
+    return json({ success: false, error: 'Invalid namespace' }, { status: 400 });
+  }
+  if (!authorPubkey || !/^[0-9a-f]{64}$/.test(authorPubkey)) {
+    return json({ success: false, error: 'Missing or invalid authorPubkey' }, { status: 400 });
+  }
+
+  // Resolve the target path from a zap.cooking URL (strict host check —
+  // the same allowlist parseUrlOrNaddr uses).
+  let target: string;
+  try {
+    const u = new URL(rawUrl);
+    const host = u.hostname.toLowerCase();
+    if (host !== 'zap.cooking' && host !== 'www.zap.cooking') {
+      throw new Error('bad host');
+    }
+    target = u.pathname;
+  } catch {
+    return json({ success: false, error: 'Invalid URL: use a zap.cooking link' }, { status: 400 });
+  }
+  if (!NAMESPACE_TARGET_RE.test(target)) {
+    return json(
+      { success: false, error: 'Unsupported target: must be a note, article, recipe, or pack path' },
+      { status: 400 }
+    );
+  }
+
+  // Verify the handle belongs to this author via the site directory.
+  const { loadHandleDirectory } = await import('$lib/handleDirectory.server');
+  const names = await loadHandleDirectory();
+  if (names[handle] !== authorPubkey) {
+    return json(
+      { success: false, error: 'This handle does not belong to that author' },
+      { status: 403 }
+    );
+  }
+
+  const code = normalizeShortCode(generateShortCode(6));
+  const key = `ns/${handle}/${code}`;
+  if (await kv.get(key, 'json')) {
+    // Astronomically unlikely (62^6); surface a retryable error rather
+    // than looping server-side.
+    return json({ success: false, error: 'Code collision — try again' }, { status: 503 });
+  }
+
+  const record: NamespacedRecord = { target, createdAt: Date.now() };
+  await kv.put(key, JSON.stringify(record), { expirationTtl: SHORTLINK_TTL_SECONDS });
+
+  return json({
+    success: true,
+    shortCode: code,
+    shortUrl: `${SITE_ORIGIN}/${handle}/${code}`
+  });
+}
+
 export const POST: RequestHandler = async ({ request, platform, getClientAddress }) => {
   const kv = platform?.env?.SHORTLINKS;
   if (!kv) {
@@ -75,6 +155,12 @@ export const POST: RequestHandler = async ({ request, platform, getClientAddress
     type?: 'recipe' | 'article' | 'pack';
     customSlug?: string;
     createdBy?: string;
+    /** Premium vanity minting: codes under zap.cooking/<namespace>/<code>.
+     *  Requires authorPubkey, which must match the directory mapping for
+     *  the namespace — otherwise anyone could mint links in anyone's
+     *  handle namespace. */
+    namespace?: string;
+    authorPubkey?: string;
   };
   try {
     body = await request.json();
@@ -85,6 +171,13 @@ export const POST: RequestHandler = async ({ request, platform, getClientAddress
   const rawUrl = body?.url?.trim();
   if (!rawUrl) {
     return json({ success: false, error: 'Missing or empty url' }, { status: 400 });
+  }
+
+  // Namespaced (vanity) minting: zap.cooking/<handle>/<code> redirecting
+  // to a note/post URL. Runs its own validation and storage shape, then
+  // returns — the legacy /s/<code> path below is untouched.
+  if (body.namespace) {
+    return mintNamespacedShortLink(kv, body.namespace, body.authorPubkey, rawUrl);
   }
 
   const parsed = parseUrlOrNaddr(rawUrl);


### PR DESCRIPTION
## What

Sharing a post by a member with a verified zap.cooking handle now mints **`zap.cooking/<handle>/<code>`** instead of `zap.cooking/s/<code>` — the premium branding follows members onto everything they share.

Four pieces:

1. **`/api/shorten`** accepts `namespace` + `authorPubkey`: the handle directory (pantry members + static names) must map the namespace to exactly that author — **403 otherwise**, so nobody can mint links in someone else's handle. Targets are restricted to internal note/article/recipe/pack paths with a strict host allowlist (no open redirects). Records live under `ns/<handle>/<code>` in the existing SHORTLINKS KV, same 1-year TTL and rate limits.
2. **`/<handle>/<slug>` route** resolves article d-tag slugs first (unchanged), then falls back to namespaced short codes; unknown codes 404.
3. **ShareModal** resolves the shared note's author handle from the directory (session-cached reverse lookup) and namespaces the mint automatically; non-member authors keep plain `/s/` codes; article shares keep their full vanity slug from #698.
4. **Restores the Share… item** in the note ⋯ menu — the feed's `on:share` handler had been dead since the menu rework, so note sharing via the modal was actually unreachable.

## Verification (production build via wrangler, live KV)

| case | result |
|---|---|
| mint with valid author (`daniel` + his pubkey) | `zap.cooking/daniel/r0i8iy` |
| mint with wrong pubkey | **403** "This handle does not belong to that author" |
| external target URL | **400** rejected |
| `GET /daniel/r0i8iy` | **302 → the note** |
| `GET /daniel/zzzz99` (unknown) | 404 |
| `GET /daniel/nostr-forever` (article) | 302 → article (slug precedence intact) |

`vitest src/lib`: 103 files / 1405 passing; `svelte-check` baseline-identical; production build green.