### PR TITLE
fix(deep-links): route event fetches through explicit relay set

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.757",
+  "version": "4.2.758",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.758",
+  "version": "4.2.759",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/authorContent.ts
+++ b/src/lib/authorContent.ts
@@ -9,6 +9,7 @@ import type NDK from '@nostr-dev-kit/ndk';
 import type { NDKEvent } from '@nostr-dev-kit/ndk';
 import { nip19 } from 'nostr-tools';
 import { RECIPE_TAGS, isHiddenRecipeEvent } from '$lib/consts';
+import { buildPoolRelaySet } from '$lib/eventFetch';
 
 export interface AuthorRailItem {
   naddr: string;
@@ -34,11 +35,17 @@ export async function fetchAuthorContent(
   if (!ndk || !pubkey) return split;
 
   try {
-    const events = await ndk.fetchEvents({
-      kinds: [30023],
-      authors: [pubkey],
-      limit: FETCH_LIMIT
-    });
+    // Explicit relay set — author-filtered fetches on a cold pool can
+    // compute an empty relay set via the outbox tracker (see eventFetch).
+    const events = await ndk.fetchEvents(
+      {
+        kinds: [30023],
+        authors: [pubkey],
+        limit: FETCH_LIMIT
+      },
+      undefined,
+      buildPoolRelaySet(ndk)
+    );
 
     // Newest-first so each type's top-5 are the author's most recent.
     const sorted = [...events].sort((a, b) => (b.created_at || 0) - (a.created_at || 0));

--- a/src/lib/eventFetch.ts
+++ b/src/lib/eventFetch.ts
@@ -1,0 +1,72 @@
+import type NDK from '@nostr-dev-kit/ndk';
+import { NDKRelaySet, type NDKEvent, type NDKFilter } from '@nostr-dev-kit/ndk';
+
+/**
+ * Single-event fetch with an explicit relay set.
+ *
+ * Why not plain `ndk.fetchEvent(filter)`: with the outbox model enabled,
+ * NDK routes author-filtered REQs through the outbox tracker. When the
+ * author's write relays are unknown (first time seeing this author) the
+ * tracker falls back to connected pool relays — and during a cold
+ * deep-link that set is empty, so the computed relay set is EMPTY: the
+ * REQ is never sent, no EOSE ever arrives beyond the first-connecting
+ * relay (which often doesn't have the event), and fetchEvent resolves
+ * null after its 10s timeout. The page then shows "not found" for
+ * content that relays actually hold.
+ *
+ * Passing an explicit relay set bypasses that computation entirely:
+ * NDKSubscription.startWithRelays sends the filters to every relay in
+ * the set, and each relay-level subscription waits for its relay to
+ * finish connecting before issuing the REQ.
+ */
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+function normalizeRelayUrl(url: string): string {
+  return url.trim().replace(/\/+$/, '');
+}
+
+export interface FetchEventOptions {
+  /** Extra relay URLs (e.g. bech32 relay hints) merged into the set. */
+  hintRelayUrls?: string[];
+  /** Overall timeout; resolves null when exceeded. Default 10s. */
+  timeoutMs?: number;
+}
+
+export function buildPoolRelaySet(ndk: NDK, hintRelayUrls: string[] = []): NDKRelaySet | undefined {
+  const urls = new Set<string>();
+
+  for (const url of ndk.explicitRelayUrls ?? []) urls.add(normalizeRelayUrl(url));
+  // Include pool relays still mid-connect so their REQs queue up rather
+  // than race the connection. `relays` is a Map on NDKRelayPool; guard
+  // for API shape differences across NDK versions.
+  const poolUrls = ndk.pool?.relays?.keys?.() ?? [];
+  for (const url of poolUrls) urls.add(normalizeRelayUrl(url));
+
+  for (const url of hintRelayUrls) {
+    if (typeof url === 'string' && url.startsWith('wss://')) {
+      urls.add(normalizeRelayUrl(url));
+    }
+  }
+
+  if (urls.size === 0) return undefined;
+  // addConnectedRelays=true would re-add the connected pool relays; the
+  // set already carries the full pool, so keep it exact.
+  return NDKRelaySet.fromRelayUrls([...urls], ndk, false);
+}
+
+export async function fetchEventWithRelayHints(
+  ndk: NDK,
+  filter: NDKFilter,
+  options: FetchEventOptions = {}
+): Promise<NDKEvent | null> {
+  const relaySet = buildPoolRelaySet(ndk, options.hintRelayUrls);
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const fetchPromise = ndk.fetchEvent(filter, {}, relaySet);
+  const timeoutPromise = new Promise<null>((resolve) => {
+    setTimeout(() => resolve(null), timeoutMs);
+  });
+
+  return Promise.race([fetchPromise, timeoutPromise]);
+}

--- a/src/routes/reads/[naddr]/+page.svelte
+++ b/src/routes/reads/[naddr]/+page.svelte
@@ -17,12 +17,15 @@
   import ShareFatIcon from 'phosphor-svelte/lib/ShareFat';
   import { stripTrackingParams } from '$lib/utils/stripTrackingParams';
   import { fetchAuthorContent } from '$lib/authorContent';
+  import { fetchEventWithRelayHints } from '$lib/eventFetch';
 
   let event: NDKEvent | null = null;
   let naddr: string = '';
   let loading = true;
   let error: string | null = null;
   let shareModalOpen = false;
+  // Single-flight token for loadData (see guard inside).
+  let lastRequestedSlug = '';
 
   // "More from this author / this chef" rails — one fetch, both types.
   let moreArticles: { naddr: string; title: string; image: string; href: string }[] = [];
@@ -56,14 +59,20 @@
   }
 
   async function loadData() {
-    if (!$page.params.naddr) return;
+    const slug = $page.params.naddr;
+    if (!slug) return;
+
+    // Single-flight: the reactive block re-runs on every `$page` store
+    // emission (URL cleanups, layout state), and each run used to start
+    // a fresh fetch whose null result could clobber an already-loaded
+    // article with "Article not found".
+    if (slug === lastRequestedSlug && (loading || event)) return;
+    lastRequestedSlug = slug;
 
     loading = true;
     error = null;
 
     try {
-      const slug = $page.params.naddr;
-
       if (slug.startsWith('naddr1')) {
         const a = nip19.decode(slug);
         if (a.type !== 'naddr') {
@@ -78,17 +87,21 @@
           kind: 30023
         });
 
-        // Add timeout protection for article loading
-        const fetchPromise: Promise<NDKEvent | null> = $ndk.fetchEvent({
-          '#d': [b.identifier],
-          authors: [b.pubkey],
-          kinds: [30023]
-        });
-        const timeoutPromise = new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error('Article loading timeout - relays may be unreachable')), 10000)
+        // Add timeout protection for article loading. The explicit relay
+        // set (pool + the naddr's bech32 relay hints) routes around the
+        // cold-start race where NDK's outbox tracker returns an empty
+        // relay set for an unknown author and the REQ is never sent.
+        const e = await fetchEventWithRelayHints(
+          $ndk,
+          {
+            '#d': [b.identifier],
+            authors: [b.pubkey],
+            kinds: [30023]
+          },
+          { hintRelayUrls: b.relays, timeoutMs: 10_000 }
         );
-
-        const e = await Promise.race<NDKEvent | null>([fetchPromise, timeoutPromise]);
+        // The user may have navigated away while we fetched.
+        if ($page.params.naddr !== slug) return;
         if (e) {
           // Reject recipe-shaped events; anything else is treated as an article
           const hasRecipeTag = e.tags.some(
@@ -113,6 +126,12 @@
         throw new Error('Invalid article URL format');
       }
     } catch (err) {
+      // Don't clobber a loaded article with a stale failure (e.g. the
+      // fetch raced a navigation or a second loadData call).
+      if ($page.params.naddr !== slug || event) {
+        loading = false;
+        return;
+      }
       loading = false;
       error = err instanceof Error ? err.message : 'Failed to load article';
       event = null;

--- a/src/routes/recipe/[slug]/+page.svelte
+++ b/src/routes/recipe/[slug]/+page.svelte
@@ -19,11 +19,14 @@
   import { getRecipeOgMeta } from '$lib/recipeOgMeta';
   import { stripTrackingParams } from '$lib/utils/stripTrackingParams';
   import { fetchAuthorContent } from '$lib/authorContent';
+  import { fetchEventWithRelayHints } from '$lib/eventFetch';
 
   let event: NDKEvent | null = null;
   let naddr: string = '';
   let loading = true;
   let error: string | null = null;
+  // Single-flight token for loadData (see guard inside).
+  let lastRequestedSlug = '';
 
   // "More from this chef / this author" rails — one fetch, both types.
   let moreRecipes: { naddr: string; title: string; image: string; href: string }[] = [];
@@ -53,14 +56,21 @@
   }
 
   async function loadData() {
-    if (!$page.params.slug) return;
+    const slug = $page.params.slug;
+    if (!slug) return;
+
+    // Single-flight: the reactive block re-runs on every `$page` store
+    // emission; a duplicate run's null result could clobber an
+    // already-loaded recipe.
+    if (slug === lastRequestedSlug && (loading || event)) return;
+    lastRequestedSlug = slug;
 
     loading = true;
     error = null;
 
     try {
-      if ($page.params.slug.startsWith('naddr1')) {
-        const a = nip19.decode($page.params.slug);
+      if (slug.startsWith('naddr1')) {
+        const a = nip19.decode(slug);
         if (a.type !== 'naddr') {
           throw new Error('Invalid naddr format');
         }
@@ -82,20 +92,19 @@
           kind: recipeKind
         });
 
-        // Add timeout protection for recipe loading
-        const fetchPromise: Promise<NDKEvent | null> = $ndk.fetchEvent({
-          '#d': [b.identifier],
-          authors: [b.pubkey],
-          kinds: [recipeKind as number]
-        });
-        const timeoutPromise = new Promise<never>((_, reject) =>
-          setTimeout(
-            () => reject(new Error('Recipe loading timeout - relays may be unreachable')),
-            10000
-          )
+        // Explicit relay set (pool + naddr hints) — plain fetchEvent on a
+        // cold pool can compute an empty relay set for unknown authors
+        // and never send the REQ (see eventFetch.ts).
+        const e = await fetchEventWithRelayHints(
+          $ndk,
+          {
+            '#d': [b.identifier],
+            authors: [b.pubkey],
+            kinds: [recipeKind as number]
+          },
+          { hintRelayUrls: b.relays, timeoutMs: 10_000 }
         );
-
-        const e = await Promise.race<NDKEvent | null>([fetchPromise, timeoutPromise]);
+        if ($page.params.slug !== slug) return;
         if (e) {
           event = e;
           loading = false;
@@ -104,16 +113,14 @@
           error = 'Recipe not found';
         }
       } else {
-        // Add timeout protection for direct event ID loading
-        const fetchPromise: Promise<NDKEvent | null> = $ndk.fetchEvent($page.params.slug);
-        const timeoutPromise = new Promise<never>((_, reject) =>
-          setTimeout(
-            () => reject(new Error('Recipe loading timeout - relays may be unreachable')),
-            10000
-          )
-        );
-
-        const e = await Promise.race<NDKEvent | null>([fetchPromise, timeoutPromise]);
+        // Direct event-ID (note1/nevent1) loading. These resolve to
+        // ids-based filters inside NDK, which always go to the explicit
+        // relay list — no empty-relay-set race here; just a timeout.
+        const e = await Promise.race<NDKEvent | null>([
+          $ndk.fetchEvent(slug),
+          new Promise<null>((resolve) => setTimeout(() => resolve(null), 10_000))
+        ]);
+        if ($page.params.slug !== slug) return;
         if (e) {
           if (isHiddenRecipeEvent(e)) {
             loading = false;
@@ -140,6 +147,11 @@
         }
       }
     } catch (err) {
+      // Don't clobber a loaded recipe with a stale failure.
+      if ($page.params.slug !== slug || event) {
+        loading = false;
+        return;
+      }
       loading = false;
       error = err instanceof Error ? err.message : 'Failed to load recipe';
       event = null;


### PR DESCRIPTION
## What

Cold deep-links to `/reads` and `/recipe` intermittently showed **"Article/Recipe not found"** for content relays actually hold.

**Root cause** (found by instrumented reproduction): with NDK's outbox model enabled, author-filtered REQs route through the outbox tracker. For an author whose write relays are unknown, the tracker falls back to connected pool relays — **empty during a cold deep-link** — so the computed relay set is empty (`No relays found for filter` in the logs). The REQ only ever attaches to whichever relay connects first (often one without the event), EOSEs empty, and `fetchEvent` resolves null after 10s. Additionally `loadData` re-runs on every `\` store emission, so a duplicate fetch could clobber a successful load with "not found".

## Fix
- New `src/lib/eventFetch.ts`: `fetchEventWithRelayHints` builds an explicit relay set (pool + explicit + naddr bech32 hints), bypassing the empty-set computation; NDK queues each REQ until its relay connects.
- Single-flight + stale-result guards on both pages' `loadData`.
- Same relay-set hardening for the "more from this author" rail fetch (`authorContent.ts`).

## Verification
- The three articles that failed reliably before (Nostr/YunoHost, Four Layers, Tesla Cybercab), Daniel's article, and a recipe page all **load on first cold open** now
- 1418 tests green, `pnpm check` at baseline, build clean

*(Dev-only note: `src/lib/nostr.ts` evaluates twice under Vite HMR versioning, briefly churning NDK instances; not reproducible in production builds.)*