### PR TITLE
fix(profile): explicit relay set for author-scoped 30023 subscriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.759",
+  "version": "4.2.760",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.760",
+  "version": "4.2.761",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/myRecipesPack.test.ts
+++ b/src/lib/myRecipesPack.test.ts
@@ -1,12 +1,17 @@
 import { describe, it, expect, vi } from 'vitest';
-import { fetchMyAuthoredRecipeEvents, fetchMyAuthoredRecipes } from './myRecipesPack';
 
 // Sentinel relay set: the fetch must hand whatever buildPoolRelaySet returns
 // straight to ndk.subscribe as its third argument (explicit relay routing).
-const POOL_RELAY_SET = { sentinel: 'pool-relay-set' } as any;
+// vi.mock is hoisted above the imports, so anything its factory closes over
+// must be hoisted too.
+const { POOL_RELAY_SET } = vi.hoisted(() => ({
+  POOL_RELAY_SET: { sentinel: 'pool-relay-set' } as any
+}));
 vi.mock('$lib/eventFetch', () => ({
   buildPoolRelaySet: vi.fn(() => POOL_RELAY_SET)
 }));
+
+import { fetchMyAuthoredRecipeEvents, fetchMyAuthoredRecipes } from './myRecipesPack';
 
 const PUBKEY = 'a'.repeat(64);
 

--- a/src/lib/myRecipesPack.test.ts
+++ b/src/lib/myRecipesPack.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { fetchMyAuthoredRecipeEvents, fetchMyAuthoredRecipes } from './myRecipesPack';
+
+// Sentinel relay set: the fetch must hand whatever buildPoolRelaySet returns
+// straight to ndk.subscribe as its third argument (explicit relay routing).
+const POOL_RELAY_SET = { sentinel: 'pool-relay-set' } as any;
+vi.mock('$lib/eventFetch', () => ({
+  buildPoolRelaySet: vi.fn(() => POOL_RELAY_SET)
+}));
 
 const PUBKEY = 'a'.repeat(64);
 
@@ -37,9 +44,10 @@ function recipeEvent(opts: {
  * delivers the given events (then eose) on a microtask, mirroring the
  * async arrival the real implementation sees.
  */
-function fakeNdk(events: any[]) {
+function fakeNdk(events: any[], calls: { filter: any; opts: any; relaySet: any }[] = []) {
   return {
-    subscribe: () => {
+    subscribe: (filter: any, opts: any, relaySet: any) => {
+      calls.push({ filter, opts, relaySet });
       const handlers: Record<string, (arg?: any) => void> = {};
       queueMicrotask(() => {
         for (const e of events) handlers['event']?.(e);
@@ -56,6 +64,20 @@ function fakeNdk(events: any[]) {
 }
 
 describe('fetchMyAuthoredRecipeEvents', () => {
+  it('subscribes with the explicit pool relay set from buildPoolRelaySet', async () => {
+    const calls: { filter: any; opts: any; relaySet: any }[] = [];
+    const ndk = fakeNdk([recipeEvent({ dTag: 'tacos', createdAt: 100 })], calls);
+
+    await fetchMyAuthoredRecipeEvents(ndk, PUBKEY);
+
+    const { buildPoolRelaySet } = await import('$lib/eventFetch');
+    expect(buildPoolRelaySet).toHaveBeenCalledWith(ndk);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].filter.authors).toEqual([PUBKEY]);
+    expect(calls[0].opts).toEqual({ closeOnEose: true });
+    expect(calls[0].relaySet).toBe(POOL_RELAY_SET);
+  });
+
   it('dedupes a revised recipe by coordinate, keeping the newest version', async () => {
     const original = recipeEvent({ dTag: 'tacos', createdAt: 100, title: 'Tacos v1' });
     const revision = recipeEvent({ dTag: 'tacos', createdAt: 200, title: 'Tacos v2' });

--- a/src/lib/myRecipesPack.ts
+++ b/src/lib/myRecipesPack.ts
@@ -18,6 +18,7 @@ import type NDK from '@nostr-dev-kit/ndk';
 import type { NDKEvent, NDKFilter } from '@nostr-dev-kit/ndk';
 import { validateMarkdownTemplate } from '$lib/parser';
 import { RECIPE_TAGS, isHiddenRecipeCoordinate } from '$lib/consts';
+import { buildPoolRelaySet } from '$lib/eventFetch';
 
 export interface MyRecipeForPack {
   /** Addressable a-tag in `kind:pubkey:dTag` form, ready to drop into a Recipe Pack event. */
@@ -70,7 +71,10 @@ export async function fetchMyAuthoredRecipeEvents(ndk: NDK, pubkey: string): Pro
   const byATag = new Map<string, NDKEvent>();
 
   await new Promise<void>((resolve) => {
-    const subscription = ndk.subscribe(filter, { closeOnEose: true });
+    // Explicit pool relay set: with the outbox model on, an `authors` REQ is
+    // routed only to the author's NIP-65 relays, which are not where this app
+    // publishes recipes. See buildPoolRelaySet in $lib/eventFetch.ts.
+    const subscription = ndk.subscribe(filter, { closeOnEose: true }, buildPoolRelaySet(ndk));
 
     const safetyTimeout = setTimeout(() => {
       try {

--- a/src/routes/user/[slug]/+page.svelte
+++ b/src/routes/user/[slug]/+page.svelte
@@ -8,6 +8,7 @@
   import { isNofferString } from '$lib/clink/noffer';
   import Feed from '../../../components/Feed.svelte';
   import { validateMarkdownTemplate } from '$lib/parser';
+  import { buildPoolRelaySet } from '$lib/eventFetch';
   import { goto } from '$app/navigation';
   import { page } from '$app/stores';
   import { browser } from '$app/environment';
@@ -296,7 +297,9 @@
           '#t': RECIPE_TAGS
         };
 
-        let subscription = $ndk.subscribe(filter);
+        // Explicit pool relay set: with the outbox model on, an `authors` REQ is routed only to
+        // the author's NIP-65 relays, not where this app publishes. See buildPoolRelaySet in $lib/eventFetch.ts.
+        let subscription = $ndk.subscribe(filter, undefined, buildPoolRelaySet($ndk));
 
         subscription.on('event', (ev: NDKEvent) => {
           if (isDeletedEvent(ev)) return;
@@ -523,7 +526,9 @@
         until: oldestRecipeTime - 1
       };
 
-      const subscription = $ndk.subscribe(filter);
+      // Explicit pool relay set: with the outbox model on, an `authors` REQ is routed only to
+      // the author's NIP-65 relays, not where this app publishes. See buildPoolRelaySet in $lib/eventFetch.ts.
+      const subscription = $ndk.subscribe(filter, undefined, buildPoolRelaySet($ndk));
       const newRecipes: NDKEvent[] = [];
 
       await new Promise<void>((resolve) => {
@@ -733,7 +738,9 @@
         limit: 20
       };
 
-      const subscription = $ndk.subscribe(filter);
+      // Explicit pool relay set: with the outbox model on, an `authors` REQ is routed only to
+      // the author's NIP-65 relays, not where this app publishes. See buildPoolRelaySet in $lib/eventFetch.ts.
+      const subscription = $ndk.subscribe(filter, undefined, buildPoolRelaySet($ndk));
       const fetchedEvents: NDKEvent[] = [];
       const seenIds = new Set<string>();
 
@@ -808,7 +815,9 @@
         until: oldestReadsTime - 1
       };
 
-      const subscription = $ndk.subscribe(filter);
+      // Explicit pool relay set: with the outbox model on, an `authors` REQ is routed only to
+      // the author's NIP-65 relays, not where this app publishes. See buildPoolRelaySet in $lib/eventFetch.ts.
+      const subscription = $ndk.subscribe(filter, undefined, buildPoolRelaySet($ndk));
       const newReads: NDKEvent[] = [];
       const existingIds = new Set(readsEvents.map((e) => e.id));
 


### PR DESCRIPTION
## Symptom
`/user/npub1c6dhrhzkflwr2zkdmlujnujawgp2c9rsep6gscyt6mvcusnt5a3srnzmx3?tab=recipes` shows 1 recipe; the author has 18 published. The Reads tab on the same profile shows nothing.

## Root cause
With `enableOutboxModel: true` (`src/lib/nostr.ts`), NDK 2.10 routes any REQ that carries `authors` through the outbox tracker (`calculateRelaySetsFromFilter` → `chooseRelayCombinationForPubkeys`). Once the author's NIP-65 list is known, the REQ goes **only** to relays from that list: connected pool relays that appear in the list, topped up to 2 from the list as temporary connections. It never goes to the pool as such.

This app publishes recipes to the pool + Pantry (`publishQueue.ts`), not to the author's NIP-65 relays. For this author the NIP-65 list is damus / primal / ditto / nostr.build, so the warm REQ goes to `wss://relay.primal.net` (the one pool relay in the list) — which holds **zero** of this author's kind-30023 events. What the user sees is the Dexie `CACHE_FIRST` replay of whatever the browser cached earlier.

On a cold browser the tracker doesn't know the list yet and falls back to the permanent pool relays, so the bug only reproduces once the relay list has been seen (any earlier visit to the profile, or the outbox tracker fetching it for another feed). That's why it's intermittent.

PR #708 fixed this class for `/reads`, `/recipe` and the author rail with `buildPoolRelaySet()` in `src/lib/eventFetch.ts`. The profile page and `myRecipesPack.ts` weren't covered. Same fix here.

## Change
Pass `buildPoolRelaySet(ndk)` as the explicit relay set at the author-scoped kind-30023 sites:

- `src/routes/user/[slug]/+page.svelte` — recipes initial load, `loadMoreRecipes`, `loadReads`, `loadMoreReads` (`$ndk.subscribe(filter, undefined, buildPoolRelaySet($ndk))`, precedent: `LongformFoodFeed.svelte`).
- `src/lib/myRecipesPack.ts` — `fetchMyAuthoredRecipeEvents` (My Kitchen → Published, Share-as-pack, recipe picker).
- `src/lib/myRecipesPack.test.ts` — mocks `$lib/eventFetch` and asserts the relay set is passed through as the third `subscribe` argument.

Left alone on purpose: the kind-1 posts/media subscriptions (kind-1 from other clients legitimately lives on the author's NIP-65 relays; needs pool ∪ author write relays — #712), eose/stop timing (#713), the always-true `validateMarkdownTemplate(...) != null` check (#714), and the title-derived `d` tag (#715). No NDK config, publishQueue, or relay list changes. The optional "author write relays as hints" rider was skipped: the author's own relay (ditto) holds exactly the same 18 recipes as nos.lol, nothing pool-only-missing.

## Phase 0 — relay evidence (nak / raw REQ)
Author `c69b71dc…ba763`, kind 10002 (from nos.lol; purplepag.es returned 502):
```
["r","wss://relay.damus.io/"],["r","wss://relay.primal.net/"],["r","wss://relay.ditto.pub/"],["r","wss://relay.nostr.build/"]
```
kind 30023 + 35000 by author, per relay:

| relay | 30023 events | distinct `d` | tagged `zapcooking`/`nostrcooking` |
|---|---|---|---|
| wss://nos.lol | 45 | 45 | **18** (5 zapcooking + 13 nostrcooking) |
| wss://relay.primal.net | 0 | 0 | 0 |
| wss://nostr.wine | 0 | 0 | 0 |
| wss://relay.damus.io | 3 | 3 | 0 |
| wss://relay.ditto.pub | 27 | 27 | 18 (same 18 `d` tags as nos.lol) |
| wss://relay.nostr.build | auth-required | – | – |

No kind 35000, no `d` collisions, all 18 are kind 30023 on a pool relay → stop-gate passed.

## Phase 2 — verification
`pnpm test` 124 files / 1658 tests green · `pnpm run check` 0 errors (150 pre-existing warnings, none in touched files) · `pnpm build` clean. (First run with the main checkout's node_modules symlinked failed on unrelated dual-Dexie / spark-SDK type drift — the main checkout's lockfile differs from `main`; a real `pnpm install --frozen-lockfile` in the worktree fixed that.)

Headless Chrome (fresh profile = empty Dexie) with CDP WebSocket frame capture, warm-up via `?tab=posts` first so the outbox tracker learns the NIP-65 list, then:

| check | before (zap.cooking) | after (this branch, `vite preview`) |
|---|---|---|
| `?tab=recipes` authors+`#t` REQ sent to | `wss://relay.primal.net` only | `wss://nos.lol`, `wss://relay.primal.net`, `wss://nostr.wine` |
| recipes rendered | 18 only because the warm-up run had already cached them; 0 from the network | **18** = Phase 0 count |
| `?tab=reads` REQ sent to | `wss://relay.primal.net` only | the 3 pool relays |
| reads rendered | 0 | 13 (newest 20 articles minus the recipes) |
| My Kitchen → Published as the author (read-only NIP-07 shim) | 18 (cold session) | **18**, REQ to the 3 pool relays |

Pagination (author has only 18 < 20, so no sentinel; verified with `npub1cgcwm56…e52ndy`, 22 recipes): initial 21 unique → scroll sentinel into view → `loadMoreRecipes` sends `until=1724634828` to the 3 pool relays → 23 unique, 0 duplicates. Note for anyone reproducing: the page scrolls inside a container, `window.scrollTo` does nothing; use `scrollIntoView` on the sentinel.

Observation, not changed here: `buildPoolRelaySet` includes every relay currently in `ndk.pool.relays`, so while another feed has outbox temp connections open (e.g. the posts tab) the REQ also fans out to those (12 relays observed during warm-up). That's #708's existing behavior; it's a superset and harmless for correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmjAxsLr1eoA9LhxJNvk2B
