### PR TITLE
fix(engagement): attribute reactions to their NIP-10 target, not any e-tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.755",
+  "version": "4.2.756",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/Reactions/ReactionButton.svelte
+++ b/src/components/Reactions/ReactionButton.svelte
@@ -6,6 +6,7 @@
   import { aggregateReactions } from '$lib/reactionAggregator';
   import { publishReaction, canPublishReaction } from '$lib/reactions/publishReaction';
   import { fetchCount } from '$lib/countQuery';
+  import { targetsEvent } from '$lib/engagementTarget';
   import EmojiReactionPicker from './EmojiReactionPicker.svelte';
   import FullEmojiPicker from './FullEmojiPicker.svelte';
   import HeartIcon from 'phosphor-svelte/lib/Heart';
@@ -119,6 +120,10 @@
       subscription.on('event', (e: NDKEvent) => {
         if (myToken !== currentLoadToken) return;
         if (!e.id || processedIds.has(e.id)) return;
+        // The '#e' filter matches context e-tags too; only the effective
+        // NIP-10 target's note counts. Recipes match via '#a' and their
+        // reactions may carry no e tag at all, so they are exempt.
+        if (targetType !== 'recipe' && !targetsEvent(e.tags, event.id)) return;
         processedIds.add(e.id);
         reactionEvents = [...reactionEvents, e];
         processEvents();

--- a/src/lib/engagementCache.ts
+++ b/src/lib/engagementCache.ts
@@ -4,6 +4,7 @@ import NDK, { NDKRelaySet } from '@nostr-dev-kit/ndk';
 import { browser } from '$app/environment';
 import { getEngagementCounts, batchFetchFromServerAPI } from './countQuery';
 import { extractZapAmountSats } from './zapAmount';
+import { getEngagementTargetId, engagementTargetsNote } from './engagementTarget';
 
 // Aggregator relays that index zap receipts — LNURL providers publish kind:9735
 // to these relays, which may not overlap with the app's default relay set.
@@ -263,8 +264,10 @@ function applyEngagementEvent(
       processZap(data, event, userPubkey, targetEventId);
       break;
     case 1: // Comment
-      // Only count as comment if it's replying to this event
-      if (event.tags.some(t => t[0] === 'e' && t[1] === targetEventId)) {
+      // Only count as comment when this note is the reply's effective
+      // NIP-10 target — a reply to a reply also carries the root and any
+      // intermediary e-tags, and must not inflate their comment counts.
+      if (engagementTargetsNote(event.tags, event.kind, targetEventId)) {
         data.comments.count++;
       }
       break;
@@ -640,6 +643,13 @@ export async function fetchEngagement(
 
       // Mark subscription as active on new events
       touchEngagementSubscription(eventId);
+
+      // The '#e' filter matches events that mention eventId in ANY e-tag
+      // position. Clients that publish reactions/zaps with full thread
+      // context ([root, intermediary, target]) would otherwise be counted
+      // as engaging with every note they mention — only count events whose
+      // effective NIP-10 target is this note.
+      if (!engagementTargetsNote(event.tags, event.kind, eventId)) return;
 
       queueEngagementEvent(eventId, event, userPublickey);
     });
@@ -1277,9 +1287,17 @@ export async function batchFetchEngagement(
     const sub = ndk.subscribe(filter, { closeOnEose: true });
     
     sub.on('event', (event: NDKEvent) => {
-      // Find which target event this is for
-      const targetEventId = event.tags.find(t => t[0] === 'e' && toFetch.includes(t[1]))?.[1];
-      if (!targetEventId) return;
+      // Route by the event's effective NIP-10 target. Matching on the
+      // first e-tag in `toFetch` mis-routes context-tagged events
+      // ([root, intermediary, target]) to their root, and matching any
+      // position counts them against every note they mention. Zap
+      // receipts keep any-position matching (see engagementTargetsNote).
+      const routedId =
+        event.kind === 9735
+          ? event.tags.find((t) => t[0] === 'e' && toFetch.includes(t[1]))?.[1]
+          : getEngagementTargetId(event.tags);
+      if (!routedId || !toFetch.includes(routedId)) return;
+      const targetEventId = routedId;
 
       const processed = processedEventIds.get(targetEventId);
       if (!processed || !event.id || processed.has(event.id)) return;

--- a/src/lib/engagementTarget.test.ts
+++ b/src/lib/engagementTarget.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { getEngagementTargetId, targetsEvent, engagementTargetsNote } from './engagementTarget';
+
+// Live payload shape from the bug report (Damus reaction to a reply,
+// carrying root + intermediary context): the reaction targets the LAST
+// tag, not the root or the intermediary it passes through.
+const ROOT = '169c9e5206f57472048a4f7f33cf518c7bd88c45fc6f5d7db3d3b7b934f213f1';
+const INTERMEDIARY = '5642ad912c9658ea4e99cd73fbfd4b2d3202ace97c2bb7809e6f0a8d95de80e8';
+const TARGET = '5516783eb01000000000000000000000000000000000000000000000000dead';
+
+describe('getEngagementTargetId', () => {
+  it('uses the last positional tag for context-tagged events', () => {
+    const tags = [
+      ['e', ROOT, 'wss://eden.nostr.land'],
+      ['e', INTERMEDIARY, ''],
+      ['e', TARGET, ''],
+      ['p', 'aa'.repeat(32)]
+    ];
+    expect(getEngagementTargetId(tags)).toBe(TARGET);
+  });
+
+  it('prefers a reply-marked tag over positional ones', () => {
+    const tags = [
+      ['e', ROOT, '', 'root'],
+      ['e', TARGET, '', 'reply']
+    ];
+    expect(getEngagementTargetId(tags)).toBe(TARGET);
+  });
+
+  it('returns the only tag for a single-tag reaction', () => {
+    expect(getEngagementTargetId([['e', TARGET], ['p', 'ff'.repeat(32)]])).toBe(TARGET);
+  });
+
+  it('returns the last positional tag even when a root marker is present', () => {
+    const tags = [
+      ['e', ROOT, '', 'root'],
+      ['e', TARGET]
+    ];
+    expect(getEngagementTargetId(tags)).toBe(TARGET);
+  });
+
+  it('falls back to a lone root-marked tag', () => {
+    expect(getEngagementTargetId([['e', ROOT, '', 'root']])).toBe(ROOT);
+  });
+
+  it('never targets mention-marked tags', () => {
+    const tags = [
+      ['e', ROOT, '', 'root'],
+      ['e', INTERMEDIARY, '', 'mention']
+    ];
+    // No positional or reply tag exists; degenerate fallback is the last
+    // e tag overall — document that behavior explicitly.
+    expect(getEngagementTargetId(tags)).toBe(INTERMEDIARY);
+  });
+
+  it('returns null when there are no e tags', () => {
+    expect(getEngagementTargetId([['p', 'ff'.repeat(32)]])).toBeNull();
+    expect(getEngagementTargetId(undefined)).toBeNull();
+    expect(getEngagementTargetId([])).toBeNull();
+  });
+
+  it('ignores malformed tags', () => {
+    const tags = [['e'], ['e', ''], ['e', TARGET]] as string[][];
+    expect(getEngagementTargetId(tags)).toBe(TARGET);
+  });
+});
+
+describe('targetsEvent', () => {
+  const contextReaction = [
+    ['e', ROOT, 'wss://eden.nostr.land'],
+    ['e', INTERMEDIARY, ''],
+    ['e', TARGET, '']
+  ];
+
+  it('accepts the effective target only', () => {
+    expect(targetsEvent(contextReaction, TARGET)).toBe(true);
+    expect(targetsEvent(contextReaction, INTERMEDIARY)).toBe(false);
+    expect(targetsEvent(contextReaction, ROOT)).toBe(false);
+  });
+
+  it('rejects when there are no e tags', () => {
+    expect(targetsEvent([['p', 'ff'.repeat(32)]], TARGET)).toBe(false);
+  });
+});
+
+describe('engagementTargetsNote', () => {
+  const contextReaction = [
+    ['e', ROOT, 'wss://eden.nostr.land'],
+    ['e', INTERMEDIARY, ''],
+    ['e', TARGET, '']
+  ];
+
+  it('applies the strict rule to reactions and comments', () => {
+    expect(engagementTargetsNote(contextReaction, 7, TARGET)).toBe(true);
+    expect(engagementTargetsNote(contextReaction, 7, ROOT)).toBe(false);
+    expect(engagementTargetsNote(contextReaction, 1, INTERMEDIARY)).toBe(false);
+  });
+
+  it('keeps any-position matching for zap receipts', () => {
+    expect(engagementTargetsNote(contextReaction, 9735, ROOT)).toBe(true);
+    expect(engagementTargetsNote(contextReaction, 9735, INTERMEDIARY)).toBe(true);
+    expect(engagementTargetsNote([['p', 'ff'.repeat(32)]], 9735, ROOT)).toBe(false);
+  });
+});

--- a/src/lib/engagementTarget.ts
+++ b/src/lib/engagementTarget.ts
@@ -1,0 +1,66 @@
+/**
+ * NIP-10 engagement-target resolution.
+ *
+ * Some clients (e.g. Damus) publish reactions, reposts and zaps with full
+ * thread context in their `e` tags — [root, intermediary, target] — instead
+ * of the single target tag NIP-25/18/57 prescribe. A relay `#e` filter
+ * matches an event when the id appears in ANY tag position, so counting
+ * everything a `#e` subscription returns attributes context-tagged events
+ * to every note they mention: a reaction to one reply shows up as a
+ * reaction on its root and on every intermediary reply. To attribute an
+ * engagement event to a note, the note must be the event's effective
+ * target, resolved here:
+ *
+ *   1. the first `e` tag marked `reply` (NIP-10 marker form)
+ *   2. else the last positional (unmarked) `e` tag — NIP-10's deprecated
+ *      positional form, where the last tag is the replied-to event
+ *   3. else the last `e` tag overall (degenerate single `root`-marked tag)
+ *
+ * `root`- and `mention`-marked tags are never targets.
+ */
+
+type Tag = string[];
+
+export function getEngagementTargetId(tags: Tag[] | undefined): string | null {
+  if (!tags) return null;
+
+  let lastPositional: string | null = null;
+  let lastAny: string | null = null;
+
+  for (const tag of tags) {
+    if (!Array.isArray(tag) || tag[0] !== 'e' || typeof tag[1] !== 'string') continue;
+    lastAny = tag[1];
+    if (tag[3] === 'reply') return tag[1];
+    if (tag[3] === undefined || tag[3] === '') lastPositional = tag[1];
+  }
+
+  return lastPositional ?? lastAny;
+}
+
+/**
+ * True when `eventTags` make `noteId` the effective engagement target —
+ * i.e. the event is a reaction/repost/zap/comment ON this note, not merely
+ * one that mentions it as thread context.
+ *
+ * Zap receipts (kind 9735) are exempt: NIP-57 documents no ordering for
+ * multi-e receipts, so any e-tag match counts for them exactly as it did
+ * before this helper existed.
+ */
+export function engagementTargetsNote(
+  tags: Tag[] | undefined,
+  kind: number | undefined,
+  noteId: string
+): boolean {
+  if (kind === 9735) {
+    return !!tags?.some((tag) => Array.isArray(tag) && tag[0] === 'e' && tag[1] === noteId);
+  }
+  return getEngagementTargetId(tags) === noteId;
+}
+
+/**
+ * Strict form used where the kind is already known to be a reaction or
+ * repost: the note must be the effective NIP-10/NIP-25 target.
+ */
+export function targetsEvent(tags: Tag[] | undefined, noteId: string): boolean {
+  return getEngagementTargetId(tags) === noteId;
+}

--- a/src/lib/postEngagementDetails.test.ts
+++ b/src/lib/postEngagementDetails.test.ts
@@ -67,4 +67,41 @@ describe('aggregatePostEngagementEvents', () => {
     ]);
     warn.mockRestore();
   });
+
+  it('excludes context-tagged events when a targetEventId is given', () => {
+    const root = 'root'.padEnd(64, '0');
+    const target = 'target'.padEnd(64, '1');
+    const elsewhere = 'elsewhere'.padEnd(64, '2');
+    // Damus-style reaction to `elsewhere` that carries [root, target,
+    // elsewhere] — `target` appears only as thread context
+    const contextReaction = event(
+      'ctx',
+      7,
+      'alice',
+      '🤙',
+      [['e', root, 'wss://eden.nostr.land'], ['e', target, ''], ['e', elsewhere, '']]
+    );
+    const directReaction = event('direct', 7, 'bob', '💯', [['e', target]]);
+
+    const withTarget = aggregatePostEngagementEvents(
+      [contextReaction, directReaction],
+      [],
+      target
+    );
+    expect(withTarget.reactions).toEqual([{ emoji: '💯', pubkeys: ['bob'] }]);
+
+    const onRoot = aggregatePostEngagementEvents([contextReaction], [], root);
+    expect(onRoot.reactions).toEqual([]);
+
+    // The reaction does credit its effective target, `elsewhere`
+    const onElsewhere = aggregatePostEngagementEvents([contextReaction], [], elsewhere);
+    expect(onElsewhere.reactions).toEqual([{ emoji: '🤙', pubkeys: ['alice'] }]);
+
+    // Without a targetEventId (legacy callers) behavior is unchanged
+    const unfiltered = aggregatePostEngagementEvents([contextReaction, directReaction]);
+    expect(unfiltered.reactions).toEqual([
+      { emoji: '💯', pubkeys: ['bob'] },
+      { emoji: '🤙', pubkeys: ['alice'] }
+    ]);
+  });
 });

--- a/src/lib/postEngagementDetails.ts
+++ b/src/lib/postEngagementDetails.ts
@@ -5,6 +5,7 @@ import NDK, {
   type NDKRelay
 } from '@nostr-dev-kit/ndk';
 import { extractZapAmountSats } from './zapAmount';
+import { engagementTargetsNote } from './engagementTarget';
 
 const DETAIL_CACHE_TTL = 2 * 60 * 1000;
 const DETAIL_FETCH_TIMEOUT = 4500;
@@ -82,7 +83,8 @@ function parseZapDetail(event: NDKEvent): ZapDetail | null {
 
 export function aggregatePostEngagementEvents(
   events: Iterable<NDKEvent>,
-  relayUrls: Iterable<string> = []
+  relayUrls: Iterable<string> = [],
+  targetEventId?: string
 ): PostEngagementDetails {
   const reactions = new Map<string, Set<string>>();
   const reposts = new Set<string>();
@@ -90,6 +92,11 @@ export function aggregatePostEngagementEvents(
 
   for (const event of events) {
     if (!event.id) continue;
+
+    // Engagement events can carry thread-context e-tags ([root,
+    // intermediary, target]); only the effective target's note gets the
+    // credit. See engagementTargetsNote in engagementTarget.ts.
+    if (targetEventId && !engagementTargetsNote(event.tags, event.kind, targetEventId)) continue;
 
     if (event.kind === 7) {
       const emoji = reactionEmoji(event.content);
@@ -178,7 +185,7 @@ export async function loadPostEngagementDetails(
   ]);
 
   const emitUpdate = () => {
-    const details = aggregatePostEngagementEvents(events.values(), relays);
+    const details = aggregatePostEngagementEvents(events.values(), relays, targetEvent.id);
     onUpdate?.(details);
     return details;
   };
@@ -218,7 +225,7 @@ export async function loadPostEngagementDetails(
     sub.on('event', (event, relay) => {
       if (event.id === targetEvent.id) {
         recordRelay(relay);
-      } else if (event.id) {
+      } else if (event.id && engagementTargetsNote(event.tags, event.kind, targetEvent.id)) {
         events.set(event.id, event);
       }
       emitUpdate();


### PR DESCRIPTION
## What

Some clients (Damus and others) publish kind-7 reactions with **full thread context e-tags** — `[root, intermediary, target]` — instead of the single target tag NIP-25 prescribes. A relay `#e` filter matches when the id appears in **any** tag position, so every engagement collection site was counting context-tagged events against **every note they mention**: a reaction to one reply showed up on its root and on every intermediary reply.

Reported as `reactions showing up on the wrong events` on a thread — confirmed on-wire: kidwarp's 🤙 reaction to Daniel's reply carried `e:[root, kidwarps-reply, daniels-reply]` and rendered as a reaction on kidwarp's own reply (which already had Daniel's legit 💯 → 💯×2 with a stray 🤙).

## Fix

New shared helper `src/lib/engagementTarget.ts` resolves an engagement event's effective target per NIP-10/NIP-25:

1. first `e` tag marked `reply`
2. else the last positional (unmarked) `e` tag
3. `root`/`mention`-marked tags are never targets

Applied before counting at every collection site:

| site | fix |
|---|---|
| `engagementCache` persistent per-note sub | verify target before queueing |
| `engagementCache` batched fetch routing | route by effective target (was: **first** e-tag in batch — mis-routed context events to their root) |
| `engagementCache` kind-1 comment count | effective-target check (was: `tags.some` — a reply to a reply inflated every mentioned note's comment count) |
| `postEngagementDetails` panel | filter at collection + aggregation |
| `ReactionButton` pills / user-reacted | strict check for note targets; recipe `#a` reactions exempt (they carry no e-tag) |

**Zap receipts (9735) keep any-position matching** — NIP-57 documents no multi-e ordering, so strict targeting could drop legit zaps.

## Verification

- 13 new unit tests (helper + aggregator filtering); full suite **1418 passed** (104 files)
- `pnpm check` at baseline (1 pre-existing renewalRetry error); `pnpm build` clean
- **Live on the reporting thread** (dev server, real relays): kidwarp's reply now shows only the 💯 that targets it; the context-tagged 🤙 now renders on the reply it actually reacted to; comment counts per note match their direct replies only