### PR TITLE
feat(vanity): extend vanity URLs to recipes

### DIFF
--- a/src/components/Recipe/Recipe.svelte
+++ b/src/components/Recipe/Recipe.svelte
@@ -71,6 +71,7 @@
   import { resolveScore } from '$lib/nourish/scoreResolver';
   import { NOURISH_PROMPT_VERSION } from '$lib/nourish/types';
   import { membershipStatusMap, queueMembershipLookup, type MembershipStatus } from '$lib/stores/membershipStatus';
+  import { resolveVanityShareUrl } from '$lib/vanityUrl';
 
   export let event: NDKEvent;
   export let isPremium = false;
@@ -186,6 +187,15 @@
 
   // Construct the canonical recipe URL for sharing (uses short /r/ format)
   $: shareUrl = buildCanonicalRecipeShareUrl(computedNaddr);
+
+  // Premium vanity URL (zap.cooking/<handle>/<slug>) when the author has a
+  // verified handle — preferred by the share modal over the /r/ short URL.
+  let vanityShareUrl = '';
+  $: if (browser && event.pubkey && event.replaceableDTag()) {
+    resolveVanityShareUrl(event.pubkey, event.replaceableDTag()).then((url) => {
+      vanityShareUrl = url;
+    });
+  }
 
   // Get recipe title and image for sharing
   $: recipeTitle =
@@ -748,7 +758,13 @@
 
 <ZapModal bind:open={zapModal} {event} on:zap-complete={handleZapComplete} />
 
-<ShareModal bind:open={shareModal} url={shareUrl} title={recipeTitle} imageUrl={recipeImage} />
+<ShareModal
+  bind:open={shareModal}
+  url={shareUrl}
+  vanityUrl={vanityShareUrl}
+  title={recipeTitle}
+  imageUrl={recipeImage}
+/>
 
 <!-- Add to Grocery List Modal -->
 <AddToListModal bind:open={groceryModal} recipeEvent={event} />

--- a/src/components/RecipePackCard.svelte
+++ b/src/components/RecipePackCard.svelte
@@ -302,6 +302,7 @@
       : ''}
     title={title || 'Recipe Pack'}
     imageUrl={image || ''}
+    authorPubkey={event.pubkey || ''}
   />
 {/if}
 

--- a/src/components/ShareModal.svelte
+++ b/src/components/ShareModal.svelte
@@ -19,6 +19,7 @@
     buildRichShareText,
     socialShareUrls
   } from '$lib/utils/share';
+  import { resolveHandleForPubkey } from '$lib/vanityUrl';
 
   export let open = false;
   export let url = '';
@@ -193,28 +194,10 @@
   }
 
   // Author pubkey -> verified zap.cooking handle (directory reverse
-  // lookup), for namespaced short links. Session-cached: the modal can
-  // open repeatedly while scrolling someone's posts.
-  let namespaceForAuthor = '';
-
+  // lookup, memoized in $lib/vanityUrl), for namespaced short links.
   async function resolveNamespace(): Promise<string> {
     if (!browser || !authorPubkey) return '';
-    if (namespaceForAuthor) return namespaceForAuthor;
-    try {
-      const res = await fetch('/.well-known/nostr.json');
-      if (!res.ok) return '';
-      const names = (await res.json())?.names;
-      if (!names || typeof names !== 'object') return '';
-      for (const [handle, pubkey] of Object.entries(names)) {
-        if (pubkey === authorPubkey && /^[a-z0-9-_.]{1,30}$/.test(handle)) {
-          namespaceForAuthor = handle;
-          return handle;
-        }
-      }
-    } catch {
-      // Fall back to a plain /s/ code.
-    }
-    return '';
+    return resolveHandleForPubkey(authorPubkey);
   }
 
   async function getShortLink() {

--- a/src/lib/vanityUrl.test.ts
+++ b/src/lib/vanityUrl.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resolveVanityShareUrl, clearVanityDirectoryCache } from './vanityUrl';
+
+function mockDirectory(names: Record<string, string>) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ names })
+  });
+}
+
+describe('resolveVanityShareUrl', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    clearVanityDirectoryCache();
+  });
+
+  it('returns the vanity URL for a directory author', async () => {
+    vi.stubGlobal('fetch', mockDirectory({ daniel: 'ee6ea13a'.padEnd(64, 'a') }));
+    const url = await resolveVanityShareUrl('ee6ea13a'.padEnd(64, 'a'), 'my-article');
+    expect(url).toBe('https://zap.cooking/daniel/my-article');
+  });
+
+  it('returns empty string for an author without a handle', async () => {
+    vi.stubGlobal('fetch', mockDirectory({ daniel: 'ee6ea13a'.padEnd(64, 'a') }));
+    const url = await resolveVanityShareUrl('ff'.padEnd(64, '0'), 'my-article');
+    expect(url).toBe('');
+  });
+
+  it('ignores malformed handles in the directory', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockDirectory({ 'UPPER CASE': 'ee6ea13a'.padEnd(64, 'a'), 'ok-handle': 'ff'.padEnd(64, '0') })
+    );
+    const url = await resolveVanityShareUrl('ee6ea13a'.padEnd(64, 'a'), 'my-article');
+    expect(url).toBe('');
+  });
+
+  it('returns empty string when the directory fetch fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new Error('network down'))
+    );
+    const url = await resolveVanityShareUrl('ee6ea13a'.padEnd(64, 'a'), 'my-article');
+    expect(url).toBe('');
+  });
+
+  it('returns empty string for missing inputs', async () => {
+    vi.stubGlobal('fetch', mockDirectory({}));
+    expect(await resolveVanityShareUrl('', 'slug')).toBe('');
+    expect(await resolveVanityShareUrl('ee6ea13a'.padEnd(64, 'a'), '')).toBe('');
+  });
+});

--- a/src/lib/vanityUrl.ts
+++ b/src/lib/vanityUrl.ts
@@ -47,16 +47,24 @@ export function clearVanityDirectoryCache(): void {
 }
 
 /**
+ * Reverse lookup: the author's verified handle, or '' when they don't
+ * have one. Used for namespaced short codes (zap.cooking/<handle>/<code>).
+ */
+export async function resolveHandleForPubkey(pubkey: string): Promise<string> {
+  if (!pubkey) return '';
+  const entries = await loadDirectoryEntries();
+  for (const [handle, pk] of entries) {
+    if (pk === pubkey) return handle;
+  }
+  return '';
+}
+
+/**
  * Resolve the author's vanity share URL for a `d` identifier, or '' when
  * the author has no verified handle.
  */
 export async function resolveVanityShareUrl(pubkey: string, dTag: string): Promise<string> {
   if (!pubkey || !dTag) return '';
-  const entries = await loadDirectoryEntries();
-  for (const [handle, pk] of entries) {
-    if (pk === pubkey) {
-      return `https://zap.cooking/${handle}/${dTag}`;
-    }
-  }
-  return '';
+  const handle = await resolveHandleForPubkey(pubkey);
+  return handle ? `https://zap.cooking/${handle}/${dTag}` : '';
 }

--- a/src/lib/vanityUrl.ts
+++ b/src/lib/vanityUrl.ts
@@ -1,0 +1,62 @@
+/**
+ * Vanity share URLs for premium members: zap.cooking/<handle>/<slug>
+ *
+ * The handle must be the author's verified @zap.cooking name (pantry
+ * nostr.json + static directory, same source the [handle]/[slug] route
+ * resolves against). Returns '' when the author has no handle — callers
+ * keep their minted-short-link default in that case.
+ */
+
+const HANDLE_RE = /^[a-z0-9-_.]{1,30}$/;
+
+interface DirectoryCache {
+  at: number;
+  entries: Array<[handle: string, pubkey: string]>;
+}
+
+// Shared by the reads page and the Recipe component (both render share
+// modals for the same event); a short memo keeps the double resolution
+// to one nostr.json fetch.
+const DIRECTORY_TTL_MS = 30_000;
+let directoryCache: DirectoryCache | null = null;
+
+async function loadDirectoryEntries(): Promise<Array<[string, string]>> {
+  const now = Date.now();
+  if (directoryCache && now - directoryCache.at < DIRECTORY_TTL_MS) {
+    return directoryCache.entries;
+  }
+
+  try {
+    const res = await fetch('/.well-known/nostr.json');
+    if (!res.ok) return [];
+    const names = (await res.json())?.names as Record<string, unknown> | undefined;
+    if (!names || typeof names !== 'object') return [];
+    const entries = Object.entries(names).filter(
+      (entry): entry is [string, string] => typeof entry[1] === 'string' && HANDLE_RE.test(entry[0])
+    );
+    directoryCache = { at: now, entries };
+    return entries;
+  } catch {
+    return [];
+  }
+}
+
+/** Drop the memoized handle directory (tests, forced refresh). */
+export function clearVanityDirectoryCache(): void {
+  directoryCache = null;
+}
+
+/**
+ * Resolve the author's vanity share URL for a `d` identifier, or '' when
+ * the author has no verified handle.
+ */
+export async function resolveVanityShareUrl(pubkey: string, dTag: string): Promise<string> {
+  if (!pubkey || !dTag) return '';
+  const entries = await loadDirectoryEntries();
+  for (const [handle, pk] of entries) {
+    if (pk === pubkey) {
+      return `https://zap.cooking/${handle}/${dTag}`;
+    }
+  }
+  return '';
+}

--- a/src/routes/[handle]/[slug]/+page.server.ts
+++ b/src/routes/[handle]/[slug]/+page.server.ts
@@ -1,12 +1,13 @@
 /**
- * Vanity article URLs for premium members: zap.cooking/<handle>/<slug>
+ * Vanity URLs for premium members: zap.cooking/<handle>/<slug>
  *
  * The handle must be the author's verified @zap.cooking NIP-05 name
- * (premium benefit). The slug is the article's `d` identifier. Resolves
- * handle → pubkey via the handle directory, then the article via the
- * same raw-WebSocket relay race the OG path uses, and 302-redirects to
- * the canonical /reads/<naddr> URL (which carries OG tags, the share
- * short-link flow, and all client behavior unchanged).
+ * (premium benefit). The slug is the post's `d` identifier — an article,
+ * a recipe, or a premium (gated) recipe. Resolves handle → pubkey via
+ * the handle directory, then the event via the same raw-WebSocket relay
+ * race the OG path uses, and 302-redirects to the canonical /reads or
+ * /recipe URL (which carry OG tags, the share short-link flow, and all
+ * client behavior unchanged).
  *
  * A 302 rather than a 301 because the handle→pubkey mapping is mutable:
  * memberships lapse and handles get reassigned, so crawlers must keep
@@ -19,6 +20,8 @@ import { error, redirect } from '@sveltejs/kit';
 import { nip19 } from 'nostr-tools';
 import { resolveHandlePubkey } from '$lib/handleDirectory.server';
 import { raceRelays } from '$lib/recipePackOg.server';
+import { RECIPE_TAGS, GATED_RECIPE_KIND } from '$lib/consts';
+import { validateMarkdownTemplate } from '$lib/parser';
 
 /** NIP-05 name characters, lowercased. */
 const HANDLE_RE = /^[a-z0-9-_.]{1,30}$/;
@@ -29,6 +32,21 @@ const SHORTCODE_RE = /^[0-9a-z]{4,12}$/;
 
 const RESOLVE_TIMEOUT_MS = 5000;
 const ARTICLE_KIND = 30023;
+
+/**
+ * Mirror of the /reads page's recipe rejection: an event with a recipe
+ * `t` tag or recipe-shaped markdown belongs on /recipe — /reads would
+ * bounce it with "This is a recipe, not an article".
+ */
+function isRecipeEvent(evt: unknown): boolean {
+  const tags: string[][] = Array.isArray((evt as any)?.tags) ? (evt as any).tags : [];
+  const hasRecipeTag = tags.some(
+    (t) => t[0] === 't' && RECIPE_TAGS.includes((t[1] || '').toLowerCase())
+  );
+  if (hasRecipeTag) return true;
+  const content = typeof (evt as any)?.content === 'string' ? (evt as any).content : '';
+  return typeof validateMarkdownTemplate(content) !== 'string';
+}
 
 interface NamespacedShortLink {
   target: string;
@@ -61,14 +79,25 @@ export const load = async ({
     throw error(404, `No zap.cooking handle “${handle}”`);
   }
 
-  const event = await withTimeout(
+  let event = await withTimeout(
     raceRelays({ kinds: [ARTICLE_KIND], authors: [pubkey], '#d': [slug] })
   );
+  let kind = ARTICLE_KIND;
+
+  // Premium (gated) recipes live at kind 35000.
+  if (!event) {
+    event = await withTimeout(
+      raceRelays({ kinds: [GATED_RECIPE_KIND], authors: [pubkey], '#d': [slug] })
+    );
+    kind = GATED_RECIPE_KIND;
+  }
 
   if (event) {
+    // Recipe-shaped content redirects to /recipe — /reads rejects it.
+    const base = kind === GATED_RECIPE_KIND || isRecipeEvent(event) ? '/recipe' : '/reads';
     throw redirect(
       302,
-      `/reads/${nip19.naddrEncode({ kind: ARTICLE_KIND, pubkey, identifier: slug })}`
+      `${base}/${nip19.naddrEncode({ kind, pubkey, identifier: slug })}`
     );
   }
 

--- a/src/routes/pack/[naddr]/+page.svelte
+++ b/src/routes/pack/[naddr]/+page.svelte
@@ -402,6 +402,7 @@
   url={viewUrl}
   title={title || 'Recipe Pack'}
   imageUrl={image || ''}
+  authorPubkey={packEvent?.pubkey || ''}
 />
 
 <!-- Export as Cookbook (free for Pro / 2100 sats for everyone else) -->

--- a/src/routes/reads/[naddr]/+page.svelte
+++ b/src/routes/reads/[naddr]/+page.svelte
@@ -18,6 +18,7 @@
   import { stripTrackingParams } from '$lib/utils/stripTrackingParams';
   import { fetchAuthorContent } from '$lib/authorContent';
   import { fetchEventWithRelayHints } from '$lib/eventFetch';
+  import { resolveVanityShareUrl as resolveVanityShareUrlFor } from '$lib/vanityUrl';
 
   let event: NDKEvent | null = null;
   let naddr: string = '';
@@ -153,21 +154,7 @@
     if (!browser) return;
     const dTag = e.tags.find((t) => t[0] === 'd')?.[1];
     if (!dTag) return;
-
-    try {
-      const res = await fetch('/.well-known/nostr.json');
-      if (!res.ok) return;
-      const names = (await res.json())?.names;
-      if (!names || typeof names !== 'object') return;
-      for (const [handle, pubkey] of Object.entries(names)) {
-        if (pubkey === e.pubkey && /^[a-z0-9-_.]{1,30}$/.test(handle)) {
-          vanityShareUrl = `https://zap.cooking/${handle}/${dTag}`;
-          return;
-        }
-      }
-    } catch {
-      // Keep the minted-short-link default.
-    }
+    vanityShareUrl = await resolveVanityShareUrlFor(e.pubkey, dTag);
   }
 
   // OG/meta derived entirely from the client-fetched NDK event, with static


### PR DESCRIPTION
## What

`zap.cooking/<handle>/<slug>` previously resolved every slug against kind 30023 and redirected to `/reads` — including recipe-shaped events, which `/reads` then rejects with "This is a recipe, not an article". A premium member's recipe vanity URL was a dead end.

- `[handle]/[slug]` resolver: recipe-shaped events (recipe `t`-tag or recipe markdown template, mirroring the `/reads` rejection) now redirect to `/recipe/<naddr>`; gated recipes resolve at kind 35000
- Share flow: vanity resolution extracted to `src/lib/vanityUrl.ts` (30s-memoized nostr.json fetch, unit-tested) and wired into the Recipe component's ShareModal, so recipes — and the Recipe-rendered share on articles — prefer `zap.cooking/<handle>/<slug>` the way article pages already do

## Verification
`/daniel/zesty-dill-yogurt-sauce` 302s to `/recipe` and loads; `/daniel/sidecar-…` still 302s to `/reads`; both share modals show the vanity URL. 1423 tests green, check at baseline, build clean.

*(Also touches `reads/[naddr]/+page.svelte` in a different region than #708 — trivially mergeable, happy to rebase.)*