### PR TITLE
feat(profile): real header and compact actions in the profile sheet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.763",
+  "version": "4.2.764",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap.cooking",
   "license": "MIT",
-  "version": "4.2.762",
+  "version": "4.2.763",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/components/Avatar.svelte
+++ b/src/components/Avatar.svelte
@@ -17,6 +17,10 @@
   export let className: string = '';
   // Backwards-compatible alias used by existing callsites.
   export let imageUrl: string | null = null;
+  // False renders a plain image: no button role, no tab stop, and no
+  // membership tooltip swallowing the first click. Use it when a parent
+  // control (a link, a zoom button) owns the interaction.
+  export let interactive: boolean = true;
 
   const dispatch = createEventDispatcher();
 
@@ -57,6 +61,7 @@
   }
 
   function handleClick(event: MouseEvent): void {
+    if (!interactive) return;
     if (isActiveMember) {
       if (!openTooltip) {
         // First tap/click opens tooltip without immediately triggering parent link navigation.
@@ -73,6 +78,7 @@
   }
 
   function handleKeydown(event: KeyboardEvent): void {
+    if (!interactive) return;
     if (event.key === 'Escape') {
       openTooltip = false;
       return;
@@ -119,22 +125,33 @@
   });
 </script>
 
+<!-- role and tabindex flip together: button+0 when interactive, img with
+     no tab stop otherwise. The static check can't see that pairing. -->
+<!-- svelte-ignore a11y-no-noninteractive-tabindex -->
 <div
   bind:this={wrapperEl}
   class="avatar-wrapper {className}"
   style="--avatar-size: {size}px; {glowStyle}"
-  role="button"
-  tabindex="0"
+  role={interactive ? 'button' : 'img'}
+  tabindex={interactive ? 0 : undefined}
   aria-label={alt}
-  aria-expanded={isActiveMember ? openTooltip : undefined}
+  aria-expanded={interactive && isActiveMember ? openTooltip : undefined}
   on:click={handleClick}
   on:keydown={handleKeydown}
 >
   <div class="avatar-inner">
-    <CustomAvatar pubkey={pubkey} size={innerSize} imageUrl={avatarSrc} className="" />
+    <CustomAvatar
+      pubkey={pubkey}
+      size={innerSize}
+      imageUrl={avatarSrc}
+      className=""
+      {interactive}
+      on:load
+      on:fallback
+    />
   </div>
 
-  {#if isActiveMember && openTooltip}
+  {#if interactive && isActiveMember && openTooltip}
     <div class="membership-tooltip" role="tooltip">
       {tooltipLabel}
     </div>

--- a/src/components/CustomAvatar.svelte
+++ b/src/components/CustomAvatar.svelte
@@ -53,6 +53,22 @@
     return `https://images.weserv.nl/?url=${encodeURIComponent(u)}&w=${w}&h=${h}&fit=cover&a=attention`;
   }
 
+  // The candidate that loaded, minus avatar-sized resizing. Consumers that
+  // enlarge the picture (a lightbox) want the same host that worked — the
+  // raw URL may be blocked while weserv isn't — but not the `size`px crop.
+  function toFullSize(url: string): string {
+    try {
+      const parsed = new URL(url);
+      if (parsed.hostname === 'images.weserv.nl') {
+        for (const param of ['w', 'h', 'fit', 'a']) parsed.searchParams.delete(param);
+        return parsed.toString();
+      }
+    } catch {
+      // Not an absolute URL (data:/blob:) — return as-is.
+    }
+    return url;
+  }
+
   // Normalize URL: convert protocol-relative and domain/path strings to https://
   // Passes through http(s)://, data:, blob:, returns null for invalid URLs
   function normalizeUrl(url: string | null | undefined): string | null {
@@ -223,6 +239,7 @@
       profilePicture = null;
     } finally {
       loading = false;
+      if (!profilePicture) dispatch('fallback');
     }
   }
 
@@ -246,6 +263,9 @@
   $: avatarColor = generateAvatar(pubkey);
 </script>
 
+<!-- role and tabindex flip together: button+0 when interactive, img with
+     no tab stop otherwise. The static check can't see that pairing. -->
+<!-- svelte-ignore a11y-no-noninteractive-tabindex -->
 <div 
   class="avatar {className}"
   style="
@@ -267,9 +287,8 @@
       dispatch('click');
     }
   }}
-  role="button"
-  tabindex={interactive ? 0 : -1}
-  aria-disabled={!interactive}
+  role={interactive ? 'button' : 'img'}
+  tabindex={interactive ? 0 : undefined}
   aria-label={ariaLabel}
   on:keydown={(e) => {
     if (interactive && (e.key === 'Enter' || e.key === ' ')) {
@@ -290,6 +309,10 @@
         object-fit: cover; 
         border-radius: 50%;
       "
+      on:load={() => {
+        if (!profilePicture) return;
+        dispatch('load', { src: profilePicture, fullSrc: toFullSize(profilePicture) });
+      }}
       on:error={() => {
         // Index-based fallback: advance to next candidate, skip imgproxy.snort.social
         while (currentCandidateIndex < imageCandidates.length - 1) {
@@ -304,6 +327,7 @@
         // All candidates exhausted - show initials
         imageError = true;
         profilePicture = null;
+        dispatch('fallback');
       }}
     />
   {:else}

--- a/src/components/MediaLightbox.svelte
+++ b/src/components/MediaLightbox.svelte
@@ -32,6 +32,12 @@
   $: if (count === 0) onClose();
 
   let scroller: HTMLDivElement;
+  let rootEl: HTMLDivElement;
+  let closeButtonEl: HTMLButtonElement;
+  // Focus moves onto the lightbox while it's up and goes back to whatever
+  // opened it afterwards. The lightbox is portaled to body, so without
+  // this a parent dialog's Tab trap can't reach our close button.
+  let previousActiveElement: HTMLElement | null = null;
 
   function paneWidth(): number {
     return scroller?.offsetWidth || 0;
@@ -41,7 +47,37 @@
     // Jump straight to the tapped image (no animation on open).
     const w = paneWidth();
     if (w && index > 0) scroller.scrollLeft = index * w;
+    previousActiveElement = (document.activeElement as HTMLElement) || null;
+    closeButtonEl?.focus();
   });
+
+  function getFocusable(): HTMLElement[] {
+    if (!rootEl) return [];
+    return Array.from(rootEl.querySelectorAll<HTMLElement>('button:not([disabled])')).filter(
+      (el) => el.getClientRects().length > 0
+    );
+  }
+
+  // Keep Tab inside the lightbox: it's a modal layer over a page (and
+  // possibly a dialog) that is otherwise still reachable.
+  function trapTab(e: KeyboardEvent) {
+    const focusable = getFocusable();
+    if (focusable.length === 0) {
+      e.preventDefault();
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement as HTMLElement | null;
+    const inside = !!active && rootEl.contains(active);
+    if (e.shiftKey && (active === first || !inside)) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && (active === last || !inside)) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
 
   function handleScroll() {
     const w = paneWidth();
@@ -57,6 +93,7 @@
 
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === 'Escape') onClose();
+    else if (e.key === 'Tab') trapTab(e);
     else if (e.key === 'ArrowLeft' && index > 0) scrollToIndex(index - 1);
     else if (e.key === 'ArrowRight' && index < count - 1) scrollToIndex(index + 1);
   }
@@ -144,6 +181,12 @@
 
   onDestroy(() => {
     if (snapRestoreTimer) clearTimeout(snapRestoreTimer);
+    // Only hand focus back if it's still ours (or nowhere). If a parent
+    // has already moved it — e.g. a dialog closing underneath us and
+    // restoring its own opener — leave that alone.
+    const active = document.activeElement;
+    const ours = active === document.body || (!!active && rootEl?.contains(active));
+    if (ours && previousActiveElement?.isConnected) previousActiveElement.focus();
   });
 </script>
 
@@ -151,6 +194,7 @@
 
 <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-noninteractive-element-interactions -->
 <div
+  bind:this={rootEl}
   class="fixed inset-0 z-[10001] bg-black/85 overflow-hidden"
   use:portal={portalTarget ?? document.body}
   on:click={onClose}
@@ -188,6 +232,7 @@
 
   <!-- Close button -->
   <button
+    bind:this={closeButtonEl}
     class="absolute top-3 right-3 z-10 bg-white/10 hover:bg-white/20 text-white rounded-full p-2 transition"
     on:click|stopPropagation={onClose}
     aria-label="Close image"

--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -28,6 +28,11 @@
   export let maxWidth: string | null = null;
   export let autoHeight = false;
   export let fullScreenMobile = false;
+  // While true the dialog stays open but stops handling Escape and Tab.
+  // For a parent that stacks a second overlay (a lightbox portaled to
+  // body) on top of this one: without this, Tab is pulled back into the
+  // dialog and Escape closes both layers at once.
+  export let suspended = false;
 
   // Portal target - render at document body level. Initialized
   // synchronously when document is available so the dialog can mount
@@ -62,7 +67,7 @@
   }
 
   function handleKeydown(e: KeyboardEvent) {
-    if (!open) return;
+    if (!open || suspended) return;
     if (e.key === 'Escape') {
       close();
       return;

--- a/src/routes/user/[slug]/+page.svelte
+++ b/src/routes/user/[slug]/+page.svelte
@@ -50,6 +50,8 @@
   import QuestionIcon from 'phosphor-svelte/lib/Question';
   import ArrowCounterClockwiseIcon from 'phosphor-svelte/lib/ArrowCounterClockwise';
   import MuteListEditor from '../../../components/MuteListEditor.svelte';
+  import MediaLightbox from '../../../components/MediaLightbox.svelte';
+  import CloseIcon from 'phosphor-svelte/lib/X';
 
   let hexpubkey: string | undefined = undefined;
   let events: NDKEvent[] = [];
@@ -163,6 +165,21 @@
   let uploadingPicture = false;
   let pictureInputEl: HTMLInputElement | null = null;
   let avatarRefreshKey = 0; // Used to force Avatar remount after picture change
+  let avatarLightboxOpen = false;
+
+  // The picture the profile sheet shows and enlarges. Own profile prefers
+  // the just-uploaded override so a fresh picture isn't a stale relay copy;
+  // empty means there's only a generated fallback, which isn't worth zooming.
+  // NDK normalizes kind-0 `picture` onto `image`, so `image` is what's
+  // actually populated here — `picture` is read as a fallback for profiles
+  // that came from somewhere else. String() because the type's index
+  // signature widens both to string | number, which Avatar's `src` won't take.
+  $: modalPicture = String(
+    ($userPublickey === hexpubkey ? $userProfilePictureOverride : null) ||
+      profile?.image ||
+      profile?.picture ||
+      ''
+  );
 
   // Profile edit modal state
   let profileEditModal = false;
@@ -1312,6 +1329,7 @@
 
   function qrModalCleanup() {
     qrModal = false;
+    avatarLightboxOpen = false;
     npubCopied = false;
     lightningCopied = false;
   }
@@ -1758,89 +1776,137 @@
   }}
 />
 
-<Modal cleanup={qrModalCleanup} open={qrModal}>
-  <h1 slot="title">
-    {profile
-      ? profile.displayName || profile.display_name || profile.name || '...'
-      : '...'}'s Profile
-  </h1>
+<Modal cleanup={qrModalCleanup} open={qrModal} noHeader autoHeight>
+  <!-- Profile header. The banner bleeds to the dialog's edges by undoing
+       its px-4/md:px-8/pt-6 padding, so the sheet opens on the same
+       banner-and-avatar composition as the profile page rather than a
+       bare title row. Modal's own header is off for that reason; the
+       close button below is still the single dismiss affordance. -->
+  <div class="-mx-4 -mt-6 md:-mx-8">
+    <div class="relative">
+      <div
+        class="h-24 overflow-hidden rounded-t-3xl sm:h-28"
+        style="background: {profile?.banner
+          ? 'transparent'
+          : 'linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-hover) 100%)'}"
+      >
+        {#if profile?.banner}
+          <img src={profile.banner} alt="" class="w-full h-full object-cover" />
+        {/if}
+      </div>
 
-  <div class="flex flex-col items-center gap-6">
-    <!-- Profile Info -->
-    <div class="w-full space-y-3 border-t pt-4">
-      <!-- NIP-05 -->
+      <button
+        class="absolute top-2 right-2 flex h-9 w-9 items-center justify-center rounded-full bg-black/45 text-white transition-colors hover:bg-black/70"
+        aria-label="Close"
+        on:click={qrModalCleanup}
+      >
+        <CloseIcon size={20} />
+      </button>
+
+      <!-- Avatar overlaps the banner. It only becomes a button when there
+           is a real picture behind it — enlarging a generated fallback
+           would just show a bigger placeholder. -->
+      <div class="absolute -bottom-8 left-4 md:left-8">
+        {#if modalPicture}
+          <button
+            class="rounded-full ring-4 transition-opacity hover:opacity-90"
+            style="--tw-ring-color: var(--color-bg-secondary)"
+            on:click={() => (avatarLightboxOpen = true)}
+            aria-label="View profile picture"
+            title="View profile picture"
+          >
+            {#key `${hexpubkey}-${avatarRefreshKey}`}
+              <Avatar
+                className="cursor-zoom-in"
+                pubkey={hexpubkey || ''}
+                size={72}
+                src={modalPicture}
+              />
+            {/key}
+          </button>
+        {:else}
+          <div class="rounded-full ring-4" style="--tw-ring-color: var(--color-bg-secondary)">
+            <Avatar pubkey={hexpubkey || ''} size={72} />
+          </div>
+        {/if}
+      </div>
+    </div>
+  </div>
+
+  <!-- pt clears the avatar's overhang; Modal's own gap-6 supplies the rest. -->
+  <div class="flex flex-col gap-4 pt-4">
+    <!-- Identity -->
+    <div class="flex flex-col gap-1 min-w-0">
+      <h2 class="flex items-center gap-1.5 text-lg font-bold min-w-0">
+        <span class="truncate"><CustomName pubkey={hexpubkey || ''} /></span>
+        <MembershipBeltBadge pubkey={hexpubkey || ''} size={18} />
+      </h2>
+
       {#if profile?.nip05}
-        <div class="flex items-center gap-2 text-sm">
-          <SealCheckIcon size={18} weight="fill" class="text-purple-500 flex-shrink-0" />
-          <span class="break-all" style="color: var(--color-text-primary)">{profile.nip05}</span>
+        <div class="flex items-center gap-1.5 text-xs" style="color: var(--color-text-caption)">
+          <SealCheckIcon size={14} weight="fill" class="text-purple-500 flex-shrink-0" />
+          <span class="break-all">{profile.nip05}</span>
         </div>
       {/if}
 
-      <!-- Lightning Address -->
       {#if profile?.lud16 || profile?.lud06}
-        <div class="flex items-center gap-2 text-sm">
-          <LightningIcon size={18} weight="fill" class="text-yellow-500 flex-shrink-0" />
-          <span class="break-all flex-1" style="color: var(--color-text-primary)"
-            >{profile.lud16 || profile.lud06}</span
-          >
+        <div class="flex items-center gap-1.5 text-xs" style="color: var(--color-text-caption)">
+          <LightningIcon size={14} weight="fill" class="text-yellow-500 flex-shrink-0" />
+          <span class="break-all">{profile.lud16 || profile.lud06}</span>
           <button
             on:click={() => copyLightningAddress(profile?.lud16 || profile?.lud06 || '')}
             class="text-caption hover:text-primary transition-colors cursor-pointer flex-shrink-0"
             title="Copy lightning address"
           >
             {#if lightningCopied}
-              <CheckIcon size={16} weight="bold" class="text-green-500" />
+              <CheckIcon size={14} weight="bold" class="text-green-500" />
             {:else}
-              <CopyIcon size={16} />
+              <CopyIcon size={14} />
             {/if}
           </button>
         </div>
       {/if}
+    </div>
 
-
-      <!-- Action buttons for other users -->
+    <!-- Actions. Compact pills in a wrapping row: the stacked full-width
+         blocks made a five-item sheet taller than the profile it describes. -->
+    <div class="flex flex-wrap items-center gap-2">
       {#if hexpubkey !== $userPublickey}
-        <!-- Zap Button (hidden for muted users) -->
         {#if (profile?.lud16 || profile?.lud06) && hexpubkey && !$mutedPubkeys.has(hexpubkey)}
           <button
-            class="w-full flex items-center justify-center gap-2 px-4 py-4 rounded-lg font-medium text-base transition-colors bg-yellow-500 text-black hover:bg-yellow-400 disabled:opacity-50"
+            class="flex items-center gap-1.5 rounded-lg bg-yellow-500 px-3 py-1.5 text-sm font-medium text-black transition-colors hover:bg-yellow-400 disabled:opacity-50"
             disabled={isZapping}
             on:click={() => {
               qrModal = false;
               handleZapClick();
             }}
           >
-            <LightningIcon size={22} weight="fill" />
-            <span>{isZapping ? 'Zapping...' : 'Send Zap'}</span>
+            <LightningIcon size={16} weight="fill" />
+            <span>{isZapping ? 'Zapping...' : 'Zap'}</span>
           </button>
         {/if}
 
-        <!-- CLINK offer — full-width CTA, gradient brand orange. Sits
-             alongside Send Zap so the two payment paths read as peers
-             rather than the noffer feeling buried. -->
         {#if profileNoffer && hexpubkey && !$mutedPubkeys.has(hexpubkey)}
-          <NofferButton noffer={profileNoffer} variant="cta" />
+          <NofferButton noffer={profileNoffer} />
         {/if}
 
-        <!-- DM Button -->
         {#if $userPublickey && hexpubkey && !$mutedPubkeys.has(hexpubkey)}
           <a
             href="/messages?pubkey={hexpubkey}"
-            class="w-full flex items-center justify-center gap-2 px-4 py-2 rounded-lg font-medium text-sm transition-colors bg-input hover:bg-accent-gray"
+            class="flex items-center gap-1.5 rounded-lg bg-input px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent-gray"
             style="color: var(--color-text-primary)"
             on:click={() => (qrModal = false)}
           >
-            <ChatCircleIcon size={18} weight="bold" />
+            <ChatCircleIcon size={16} weight="bold" />
             <span>Message</span>
           </a>
         {/if}
 
-        <!-- Follow Button with mute indicator -->
         {#if $userPublickey}
           <button
             on:click={toggleFollow}
             disabled={followLoading}
-            class="w-full flex items-center justify-center gap-2 px-4 py-2 rounded-lg font-medium text-sm transition-colors disabled:opacity-50 {isFollowing
+            class="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-50 {isFollowing
               ? 'bg-input hover:bg-accent-gray'
               : 'bg-orange-500 text-white hover:bg-orange-600'}"
             style={isFollowing ? 'color: var(--color-text-primary)' : ''}
@@ -1848,58 +1914,61 @@
             {#if followLoading}
               <span class="animate-pulse">...</span>
             {:else if isFollowing}
-              <CheckIcon size={18} weight="bold" />
+              <CheckIcon size={16} weight="bold" />
               <span>Following</span>
             {:else}
-              <UserPlusIcon size={18} weight="bold" />
+              <UserPlusIcon size={16} weight="bold" />
               <span>Follow</span>
             {/if}
             {#if hexpubkey && $mutedPubkeys.has(hexpubkey)}
-              <SpeakerSimpleSlashIcon size={18} weight="bold" class="opacity-70" />
+              <SpeakerSimpleSlashIcon size={16} weight="bold" class="opacity-70" />
             {/if}
           </button>
         {/if}
       {/if}
+    </div>
 
-      <!-- Copy Npub Button -->
+    <!-- Secondary actions read as utilities, not peers of Zap/Follow. -->
+    <div
+      class="flex flex-wrap items-center gap-x-4 gap-y-2 border-t pt-3 text-xs"
+      style="border-color: var(--color-input-border)"
+    >
       <button
         on:click={copyNpub}
-        class="w-full flex items-center justify-center gap-2 px-4 py-2 bg-input hover:bg-accent-gray rounded-lg transition-colors text-sm font-medium"
-        style="color: var(--color-text-primary)"
+        class="flex items-center gap-1.5 transition-colors hover:opacity-80"
+        style="color: var(--color-text-caption)"
       >
         {#if npubCopied}
-          <CheckIcon size={18} weight="bold" />
+          <CheckIcon size={14} weight="bold" class="text-green-500" />
           <span>Copied!</span>
         {:else}
-          <CopyIcon size={18} />
+          <CopyIcon size={14} />
           <span>Copy npub</span>
         {/if}
       </button>
 
-      <!-- Mute Button -->
       {#if hexpubkey !== $userPublickey && $userPublickey}
         <button
           on:click={toggleMute}
           disabled={muteLoading}
-          class="w-full flex items-center justify-center gap-2 px-4 py-2 rounded-lg font-medium text-sm transition-colors disabled:opacity-50 {isMuted
-            ? 'bg-red-100 text-red-700 hover:bg-red-200'
-            : 'bg-input hover:bg-accent-gray'}"
-          style={!isMuted ? 'color: var(--color-text-primary)' : ''}
+          class="flex items-center gap-1.5 transition-colors hover:opacity-80 disabled:opacity-50"
+          style="color: {isMuted ? 'rgb(248 113 113)' : 'var(--color-text-caption)'}"
         >
           {#if muteLoading}
             <span class="animate-pulse">...</span>
-          {:else if isMuted}
-            <SpeakerSlashIcon size={18} weight="bold" />
-            <span>Unmute User</span>
           {:else}
-            <SpeakerSlashIcon size={18} />
-            <span>Mute User</span>
+            <SpeakerSlashIcon size={14} weight={isMuted ? 'bold' : 'regular'} />
+            <span>{isMuted ? 'Unmute user' : 'Mute user'}</span>
           {/if}
         </button>
       {/if}
     </div>
   </div>
 </Modal>
+
+{#if avatarLightboxOpen && modalPicture}
+  <MediaLightbox images={[modalPicture]} index={0} onClose={() => (avatarLightboxOpen = false)} />
+{/if}
 
 <div class="max-w-4xl w-full px-4">
   <!-- Profile Banner. Below xl (no sidebar) it's full-bleed and flush under

--- a/src/routes/user/[slug]/+page.svelte
+++ b/src/routes/user/[slug]/+page.svelte
@@ -167,19 +167,35 @@
   let avatarRefreshKey = 0; // Used to force Avatar remount after picture change
   let avatarLightboxOpen = false;
 
-  // The picture the profile sheet shows and enlarges. Own profile prefers
-  // the just-uploaded override so a fresh picture isn't a stale relay copy;
-  // empty means there's only a generated fallback, which isn't worth zooming.
-  // NDK normalizes kind-0 `picture` onto `image`, so `image` is what's
-  // actually populated here — `picture` is read as a fallback for profiles
-  // that came from somewhere else. String() because the type's index
-  // signature widens both to string | number, which Avatar's `src` won't take.
+  // The picture the profile sheet's avatar is asked to show. Own profile
+  // prefers the just-uploaded override so a fresh picture isn't a stale
+  // relay copy. NDK normalizes kind-0 `picture` onto `image`, so `image`
+  // is what's actually populated here — `picture` is read as a fallback
+  // for profiles that came from somewhere else. String() because the
+  // type's index signature widens both to string | number, which Avatar's
+  // `src` won't take.
   $: modalPicture = String(
     ($userPublickey === hexpubkey ? $userProfilePictureOverride : null) ||
       profile?.image ||
       profile?.picture ||
       ''
   );
+
+  // What the avatar actually rendered, at full size — set from Avatar's
+  // `load` event, cleared on `fallback`. The zoom button and the lightbox
+  // key off this rather than modalPicture: CustomAvatar may skip or proxy
+  // the raw URL (void.cat, snort imgproxy) or exhaust every candidate and
+  // draw the generated placeholder, and in either case enlarging the raw
+  // URL would show a broken image or nothing worth a click.
+  let modalResolvedPicture: string | null = null;
+  $: {
+    // Clear whenever the avatar's inputs change so a URL from the
+    // previous picture can't outlive its remount.
+    void modalPicture;
+    void hexpubkey;
+    void avatarRefreshKey;
+    modalResolvedPicture = null;
+  }
 
   // Profile edit modal state
   let profileEditModal = false;
@@ -1330,6 +1346,7 @@
   function qrModalCleanup() {
     qrModal = false;
     avatarLightboxOpen = false;
+    modalResolvedPicture = null;
     npubCopied = false;
     lightningCopied = false;
   }
@@ -1776,7 +1793,7 @@
   }}
 />
 
-<Modal cleanup={qrModalCleanup} open={qrModal} noHeader autoHeight>
+<Modal cleanup={qrModalCleanup} open={qrModal} noHeader autoHeight suspended={avatarLightboxOpen}>
   <!-- Profile header. The banner bleeds to the dialog's edges by undoing
        its px-4/md:px-8/pt-6 padding, so the sheet opens on the same
        banner-and-avatar composition as the profile page rather than a
@@ -1803,31 +1820,33 @@
         <CloseIcon size={20} />
       </button>
 
-      <!-- Avatar overlaps the banner. It only becomes a button when there
-           is a real picture behind it — enlarging a generated fallback
-           would just show a bigger placeholder. -->
-      <div class="absolute -bottom-8 left-4 md:left-8">
-        {#if modalPicture}
+      <!-- Avatar overlaps the banner. The avatar itself is non-interactive
+           (no nested button role, no membership tooltip eating the first
+           click); a single transparent zoom button is laid over it once an
+           image has actually loaded. With only the generated placeholder
+           there is nothing to enlarge, so no control is offered. -->
+      <div
+        class="absolute -bottom-8 left-4 md:left-8 rounded-full ring-4"
+        style="--tw-ring-color: var(--color-bg-secondary)"
+      >
+        {#key `${hexpubkey}-${avatarRefreshKey}`}
+          <Avatar
+            pubkey={hexpubkey || ''}
+            size={72}
+            src={modalPicture || null}
+            alt="Profile picture"
+            interactive={false}
+            on:load={(e) => (modalResolvedPicture = e.detail.fullSrc)}
+            on:fallback={() => (modalResolvedPicture = null)}
+          />
+        {/key}
+        {#if modalResolvedPicture}
           <button
-            class="rounded-full ring-4 transition-opacity hover:opacity-90"
-            style="--tw-ring-color: var(--color-bg-secondary)"
+            class="absolute inset-0 rounded-full cursor-zoom-in transition-colors hover:bg-black/10 focus-visible:ring-2 focus-visible:ring-orange-500"
             on:click={() => (avatarLightboxOpen = true)}
             aria-label="View profile picture"
             title="View profile picture"
-          >
-            {#key `${hexpubkey}-${avatarRefreshKey}`}
-              <Avatar
-                className="cursor-zoom-in"
-                pubkey={hexpubkey || ''}
-                size={72}
-                src={modalPicture}
-              />
-            {/key}
-          </button>
-        {:else}
-          <div class="rounded-full ring-4" style="--tw-ring-color: var(--color-bg-secondary)">
-            <Avatar pubkey={hexpubkey || ''} size={72} />
-          </div>
+          ></button>
         {/if}
       </div>
     </div>
@@ -1837,8 +1856,8 @@
   <div class="flex flex-col gap-4 pt-4">
     <!-- Identity -->
     <div class="flex flex-col gap-1 min-w-0">
-      <h2 class="flex items-center gap-1.5 text-lg font-bold min-w-0">
-        <span class="truncate"><CustomName pubkey={hexpubkey || ''} /></span>
+      <h2 id="title" class="flex items-center gap-1.5 text-lg font-bold min-w-0">
+        <span class="truncate"><CustomName pubkey={hexpubkey || ''} interactive={false} /></span>
         <MembershipBeltBadge pubkey={hexpubkey || ''} size={18} />
       </h2>
 
@@ -1966,8 +1985,12 @@
   </div>
 </Modal>
 
-{#if avatarLightboxOpen && modalPicture}
-  <MediaLightbox images={[modalPicture]} index={0} onClose={() => (avatarLightboxOpen = false)} />
+{#if avatarLightboxOpen && modalResolvedPicture}
+  <MediaLightbox
+    images={[modalResolvedPicture]}
+    index={0}
+    onClose={() => (avatarLightboxOpen = false)}
+  />
 {/if}
 
 <div class="max-w-4xl w-full px-4">


### PR DESCRIPTION
Tapping an avatar or name on a profile page opened a sheet with a title row and five stacked full-width buttons — taller than the profile it describes, with none of the profile actually visible in it.

## What changed

**A real header.** The banner bleeds to the dialog's edges (negative margins undoing Modal's `px-4 md:px-8 pt-6`), the avatar overlaps it bottom-left, and the name carries the identity instead of an `"X's Profile"` title. Profiles without a banner get the same gradient the profile page uses. Modal's own header is off so the banner can reach the top edge; the close button over the banner is still the single dismiss affordance and runs the same `qrModalCleanup`.

**Compact actions.** Zap/Message/Follow are pills in a wrapping row (`px-3 py-1.5 text-sm`) rather than stacked full-width blocks, and Copy npub/Mute drop to a text-size utility row under a divider. The CLINK offer uses NofferButton's `pill` variant instead of `cta`. The sheet is roughly half its old height.

**Enlargeable picture.** The avatar becomes a button when there's a real picture and opens it in MediaLightbox (`z-[10001]`, above Modal's `z-[10000]`). With only a generated fallback it stays a plain div — zooming a placeholder isn't worth a click target.

## One note for reviewers

The avatar wouldn't become clickable at first: NDK normalizes kind-0's `picture` onto `image`, so `profile.picture` is `undefined` on this object. The lookup reads `image` first with `picture` as a fallback.

Worth knowing that the same confusion sits in existing code — `og_meta.image` reads `profile?.picture`, so a profile page's own `og:image` always emits the default share image rather than the avatar. It's masked because the layout emits an og:image first and crawlers take that one. Left alone here as unrelated to this redesign.

## Testing

Desktop and 390px mobile, on two profiles with different banners: header renders, buttons stay compact and wrap, avatar click opens the lightbox with the right image. 1732 tests green, `pnpm build` clean, `svelte-check` unchanged from main.

Message/Follow/Mute only render when signed in, so those paths weren't clicked — the logic is unchanged from before, only restyled.