### PR TITLE
fix(articles): hide imageless hero, add publish date, mono rail placeholder mark

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.756",
+  "version": "4.2.757",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/AuthorProfile.svelte
+++ b/src/components/AuthorProfile.svelte
@@ -1,14 +1,28 @@
 <script lang="ts">
   import { nip19 } from 'nostr-tools';
+  import { format } from 'date-fns';
   import Avatar from './Avatar.svelte';
   import CustomName from './CustomName.svelte';
 
   export let pubkey: string;
+  /** Event created_at (seconds) — shown as a publish date under the
+   * name when provided, e.g. on article/recipe pages. */
+  export let timestamp: number | undefined = undefined;
 </script>
 
 <div class="flex gap-4 items-center">
   <a href="/user/{nip19.npubEncode(pubkey)}" class="flex gap-4 self-center">
     <Avatar className="self-center" {pubkey} size={56} />
-    <CustomName className="self-center" {pubkey} />
+    <span class="flex flex-col self-center">
+      <CustomName className="self-center" {pubkey} />
+      {#if timestamp}
+        <span
+          class="text-caption mt-0.5"
+          title={new Date(timestamp * 1000).toLocaleString()}
+        >
+          {format(timestamp * 1000, 'MMM d, yyyy')}
+        </span>
+      {/if}
+    </span>
   </a>
 </div>

--- a/src/components/Recipe/Recipe.svelte
+++ b/src/components/Recipe/Recipe.svelte
@@ -646,14 +646,19 @@
     carouselEl.scrollBy({ left: width, behavior: 'smooth' });
   }
 
-  // Deduplicate image tags by URL, use placeholder if no images or all images are empty
+  // Deduplicate image tags by URL, use placeholder if no images or all images are empty.
+  // General long-form articles are the exception: the stock placeholder
+  // reads fine at thumbnail size but not as a full-width hero, so articles
+  // without a real image get no carousel at all (the render guards on
+  // length). Recipes keep the placeholder — a cooking post without a
+  // photo is still expected to show one.
   $: uniqueImages = (() => {
     const images = event.tags
       .filter((e) => e[0] === 'image' && e[1] && e[1].trim() !== '')
       .filter((img, index, arr) => arr.findIndex((t) => t[1] === img[1]) === index);
-    // If no valid images, return a placeholder
+    // If no valid images, return a placeholder (recipes only)
     if (images.length === 0) {
-      return [['image', getPlaceholderImage(event.id)]];
+      return isActualRecipe ? [['image', getPlaceholderImage(event.id)]] : [];
     }
     return images;
   })();
@@ -808,7 +813,7 @@
         <!-- Author + Action Buttons Row -->
         <div class="flex justify-between items-center gap-4">
           <!-- Left: Author Profile -->
-          <AuthorProfile pubkey={event.author.pubkey} />
+          <AuthorProfile pubkey={event.author.pubkey} timestamp={event.created_at} />
 
           <!-- Right: Save button -->
           <div class="flex gap-2">

--- a/src/components/ZapMarkMono.svelte
+++ b/src/components/ZapMarkMono.svelte
@@ -1,0 +1,37 @@
+<!--
+  Monochrome zap ring mark — the favicon/badge geometry (ring + bolt)
+  in a single currentColor, no gradient disc and no shine. Used where a
+  quiet placeholder mark is needed (e.g. empty article rail thumbnails).
+  Fills the parent container; it scales to whatever box it's given.
+-->
+<div class="zap-mark-mono">
+  <svg viewBox="0 0 382 382" fill="none" aria-hidden="true">
+    <path
+      class="zap-mono-bolt"
+      fill="currentColor"
+      d="M221.87 96.87C219.23 95.53 216.2 96.16 214.32 98.45L125.94 206.16C124.41 208.02 124.1 210.53 125.13 212.7C126.16 214.88 128.29 216.23 130.7 216.23H172.61L172.81 216.49L156.56 279.01C155.82 281.88 157.09 284.71 159.73 286.05C160.65 286.52 161.62 286.75 162.57 286.75C164.34 286.75 166.06 285.96 167.28 284.47L255.66 176.76C257.19 174.9 257.5 172.39 256.47 170.22C255.44 168.04 253.31 166.69 250.9 166.69H208.99L208.79 166.43L225.04 103.91C225.78 101.04 224.51 98.21 221.87 96.87Z"
+    />
+    <path
+      class="zap-mono-ring"
+      fill="currentColor"
+      fill-rule="evenodd"
+      d="M191 0C296.486 0 382 85.514 382 191C382 296.486 296.486 382 191 382C85.514 382 0 296.486 0 191C0 85.514 85.514 0 191 0ZM303.113 79.249C241.291 17.438 141.07 17.438 79.258 79.249C17.446 141.071 17.446 241.294 79.258 303.105C141.08 364.917 241.302 364.917 303.113 303.105C364.925 241.284 364.925 141.061 303.113 79.249Z"
+    />
+  </svg>
+</div>
+
+<style>
+  .zap-mark-mono {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    aspect-ratio: 1;
+  }
+  .zap-mark-mono svg {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+</style>

--- a/src/routes/reads/[naddr]/+page.svelte
+++ b/src/routes/reads/[naddr]/+page.svelte
@@ -10,6 +10,7 @@
   import ShareModal from '../../../components/ShareModal.svelte';
   import RightRail from '../../../components/RightRail.svelte';
   import RailCard from '../../../components/RailCard.svelte';
+  import ZapMarkMono from '../../../components/ZapMarkMono.svelte';
   import { RECIPE_TAGS, isHiddenRecipeEvent } from '$lib/consts';
   import { validateMarkdownTemplate } from '$lib/parser';
   import ArrowLeftIcon from 'phosphor-svelte/lib/ArrowLeft';
@@ -294,7 +295,9 @@
                 <span
                   class="reads-rail-thumb"
                   style:background-image={a.image ? `url('${a.image}')` : 'none'}
-                ></span>
+                >
+                  {#if !a.image}<span class="reads-rail-thumb-mark"><ZapMarkMono /></span>{/if}
+                </span>
                 <span class="reads-rail-title">{a.title}</span>
               </a>
             {/each}
@@ -307,7 +310,9 @@
                 <span
                   class="reads-rail-thumb"
                   style:background-image={r.image ? `url('${r.image}')` : 'none'}
-                ></span>
+                >
+                  {#if !r.image}<span class="reads-rail-thumb-mark"><ZapMarkMono /></span>{/if}
+                </span>
                 <span class="reads-rail-title">{r.title}</span>
               </a>
             {/each}
@@ -362,6 +367,17 @@
     background-color: var(--color-input-bg);
     background-size: cover;
     background-position: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  /* Monochrome zap mark shown when the article has no image, so the
+     thumb reads as a deliberate placeholder instead of an empty box. */
+  .reads-rail-thumb-mark {
+    width: 1.375rem;
+    height: 1.375rem;
+    color: var(--color-caption);
+    opacity: 0.55;
   }
   .reads-rail-title {
     font-size: 0.875rem;


### PR DESCRIPTION
## What

Three article-page presentation fixes, reported from https://zap.cooking/reads/naddr1qvzqqqr4gupzpmnw5yatnljuff5w47d35d87q99xddqpzlzsac4xzn6vm22ekmn5qqrrxdpn8ymnwxej6hu:

### 1. No more stock placeholder as a full-size hero
Articles without an `image` tag were rendering a random stock food photo as a full-width `aspect-video` hero (via `uniqueImages` falling back to `getPlaceholderImage`). The placeholder is fine at thumbnail size, wrong at full size — imageless articles now omit the carousel entirely. **Recipes keep the placeholder** (a cooking post is still expected to show a photo; discriminator is the existing `isActualRecipe` check).

### 2. Publish date in the header
Article pages showed no timestamp at all. `AuthorProfile` gains an optional `timestamp` prop rendering the event's `created_at` under the author name as an absolute date (`MMM d, yyyy`, e.g. "Dec 8, 2023") with the full date/time in a tooltip. All other `AuthorProfile` callers are unaffected.

### 3. Monochrome zap mark in empty rail thumbnails
Empty "More from this author/chef" thumbnails were plain gray boxes. They now show the favicon's ring+bolt geometry in a single muted `currentColor` (new `ZapMarkMono.svelte`, same paths as `ZapRingBadge`/favicon — no gradient, no shine).

## Verification
- `pnpm check` at baseline (1 pre-existing error), full suite **1418 passed**, `pnpm build` clean
- Live on the reporting article: no hero block, "Dec 8, 2023" under the author name, rail shows photos for imaged posts and the mono mark for the 2 imageless ones
- Regression-checked on a with-image article: real heroes still render (thumbnails/cards untouched)