### PR TITLE
Add /support page for App Store Guideline 1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.761",
+  "version": "4.2.762",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -1,32 +1,8 @@
 <script lang="ts">
   import GithubLogo from 'phosphor-svelte/lib/GithubLogo';
   import { VERSION, BUILD_HASH } from '$lib/version';
-  import { ndk } from '$lib/nostr';
-  import { NDKUser } from '@nostr-dev-kit/ndk';
-  import Modal from './Modal.svelte';
-  import ZapModal from './ZapModal.svelte';
-  import { qr } from '@svelte-put/qr/svg';
-  import BrantaBadge from './BrantaBadge.svelte';
-
-  // ZapCooking's pubkey (npub1xxdd8eusvdxmaph3fkuu9x2mymhrcc3ghe2l38zv0l4f4nqp659qskkt7a)
-  const ZAPCOOKING_PUBKEY = '31acd3e790619b7437c54b39c236d93d72e3c6228be5f13898fe9d536028d6a5';
 
   const currentYear = new Date().getFullYear();
-  let supportModalOpen = false;
-  let zapModalOpen = false;
-
-  async function copySupportAddress(event: MouseEvent): Promise<void> {
-    await navigator.clipboard.writeText('ZapCooking@getalby.com');
-    const button = event.currentTarget;
-    if (!(button instanceof HTMLButtonElement)) return;
-    const originalText = button.textContent;
-    button.textContent = '✓';
-    setTimeout(() => {
-      button.textContent = originalText;
-    }, 1500);
-  }
-
-  $: zapCookingUser = $ndk ? new NDKUser({ pubkey: ZAPCOOKING_PUBKEY }) : null;
 </script>
 
 <footer
@@ -36,13 +12,12 @@
   <div class="footer-inner">
     <!-- Utility links — de-emphasized (rarely clicked). -->
     <nav class="footer-links text-caption">
-      <button
-        on:click={() => (supportModalOpen = true)}
-        class="text-orange-500 hover:text-orange-600 font-semibold transition-colors cursor-pointer bg-transparent border-0 p-0"
-        type="button"
+      <a
+        href="/support"
+        class="text-orange-500 hover:text-orange-600 font-semibold transition-colors"
       >
         ⚡ Support
-      </button>
+      </a>
       <a href="/about" class="hover:text-primary transition-colors">About</a>
       <a href="/founders" class="hover:text-primary transition-colors">Founders</a>
       <a href="/sponsors" class="hover:text-primary transition-colors">Sponsors</a>
@@ -129,86 +104,6 @@
     </div>
   </div>
 </footer>
-
-<!-- Support Modal -->
-<Modal bind:open={supportModalOpen} noHeader>
-  <div class="flex flex-col gap-4">
-    <!-- Header -->
-    <div class="text-center">
-      <h2 class="text-lg font-bold" style="color: var(--color-text-primary)">
-        ⚡ Support Zap Cooking
-      </h2>
-      <p class="text-xs text-caption mt-1">Help keep Zap Cooking running!</p>
-    </div>
-
-    <!-- QR Code + Lightning Address side by side on larger screens -->
-    <div class="flex flex-col sm:flex-row gap-4 items-center">
-      <!-- QR Code -->
-      <div class="flex flex-col items-center gap-2">
-        <div class="p-3 bg-white rounded-xl flex-shrink-0">
-          <svg
-            class="w-32 h-32"
-            use:qr={{
-              data: 'lightning:ZapCooking@getalby.com',
-              logo: 'https://zap.cooking/favicon.svg',
-              shape: 'circle',
-              // Force black modules so the QR stays scannable in dark mode
-              // (they otherwise inherit the theme's light text color). The
-              // container's bg-white supplies the light background.
-              moduleFill: '#000000',
-              anchorOuterFill: '#000000',
-              anchorInnerFill: '#000000'
-            }}
-          />
-        </div>
-        <BrantaBadge paymentString="ZapCooking@getalby.com" />
-      </div>
-
-      <!-- Lightning Address + Buttons -->
-      <div class="flex flex-col gap-3 flex-1 w-full">
-        <div class="flex items-center gap-2">
-          <div
-            class="flex-1 bg-input border rounded-lg px-3 py-2 text-xs truncate"
-            style="color: var(--color-text-primary); border-color: var(--color-input-border);"
-            title="ZapCooking@getalby.com"
-          >
-            ZapCooking@getalby.com
-          </div>
-          <button
-            on:click={copySupportAddress}
-            class="bg-input hover:bg-accent-gray px-3 py-2 rounded-lg text-xs font-medium transition duration-200 flex-shrink-0"
-            style="color: var(--color-text-primary);"
-            title="Copy lightning address"
-          >
-            Copy
-          </button>
-        </div>
-
-        <button
-          on:click={() => {
-            supportModalOpen = false;
-            zapModalOpen = true;
-          }}
-          class="w-full bg-gradient-to-r from-yellow-400 to-orange-500 hover:from-yellow-500 hover:to-orange-600 text-white font-semibold py-2.5 px-4 rounded-lg transition duration-300 text-center text-sm"
-        >
-          ⚡ Zap with Wallet
-        </button>
-        <a
-          href="lightning:ZapCooking@getalby.com"
-          class="w-full bg-input hover:bg-accent-gray font-medium py-2 px-4 rounded-lg transition duration-300 text-center text-xs"
-          style="color: var(--color-text-primary);"
-        >
-          Open in External Wallet
-        </a>
-      </div>
-    </div>
-  </div>
-</Modal>
-
-<!-- Zap Modal for connected wallet -->
-{#if zapCookingUser}
-  <ZapModal bind:open={zapModalOpen} event={zapCookingUser} />
-{/if}
 
 <style>
   /* Compact two-row footer: a de-emphasized links row and a meta row.

--- a/src/routes/support/+page.svelte
+++ b/src/routes/support/+page.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+  // Cloudflare Scrape Shield rewrites email addresses in the served HTML to
+  // "[email protected]" and restores them only via a JS decoder. Apple's
+  // reviewer (and any no-JS fetch) must see a working address. <!--email_off-->
+  // is Cloudflare's opt-out. Svelte strips comments from templates, so the
+  // markers are injected as raw HTML and wrap the whole anchor — Cloudflare
+  // rewrites mailto: hrefs as well as visible text.
+  const SUPPORT_EMAIL =
+    '<!--email_off--><a href="mailto:support@zap.cooking" class="text-primary hover:underline">support@zap.cooking</a><!--/email_off-->';
+</script>
+
+<svelte:head>
+  <title>Support | Zap Cooking</title>
+  <meta
+    name="description"
+    content="Get help with Zap Cooking — contact support, common questions, how to report content or a user, and how to report a bug."
+  />
+</svelte:head>
+
+<article class="max-w-2xl mx-auto">
+  <h1 class="text-3xl font-bold mb-8" style="color: var(--color-text-primary)">Support</h1>
+
+  <div class="flex flex-col gap-6 leading-relaxed" style="color: var(--color-text-primary)">
+    <p class="text-sm opacity-75">Last updated: September 7, 2026</p>
+
+    <p>
+      This page is how to reach us, how common parts of Zap Cooking work, and how to report a
+      problem. Zap Cooking is a recipe and food community built on Nostr. You can use the website
+      and the iOS and Android apps.
+    </p>
+
+    <h2 class="text-2xl font-bold mt-8 mb-4" style="color: var(--color-text-primary)">
+      How to get help
+    </h2>
+
+    <p>Email us at {@html SUPPORT_EMAIL}.</p>
+
+    <p>
+      Use that address for questions, account help, membership issues, and reports. It is a
+      monitored inbox. We do not publish a response-time promise here. Child safety reports are
+      prioritized; see our
+      <a href="/child-safety" class="text-primary hover:underline">Child Safety Standards</a> for
+      how those are handled.
+    </p>
+
+    <h2 class="text-2xl font-bold mt-8 mb-4" style="color: var(--color-text-primary)">
+      Common questions
+    </h2>
+
+    <h3 class="text-xl font-semibold mt-4 mb-2" style="color: var(--color-text-primary)">
+      What is a Nostr account, and why is there no password?
+    </h3>
+
+    <p>
+      Zap Cooking does not create a traditional username-and-password account. When you join, a
+      cryptographic key pair is created on your device. Your public key (it starts with
+      <code>npub</code>) is your identity. Your private key (it starts with <code>nsec</code>) is
+      how you sign in and prove that identity. We do not store a password, so there is nothing for
+      us to reset. If you lose the private key and have no backup, we cannot recover the account.
+    </p>
+
+    <h3 class="text-xl font-semibold mt-4 mb-2" style="color: var(--color-text-primary)">
+      How do I back up and recover my key?
+    </h3>
+
+    <p>
+      When you create an account, the app shows your private key and lets you download a backup
+      file or copy the key. Keep that copy somewhere safe and private. You can also save an
+      encrypted backup to your own Google Drive, unlocked with a PIN you choose. On the website,
+      you can protect the key on this device with a passkey (Face ID, Touch ID, or your screen
+      lock). A passkey is not a backup — it only unlocks the copy already on that device.
+    </p>
+
+    <p>
+      To recover an account, sign in by entering your private key, or restore the Google Drive
+      backup with your PIN. Signed-in users can also reveal the private key in Settings if it is
+      stored on that device. If you used a browser extension or a remote signer, the key stays in
+      that tool, not in Zap Cooking.
+    </p>
+
+    <h3 class="text-xl font-semibold mt-4 mb-2" style="color: var(--color-text-primary)">
+      What does Cook+ include, and how do I cancel?
+    </h3>
+
+    <p>
+      Cook+ is the optional paid membership. On the
+      <a href="/membership" class="text-primary hover:underline">membership page</a> it currently
+      includes Sous Chef (pull a recipe from a link, photo, or pasted text), Nourish (how a recipe
+      scores for things like gut health, protein, and real food), Cheffy (300 cooking-help
+      messages per month), buying and selling on the Market, featured recipe collections, a Cook+
+      member badge, a verified <code>you@zap.cooking</code> identity, access to the
+      pantry.zap.cooking member relay, early access to new features, and a vote on the roadmap.
+      Pricing shown there is $49/year or $4.99/month, paid with Bitcoin via Lightning or with a
+      card.
+    </p>
+
+    <p>
+      To cancel a card membership, open
+      <a href="/membership" class="text-primary hover:underline">/membership</a> while signed in
+      and choose Cancel Membership. That opens the billing portal. A Lightning payment covers one
+      term and does not renew on its own — you renew it yourself if you want another term. If you
+      still need help canceling, email {@html SUPPORT_EMAIL}. Access continues through the end of
+      the period you already paid for. Your published recipes stay yours if you cancel.
+    </p>
+
+    <h3 class="text-xl font-semibold mt-4 mb-2" style="color: var(--color-text-primary)">
+      What is a zap?
+    </h3>
+
+    <p>
+      A zap is an optional Bitcoin tip sent over the Lightning Network. On Zap Cooking you can
+      send one to a cook or a recipe from the lightning button. The payment goes to that person's
+      Lightning address, not to Zap Cooking. It is not a membership and it is not required to use
+      the app.
+    </p>
+
+    <h3 class="text-xl font-semibold mt-4 mb-2" style="color: var(--color-text-primary)">
+      How do I delete my account?
+    </h3>
+
+    <p>
+      Email {@html SUPPORT_EMAIL} with the subject line "Delete my account" and include the public
+      key (npub) of the account you want deleted. You can copy the npub from your profile. We
+      acknowledge deletion requests within 3 business days and complete deletion within 30 days.
+      If you have a recurring card membership, requesting deletion also cancels future renewals.
+      What we delete, what we cannot delete (because content lives on public Nostr relays we do
+      not operate), and what the law requires us to keep are explained on
+      <a href="/delete-account" class="text-primary hover:underline">Account and Data Deletion</a>.
+    </p>
+
+    <h2 class="text-2xl font-bold mt-8 mb-4" style="color: var(--color-text-primary)">
+      How to report content or a user
+    </h2>
+
+    <p>
+      Email {@html SUPPORT_EMAIL} with a link to the post, recipe, listing, or profile, and a
+      short description of the problem. Anyone can report, including people who do not have a Zap
+      Cooking account. This is the reporting route from the website and from any surface that does
+      not yet have an in-app report control.
+    </p>
+
+    <p>
+      To hide someone from your own view: open their profile while signed in and tap Mute User.
+      Their recipes and posts stop appearing in your feeds. You can review muted people, words,
+      and phrases from the Muted tab on your own profile.
+    </p>
+
+    <p>
+      On Android, group chats also have an in-app report control, including a dedicated child
+      safety category. Those reports go to our moderation accounts and do not require an email
+      address.
+    </p>
+
+    <p>
+      We can act on surfaces we operate — our website and apps, our feeds, and the
+      pantry.zap.cooking relay we run. Content that has been copied onto other Nostr relays may
+      remain there; we can stop showing it in Zap Cooking and ask those relays to delete it, but
+      we cannot compel them.
+    </p>
+
+    <p>
+      For child sexual abuse material or exploitation, follow the steps on
+      <a href="/child-safety" class="text-primary hover:underline">Child Safety Standards</a>. Do
+      not download, save, or attach the material. If a child is in immediate danger, contact local
+      law enforcement first.
+    </p>
+
+    <h2 class="text-2xl font-bold mt-8 mb-4" style="color: var(--color-text-primary)">
+      How to report a bug
+    </h2>
+
+    <p>
+      Email {@html SUPPORT_EMAIL} if something in the app or website is broken. That is the path
+      for most people.
+    </p>
+
+    <p>
+      If you are comfortable using GitHub, you can also open an issue at
+      <a
+        href="https://github.com/zapcooking/frontend/issues/new"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-primary hover:underline">github.com/zapcooking/frontend/issues/new</a
+      >. That is the developer path, not the main support channel.
+    </p>
+
+    <h2 class="text-2xl font-bold mt-8 mb-4" style="color: var(--color-text-primary)">Legal</h2>
+
+    <ul class="list-disc pl-6 space-y-2">
+      <li>
+        <a href="/terms" class="text-primary hover:underline">Terms of Service</a>
+      </li>
+      <li>
+        <a href="/privacy" class="text-primary hover:underline">Privacy Policy</a>
+      </li>
+      <li>
+        <a href="/child-safety" class="text-primary hover:underline">Child Safety Standards</a>
+      </li>
+    </ul>
+  </div>
+</article>


### PR DESCRIPTION
## Summary
- Adds `zap.cooking/support` using the same legal-page layout as `/terms`, `/privacy`, and `/child-safety`, with a visible `support@zap.cooking` contact address.
- Covers how to get help, common questions drawn from the live product (Nostr keys, Cook+, zaps, account deletion), how to report content or a user, a secondary GitHub bug path, and links to the legal pages.
- Repoints the footer ⚡ Support link from the dead send-sats modal to `/support`.

## Test plan
- [ ] Open `/support` and confirm the page title, description, and canonical URL follow the legal-page pattern (`https://zap.cooking/support`).
- [ ] Confirm `support@zap.cooking` is visible as a `mailto:` link (view source / disable JS — Cloudflare should not rewrite it to `[email protected]`).
- [ ] Click the footer ⚡ Support link from another page and land on `/support` (no Lightning/QR modal).
- [ ] Check FAQ answers against the live app: key backup, Cook+ cancel paths (card portal vs Lightning), mute-on-profile, Android group-chat report, `/delete-account`.
- [ ] Confirm `/terms`, `/privacy`, and `/child-safety` are unchanged.


Made with [Cursor](https://cursor.com)