### PR TITLE
fix(thread): parent posts missing on notification deep links

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.749",
+  "version": "4.2.750",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/routes/[nip19]/+page.svelte
+++ b/src/routes/[nip19]/+page.svelte
@@ -172,6 +172,56 @@
   }
 
   // Fetch parent thread recursively
+  // Parent notes frequently live on the reply author's write relays, not
+  // the default pool — the same reason fetchReplies builds a merged relay
+  // set. Without the hints (and on a cold deep link, before the pool has
+  // finished connecting), the parent fetch came back null, the walk broke
+  // immediately, and the thread rendered as just the reply until a manual
+  // reload warmed everything.
+  function buildParentRelaySet(evt: NDKEvent): NDKRelaySet | undefined {
+    try {
+      const extraUrls = new Set<string>();
+      const sourceRelay = evt.relay?.url || (evt as any).onRelays?.[0]?.url;
+      if (sourceRelay?.startsWith('wss://')) extraUrls.add(sourceRelay);
+      for (const tag of evt.tags) {
+        if ((tag[0] === 'e' || tag[0] === 'p') && tag[2]?.startsWith('wss://')) {
+          extraUrls.add(tag[2]);
+        }
+      }
+      if (extraUrls.size === 0 || !$ndk) return undefined;
+      const poolUrls = Array.from($ndk.pool?.relays?.keys?.() ?? []);
+      if (poolUrls.length === 0) return undefined; // default pool, not hints-only
+      const merged = [...new Set([...poolUrls, ...[...extraUrls].slice(0, 3)])];
+      return NDKRelaySet.fromRelayUrls(merged, $ndk, true);
+    } catch {
+      return undefined;
+    }
+  }
+
+  async function fetchParentById(
+    parentId: string,
+    relaySet: NDKRelaySet | undefined
+  ): Promise<NDKEvent | null> {
+    for (let attempt = 0; attempt < 3; attempt++) {
+      if (attempt > 0) {
+        // Cold-start window: give pool/hint relays a moment to finish
+        // connecting before retrying.
+        await new Promise((r) => setTimeout(r, 600 * attempt));
+      }
+      try {
+        const note = await $ndk.fetchEvent(
+          { kinds: [1, 1068, 1111] as any, ids: [parentId] },
+          undefined,
+          relaySet
+        );
+        if (note) return note;
+      } catch {
+        // Try again — a dropped socket mid-fetch is transient.
+      }
+    }
+    return null;
+  }
+
   async function fetchParentThread(evt: NDKEvent) {
     loadingParents = true;
     const parents: NDKEvent[] = [];
@@ -185,7 +235,7 @@
 
         seenIds.add(parentId);
 
-        const parentNote = await $ndk.fetchEvent({ kinds: [1, 1068, 1111] as any, ids: [parentId] });
+        const parentNote = await fetchParentById(parentId, buildParentRelaySet(currentEvent));
         if (!parentNote) break;
 
         parents.unshift(parentNote); // Add to beginning for chronological order


### PR DESCRIPTION
## What

User-reported: landing on a reply from the notifications window sometimes showed **only the reply, no parent**, until a manual reload. Yes — it was a race, with two stacked causes in `fetchParentThread`:

1. **Wrong relays**: it queried the default pool only, but parent notes commonly live on the reply author's write relays — the exact reason `fetchReplies` (a few lines below) builds a hint-merged relay set. The parent walk never got that treatment.
2. **No retry against the cold-start window**: the parent fetch fires the instant the reply arrives. On a fresh deep link the pool is still connecting; the bare `fetchEvent` resolves null mid-handshake, the walk `break`s, and the thread renders as just the reply. On reload everything is warm — hence "works after refresh".

Fix: the parent walk now uses the **same merged relay set as fetchReplies** (default pool + the reply's source relay + its e-tag `wss://` hints, additively — never hints-only, which would reintroduce the dead-hint failure mode), and a null parent fetch **retries up to 3× with short backoff** to ride out the connection warm-up.

## Verification

- Live on a real reply fetched from nos.lol (parent by `captjack`): warm load renders **2 articles** (parent + reply); **cold-start** (fresh browser profile, direct deep link — the exact race window) also renders **2 articles**, where the old code intermittently rendered 1
- `vitest src/lib`: 103 files / 1405 passing; `svelte-check` baseline-identical