### PR TITLE
fix(nwc): repair NIP-47 after the nostr-tools/NDK dependency drift

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.754",
+  "version": "4.2.755",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/wallet/nwc.ts
+++ b/src/lib/wallet/nwc.ts
@@ -11,6 +11,7 @@ import { get } from 'svelte/store'
 import { NDKEvent, NDKPrivateKeySigner } from '@nostr-dev-kit/ndk'
 import type { NDKRelay } from '@nostr-dev-kit/ndk'
 import { nip04, nip19, getPublicKey as nostrGetPublicKey } from 'nostr-tools'
+import { hexToBytes } from '@noble/hashes/utils.js'
 
 // Helper to get NDK instance from store
 function getNdk() {
@@ -149,7 +150,10 @@ function normalizeSecretKey(secret: string): string {
  */
 function getPublicKey(secret: string): string {
 	const secretHex = normalizeSecretKey(secret)
-	return nostrGetPublicKey(secretHex as any)
+	// nostr-tools >= 2.25 requires bytes — a hex string throws
+	// "expected Uint8Array" from @noble/secp256k1 and killed every NIP-47
+	// request (balance, history, invoices).
+	return nostrGetPublicKey(hexToBytes(secretHex))
 }
 
 /**
@@ -162,7 +166,7 @@ export async function connectNwc(connectionUrl: string): Promise<boolean> {
 	await ndkReady
 
 	// Already connected to this URL (INLINED to avoid TDZ - isNwcConnectedTo is defined later)
-	if (currentConnectionUrl === connectionUrl && nwcSecret !== null && nwcWalletPubkey !== null && nwcRelay?.status === 1) {
+	if (currentConnectionUrl === connectionUrl && nwcSecret !== null && nwcWalletPubkey !== null && nwcRelay?.connectivity?.isAvailable()) {
 		return true
 	}
 
@@ -223,8 +227,10 @@ export async function connectNwc(connectionUrl: string): Promise<boolean> {
 
 async function waitForRelayConnection(relay: NDKRelay, timeoutMs: number): Promise<void> {
 	return new Promise<void>((resolve, reject) => {
-		// Check if already connected before setting up listeners
-		if (relay.status === 1) {
+		// Check if already connected before setting up listeners.
+		// NDKRelayStatus numbers are not intuitive (DISCONNECTED=1,
+		// CONNECTED=5) — always use isAvailable().
+		if (relay.connectivity?.isAvailable()) {
 			resolve()
 			return
 		}
@@ -276,7 +282,7 @@ export async function disconnectNwc(): Promise<void> {
  * Check if NWC is connected
  */
 export function isNwcConnected(): boolean {
-	return nwcSecret !== null && nwcWalletPubkey !== null && nwcRelay?.status === 1
+	return nwcSecret !== null && nwcWalletPubkey !== null && (nwcRelay?.connectivity?.isAvailable() ?? false)
 }
 
 /**
@@ -284,7 +290,7 @@ export function isNwcConnected(): boolean {
  * NOTE: Inlined to avoid TDZ bundler errors - do not call isNwcConnected() here
  */
 export function isNwcConnectedTo(connectionUrl: string): boolean {
-	return currentConnectionUrl === connectionUrl && nwcSecret !== null && nwcWalletPubkey !== null && nwcRelay?.status === 1
+	return currentConnectionUrl === connectionUrl && nwcSecret !== null && nwcWalletPubkey !== null && (nwcRelay?.connectivity?.isAvailable() ?? false)
 }
 
 /**
@@ -324,6 +330,9 @@ async function executeNip47Request(method: string, params: Record<string, any> =
 	const relaySet = new NDKRelaySet(new Set([nwcRelay]), ndkInstance)
 
 	// Set up subscription for response before publishing
+	// Unique subId per request: NDK groups subscriptions by filter shape,
+	// and a reused/merged subscription keeps the FIRST request's #e — the
+	// second and later NIP-47 calls then never receive their responses.
 	const sub = ndkInstance.subscribe(
 		{
 			kinds: [23195],
@@ -331,7 +340,15 @@ async function executeNip47Request(method: string, params: Record<string, any> =
 			'#p': [clientPubkey],
 			'#e': [event.id!]
 		},
-		{ closeOnEose: false },
+		{
+			closeOnEose: false,
+			subId: `nwc-req-${event.id}`,
+			// NDK's groupable fingerprint hashes filter KEYS only, so every
+			// request's response sub merges into one relay subscription that
+			// keeps the FIRST request's #e — later requests never see their
+			// responses. Disable grouping; each request gets its own REQ.
+			groupable: false
+		},
 		relaySet
 	)
 


### PR DESCRIPTION
## What

User-reported: NWC wallet balances and history no longer loading. Reproduced with a local relay + fake NWC wallet harness driving the real app code — three stacked breaks, all in `nwc.ts`, all triggered by dependency drift:

1. **`getPublicKey` needs bytes** — nostr-tools 2.25.2 (the #664 upgrade) requires `Uint8Array`; nwc.ts passed a hex string with `as any`. Every NIP-47 request threw `"expected Uint8Array, got type=string"` before leaving the client. This is the error in the user's console.
2. **Inverted relay status checks** — NDK 2.10's `NDKRelayStatus` is `DISCONNECTED=1, CONNECTED=5`; `status === 1` was checked as "connected" everywhere. `isNwcConnected()` returned false once the relay actually connected, so every call after the first threw "NWC not connected".
3. **Grouped response subscriptions** — NDK's groupable fingerprint hashes filter *keys* only, so all kind-23195 response subscriptions merged into one relay subscription holding the first request's `#e`. History/info requests timed out waiting for responses that could never match. Fixed with `groupable: false` + unique `subId` per request.

## Verification

Fake wallet + local relay (NIP-47 over NIP-04, separate client/wallet keys), driving the real `nwc.ts` in the browser:

| call | before | after |
|---|---|---|
| get_balance | threw `expected Uint8Array` | **123 sats** |
| list_transactions | "NWC not connected" / timeout | **2 txs, descriptions intact** |
| get_info | timeout | **alias returned** |

Sequential over one connection; each response delivered to exactly its own subscription (verified in relay logs). `vitest src/lib`: 103/103 files, 1405 tests; `svelte-check` baseline-identical; production build green.