### PR TITLE
feat(search): NIP-50 post search in the search dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.759",
+  "version": "4.2.760",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/TagsSearchAutocomplete.svelte
+++ b/src/components/TagsSearchAutocomplete.svelte
@@ -27,19 +27,29 @@
     tags: recipeTagSimple[];
     recipes: { title: string; naddr: string; author: string }[];
     users: { name: string; npub: string; picture?: string }[];
+    posts: { id: string; content: string; pubkey: string }[];
     note: { id: string; preview?: string } | null;
-  } = { tags: [], recipes: [], users: [], note: null };
+  } = { tags: [], recipes: [], users: [], posts: [], note: null };
   let isSearching = false;
   let searchTimeout: ReturnType<typeof setTimeout>;
 
   // Prevent stale user search results
   let userSearchVersion = 0;
 
-  // NIP-50 full-text search via search.nostrarchives.com
-  const NIP50_SEARCH_RELAY = 'wss://search.nostrarchives.com';
+  // NIP-50 full-text search relays. Both index kind-1 posts; results are
+  // fanned in from both and deduped, so one being slow or down doesn't
+  // blank the Posts section (verified answering {kinds:[1], search} REQs).
+  const NIP50_SEARCH_RELAYS = ['wss://search.nos.today', 'wss://search.nostrarchives.com'];
   let networkSearchSub: any = null;
   let networkSearchVersion = 0;
   let networkSearchTimeout: ReturnType<typeof setTimeout> | null = null;
+  let postSearchSubs: any[] = [];
+  let postSearchVersion = 0;
+  let postSearchTimeouts: ReturnType<typeof setTimeout>[] = [];
+  // Subscriptions still open for the current query — keeps "No results
+  // found" from flashing while post results stream in.
+  let postSearchActive = 0;
+  $: postSearchPending = postSearchActive > 0;
 
   // Recipe cache for fast client-side search
   let recipeCache: Array<{ title: string; summary: string; naddr: string; author: string }> = [];
@@ -59,9 +69,10 @@
 
     // If query is empty or only whitespace, reset state
     if (normalizedQuery.length === 0) {
-      searchResults = { tags: [], recipes: [], users: [], note: null };
+      searchResults = { tags: [], recipes: [], users: [], posts: [], note: null };
       showAutocomplete = false;
       cancelNetworkSearch();
+      cancelPostSearch();
       return;
     }
 
@@ -96,12 +107,13 @@
     // Immediate recipe search (client-side cache)
     searchRecipes(normalizedQuery);
 
-    // Debounced network searches (user API + NIP-50 relay)
+    // Debounced network searches (user API + NIP-50 relays)
     searchTimeout = setTimeout(async () => {
       isSearching = true;
       try {
-        // NIP-50 recipe search fires and streams results independently
+        // NIP-50 searches fire and stream results independently
         searchNetworkRecipes(normalizedQuery);
+        searchNetworkPosts(normalizedQuery);
         await searchUsers(normalizedQuery);
       } catch (e) {
         console.debug('Search error:', e);
@@ -284,7 +296,7 @@
   function selectTag(title: string) {
     action(title);
     tagquery = '';
-    searchResults = { tags: [], recipes: [], users: [], note: null };
+    searchResults = { tags: [], recipes: [], users: [], posts: [], note: null };
     showAutocomplete = false;
   }
 
@@ -292,7 +304,7 @@
     // Navigate to recipe
     window.location.href = `/recipe/${naddr}`;
     tagquery = '';
-    searchResults = { tags: [], recipes: [], users: [], note: null };
+    searchResults = { tags: [], recipes: [], users: [], posts: [], note: null };
     showAutocomplete = false;
   }
 
@@ -300,7 +312,7 @@
     // Navigate to user profile
     window.location.href = `/user/${npub}`;
     tagquery = '';
-    searchResults = { tags: [], recipes: [], users: [], note: null };
+    searchResults = { tags: [], recipes: [], users: [], posts: [], note: null };
     showAutocomplete = false;
   }
 
@@ -308,7 +320,15 @@
     // Navigate to note
     window.location.href = `/${noteId}`;
     tagquery = '';
-    searchResults = { tags: [], recipes: [], users: [], note: null };
+    searchResults = { tags: [], recipes: [], users: [], posts: [], note: null };
+    showAutocomplete = false;
+  }
+
+  function selectPost(postId: string) {
+    // Navigate to the note thread page
+    window.location.href = `/${nip19.noteEncode(postId)}`;
+    tagquery = '';
+    searchResults = { tags: [], recipes: [], users: [], posts: [], note: null };
     showAutocomplete = false;
   }
 
@@ -330,15 +350,19 @@
     const ndkInstance = get(ndk);
     if (!ndkInstance) return;
 
-    // Pre-connect so the first REQ doesn't miss the relay
-    try {
-      const relay = ndkInstance.pool.getRelay(NIP50_SEARCH_RELAY, true, true);
-      if (relay.connectivity?.status !== 1) await relay.connect();
-    } catch { /* non-fatal */ }
+    // Pre-connect so the first REQ doesn't miss the relays
+    await Promise.all(
+      NIP50_SEARCH_RELAYS.map(async (url) => {
+        try {
+          const relay = ndkInstance.pool.getRelay(url, true, true);
+          if (relay.connectivity?.status !== 1) await relay.connect();
+        } catch { /* non-fatal */ }
+      })
+    );
 
     if (thisVersion !== networkSearchVersion) return;
 
-    const relaySet = NDKRelaySet.fromRelayUrls([NIP50_SEARCH_RELAY], ndkInstance, false);
+    const relaySet = NDKRelaySet.fromRelayUrls(NIP50_SEARCH_RELAYS, ndkInstance, false);
     const sub = ndkInstance.subscribe(
       { kinds: [30023], search: query, limit: 50 },
       { closeOnEose: true },
@@ -349,8 +373,10 @@
     sub.on('event', (event: NDKEvent) => {
       if (thisVersion !== networkSearchVersion) return;
       const d = event.tags.find((t: string[]) => t[0] === 'd')?.[1];
-      const title = event.tags.find((t: string[]) => t[0] === 'title')?.[1];
-      if (!d || !title) return;
+      if (!d) return;
+      // Title-less long-form still searches; show the d-tag like the
+      // article pages do.
+      const title = event.tags.find((t: string[]) => t[0] === 'title')?.[1] || d;
       if (isHiddenRecipeEvent(event)) return;
 
       const naddr = nip19.naddrEncode({ kind: 30023, pubkey: event.pubkey, identifier: d });
@@ -374,9 +400,87 @@
     }, 5000);
   }
 
+  /**
+   * NIP-50 full-text search over posts (kind 1 and our kind 1068 feed
+   * posts) — the "posts with the word in it" results other clients show.
+   * Fans a REQ out to every search relay and dedupes by event id as
+   * results stream in; version-guarded against stale keystrokes.
+   */
+  async function searchNetworkPosts(query: string) {
+    const thisVersion = ++postSearchVersion;
+    cancelPostSearch();
+
+    const ndkInstance = get(ndk);
+    if (!ndkInstance) return;
+
+    await Promise.all(
+      NIP50_SEARCH_RELAYS.map(async (url) => {
+        try {
+          const relay = ndkInstance.pool.getRelay(url, true, true);
+          if (relay.connectivity?.status !== 1) await relay.connect();
+        } catch { /* non-fatal */ }
+      })
+    );
+
+    if (thisVersion !== postSearchVersion) return;
+
+    searchResults.posts = [];
+
+    for (const url of NIP50_SEARCH_RELAYS) {
+      const relaySet = NDKRelaySet.fromRelayUrls([url], ndkInstance, false);
+      const sub = ndkInstance.subscribe(
+        { kinds: [1, 1068] as any, search: query, limit: 30 },
+        { closeOnEose: true },
+        relaySet
+      );
+      postSearchSubs.push(sub);
+      postSearchActive++;
+
+      sub.on('event', (event: NDKEvent) => {
+        if (thisVersion !== postSearchVersion) return;
+        if (!event.id || !event.content) return;
+        if (isHiddenRecipeEvent(event)) return;
+        if (searchResults.posts.some((p) => p.id === event.id)) return;
+
+        const snippet = event.content
+          .replace(/\s+/g, ' ')
+          .trim()
+          .slice(0, 90);
+        if (!snippet) return;
+
+        searchResults.posts = [...searchResults.posts, { id: event.id, content: snippet, pubkey: event.pubkey }].slice(0, 8);
+        searchResults = searchResults;
+      });
+
+      const settle = () => {
+        postSearchActive = Math.max(0, postSearchActive - 1);
+        postSearchSubs = postSearchSubs.filter((s) => s !== sub);
+      };
+      const timeout = setTimeout(() => {
+        try { sub.stop(); } catch { /* ignore */ }
+        settle();
+      }, 5000);
+      postSearchTimeouts.push(timeout);
+      sub.on('eose', () => {
+        clearTimeout(timeout);
+        settle();
+      });
+    }
+  }
+
+  function cancelPostSearch() {
+    for (const sub of postSearchSubs) {
+      try { sub.stop(); } catch { /* ignore */ }
+    }
+    postSearchSubs = [];
+    for (const t of postSearchTimeouts) clearTimeout(t);
+    postSearchTimeouts = [];
+    postSearchActive = 0;
+  }
+
   onMount(() => {
     // Initialize empty search results
-    searchResults = { tags: [], recipes: [], users: [], note: null };
+    searchResults = { tags: [], recipes: [], users: [], posts: [], note: null };
 
     // Preload recipes in background for fast search
     preloadRecipes();
@@ -389,6 +493,7 @@
       recipeSubscription = null;
     }
     cancelNetworkSearch();
+    cancelPostSearch();
   });
 </script>
 
@@ -422,7 +527,7 @@
         // Fallback: treat as tag search if no results
         action(tagquery.trim());
         tagquery = '';
-        searchResults = { tags: [], recipes: [], users: [], note: null };
+        searchResults = { tags: [], recipes: [], users: [], posts: [], note: null };
       }
     }}
   >
@@ -440,7 +545,7 @@
     <input type="submit" class="hidden" />
   </form>
 
-  {#if showAutocomplete && (searchResults.note || searchResults.tags.length > 0 || searchResults.recipes.length > 0 || searchResults.users.length > 0 || isSearching)}
+  {#if showAutocomplete && (searchResults.note || searchResults.tags.length > 0 || searchResults.recipes.length > 0 || searchResults.posts.length > 0 || searchResults.users.length > 0 || isSearching)}
     <ul
       class="max-h-[320px] overflow-y-auto absolute top-full left-0 w-full bg-input border shadow-lg rounded-xl mt-1 z-[60]"
       style="border-color: var(--color-input-border); color: var(--color-text-primary);"
@@ -503,6 +608,25 @@
         {/each}
       {/if}
 
+      {#if searchResults.posts.length > 0}
+        <li
+          class="px-3 py-1.5 text-xs font-semibold text-caption bg-accent-gray border-b border-t"
+          style="border-color: var(--color-input-border)"
+        >
+          💬 Posts
+        </li>
+        {#each searchResults.posts as post (post.id)}
+          <!-- svelte-ignore a11y-click-events-have-key-events -->
+          <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+          <li
+            on:click={() => selectPost(post.id)}
+            class="cursor-pointer px-3 py-2 hover:bg-accent-gray"
+          >
+            <span class="text-sm line-clamp-2">{post.content}</span>
+          </li>
+        {/each}
+      {/if}
+
       {#if searchResults.users.length > 0}
         <li
           class="px-3 py-1.5 text-xs font-semibold text-caption bg-accent-gray border-b border-t"
@@ -533,7 +657,7 @@
         <li class="px-3 py-2 text-sm text-caption text-center">Searching...</li>
       {/if}
 
-      {#if !recipeCacheLoading && !isSearching && !searchResults.note && searchResults.tags.length === 0 && searchResults.recipes.length === 0 && searchResults.users.length === 0 && tagquery.length > 0}
+      {#if !recipeCacheLoading && !isSearching && !postSearchPending && !searchResults.note && searchResults.tags.length === 0 && searchResults.recipes.length === 0 && searchResults.posts.length === 0 && searchResults.users.length === 0 && tagquery.length > 0}
         <li class="px-3 py-2 text-sm text-caption text-center">
           {#if !recipeCacheLoaded}
             ⏳ Loading recipes...


### PR DESCRIPTION
## What

Keyword search never looked at posts — only tags (client-side), users (Primal API), and recipes (NIP-50 kind 30023). Searching `sourdough` returned tags and users but none of the posts containing the word, unlike full Nostr clients (Jumble et al.).

**Posts section added:** kind 1 + 1068 full-text search via NIP-50 `search` filters against two verified search relays (`search.nos.today`, `search.nostrarchives.com`) — fan-in from both, deduped by event id, version-guarded against stale keystrokes, 5s hard timeout per relay. Two-line content snippet per result; click opens the note thread.

Also:
- Recipe network search queries **both** relays now (was a single one)
- Title-less long-form results fall back to the d-tag instead of being silently dropped
- "No results found" waits for post subscriptions to settle (no flash while results stream)

## Verification
Live on dev: searching **sourdough** shows 🏷️ Tags, 📖 Recipes, 💬 **Posts** (real posts with the word — same results Jumble surfaces), 👤 Users; clicking a post navigates to its thread and it loads. Relay choices verified by direct REQ testing (both answer `{kinds:[1], search}`; relay.nostr.band timed out from this network so it was excluded). 1423 tests green, check at baseline, build clean.